### PR TITLE
[WIP] Remove calls to deprecated Engine.init, by removing use of System properties for Spark config

### DIFF
--- a/scripts/bigdl.sh
+++ b/scripts/bigdl.sh
@@ -54,10 +54,6 @@ parse() {
             export DL_CORE_NUMBER="$2"
             shift 2
             ;;
-            -l|--local)
-            export BIGDL_LOCAL_MODE="1"
-            shift 1
-            ;;
             --)
             shift
             for token in "$@"; do

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/imageclassification/ImagePredictor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/imageclassification/ImagePredictor.scala
@@ -22,7 +22,7 @@ import com.intel.analytics.bigdl.example.imageclassification.MlUtils._
 import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.utils.{Engine, LoggerFilter}
 import org.apache.log4j.{Level, Logger}
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.ml.{DLClassifier => SparkDLClassifier}
 import org.apache.spark.sql.SQLContext
@@ -36,10 +36,11 @@ object ImagePredictor {
 
   def main(args: Array[String]): Unit = {
     predictParser.parse(args, new PredictParams()).map(param => {
-      val conf = Engine.createSparkConf()
-      conf.setAppName("Predict with trained model")
-      val sc = new SparkContext(conf)
-      Engine.init
+      val conf = Engine.createSparkConf(new SparkConf()
+        .setIfMissing("spark.master", "local[*]")
+        .setAppName("Predict with trained model"))
+      val sc = SparkContext.getOrCreate(conf)
+      Engine.init(conf)
       val sqlContext = new SQLContext(sc)
 
       val partitionNum = Engine.nodeNumber() * Engine.coreNumber()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/loadmodel/ModelValidator.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/loadmodel/ModelValidator.scala
@@ -16,11 +16,9 @@
 
 package com.intel.analytics.bigdl.example.loadmodel
 
-import java.nio.file.Paths
-
 import com.intel.analytics.bigdl.models.inception.Inception_v1_NoAuxClassifier
 import com.intel.analytics.bigdl.nn.Module
-import com.intel.analytics.bigdl.optim.{Top1Accuracy, Top5Accuracy, Validator}
+import com.intel.analytics.bigdl.optim.{Top1Accuracy, Top5Accuracy}
 import com.intel.analytics.bigdl.utils.Engine
 import org.apache.log4j.Logger
 import org.apache.spark.SparkContext
@@ -100,8 +98,8 @@ object ModelValidator {
     testLocalParser.parse(args, TestLocalParams()).foreach(param => {
       val conf = Engine.createSparkConf()
       conf.setAppName("BigDL Image Classifier Example")
-      val sc = new SparkContext(conf)
-      Engine.init
+      val sc = SparkContext.getOrCreate(conf)
+      Engine.init(conf)
 
       val valPath = param.folder
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/udfpredictor/DataframePredictor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/udfpredictor/DataframePredictor.scala
@@ -34,8 +34,8 @@ object DataframePredictor {
       val conf = Engine.createSparkConf()
       conf.setAppName("Text classification")
         .set("spark.task.maxFailures", "1")
-      val sc = new SparkContext(conf)
-      Engine.init
+      val sc = SparkContext.getOrCreate(conf)
+      Engine.init(conf)
 
       // Create spark session
       val spark = new SQLContext(sc)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/udfpredictor/StructuredStreamPredictor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/udfpredictor/StructuredStreamPredictor.scala
@@ -41,7 +41,7 @@ object  StructuredStreamPredictor {
         .builder
         .config(sparkConf)
         .getOrCreate()
-      Engine.init
+      Engine.init(sparkConf)
       val sc = spark.sparkContext
 
       var word2Meta = None: Option[Map[String, WordMeta]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/utils/TextClassifier.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/utils/TextClassifier.scala
@@ -24,10 +24,9 @@ import com.intel.analytics.bigdl.dataset._
 import com.intel.analytics.bigdl.nn.{ClassNLLCriterion, _}
 import com.intel.analytics.bigdl.optim._
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.bigdl.utils.{Engine, LoggerFilter, T}
+import com.intel.analytics.bigdl.utils.{Engine, T}
 import com.intel.analytics.bigdl.example.utils.SimpleTokenizer._
 import org.apache.spark.SparkContext
-import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -203,8 +202,8 @@ class TextClassifier(param: AbstractTextClassificationParams) extends Serializab
     val conf = Engine.createSparkConf()
       .setAppName("Text classification")
       .set("spark.task.maxFailures", "1")
-    val sc = new SparkContext(conf)
-    Engine.init
+    val sc = SparkContext.getOrCreate(conf)
+    Engine.init(conf)
     val sequenceLen = param.maxSequenceLength
     val embeddingDim = param.embeddingDim
     val trainingSplit = param.trainingSplit

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/autoencoder/Train.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/autoencoder/Train.scala
@@ -26,7 +26,7 @@ import com.intel.analytics.bigdl.optim._
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric._
 import com.intel.analytics.bigdl.utils.{Engine, T}
 import org.apache.log4j.{Level, Logger}
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkConf, SparkContext}
 
 object toAutoencoderBatch {
   def apply(): toAutoencoderBatch[Float] = new toAutoencoderBatch[Float]()
@@ -50,10 +50,11 @@ object Train {
 
   def main(args: Array[String]): Unit = {
     trainParser.parse(args, new TrainParams()).map(param => {
-      val conf = Engine.createSparkConf().setAppName("Train Autoencoder on MNIST")
-
-      val sc = new SparkContext(conf)
-      Engine.init
+      val conf = Engine.createSparkConf(new SparkConf()
+        .setMaster("local[*]")
+        .setAppName("Train Autoencoder on MNIST"))
+      val sc = SparkContext.getOrCreate(conf)
+      Engine.init(conf)
 
       val trainData = Paths.get(param.folder, "/train-images-idx3-ubyte")
       val trainLabel = Paths.get(param.folder, "/train-labels-idx1-ubyte")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/inception/Test.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/inception/Test.scala
@@ -19,11 +19,11 @@ package com.intel.analytics.bigdl.models.inception
 import com.intel.analytics.bigdl.dataset.{ByteRecord, DataSet}
 import com.intel.analytics.bigdl.dataset.image._
 import com.intel.analytics.bigdl.nn.Module
-import com.intel.analytics.bigdl.optim.{Top1Accuracy, Top5Accuracy, Validator}
+import com.intel.analytics.bigdl.optim.{Top1Accuracy, Top5Accuracy}
 import com.intel.analytics.bigdl.utils.Engine
 import org.apache.hadoop.io.Text
 import org.apache.log4j.{Level, Logger}
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkConf, SparkContext}
 
 object Test {
   Logger.getLogger("org").setLevel(Level.ERROR)
@@ -38,9 +38,11 @@ object Test {
   def main(args: Array[String]) {
     testParser.parse(args, new TestParams()).foreach { param =>
       val batchSize = param.batchSize.getOrElse(128)
-      val conf = Engine.createSparkConf().setAppName("Test Inception on ImageNet")
-      val sc = new SparkContext(conf)
-      Engine.init
+      val conf = Engine.createSparkConf(new SparkConf()
+        .setMaster("local[*]")
+        .setAppName("Test Inception on ImageNet"))
+      val sc = SparkContext.getOrCreate(conf)
+      Engine.init(conf)
 
       // We set partition number to be node*core, actually you can also assign other partitionNum
       val partitionNum = Engine.nodeNumber() * Engine.coreNumber()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/inception/Train.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/inception/Train.scala
@@ -20,7 +20,7 @@ import com.intel.analytics.bigdl.nn.{ClassNLLCriterion, Module}
 import com.intel.analytics.bigdl.optim._
 import com.intel.analytics.bigdl.utils.{Engine, LoggerFilter, T}
 import org.apache.log4j.{Level, Logger}
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkConf, SparkContext}
 
 object TrainInceptionV1 {
   LoggerFilter.redirectSparkInfoLogs()
@@ -31,10 +31,12 @@ object TrainInceptionV1 {
   def main(args: Array[String]): Unit = {
     trainParser.parse(args, new TrainParams()).map(param => {
       val imageSize = 224
-      val conf = Engine.createSparkConf().setAppName("BigDL Inception v1 Train Example")
-        .set("spark.task.maxFailures", "1")
-      val sc = new SparkContext(conf)
-      Engine.init
+      val conf = Engine.createSparkConf(new SparkConf()
+        .setMaster("local[*]")
+        .setAppName("BigDL Inception v1 Train Example")
+        .set("spark.task.maxFailures", "1"))
+      val sc = SparkContext.getOrCreate(conf)
+      Engine.init(conf)
 
       val trainSet = ImageNet2012(
         param.folder + "/train",

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/lenet/Test.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/lenet/Test.scala
@@ -16,15 +16,12 @@
 
 package com.intel.analytics.bigdl.models.lenet
 
-import java.nio.file.Paths
-
-import com.intel.analytics.bigdl.dataset.DataSet
 import com.intel.analytics.bigdl.dataset.image.{BytesToGreyImg, GreyImgNormalizer, GreyImgToSample}
 import com.intel.analytics.bigdl.nn.Module
 import com.intel.analytics.bigdl.optim.Top1Accuracy
 import com.intel.analytics.bigdl.utils.Engine
 import org.apache.log4j.{Level, Logger}
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkConf, SparkContext}
 
 object Test {
   Logger.getLogger("org").setLevel(Level.ERROR)
@@ -36,11 +33,13 @@ object Test {
 
   def main(args: Array[String]): Unit = {
     testParser.parse(args, new TestParams()).foreach { param =>
-      val conf = Engine.createSparkConf().setAppName("Test Lenet on MNIST")
-        .set("spark.akka.frameSize", 64.toString)
-        .set("spark.task.maxFailures", "1")
-      val sc = new SparkContext(conf)
-      Engine.init
+      val conf = Engine.createSparkConf(new SparkConf()
+        .setMaster("local[*]")
+        .setAppName("Test Lenet on MNIST")
+        .set("spark.akka.frameSize", "64")
+        .set("spark.task.maxFailures", "1"))
+      val sc = SparkContext.getOrCreate(conf)
+      Engine.init(conf)
 
       val validationData = param.folder + "/t10k-images-idx3-ubyte"
       val validationLabel = param.folder + "/t10k-labels-idx1-ubyte"

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/lenet/Train.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/lenet/Train.scala
@@ -16,8 +16,6 @@
 
 package com.intel.analytics.bigdl.models.lenet
 
-import java.nio.file.Paths
-
 import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.dataset.DataSet
 import com.intel.analytics.bigdl.dataset.image.{BytesToGreyImg, GreyImgNormalizer, GreyImgToBatch}
@@ -26,7 +24,7 @@ import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.optim._
 import com.intel.analytics.bigdl.utils.{Engine, LoggerFilter, T}
 import org.apache.log4j.{Level, Logger}
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkConf, SparkContext}
 
 object Train {
   LoggerFilter.redirectSparkInfoLogs()
@@ -36,11 +34,12 @@ object Train {
 
   def main(args: Array[String]): Unit = {
     trainParser.parse(args, new TrainParams()).map(param => {
-      val conf = Engine.createSparkConf()
+      val conf = Engine.createSparkConf(new SparkConf()
+        .setIfMissing("spark.master", "local[*]")
         .setAppName("Train Lenet on MNIST")
-        .set("spark.task.maxFailures", "1")
-      val sc = new SparkContext(conf)
-      Engine.init
+        .set("spark.task.maxFailures", "1"))
+      val sc = SparkContext.getOrCreate(conf)
+      Engine.init(conf)
 
       val trainData = param.folder + "/train-images-idx3-ubyte"
       val trainLabel = param.folder + "/train-labels-idx1-ubyte"

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/resnet/Train.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/resnet/Train.scala
@@ -22,7 +22,7 @@ import com.intel.analytics.bigdl.models.resnet.ResNet.{DatasetType, ShortcutType
 import com.intel.analytics.bigdl.optim._
 import com.intel.analytics.bigdl.utils.{Engine, LoggerFilter, T}
 import org.apache.log4j.{Level, Logger}
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkConf, SparkContext}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric._
 
 object Train {
@@ -36,9 +36,11 @@ object Train {
 
   def main(args: Array[String]): Unit = {
     trainParser.parse(args, new TrainParams()).map(param => {
-      val conf = Engine.createSparkConf().setAppName("Train ResNet on Cifar10")
-      val sc = new SparkContext(conf)
-      Engine.init
+      val conf = Engine.createSparkConf(new SparkConf()
+        .setMaster("local[*]")
+        .setAppName("Train ResNet on Cifar10"))
+      val sc = SparkContext.getOrCreate(conf)
+      Engine.init(conf)
 
       val batchSize = param.batchSize
       val (imageSize, lrSchedule, maxEpoch, dataSet) =

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Test.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Test.scala
@@ -17,16 +17,13 @@
 package com.intel.analytics.bigdl.models.rnn
 
 
-import com.intel.analytics.bigdl.dataset.{DataSet, LocalDataSet, MiniBatch, SampleToBatch}
+import com.intel.analytics.bigdl.dataset.SampleToBatch
 import com.intel.analytics.bigdl.dataset.text.{Dictionary, LabeledSentence, LabeledSentenceToSample}
-import com.intel.analytics.bigdl.nn.{Concat, Identity, LogSoftMax, Module}
+import com.intel.analytics.bigdl.nn.Module
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Engine
 import org.apache.log4j.{Level, Logger}
-import org.apache.spark.SparkContext
-import org.apache.spark.rdd.RDD
-
-import scala.util.Random
+import org.apache.spark.{SparkConf, SparkContext}
 
 object Test {
   Logger.getLogger("org").setLevel(Level.ERROR)
@@ -41,11 +38,12 @@ object Test {
     testParser.parse(args, new TestParams()).foreach { param =>
 
       val vocab = Dictionary(param.folder)
-      val conf = Engine.createSparkConf()
-        .setAppName("Test rnn on text")
-        .set("spark.task.maxFailures", "1")
-      val sc = new SparkContext(conf)
-      Engine.init
+      val conf = Engine.createSparkConf(new SparkConf()
+        .setIfMissing("spark.master", "local[*]")
+        .setAppName("Test RNN on text")
+        .set("spark.task.maxFailures", "1"))
+      val sc = SparkContext.getOrCreate(conf)
+      Engine.init(conf)
 
       val model = Module.load[Float](param.modelSnapshot.get)
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Train.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Train.scala
@@ -17,7 +17,7 @@
 package com.intel.analytics.bigdl.models.rnn
 
 import com.intel.analytics.bigdl._
-import com.intel.analytics.bigdl.dataset.{DataSet, SampleToBatch}
+import com.intel.analytics.bigdl.dataset.SampleToBatch
 import com.intel.analytics.bigdl.dataset.text.LabeledSentenceToSample
 import com.intel.analytics.bigdl.dataset.text._
 import com.intel.analytics.bigdl.dataset.text.utils.SentenceToken
@@ -27,7 +27,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.{Engine, T}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric._
 import org.apache.log4j.{Level, Logger}
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkConf, SparkContext}
 
 object Train {
   Logger.getLogger("org").setLevel(Level.ERROR)
@@ -38,12 +38,12 @@ object Train {
   val logger = Logger.getLogger(getClass)
   def main(args: Array[String]): Unit = {
     trainParser.parse(args, new TrainParams()).map(param => {
-
-      val conf = Engine.createSparkConf()
-        .setAppName("Train rnn on text")
-        .set("spark.task.maxFailures", "1")
-      val sc = new SparkContext(conf)
-      Engine.init
+      val conf = Engine.createSparkConf(new SparkConf()
+        .setIfMissing("spark.master", "local[*]")
+        .setAppName("Train RNN on text")
+        .set("spark.task.maxFailures", "1"))
+      val sc = SparkContext.getOrCreate(conf)
+      Engine.init(conf)
 
       val tokens = SequencePreprocess(
         param.dataFolder + "/train.txt",

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/DistriOptimizerPerf.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/DistriOptimizerPerf.scala
@@ -103,8 +103,8 @@ object DistriOptimizerPerf {
     val criterion = ClassNLLCriterion[Float]()
     val labels = Tensor(param.batchSize).fill(1)
 
-    val sc = new SparkContext(conf)
-    Engine.init
+    val sc = SparkContext.getOrCreate(conf)
+    Engine.init(conf)
     val broadcast = sc.broadcast(MiniBatch(input, labels))
     val rdd = sc.parallelize((1 to Engine.nodeNumber()), Engine.nodeNumber())
       .mapPartitions(iter => {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/Test.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/Test.scala
@@ -16,14 +16,12 @@
 
 package com.intel.analytics.bigdl.models.vgg
 
-import com.intel.analytics.bigdl.dataset.DataSet
 import com.intel.analytics.bigdl.dataset.image._
-import com.intel.analytics.bigdl.models.lenet.Utils._
 import com.intel.analytics.bigdl.nn.Module
-import com.intel.analytics.bigdl.optim.{Top1Accuracy, Validator}
+import com.intel.analytics.bigdl.optim.Top1Accuracy
 import com.intel.analytics.bigdl.utils.Engine
 import org.apache.log4j.{Level, Logger}
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkConf, SparkContext}
 
 object Test {
   Logger.getLogger("org").setLevel(Level.ERROR)
@@ -35,10 +33,11 @@ object Test {
 
   def main(args: Array[String]) {
     testParser.parse(args, new TestParams()).foreach { param =>
-      val conf = Engine.createSparkConf().setAppName("Test Vgg on Cifar10")
-        .set("spark.akka.frameSize", 64.toString)
-      val sc = new SparkContext(conf)
-      Engine.init
+      val conf = Engine.createSparkConf(new SparkConf()
+        .setIfMissing("spark.master", "local[*]")
+        .setAppName("Test Vgg on Cifar10"))
+      val sc = SparkContext.getOrCreate(conf)
+      Engine.init(conf)
 
       val partitionNum = Engine.nodeNumber() * Engine.coreNumber()
       val rddData = sc.parallelize(Utils.loadTest(param.folder), partitionNum)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/Train.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/Train.scala
@@ -23,7 +23,7 @@ import com.intel.analytics.bigdl.optim._
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric._
 import com.intel.analytics.bigdl.utils.{Engine, LoggerFilter, T}
 import org.apache.log4j.{Level, Logger}
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkConf, SparkContext}
 
 object Train {
   LoggerFilter.redirectSparkInfoLogs()
@@ -33,9 +33,11 @@ object Train {
 
   def main(args: Array[String]): Unit = {
     trainParser.parse(args, new TrainParams()).map(param => {
-      val conf = Engine.createSparkConf().setAppName("Train Vgg on Cifar10")
-      val sc = new SparkContext(conf)
-      Engine.init
+      val conf = Engine.createSparkConf(new SparkConf()
+        .setIfMissing("spark.master", "local[*]")
+        .setAppName("Train Vgg on Cifar10"))
+      val sc = SparkContext.getOrCreate(conf)
+      Engine.init(conf)
 
       val trainDataSet = DataSet.array(Utils.loadTrain(param.folder), sc) ->
         BytesToBGRImg() -> BGRImgNormalizer(trainMean, trainStd) ->

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -353,7 +353,7 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag,
    * @return node containing current module
    */
   def apply(nodes : ModuleNode[T]*): ModuleNode[T] = {
-    require(this.isInstanceOf[AbstractModule[_, Tensor[T], T]],
+    require(this.isInstanceOf[AbstractModule[_, _, _]],
       "AbstractModule: Only module with tensor output can be added into a graph node")
     val curNode = new ModuleNode[T](this.asInstanceOf[AbstractModule[Activity, Tensor[T], T]])
     nodes.foreach(node => {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -23,9 +23,8 @@ import com.intel.analytics.bigdl.parameters.AllReduceParameter
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils._
-import java.io.{File, FileFilter, FilenameFilter}
+import java.io.{File, FilenameFilter}
 import java.text.SimpleDateFormat
-import java.util.Calendar
 
 import org.apache.commons.lang.exception.ExceptionUtils
 import com.intel.analytics.bigdl.visualization.{TrainSummary, ValidationSummary}
@@ -720,7 +719,7 @@ class DistriOptimizer[T: ClassTag] (
 
     if (checkpointPath.isDefined) {
       val file = checkpointPath.get + "/" +
-        new SimpleDateFormat("yyyyMMdd_HHmmss").format(Calendar.getInstance().getTime())
+        new SimpleDateFormat("yyyyMMdd_HHmmss").format(System.currentTimeMillis())
       new File(file).mkdir()
       checkpointPath = Some(file)
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -19,7 +19,7 @@ package com.intel.analytics.bigdl.python.api
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, Map => JMap}
 
 import com.intel.analytics.bigdl._
-import com.intel.analytics.bigdl.dataset.{Sample => JSample, Identity => DIdentity, _}
+import com.intel.analytics.bigdl.dataset.{Identity => DIdentity, Sample => JSample, _}
 import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, TensorCriterion, TensorModule}
 import com.intel.analytics.bigdl.numeric._
@@ -28,6 +28,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils._
 import com.intel.analytics.bigdl.visualization.{Summary, TrainSummary, ValidationSummary}
+import org.apache.spark.SparkConf
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.rdd.RDD
 import java.lang.{Integer, Boolean => JBoolean}
@@ -1333,7 +1334,7 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
 
 
   def initEngine(): Unit = {
-    Engine.init
+    Engine.init(Engine.createSparkConf())
   }
 
   def uniform(a: Double, b: Double, size: JList[Int]): JTensor = {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/SparkContextSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/SparkContextSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl
+
+import com.intel.analytics.bigdl.utils.Engine
+import org.apache.spark.{SparkConf, SparkContext}
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+
+/**
+ * Superclass for Specs that need to set up and tear down a SparkContext
+ */
+private[bigdl] abstract class SparkContextSpec extends FlatSpec with Matchers with BeforeAndAfter {
+
+  private var _sc: SparkContext = _
+
+  // Tests can override these to change master, config
+  private[bigdl] def getNodeNumber: Int = 1
+  private[bigdl] def getCoreNumber: Int = 1
+  private[bigdl] def getExtraConf: Map[String, String] = Map()
+  
+  private[bigdl] def sc: SparkContext = {
+    if (_sc == null) {
+      val conf = new SparkConf()
+        .setAppName(getClass.getSimpleName)
+        .setMaster(s"local[$getCoreNumber]")
+        .set("spark.executor.cores", getCoreNumber.toString)
+      conf.setAll(getExtraConf)
+      val bigdlConf = Engine.createSparkConf(conf)
+      _sc = SparkContext.getOrCreate(bigdlConf)
+      Engine.init(bigdlConf)
+      // hacky: always test in local mode but pretend like we have many nodes if > 1
+      if (getNodeNumber > 1) {
+        Engine.setNodeNumber(getNodeNumber)
+      }
+    }
+    _sc
+  }
+
+  after {
+    if (_sc != null) {
+      _sc.stop()
+      _sc = null
+      Engine.reset()
+    }
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/text/DictionarySpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/text/DictionarySpec.scala
@@ -18,29 +18,12 @@ package com.intel.analytics.bigdl.dataset.text
 
 import java.io.PrintWriter
 
+import com.intel.analytics.bigdl.SparkContextSpec
 import com.intel.analytics.bigdl.dataset.DataSet
-import com.intel.analytics.bigdl.utils.Engine
-import org.apache.spark.{SparkConf, SparkContext}
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.io.Source
 
-class DictionarySpec extends FlatSpec with Matchers with BeforeAndAfter {
-  var sc: SparkContext = null
-
-  before {
-    val nodeNumber = 1
-    val coreNumber = 1
-    Engine.init(nodeNumber, coreNumber, true)
-    val conf = new SparkConf().setMaster("local[1]").setAppName("DictionarySpec")
-    sc = new SparkContext(conf)
-  }
-
-  after {
-    if (sc != null) {
-      sc.stop()
-    }
-  }
+class DictionarySpec extends SparkContextSpec {
 
   "DictionarySpec" should "creates dictionary correctly on Spark" in {
     val tmpFile = java.io.File

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/text/SentenceBiPaddingSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/text/SentenceBiPaddingSpec.scala
@@ -18,29 +18,15 @@ package com.intel.analytics.bigdl.dataset.text
 
 import java.io.PrintWriter
 
+import com.intel.analytics.bigdl.SparkContextSpec
 import com.intel.analytics.bigdl.dataset.DataSet
 import com.intel.analytics.bigdl.dataset.text.utils.SentenceToken
-import com.intel.analytics.bigdl.utils.Engine
 import org.apache.spark.SparkContext
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.io.Source
 
 @com.intel.analytics.bigdl.tags.Serial
-class SentenceBiPaddingSpec extends FlatSpec with Matchers with BeforeAndAfter {
-  var sc: SparkContext = null
-
-  before {
-    val nodeNumber = 1
-    val coreNumber = 1
-    Engine.init(nodeNumber, coreNumber, true)
-  }
-
-  after {
-    if (sc != null) {
-      sc.stop()
-    }
-  }
+class SentenceBiPaddingSpec extends SparkContextSpec {
 
   "SentenceBiPaddingSpec" should "pads articles correctly on Spark" in {
     val tmpFile = java.io.File
@@ -56,7 +42,6 @@ class SentenceBiPaddingSpec extends FlatSpec with Matchers with BeforeAndAfter {
       write(sentences.mkString("\n")); close
     }
 
-    sc = new SparkContext("local[1]", "DocumentTokenizer")
     val sents = DataSet.rdd(sc.textFile(tmpFile)
       .filter(!_.isEmpty)).transform(SentenceSplitter())
       .toDistributed().data(train = false).flatMap(item => item.iterator).collect()
@@ -76,7 +61,6 @@ class SentenceBiPaddingSpec extends FlatSpec with Matchers with BeforeAndAfter {
       startToken should be (SentenceToken.start)
       endToken should be (SentenceToken.end)
     })
-    sc.stop()
   }
 
   "SentenceBiPaddingSpec" should "pads articles correctly on local" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/text/SentenceTokenizerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/text/SentenceTokenizerSpec.scala
@@ -18,14 +18,12 @@ package com.intel.analytics.bigdl.dataset.text
 
 import java.io.PrintWriter
 
+import com.intel.analytics.bigdl.SparkContextSpec
 import com.intel.analytics.bigdl.dataset.DataSet
-import com.intel.analytics.bigdl.utils.Engine
-import org.apache.spark.{SparkConf, SparkContext}
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.io.Source
 
-class SentenceTokenizerSpec extends FlatSpec with Matchers {
+class SentenceTokenizerSpec extends SparkContextSpec {
 
   "SentenceTokenizerSpec" should "tokenizes articles correctly on Spark" in {
     val tmpFile = java.io.File
@@ -41,9 +39,6 @@ class SentenceTokenizerSpec extends FlatSpec with Matchers {
       write(sentences.mkString("\n")); close
     }
 
-    Engine.init(1, 1, true)
-    val conf = new SparkConf().setMaster("local[1]").setAppName("DocumentTokenizer")
-    val sc = new SparkContext(conf)
     val sents = DataSet.rdd(sc.textFile(tmpFile)
       .filter(!_.isEmpty)).transform(SentenceSplitter())
       .toDistributed().data(train = false).flatMap(item => item.iterator).collect()

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/text/TextToLabeledSentenceSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/text/TextToLabeledSentenceSpec.scala
@@ -18,29 +18,13 @@ package com.intel.analytics.bigdl.dataset.text
 
 import java.io.PrintWriter
 
+import com.intel.analytics.bigdl.SparkContextSpec
 import com.intel.analytics.bigdl.dataset.DataSet
-import com.intel.analytics.bigdl.utils.Engine
-import org.apache.spark.SparkContext
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.io.Source
 
 @com.intel.analytics.bigdl.tags.Serial
-class TextToLabeledSentenceSpec extends FlatSpec with Matchers with BeforeAndAfter {
-  var sc: SparkContext = null
-
-  before {
-    val nodeNumber = 1
-    val coreNumber = 1
-    Engine.init(nodeNumber, coreNumber, true)
-    sc = new SparkContext("local[1]", "TextToLabeledSentence")
-  }
-
-  after {
-    if (sc != null) {
-      sc.stop()
-    }
-  }
+class TextToLabeledSentenceSpec extends SparkContextSpec {
 
   "TextToLabeledSentenceSpec" should "indexes sentences correctly on Spark" in {
     val tmpFile = java.io.File

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/integration/HdfsSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/integration/HdfsSpec.scala
@@ -19,25 +19,16 @@ import java.nio.file.{Files, Paths}
 
 import com.intel.analytics.bigdl.models.lenet.LeNet5
 import com.intel.analytics.bigdl.nn.Module
-import com.intel.analytics.bigdl.utils.File
+import com.intel.analytics.bigdl.utils.{File, TestUtils}
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
-
 
 @com.intel.analytics.bigdl.tags.Integration
 class HdfsSpec extends FlatSpec with Matchers with BeforeAndAfter{
 
-    val hdfs = System.getProperty("hdfsMaster")
-    val mnistFolder = System.getProperty("mnist")
+  private val hdfs = System.getProperty("hdfsMaster")
+  private val mnistFolder = System.getProperty("mnist")
 
-  private def processPath(path: String): String = {
-    if (path.contains(":")) {
-      path.substring(1)
-    } else {
-      path
-    }
-  }
-
-  "save and load model from hdfs" should "be correct" in {
+  "save and load model from HDFS" should "be correct" in {
     val model = LeNet5(10)
     val hdfsPath = hdfs + "/lenet.obj"
     File.saveToHdfs(model, hdfsPath, true)
@@ -51,13 +42,13 @@ class HdfsSpec extends FlatSpec with Matchers with BeforeAndAfter{
     hdfsModel should be (localModel)
   }
 
-  "load minist from hdfs" should "be correct" in {
+  "load MNIST from HDFS" should "be correct" in {
     val folder = mnistFolder + "/t10k-images-idx3-ubyte"
     val resource = getClass().getClassLoader().getResource("mnist")
 
     val hdfsData = File.readHdfsByte(folder)
     val localData = Files.readAllBytes(
-      Paths.get(processPath(resource.getPath()), "/t10k-images.idx3-ubyte"))
+      Paths.get(TestUtils.processPath(resource.getPath()), "/t10k-images.idx3-ubyte"))
 
     hdfsData should be (localData)
   }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/integration/SparkModeSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/integration/SparkModeSpec.scala
@@ -23,18 +23,17 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 @com.intel.analytics.bigdl.tags.Integration
 class SparkModeSpec extends FlatSpec with Matchers with BeforeAndAfter{
 
-  val mnistFolder = System.getProperty("mnist")
-  val cifarFolder = System.getProperty("cifar")
-  val jarPath = System.getProperty("spark.jars")
+  private val mnistFolder = System.getProperty("mnist")
+  private val cifarFolder = System.getProperty("cifar")
 
   "Lenet model train and validate" should "be correct" in {
-    val batchSize = System.getProperty("spark.cores.max").toInt * 4
+    val batchSize = 2 * 4
     val args = Array("--folder", mnistFolder, "-b", batchSize.toString, "-e", "1")
     lenet.Train.main(args)
   }
 
   "Vgg model train and validate" should "be correct" in {
-    val batchSize = System.getProperty("spark.cores.max").toInt * 4
+    val batchSize = 2 * 4
     val args = Array("--folder", cifarFolder, "-b", batchSize.toString, "-e", "1")
     vgg.Train.main(args)
   }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcastSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcastSpec.scala
@@ -15,20 +15,14 @@
  */
 package com.intel.analytics.bigdl.models.utils
 
+import com.intel.analytics.bigdl.SparkContextSpec
 import com.intel.analytics.bigdl.models.lenet.LeNet5
 import org.apache.log4j.{Level, Logger}
-import org.apache.spark.{SparkConf, SparkContext}
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
-class ModelBroadcastSpec extends FlatSpec with Matchers with BeforeAndAfter {
-
-  var sc: SparkContext = null
+class ModelBroadcastSpec extends SparkContextSpec {
 
   Logger.getLogger("org").setLevel(Level.WARN)
   Logger.getLogger("akka").setLevel(Level.WARN)
-  before {
-    sc = new SparkContext(new SparkConf().setMaster("local[1]").setAppName("ModelBroadcast"))
-  }
 
   "model broadcast" should "work properly" in {
     val model = LeNet5(10)
@@ -47,10 +41,5 @@ class ModelBroadcastSpec extends FlatSpec with Matchers with BeforeAndAfter {
     modelBroadCast.value().parameters()._1 should be(model.parameters()._1)
   }
 
-  after {
-    if (sc != null) {
-      sc.stop()
-    }
-  }
 
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DistributedMetricsSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DistributedMetricsSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.optim
+
+import com.intel.analytics.bigdl.SparkContextSpec
+import org.apache.spark.SparkException
+
+@com.intel.analytics.bigdl.tags.Serial
+class DistributedMetricsSpec extends SparkContextSpec {
+
+  override def getCoreNumber: Int = 5
+ 
+  it should "work on distributed metric" in {
+    val metric = new Metrics
+    metric.set("test", 1.0, sc, 5)
+    sc.parallelize((1 to 5)).map(i => metric.add("test", i)).count
+    val result = metric.get("test")
+    result._1 should be(16.0)
+    result._2 should be(5)
+  }
+
+  it should "throw exception when the distributed metric isn't exsited" in {
+    val metric = new Metrics
+    intercept[SparkException] {
+      sc.parallelize((1 to 5)).map(i => metric.add("test", i)).count
+    }
+  }
+
+  "summary" should "work" in {
+    val metric = new Metrics
+    metric.set("test1", 1.0, sc, 5)
+    metric.set("test2", 5.0, sc, 2)
+    metric.summary() should be("========== Metrics Summary ==========\n" +
+      "test2 : 2.5E-9 s\ntest1 : 2.0E-10 s\n=====================================")
+  }
+
+  it should "work when change the unit and scale" in {
+    val metric = new Metrics
+    metric.set("test1", 1.0, sc, 5)
+    metric.set("test2", 5.0, sc, 2)
+    metric.summary("ms", 1e6) should be("========== Metrics Summary ==========\n" +
+      "test2 : 2.5E-6 ms\ntest1 : 2.0000000000000002E-7 ms\n=====================================")
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/EvaluatorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/EvaluatorSpec.scala
@@ -16,41 +16,14 @@
 
 package com.intel.analytics.bigdl.optim
 
-import com.intel.analytics.bigdl.dataset.{DataSet, Sample, SampleToBatch}
+import com.intel.analytics.bigdl.dataset.{DataSet, Sample}
 import com.intel.analytics.bigdl.models.lenet.LeNet5
 import com.intel.analytics.bigdl.nn.CrossEntropyCriterion
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.bigdl.utils.Engine
 import com.intel.analytics.bigdl.utils.RandomGenerator._
-import org.apache.spark.{SparkConf, SparkContext}
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import com.intel.analytics.bigdl._
 
-class EvaluatorSpec extends FlatSpec with Matchers with BeforeAndAfter{
-
-  var sc: SparkContext = null
-  val nodeNumber = 1
-  val coreNumber = 1
-
-  before {
-    Engine.init(nodeNumber, coreNumber, true)
-    val conf = new SparkConf().setMaster("local[1]").setAppName("evaluator")
-    sc = new SparkContext(conf)
-  }
-
-  after {
-    if (sc != null) {
-      sc.stop()
-    }
-  }
-
-  private def processPath(path: String): String = {
-    if (path.contains(":")) {
-      path.substring(1)
-    } else {
-      path
-    }
-  }
+class EvaluatorSpec extends SparkContextSpec {
 
   "Evaluator" should "be correct" in {
     RNG.setSeed(100)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/LocalOptimizerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/LocalOptimizerSpec.scala
@@ -112,17 +112,12 @@ object LocalOptimizerSpecModel {
 }
 
 @com.intel.analytics.bigdl.tags.Serial
-class LocalOptimizerSpec extends FlatSpec with Matchers with BeforeAndAfter{
+class LocalOptimizerSpec extends SparkContextSpec {
+
   import LocalOptimizerSpecModel._
   import DummyDataSet._
 
-  val nodeNumber = 1
-  val coreNumber = 4
-
-  before {
-    Engine.localMode = true
-    Engine.init(nodeNumber, coreNumber, false)
-  }
+  override def getCoreNumber: Int = 4
 
   "Train model with CrossEntropy and SGD" should "be good" in {
     RandomGenerator.RNG.setSeed(1000)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/PredictorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/PredictorSpec.scala
@@ -16,30 +16,14 @@
 
 package com.intel.analytics.bigdl.optim
 
+import com.intel.analytics.bigdl.SparkContextSpec
 import com.intel.analytics.bigdl.dataset.Sample
 import com.intel.analytics.bigdl.models.lenet.LeNet5
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Engine
 import com.intel.analytics.bigdl.utils.RandomGenerator._
-import org.apache.spark.{SparkConf, SparkContext}
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
-class PredictorSpec extends FlatSpec with Matchers with BeforeAndAfter{
-  var sc: SparkContext = null
-  val nodeNumber = 1
-  val coreNumber = 1
-
-  before {
-    Engine.init(nodeNumber, coreNumber, true)
-    val conf = new SparkConf().setMaster("local[1]").setAppName("predictor")
-    sc = new SparkContext(conf)
-  }
-
-  after {
-    if (sc != null) {
-      sc.stop()
-    }
-  }
+class PredictorSpec extends SparkContextSpec {
 
   "model.predict" should "be correct" in {
     RNG.setSeed(100)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/ValidatorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/ValidatorSpec.scala
@@ -20,38 +20,10 @@ import com.intel.analytics.bigdl.dataset.{DataSet, Sample, SampleToBatch}
 import com.intel.analytics.bigdl.models.lenet.LeNet5
 import com.intel.analytics.bigdl.nn.CrossEntropyCriterion
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.bigdl.utils.Engine
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 import com.intel.analytics.bigdl._
-import org.apache.spark.{SparkConf, SparkContext}
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
-
-class ValidatorSpec extends FlatSpec with Matchers with BeforeAndAfter{
-
-  var sc: SparkContext = null
-  val nodeNumber = 1
-  val coreNumber = 1
-
-  before {
-    Engine.init(nodeNumber, coreNumber, true)
-    val conf = new SparkConf().setMaster("local[1]").setAppName("validator")
-    sc = new SparkContext(conf)
-  }
-
-  after {
-    if (sc != null) {
-      sc.stop()
-    }
-  }
-
-  private def processPath(path: String): String = {
-    if (path.contains(":")) {
-      path.substring(1)
-    } else {
-      path
-    }
-  }
+class ValidatorSpec extends SparkContextSpec {
 
   "DistriValidator" should "be correct" in {
     RNG.setSeed(100)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
@@ -23,37 +23,18 @@ import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.optim.SGD
 import com.intel.analytics.bigdl.optim.Trigger
-import com.intel.analytics.bigdl.utils.Engine
 import com.intel.analytics.bigdl.visualization.{TrainSummary, ValidationSummary}
 import org.apache.log4j.{Level, Logger}
-import org.apache.spark.SparkContext
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.bigdl.api.python.BigDLSerDe
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 
 import scala.util.Random
 
+class PythonSpec extends SparkContextSpec {
 
-class PythonSpec extends FlatSpec with Matchers with BeforeAndAfter {
-
-  var sc: SparkContext = null
-
-  before {
-    sc = new SparkContext(
-      Engine.init(1, 4, true).get
-        .setAppName("Text classification")
-        .set("spark.akka.frameSize", 64.toString)
-        .setMaster("local[2]"))
-  }
-
-  after {
-    if (sc != null) {
-      sc.stop()
-    }
-  }
-
+  override def getCoreNumber: Int = 2
 
   "to jtensor" should "be test" in {
     val pythonBigDL = PythonBigDL.ofFloat()

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/GRUSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/GRUSpec.scala
@@ -23,15 +23,14 @@ import com.intel.analytics.bigdl.numeric.NumericDouble
 import com.intel.analytics.bigdl.optim.SGD
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator._
-import com.intel.analytics.bigdl.utils.{Engine, T}
+import com.intel.analytics.bigdl.utils.T
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.sys.process._
 
 @com.intel.analytics.bigdl.tags.Serial
-class GRUSpec  extends FlatSpec with BeforeAndAfter with Matchers {
-  System.setProperty("bigdl.disableCheckSysEnv", "true")
-  Engine.init(1, 1, true)
+class GRUSpec extends FlatSpec with BeforeAndAfter with Matchers {
+
   before {
     if (!TH.hasTorch()) {
       cancel("Torch is not installed")

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/DLClassifierSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/DLClassifierSpec.scala
@@ -16,37 +16,26 @@
 
 package com.intel.analytics.bigdl.utils
 
+import com.intel.analytics.bigdl.SparkContextSpec
 import com.intel.analytics.bigdl.models.lenet.LeNet5
 import com.intel.analytics.bigdl.tensor.Tensor
 import org.apache.log4j.{Level, Logger}
-import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.ml.DLClassifier
 import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.mllib.linalg.DenseVector
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.sql.{Row, SQLContext}
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
 @com.intel.analytics.bigdl.tags.Parallel
-class DLClassifierSpec extends FlatSpec with Matchers{
-
-  private def processPath(path: String): String = {
-    if (path.contains(":")) {
-      path.substring(1)
-    } else {
-      path
-    }
-  }
+class DLClassifierSpec extends SparkContextSpec {
 
   "DLClassifier" should "get good result" in {
     Logger.getLogger("org").setLevel(Level.WARN)
     Logger.getLogger("akka").setLevel(Level.WARN)
 
-    val conf = new SparkConf().setMaster("local[1]").setAppName("DLClassifier")
-    val sc = new SparkContext(conf)
     val sqlContext = new SQLContext(sc)
     val batchSize = 10
     val model = LeNet5(10)
@@ -86,7 +75,6 @@ class DLClassifierSpec extends FlatSpec with Matchers{
       tensorBuffer.clear()
       m += 1
     }
-    sc.stop()
   }
 }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/LoggerFilterSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/LoggerFilterSpec.scala
@@ -16,28 +16,21 @@
 
 package com.intel.analytics.bigdl.utils
 
+import com.intel.analytics.bigdl.SparkContextSpec
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.numeric.NumericDouble
 import com.intel.analytics.bigdl.optim.{Optimizer, SGD, Trigger}
 import com.intel.analytics.bigdl.nn.{Linear, MSECriterion, Sequential}
 import com.intel.analytics.bigdl.dataset.{DataSet, MiniBatch, Sample, SampleToBatch}
 
-import scala.io.Source
 import java.io.StringWriter
 import java.nio.file.{Files, Paths}
-import org.apache.spark.SparkContext
 import org.apache.log4j.{Level, Logger, PatternLayout, WriterAppender}
 
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
-
 @com.intel.analytics.bigdl.tags.Serial
-class LoggerFilterSpec extends FlatSpec with BeforeAndAfter with Matchers {
+class LoggerFilterSpec extends SparkContextSpec {
 
-  var sc: SparkContext = null
-
-  after {
-    if (sc != null) { sc.stop() }
-  }
+  override def getExtraConf: Map[String, String] = Map("spark.task.maxFailures" -> "1")
 
   def writerAndAppender: (WriterAppender, StringWriter) = {
     // add an appender to optmClz because it's very hard to get the stdout of Log4j.
@@ -69,13 +62,6 @@ class LoggerFilterSpec extends FlatSpec with BeforeAndAfter with Matchers {
     val model = Sequential()
       .add(layer)
     model.reset()
-
-    sc = new SparkContext(
-      Engine.init(1, 1, true).get
-        .setAppName(s"LoggerFilter test")
-        .set("spark.task.maxFailures", "1")
-        .setMaster("local[1]")
-    )
 
     val maxEpoch = 1
     val recordSize = 100
@@ -135,13 +121,6 @@ class LoggerFilterSpec extends FlatSpec with BeforeAndAfter with Matchers {
     LoggerFilter.redirectSparkInfoLogs()
     Logger.getLogger(optimClz).setLevel(Level.INFO)
 
-    sc = new SparkContext(
-      Engine.init(1, 1, true).get
-        .setAppName(s"LoggerFilter test")
-        .set("spark.task.maxFailures", "1")
-        .setMaster("local[1]")
-    )
-
     val data = sc.parallelize(List("bigdl", "spark", "deep", "learning"))
     val y = data.map(x => (x, x.length))
 
@@ -163,13 +142,6 @@ class LoggerFilterSpec extends FlatSpec with BeforeAndAfter with Matchers {
     Logger.getLogger("org").setLevel(Level.INFO)
     LoggerFilter.redirectSparkInfoLogs()
     Logger.getLogger(optimClz).setLevel(Level.INFO)
-
-    sc = new SparkContext(
-      Engine.init(1, 1, true).get
-        .setAppName(s"LoggerFilter test")
-        .set("spark.task.maxFailures", "1")
-        .setMaster("local[1]")
-    )
 
     val data = sc.parallelize(List("bigdl", "spark", "deep", "learning"))
     val y = data.map(x => (x, x.length))
@@ -201,13 +173,6 @@ class LoggerFilterSpec extends FlatSpec with BeforeAndAfter with Matchers {
 
     logger.info("HELLO")
 
-    sc = new SparkContext(
-      Engine.init(1, 1, true).get
-        .setAppName(s"LoggerFilter test")
-        .set("spark.task.maxFailures", "1")
-        .setMaster("local[1]")
-    )
-
     val data = sc.parallelize(List("bigdl", "spark", "deep", "learning"))
     val y = data.map(x => (x, x.length))
 
@@ -236,13 +201,6 @@ class LoggerFilterSpec extends FlatSpec with BeforeAndAfter with Matchers {
     Logger.getLogger("org").setLevel(Level.INFO)
     LoggerFilter.redirectSparkInfoLogs()
     Logger.getLogger(optimClz).setLevel(Level.INFO)
-
-    sc = new SparkContext(
-      Engine.init(1, 1, true).get
-        .setAppName(s"LoggerFilter test")
-        .set("spark.task.maxFailures", "1")
-        .setMaster("local[1]")
-    )
 
     val data = sc.parallelize(List("bigdl", "spark", "deep", "learning"))
     val y = data.map(x => (x, x.length))

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/TestUtils.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/TestUtils.scala
@@ -26,77 +26,7 @@ import scala.reflect.ClassTag
 
 object TestUtils {
   /**
-   * Set envs for spark local mode
-   */
-  def sparkLocalEnv[T](
-    core : Int = 4
-  )(body : => T): Unit = {
-    System.setProperty("SPARK_SUBMIT", "true")
-    System.setProperty("spark.master", s"local[$core]")
-    body
-    System.clearProperty("SPARK_SUBMIT")
-    System.clearProperty("spark.master")
-  }
-
-  /**
-   * Set envs for spark standalone mode
-   */
-  def sparkStandaloneEnv[T](
-    totalCore : Int,
-    core : Int
-  )(body : => T): Unit = {
-    System.setProperty("SPARK_SUBMIT", "true")
-    System.setProperty("spark.master", s"spark://host:7077")
-    System.setProperty("spark.cores.max", totalCore.toString)
-    System.setProperty("spark.executor.cores", core.toString)
-    body
-    System.clearProperty("SPARK_SUBMIT")
-    System.clearProperty("spark.master")
-    System.clearProperty("spark.cores.max")
-    System.clearProperty("spark.executor.cores")
-  }
-
-  /**
-   * Set envs for spark yarn mode
-   */
-  def sparkYarnEnv[T](
-    executors : Int,
-    core : Int
-  )(body : => T): Unit = {
-    System.setProperty("SPARK_SUBMIT", "true")
-    System.setProperty("spark.master", s"yarn")
-    System.setProperty("spark.executor.instances", executors.toString)
-    System.setProperty("spark.executor.cores", core.toString)
-    body
-    System.clearProperty("SPARK_SUBMIT")
-    System.clearProperty("spark.master")
-    System.clearProperty("spark.executor.instances")
-    System.clearProperty("spark.executor.cores")
-  }
-
-  /**
-   * Set envs for mesos yarn mode
-   */
-  def sparkMesosEnv[T](
-    totalCore : Int,
-    core : Int
-  )(body : => T): Unit = {
-    System.setProperty("SPARK_SUBMIT", "true")
-    System.setProperty("spark.master", s"mesos")
-    System.setProperty("spark.cores.max", totalCore.toString)
-    System.setProperty("spark.executor.cores", core.toString)
-    body
-    System.clearProperty("SPARK_SUBMIT")
-    System.clearProperty("spark.master")
-    System.clearProperty("spark.cores.max")
-    System.clearProperty("spark.executor.cores")
-  }
-
-  /**
    * Process different paths format under windows and linux
-   *
-   * @param path
-   * @return
    */
   def processPath(path: String): String = {
     if (path.contains(":")) {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/ZippedPartitionsWithLocalityRDDSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/ZippedPartitionsWithLocalityRDDSpec.scala
@@ -16,24 +16,13 @@
 
 package com.intel.analytics.bigdl.utils
 
-import org.apache.spark.{SparkConf, SparkContext}
+import com.intel.analytics.bigdl.SparkContextSpec
 import org.apache.spark.rdd.ZippedPartitionsWithLocalityRDD
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 @com.intel.analytics.bigdl.tags.Serial
-class ZippedPartitionsWithLocalityRDDSpec extends FlatSpec with Matchers with BeforeAndAfter {
-  var sc: SparkContext = null
-  before {
-    val conf = new SparkConf().setMaster("local[4]")
-      .setAppName("ZippedPartitionsWithLocalityRDDSpec")
-    sc = new SparkContext(conf)
-  }
+class ZippedPartitionsWithLocalityRDDSpec extends SparkContextSpec {
 
-  after {
-    if (sc != null) {
-      sc.stop()
-    }
-  }
+  override def getCoreNumber: Int = 4
 
   "two uncached rdd zip partition" should "not throw exception" in {
     val rdd1 = sc.parallelize((1 to 100), 4)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/visualization/SummarySpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/visualization/SummarySpec.scala
@@ -20,17 +20,14 @@ import com.intel.analytics.bigdl.example.loadmodel.AlexNet
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.{Engine, RandomGenerator}
 import Summary._
+import com.intel.analytics.bigdl.SparkContextSpec
 import com.intel.analytics.bigdl.visualization.tensorboard.{FileReader, FileWriter}
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import org.tensorflow.framework
 
 @com.intel.analytics.bigdl.tags.Serial
-class SummarySpec extends FlatSpec with Matchers with BeforeAndAfter {
+class SummarySpec extends SparkContextSpec {
 
-  before {
-    Engine.localMode = false
-    Engine.init(1, 4, true)
-  }
+  override def getCoreNumber: Int = 4
 
   "write scalar summary" should "work properly" in {
     val logdir = com.google.common.io.Files.createTempDir()


### PR DESCRIPTION
See https://github.com/intel-analytics/BigDL/issues/788
It's a big change and am interested in feedback on whether this is good cleanup or a bit too far.

## Changes

- Remove (unused?) "local" mode in `Engine`, along with `BIG_DL_LOCAL_MODE` and script arg `--local`
- Remove use of System property for Spark config, instead using SparkConf to get/set them
- As a result, remove calls to deprecated `Engine.init` method
- Standardize how `Engine.createContext`, `Engine.init` and creation of `SparkConf` and `SparkContext` are handled
- Use `SparkContext.getOrCreate()` instead of `new SparkContext` consistently
- Introduce `SparkContextSpec` to uniformly handled creating and cleaning up a SparkContext for tests that need it.
- Remove duplicated definitions of `processPath`
- (A few minor changes along the way: fix build warning, remove dead imports)

Note that docs will need to be updated to match the new style of invoking `Engine.init` if this is accepted.

## Test failures

I am seeing test failures when I run with these changes, although each one I believe is not due to the change.

I am seeing the failures mentioned at https://github.com/intel-analytics/BigDL/issues/810

One type is memory-related, and I'm not sure how to give `luajit` more memory. I wonder if the test is too big?

```
- should generate correct output and grad
InceptionSpec:
Inception+bn
...
============== lua code end ================

/var/folders/gn/2df1bw014_d91xr49gpdm3b00000gn/T/UnitTest3826245994945462751lua
/Users/srowen/Documents/torch/install/bin/luajit: not enough memory
- should generate correct output *** FAILED ***
  java.lang.RuntimeException: Nonzero exit value: 1
  at scala.sys.package$.error(package.scala:27)
  at scala.sys.process.ProcessBuilderImpl$AbstractBuilder.slurp(ProcessBuilderImpl.scala:132)
  at scala.sys.process.ProcessBuilderImpl$AbstractBuilder.$bang$bang(ProcessBuilderImpl.scala:102)
  at com.intel.analytics.bigdl.torch.TH$.runNM(TH.scala:121)
...
```

This one looks like the test is just a little overly sensitive; should I adjust it here?

```
============== lua code end ================

/var/folders/gn/2df1bw014_d91xr49gpdm3b00000gn/T/UnitTest2144912581200729840lua
luaTime:0.0021841526031494
- should generate correct output and grad *** FAILED ***
  0.6081933956886484 was not equal to 0.608193395686766 (MultiLabelSoftMarginCriterionSpec.scala:60)
```

Finally a Java out-of-memory error but I'm running with 6GB of heap, in `MAVEN_OPTS` and in the surefire config. I think we might again have a test that's a bit too big.

```
AlexNetSpec:
AlexNet float
...
============== lua code end ================

/var/folders/gn/2df1bw014_d91xr49gpdm3b00000gn/T/UnitTest99989901690624529lua
luaTime:6.6072199344635
outputAbs:0.0020193526779470616
3.005603490535691E-7
gradOutputTestAbs:0.0
gradInputTestAbs:2.3282740185348278E-7
*** RUN ABORTED ***
  java.lang.OutOfMemoryError: Java heap space
  at scala.reflect.ManifestFactory$$anon$12.newArray(Manifest.scala:141)
  at scala.reflect.ManifestFactory$$anon$12.newArray(Manifest.scala:139)
...
```