### PR TITLE
[Issue #477] Make linear support no bias for GRU and LSTM support

### DIFF
--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/Linear.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/Linear.scala
@@ -199,7 +199,7 @@ object Linear {
       inputSize: Int,
       outputSize: Int,
       initMethod: InitializationMethod = Default,
-      withBias: Boolean = false
+      withBias: Boolean = true
   )(implicit ev: TensorNumeric[T]) : Linear[T] = {
     new Linear[T](inputSize, outputSize, initMethod, withBias)
   }

--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/Linear.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/Linear.scala
@@ -44,14 +44,15 @@ import com.intel.analytics.bigdl.nn.abstractnn.TensorModule
 class Linear[T: ClassTag](
   inputSize: Int,
   outputSize: Int,
-  private var initMethod: InitializationMethod = Default
+  private var initMethod: InitializationMethod = Default,
+  withBias: Boolean = true
 )(implicit ev: TensorNumeric[T]) extends TensorModule[T] {
   val weight: Tensor[T] = Tensor[T](outputSize, inputSize)
-  val bias: Tensor[T] = Tensor[T](outputSize)
+  val bias: Tensor[T] = if (withBias) Tensor[T](outputSize) else null
   val addBuffer: Tensor[T] = Tensor[T]()
 
   val gradWeight: Tensor[T] = Tensor[T](outputSize, inputSize)
-  val gradBias: Tensor[T] = Tensor[T](outputSize)
+  val gradBias: Tensor[T] = if (withBias) Tensor[T](outputSize) else null
   reset()
 
   def setInitMethod(initMethod: InitializationMethod): this.type = {
@@ -64,13 +65,13 @@ class Linear[T: ClassTag](
       case Default =>
         val stdv = 1.0 / math.sqrt(weight.size(2))
         weight.apply1(_ => ev.fromType[Double](RNG.uniform(0, 1) * 2 * stdv - stdv))
-        bias.apply1(_ => ev.fromType[Double](RNG.uniform(0, 1) * 2 * stdv - stdv))
+        if (withBias) bias.apply1(_ => ev.fromType[Double](RNG.uniform(0, 1) * 2 * stdv - stdv))
       case Xavier =>
         val fanIn = weight.size(2)
         val fanOut = weight.size(1)
         val stdv = math.sqrt(6.0 / (fanIn + fanOut))
         weight.apply1(_ => ev.fromType[Double](RNG.uniform(-stdv, stdv)))
-        bias.fill(ev.fromType(0))
+        if (withBias) bias.fill(ev.fromType(0))
       case _ =>
         throw new IllegalArgumentException(s"Unsupported initMethod type ${initMethod}")
     }
@@ -83,13 +84,13 @@ class Linear[T: ClassTag](
 
     if (input.dim() == 1) {
       output.resize(Array(outputSize))
-      output.copy(bias)
+      if (withBias) output.copy(bias) else output.zero()
       output.addmv(ev.fromType[Int](1), weight, input)
     }
     else if (input.dim() == 2) {
       val nFrame = input.size(1)
       val nElement = output.nElement
-      val t = Array(nFrame, bias.size(1))
+      val t = Array(nFrame, weight.size(1))
       output.resize(t)
       if (output.nElement() != nElement) {
         output.zero()
@@ -100,7 +101,7 @@ class Linear[T: ClassTag](
       }
 
       output.addmm(ev.fromType[Int](0), output, ev.fromType[Int](1), input, weight.t)
-      output.addr(ev.fromType[Int](1), addBuffer, bias)
+      if (withBias) output.addr(ev.fromType[Int](1), addBuffer, bias)
     }
     output
   }
@@ -129,22 +130,22 @@ class Linear[T: ClassTag](
     val value = ev.fromType[Double](scale)
     if (input.dim() == 1) {
       gradWeight.addr(value, gradOutput, input)
-      gradBias.add(value, gradOutput)
+      if (withBias) gradBias.add(value, gradOutput)
     }
     else if (input.dim() == 2) {
       gradWeight.addmm(value, gradOutput.t, input)
-      gradBias.addmv(value, gradOutput.t, addBuffer)
+      if (withBias) gradBias.addmv(value, gradOutput.t, addBuffer)
     }
   }
 
   override def updateParameters(learningRate: T): Unit = {
     weight.add(ev.negative(learningRate), gradWeight)
-    bias.add(ev.negative(learningRate), gradBias)
+    if (withBias) bias.add(ev.negative(learningRate), gradBias)
   }
 
   override def zeroGradParameters(): Unit = {
     gradWeight.zero()
-    gradBias.zero()
+    if (withBias) gradBias.zero()
   }
 
   override def clearState() : this.type = {
@@ -197,7 +198,9 @@ object Linear {
   def apply[@specialized(Float, Double) T: ClassTag](
       inputSize: Int,
       outputSize: Int,
-      initMethod: InitializationMethod = Default)(implicit ev: TensorNumeric[T]) : Linear[T] = {
-    new Linear[T](inputSize, outputSize, initMethod)
+      initMethod: InitializationMethod = Default,
+      withBias: Boolean = false
+  )(implicit ev: TensorNumeric[T]) : Linear[T] = {
+    new Linear[T](inputSize, outputSize, initMethod, withBias)
   }
 }

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
@@ -19,6 +19,7 @@ package com.intel.analytics.bigdl.nn
 
 import org.scalatest.{FlatSpec, Matchers}
 import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl._
 
 import scala.math._
 import com.intel.analytics.bigdl._

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
@@ -127,6 +127,52 @@ class LinearSpec extends FlatSpec with Matchers {
     assert(err < 1e-6)
   }
 
+  "Linear module in batch mode without bias" should "converate to correct weight and bias" in {
+    val inputN = 5
+    val outputN = 2
+    val batchN = 3
+
+    val linear = new Linear[Double](inputN, outputN, withBias = false)
+    val mse = new MSECriterion[Double]
+
+    val input = Tensor[Double](batchN, inputN)
+    val res = Tensor[Double](batchN, outputN)
+    var err = 0.0
+    for (i <- 1 to 10000) {
+      input.rand()
+      for (k <- 1 to batchN) {
+        for (y <- 1 to outputN) {
+          res(Array(k, y)) = 0
+          for (x <- 1 to inputN) {
+            res(Array(k, y)) += 0.1 * y * x * input(Array(k, x))
+          }
+        }
+      }
+      val output = linear.forward(input)
+      err = mse.forward(output, res)
+      val grad = mse.backward(output, res)
+      linear.zeroGradParameters()
+      linear.backward(input, grad)
+      linear.updateParameters(0.5 / log(i + 3))
+    }
+    val params = linear.parameters()
+    val weight = params._1(0)
+    val bias = params._1(1)
+
+    val expectedWeight = Tensor[Double](outputN, inputN)
+    for (y <- 1 to outputN) {
+      for (x <- 1 to inputN) {
+        expectedWeight(Array(y, x)) = 0.1 * y * x
+      }
+    }
+
+    expectedWeight.map(weight, (v1, v2) => {
+      assert(abs(v1 - v2) < 1e-6);
+      v1
+    })
+    assert(err < 1e-6)
+  }
+
   "Linear module in batch mode" should "be good in gradient check" in {
     val linear = new Linear[Double](5, 2)
     linear.reset()

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/LinearSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/LinearSpec.scala
@@ -80,7 +80,54 @@ class LinearSpec extends FlatSpec with BeforeAndAfter with Matchers {
     println("Test case : Linear, Torch : " + luaTime + " s, Scala : " + scalaTime / 1e9 + " s")
   }
 
-  "Linear (1024, 1000)" should "converge to correct weight and bias" in {
+  "Linear module without bias" should "converate to correct weight and bias" in {
+    val inputN = 5
+    val outputN = 2
+
+    val linear = new Linear[Double](inputN, outputN, withBias = false)
+    val mse = new MSECriterion[Double]
+
+    val input = Tensor[Double](inputN)
+    val res = Tensor[Double](outputN)
+    val grad = Tensor[Double](outputN).rand()
+    val seed = 100
+
+    input.rand()
+
+    val code = "torch.manualSeed(" + seed + ")\n" +
+      "linear:reset()\n" +
+      "weight = linear.weight\n" +
+      "bias = linear.bias\n" +
+      "output1 = linear:forward(input)\n" +
+      "output2 = linear:backward(input, grad)"
+
+    val (luaTime, torchResult) = TH.run(code, Map("linear" -> linear,
+      "input" -> input, "grad" -> grad),
+      Array("weight", "bias", "output1", "output2"))
+    val luaOutput1 = torchResult("output1").asInstanceOf[Tensor[Double]]
+    val luaOutput2 = torchResult("output2").asInstanceOf[Tensor[Double]]
+    val luaWeight = torchResult("weight").asInstanceOf[Tensor[Double]]
+    val luaBias = torchResult("bias").asInstanceOf[Tensor[Double]]
+
+    val start = System.nanoTime()
+    RNG.setSeed(seed)
+    linear.reset()
+    val weight = linear.weight
+    val bias = linear.bias
+    val output1 = linear.forward(input)
+    val output2 = linear.backward(input, grad)
+    val end = System.nanoTime()
+    val scalaTime = end - start
+
+    luaOutput1 should be(output1)
+    luaOutput2 should be(output2)
+    luaWeight should be(weight)
+    luaBias should be(bias)
+
+    println("Test case : Linear, Torch : " + luaTime + " s, Scala : " + scalaTime / 1e9 + " s")
+  }
+
+  "Linear (1024, 1000)" should "converate to correct weight and bias" in {
     val inputN = 1024
     val outputN = 1000
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make `Linear` layer support no bias, for GRU and LSTM support.

## How was this patch tested?

Add tests to LinearSpec

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/477

