### PR TITLE
[Issue 792]throw exceptions after retry exceeds settings

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -741,6 +741,8 @@ class DistriOptimizer[T: ClassTag] (
         )
         retryNum = Int.MaxValue
       } catch {
+        case e: IllegalArgumentException =>
+          throw e
         case t: Throwable =>
           DistriOptimizer.logger.error("Error: " + ExceptionUtils.getStackTrace(t))
           if (checkpointPath.isDefined) {
@@ -750,6 +752,9 @@ class DistriOptimizer[T: ClassTag] (
              */
             if (System.nanoTime() - lastFailureTimestamp < maxRetry * retryTimeInterval * 1e9) {
               retryNum += 1
+              if (retryNum == maxRetry) {
+                throw t
+              }
             } else {
               retryNum = 1
             }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DistriOptimizerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DistriOptimizerSpec.scala
@@ -389,6 +389,8 @@ class DistriOptimizerSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     val result2 = model.forward(input2).asInstanceOf[Tensor[Double]]
     result2(Array(1)) should be(1.0 +- 5e-2)
+
+    ExceptionTest.resetCount()
   }
 
   "Train with MSE and SGD" should "be trained with good result with failures in big interval" in {
@@ -411,5 +413,27 @@ class DistriOptimizerSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     val result2 = model.forward(input2).asInstanceOf[Tensor[Double]]
     result2(Array(1)) should be(1.0 +- 5e-2)
+
+    ExceptionTest.resetCount()
+  }
+
+  "Train with MSE and SGD" should "throw exception after retry times exceed settings" in {
+    val filePath = java.io.File.createTempFile("OptimizerSpec", "model").getAbsolutePath
+    Files.delete(Paths.get(filePath))
+    Files.createDirectory(Paths.get(filePath))
+    val failCountNumberList = Array(800, 850, 900)
+    System.setProperty("bigdl.failure.retryTimes", "3")
+    val mm = mserf(failCountNumberList)
+    mm.getParameters()._1.fill(0.125)
+    val optimizer = new DistriOptimizer[Double](mm, dataSet, new MSECriterion[Double]())
+      .setState(T("learningRate" -> 20.0))
+      .setEndWhen(Trigger.maxEpoch(5))
+      .setCheckpoint(filePath, Trigger.everyEpoch)
+
+    intercept[Exception] {
+      optimizer.optimize()
+    }
+
+    ExceptionTest.resetCount()
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/TestUtils.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/TestUtils.scala
@@ -182,4 +182,8 @@ class ExceptionTest[T: ClassTag](failCountNumberLists: Array[Int], sleep: Boolea
 
 object ExceptionTest {
   var count = new AtomicInteger(0)
+
+  def resetCount(): Unit = {
+    count.set(0)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Optimizer throw exceptions if retry numbers exceed max retry numbers.

## How was this patch tested?
unit test

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/792

