### PR TITLE
padding words to the beginning and end of the sentences

### DIFF
--- a/dl/src/main/scala/com/intel/analytics/bigdl/dataset/text/Dictionary.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/dataset/text/Dictionary.scala
@@ -19,6 +19,7 @@ package com.intel.analytics.bigdl.dataset.text
 import java.io.{File, PrintWriter, Serializable}
 
 import org.apache.log4j.Logger
+import org.apache.log4j.spi.LoggerFactory
 import org.apache.spark.rdd.RDD
 
 import scala.util.Random

--- a/dl/src/main/scala/com/intel/analytics/bigdl/dataset/text/SentenceBiPadding.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/dataset/text/SentenceBiPadding.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.dataset.text
+
+import com.intel.analytics.bigdl.dataset.Transformer
+import com.intel.analytics.bigdl.dataset.text.utils.SentenceToken
+
+import scala.collection.Iterator
+
+/**
+ * x =>  ["start", x, "end"]
+ */
+
+class SentenceBiPadding(
+  start: Option[String] = None,
+  end: Option[String] = None)
+  extends Transformer[String, String] {
+
+  val sentenceStart = start.getOrElse(SentenceToken.start)
+  val sentenceEnd = end.getOrElse(SentenceToken.end)
+
+  override def apply(prev: Iterator[String]): Iterator[String] = {
+    prev.map(x => {
+      val sentence = sentenceStart + " " + x + " " + sentenceEnd
+      sentence
+    })
+  }
+}
+
+object SentenceBiPadding {
+  def apply(start: Option[String] = None,
+            end: Option[String] = None):
+  SentenceBiPadding = new SentenceBiPadding(start, end)
+}

--- a/dl/src/main/scala/com/intel/analytics/bigdl/dataset/text/utils/Types.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/dataset/text/utils/Types.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.dataset.text.utils
+
+sealed trait AbstractToken
+
+object SentenceToken extends AbstractToken {
+  val start = "SENTENCESTART"
+  val end = "SENTENCEEND"
+}

--- a/dl/src/test/scala/com/intel/analytics/bigdl/dataset/DictionarySpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/dataset/DictionarySpec.scala
@@ -18,8 +18,8 @@ package com.intel.analytics.bigdl.dataset.text
 
 import java.io.PrintWriter
 
-import com.intel.analytics.bigdl.dataset.DataSet
-import com.intel.analytics.bigdl.utils.Engine
+import com.intel.analytics.bigdl.utils.{Engine, T}
+import com.intel.analytics.bigdl.dataset.{DataSet, LocalArrayDataSet}
 import org.apache.spark.SparkContext
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 

--- a/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SentenceBiPaddingSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SentenceBiPaddingSpec.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.dataset.text
+
+import java.io.PrintWriter
+
+import com.intel.analytics.bigdl.dataset.DataSet
+import com.intel.analytics.bigdl.dataset.text.utils.SentenceToken
+import com.intel.analytics.bigdl.utils.Engine
+import org.apache.spark.SparkContext
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+
+import scala.io.Source
+
+@com.intel.analytics.bigdl.tags.Serial
+class SentenceBiPaddingSpec extends FlatSpec with Matchers with BeforeAndAfter {
+  var sc: SparkContext = null
+
+  before {
+    val nodeNumber = 1
+    val coreNumber = 1
+    Engine.init(nodeNumber, coreNumber, true)
+  }
+
+  after {
+    if (sc != null) {
+      sc.stop()
+    }
+  }
+
+  "SentenceBiPaddingSpec" should "pads articles correctly on Spark" in {
+    val tmpFile = java.io.File
+      .createTempFile("UnitTest", "DocumentTokenizerSpec").getPath
+
+    val sentence1 = "Enter Barnardo and Francisco, two sentinels."
+    val sentence2 = "Who’s there?"
+    val sentence3 = "I think I hear them. Stand ho! Who is there?"
+    val sentence4 = "The Dr. lives in a blue-painted box."
+
+    val sentences = Array(sentence1, sentence2, sentence3, sentence4)
+    new PrintWriter(tmpFile) {
+      write(sentences.mkString("\n")); close
+    }
+
+    sc = new SparkContext("local[1]", "DocumentTokenizer")
+    val sents = DataSet.rdd(sc.textFile(tmpFile)
+      .filter(!_.isEmpty)).transform(SentenceSplitter())
+      .toDistributed().data(train = false).flatMap(item => item.iterator).collect()
+      .asInstanceOf[Array[String]]
+    val tokens = DataSet.rdd(sc.parallelize(sents))
+      .transform(SentenceBiPadding())
+    val output = tokens.toDistributed().data(train = false).collect()
+
+    var count = 0
+    println("padding sentences:")
+    output.foreach(x => {
+      count += x.length
+      println(x)
+      val words = x.split(" ")
+      val startToken = words(0)
+      val endToken = words(words.length - 1)
+      startToken should be (SentenceToken.start)
+      endToken should be (SentenceToken.end)
+    })
+    sc.stop()
+  }
+
+  "SentenceBiPaddingSpec" should "pads articles correctly on local" in {
+    val tmpFile = java.io.File
+      .createTempFile("UnitTest", "DocumentTokenizerSpec").getPath
+
+    val sentence1 = "Enter Barnardo and Francisco, two sentinels."
+    val sentence2 = "Who’s there?"
+    val sentence3 = "I think I hear them. Stand ho! Who is there?"
+    val sentence4 = "The Dr. lives in a blue-painted box."
+
+    val sentences = Array(sentence1, sentence2, sentence3, sentence4)
+
+    new PrintWriter(tmpFile) {
+      write(sentences.mkString("\n")); close
+    }
+
+    val logData = Source.fromFile(tmpFile).getLines().toArray
+    val sents = DataSet.array(logData
+      .filter(!_.isEmpty)).transform(SentenceSplitter())
+      .toLocal().data(train = false).flatMap(item => item.iterator)
+    val tokens = DataSet.array(sents.toArray)
+      .transform(SentenceBiPadding())
+    val output = tokens.toLocal().data(train = false).toArray
+
+    var count_word = 0
+    println("padding sentences:")
+    output.foreach(x => {
+      count_word += x.length
+      println(x)
+      val words = x.split(" ")
+      val startToken = words(0)
+      val endToken = words(words.length - 1)
+      startToken should be (SentenceToken.start)
+      endToken should be (SentenceToken.end)
+    })
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add new transformers to BigDL

SentenceBiPadding:

pad start and end tokens to the sentences.
Default tokens are "SENTENCESTART" and "SENTENCEEND"

## How was this patch tested?
Unit Test

Test the padding is correct.

