### PR TITLE
exclude some artifact in dl's maven-shade-plugin

### DIFF
--- a/spark/dl/pom.xml
+++ b/spark/dl/pom.xml
@@ -158,6 +158,20 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.0.0</version>
                 <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <artifactSet>
+                        <includes>
+                            <include>com.google.protobuf</include>
+                        </includes>
+                    </artifactSet>
+                    <filters>
+                        <filter>
+                            <artifact>com.google.protobuf</artifact>
+                            <excludes>
+                                <exclude>META-INF/maven/com.google.protobuf/protobuf-java/*</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                     <relocations>
                         <relocation>
                             <pattern>com.google.protobuf</pattern>


### PR DESCRIPTION
## What changes were proposed in this pull request?

exclude some artifacts in dl's maven-shade-plugin, and reduce the size of bigdl-0.2.0-SNAPSHOT.jar from 50+MB to about 6MB

## How was this patch tested?

manual tests

