### PR TITLE
fix next null exception for unit test

### DIFF
--- a/dl/src/test/scala/com/intel/analytics/bigdl/dataset/DataSetSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/dataset/DataSetSpec.scala
@@ -244,7 +244,9 @@ class DataSetSpec extends FlatSpec with Matchers with BeforeAndAfter {
           var cc = 0
           while (iter.hasNext) {
             val img = iter.next()
-            cc += img.label().toInt
+            if (null != img) {
+              cc += img.label().toInt
+            }
             Thread.sleep(1)
           }
           cc


### PR DESCRIPTION
when do parallel for an iterator, iterator.next() may be null, so add some judgment.