### PR TITLE
log learning rate to DistriOptimizer and LocalOptimizer

### DIFF
--- a/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -238,10 +238,10 @@ object DistriOptimizer {
         accumulateCount += recordsNum.value
         val end = System.nanoTime()
         wallClockTime += end - start
+        optimMethod.updateHyperParameter(state, driverState)
         logger.info(s"${_header} Train ${recordsNum.value} in ${(end - start) / 1e9}seconds. " +
           s"Throughput is ${recordsNum.value / ((end - start) / 1e9)} records/second. Loss is ${
-            lossSum.value / finishedModelNum
-          }. ")
+            lossSum.value / finishedModelNum}. ${optimMethod.getHyperParameter(state)}")
         logger.debug("\n" + metrics.summary())
         logger.debug("Dropped modules: " + (driverSubModelNum - finishedModelNum))
         lossArray = new Array[Double](_subModelNumber)

--- a/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalOptimizer.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalOptimizer.scala
@@ -153,7 +153,9 @@ class LocalOptimizer[T: ClassTag] private[optim](
         s"loss is $loss, iteration time is ${(end - start) / 1e9}s " +
         s"data fetch time is ${(dataFetchTime - start) / 1e9}s, " +
         s"train time ${(end - dataFetchTime) / 1e9}s. " +
-        s"Throughput is ${batch.data.size(1).toDouble / (end - start) * 1e9} record / second")
+        s"Throughput is ${batch.data.size(1).toDouble / (end - start) * 1e9} record / second. " +
+        optimMethod.getHyperParameter(state)
+        )
       state("neval") = state[Int]("neval") + 1
 
       if (count >= dataset.size()) {

--- a/dl/src/main/scala/com/intel/analytics/bigdl/optim/OptimMethod.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/optim/OptimMethod.scala
@@ -45,6 +45,25 @@ trait OptimMethod[@specialized(Float, Double) T] extends Serializable {
    * @return
    */
   def clearHistory(state: Table): Table
+
+  /**
+   * Update hyper parameter.
+   * We have updated hyper parameter in method optimize(). But in DistriOptimizer, the method
+   * optimize() is only called on the executor side, the driver's hyper parameter is unchanged.
+   * So this method is using to update hyper parameter on the driver side.
+   *
+   * @param config config table.
+   * @param state state Table.
+   * @return A string.
+   */
+  def updateHyperParameter(config: Table, state: Table): Unit = {}
+
+  /**
+   * Get hyper parameter from config table.
+   *
+   * @param config a table contains the hyper parameter.
+   */
+  def getHyperParameter(config: Table): String = ""
 }
 
 trait IterateByItself

--- a/dl/src/main/scala/com/intel/analytics/bigdl/optim/SGD.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/optim/SGD.scala
@@ -98,6 +98,18 @@ class SGD[@specialized(Float, Double) T: ClassTag](implicit ev: TensorNumeric[T]
     state.delete("dfdx")
     state.delete("deltaParameters")
   }
+
+  /**
+   * return an string of current learning Rate.
+   */
+  override def getHyperParameter(config: Table): String = {
+    s"Current learning rate is ${-config[Double]("clr")}."
+  }
+
+  override def updateHyperParameter(config: Table, state: Table): Unit = {
+    val lrSchedule = config.get[LearningRateSchedule]("learningRateSchedule").getOrElse(Default())
+    lrSchedule.updateHyperParameter(config, state)
+  }
 }
 
 object SGD {

--- a/dl/src/main/scala/com/intel/analytics/bigdl/optim/SGD.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/optim/SGD.scala
@@ -100,10 +100,23 @@ class SGD[@specialized(Float, Double) T: ClassTag](implicit ev: TensorNumeric[T]
   }
 
   /**
-   * return an string of current learning Rate.
+   * return an string of current hyperParameter.
    */
   override def getHyperParameter(config: Table): String = {
-    s"Current learning rate is ${-config[Double]("clr")}."
+    val clr = -config[Double]("clr")
+    val wd = config.get[Double]("weightDecay").getOrElse(0.0)
+    val mom = config.get[Double]("momentum").getOrElse(0.0)
+    val damp = config.get[Double]("dampening").getOrElse(mom)
+    val nesterov = config.get[Boolean]("nesterov").getOrElse(false)
+    val lrs = config.get[Tensor[T]]("learningRates").getOrElse(null)
+    val wds = config.get[Tensor[T]]("weightDecays").getOrElse(null)
+    s"Current learning rate is $clr. " +
+      {if (wd != 0) s"Current weight decay is $wd. " else ""} +
+      {if (mom != 0) s"Current momentum is $mom. " else ""} +
+      {if (damp != 0) s"Current dampening is $damp. " else ""} +
+      {if (nesterov) s"Current nesterov is true. " else ""} +
+      {if (null != lrs) s"Current learningRates is a Tensor. " else ""} +
+      {if (null != wds) s"Current weightDecays is a Tensor. " else ""}
   }
 
   override def updateHyperParameter(config: Table, state: Table): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

log the learning rate, DistriOptimizer's log will be like below.
2017-02-27 09:27:22 INFO  DistriOptimizer$:244 - [Epoch 5 864/1024][Iteration 156][Wall Clock 5.075152322s] Train 32 in 0.015700029seconds. Throughput is 2038.2127956578934 records/second. Loss is 9.906649950740335E-5. Current learning rate is 19.969047975637764.
2017-02-27 09:27:22 INFO  DistriOptimizer$:244 - [Epoch 5 896/1024][Iteration 157][Wall Clock 5.090852351s] Train 32 in 0.020827232seconds. Throughput is 1536.449970884273 records/second. Loss is 9.906649950740335E-5. Current learning rate is 19.968848596189943.
2017-02-27 09:27:22 INFO  DistriOptimizer$:244 - [Epoch 5 928/1024][Iteration 158][Wall Clock 5.111679583s] Train 32 in 0.021485274seconds. Throughput is 1489.3922227847781 records/second. Loss is 9.906649950740335E-5. Current learning rate is 19.968649220723464.
2017-02-27 09:27:22 INFO  DistriOptimizer$:244 - [Epoch 5 960/1024][Iteration 159][Wall Clock 5.133164857s] Train 32 in 0.016589597seconds. Throughput is 1928.919671767795 records/second. Loss is 9.906649950740335E-5. Current learning rate is 19.968449849238205.
2017-02-27 09:27:22 INFO  DistriOptimizer$:244 - [Epoch 5 992/1024][Iteration 160][Wall Clock 5.149754454s] Train 32 in 0.018321964seconds. Throughput is 1746.5376528411475 records/second. Loss is 9.906649950740335E-5. Current learning rate is 19.968250481734042.

LocalOptimizer's log will be like this:
2017-02-27 09:33:32 INFO  LocalOptimizer$:152 - [Epoch 1 4/10][Iteration 1][Wall Clock 0.029223113s] loss is 0.34205079451203346, iteration time is 0.029223113s data fetch time is 6.15545E-4s, train time 0.028607568s. Throughput is 136.87795684190112 record / second. Current learning rate is 1.0.
2017-02-27 09:33:32 INFO  LocalOptimizer$:152 - [Epoch 1 8/10][Iteration 2][Wall Clock 0.030840435s] loss is 0.32582034543156624, iteration time is 0.001617322s data fetch time is 3.9009E-5s, train time 0.001578313s. Throughput is 2473.2242558995677 record / second. Current learning rate is 0.9999990000010001.
2017-02-27 09:33:32 INFO  LocalOptimizer$:152 - [Epoch 1 12/10][Iteration 3][Wall Clock 0.032005895s] loss is 0.3102036081254482, iteration time is 0.00116546s data fetch time is 3.4779E-5s, train time 0.001130681s. Throughput is 3432.1212225215795 record / second. Current learning rate is 0.999998000004.
2017-02-27 09:33:32 INFO  LocalOptimizer$:152 - [Epoch 2 4/10][Iteration 4][Wall Clock 0.033181788s] loss is 0.29606756940484047, iteration time is 0.001175893s data fetch time is 3.4629E-5s, train time 0.001141264s. Throughput is 3401.670049911004 record / second. Current learning rate is 0.999997000009.
2017-02-27 09:33:32 INFO  LocalOptimizer$:152 - [Epoch 2 8/10][Iteration 5][Wall Clock 0.034969399s] loss is 0.2840557247400284, iteration time is 0.001787611s data fetch time is 4.4169E-5s, train time 0.001743442s. Throughput is 2237.623286050489 record / second. Current learning rate is 0.9999960000160001.

## How was this patch tested?

unit test, manual test.

## Related links or issues (optional)
#257 

