### PR TITLE
Table class should not publish internal mutable state to the outside world

### DIFF
--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/DotProduct.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/DotProduct.scala
@@ -56,7 +56,7 @@ class DotProduct[T: ClassTag] (implicit ev: TensorNumeric[T])
     var input2: Tensor[T] = input(2)
     var notBatch = false
 
-    if (gradInput.getState().size != 2) {
+    if (gradInput.length() != 2) {
       if (!gradInput.contains(1)) {
         gradInput.update(1, Tensor[T]())
       }

--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/JoinTable.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/JoinTable.scala
@@ -91,7 +91,7 @@ class JoinTable[T: ClassTag] (
     val dimension = getPositiveDimension(input)
 
     var i = 1
-    while (i <= input.getState().size) {
+    while (i <= input.length()) {
       if (!gradInput.contains(i)) {
         gradInput(i) = Tensor()
       }
@@ -101,7 +101,7 @@ class JoinTable[T: ClassTag] (
 
     var offset = 1
     i = 1
-    while (i <= input.getState().size) {
+    while (i <= input.length()) {
       val currentOutput: Tensor[T] = input(i)
       val currentGradInput = gradOutput
         .narrow(dimension, offset, currentOutput.size(dimension))

--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/MM.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/MM.scala
@@ -39,7 +39,7 @@ class MM[T: ClassTag](
   gradInput = T(Tensor[T], Tensor[T]())
 
   private def checkInputFormat(input: Table): (Tensor[T], Tensor[T]) = {
-    require(input.getState().size == 2 && input(1).isInstanceOf[Tensor[T]] &&
+    require(input.length() == 2 && input(1).isInstanceOf[Tensor[T]] &&
       input(2).isInstanceOf[Tensor[T]], "Input must be two tensors")
     val m1: Tensor[T] = input(1)
     val m2: Tensor[T] = input(2)

--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/MV.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/MV.scala
@@ -36,7 +36,7 @@ class MV[T: ClassTag](val trans: Boolean = false)
   gradInput = T(Tensor[T], Tensor[T]())
 
   private def checkInputFormat(input: Table): (Tensor[T], Tensor[T]) = {
-    require(input.getState().size == 2 && input(1).isInstanceOf[Tensor[T]] &&
+    require(input.length() == 2 && input(1).isInstanceOf[Tensor[T]] &&
       input(2).isInstanceOf[Tensor[T]], "Input must be two tensors")
     val m: Tensor[T] = input(1)
     val v: Tensor[T] = input(2)

--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/MapTable.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/MapTable.scala
@@ -58,9 +58,9 @@ class MapTable[T: ClassTag](
   }
 
   override def updateOutput(input: Table): Table = {
-    extend(input.getState().size)
+    extend(input.length())
     var i = 0
-    while (i < input.getState().size) {
+    while (i < input.length()) {
       output.update(i + 1, modules(i).updateOutput(input(i + 1)))
       i += 1
     }
@@ -68,9 +68,9 @@ class MapTable[T: ClassTag](
   }
 
   override def updateGradInput(input: Table, gradOutput: Table): Table = {
-    extend(input.getState().size)
+    extend(input.length())
     var i = 0
-    while (i < input.getState().size) {
+    while (i < input.length()) {
       gradInput.update(i + 1, modules(i).updateGradInput(input(i + 1), gradOutput(i + 1)))
       i += 1
     }
@@ -79,9 +79,9 @@ class MapTable[T: ClassTag](
 
   override def accGradParameters(input: Table, gradOutput: Table,
     scale: Double = 1.0): Unit = {
-    extend(input.getState().size)
+    extend(input.length())
     var i = 0
-    while (i < input.getState().size) {
+    while (i < input.length()) {
         modules(i).accGradParameters(input(i + 1), gradOutput(i + 1), scale)
       i += 1
     }

--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/ParallelTable.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/ParallelTable.scala
@@ -32,7 +32,7 @@ class ParallelTable[T: ClassTag]
 
   override def updateOutput(input: Table): Table = {
     var i = 0
-    while (i < input.getState().size) {
+    while (i < input.length()) {
       output.update(i + 1, modules(i).updateOutput(input(i + 1)))
       i += 1
     }

--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/SelectTable.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/SelectTable.scala
@@ -36,7 +36,7 @@ class SelectTable[T: ClassTag](
   (implicit ev: TensorNumeric[T]) extends Container[Table, Activity, T]  {
 
   override def updateOutput(input: Table): Activity = {
-    val index = if (this.index < 0) input.getState().size + this.index else this.index
+    val index = if (this.index < 0) input.length() + this.index else this.index
 
     require(input.contains(index), "index does not exist in the input table")
     output = input[Activity](index)

--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/Utils.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/Utils.scala
@@ -37,7 +37,7 @@ object Utils {
    */
   def zeroTableCopy[T : ClassTag](t1: Table, t2: Table)(
     implicit ev: TensorNumeric[T]): Table = {
-    for ((k, v) <- t2.getState()) {
+    t2.foreach { case ((k: Any, v: Any)) =>
       if (v.isInstanceOf[Table]) {
         t1.update(k, zeroTableCopy(if (t1.contains(k)) t1(k) else T(), t2(k)))
       } else {
@@ -51,7 +51,7 @@ object Utils {
         }
       }
     }
-    for ((k, v) <- t1.getState()) {
+    t1.foreach { case ((k: Any, v: Any)) =>
       if (!t2.contains(k)) {
         t1.update(k, null)
       }

--- a/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
@@ -649,11 +649,10 @@ object Tensor {
    */
   def apply[@specialized(Float, Double) T: ClassTag](xs : Table)(
     implicit ev: TensorNumeric[T]): Tensor[T] = {
-    val map = xs.flatten().getState().asInstanceOf[Map[Int, T]]
-    val content = new Array[T](map.values.size)
-    var i = 1
-    for (i <- 1 to content.size) {
-      content(i - 1) = map(i)
+    val flatTable = xs.flatten()
+    val content = new Array[T](flatTable.length())
+    for (i <- 1 to content.length) {
+      content(i - 1) = flatTable(i)
     }
 
     val dims = new ArrayBuffer[Int]()

--- a/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
@@ -23,6 +23,7 @@ import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 
 import scala.collection.mutable
 import scala.collection.mutable.Map
+import scala.collection.Set
 
 /**
  * Simulate the Table data structure in lua
@@ -31,7 +32,7 @@ import scala.collection.mutable.Map
  * @param topIndex
  */
 class Table private[bigdl](
-  state: Map[Any, Any] = new mutable.HashMap[Any, Any](),
+  private val state: Map[Any, Any] = new mutable.HashMap[Any, Any](),
   // index of last element in the contiguous numeric number indexed elements start from 1
   private var topIndex: Int = 0
 ) extends Serializable with Activity {
@@ -53,14 +54,20 @@ class Table private[bigdl](
     this
   }
 
-  def getState(): Map[Any, Any] = this.state
+  def getState(): Map[Any, Any] = {
+    val newState = mutable.Map[Any, Any]()
+    for ((k, v) <- this.state) {
+      newState(k) = v
+    }
+    newState
+  }
+
+  def keySet: Set[Any] = state.keySet
+
+  def foreach[U](f: ((Any, Any)) => U): Unit = state.foreach(f)
 
   def get[T](key: Any): Option[T] = {
-    if (!state.contains(key)) {
-      return None
-    }
-
-    Option(state(key).asInstanceOf[T])
+    state.get(key).map(_.asInstanceOf[T])
   }
 
   def getOrElse[T](key: Any, default: T): T = {
@@ -90,7 +97,7 @@ class Table private[bigdl](
     val result = new Table()
 
     for (k <- state.keys) {
-      result(k) = state.get(k).get
+      result(k) = state(k)
     }
 
     result
@@ -113,11 +120,11 @@ class Table private[bigdl](
     if (this.eq(other)) {
       return true
     }
-    if (this.state.keys.size != other.getState().keys.size) {
+    if (this.state.keys.size != other.state.keys.size) {
       return false
     }
     this.state.keys.foreach(key => {
-      if (this.state(key) != other.getState()(key)) {
+      if (this.state(key) != other.state(key)) {
         return false
       }
     })
@@ -192,7 +199,7 @@ class Table private[bigdl](
   }
 
   def add(other: Table): this.type = {
-    for (s <- other.getState().keys) {
+    for (s <- other.state.keys) {
       require(s.isInstanceOf[String])
       this.state(s) = other(s)
     }
@@ -224,7 +231,7 @@ class Table private[bigdl](
       state.get(i).get match {
         case table: Table =>
           val newTable = table.flatten(resultIndex)
-          newState ++= newTable.getState()
+          newState ++= newTable.state
           resultIndex += newState.size
         case other =>
           newState.put(resultIndex, other)
@@ -257,12 +264,12 @@ class Table private[bigdl](
     var resultIndex = startIndex
     val newState = mutable.Map[Any, Any]()
 
-    while (i <= target.getState().size) {
-      target.getState().get(i).get match {
+    while (i <= target.length()) {
+      target.state.get(i).get match {
         case table: Table =>
           val newTable = inverseFlatten(table, resultIndex)
-          newState.put(i, new Table(newTable.getState()))
-          resultIndex += newTable.getState().size
+          newState.put(i, new Table(newTable.state))
+          resultIndex += newTable.length()
         case other =>
           newState.put(i, state.get(resultIndex).get)
       }

--- a/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
@@ -54,14 +54,6 @@ class Table private[bigdl](
     this
   }
 
-  def getState(): Map[Any, Any] = {
-    val newState = mutable.Map[Any, Any]()
-    for ((k, v) <- this.state) {
-      newState(k) = v
-    }
-    newState
-  }
-
   def keySet: Set[Any] = state.keySet
 
   def foreach[U](f: ((Any, Any)) => U): Unit = state.foreach(f)

--- a/dl/src/test/scala/com/intel/analytics/bigdl/torch/TH.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/torch/TH.scala
@@ -88,7 +88,7 @@ object TH {
         case _: AbstractModule[_, _, _] =>
           File.saveTorch(parameters(k), tmpPath, TYPE_MODULE, true)
         case _: Table =>
-          File.saveTorch(parameters(k).asInstanceOf[Table].getState(), tmpPath, TYPE_TABLE, true)
+          File.saveTorch(parameters(k).asInstanceOf[Table], tmpPath, TYPE_TABLE, true)
         case _ =>
       }
       varCode.append(k + " = torch.load(\'" + tmpPath + "\')\n")


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `Table` class has a `getState()` which used to return the internal mutable state to caller. It is a little dangerous to do that since the `state` could be modified somewhere else, which make it hard for Table to ensure its own invariants. 

This pr fixes this issue by 
1. add `foreach` and `keySet` methods for the caller to get easy readonly access to the elements of the internal `state`
2. modify `getState()` to return a defensive copy of the original state

## How was this patch tested?

existing tests
