### PR TITLE
split unit tests to parallel and serial parts to reduce almost a half of the running time

### DIFF
--- a/dl/pom.xml
+++ b/dl/pom.xml
@@ -128,6 +128,7 @@
                     <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                     <junitxml>.</junitxml>
                     <filereports>bigdl-test-report.txt</filereports>
+                    <parallel>${runSpecsInParallel}</parallel>
                 </configuration>
                 <executions>
                     <execution>
@@ -239,4 +240,27 @@
             </plugin>
         </plugins>
     </reporting>
+    
+    <profiles>
+    	<profile>
+    		<id>parallel-tests</id>
+   			<properties>
+      			<runSpecsInParallel>true</runSpecsInParallel>
+      			<tagsToInclude>com.intel.analytics.bigdl.tags.Parallel</tagsToInclude>
+   			</properties>
+		</profile>
+		<profile>
+    		<id>serial-tests</id>
+   			<properties>
+      			<runSpecsInParallel>false</runSpecsInParallel>
+      			<tagsToExclude>com.intel.analytics.bigdl.tags.Parallel</tagsToExclude>
+   			</properties>
+		</profile>
+		<profile>
+    		<id>serial-all</id>
+   			<properties>
+      			<runSpecsInParallel>false</runSpecsInParallel>
+   			</properties>
+		</profile>
+    </profiles>
 </project>

--- a/dl/src/test/java/com/intel/analytics/bigdl/tags/Parallel.java
+++ b/dl/src/test/java/com/intel/analytics/bigdl/tags/Parallel.java
@@ -1,0 +1,14 @@
+package com.intel.analytics.bigdl.tags;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@org.scalatest.TagAnnotation
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
+public @interface Parallel {
+}

--- a/dl/src/test/java/com/intel/analytics/bigdl/tags/Serial.java
+++ b/dl/src/test/java/com/intel/analytics/bigdl/tags/Serial.java
@@ -1,0 +1,14 @@
+package com.intel.analytics.bigdl.tags;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@org.scalatest.TagAnnotation
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
+public @interface Serial {
+}

