### PR TITLE
sort dataset

### DIFF
--- a/dl/src/main/scala/com/intel/analytics/bigdl/optim/Optimizer.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/optim/Optimizer.scala
@@ -162,6 +162,21 @@ object Optimizer {
     ).asInstanceOf[Optimizer[T, MiniBatch[T]]]
   }
 
+  def apply[T: ClassTag](
+    model: Module[T],
+    sampleRDD: RDD[Sample[T]],
+    criterion: Criterion[T],
+    batchSize: Int,
+    isInOrder: Boolean
+  )(implicit ev: TensorNumeric[T]): Optimizer[T, MiniBatch[T]] = {
+    new DistriOptimizer[T](
+      model = model,
+      dataset = (DataSet.rdd(sampleRDD, isInOrder, batchSize) -> SampleToBatch(batchSize))
+        .asInstanceOf[DistributedDataSet[MiniBatch[T]]],
+      criterion = criterion
+    ).asInstanceOf[Optimizer[T, MiniBatch[T]]]
+  }
+
   def apply[T: ClassTag, D](
     model: Module[T],
     dataset: DataSet[D],


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. local dataset shuffle index, and use random offset when training
2. get original rdd dataset indexes when no shuffle
3. shuffle index range: form 0 to data.length - groupSize (default 1)
3. no shuffle if users want.

## How was this patch tested?
add some unit test for sorted buffer
1. local dataset should be good with default groupSize = 1
2. local dataset should be good with  groupSize > 1
3. rdd dataset should be good for multi partitions
4. rdd dataset should be same to the original data with one partition

