### PR TITLE
Support 3d input for Criterions

### DIFF
--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributedCriterion.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributedCriterion.scala
@@ -29,7 +29,7 @@ import scala.reflect.ClassTag
  * @param critrn
  */
 
-class CriterionWrapper[T : ClassTag](critrn : TensorCriterion[T])
+class TimeDistributedCriterion[T : ClassTag](critrn : TensorCriterion[T])
 (implicit ev: TensorNumeric[T]) extends TensorCriterion[T] {
 
   private val fInput: Tensor[T] = Tensor[T]()
@@ -39,7 +39,7 @@ class CriterionWrapper[T : ClassTag](critrn : TensorCriterion[T])
 
   private def combine(src: Array[Int], target: Array[Int]): Unit = {
     require(src.length == target.length + 1,
-      "CriterionWrapper: combine method requires src.length == target.length + 1" +
+      "TimeDistributedCriterion: combine method requires src.length == target.length + 1" +
         s" Current src.length = ${src.length}" +
         s" Current target.length = ${target.length}")
     target(0) = src(0) * src(1)
@@ -77,10 +77,10 @@ class CriterionWrapper[T : ClassTag](critrn : TensorCriterion[T])
     gradInput
   }
 
-  override def canEqual(other: Any): Boolean = other.isInstanceOf[CriterionWrapper[T]]
+  override def canEqual(other: Any): Boolean = other.isInstanceOf[TimeDistributedCriterion[T]]
 
   override def equals(other: Any): Boolean = other match {
-    case that: CriterionWrapper[T] =>
+    case that: TimeDistributedCriterion[T] =>
       super.equals(that) &&
         (that canEqual this) &&
         fInput == that.fInput &&
@@ -96,10 +96,10 @@ class CriterionWrapper[T : ClassTag](critrn : TensorCriterion[T])
   }
 }
 
-object CriterionWrapper {
+object TimeDistributedCriterion {
   def apply[@specialized(Float, Double) T: ClassTag](
     critrn: TensorCriterion[T] = null)
-  (implicit ev: TensorNumeric[T]) : CriterionWrapper[T] = {
-    new CriterionWrapper[T](critrn)
+  (implicit ev: TensorNumeric[T]) : TimeDistributedCriterion[T] = {
+    new TimeDistributedCriterion[T](critrn)
   }
 }

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/TimeDistributedCriterionSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/TimeDistributedCriterionSpec.scala
@@ -23,10 +23,11 @@ import org.scalatest.{FlatSpec, Matchers}
 
 import scala.math._
 
-class CriterionWrapperSpec extends FlatSpec with Matchers {
+class TimeDistributedCriterionSpec extends FlatSpec with Matchers {
   "A ClassNLL Criterion" should "generate correct output and grad" in {
     val criterion = ClassNLLCriterion[Double]()
-    val layer = CriterionWrapper[Double](criterion)
+    val layer = TimeDistributedCriterion[Double](criterion)
+
     val input = Tensor[Double](3, 2, 3)
     input(Array(1, 1, 1)) = -1.0262627674932
     input(Array(1, 1, 2)) = -1.2412600935171
@@ -86,7 +87,8 @@ class CriterionWrapperSpec extends FlatSpec with Matchers {
 
   "A ClassNLL Criterion with sizeAverage False" should "generate correct output and grad" in {
     val criterion = ClassNLLCriterion[Double](null, false)
-    val layer = CriterionWrapper[Double](criterion)
+    val layer = TimeDistributedCriterion[Double](criterion)
+
     val input = Tensor[Double](3, 2, 3)
     input(Array(1, 1, 1)) = -1.0262627674932
     input(Array(1, 1, 2)) = -1.2412600935171
@@ -146,7 +148,8 @@ class CriterionWrapperSpec extends FlatSpec with Matchers {
 
   "A BCE Criterion" should "generate correct output and grad" in {
     val criterion = BCECriterion[Double]()
-    val layer = CriterionWrapper[Double](criterion)
+    val layer = TimeDistributedCriterion[Double](criterion)
+
     val output = Tensor[Double](3, 2)
     output(Array(1, 1)) = 0.4
     output(Array(1, 2)) = 0.4
@@ -176,7 +179,7 @@ class CriterionWrapperSpec extends FlatSpec with Matchers {
 
   "A CrossEntropy Criterion" should "generate correct output and grad" in {
     val criterion = CrossEntropyCriterion[Double]()
-    val layer = CriterionWrapper[Double](criterion)
+    val layer = TimeDistributedCriterion[Double](criterion)
 
     val input = Tensor[Double](3, 2, 3)
     input(Array(1, 1, 1)) = 0.33655226649716
@@ -240,7 +243,7 @@ class CriterionWrapperSpec extends FlatSpec with Matchers {
 
   "A MSE Criterion" should "generate correct output and grad" in {
     val criterion = MSECriterion[Double]()
-    val layer = CriterionWrapper[Double](criterion)
+    val layer = TimeDistributedCriterion[Double](criterion)
 
     val input = Tensor[Double](2, 2, 2)
     input(Array(1, 1, 1)) = 0.17503996845335
@@ -285,7 +288,7 @@ class CriterionWrapperSpec extends FlatSpec with Matchers {
   "A MSE Criterion with sizeAverage false" should "generate correct output and grad" in {
     val criterion = MSECriterion[Double]()
     criterion.sizeAverage = false
-    val layer = CriterionWrapper[Double](criterion)
+    val layer = TimeDistributedCriterion[Double](criterion)
 
     val input = Tensor[Double](2, 2, 2)
     input(Array(1, 1, 1)) = 0.64631252549589
@@ -328,7 +331,7 @@ class CriterionWrapperSpec extends FlatSpec with Matchers {
 
   "A MultiLabelSoftMargin Criterion" should "generate correct output and grad" in {
     val criterion = MultiLabelSoftMarginCriterion[Double]()
-    val layer = CriterionWrapper[Double](criterion)
+    val layer = TimeDistributedCriterion[Double](criterion)
 
     val output = Tensor[Double](3, 2)
     output(Array(1, 1)) = 0.4
@@ -409,7 +412,7 @@ class CriterionWrapperSpec extends FlatSpec with Matchers {
     expectedGrad(Array(3, 2, 3)) = -0.16666666666666666
 
     val nll = ClassNLLCriterion[Double]()
-    val layer1 = CriterionWrapper[Double](nll)
+    val layer1 = TimeDistributedCriterion[Double](nll)
     criterion.add(layer1, 1)
 
     val output = criterion.forward(T(input), T(target))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a layer to wrapper the time dimension of inputs for all criterions

## How was this patch tested?

Test on ClassNLLCriterion, BCECriterion, CrossEntropyCriterion, MSECriterion, MultiLabelSoftMarginCriterion, ParallelCriterion.

