### PR TITLE
Recurrent: reshape input to boost the performance

### DIFF
--- a/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Model.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Model.scala
@@ -25,10 +25,11 @@ object SimpleRNN {
   inputSize: Int,
   hiddenSize: Int,
   outputSize: Int,
-  bpttTruncate: Int = 4)
+  bpttTruncate: Int = 4,
+  timeDim: Int = 2)
   : Module[Float] = {
     val model = Sequential[Float]()
-    model.add(Recurrent[Float](hiddenSize, bpttTruncate)
+    model.add(Recurrent[Float](hiddenSize, bpttTruncate, timeDim)
       .add(RnnCell[Float](inputSize, hiddenSize))
       .add(Tanh[Float]()))
       .add(Select(1, 1))

--- a/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Train.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Train.scala
@@ -72,7 +72,8 @@ object Train {
           inputSize = dictionaryLength,
           hiddenSize = param.hiddenSize,
           outputSize = dictionaryLength,
-          bpttTruncate = param.bptt)
+          bpttTruncate = param.bptt,
+          timeDim = 2)
         curModel.reset()
         curModel
       }

--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -46,7 +46,7 @@ class Recurrent[T : ClassTag] (
    * Otherwise, the input will remain unchanged.
    */
 
-  require(timeDim == 1 | timeDim == 2,
+  require(timeDim == 1 || timeDim == 2,
     "In Recurrent: the timeDim should be 1 or 2," +
       s"Current timeDim = ${timeDim}")
 

--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -102,7 +102,11 @@ class Recurrent[T : ClassTag] (
     hidden.resize(Array(times + 1, batchSize, hiddenSize))
 
     if (dataSelect != timeDim && !legacyMode) {
-      fInput = input.transpose(batchDim, timeDim).contiguous
+      if (train) {
+        fInput = input.transpose(batchDim, timeDim).contiguous
+      } else {
+        fInput = input.transpose(batchDim, timeDim)
+      }
     } else {
       fInput = input
     }
@@ -147,7 +151,12 @@ class Recurrent[T : ClassTag] (
     gradInput.resizeAs(input)
 
     if (dataSelect != timeDim && !legacyMode) {
-      fGradOutput = gradOutput.transpose(batchDim, timeDim).contiguous()
+      fGradOutput = gradOutput.transpose(batchDim, timeDim)
+      if (train) {
+        fGradOutput = gradOutput.transpose(batchDim, timeDim).contiguous()
+      } else {
+        fGradOutput = gradOutput.transpose(batchDim, timeDim)
+      }
     } else {
       fGradOutput = gradOutput
     }

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
@@ -268,7 +268,7 @@ class RecurrentSpec extends FlatSpec with Matchers {
     println(s"Average total time is ${totalClockTime / (nEpoch * 1e9)} seconds")
   }
 
-  "A Recurrent Module " should "output elapse time in contiguous tensor for RnnCell" in {
+  "A Recurrent Module " should "output elapse time in outside transpose tensor for RnnCell" in {
 
     val batchSize = 50
     val nWords = 20

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
@@ -21,7 +21,7 @@ import com.intel.analytics.bigdl.optim.SGD
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator.RNG
 import com.intel.analytics.bigdl.utils.T
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{FlatSpec, Matchers, PrivateMethodTester}
 
 @com.intel.analytics.bigdl.tags.Parallel
 class RecurrentSpec extends FlatSpec with Matchers {
@@ -162,7 +162,8 @@ class RecurrentSpec extends FlatSpec with Matchers {
       .add(Select(2, nWords))
       .add(Linear[Double](hiddenSize, outputSize))
 
-    recurrent.setLegacyMode()
+    val setLegacyMode = PrivateMethodTester.PrivateMethod[Recurrent[Double]]('setLegacyMode)
+    setLegacyMode(recurrent)
 
     val criterion = CrossEntropyCriterion[Double]()
     val logSoftMax = LogSoftMax[Double]()
@@ -293,7 +294,8 @@ class RecurrentSpec extends FlatSpec with Matchers {
       .add(Select(2, nWords))
       .add(Linear[Double](hiddenSize, outputSize))
 
-    recurrent.setLegacyMode()
+    val setLegacyMode = PrivateMethodTester.PrivateMethod[Recurrent[Double]]('setLegacyMode)
+    setLegacyMode(recurrent)
     model.evaluate()
 
     val criterion = CrossEntropyCriterion[Double]()
@@ -354,7 +356,7 @@ class RecurrentSpec extends FlatSpec with Matchers {
       .add(Tanh()))
       .add(Select(2, nWords))
       .add(Linear[Double](hiddenSize, outputSize))
-    model.evaluate()
+    model.training()
 
     val criterion = CrossEntropyCriterion[Double]()
     val logSoftMax = LogSoftMax[Double]()

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
@@ -294,6 +294,7 @@ class RecurrentSpec extends FlatSpec with Matchers {
       .add(Linear[Double](hiddenSize, outputSize))
 
     recurrent.setLegacyMode()
+    model.evaluate()
 
     val criterion = CrossEntropyCriterion[Double]()
     val logSoftMax = LogSoftMax[Double]()
@@ -348,11 +349,12 @@ class RecurrentSpec extends FlatSpec with Matchers {
     RNG.setSeed(seed)
 
     val model = Sequential[Double]()
-    model.add(Recurrent[Double](hiddenSize, bpttTruncate, timeDim = 1)
+    model.add(Recurrent[Double](hiddenSize, bpttTruncate, timeDim = 2)
       .add(RnnCell[Double](inputSize, hiddenSize))
       .add(Tanh()))
       .add(Select(2, nWords))
       .add(Linear[Double](hiddenSize, outputSize))
+    model.evaluate()
 
     val criterion = CrossEntropyCriterion[Double]()
     val logSoftMax = LogSoftMax[Double]()

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
@@ -21,7 +21,7 @@ import com.intel.analytics.bigdl.optim.SGD
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator.RNG
 import com.intel.analytics.bigdl.utils.T
-import org.scalatest.{FlatSpec, Matchers, PrivateMethodTester}
+import org.scalatest.{FlatSpec, Matchers}
 
 @com.intel.analytics.bigdl.tags.Parallel
 class RecurrentSpec extends FlatSpec with Matchers {


### PR DESCRIPTION
fastmode test

## What changes were proposed in this pull request?
In Recurrent layer, previously use Tensor.select(2, i) to form a 2D matrix, resulting in a discontiguous storage. Add a transpose layer ahead and after the model to boost the performance.

## How was this patch tested?

test comparison between the original recurrent layer and boosted layer. 
They should yield the same outputs.
```
    val batchSize = 10
    val nWords = 5
    val hiddenSize = 4
    val inputSize = 5
    val outputSize = 5
    val bpttTruncate = 3
```
The boosted recurrent layer output:
```
1-th loss = 1.7208151374781946
2-th loss = 1.6437483026807242
3-th loss = 1.588589862337444
4-th loss = 1.546502647475069
5-th loss = 1.5122343688179611
6-th loss = 1.4820277319857593
7-th loss = 1.4532184745823775
8-th loss = 1.423996271305294
9-th loss = 1.393202500769242
10-th loss = 1.3601207835231857
11-th loss = 1.3243031658388933
12-th loss = 1.2854901773062697
13-th loss = 1.2436207891776232
14-th loss = 1.1988841429635386
15-th loss = 1.1517747080464198
16-th loss = 1.1031160939960707
17-th loss = 1.0539955861618664
18-th loss = 1.0055591811744848
19-th loss = 0.9587237255737998
20-th loss = 0.9139874263089901
21-th loss = 0.8714513132386527
22-th loss = 0.8309683094621219
23-th loss = 0.7922852310298951
24-th loss = 0.7551259365838042
25-th loss = 0.71922366386225
26-th loss = 0.6843226960866249
27-th loss = 0.6501750701749818
28-th loss = 0.6165679246376932
29-th loss = 0.5834084797893359
30-th loss = 0.5508311175279348
31-th loss = 0.5191993675987441
32-th loss = 0.4889363857214196
33-th loss = 0.46034216895242297
34-th loss = 0.4335482614955519
35-th loss = 0.40856704821033113
36-th loss = 0.38535108296623966
37-th loss = 0.3638288337901121
38-th loss = 0.34391885414011847
39-th loss = 0.32553310008330955
40-th loss = 0.3085772198541273
41-th loss = 0.29295144097855785
42-th loss = 0.27855289090984864
43-th loss = 0.2652787376831657
44-th loss = 0.2530292753685399
45-th loss = 0.2417103143777617
46-th loss = 0.23123467134057182
47-th loss = 0.22152282538857349
48-th loss = 0.21250296062898827
49-th loss = 0.20411061436291272
50-th loss = 0.19628811821965705
```

The original recurrent layer output:
```
1-th loss = 1.7208151374781946
2-th loss = 1.6437483026807242
3-th loss = 1.588589862337444
4-th loss = 1.546502647475069
5-th loss = 1.5122343688179611
6-th loss = 1.4820277319857593
7-th loss = 1.4532184745823775
8-th loss = 1.423996271305294
9-th loss = 1.393202500769242
10-th loss = 1.3601207835231857
11-th loss = 1.3243031658388933
12-th loss = 1.2854901773062697
13-th loss = 1.2436207891776232
14-th loss = 1.1988841429635386
15-th loss = 1.1517747080464198
16-th loss = 1.1031160939960707
17-th loss = 1.0539955861618664
18-th loss = 1.0055591811744848
19-th loss = 0.9587237255737998
20-th loss = 0.9139874263089901
21-th loss = 0.8714513132386527
22-th loss = 0.8309683094621219
23-th loss = 0.7922852310298951
24-th loss = 0.7551259365838042
25-th loss = 0.71922366386225
26-th loss = 0.6843226960866249
27-th loss = 0.6501750701749818
28-th loss = 0.6165679246376932
29-th loss = 0.5834084797893359
30-th loss = 0.5508311175279348
31-th loss = 0.5191993675987441
32-th loss = 0.4889363857214196
33-th loss = 0.46034216895242297
34-th loss = 0.4335482614955519
35-th loss = 0.40856704821033113
36-th loss = 0.38535108296623966
37-th loss = 0.3638288337901121
38-th loss = 0.34391885414011847
39-th loss = 0.32553310008330955
40-th loss = 0.3085772198541273
41-th loss = 0.29295144097855785
42-th loss = 0.27855289090984864
43-th loss = 0.2652787376831657
44-th loss = 0.2530292753685399
45-th loss = 0.2417103143777617
46-th loss = 0.23123467134057182
47-th loss = 0.22152282538857349
48-th loss = 0.21250296062898827
49-th loss = 0.20411061436291272
50-th loss = 0.19628811821965705
```
The speed for boosted recurrent should be faster than the lecayMode:
```
    val batchSize = 50
    val nWords = 20
    val hiddenSize = 40
    val inputSize = 1000
    val outputSize = 1000
    val bpttTruncate = 5
    val nEpoch = 50
```
Note that the testing data might variate given the data randomness.

|  (second)        | forward           | backward  |
| ---------------- |:-------------:| -----:|
| Boosted        | 0.01561445816 | 0.06007293678  |
| Original | 0.01116085474 |  0.1658622401  |

The boosting mode might not outperform original model for the forward because the time for Tensor.resize.copy operations compensate the boosting time for Tensor.select. However, it diminishes the backward time noticeably.