### PR TITLE
[Issue #704] fix the bug of modelbroadcast when all weights and biases share the one storage

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
@@ -76,8 +76,10 @@ class ModelBroadcast[T: ClassTag](implicit ev: TensorNumeric[T]) extends Seriali
     }
     i = 0
     while (i < parameters._1.length) {
-      if (parameters._2(i) != null) {
+      if (parameters._1(i) != null) {
         parameters._1(i).set()
+      }
+      if (parameters._2(i) != null) {
         parameters._2(i).set()
       }
       i += 1

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
@@ -74,10 +74,10 @@ class ModelBroadcast[T: ClassTag](implicit ev: TensorNumeric[T]) extends Seriali
       }
       i += 1
     }
+    i = 0
     while (i < parameters._1.length) {
-      if (parameters._1(i) != null) {
-        val wb = parameters._1(i)
-        wb.set()
+      if (parameters._2(i) != null) {
+        parameters._1(i).set()
         parameters._2(i).set()
       }
       i += 1

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
@@ -71,6 +71,12 @@ class ModelBroadcast[T: ClassTag](implicit ev: TensorNumeric[T]) extends Seriali
         val wb = parameters._1(i)
         weightsBias(i) = Tensor[T](Storage(wb.storage().array()),
           wb.storageOffset(), wb.size(), wb.stride())
+      }
+      i += 1
+    }
+    while (i < parameters._1.length) {
+      if (parameters._1(i) != null) {
+        val wb = parameters._1(i)
         wb.set()
         parameters._2(i).set()
       }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcastSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcastSpec.scala
@@ -25,11 +25,27 @@ class ModelBroadcastSpec extends FlatSpec with Matchers {
   Logger.getLogger("org").setLevel(Level.WARN)
   Logger.getLogger("akka").setLevel(Level.WARN)
 
-  val sc = new SparkContext(new SparkConf().setMaster("local[1]").setAppName("ModelBroadcast"))
-  val model = LeNet5(10)
+  "model broadcast" should "work properly" in {
+    val sc = new SparkContext(new SparkConf().setMaster("local[1]").setAppName("ModelBroadcast"))
 
-  val modelBroadCast = ModelBroadcast[Float].broadcast(sc, model)
-  modelBroadCast.value().toString should be(model.toString)
-  modelBroadCast.value().parameters()._1 should be(model.parameters()._1)
-  sc.stop()
+    val model = LeNet5(10)
+
+    val modelBroadCast = ModelBroadcast[Float].broadcast(sc, model)
+    modelBroadCast.value().toString should be(model.toString)
+    modelBroadCast.value().parameters()._1 should be(model.parameters()._1)
+    sc.stop()
+  }
+
+  "model broadcast with getParameters" should "work properly" in {
+    val sc = new SparkContext(new SparkConf().setMaster("local[1]").setAppName("ModelBroadcast"))
+
+    val model = LeNet5(10)
+    model.getParameters()
+
+    val modelBroadCast = ModelBroadcast[Float].broadcast(sc, model)
+    modelBroadCast.value().toString should be(model.toString)
+    modelBroadCast.value().parameters()._1 should be(model.parameters()._1)
+    sc.stop()
+  }
+
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcastSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcastSpec.scala
@@ -18,34 +18,39 @@ package com.intel.analytics.bigdl.models.utils
 import com.intel.analytics.bigdl.models.lenet.LeNet5
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.{SparkConf, SparkContext}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
-class ModelBroadcastSpec extends FlatSpec with Matchers {
+class ModelBroadcastSpec extends FlatSpec with Matchers with BeforeAndAfter {
+
+  var sc: SparkContext = null
 
   Logger.getLogger("org").setLevel(Level.WARN)
   Logger.getLogger("akka").setLevel(Level.WARN)
+  before {
+    sc = new SparkContext(new SparkConf().setMaster("local[1]").setAppName("ModelBroadcast"))
+  }
 
   "model broadcast" should "work properly" in {
-    val sc = new SparkContext(new SparkConf().setMaster("local[1]").setAppName("ModelBroadcast"))
-
     val model = LeNet5(10)
 
     val modelBroadCast = ModelBroadcast[Float].broadcast(sc, model)
     modelBroadCast.value().toString should be(model.toString)
     modelBroadCast.value().parameters()._1 should be(model.parameters()._1)
-    sc.stop()
   }
 
   "model broadcast with getParameters" should "work properly" in {
-    val sc = new SparkContext(new SparkConf().setMaster("local[1]").setAppName("ModelBroadcast"))
-
     val model = LeNet5(10)
     model.getParameters()
 
     val modelBroadCast = ModelBroadcast[Float].broadcast(sc, model)
     modelBroadCast.value().toString should be(model.toString)
     modelBroadCast.value().parameters()._1 should be(model.parameters()._1)
-    sc.stop()
+  }
+
+  after {
+    if (sc != null) {
+      sc.stop()
+    }
   }
 
 }


### PR DESCRIPTION

## What changes were proposed in this pull request?

fix the bug of modelbroadcast when all weights and biases share the one storage

## How was this patch tested?

unit test

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/704

