### PR TITLE
Add accGradParameters to Sequential and test it

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Sequential.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Sequential.scala
@@ -74,6 +74,20 @@ class Sequential[T: ClassTag]
     currentModule.accGradParameters(input, currentGradOutput, scale)
   }
 
+  override def backward(input: Activity, nextError: Activity): Activity = {
+    var i = modules.length - 1
+    var error = nextError.asInstanceOf[Activity]
+    while (i > 0) {
+      val input = modules(i - 1).output
+      error = modules(i).backward(input, error)
+      i -= 1
+    }
+    error = modules(0).backward(input, error)
+
+    this.gradInput = error
+    gradInput
+  }
+
   override def equals(obj: Any): Boolean = {
     if (!super.equals(obj)) {
       return false

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Sequential.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Sequential.scala
@@ -28,7 +28,7 @@ import scala.reflect.ClassTag
 
 @SerialVersionUID(5375403296928513267L)
 class Sequential[T: ClassTag]
-  (implicit ev: TensorNumeric[T]) extends Container[Activity, Activity, T] {
+(implicit ev: TensorNumeric[T]) extends Container[Activity, Activity, T] {
 
   override def updateOutput(input: Activity): Activity = {
     var i = 0
@@ -47,13 +47,31 @@ class Sequential[T: ClassTag]
     var error = nextError.asInstanceOf[Activity]
     while (i > 0) {
       val input = modules(i - 1).output
-      error = modules(i).backward(input, error)
+      error = modules(i).updateGradInput(input, error)
       i -= 1
     }
-    error = modules(0).backward(input, error)
+    error = modules(0).updateGradInput(input, error)
 
     this.gradInput = error
     gradInput
+  }
+
+  override def accGradParameters(
+    input: Activity,
+    gradOutput: Activity,
+    scale: Double = 1.0): Unit = {
+    var i = modules.length - 1
+    var currentModule = modules(i)
+    var currentGradOutput = gradOutput
+    while (i > 0) {
+      val previousModule = modules(i - 1)
+      currentModule.accGradParameters(previousModule.output, currentGradOutput, scale)
+      currentGradOutput = currentModule.gradInput
+      currentModule = previousModule
+      i -= 1
+    }
+
+    currentModule.accGradParameters(input, currentGradOutput, scale)
   }
 
   override def equals(obj: Any): Boolean = {
@@ -120,7 +138,7 @@ class Sequential[T: ClassTag]
 
 object Sequential {
   def apply[@specialized(Float, Double) T: ClassTag]()
-      (implicit ev: TensorNumeric[T]) : Sequential[T] = {
+    (implicit ev: TensorNumeric[T]) : Sequential[T] = {
     new Sequential[T]()
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/SequentialSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/SequentialSpec.scala
@@ -79,7 +79,8 @@ class SequentialSpec extends FlatSpec with BeforeAndAfter with Matchers {
     var gradInput = Tensor[Double]()
     while (i < 10) {
       output = module.forward(input).toTensor[Double]
-      gradInput = module.backward(input, gradOutput).toTensor[Double]
+      gradInput = module.updateGradInput(input, gradOutput).toTensor[Double]
+      module.accGradParameters(input, gradOutput)
       i += 1
     }
     val end = System.nanoTime()


### PR DESCRIPTION
## What changes were proposed in this pull request?

`Sequential` Implementation (not same as Torch) has an issue, maybe `updateGradInput` and `accGradParameters` should be seperate rather than updating them together, otherwise it may not work correctly in some case, for example in `Recurrent`.

Hence added accGradParameters to Sequential and test it

## How was this patch tested?

Unit test in SequentialSpec

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/497

