### PR TITLE
[Issue #460] Implemented `toTable` and `toTensor` as virtual functions in Tensor or Table

### DIFF
--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/Activity.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/Activity.scala
@@ -24,21 +24,9 @@ import com.intel.analytics.bigdl.utils.{T, Table}
 import scala.reflect._
 
 trait Activity {
-  def toTensor[T](implicit ev: TensorNumeric[T]): Tensor[T] = this match {
-    case tensor: Tensor[T] => tensor
-    case table: Table => throw
-      new IllegalArgumentException("Table cannot be cast to Tensor")
-    case _ => throw
-      new IllegalArgumentException("Activity only support tensor and table now")
-  }
+  def toTensor[D](implicit ev: TensorNumeric[D]): Tensor[D]
 
-  def toTable: Table = this match {
-    case table: Table => table
-    case tensor: Tensor[_] => throw
-      new IllegalArgumentException("Tensor cannot be cast to Table")
-    case _ => throw
-      new IllegalArgumentException("Activity only support tensor and table now")
-  }
+  def toTable: Table
 }
 
 object Activity {

--- a/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
@@ -1881,9 +1881,9 @@ private[tensor] class DenseTensor[@specialized(Float, Double) T: ClassTag](
     if (ev.getType() == env.getType()) {
       this.asInstanceOf[Tensor[D]]
     } else {
-      throw new IllegalArgumentException(s"The type ${env.getType()}" +
-        s" in toTensor[${env.getType()}] is not same" +
-        s"as the numeric type ${ev.getType()} of the " +
+      throw new IllegalArgumentException(s"The type ${env.getType().getClass}" +
+        s" in toTensor[${env.getType().getClass}] is not same" +
+        s"as the numeric type ${ev.getType().getClass} of the " +
         "corresponding module, please keep them same.")
     }
   }

--- a/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
@@ -1876,6 +1876,15 @@ private[tensor] class DenseTensor[@specialized(Float, Double) T: ClassTag](
     }
     this
   }
+
+  override def toTensor[D](implicit env: TensorNumeric[D]): Tensor[D] = {
+    if (ev == env) {
+      this.asInstanceOf[Tensor[D]]
+    } else {
+      throw new IllegalArgumentException("The type D in toTensor[D] is not same" +
+        "as the numeric type of the corresponding module, please keep them same.")
+    }
+  }
 }
 
 object DenseTensor {

--- a/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
@@ -1878,11 +1878,13 @@ private[tensor] class DenseTensor[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toTensor[D](implicit env: TensorNumeric[D]): Tensor[D] = {
-    if (ev == env) {
+    if (ev.getType() == env.getType()) {
       this.asInstanceOf[Tensor[D]]
     } else {
-      throw new IllegalArgumentException("The type D in toTensor[D] is not same" +
-        "as the numeric type of the corresponding module, please keep them same.")
+      throw new IllegalArgumentException(s"The type ${env.getType()}" +
+        s" in toTensor[${env.getType()}] is not same" +
+        s"as the numeric type ${ev.getType()} of the " +
+        "corresponding module, please keep them same.")
     }
   }
 }

--- a/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
@@ -597,6 +597,9 @@ trait Tensor[T] extends Serializable with TensorMath[T] with Activity {
    * @return
    */
   def save(path : String, overWrite : Boolean = false) : this.type
+
+  override def toTable: Table =
+    throw new IllegalArgumentException("Tensor cannot be cast to Table")
 }
 
 sealed trait TensorDataType

--- a/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
@@ -18,6 +18,8 @@
 package com.intel.analytics.bigdl.utils
 
 import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 
 import scala.collection.mutable
 import scala.collection.mutable.Map
@@ -270,6 +272,12 @@ class Table private[bigdl](
 
     new Table(newState)
   }
+
+  override def toTensor[D]
+  (implicit ev: TensorNumeric[D]): Tensor[D] =
+    throw new IllegalArgumentException("Table cannot be cast to Tensor")
+
+  override def toTable: Table = this
 }
 
 object T {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/models/AlexNetSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/models/AlexNetSpec.scala
@@ -260,7 +260,7 @@ gradInput = model.gradInput
 
     for (i <- 1 to 4) {
       model.zeroGradParameters()
-      val outputtest = model.forward(input).toTensor[Double]
+      val outputtest = model.forward(input).toTensor[Float]
       val loss = criterion.forward(outputtest, labels)
       val gradoutputtest = criterion.backward(outputtest, labels)
       model.backward(input, gradoutputtest)

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/ConcatTableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/ConcatTableSpec.scala
@@ -24,10 +24,10 @@ import org.scalatest.{FlatSpec, Matchers}
 @com.intel.analytics.bigdl.tags.Parallel
 class ConcatTableSpec extends FlatSpec with Matchers {
 
-  "A ConcatTable" should "return right output and grad" in {
-    val ct = new ConcatTable[Double]()
-    ct.add(new Identity[Double]())
-    ct.add(new Identity[Double]())
+  "A ConcateTable" should "return right output and grad" in {
+    val ct = new ConcatTable[Float]()
+    ct.add(new Identity[Float]())
+    ct.add(new Identity[Float]())
 
     val input = T(Tensor[Float](
       Storage(Array(1f, 2, 3))),

--- a/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
@@ -17,6 +17,7 @@
 
 package com.intel.analytics.bigdl.optim
 
+import com.intel.analytics.bigdl.nn.{ConcatTable, Linear}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.T
 import org.scalatest.{FlatSpec, Matchers}
@@ -237,15 +238,40 @@ class TableSpec extends FlatSpec with Matchers {
     val t = T(1, 2, 3, 4, 5, 6)
 
     val r = t.clear()
-    r.get() should be (None)
-    r.contains(1) should be (false)
-    r.length() should be (0)
-    t.length() should be (0)
+    r.get() should be(None)
+    r.contains(1) should be(false)
+    r.length() should be(0)
+    t.length() should be(0)
 
     t.insert(1, 1)
-    t.length() should be (1)
+    t.length() should be(1)
 
     t.insert(100)
     t[Int](2) should be(100)
+  }
+
+  "toTensor" should "work correclty" in {
+    val input = Tensor[Float](3, 4)
+    val module = ConcatTable[Tensor[Float], Float]()
+      .add(Linear(4, 5))
+      .add(Linear(4, 5))
+    val output = module.forward(input)
+
+    try {
+      output.toTensor[Float]
+      fail()
+    } catch {
+      case ex: IllegalArgumentException =>
+    }
+  }
+
+  "toTable" should "work correclty" in {
+    val input = Tensor[Float](3, 4)
+    val module = ConcatTable[Tensor[Float], Float]()
+      .add(Linear(4, 5))
+      .add(Linear(4, 5))
+    val output = module.forward(input)
+
+    output.toTable should be(output)
   }
 }

--- a/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DenseTensorSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DenseTensorSpec.scala
@@ -18,6 +18,7 @@
 package com.intel.analytics.bigdl.tensor
 
 import breeze.linalg.{DenseMatrix => BrzDenseMatrix, DenseVector => BrzDenseVector}
+import com.intel.analytics.bigdl.nn.Linear
 import com.intel.analytics.bigdl.utils.T
 import org.apache.spark.mllib.linalg.{DenseMatrix, DenseVector}
 import org.scalatest.{FlatSpec, Matchers}
@@ -698,4 +699,30 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     tensor.size(4) should be(4)
   }
 
+  "toTensor" should "work correclty" in {
+    val input = Tensor[Float](3, 4)
+    val module = Linear[Float](4, 5)
+    val output = module.forward(input)
+
+    output.toTensor[Float] should be(output)
+    try {
+      output.toTensor[Double]
+      fail()
+    } catch {
+      case ex: IllegalArgumentException =>
+    }
+  }
+
+  "toTable" should "work correclty" in {
+    val input = Tensor[Float](3, 4)
+    val module = Linear[Float](4, 5)
+    val output = module.forward(input)
+
+    try {
+      output.toTable
+      fail()
+    } catch {
+      case ex: IllegalArgumentException =>
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Instead of using pattern match based on types (in essence instanceof operator in JVM), implement them as virtual functions in Tensor or Table.

Add corresponding tests

## How was this patch tested?

`toTable` and `toTensor` are tested in `DensenTensorSpec` and `TableSpec`

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/460

