### PR TITLE
(the same as #762 but for master branch) skip some packages in scala doc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -404,6 +404,14 @@
                         <goals>
                             <goal>doc-jar</goal>
                         </goals>
+                        <configuration>
+                            <args>
+                                <!-- Do not change the arg orders. It is a weird way to pass in
+                                this arg. Maybe it is a bug of the plugin. -->
+                                <arg>-skip-packages</arg>
+                                <arg>caffe:org.tensorflow:netty:org.apache.spark.sparkExtension:org.apache.spark.rdd:org.apache.spark.storage:org.apache.spark.bigdl</arg>
+                            </args>
+                        </configuration>
                     </execution>
                 </executions>
                 <configuration>


### PR DESCRIPTION
(the same as #762 but for master branch)
## What changes were proposed in this pull request?

Skip `caffe`, `org.tensorflow` and `netty` package when building scala doc.

It is kind of weird to pass args this way, since `-skip-packages caffe:org.tensorflow:netty` is one argument. But it is the only way it works.

The actual scaladoc usage should be `scaladoc -skip-packages <pack1>:...:<packN>` and I have tried using
```
<configuration>
    <args>
        <arg>-skip-packages caffe:org.tensorflow:netty</arg>
    </args>
</configuration>
```
and 
```
 <configuration>
    <args>
       <arg>caffe:org.tensorflow:netty</arg>
       <arg>-skip-packages </arg>
    </args>
</configuration>
```
Unfortunately neither of them work.

I think it is a bug of scala-maven-plugin. (I also tried different versions of scala-maven-plugin, also did not work.)


## How was this patch tested?

verified using mvn install