### PR TITLE
Fix optimizer can only run once issue

### DIFF
--- a/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -511,9 +511,12 @@ class DistriOptimizer[T: ClassTag] (
   private var models: RDD[DistriOptimizer.Cache[T]] = null
 
   /**
-   * Clean some flags left on executor.
+   * Clean some internal states, so this or other optimizers can run optimize again
+   *
+   * This method will be called at the end of optimize. You need not call it if optimize succeed.
+   * If the optimize fails, you may call it before next optimize.
    */
-  def cleanExecutorFlags() : Unit = {
+  def clearState() : Unit = {
     // Reset the singleton flag, so other optimizers can run
     models.mapPartitions(iter => {
       Engine.resetSingletonFlag()
@@ -563,8 +566,8 @@ class DistriOptimizer[T: ClassTag] (
 
     nn.Utils.copyModule(trainedModel, model)
 
-    // Reset the singleton flag, so other optimizers can run
-    cleanExecutorFlags()
+    // Reset some internal states, so this or other optimizers can run optimize again
+    clearState()
 
     model
   }

--- a/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -510,6 +510,17 @@ class DistriOptimizer[T: ClassTag] (
 
   private var models: RDD[DistriOptimizer.Cache[T]] = null
 
+  /**
+   * Clean some flags left on executor.
+   */
+  def cleanExecutorFlags() : Unit = {
+    // Reset the singleton flag, so other optimizers can run
+    models.mapPartitions(iter => {
+      Engine.resetSingletonFlag()
+      iter
+    }).count()
+  }
+
   override def optimize(): Module[T] = {
     this.assertEngineInited()
 
@@ -551,6 +562,10 @@ class DistriOptimizer[T: ClassTag] (
     val trainedModel = DistriOptimizer.getModel(models, parameters)
 
     nn.Utils.copyModule(trainedModel, model)
+
+    // Reset the singleton flag, so other optimizers can run
+    cleanExecutorFlags()
+
     model
   }
 }

--- a/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
@@ -224,6 +224,13 @@ object Engine {
     (count == 1)
   }
 
+  /**
+   * Reset the singleton flag
+   */
+  def resetSingletonFlag(): Unit = {
+    singletonCounter.set(0)
+  }
+
   private var physicalCoreNumber = {
     val env = System.getenv("DL_CORE_NUMBER")
     if(env == null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Optimizer will set a flag in executor but not clean. The cause there's at most one Optimizer.optimize job in the life cycle.

In the PR, the optimizer will clean the flag when an optimization is done. We also provide a public method of DistriOptimizer to allow user to clean it manually if some exception happened.

## How was this patch tested?
all old and unit tests and a new unit test

