### PR TITLE
Add dataset.cache() method to trigger the computation of this dataset and cache it in memory

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/DataSet.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/DataSet.scala
@@ -189,8 +189,8 @@ trait DistributedDataSet[T] extends AbstractDataSet[T, RDD[T]] {
   }
 
   /**
-    * Trigger the computation of this dataset and cache it in memory.
-    */
+   * Trigger the computation of this dataset and cache it in memory.
+   */
   def cache(): Unit
 
   /**

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/DistriOptimizerPerf.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/DistriOptimizerPerf.scala
@@ -114,6 +114,7 @@ object DistriOptimizerPerf {
     val dummyDataSet = new DistributedDataSet[MiniBatch[Float]] {
       override def size(): Long = 10000
       override def shuffle(): Unit = {}
+      override def cache(): Unit = rdd.cache().count()
       override def originRDD(): RDD[_] = rdd
       override def data(train: Boolean): RDD[MiniBatch[Float]] = rdd
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -719,7 +719,7 @@ class DistriOptimizer[T: ClassTag] (
           val t3 = System.nanoTime()
           v.cache()
           val t4 = System.nanoTime()
-          DistriOptimizer.logger.info(s"Prepare and cache training data... Done. " +
+          DistriOptimizer.logger.info(s"Prepare and cache validation data... Done. " +
             s"Takes ${(t4 - t3)/1e9}s")
         case _ =>
       }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DistriOptimizerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DistriOptimizerSpec.scala
@@ -125,6 +125,8 @@ class DistriOptimizerSpec extends FlatSpec with Matchers with BeforeAndAfter {
       override def size(): Long = 256 * nodeNumber
 
       override def shuffle(): Unit = {}
+
+      override def cache(): Unit = rdd.cache().count()
     }
 
     plusOne = 0.0
@@ -274,6 +276,8 @@ class DistriOptimizerSpec extends FlatSpec with Matchers with BeforeAndAfter {
       override def size(): Long = 256 * nodeNumber
 
       override def shuffle(): Unit = {}
+
+      override def cache(): Unit = rdd.cache().count()
     }
     val optimizer = new DistriOptimizer[Double](mm, dataSet, new MSECriterion[Double]())
       .setState(T("learningRate" -> 20.0))

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/OptimizerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/OptimizerSpec.scala
@@ -188,6 +188,7 @@ class OptimizerSpec extends FlatSpec with Matchers with BeforeAndAfter {
       override def data(train: Boolean): RDD[Float] = null
       override def size(): Long = 0
       override def shuffle(): Unit = {}
+      override def cache(): Unit = {}
     }
 
     val model = Linear[Float](4, 3)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/LoggerFilterSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/LoggerFilterSpec.scala
@@ -110,7 +110,7 @@ class LoggerFilterSpec extends FlatSpec with BeforeAndAfter with Matchers {
 
     // check the first line and the last line of BigDL
     {
-      val pattern = ".*INFO.*DistriOptimizer.*Cache thread models..."
+      val pattern = ".*INFO.*DistriOptimizer.*Prepare and cache training data..."
       val firstLine = allString.split('\n')(0)
       require(firstLine.matches(pattern), s"output can't matchs the specific output")
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Originally the computation and cache of training and validation dataset is trigger at the optimizer creation time by the transform method of dataset (we use `SampleToBatch` transformer here).  This is a little confusing for users because the creation of optimizer takes too much time. User have to checkout the spark web ui to figure out what is going on.

This pr changed the `DateSet.tranform` method, so it would not trigger any computation and cache. And add a `cache()` method to trigger computation and cache explicitly.  

This pr also add calls of `DataSet.cache()` to `Optimizer.optimize` method before the actual training and add additional logging so data preparation time is not add to the training time.

After this pr, creation of optimizer would return instantly and the log would look something like this.
```
2017-04-13 13:12:39 INFO  DistriOptimizer$:709 - Prepare and cache training data...
2017-04-13 13:13:11 INFO  DistriOptimizer$:713 - Prepare and cache training data... Done. Takes 32.180678712s
2017-04-13 13:13:11 INFO  DistriOptimizer$:718 - Prepare and cache validation data...
2017-04-13 13:13:37 INFO  DistriOptimizer$:722 - Prepare and cache validation data... Done. Takes 25.844103993s
2017-04-13 13:13:37 INFO  DistriOptimizer$:531 - Cache thread models...
2017-04-13 13:13:37 INFO  DistriOptimizer$:516 - model thread pool size is 1
2017-04-13 13:13:37 INFO  DistriOptimizer$:533 - Cache thread models... done
2017-04-13 13:13:37 INFO  DistriOptimizer$:118 - config  {
        learningRate: 0.01
        maxDropPercentage: 0.0
        computeThresholdbatchSize: 100
        warmupIterationNum: 200
        learningRateDecay: 2.0E-4
        dropPercentage: 0.0
 }
2017-04-13 13:13:37 INFO  DistriOptimizer$:119 - Shuffle data
2017-04-13 13:13:37 INFO  DistriOptimizer$:123 - Shuffle data complete. Takes 0.018002131s
2017-04-13 13:13:38 INFO  DistriOptimizer$:281 - [Epoch 1 0/15959][Iteration 1][Wall Clock 0.0s] Train 128 in 1.327050399seconds. Throughput is 96.454506 records/second. Loss is 3.0012667.
2017-04-13 13:13:39 INFO  DistriOptimizer$:281 - [Epoch 1 128/15959][Iteration 2][Wall Clock 1.327050399s] Train 128 in 0.498763353seconds. Throughput is 256.63474 records/second. Loss is 6.8330793.
2017-04-13 13:13:39 INFO  DistriOptimizer$:281 - [Epoch 1 256/15959][Iteration 3][Wall Clock 1.825813752s] Train 128 in 0.416944447seconds. Throughput is 306.99533 records/second. Loss is 2.9985175.

```

## How was this patch tested?

manually tested

