### PR TITLE
Use sonatype instead of internal nexus repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
     </properties>
 
     <distributionManagement>
-        <repository>
+        <!--repository>
             <id>arda.nexus.releases</id>
             <name>arda's nexus</name>
             <url>http://10.239.45.219:8081/content/repositories/releases/</url>
@@ -165,6 +165,10 @@
             <id>arda.nexus.snapshots</id>
             <name>arda's nexus</name>
             <url>http://10.239.45.219:8081/content/repositories/snapshots/</url>
+        </snapshotRepository-->
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
 
@@ -400,6 +404,17 @@
                         </compilerPlugin>
                     </compilerPlugins>
                 </configuration>
+            </plugin>
+	    <plugin>
+	        <groupId>org.sonatype.plugins</groupId>
+	        <artifactId>nexus-staging-maven-plugin</artifactId>
+	        <version>1.6.7</version>
+	        <extensions>true</extensions>
+	        <configuration>
+	            <serverId>ossrh</serverId>
+	            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+	            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+	        </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,25 @@
     <packaging>pom</packaging>
     <version>0.1.0-SNAPSHOT</version>
 
+    <name>BigDL</name>
+    <description>A distributed deep learning library for Apache Spark.</description>
+    <url>https://github.com/intel-analytics/BigDL</url>
+
+    <developers>
+        <developer>
+            <name>Jason Dai</name>
+            <email>jason.dai@intel.com</email>
+            <organization>Intel</organization>
+            <organizationUrl>http://www.intel.com</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:git@github.com:intel-analytics/BigDL.git</connection>
+        <developerConnection>scm:git:ssh://github.com:simpligility/ossrh-demo.git</developerConnection>
+        <url>https://github.com/intel-analytics/BigDL/tree/master</url>
+    </scm>
+
     <repositories>
         <repository>
             <id>central</id>
@@ -44,9 +63,9 @@
             </snapshots>
         </repository>
         <repository>
-            <id>intel-bdta-repo</id>
-            <name>intel bdta repository</name>
-            <url>http://10.239.45.219:8081/content/groups/public/</url>
+            <id>sonatype</id>
+            <name>sonatype repository</name>
+            <url>https://oss.sonatype.org/content/groups/public/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -156,16 +175,6 @@
     </properties>
 
     <distributionManagement>
-        <!--repository>
-            <id>arda.nexus.releases</id>
-            <name>arda's nexus</name>
-            <url>http://10.239.45.219:8081/content/repositories/releases/</url>
-        </repository>
-        <snapshotRepository>
-            <id>arda.nexus.snapshots</id>
-            <name>arda's nexus</name>
-            <url>http://10.239.45.219:8081/content/repositories/snapshots/</url>
-        </snapshotRepository-->
         <snapshotRepository>
             <id>ossrh</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>


### PR DESCRIPTION
This PR includes:
1. Use sonatype instead of internal nexus repo.
2. add other component in pom.xml to meet the requirement of Maven central repo