### PR TITLE
[issue 528]Bug fix for null pointer exception caused by parameters()

### DIFF
--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/BatchNormalization.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/BatchNormalization.scala
@@ -609,12 +609,18 @@ class BatchNormalization[@specialized(Float, Double) T: ClassTag](
   }
 
   override def zeroGradParameters(): Unit = {
-    gradWeight.zero()
-    gradBias.zero()
+    if (affine) {
+      gradWeight.zero()
+      gradBias.zero()
+    }
   }
 
   override def parameters(): (Array[Tensor[T]], Array[Tensor[T]]) = {
-    (Array(this.weight, this.bias), Array(this.gradWeight, this.gradBias))
+    if (affine) {
+      (Array(this.weight, this.bias), Array(this.gradWeight, this.gradBias))
+    } else {
+      null
+    }
   }
 
   override def toString(): String = {

--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/Bilinear.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/Bilinear.scala
@@ -182,7 +182,11 @@ class Bilinear[T: ClassTag](
   }
 
   override def parameters(): (Array[Tensor[T]], Array[Tensor[T]]) = {
-    (Array(this.weight, this.bias), Array(this.gradWeight, this.gradBias))
+    if (null == bias) {
+      (Array(this.weight), Array(this.gradWeight))
+    } else {
+      (Array(this.weight, this.bias), Array(this.gradWeight, this.gradBias))
+    }
   }
 
   override def toString(): String = {

--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/Linear.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/Linear.scala
@@ -155,7 +155,11 @@ class Linear[T: ClassTag](
   }
 
   override def parameters(): (Array[Tensor[T]], Array[Tensor[T]]) = {
-    (Array(this.weight, this.bias), Array(this.gradWeight, this.gradBias))
+    if (null == bias) {
+      (Array(this.weight), Array(this.gradWeight))
+    } else {
+      (Array(this.weight, this.bias), Array(this.gradWeight, this.gradBias))
+    }
   }
 
   override def equals(obj: Any): Boolean = {

--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolution.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolution.scala
@@ -681,7 +681,11 @@ class SpatialFullConvolution[A <: Activity : ClassTag, T: ClassTag](
   }
 
   override def parameters(): (Array[Tensor[T]], Array[Tensor[T]]) = {
-    (Array(this.weight, this.bias), Array(this.gradWeight, this.gradBias))
+    if (null == bias) {
+      (Array(this.weight), Array(this.gradWeight))
+    } else {
+      (Array(this.weight, this.bias), Array(this.gradWeight, this.gradBias))
+    }
   }
 
   override def clearState() : this.type = {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
@@ -157,7 +157,6 @@ class LinearSpec extends FlatSpec with Matchers {
     }
     val params = linear.parameters()
     val weight = params._1(0)
-    val bias = params._1(1)
 
     val expectedWeight = Tensor[Double](outputN, inputN)
     for (y <- 1 to outputN) {

--- a/dl/src/test/scala/com/intel/analytics/bigdl/nn/ModuleSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/nn/ModuleSpec.scala
@@ -70,19 +70,44 @@ class ModuleSpec extends FlatSpec with Matchers {
   }
 
   "getParameter" should "behave correctly" in {
-    val module = new Sequential[Double]
-    val subModule1 = new Linear[Double](2, 3)
-    val subModule2 = new Linear[Double](4, 5)
+    val module = Sequential[Double]
+    val subModule1 = Linear[Double](2, 3)
+    val subModule2 = Linear[Double](4, 5, Default, false)
+    val subModule3 = BatchNormalization[Double](5)
+    val subModule4 = BatchNormalization[Double](5, 1e-5, 0.1, false)
+    val subModule5 = Bilinear[Double](1, 2, 3)
+    val subModule6 = Bilinear[Double](1, 2, 3, false)
+    val subModule7 = SpatialFullConvolution[Tensor[Double], Double](1, 2, 3, 4)
+    val subModule8 = SpatialFullConvolution[Tensor[Double], Double](1, 2, 3, 4,
+      1, 1, 0, 0, 0, 0, 1, true
+    )
+
     module.add(subModule1)
     module.add(subModule2)
+    module.add(subModule3)
+    module.add(subModule4)
+    module.add(subModule5)
+    module.add(subModule6)
+    module.add(subModule7)
+    module.add(subModule8)
 
     val (weight, grad) = module.getParameters()
     weight.dim() should be(1)
     weight.size(1) should be(subModule1.parameters()._1.foldLeft(0)(_ + _.nElement()) +
-      subModule2.parameters()._1.foldLeft(0)(_ + _.nElement()))
+      subModule2.parameters()._1.foldLeft(0)(_ + _.nElement()) +
+      subModule3.parameters()._1.foldLeft(0)(_ + _.nElement()) +
+      subModule5.parameters()._1.foldLeft(0)(_ + _.nElement()) +
+      subModule6.parameters()._1.foldLeft(0)(_ + _.nElement()) +
+      subModule7.parameters()._1.foldLeft(0)(_ + _.nElement()) +
+      subModule8.parameters()._1.foldLeft(0)(_ + _.nElement()))
 
     grad.size(1) should be(subModule1.parameters()._2.foldLeft(0)(_ + _.nElement()) +
-      subModule2.parameters()._2.foldLeft(0)(_ + _.nElement()))
+      subModule2.parameters()._2.foldLeft(0)(_ + _.nElement()) +
+      subModule3.parameters()._2.foldLeft(0)(_ + _.nElement()) +
+      subModule5.parameters()._2.foldLeft(0)(_ + _.nElement()) +
+      subModule6.parameters()._2.foldLeft(0)(_ + _.nElement()) +
+      subModule7.parameters()._2.foldLeft(0)(_ + _.nElement()) +
+      subModule8.parameters()._2.foldLeft(0)(_ + _.nElement()))
 
     val newValue = Random.nextDouble()
     weight.fill(newValue)


### PR DESCRIPTION
## What changes were proposed in this pull request?

BatchNormalization Bilinear Linear SpatialFullConvolution's function `parameters()` may return null Tensor. And cause a NullPointerException in `getParameters()`.
Fix this issue.

## How was this patch tested?

unit test

## Related links or issues (optional)
fixed #528 

