### PR TITLE
Add new APIs: parameters set_name get_name for layers

### DIFF
--- a/dl/src/main/python/models/lenet/lenet5.py
+++ b/dl/src/main/python/models/lenet/lenet5.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
             criterion=ClassNLLCriterion(),
             optim_method="SGD",
             state=state,
-            end_trigger=MaxEpoch(100),
+            end_trigger=MaxEpoch(2),
             batch_size=int(options.batchSize))
         optimizer.setvalidation(
             batch_size=32,
@@ -89,6 +89,7 @@ if __name__ == "__main__":
         )
         optimizer.setcheckpoint(EveryEpoch(), "/tmp/lenet5/")
         trained_model = optimizer.optimize()
+        parameters = trained_model.parameters()
     elif options.action == "test":
         test_data = get_minst("test").map(
             normalizer(mnist.TEST_MEAN, mnist.TEST_STD))

--- a/dl/src/main/python/test/simple_integration_test.py
+++ b/dl/src/main/python/test/simple_integration_test.py
@@ -20,53 +20,66 @@ from nn.layer import *
 from optim.optimizer import *
 from util.common import *
 import numpy as np
+import unittest
+
+
+class TestWorkFlow(unittest.TestCase):
+
+    def test_simple_flow(self):
+        sparkConf = create_spark_conf(1, 4)
+        sc = SparkContext(master="local[*]", appName="test model",
+                          conf=sparkConf)
+        initEngine(1, 4)
+        FEATURES_DIM = 2
+
+        def gen_rand_sample():
+            features = np.random.uniform(0, 1, (FEATURES_DIM))
+            label = (2 * features).sum() + 0.4
+            return Sample.from_ndarray(features, label)
+
+        trainingData = sc.parallelize(range(0, 100)).map(
+            lambda i: gen_rand_sample())
+
+        model = Sequential()
+        l1 = Linear(FEATURES_DIM, 1, "Xavier").set_name("linear1")
+        self.assertEqual("linear1", l1.name())
+        model.add(l1)
+
+        state = {"learningRate": 0.01,
+                 "learningRateDecay": 0.0002}
+        optimizer = Optimizer(
+            model=model,
+            training_rdd=trainingData,
+            criterion=MSECriterion(),
+            optim_method="Adagrad",
+            state=state,
+            end_trigger=MaxEpoch(5),
+            batch_size=32)
+        optimizer.setvalidation(
+            batch_size=32,
+            val_rdd=trainingData,
+            trigger=EveryEpoch(),
+            val_method=["top1"]
+        )
+        optimizer.setcheckpoint(SeveralIteration(1), "/tmp/prototype/")
+
+        trained_model = optimizer.optimize()
+        # TODO: add result validation
+        parameters = trained_model.parameters()
+        self.assertIsNotNone(parameters["linear1"])
+        print("parameters %s" % parameters["linear1"])
+        predict_result = trained_model.predict(trainingData)
+        p = predict_result.take(2)
+        print("predict predict: \n")
+        for i in p:
+            print(str(i) + "\n")
+        print(len(p))
+
+        test_results = trained_model.test(trainingData, 32, ["top1"])
+        for test_result in test_results:
+            print(test_result)
+        sc.stop()
+
 
 if __name__ == "__main__":
-    sparkConf = create_spark_conf(1, 4)
-    sc = SparkContext(master="local[*]", appName="test model", conf=sparkConf)
-    initEngine(1, 4)
-    FEATURES_DIM = 2
-
-    def gen_rand_sample():
-        features = np.random.uniform(0, 1, (FEATURES_DIM))
-        label = (2*features).sum() + 0.4
-        return Sample.from_ndarray(features, label)
-
-    trainingData = sc.parallelize(range(0, 100)).map(
-        lambda i: gen_rand_sample())
-
-    model = Sequential()
-    model.add(Linear(FEATURES_DIM, 1, "Xavier"))
-    state = {"learningRate": 0.01,
-             "learningRateDecay": 0.0002}
-    optimizer = Optimizer(
-        model=model,
-        training_rdd=trainingData,
-        criterion=MSECriterion(),
-        optim_method="Adagrad",
-        state=state,
-        end_trigger=MaxEpoch(5),
-        batch_size=32)
-    optimizer.setvalidation(
-        batch_size=32,
-        val_rdd=trainingData,
-        trigger=EveryEpoch(),
-        val_method=["top1"]
-    )
-    optimizer.setcheckpoint(SeveralIteration(1), "/tmp/prototype/")
-
-    trained_model = optimizer.optimize()
-    # TODO: add result validation
-    parameters = trained_model.parameters()
-    print("parameters %s" % parameters["weights"])
-    predict_result = trained_model.predict(trainingData)
-    p = predict_result.take(5)
-    print("predict predict: \n")
-    for i in p:
-        print(str(i) + "\n")
-    print(len(p))
-
-    test_results = trained_model.test(trainingData, 32, ["top1"])
-    for test_result in test_results:
-        print(test_result)
-    sc.stop()
+    unittest.main()

