### PR TITLE
TimeDistributed Layer as a wrapper to accept D dimension input and hand it to layers that have the D-1 dimension input requirement

### DIFF
--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributed.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributed.scala
@@ -1,0 +1,163 @@
+/*
+ * Licensed to Intel Corporation under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * Intel Corporation licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn
+
+import com.intel.analytics.bigdl.Module
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+
+import scala.reflect.ClassTag
+
+/**
+ * This layer is intended to apply contained layer to each temporal time slice
+ * of input tensor.
+ *
+ * For instance, The TimeDistributed Layer can feed each time slice of input tensor
+ * to the Linear layer.
+ *
+ * @param ev
+ * @tparam T
+ */
+
+class TimeDistributed[T : ClassTag] ()
+(implicit ev: TensorNumeric[T]) extends Container[Tensor[T], Tensor[T], T] {
+
+  private def layer: Module[T] = modules(0)
+
+  private val fInput: Tensor[T] = Tensor[T]()
+  private val fGradOutput: Tensor[T] = Tensor[T]()
+  private var inputSize: Array[Int] = _
+  private var gradOutputSize: Array[Int] = _
+  private var outputSize: Array[Int] = _
+
+  private def combine(src: Array[Int], target: Array[Int]): Unit = {
+    require(src.length == target.length + 1,
+      "TimeDistributed: combine method requires src.length == target.length + 1" +
+        s" Current src.length = ${src.length}" +
+        s" Current target.length = ${target.length}")
+
+    target(0) = src(0) * src(1)
+    var j = 1
+    while (j < target.length) {
+      target(j) = src(j + 1)
+      j += 1
+    }
+  }
+
+  private def split(src: Array[Int], target: Array[Int], dim1: Int, dim2: Int): Unit = {
+    require(src.length == target.length - 1,
+      "TimeDistributed: split method requires src.length == target.length - 1" +
+        s" Current src.length = ${src.length}" +
+        s" Current target.length = ${target.length}")
+    require(dim1 * dim2 == src(0),
+    "TimeDistributed: split method requires dim1 * dim2 == src(0), " +
+      s"Current dim1 = ${dim1}, dim2 = ${dim2}, src(0) = ${src(0)}")
+
+    target(0) = dim1
+    target(1) = dim2
+    var j = 1
+    while (j < src.length) {
+      target(j + 1) = src(j)
+      j += 1
+    }
+  }
+
+
+  override def updateOutput(input: Tensor[T]): Tensor[T] = {
+    require(input.dim >= 3,
+      "TimeDistributed: input should be at least a 3D Tensor, e.g [batch, time, inputDim]. " +
+        s"Current input.dim = ${input.dim}")
+    require(modules.length == 1,
+      "TimeDistributed: container can only process one layer, " +
+        s"current container has ${modules.length} layers.")
+
+    if (inputSize == null) {
+      inputSize = new Array[Int](input.size.length - 1)
+    }
+    if (outputSize == null) {
+      outputSize = new Array[Int](input.size.length)
+    }
+
+    /**
+     * combine: [B, T, D] => [B * T, D]
+     * split:   [B * T, D] => [B, T, D]
+     */
+    combine(input.size, inputSize)
+    fInput.set(input).resize(inputSize)
+    val _output = layer.updateOutput(fInput).toTensor[T]
+    split(_output.size, outputSize, input.size(1), input.size(2))
+    output.set(_output).resize(outputSize)
+    output
+  }
+
+  override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
+    gradOutputSize = inputSize
+    combine(gradOutput.size, gradOutputSize)
+    fGradOutput.set(gradOutput).resize(gradOutputSize)
+    val _gradInput = layer.updateGradInput(fInput, fGradOutput).toTensor[T]
+    gradInput.set(_gradInput).resize(input.size)
+    gradInput
+  }
+
+  override def accGradParameters(input: Tensor[T], gradOutput: Tensor[T],
+                                 scale: Double = 1.0): Unit = {
+    layer.accGradParameters(fInput, fGradOutput)
+  }
+
+  override def clearState(): TimeDistributed.this.type = {
+    super.clearState()
+    fInput.set()
+    fGradOutput.set()
+    inputSize = null
+    gradOutputSize = null
+    outputSize = null
+    this
+  }
+
+  override def toString(): String = {
+    val str = "nn.TimeDistributed"
+    str
+  }
+
+  override def canEqual(other: Any): Boolean = other.isInstanceOf[TimeDistributed[T]]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: TimeDistributed[T] =>
+      super.equals(that) &&
+        (that canEqual this) &&
+        fInput == that.fInput &&
+        fGradOutput == that.fGradOutput &&
+        inputSize == that.inputSize &&
+        gradOutputSize == that.gradOutputSize &&
+        outputSize == that.outputSize
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    val state = Seq(super.hashCode(),
+      fInput, fGradOutput, inputSize, gradOutputSize, outputSize)
+    state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
+  }
+}
+
+object TimeDistributed {
+  def apply[@specialized(Float, Double) T: ClassTag]()
+  (implicit ev: TensorNumeric[T]): TimeDistributed[T] = {
+    new TimeDistributed[T]()
+  }
+}

