### PR TITLE
issue[#395]Optimizer.optimize update and return the input model

### DIFF
--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
@@ -17,6 +17,7 @@
 
 package com.intel.analytics.bigdl.nn
 
+import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.{Activity, AbstractModule}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
@@ -87,6 +88,20 @@ abstract class Container[A <: Activity : ClassTag,
       }
     })
     (weights.toArray, gradWeights.toArray)
+  }
+
+  override def copyStatus(src: Module[T]): this.type = {
+    require(canEqual(src), s"copyStatus: type mismatch, $src is different from $this")
+    val srcContainer = src.asInstanceOf[Container[A, B, T]]
+    require(srcContainer.modules.length == modules.length,
+      s"copyStatus: container's length mismatch" +
+        s"excepted ${modules.length}, but get ${srcContainer.modules.length}")
+    var i = 0
+    while (i < modules.length) {
+      modules(i).copyStatus(srcContainer.modules(i))
+      i += 1
+    }
+    this
   }
 
   override def clearState() : this.type = {

--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/Utils.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/Utils.scala
@@ -218,4 +218,21 @@ object Utils {
     getModules(model)
     namedModules
   }
+
+  /**
+   * copy src's parameters and running status to dst
+   * @param src source model
+   * @param dst destination model
+   */
+  def copyModule[T](src: Module[T], dst: Module[T]): Module[T] = {
+    // copy parameters
+    val srcParameters = src.getParameters()._1
+    val dstParameters = dst.getParameters()._1
+    require(srcParameters.size(1) == dstParameters.size(1),
+      s"$src and $dst is not the same type.")
+    dstParameters.copy(srcParameters)
+    // copy running status
+    dst.copyStatus(src)
+    dst
+  }
 }

--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -17,6 +17,7 @@
 
 package com.intel.analytics.bigdl.nn.abstractnn
 
+import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.tensor.{Tensor, TensorDataType}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils._
@@ -51,6 +52,18 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag,
    */
   var gradInput: A = Activity[A, T]()
 
+  /**
+   * Copy the useful running status from src to this.
+   *
+   * The subclass should override this method if it has some parameters besides weight and bias.
+   * Such as runningMean and runningVar of BatchNormalization.
+   *
+   * @param src source Module
+   * @return this
+   */
+  def copyStatus(src: Module[T]) : this.type = {
+    this
+  }
 
   /**
    * Clear cached activities to save storage space or network bandwidth. Note that we use

--- a/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -468,10 +468,9 @@ object DistriOptimizer {
     })
   }
 
-
-  private def getModel[T: ClassTag](models: RDD[Cache[T]],
-      parameters: AllReduceParameter[T])
-  : Module[T] = {
+  private def getModel[T: ClassTag](
+      models: RDD[Cache[T]],
+      parameters: AllReduceParameter[T]): Module[T] = {
     val partitionNum = models.partitions.length
     val trainedModel = models.map(_.localModels.head.clearState()).first()
     val weights = models.mapPartitions(iter => {
@@ -546,7 +545,10 @@ class DistriOptimizer[T: ClassTag] private[optim](
       isOverWrite
     )
 
-    DistriOptimizer.getModel(models, parameters)
+    val trainedModel = DistriOptimizer.getModel(models, parameters)
+
+    nn.Utils.copyModule(trainedModel, model)
+    model
   }
 }
 

--- a/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalOptimizer.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalOptimizer.scala
@@ -167,6 +167,9 @@ class LocalOptimizer[T: ClassTag] private[optim](
       checkpoint(wallClockTime)
     }
 
+    // copy running status from workingModels to model
+    model.copyStatus(workingModels.head)
+
     model
   }
 


### PR DESCRIPTION
#395 
Add two functions to nn.Utils, copyModule and recursiveCopyState.
Use copyModule at the end of DistriOptimizer.optimize to copy the trained Module's parameters and running state to `model`.
Use recursiveCopyState at the end of LocalOptimizer.optimize to copy the `workingModels`'s running state to the `model`, and parameters is already shared between `workingModels` and `model`.