### PR TITLE
Replace scalar type T with Double

### DIFF
--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/AddConstant.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/AddConstant.scala
@@ -56,6 +56,23 @@ class AddConstant[T: ClassTag](
     gradInput
   }
 
+  override def canEqual(other: Any): Boolean = other.isInstanceOf[AddConstant[T]]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: AddConstant[T] =>
+      super.equals(that) &&
+        (that canEqual this) &&
+        constant_scalar == that.constant_scalar &&
+        inplace == that.inplace
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    def getHashCode(a: Any): Int = if (a == null) 0 else a.hashCode()
+    val state = Seq(super.hashCode(), constant_scalar, inplace)
+    state.map(getHashCode).foldLeft(0)((a, b) => 31 * a + b)
+  }
+
   override def toString(): String = {
     s"nn.AddConstant ($constant_scalar, $inplace)"
   }

--- a/dl/src/main/scala/com/intel/analytics/bigdl/nn/MulConstant.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/nn/MulConstant.scala
@@ -26,14 +26,15 @@ import scala.reflect.ClassTag
 /**
  * Multiplies input Tensor by a (non-learnable) scalar constant.
  * This module is sometimes useful for debugging purposes.
- * @param scalar scalar constant
+ * @param constant scalar constant
  * @param inplace Can optionally do its operation in-place without using extra state memory
  */
 
 @SerialVersionUID(- 8747642888169310696L)
 class MulConstant[@specialized(Float, Double) T: ClassTag](
-  val scalar : T, val inplace : Boolean = false)(
+  val constant : Double, val inplace : Boolean = false)(
   implicit ev: TensorNumeric[T]) extends TensorModule[T]  {
+  val scalar = ev.fromType[Double](constant)
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
     if (inplace) {
@@ -83,8 +84,8 @@ class MulConstant[@specialized(Float, Double) T: ClassTag](
 
 object MulConstant {
   def apply[@specialized(Float, Double) T: ClassTag](
-      scalar : T,
-      inplace : Boolean = false)(implicit ev: TensorNumeric[T]) : MulConstant[T] = {
+    scalar : Double,
+    inplace : Boolean = false)(implicit ev: TensorNumeric[T]) : MulConstant[T] = {
     new MulConstant[T](scalar, inplace)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In order to be more user-friendly, it is better to define constant type in `AddConstant` and `MultConstant` layer as `Double` rather than `T`.

Because when user define model which including `AddConstant` or `MultConstant`, they may just `add(AddConstant[T](5.5))`, something like that, but not based on the tensor numeric type `T` like `add(AddConstant[T](ev.FromType[Double](5.5)))`

## How was this patch tested?

Unit tests

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/559