--- a/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
@@ -1428,7 +1428,11 @@ private[tensor] class DenseTensor[@specialized(Float, Double) T: ClassTag](
   }
 
   override def reshape(sizes: Array[Int]): Tensor[T] = {
-    require(sizes.reduce(_ * _) == this.nElement())
+    require(sizes.product == this.nElement(),
+      "DenseTensor: nElement of this tensor is not equal to nElement specified by sizes," +
+        s" specified sizes = (${sizes.mkString(",")})," +
+        s" nElement specified by sizes = ${sizes.reduce(_ * _)}," +
+        s" nElement of this tensor = ${this.nElement()}")
     val result = new DenseTensor[T]()
     result.resize(sizes)
     result.copy(this)

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/TimeDistributedSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/TimeDistributedSpec.scala
@@ -1,0 +1,127 @@
+/*
+ * Licensed to Intel Corporation under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * Intel Corporation licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn
+
+import org.scalatest.FlatSpec
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.RandomGenerator._
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.math.abs
+import scala.util.Random
+
+class TimeDistributedSpec extends FlatSpec with Matchers {
+  "A TimeDistributed Module " should "generate correct output and grad for Linear in 3D input " +
+    "along first dimension" in {
+    val batchSize = 5
+    val times = 5
+    val inputDim = 3
+    val outputDim = 4
+    val timeDim = 1
+
+    val input = Tensor[Float](Array(batchSize, times, inputDim)).randn()
+    val linear1 = Linear[Float](inputDim, outputDim)
+    val linear2 = Linear[Float](inputDim, outputDim)
+    linear2.weight.map(linear1.weight, (a, b) => {b})
+    linear2.bias.map(linear1.bias, (a, b) => {b})
+    val model = Sequential[Float]()
+      .add(TimeDistributed[Float]()
+        .add(linear1))
+
+    val output = model.forward(input).toTensor[Float].clone
+    var i = 1
+    while (i <= times) {
+      val expectedOut = linear2.forward(input.select(timeDim, i))
+      output.select(timeDim, i) should be (expectedOut)
+      i += 1
+    }
+
+    val gradOutput = Tensor[Float](Array(batchSize, times, outputDim)).randn()
+    val gradInput = model.backward(input, gradOutput).toTensor[Float].clone
+    i = 1
+    while (i <= times) {
+      val expectedOut = linear2.backward(input.select(timeDim, i), gradOutput.select(timeDim, i))
+      gradInput.select(timeDim, i) should be (expectedOut)
+      i += 1
+    }
+  }
+
+  "A TimeDistributed Module " should "generate correct output and grad for Linear in 3D input " +
+    "along second dimension" in {
+    val batchSize = 5
+    val times = 3
+    val inputDim = 3
+    val outputDim = 4
+    val timeDim = 2
+
+    val input = Tensor[Float](Array(batchSize, times, inputDim)).randn()
+    val linear1 = Linear[Float](inputDim, outputDim)
+    val linear2 = Linear[Float](inputDim, outputDim)
+    linear2.weight.map(linear1.weight, (a, b) => {b})
+    linear2.bias.map(linear1.bias, (a, b) => {b})
+    val model = Sequential[Float]()
+      .add(TimeDistributed[Float]()
+        .add(linear1))
+
+    val output = model.forward(input).toTensor[Float].clone
+    var i = 1
+    while (i <= times) {
+      val expectedOut = linear2.forward(input.select(timeDim, i))
+      output.select(timeDim, i) should be (expectedOut)
+      i += 1
+    }
+
+    val gradOutput = Tensor[Float](Array(batchSize, times, outputDim)).randn()
+    val gradInput = model.backward(input, gradOutput).toTensor[Float].clone
+    i = 1
+    while (i <= times) {
+      val expectedOut = linear2.backward(input.select(timeDim, i), gradOutput.select(timeDim, i))
+      gradInput.select(timeDim, i) should be (expectedOut)
+      i += 1
+    }
+  }
+
+  "A TimeDistributed Module " should "generate correct output and grad for logSoftMax " +
+    "when time dimension is 2" in {
+    val batchSize = 5
+    val times = 2
+    val inputDim = 4
+    val outputDim = 4
+    val timeDim = 2
+
+    val input = Tensor[Float](Array(batchSize, times, inputDim)).randn()
+    val gradOutput = Tensor[Float](Array(batchSize, times, outputDim)).randn()
+    val logSoftMax1 = LogSoftMax[Float]()
+    val logSoftMax2 = LogSoftMax[Float]()
+    val model = Sequential[Float]()
+      .add(TimeDistributed[Float]()
+        .add(logSoftMax1))
+
+    val output = model.forward(input).toTensor[Float].clone
+    val gradInput = model.backward(input, gradOutput).toTensor[Float].clone
+    var i = 1
+    while (i <= times) {
+      val expectedOut = logSoftMax2.forward(input.select(timeDim, i))
+      output.select(timeDim, i) should be (expectedOut)
+      val expectedGradInput = logSoftMax2.backward(
+        input.select(timeDim, i), gradOutput.select(timeDim, i))
+      gradInput.select(timeDim, i) should be (expectedGradInput)
+      i += 1
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a new layer TimeDistributed as a container that will read input with dimension equal or greater than 3D and reshape the input by combining the first two dimensions in order to fit the input requirement of the contained module. The size of the output of the wrapper will be split back to the original dimensions, which means to retain the first and second dimension.

## How was this patch tested?
Tested this wrapper when contains Linear, LogSoftMax for the forward and backward cases over time dimension defined by user.

The output of the wrapper along specific time dimension should be equal to that of the contained layer. 

```Scala
   val input = Tensor[Float](Array(batchSize, times, inputDim)).randn()
    val linear1 = Linear[Float](inputDim, outputDim)
    val linear2 = Linear[Float](inputDim, outputDim)
    linear2.weight.map(linear1.weight, (a, b) => {b})
    linear2.bias.map(linear1.bias, (a, b) => {b})
    val model = Sequential[Float]()
      .add(TimeDistributed[Float]()
        .add(linear1))

    val output = model.forward(input).toTensor[Float].clone
    var i = 1
    while (i <= times) {
      val expectedOut = linear2.forward(input.select(timeDim, i))
      output.select(timeDim, i) should be (expectedOut)
      i += 1
    }
```
## Related links or issues (optional)
Please refer to keras document: [TimeDistributed](https://keras.io/layers/wrappers/)