--- a/dl/src/test/scala/com/intel/analytics/bigdl/dataset/DataSetSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/dataset/DataSetSpec.scala
@@ -27,6 +27,7 @@ import com.intel.analytics.bigdl.utils.{Engine, RandomGenerator}
 import org.apache.spark.SparkContext
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class DataSetSpec extends FlatSpec with Matchers with BeforeAndAfter {
   var sc: SparkContext = null
 

--- a/dl/src/test/scala/com/intel/analytics/bigdl/dataset/ImageSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/dataset/ImageSpec.scala
@@ -20,6 +20,7 @@ package com.intel.analytics.bigdl.dataset
 import com.intel.analytics.bigdl.dataset.image.LabeledBGRImage
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class ImageSpec extends FlatSpec with Matchers {
   "image with odd width" should "flip good" in {
     val image = new LabeledBGRImage(

--- a/dl/src/test/scala/com/intel/analytics/bigdl/dataset/LabeledSentenceSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/dataset/LabeledSentenceSpec.scala
@@ -20,6 +20,7 @@ package com.intel.analytics.bigdl.dataset
 import com.intel.analytics.bigdl.dataset.text.LabeledSentence
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class LabeledSentenceSpec extends FlatSpec with Matchers {
   "LabeledSentence with Float Array input and Array label" should "initialize well" in {
     val input = Array(0.0f, 1.0f, 2.0f, 3.0f)

--- a/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SampleSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SampleSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.dataset.image.LabeledBGRImage
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class SampleSpec extends FlatSpec with Matchers {
   "SampleSpec with Float Tensor input and Tensor label" should "initialize well" in {
     val input1 = new LabeledBGRImage(32, 32)

--- a/dl/src/test/scala/com/intel/analytics/bigdl/dataset/TransformersSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/dataset/TransformersSpec.scala
@@ -31,6 +31,7 @@ import org.apache.hadoop.io.{SequenceFile, Text}
 import org.apache.hadoop.io.SequenceFile.Reader
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class TransformersSpec extends FlatSpec with Matchers {
   import TestUtils._
 

--- a/dl/src/test/scala/com/intel/analytics/bigdl/dataset/Utils.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/dataset/Utils.scala
@@ -17,6 +17,7 @@
 
 package com.intel.analytics.bigdl.dataset
 
+@com.intel.analytics.bigdl.tags.Parallel
 object TestUtils {
   def processPath(path: String): String = {
     if (path.contains(":")) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/models/AlexNetSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/models/AlexNetSpec.scala
@@ -31,6 +31,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.math._
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class AlexNetSpec extends FlatSpec with BeforeAndAfter with Matchers {
   "AlexNet float" should "generate correct output" in {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/models/Inception.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/models/Inception.scala
@@ -29,6 +29,7 @@ import com.intel.analytics.bigdl.utils.{T, Table}
 
 import scala.reflect.ClassTag
 
+@com.intel.analytics.bigdl.tags.Parallel
 object Inception {
   def getModel[D: ClassTag](classNum: Int, modelName: String = "")(
     implicit ev: TensorNumeric[D]): Module[D] = {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/models/InceptionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/models/InceptionSpec.scala
@@ -30,6 +30,7 @@ import scala.collection.mutable.HashMap
 import scala.math._
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Parallel
 class InceptionSpec extends FlatSpec with BeforeAndAfter with Matchers {
   "Inception+bn" should "generate correct output" in {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/models/ModelGraientCheckSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/models/ModelGraientCheckSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Parallel
 class ModelGraientCheckSpec extends FlatSpec with BeforeAndAfter with Matchers {
 
   private val checkModel = true

--- a/dl/src/test/scala/com/intel/analytics/bigdl/models/ModelforCheck.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/models/ModelforCheck.scala
@@ -25,6 +25,7 @@ import com.intel.analytics.bigdl.utils.{T, Table}
 /**
  * models in this file is only for gradient check
  */
+@com.intel.analytics.bigdl.tags.Serial
 object GoogleNet_v1_test {
   def apply(classNum: Int): Module[Double] = {
     val feature1 = Sequential()

--- a/dl/src/test/scala/com/intel/analytics/bigdl/models/ResNetSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/models/ResNetSpec.scala
@@ -32,6 +32,7 @@ import scala.collection.immutable
 import scala.math._
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class ResNetSpec extends FlatSpec with BeforeAndAfter with Matchers {
 
   "ResNet Float" should "generate correct output" in {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/BCECriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/BCECriterionSpec.scala
@@ -23,6 +23,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.T
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class BCECriterionSpec extends FlatSpec with Matchers {
 
   "BCECriterion " should "return return right output and gradInput" in {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/BatchNormalizationSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/BatchNormalizationSpec.scala
@@ -20,6 +20,7 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.tensor.Tensor
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class BatchNormalizationSpec extends FlatSpec with Matchers {
   "A BatchNormalization" should "generate correct output" in {
     val bn = new BatchNormalization[Double](3)

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/CAddSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/CAddSpec.scala
@@ -22,6 +22,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import org.scalatest.{FlatSpec, Matchers}
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 
+@com.intel.analytics.bigdl.tags.Parallel
 class CAddSpec extends FlatSpec with Matchers {
 
   "A CAdd(5, 1)" should "should converge" in {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterionSpec.scala
@@ -22,6 +22,7 @@ import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 
 import scala.math._
 
+@com.intel.analytics.bigdl.tags.Parallel
 class ClassNLLCriterionSpec extends FlatSpec with Matchers {
   "A ClassNLL Criterion " should "generate correct output and grad" in {
     val criterion = new ClassNLLCriterion[Double]()

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/ConcatSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/ConcatSpec.scala
@@ -20,6 +20,7 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.tensor.Tensor
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class ConcatSpec extends FlatSpec with Matchers {
 
   "toString" should "return good value" in {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/ConcatTableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/ConcatTableSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import com.intel.analytics.bigdl.utils.{T, Table}
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class ConcatTableSpec extends FlatSpec with Matchers {
 
   "A ConcateTable" should "return right output and grad" in {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/CopySpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/CopySpec.scala
@@ -20,6 +20,7 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class CopySpec extends FlatSpec with Matchers {
   "A Copy" should "generate correct output" in {
     val output = Tensor[Double](Storage[Double](Array(

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/CrossEntropyCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/CrossEntropyCriterionSpec.scala
@@ -31,6 +31,7 @@ import scala.math._
   * Created by ywan on 16-9-21.
   */
 
+@com.intel.analytics.bigdl.tags.Parallel
 class CrossEntropyCriterionSpec extends FlatSpec with Matchers {
 
   "CrossEntropyCriterion " should "return return right output and gradInput" in {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/DotProductSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/DotProductSpec.scala
@@ -20,6 +20,7 @@ import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import com.intel.analytics.bigdl.utils.T
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class DotProductSpec extends FlatSpec with Matchers {
   "A DotProductSpec" should "generate correct output" in {
     val input = T(

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/EngineTypeSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/EngineTypeSpec.scala
@@ -20,6 +20,7 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.models.inception.Inception_v2
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class EngineTypeSpec extends FlatSpec with Matchers {
   "checkEngineType" should "return right result" in {
     val model = Inception_v2(1000)

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/ExpSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/ExpSpec.scala
@@ -20,6 +20,7 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class ExpSpec extends FlatSpec with Matchers {
   "A Exp" should "generate correct output" in {
     val input = Tensor(Storage[Double](Array(1.0, 2, 3, 4, 5, 6)), 1, Array(2, 3))

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/FlattenTableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/FlattenTableSpec.scala
@@ -20,6 +20,7 @@ import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import com.intel.analytics.bigdl.utils.T
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class FlattenTableSpec extends FlatSpec with BeforeAndAfter with Matchers {
   "An FlattenTable" should "generate correct output and grad" in {
     val layer = new FlattenTable[Double]()

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/GradientChecker.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/GradientChecker.scala
@@ -29,6 +29,7 @@ sealed trait modelCheck
 case class PartCheck(data : Int) extends modelCheck
 case class FullCheck() extends modelCheck
 
+@com.intel.analytics.bigdl.tags.Parallel
 class GradientChecker(stepSize: Double, threshold: Double = 1e-2) {
 
   private val defaultNum = 50

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/GradientCheckerRNN.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/GradientCheckerRNN.scala
@@ -25,6 +25,7 @@ import com.intel.analytics.bigdl.utils.T
 
 import scala.reflect.ClassTag
 
+@com.intel.analytics.bigdl.tags.Parallel
 class GradientCheckerRNN(stepSize: Double = 0.01, threshold: Double = 0.01) {
 
   def checkLayer[T: ClassTag](

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/IdentitySpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/IdentitySpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{FlatSpec, Matchers}
   /**
   * Created by yao on 9/20/16.
   */
+@com.intel.analytics.bigdl.tags.Parallel
 class IdentitySpec extends FlatSpec with Matchers {
   "Identity" should "generate correct output and grad" in {
     val batchN = 3

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
@@ -23,6 +23,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import scala.math._
 import com.intel.analytics.bigdl._
 
+@com.intel.analytics.bigdl.tags.Parallel
 class LinearSpec extends FlatSpec with Matchers {
   "Linear module" should "converate to correct weight and bias" in {
     val inputN = 5

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/LogSigmoidSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/LogSigmoidSpec.scala
@@ -19,6 +19,7 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.tensor.Tensor
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class LogSigmoidSpec extends FlatSpec with Matchers {
   "A LogSigmoid Module " should "generate correct output" in {
     val module = new LogSigmoid[Double]()

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/LogSoftMaxSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/LogSoftMaxSpec.scala
@@ -20,6 +20,7 @@ package com.intel.analytics.bigdl.nn
 import org.scalatest.{FlatSpec, Matchers}
 import com.intel.analytics.bigdl.tensor.Tensor
 
+@com.intel.analytics.bigdl.tags.Parallel
 class LogSoftMaxSpec extends FlatSpec with Matchers {
   "A LogSoftMax Module " should "generate correct output" in {
     val module = new LogSoftMax[Double]()

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/LogSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/LogSpec.scala
@@ -19,6 +19,7 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class LogSpec extends FlatSpec with Matchers {
   "A Log" should "generate correct output" in {
     val input = Tensor(Storage[Double](Array(1.0, 2, 3, 4, 5, 6)), 1, Array(2, 3))

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/MMSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/MMSpec.scala
@@ -20,6 +20,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.T
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class MMSpec extends FlatSpec with Matchers {
   "hashcode()" should "behave correctly" in {
     val m1 = new MM[Double]()

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/MSECriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/MSECriterionSpec.scala
@@ -22,6 +22,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 
 import scala.math._
 
+@com.intel.analytics.bigdl.tags.Parallel
 class MSECriterionSpec extends FlatSpec {
   "A MSE Criterion " should "generate correct output and grad" in {
     val mse = new MSECriterion[Double]

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/MVSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/MVSpec.scala
@@ -20,6 +20,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.T
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class MVSpec extends FlatSpec with Matchers {
   "hashcode()" should "behave correctly" in {
     val m1 = new MV[Double]()

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/MapTableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/MapTableSpec.scala
@@ -20,6 +20,7 @@ import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import com.intel.analytics.bigdl.utils.T
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class MapTableSpec  extends FlatSpec with Matchers {
   "A MapTable" should "generate correct output" in {
     val input = T(

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/ModuleSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/ModuleSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Parallel
 class ModuleSpec extends FlatSpec with Matchers {
   "hashcode()" should "behave correctly" in {
     val r1 = new ReLU[Double]()

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/MulConstantSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/MulConstantSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.FlatSpec
   /**
   * Created by yao on 9/21/16.
   */
+@com.intel.analytics.bigdl.tags.Parallel
 class MulConstantSpec extends FlatSpec {
   "MulConstant" should "generate correct output and grad" in {
     val input = Tensor[Double](2, 2, 2).randn()

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/MultiLabelSoftMarginCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/MultiLabelSoftMarginCriterionSpec.scala
@@ -19,6 +19,7 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.tensor.Tensor
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class MultiLabelSoftMarginCriterionSpec  extends FlatSpec with Matchers {
   "hashcode()" should "behave correctly" in {
     val m1 = new MultiLabelSoftMarginCriterion[Double]()

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/PairwiseDistanceSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/PairwiseDistanceSpec.scala
@@ -20,6 +20,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.T
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class PairwiseDistanceSpec extends FlatSpec with Matchers {
 
   "hashcode()" should "behave correctly" in {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/ParallelCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/ParallelCriterionSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import com.intel.analytics.bigdl.utils.{T, Table}
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class ParallelCriterionSpec extends FlatSpec with Matchers {
   "A ParallelCriterion" should "generate correct output with type Double" in {
     val pc = new ParallelCriterion[Double]()

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/ParallelTableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/ParallelTableSpec.scala
@@ -20,6 +20,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.T
 
+@com.intel.analytics.bigdl.tags.Parallel
 class ParallelTableSpec extends FlatSpec with Matchers {
   "hashcode()" should "behave correctly" in {
     val log = new Log[Double]()

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/PowerSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/PowerSpec.scala
@@ -20,6 +20,7 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class PowerSpec extends FlatSpec with Matchers {
   "A Power" should "generate correct output" in {
     val input = Tensor(Storage[Double](Array(1.0, 2, 3, 4, 5, 6)), 1, Array(2, 3))

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/ReLUSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/ReLUSpec.scala
@@ -22,6 +22,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 
 import scala.math.abs
 
+@com.intel.analytics.bigdl.tags.Parallel
 class ReLUSpec extends FlatSpec {
   "A ReLU Module " should "generate correct output and grad" in {
     val module = new ReLU[Double]()

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
@@ -23,6 +23,7 @@ import com.intel.analytics.bigdl.utils.RandomGenerator.RNG
 import com.intel.analytics.bigdl.utils.T
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class RecurrentSpec extends FlatSpec with Matchers {
 
   "A Recurrent Language Model Module " should "converge" in {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/ReshapeSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/ReshapeSpec.scala
@@ -20,6 +20,7 @@ package com.intel.analytics.bigdl.nn
 import org.scalatest.FlatSpec
 import com.intel.analytics.bigdl.tensor.Tensor
 
+@com.intel.analytics.bigdl.tags.Parallel
 class ReshapeSpec extends FlatSpec {
   "A Reshape Module " should "generate correct output and grad" in {
     val module = new Reshape[Double](Array(3, 2))

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/SigmoidSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/SigmoidSpec.scala
@@ -22,6 +22,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 
 import scala.math.abs
 
+@com.intel.analytics.bigdl.tags.Parallel
 class SigmoidSpec extends FlatSpec {
   "A Sigmoid Module " should "generate correct output and grad" in {
     val module = new Sigmoid[Double]

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialAveragePoolingSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialAveragePoolingSpec.scala
@@ -23,6 +23,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import scala.math.abs
 import com.intel.analytics.bigdl._
 
+@com.intel.analytics.bigdl.tags.Parallel
 class SpatialAveragePoolingSpec extends FlatSpec with Matchers {
   "A SpatialAveragePooling" should "generate correct output and gradInput" in {
     val module = new SpatialAveragePooling[Double](3, 2, 2, 1)

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialConvolutionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialConvolutionSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import scala.math._
 import com.intel.analytics.bigdl._
 
+@com.intel.analytics.bigdl.tags.Parallel
 class SpatialConvolutionSpec extends FlatSpec with Matchers {
   "A SpatialConvolution layer" should "generate correct output" in {
     val nInputPlane = 1

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialCrossMapLRNSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialCrossMapLRNSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl._
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class SpatialCrossMapLRNSpec extends FlatSpec with Matchers {
   private def referenceLRNForwardAcrossChannels
   (input: Tensor[Double], alpha: Double, beta: Double, size: Int): Tensor[Double] = {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolutionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolutionSpec.scala
@@ -20,6 +20,7 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class SpatialFullConvolutionSpec extends FlatSpec with Matchers {
 
   "A SpatialFullConvolution BilinearFiller" should "generate correct parameter" in {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialMaxPoolingSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialMaxPoolingSpec.scala
@@ -24,6 +24,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 
 import scala.math.abs
 
+@com.intel.analytics.bigdl.tags.Parallel
 class SpatialMaxPoolingSpec extends FlatSpec with Matchers {
 
   "A SpatialMaxPooling" should "generate correct output and gradInput" in {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/TanhSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/TanhSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 import scala.math.abs
 
+@com.intel.analytics.bigdl.tags.Parallel
 class TanhSpec extends FlatSpec with Matchers {
   "A Tanh Module " should "generate correct output and grad" in {
     val module = new Tanh[Double]()

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/ThresholdSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/ThresholdSpec.scala
@@ -22,6 +22,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 
 import scala.math.abs
 
+@com.intel.analytics.bigdl.tags.Parallel
 class ThresholdSpec extends FlatSpec {
   "A Threshold Module " should "generate correct output and grad" in {
     val module = new Threshold[Double](1, 0.8)

--- a/dl/src/test/scala/com/intel/analytics/bigdl/optim/AdagradSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/optim/AdagradSpec.scala
@@ -23,6 +23,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 
 import scala.collection.mutable.ArrayBuffer
 
+@com.intel.analytics.bigdl.tags.Parallel
 class AdagradSpec extends FlatSpec with Matchers {
   "adagrad" should "perform well on rosenbrock function" in {
     val x = Tensor[Double](2).fill(0)

--- a/dl/src/test/scala/com/intel/analytics/bigdl/optim/DistriOptimizerSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/optim/DistriOptimizerSpec.scala
@@ -75,6 +75,7 @@ object DistriOptimizerSpecModel {
   }
 }
 
+@com.intel.analytics.bigdl.tags.Serial
 class DistriOptimizerSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
   import DistriOptimizerSpec._

--- a/dl/src/test/scala/com/intel/analytics/bigdl/optim/LBFGSSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/optim/LBFGSSpec.scala
@@ -23,6 +23,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 
 import scala.collection.mutable.ArrayBuffer
 
+@com.intel.analytics.bigdl.tags.Parallel
 class LBFGSSpec extends FlatSpec with Matchers {
   "torchLBFGS in regular batch test" should "perform well on rosenbrock function" in {
     val x = Tensor[Double](2).fill(0)

--- a/dl/src/test/scala/com/intel/analytics/bigdl/optim/LocalOptimizerSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/optim/LocalOptimizerSpec.scala
@@ -112,6 +112,7 @@ object LocalOptimizerSpecModel {
   }
 }
 
+@com.intel.analytics.bigdl.tags.Parallel
 class LocalOptimizerSpec extends FlatSpec with Matchers {
   import LocalOptimizerSpecModel._
   import DummyDataSet._

--- a/dl/src/test/scala/com/intel/analytics/bigdl/optim/MetricsSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/optim/MetricsSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 
+@com.intel.analytics.bigdl.tags.Serial
 class MetricsSpec extends FlatSpec with Matchers with BeforeAndAfter {
   var sc: SparkContext = null
 

--- a/dl/src/test/scala/com/intel/analytics/bigdl/optim/OptimizerSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/optim/OptimizerSpec.scala
@@ -27,6 +27,7 @@ import com.intel.analytics.bigdl.utils.{File, T, Table}
 import org.apache.spark.rdd.RDD
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class OptimizerSpec extends FlatSpec with Matchers {
   val model = new Sequential[Float]()
 

--- a/dl/src/test/scala/com/intel/analytics/bigdl/optim/RefDistriOptimizer.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/optim/RefDistriOptimizer.scala
@@ -31,6 +31,7 @@ import scala.reflect.ClassTag
 /**
  * The class is used as a reference optimizer in distribute optimizer unit test
  */
+@com.intel.analytics.bigdl.tags.Parallel
 class RefDistriOptimizer[T: ClassTag](
   model: Module[T],
   dataset: DataSet[MiniBatch[T]],

--- a/dl/src/test/scala/com/intel/analytics/bigdl/optim/SGDSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/optim/SGDSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 import scala.collection.mutable.ArrayBuffer
 
+@com.intel.analytics.bigdl.tags.Parallel
 class SGDSpec extends FlatSpec with Matchers {
   "A SGD optimMethod with 1 parameter" should "generate correct result" in {
     val state = T("learningRate" -> 0.1, "learningRateDecay" -> 5e-7,

--- a/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.T
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class TableSpec extends FlatSpec with Matchers {
   "hashcode()" should "behave correctly" in {
     val input1 = Tensor[Double](3, 3).randn()

--- a/dl/src/test/scala/com/intel/analytics/bigdl/optim/ValidationSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/optim/ValidationSpec.scala
@@ -20,6 +20,7 @@ package com.intel.analytics.bigdl.optim
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class ValidationSpec extends FlatSpec with Matchers {
   "top1 accuracy" should "be correct on 2d tensor" in {
     val output = Tensor(Storage(Array[Double](

--- a/dl/src/test/scala/com/intel/analytics/bigdl/parameters/FP16ParameterSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/parameters/FP16ParameterSpec.scala
@@ -22,6 +22,7 @@ import com.intel.analytics.bigdl.utils.Engine
 import org.scalatest.{FlatSpec, Matchers}
 import com.intel.analytics.bigdl.tensor.Tensor
 
+@com.intel.analytics.bigdl.tags.Parallel
 class FP16ParameterSpec extends FlatSpec with Matchers {
 
   "convert double tensor to fp16 array and back" should "be same when the number is integer" in {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/parameters/FP16SplitsParameterSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/parameters/FP16SplitsParameterSpec.scala
@@ -21,6 +21,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Engine
 
+@com.intel.analytics.bigdl.tags.Serial
 class FP16SplitsParameterSpec extends FlatSpec with Matchers {
   "convert double tensor to fp16 array and back" should "be same when the number is integer" in {
     val tensor = Tensor[Double](5)

--- a/dl/src/test/scala/com/intel/analytics/bigdl/tensor/ArrayStorageSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/tensor/ArrayStorageSpec.scala
@@ -19,6 +19,7 @@ package com.intel.analytics.bigdl.tensor
 
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class ArrayStorageSpec extends FlatSpec with Matchers {
 
   "update value" should "be test" in {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DenseTensorMathSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DenseTensorMathSpec.scala
@@ -20,6 +20,7 @@ package com.intel.analytics.bigdl.tensor
 import com.intel.analytics.bigdl.utils.T
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class DenseTensorMathSpec extends FlatSpec with Matchers {
   "a.dist(b, 1)" should "be correct" in {
     val a: Tensor[Double] = new DenseTensor(Storage(Array(1.0, 2.0, 3.0)))

--- a/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DenseTensorSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DenseTensorSpec.scala
@@ -22,6 +22,7 @@ import com.intel.analytics.bigdl.utils.T
 import org.apache.spark.mllib.linalg.{DenseMatrix, DenseVector}
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class DenseTensorSpec extends FlatSpec with Matchers {
 
   "Construct with empty parameter" should "be empty" in {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/tensor/TensorConvSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/tensor/TensorConvSpec.scala
@@ -19,6 +19,7 @@ package com.intel.analytics.bigdl.tensor
 
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class TensorConvSpec extends FlatSpec with Matchers {
   "Valid conv" should "return correct value" in {
     val t = new DenseTensor[Double](3, 4)

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/AbsCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/AbsCriterionSpec.scala
@@ -20,6 +20,7 @@ import com.intel.analytics.bigdl.nn.AbsCriterion
 import com.intel.analytics.bigdl.tensor.Tensor
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class AbsCriterionSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/AbsSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/AbsSpec.scala
@@ -20,7 +20,7 @@ import com.intel.analytics.bigdl.nn.Abs
 import com.intel.analytics.bigdl.tensor.Tensor
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
-
+@com.intel.analytics.bigdl.tags.Serial
 class AbsSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/AddConstantSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/AddConstantSpec.scala
@@ -21,7 +21,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
-
+@com.intel.analytics.bigdl.tags.Serial
 class AddConstantSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/AddSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/AddSpec.scala
@@ -21,7 +21,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
-
+@com.intel.analytics.bigdl.tags.Serial
 class AddSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/BatchNormalizationSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/BatchNormalizationSpec.scala
@@ -26,6 +26,7 @@ import com.intel.analytics.bigdl._
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class BatchNormalizationSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/BilinearSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/BilinearSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.collection.mutable.HashMap
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class BilinearSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/BottleSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/BottleSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
-
+@com.intel.analytics.bigdl.tags.Serial
 class BottleSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/CAddSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/CAddSpec.scala
@@ -22,6 +22,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 
+@com.intel.analytics.bigdl.tags.Serial
 class CAddSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/CAddTableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/CAddTableSpec.scala
@@ -26,6 +26,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class CAddTableSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/CDivTableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/CDivTableSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.collection.mutable.HashMap
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class CDivTableSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/CMaxTableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/CMaxTableSpec.scala
@@ -25,7 +25,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.collection.mutable.HashMap
 import scala.util.Random
 
-
+@com.intel.analytics.bigdl.tags.Serial
 class CMaxTableSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/CMinTableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/CMinTableSpec.scala
@@ -25,7 +25,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.collection.mutable.HashMap
 import scala.util.Random
 
-
+@com.intel.analytics.bigdl.tags.Serial
 class CMinTableSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/CMulSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/CMulSpec.scala
@@ -22,6 +22,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class CMulSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/CMulTableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/CMulTableSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.collection.mutable.HashMap
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class CMulTableSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/CSubTableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/CSubTableSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.collection.mutable.HashMap
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class CSubTableSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/ClampSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/ClampSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.math._
 
+@com.intel.analytics.bigdl.tags.Serial
 class ClampSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/ClassNLLCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/ClassNLLCriterionSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.nn.ClassNLLCriterion
 import com.intel.analytics.bigdl.tensor.Tensor
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class ClassNLLCriterionSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/ClassSimplexCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/ClassSimplexCriterionSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class ClassSimplexCriterionSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/ConcatSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/ConcatSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.math._
 
+@com.intel.analytics.bigdl.tags.Serial
 class ConcatSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/ConcatTableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/ConcatTableSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class ConcatTableSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/ContiguousSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/ContiguousSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class ContiguousSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/CopySpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/CopySpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class CopySpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/CosineDistanceSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/CosineDistanceSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.collection.mutable.HashMap
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class CosineDistanceSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/CosineEmbeddingCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/CosineEmbeddingCriterionSpec.scala
@@ -26,6 +26,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class CosineEmbeddingCriterionSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/CosineSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/CosineSpec.scala
@@ -23,7 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
-
+@com.intel.analytics.bigdl.tags.Serial
 class CosineSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/CriterionTableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/CriterionTableSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.collection.mutable.HashMap
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class CriterionTableSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/CrossEntropyCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/CrossEntropyCriterionSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class CrossEntropyCriterionSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/DenseTensorMathSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/DenseTensorMathSpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.sys.process._
 
-
+@com.intel.analytics.bigdl.tags.Serial
 class DenseTensorMathSpec extends FlatSpec with BeforeAndAfter with Matchers {
 
   before {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/DistKLDivCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/DistKLDivCriterionSpec.scala
@@ -22,6 +22,7 @@ import com.intel.analytics.bigdl.utils.RandomGenerator._
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class DistKLDivCriterionSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/DropoutSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/DropoutSpec.scala
@@ -22,6 +22,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class DropoutSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/ELUSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/ELUSpec.scala
@@ -22,6 +22,7 @@ import com.intel.analytics.bigdl.utils.RandomGenerator
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class ELUSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/EuclideanSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/EuclideanSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class EuclideanSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/ExpSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/ExpSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.nn.{Exp, Power}
 import com.intel.analytics.bigdl.tensor.Tensor
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class ExpSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/GradientReversalSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/GradientReversalSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class GradientReversalSpec  extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/HardShrinkSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/HardShrinkSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class HardShrinkSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/HardTanhSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/HardTanhSpec.scala
@@ -20,7 +20,7 @@ import com.intel.analytics.bigdl.nn.HardTanh
 import com.intel.analytics.bigdl.tensor.Tensor
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
-
+@com.intel.analytics.bigdl.tags.Serial
 class HardTanhSpec  extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/HingeEmbeddingCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/HingeEmbeddingCriterionSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class HingeEmbeddingCriterionSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/IndexSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/IndexSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.collection.mutable.HashMap
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class IndexSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/JoinTableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/JoinTableSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.collection.mutable
 
+@com.intel.analytics.bigdl.tags.Serial
 class JoinTableSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/L1CostSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/L1CostSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class L1CostSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/L1HingeEmbeddingCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/L1HingeEmbeddingCriterionSpec.scala
@@ -25,7 +25,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.collection.mutable.HashMap
 import scala.util.Random
 
-
+@com.intel.analytics.bigdl.tags.Serial
 class L1HingeEmbeddingCriterionSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/L1PenaltySpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/L1PenaltySpec.scala
@@ -22,6 +22,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class L1PenaltySpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/LeakyReLUSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/LeakyReLUSpec.scala
@@ -22,6 +22,7 @@ import com.intel.analytics.bigdl.utils.RandomGenerator
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class LeakyReLUSpec  extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/LinearSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/LinearSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.util.Random
 import com.intel.analytics.bigdl._
 
+@com.intel.analytics.bigdl.tags.Serial
 class LinearSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/LogSigmoidSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/LogSigmoidSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class LogSigmoidSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/LogSoftMaxSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/LogSoftMaxSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.util.Random
 import com.intel.analytics.bigdl._
 
+@com.intel.analytics.bigdl.tags.Serial
 class LogSoftMaxSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/LogSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/LogSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class LogSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/LookupTableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/LookupTableSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class LookupTableSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/MMSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/MMSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.collection.mutable
 
+@com.intel.analytics.bigdl.tags.Serial
 class MMSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/MSECriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/MSECriterionSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.math._
 
+@com.intel.analytics.bigdl.tags.Serial
 class MSECriterionSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/MVSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/MVSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.collection.mutable
 
+@com.intel.analytics.bigdl.tags.Serial
 class MVSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/MarginCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/MarginCriterionSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class MarginCriterionSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/MarginRankingCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/MarginRankingCriterionSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.collection.mutable.HashMap
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class MarginRankingCriterionSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/MaskedSelectSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/MaskedSelectSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.collection.mutable.HashMap
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class MaskedSelectSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/MaxSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/MaxSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class MaxSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/MeanSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/MeanSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class MeanSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/MinSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/MinSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class MinSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/MixtureTableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/MixtureTableSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.collection.mutable.HashMap
 import scala.util.Random
 
-
+@com.intel.analytics.bigdl.tags.Serial
 class MixtureTableSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/ModuleSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/ModuleSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.math._
 
+@com.intel.analytics.bigdl.tags.Serial
 class ModuleSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/MulConstantSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/MulConstantSpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
-
+@com.intel.analytics.bigdl.tags.Serial
 class MulConstantSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/MulSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/MulSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class MulSpec extends FlatSpec with BeforeAndAfter with Matchers{
 
   before {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/MultiCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/MultiCriterionSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class MultiCriterionSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/MultiLabelMarginCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/MultiLabelMarginCriterionSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class MultiLabelMarginCriterionSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/MultiLabelSoftMarginCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/MultiLabelSoftMarginCriterionSpec.scala
@@ -20,6 +20,7 @@ import com.intel.analytics.bigdl.nn.MultiLabelSoftMarginCriterion
 import com.intel.analytics.bigdl.tensor.Tensor
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class MultiLabelSoftMarginCriterionSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/MultiMarginCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/MultiMarginCriterionSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class MultiMarginCriterionSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/NarrowSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/NarrowSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class NarrowSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/NarrowTableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/NarrowTableSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.collection.mutable.HashMap
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class NarrowTableSpec extends FlatSpec with BeforeAndAfter with Matchers{
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/NormalizeSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/NormalizeSpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
-
+@com.intel.analytics.bigdl.tags.Serial
 class NormalizeSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/PReLUSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/PReLUSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.math._
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class PReLUSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/PaddingSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/PaddingSpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
-
+@com.intel.analytics.bigdl.tags.Serial
 class PaddingSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/PairwiseDistanceSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/PairwiseDistanceSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class PairwiseDistanceSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/ParallelCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/ParallelCriterionSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class ParallelCriterionSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/PowerSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/PowerSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.nn.{Power}
 import com.intel.analytics.bigdl.tensor.Tensor
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class PowerSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/RReLUSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/RReLUSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers, fixture}
 
 import scala.math._
 
+@com.intel.analytics.bigdl.tags.Serial
 class RReLUSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/ReLU6Spec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/ReLU6Spec.scala
@@ -22,6 +22,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.math._
 
+@com.intel.analytics.bigdl.tags.Serial
 class ReLU6Spec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/ReLUSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/ReLUSpec.scala
@@ -26,6 +26,7 @@ import scala.math._
 import scala.util.Random
 import com.intel.analytics.bigdl._
 
+@com.intel.analytics.bigdl.tags.Serial
 class ReLUSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/ReplicateSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/ReplicateSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class ReplicateSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/ReshapeSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/ReshapeSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.math._
 
+@com.intel.analytics.bigdl.tags.Serial
 class ReshapeSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SelectSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SelectSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class SelectSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SelectTableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SelectTableSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.collection.mutable.HashMap
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class SelectTableSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SequentialSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SequentialSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.math._
 
+@com.intel.analytics.bigdl.tags.Serial
 class SequentialSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SigmoidSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SigmoidSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.math._
 
+@com.intel.analytics.bigdl.tags.Serial
 class SigmoidSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SmoothL1CriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SmoothL1CriterionSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.math._
 
+@com.intel.analytics.bigdl.tags.Serial
 class SmoothL1CriterionSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SoftMarginCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SoftMarginCriterionSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class SoftMarginCriterionSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SoftMaxSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SoftMaxSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class SoftMaxSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SoftMinSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SoftMinSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class SoftMinSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SoftPlusSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SoftPlusSpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
-
+@com.intel.analytics.bigdl.tags.Serial
 class SoftPlusSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SoftShrinkSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SoftShrinkSpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
-
+@com.intel.analytics.bigdl.tags.Serial
 class SoftShrinkSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SoftSignSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SoftSignSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class SoftSignSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialAveragePoolingSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialAveragePoolingSpec.scala
@@ -26,6 +26,7 @@ import scala.math._
 import scala.util.Random
 import com.intel.analytics.bigdl._
 
+@com.intel.analytics.bigdl.tags.Serial
 class SpatialAveragePoolingSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialBatchNormalizationSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialBatchNormalizationSpec.scala
@@ -26,7 +26,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.util.Random
 import com.intel.analytics.bigdl._
 
-
+@com.intel.analytics.bigdl.tags.Serial
 class SpatialBatchNormalizationSpec extends FlatSpec with Matchers with BeforeAndAfter {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialContrastiveNormalizationSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialContrastiveNormalizationSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class SpatialContrastiveNormalizationSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialConvolutionMapSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialConvolutionMapSpec.scala
@@ -24,6 +24,7 @@ import com.intel.analytics.bigdl.utils.RandomGenerator._
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class SpatialConvolutionMapSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialConvolutionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialConvolutionSpec.scala
@@ -26,6 +26,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class SpatialConvolutionSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialCrossMapLRNSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialCrossMapLRNSpec.scala
@@ -25,6 +25,7 @@ import com.intel.analytics.bigdl._
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class SpatialCrossMapLRNSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialDilatedConvolutionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialDilatedConvolutionSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class SpatialDilatedConvolutionSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialDivisiveNormalizationSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialDivisiveNormalizationSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class SpatialDivisiveNormalizationSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialFullConvolutionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialFullConvolutionSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class SpatialFullConvolutionSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialMaxPoolingSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialMaxPoolingSpec.scala
@@ -26,6 +26,7 @@ import scala.math._
 import scala.util.Random
 import com.intel.analytics.bigdl._
 
+@com.intel.analytics.bigdl.tags.Serial
 class SpatialMaxPoolingSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialSubtractiveNormalizationSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialSubtractiveNormalizationSpec.scala
@@ -24,6 +24,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class SpatialSubtractiveNormalizationSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SqrtSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SqrtSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class SqrtSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SquareSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SquareSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class SquareSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SqueezeSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SqueezeSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class SqueezeSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/SumSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/SumSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class SumSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/TanhShrinkSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/TanhShrinkSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class TanhShrinkSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/TanhSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/TanhSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.math._
 
+@com.intel.analytics.bigdl.tags.Serial
 class TanhSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/TensorSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/TensorSpec.scala
@@ -19,7 +19,7 @@ package com.intel.analytics.bigdl.torch
 import com.intel.analytics.bigdl.tensor.Tensor
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
-
+@com.intel.analytics.bigdl.tags.Serial
 class TensorSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/ThresholdSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/ThresholdSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.math._
 
+@com.intel.analytics.bigdl.tags.Serial
 class ThresholdSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/UnsqueezeSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/UnsqueezeSpec.scala
@@ -23,6 +23,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class UnsqueezeSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/ViewSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/ViewSpec.scala
@@ -26,6 +26,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import scala.math._
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Serial
 class ViewSpec extends FlatSpec with BeforeAndAfter with Matchers {
   before {
     if (!TH.hasTorch()) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/utils/DLClassifierSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/utils/DLClassifierSpec.scala
@@ -31,6 +31,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
+@com.intel.analytics.bigdl.tags.Parallel
 class DLClassifierSpec extends FlatSpec with Matchers{
 
   private def processPath(path: String): String = {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/utils/FileSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/utils/FileSpec.scala
@@ -24,6 +24,7 @@ import com.intel.analytics.bigdl.utils.TorchObject.TYPE_MODULE
 import org.scalatest.{FlatSpec, Matchers}
 
 
+@com.intel.analytics.bigdl.tags.Serial
 class FileSpec extends FlatSpec with Matchers {
 
   "read/write alexnet" should "work properly" in {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/utils/RandomGeneratorSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/utils/RandomGeneratorSpec.scala
@@ -19,7 +19,7 @@ package com.intel.analytics.bigdl.utils
 
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
-
+@com.intel.analytics.bigdl.tags.Parallel
 class RandomGeneratorSpec extends FlatSpec with BeforeAndAfter with Matchers {
   "uniform" should "return correct value" in {
     val a = new RandomGenerator(100)

--- a/dl/src/test/scala/com/intel/analytics/bigdl/utils/SaveObjSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/utils/SaveObjSpec.scala
@@ -23,6 +23,7 @@ import com.intel.analytics.bigdl.models.inception.Inception_v1
 import com.intel.analytics.bigdl.tensor.Tensor
 import org.scalatest.{FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Parallel
 class SaveObjSpec extends FlatSpec with Matchers {
   "A tensor load from saved file" should "be same with original tensor" in {
     val originTensor = Tensor[Float](3, 2, 4).rand()

--- a/dl/src/test/scala/com/intel/analytics/bigdl/utils/ZippedPartitionsWithLocalityRDDSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/utils/ZippedPartitionsWithLocalityRDDSpec.scala
@@ -21,6 +21,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.ZippedPartitionsWithLocalityRDD
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
+@com.intel.analytics.bigdl.tags.Serial
 class ZippedPartitionsWithLocalityRDDSpec extends FlatSpec with Matchers with BeforeAndAfter {
   var sc: SparkContext = null
   before {


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR is made to reduce the unit tests running time by add two tags: @com.intel.analytics.bigdl.tags.Serial and @com.intel.analytics.bigdl.tags.Parallel. 
Each unit test should tag with one of them. And with scalatest-maven-plugin's support, to add two more unite test profiles: parallel-tests profile to run the unit tests with tag Parallel in parallel, and serial-tests profile to run the ones with tag Serial in serial. Thus, let most of the unit tests in parallel to reduce the running time. 

## How was this patch tested?
run "mvn test -Pparallel-tests" to get the ut running time and result, e.g.
Run completed in 5 minutes, 49 seconds.
Total number of tests run: 387
Suites: completed 179, aborted 0
Tests: succeeded 387, failed 0, canceled 0, ignored 0, pending 0
All tests passed.

run "mvn test -Pserial-tests" to get the ut running time and result, e.g.
Run completed in 7 minutes, 39 seconds.
Total number of tests run: 289
Suites: completed 179, aborted 0
Tests: succeeded 289, failed 0, canceled 0, ignored 0, pending 0
All tests passed.

run "mvn test" to get the ut running time and result, e.g.
Run completed in 23 minutes, 29 seconds.
Total number of tests run: 676
Suites: completed 179, aborted 0
Tests: succeeded 676, failed 0, canceled 0, ignored 0, pending 0
All tests passed.

To check the result,
1. parallel-tests time + serial-tests << test time, here is 5 minutes, 49 seconds + 7 minutes, 39 seconds << 23 minutes, 29 seconds, 10 minutes is saved, almost the half.
2. Total number of tests run should the same, here is 387+289 = 676
3. All tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-analytics/bigdl/449)
<!-- Reviewable:end -->
