### PR TITLE
textToLabeledSentence transformer

### DIFF
--- a/dl/src/main/scala/com/intel/analytics/bigdl/dataset/text/TextToLabeledSentence.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/dataset/text/TextToLabeledSentence.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.dataset.text
+
+import com.intel.analytics.bigdl.dataset.Transformer
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+
+import scala.collection.Iterator
+import scala.reflect.ClassTag
+
+object TextToLabeledSentence {
+  def apply[T: ClassTag](dictionary: Dictionary)
+           (implicit ev: TensorNumeric[T])
+  : TextToLabeledSentence[T] =
+    new TextToLabeledSentence[T](dictionary)
+}
+
+/**
+ * Transform a string of sentence to LabeledSentence.
+ * e.g. ["I", "love", "Intel"] => [0, 1, 2]
+ *
+ * The input Array[String] should be a tokenized sentence.
+ * e.g. I love Intel => ["I", "love", "Intel"]
+ * @param dictionary
+ * @param ev
+ * @tparam T
+ */
+class TextToLabeledSentence[T: ClassTag](dictionary: Dictionary)
+  (implicit ev: TensorNumeric[T])
+  extends Transformer[Array[String], LabeledSentence[T]] {
+  private val buffer = new LabeledSentence[T]()
+
+  override def apply(prev: Iterator[Array[String]]): Iterator[LabeledSentence[T]] = {
+    prev.map(sentence => {
+      val indexes = sentence.map(x =>
+        ev.fromType[Int](dictionary.getIndex(x)))
+      val nWords = indexes.length - 1
+      val data = indexes.take(nWords)
+      val label = indexes.drop(1)
+      buffer.copy(data, label)
+    })
+  }
+}

--- a/dl/src/main/scala/com/intel/analytics/bigdl/dataset/text/TextToLabeledSentence.scala
+++ b/dl/src/main/scala/com/intel/analytics/bigdl/dataset/text/TextToLabeledSentence.scala
@@ -32,6 +32,8 @@ object TextToLabeledSentence {
 /**
  * Transform a string of sentence to LabeledSentence.
  * e.g. ["I", "love", "Intel"] => [0, 1, 2]
+ *      data:  [0, 1]
+ *      label: [1, 2]
  *
  * The input Array[String] should be a tokenized sentence.
  * e.g. I love Intel => ["I", "love", "Intel"]

--- a/dl/src/test/scala/com/intel/analytics/bigdl/dataset/TextToLabeledSentenceSpec.scala
+++ b/dl/src/test/scala/com/intel/analytics/bigdl/dataset/TextToLabeledSentenceSpec.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.dataset.text
+
+import java.io.PrintWriter
+
+import com.intel.analytics.bigdl.dataset.{DataSet, LocalArrayDataSet}
+import com.intel.analytics.bigdl.utils.Engine
+import org.apache.spark.SparkContext
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+
+import scala.collection.mutable.ArrayBuffer
+import scala.io.Source
+
+@com.intel.analytics.bigdl.tags.Serial
+class TextToLabeledSentenceSpec extends FlatSpec with Matchers with BeforeAndAfter {
+  var sc: SparkContext = null
+
+  before {
+    val nodeNumber = 1
+    val coreNumber = 1
+    Engine.init(nodeNumber, coreNumber, true)
+    sc = new SparkContext("local[1]", "TextToLabeledSentence")
+  }
+
+  after {
+    if (sc != null) {
+      sc.stop()
+    }
+  }
+
+  "TextToLabeledSentenceSpec" should "indexes sentences correctly on Spark" in {
+    val tmpFile = java.io.File
+      .createTempFile("UnitTest", "DocumentTokenizerSpec").getPath
+
+    val sentence1 = "Enter Barnardo and Francisco, two sentinels."
+    val sentence2 = "Who’s there?"
+    val sentence3 = "I think I hear them. Stand ho! Who is there?"
+    val sentence4 = "The Dr. lives in a blue-painted box."
+
+    val sentences = Array(sentence1, sentence2, sentence3, sentence4)
+
+    new PrintWriter(tmpFile) {
+      write(sentences.mkString("\n")); close
+    }
+
+    val tokens = DataSet.rdd(sc.textFile(tmpFile)
+      .filter(!_.isEmpty))
+      .transform(SentenceTokenizer())
+    val output = tokens.toDistributed().data(train = false)
+    val dictionary = Dictionary(output, 100)
+    val textToLabeledSentence = TextToLabeledSentence[Float](dictionary)
+    val labeledSentences = tokens.transform(textToLabeledSentence)
+      .toDistributed().data(false).collect()
+    labeledSentences.foreach(x => {
+      println("input = " + x.data().mkString(","))
+      println("target = " + x.label().mkString(","))
+      var i = 1
+      while (i < x.dataLength()) {
+        x.getData(i) should be (x.getLabel(i - 1))
+        i += 1
+      }
+    })
+  }
+
+  "TextToLabeledSentenceSpec" should "indexes sentences correctly on Local" in {
+    val tmpFile = java.io.File
+      .createTempFile("UnitTest", "DocumentTokenizerSpec").getPath
+
+    val sentence1 = "Enter Barnardo and Francisco, two sentinels."
+    val sentence2 = "Who’s there?"
+    val sentence3 = "I think I hear them. Stand ho! Who is there?"
+    val sentence4 = "The Dr. lives in a blue-painted box."
+
+    val sentences = Array(sentence1, sentence2, sentence3, sentence4)
+
+    new PrintWriter(tmpFile) {
+      write(sentences.mkString("\n")); close
+    }
+
+    val logData = Source.fromFile(tmpFile).getLines().toArray
+    val tokens = DataSet.array(logData
+      .filter(!_.isEmpty))
+      .transform(SentenceTokenizer())
+    val output = tokens.toLocal().data(train = false)
+
+    val dictionary = Dictionary(output, 100)
+    val textToLabeledSentence = TextToLabeledSentence[Float](dictionary)
+    val labeledSentences = tokens.transform(textToLabeledSentence)
+      .toLocal().data(false)
+    labeledSentences.foreach(x => {
+      println("input = " + x.data().mkString(","))
+      println("target = " + x.label().mkString(","))
+      var i = 1
+      while (i < x.dataLength()) {
+        x.getData(i) should be (x.getLabel(i - 1))
+        i += 1
+      }
+    })
+
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a new Transformer,


TextToLabeledSentence: transform the text to the integer index.
The integer index of a word is got from a Dictionary.

## How was this patch tested?
Unit Test:

input a sample sentence: [x1 x2 x3]
the expected output labeledSentence should be:
input = [a1 a2 a3] targets = [a2 a3 a4]; a_i is the integer

