### PR TITLE
Use Iterator.single(elem) instead of Iterator(elem)

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -231,7 +231,7 @@ object DistriOptimizer {
             cached.localModels(i).training()
             cached.localModels(i).zeroGradParameters()
           }))
-          Iterator(finishedThreads.size)
+          Iterator.single(finishedThreads.size)
         }).reduce(_ + _)
 
       dropModelNumBatch += (driverSubModelNum - finishedModelNum)
@@ -457,7 +457,7 @@ object DistriOptimizer {
       logger.info("model thread pool size is " + Engine.model.getPoolSize)
       parameters.init(weights)
 
-      Iterator(Cache(
+      Iterator.single(Cache(
         cached.map(_._1), // models
         cached.map(_._2), // weights
         cached.map(_._3), // gradients

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
@@ -407,7 +407,7 @@ trait Tensor[T] extends Serializable with TensorMath[T] with Activity {
    * 1 2 3
    * 4 5 6
    * tensor.narrow(1, 1, 1) is [1 2 3]
-   * tensor.narrow(2, 2, 3) is
+   * tensor.narrow(2, 2, 2) is
    * 2 3
    * 5 6
    *


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use Iterator.single(elem), which is equivalent but more efficient than Iterator(elem).
(According to scala doc [https://www.scala-lang.org/api/current/scala/collection/Iterator$.html](https://www.scala-lang.org/api/current/scala/collection/Iterator$.html) )

## How was this patch tested?

existing tests

