### PR TITLE
Use spark.version in spark-version/2.0 pom.xml; add 'cloudera' profile to target CDH release of Spark 2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -553,7 +553,11 @@
         <profile>
             <id>cloudera</id>
             <properties>
+                <spark-version.project>2.0</spark-version.project>
                 <spark.version>2.0.0.cloudera2</spark.version>
+                <scala.major.version>2.11</scala.major.version>
+                <scala.version>2.11.8</scala.version>
+                <scala.macros.version>2.1.0</scala.macros.version>
             </properties>
             <repositories>
                 <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -503,7 +503,7 @@
     </reporting>
 
     <profiles>
-	<profile>
+	      <profile>
             <id>spark_1.6</id>
             <properties>
                 <spark-version.project>1.5-plus</spark-version.project>
@@ -523,7 +523,7 @@
                 <scala.macros.version>2.1.0</scala.macros.version>
             </properties>
         </profile>
-	<profile>
+	      <profile>
             <id>spark_2.1</id>
             <properties>
                 <spark-version.project>2.0</spark-version.project>
@@ -549,6 +549,18 @@
                 <scala.version>2.10.5</scala.version>
                 <scala.macros.version>2.0.1</scala.macros.version>
             </properties>
+        </profile>
+        <profile>
+            <id>cloudera</id>
+            <properties>
+                <spark.version>2.0.0.cloudera2</spark.version>
+            </properties>
+            <repositories>
+                <repository>
+                    <id>cloudera</id>
+                    <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+                </repository>
+            </repositories>
         </profile>
         <profile>
             <id>all-in-one</id>

--- a/pom.xml
+++ b/pom.xml
@@ -446,16 +446,16 @@
                     </execution>
                 </executions>
             </plugin>
-	        <plugin>
-	        <groupId>org.sonatype.plugins</groupId>
-	        <artifactId>nexus-staging-maven-plugin</artifactId>
-	        <version>1.6.7</version>
-	        <extensions>true</extensions>
-	        <configuration>
-	            <serverId>ossrh</serverId>
-	            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-	            <autoReleaseAfterClose>false</autoReleaseAfterClose>
-	        </configuration>
+            <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.7</version>
+            <extensions>true</extensions>
+            <configuration>
+                <serverId>ossrh</serverId>
+                <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                <autoReleaseAfterClose>false</autoReleaseAfterClose>
+            </configuration>
             </plugin>
         </plugins>
     </build>
@@ -503,7 +503,7 @@
     </reporting>
 
     <profiles>
-	      <profile>
+        <profile>
             <id>spark_1.6</id>
             <properties>
                 <spark-version.project>1.5-plus</spark-version.project>
@@ -523,7 +523,7 @@
                 <scala.macros.version>2.1.0</scala.macros.version>
             </properties>
         </profile>
-	      <profile>
+        <profile>
             <id>spark_2.1</id>
             <properties>
                 <spark-version.project>2.0</spark-version.project>

--- a/spark/spark-version/2.0/pom.xml
+++ b/spark/spark-version/2.0/pom.xml
@@ -17,13 +17,13 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.major.version}</artifactId>
-            <version>2.0.0</version>
+            <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-mllib_${scala.major.version}</artifactId>
-            <version>2.0.0</version>
+            <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Background: BigDL accesses some internal Spark APIs, like specifically `BlockManager.putBytes`, via a shim class that has separate implementations for Spark 1.x and 2.x. The `2.0` module can support Spark 2.0, 2.1, 2.2 without source changes, but the compiled binary works with, roughly, only the same minor release of Spark as this API has changed internally several times.

The first problem is that `spark-version/2.0/pom.xml` hard-codes `spark.version` as `2.0.0` instead of `${spark.version}`. This is easily fixed so that `-Pspark_2.1` actually makes it compile and work for Spark 2.1. The binary isn't actually otherwise compatible with Spark 2.0 or 2.2.

The second problem is that, actually, CDH's release of Spark 2 back-ports some changes that will be in 2.2 to the current 2.0/2.1 release that make this particular API behave like 2.2. So neither `-Pspark_2.0` nor `-Pspark_2.1` work with CDH because of this mismatch. This internal private API varies a lot across versions and isn't otherwise guaranteed.

Two solutions: go ahead and make a Spark 2.2 profile, or, go ahead and make a Cloudera profile. The benefit of the latter is that it makes it easy to also turn on the CDH repository with a profile flag, for people that want to directly match a CDH version for reasons like this. The downside is just another profile in the build. What do you think of that choice?

Long-term of course it'd be better to see if BigDL can avoid private APIs.

## How was this patch tested?

Existing tests; verified this makes BigDL work on CDH 5.10 + Spark 2.0 CSD