### PR TITLE
[fix] multi task issue on Mesos

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
@@ -20,6 +20,7 @@ import java.io.InputStream
 import java.util.concurrent.atomic.AtomicInteger
 import org.apache.log4j.Logger
 import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.scheduler.cluster.mesos.MesosResources
 
 /**
  * define engine type trait
@@ -74,6 +75,29 @@ object Engine {
     _conf
   }
 
+  def waitAllExecutorsStartedInMesos: Unit = {
+    if (System.getProperty("spark.master").toLowerCase.startsWith("mesos")) {
+      val sc = SparkContext.getOrCreate(new SparkConf()
+        .setAppName("set mesos backend for Engine check"))
+      require(sc.appName != "set mesos backend for Engine check",
+        s"Have you created the SparkContext?")
+
+      if (MesosResources.checkAllExecutorStarted(sc)) {
+        return
+      }
+
+      // loop until all executors are started.
+      while (!MesosResources.checkAllExecutorStarted(sc)) {
+        if (sc.isStopped) {
+          throw new IllegalStateException("Spark context stopped while waiting for all executors")
+        }
+        synchronized {
+          this.wait(100)
+        }
+      }
+    }
+  }
+
   /**
    * This method should be call before any BigDL procedure and after spark context created.
    *
@@ -98,6 +122,7 @@ object Engine {
       logger.info(s"Executor number is $nExecutor and executor cores number is $executorCores")
       setNodeAndCore(nExecutor, executorCores)
       checkSparkContext
+      waitAllExecutorsStartedInMesos
     }
   }
 

--- a/spark/dl/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosResources.scala
+++ b/spark/dl/src/main/scala/org/apache/spark/scheduler/cluster/mesos/MesosResources.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler.cluster.mesos
+
+import org.apache.spark.{SparkConf, SparkContext}
+
+object MesosResources {
+  /**
+   * Get the totalCoreCount, which will be updated in RPC method (receiveAndReply),
+   *
+   * Because it's a protected attribute, we can't get it directly. We get it through
+   * `defaultParallism()` because it will call `totalCoreCount.get()` if the property
+   * `spark.default.parallelism` has not been set.
+   *
+   * @param conf spark config
+   * @param backend mesos coarse backend
+   * @return current totalCoreCount
+   */
+  private def getTotalCoreCount(conf: SparkConf,
+    backend: MesosCoarseGrainedSchedulerBackend): Int = {
+    val parallismOption = "spark.default.parallelism"
+    val containOption = conf.contains(parallismOption)
+
+    val defaultParallism = backend.defaultParallelism().toString
+
+    if (containOption) {
+      conf.remove(parallismOption)
+    }
+
+    val totalCoreCount = backend.defaultParallelism()
+
+    if (containOption) {
+      conf.set(parallismOption, defaultParallism)
+    }
+
+    totalCoreCount
+  }
+
+  def checkAllExecutorStarted(sc: SparkContext): Boolean = {
+    sc.schedulerBackend match {
+      case b: MesosCoarseGrainedSchedulerBackend =>
+        // maxCores comes from MesosCoarseGrainedSchedulerBackend, which is a public attribute
+        val maxCores = b.maxCores
+        val totalCoreCount = getTotalCoreCount(sc.conf, b)
+
+        // If we want to have the highest performance, we should wait to all resources available.
+        val minRegisteredRatio = 1.0
+
+        val ret = if (b.sufficientResourcesRegistered() &&
+          totalCoreCount >= maxCores * minRegisteredRatio) {
+          true
+        } else {
+          false
+        }
+
+        ret
+      case _ => throw new IllegalArgumentException(s"Did you set the right schduler backend?" +
+        s"We only support Mesos Coarse Scheduler Backend.")
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Multi task issue on Mesos. Because when spark driver starts to schedule, some of executors may be not started yet. So we should wait for all executors started.

## How was this patch tested?

Currently, only manual tests have done.

