### PR TITLE
fix: at the end of make-dist.sh, copy wrong file.

### DIFF
--- a/make-dist.sh
+++ b/make-dist.sh
@@ -71,6 +71,6 @@ cp $BASEDIR/scripts/classes.lst $BIN_DIR/
 cp $BASEDIR/scripts/img_class.lst $BIN_DIR/
 cp $BASEDIR/spark/dl/src/main/resources/spark-bigdl.conf $CONF_DIR/
 
-cp $BASEDIR/spark/dl/target/bigdl-$VERSION-jar-with-dependencies.jar $LIB_DIR/
-cp $BASEDIR/target/bigdl-$VERSION-python-api.zip $LIB_DIR/
+cp $BASEDIR/spark/dl/target/bigdl-$VERSION-SNAPSHOT-jar-with-dependencies.jar $LIB_DIR/
+cp $BASEDIR/target/bigdl-$VERSION-SNAPSHOT-python-api.zip $LIB_DIR/
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

copy right jar and zip, which has been changed with SNAPSHOT.

## How was this patch tested?

manual.


