### PR TITLE
[Issue #341] Add profile to build bigdl on scala 2.11

### DIFF
--- a/dl/pom.xml
+++ b/dl/pom.xml
@@ -52,13 +52,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.10</artifactId>
+            <artifactId>spark-core_${scala.major.version}</artifactId>
             <version>${spark.version}</version>
             <scope>${spark-scope}</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-mllib_2.10</artifactId>
+            <artifactId>spark-mllib_${scala.major.version}</artifactId>
             <version>${spark.version}</version>
             <scope>${spark-scope}</scope>
         </dependency>
@@ -69,7 +69,7 @@
         </dependency>
         <dependency>
             <groupId>org.scalanlp</groupId>
-            <artifactId>breeze_2.10</artifactId>
+            <artifactId>breeze_${scala.major.version}</artifactId>
             <version>0.11.2</version>
             <exclusions>
                 <!-- This is included as a compile-scoped dependency by jtransforms, which is
@@ -87,7 +87,7 @@
 
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.10</artifactId>
+            <artifactId>scalatest_${scala.major.version}</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -97,7 +97,7 @@
         </dependency>
         <dependency>
             <groupId>com.github.scopt</groupId>
-            <artifactId>scopt_2.10</artifactId>
+            <artifactId>scopt_${scala.major.version}</artifactId>
             <version>3.2.0</version>
         </dependency>
         <dependency>

--- a/dl/pom.xml
+++ b/dl/pom.xml
@@ -16,10 +16,6 @@
         <scoverage.plugin.version>1.1.1</scoverage.plugin.version>
         <scoverage.scalacPluginVersion>1.1.1</scoverage.scalacPluginVersion>
         <scoverage.aggregate>true</scoverage.aggregate>
-        <!--> this is the version of spark-version project<-->
-        <spark-version.version>1.5-plus</spark-version.version>
-        <spark.version>1.5.1</spark.version>
-        <spark-scope>provided</spark-scope>
     </properties>
 
     <dependencies>
@@ -59,7 +55,7 @@
         </dependency>
         <dependency>
             <groupId>com.intel.analytics.bigdl.spark-version</groupId>
-            <artifactId>${spark-version.version}</artifactId>
+            <artifactId>${spark-version.project}</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -234,30 +230,4 @@
             </plugin>
         </plugins>
     </reporting>
-
-    <profiles>
-        <profile>
-            <id>1.5-plus</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <spark-version.version>1.5-plus</spark-version.version>
-                <spark.version>1.5.1</spark.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>2.0</id>
-            <properties>
-                <spark-version.version>2.0</spark-version.version>
-                <spark.version>2.0.0</spark.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>all-in-one</id>
-            <properties>
-                <spark-scope>compile</spark-scope>
-            </properties>
-        </profile>
-    </profiles>
 </project>

--- a/dl/pom.xml
+++ b/dl/pom.xml
@@ -46,7 +46,7 @@
                  -->
                 <exclusion>
                     <groupId>com.intel.analytics.bigdl.native</groupId>
-                    <artifactId>mkl-native</artifactId>
+                    <artifactId>bigdl-native</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/dl/pom.xml
+++ b/dl/pom.xml
@@ -40,6 +40,15 @@
             <groupId>com.intel.analytics.bigdl.native</groupId>
             <artifactId>mkl-java</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <!-- We already copy the dynamic lib files of this project to mkl-java, so we
+                need not the dependency, which will break assembly step.
+                 -->
+                <exclusion>
+                    <groupId>com.intel.analytics.bigdl.native</groupId>
+                    <artifactId>mkl-native</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
@@ -75,10 +75,18 @@ class TableSpec extends FlatSpec with Matchers {
     state(1) = Tensor[Double](3, 3).zero()
     state(2) = T(1 -> "b", 2 -> T(1 -> "d"))
     print(state.toString)
-    state.toString() should be(" {\n\t2:  {\n\t   " +
-      "\t2:  {\n\t   \t   \t1: d\n\t   \t    }\n\t   \t1: b\n\t    }" +
-      "\n\t1: 0.0\t0.0\t0.0\t\n\t   0.0\t0.0\t0.0\t\n\t   0.0\t0.0\t0.0\t\n\t   " +
-      "[com.intel.analytics.bigdl.tensor.DenseTensor$mcD$sp of size 3x3]\n }")
+    // Handle different behavior of toString in scala 2.10 and 2.11
+    if(util.Properties.versionNumberString.contains("2.10")) {
+      state.toString() should be(" {\n\t2:  {\n\t   " +
+        "\t2:  {\n\t   \t   \t1: d\n\t   \t    }\n\t   \t1: b\n\t    }" +
+        "\n\t1: 0.0\t0.0\t0.0\t\n\t   0.0\t0.0\t0.0\t\n\t   0.0\t0.0\t0.0\t\n\t   " +
+        "[com.intel.analytics.bigdl.tensor.DenseTensor$mcD$sp of size 3x3]\n }")
+    } else if(util.Properties.versionNumberString.contains("2.11")) {
+      state.toString() should be(" {\n\t2:  {\n\t   " +
+        "\t2:  {\n\t   \t   \t1: d\n\t   \t    }\n\t   \t1: b\n\t    }" +
+        "\n\t1: 0.0\t0.0\t0.0\t\n\t   0.0\t0.0\t0.0\t\n\t   0.0\t0.0\t0.0\t\n\t   " +
+        "[com.intel.analytics.bigdl.tensor.DenseTensor of size 3x3]\n }")
+    }
   }
 
   "init with data" should "return correct value" in {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
@@ -81,7 +81,7 @@ class TableSpec extends FlatSpec with Matchers {
         "\t2:  {\n\t   \t   \t1: d\n\t   \t    }\n\t   \t1: b\n\t    }" +
         "\n\t1: 0.0\t0.0\t0.0\t\n\t   0.0\t0.0\t0.0\t\n\t   0.0\t0.0\t0.0\t\n\t   " +
         "[com.intel.analytics.bigdl.tensor.DenseTensor$mcD$sp of size 3x3]\n }")
-    } else if(util.Properties.versionNumberString.contains("2.11")) {
+    } else if (util.Properties.versionNumberString.contains("2.11")) {
       state.toString() should be(" {\n\t2:  {\n\t   " +
         "\t2:  {\n\t   \t   \t1: d\n\t   \t    }\n\t   \t1: b\n\t    }" +
         "\n\t1: 0.0\t0.0\t0.0\t\n\t   0.0\t0.0\t0.0\t\n\t   0.0\t0.0\t0.0\t\n\t   " +

--- a/native/jni/pom.xml
+++ b/native/jni/pom.xml
@@ -19,6 +19,11 @@
             <artifactId>junit</artifactId>
             <version>4.11</version>
         </dependency>
+        <dependency>
+            <groupId>com.intel.analytics.bigdl.native</groupId>
+            <artifactId>mkl-native</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/native/jni/pom.xml
+++ b/native/jni/pom.xml
@@ -21,7 +21,7 @@
         </dependency>
         <dependency>
             <groupId>com.intel.analytics.bigdl.native</groupId>
-            <artifactId>mkl-native</artifactId>
+            <artifactId>bigdl-native</artifactId>
             <version>${project.version}</version>
             <type>so</type>
         </dependency>
@@ -56,7 +56,7 @@
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>com.intel.analytics.bigdl.native</groupId>
-                                    <artifactId>mkl-native</artifactId>
+                                    <artifactId>bigdl-native</artifactId>
                                     <version>${pom.version}</version>
                                     <type>so</type>
                                     <overWrite>false</overWrite>

--- a/native/jni/pom.xml
+++ b/native/jni/pom.xml
@@ -23,6 +23,7 @@
             <groupId>com.intel.analytics.bigdl.native</groupId>
             <artifactId>mkl-native</artifactId>
             <version>${project.version}</version>
+            <type>so</type>
         </dependency>
     </dependencies>
 

--- a/native/mkl/pom.xml
+++ b/native/mkl/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.intel.analytics.bigdl.native</groupId>
-    <artifactId>mkl-native</artifactId>
+    <artifactId>bigdl-native</artifactId>
     <packaging>so</packaging>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -482,6 +482,9 @@
             <properties>
                 <spark-version.project>2.0</spark-version.project>
                 <spark.version>2.0.0</spark.version>
+                <scala.major.version>2.11</scala.major.version>
+                <scala.version>2.11.8</scala.version>
+                <scala.macros.version>2.1.0</scala.macros.version>
             </properties>
         </profile>
         <profile>
@@ -490,6 +493,15 @@
                 <scala.major.version>2.11</scala.major.version>
                 <scala.version>2.11.8</scala.version>
                 <scala.macros.version>2.1.0</scala.macros.version>
+            </properties>
+        </profile>
+        <!-- put this profile after spark_2.0 profile -->
+        <profile>
+            <id>scala_2.10</id>
+            <properties>
+                <scala.major.version>2.10</scala.major.version>
+                <scala.version>2.10.5</scala.version>
+                <scala.macros.version>2.0.1</scala.macros.version>
             </properties>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -168,11 +168,16 @@
         <commons-lang.version>2.6</commons-lang.version>
         <commons-math.version>2.2</commons-math.version>
         <collections.version>3.2.1</collections.version>
-
-        <!-- for scoverage -->
         <scoverage.plugin.version>1.1.1</scoverage.plugin.version>
-
+        <spark-version.project>1.5-plus</spark-version.project>
+        <spark.version>1.5.1</spark.version>
+        <spark-scope>provided</spark-scope>
     </properties>
+
+    <modules>
+        <module>dl</module>
+        <module>spark-version</module>
+    </modules>
 
     <distributionManagement>
         <snapshotRepository>
@@ -472,28 +477,26 @@
 
     <profiles>
         <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <modules>
-                <module>dl</module>
-                <module>spark-version</module>
-            </modules>
+            <id>2.0</id>
+            <properties>
+                <spark-version.project>2.0</spark-version.project>
+                <spark.version>2.0.0</spark.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>all-in-one</id>
+            <properties>
+                <spark-scope>compile</spark-scope>
+            </properties>
         </profile>
         <profile>
             <id>full-build</id>
             <modules>
                 <module>native</module>
-                <module>dl</module>
-                <module>spark-version</module>
             </modules>
         </profile>
         <profile>
             <id>src</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
             <build>
                 <plugins>
                     <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -478,7 +478,7 @@
 
     <profiles>
         <profile>
-            <id>2.0</id>
+            <id>spark_2.0</id>
             <properties>
                 <spark-version.project>2.0</spark-version.project>
                 <spark.version>2.0.0</spark.version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,7 @@
         <!-- define the Java language version used by the compiler -->
         <java.version>1.7</java.version>
         <javac.version>1.7</javac.version>
+        <scala.major.version>2.10</scala.major.version>
         <scala.version>2.10.5</scala.version>
         <scala.macros.version>2.0.1</scala.macros.version>
         <scalatest.version>2.2.4</scalatest.version>
@@ -215,7 +216,7 @@
             </dependency>
             <dependency>
                 <groupId>org.scalatest</groupId>
-                <artifactId>scalatest_2.10</artifactId>
+                <artifactId>scalatest_${scala.major.version}</artifactId>
                 <version>${scalatest.version}</version>
             </dependency>
         </dependencies>
@@ -481,6 +482,14 @@
             <properties>
                 <spark-version.project>2.0</spark-version.project>
                 <spark.version>2.0.0</spark.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>scala_2.11</id>
+            <properties>
+                <scala.major.version>2.11</scala.major.version>
+                <scala.version>2.11.8</scala.version>
+                <scala.macros.version>2.1.0</scala.macros.version>
             </properties>
         </profile>
         <profile>

--- a/spark-version/1.5-plus/pom.xml
+++ b/spark-version/1.5-plus/pom.xml
@@ -16,13 +16,13 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.10</artifactId>
+            <artifactId>spark-core_${scala.major.version}</artifactId>
             <version>1.5.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-mllib_2.10</artifactId>
+            <artifactId>spark-mllib_${scala.major.version}</artifactId>
             <version>1.5.1</version>
             <scope>provided</scope>
         </dependency>

--- a/spark-version/2.0/pom.xml
+++ b/spark-version/2.0/pom.xml
@@ -16,13 +16,13 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.10</artifactId>
+            <artifactId>spark-core_${scala.major.version}</artifactId>
             <version>2.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-mllib_2.10</artifactId>
+            <artifactId>spark-mllib_${scala.major.version}</artifactId>
             <version>2.0.0</version>
             <scope>provided</scope>
         </dependency>

--- a/spark-version/pom.xml
+++ b/spark-version/pom.xml
@@ -24,7 +24,7 @@
             </modules>
         </profile>
         <profile>
-            <id>2.0</id>
+            <id>spark_2.0</id>
             <modules>
                 <module>2.0</module>
             </modules>

--- a/spark-version/pom.xml
+++ b/spark-version/pom.xml
@@ -12,10 +12,22 @@
     <artifactId>spark-version</artifactId>
     <groupId>com.intel.analytics.bigdl</groupId>
     <packaging>pom</packaging>
-    <modules>
-        <module>1.5-plus</module>
-        <module>2.0</module>
-    </modules>
 
-
+    <profiles>
+        <profile>
+            <id>1.5-plus</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>1.5-plus</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>2.0</id>
+            <modules>
+                <module>2.0</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Spark 2.0 is built on scala 2.11 by default. This PR add a profile to build bigdl on scala 2.11. Here's build commands:
1. mvn clean package -DskipTests
Build for Spark 1.5/1.6 and on scala 2.10
2. mvn clean package -DskipTests -P scala_2.11
Build for Spark 1.5/1.6 and on scala 2.11
3. mvn clean package -DskipTests -P spark_2.0
Build for Spark 2.0+ and on scala 2.11
4. mvn clean package -DskipTests -P spark_2.0 -P scala_2.10
Build for Spark 2.0+ and on scala 2.10

Fix # #341 