--- a/dl/src/main/python/util/common.py
+++ b/dl/src/main/python/util/common.py
@@ -18,7 +18,7 @@
 import sys
 from py4j.protocol import Py4JJavaError
 from py4j.java_gateway import JavaObject
-from py4j.java_collections import ListConverter, JavaArray, JavaList
+from py4j.java_collections import ListConverter, JavaArray, JavaList, JavaMap
 
 from pyspark import RDD, SparkContext
 from pyspark.serializers import PickleSerializer, AutoBatchedSerializer
@@ -163,7 +163,7 @@ def _java2py(sc, r, encoding="bytes"):
 
         if clsName in _picklable_classes:
             r = sc._jvm.org.apache.spark.bigdl.api.python.BigDLSerDe.dumps(r)
-        elif isinstance(r, (JavaArray, JavaList)):
+        elif isinstance(r, (JavaArray, JavaList, JavaMap)):
             try:
                 r = sc._jvm.org.apache.spark.bigdl.api.python.BigDLSerDe.dumps(
                     r)

--- a/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Utils.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Utils.scala
@@ -27,7 +27,7 @@ object Utils {
     val batchPerUnit = if (Engine.nodeNumber().isDefined) {
       val nodeNumber = Engine.nodeNumber().get
       val coreNumber = Engine.coreNumber()
-      logger.info(s"node number: $nodeNumber, core number: $coreNumber")
+      logger.debug(s"node number: $nodeNumber, core number: $coreNumber")
       require(totalBatch % (nodeNumber * coreNumber) == 0
         , s"total batch size($totalBatch) can't be divided by node number($nodeNumber) * " +
           s"core number($coreNumber), please change your batch size")
@@ -42,7 +42,7 @@ object Utils {
     } else {
       totalBatch
     }
-    logger.info(s"Batch per unit: $batchPerUnit")
+    logger.debug(s"Batch per unit: $batchPerUnit")
     batchPerUnit
   }
 

--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialConvolution.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialConvolution.scala
@@ -120,7 +120,8 @@ class SpatialConvolution[T: ClassTag](
     val outputWidth = (inputWidth + 2 * padW - kernelW) / strideW + 1
     val outputHeight = (inputHeight + 2 * padH - kernelH) / strideH + 1
 
-    require(outputWidth >= 1 && outputHeight >= 1, "output size is too small")
+    require(outputWidth >= 1 && outputHeight >= 1,
+      s"output size is too small. outputWidth: $outputWidth, outputHeight: $outputHeight")
 
     if (onesBias.dim() != 1 || onesBias.size(1) != outputHeight * outputWidth) {
       onesBias.resize(Array(outputHeight * outputWidth)).fill(ev.fromType(1.0))

--- a/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
@@ -24,6 +24,7 @@ import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import scala.collection.mutable
 import scala.collection.mutable.Map
 import scala.collection.Set
+import scala.collection.immutable.{Map => ImmutableMap}
 
 /**
  * Simulate the Table data structure in lua
@@ -45,6 +46,9 @@ class Table private[bigdl](
     }
   }
 
+  private[bigdl] def getState(): ImmutableMap[Any, Any] = {
+    return state.toMap
+  }
   /**
    * Empty the Table
    */

--- a/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
@@ -74,8 +74,15 @@ class PythonSpec extends FlatSpec with Matchers with BeforeAndAfter {
     BigDLSerDe.javaToPython(data.toJavaRDD().asInstanceOf[JavaRDD[Any]])
 
     val model = Sequential[Double]()
-    model.add(Linear[Double](100, 10))
+    model.add(Linear[Double](100, 100))
     model.add(ReLU[Double]())
+
+    val m2 = Sequential[Double]()
+    m2.add(Linear[Double](100, 10))
+    m2.add(ReLU[Double]())
+
+    model.add(m2)
+
     model.add(LogSoftMax[Double]())
 
     val pp = PythonBigDL.ofDouble()


### PR DESCRIPTION
## What changes were proposed in this pull request?
* Add new APIs: parameters, set_name, get_name for layers
* layer.parameters() would return [layer_name-> [params_name->ndarray]]
i.e:
```
 ["linear1" -> ["weights" -> ndarray, "bias"->ndarray]]
```
## How was this patch tested?
unit-test


