### PR TITLE
Harmonize Hadoop dependency to hadoop.version (and bump to 2.7.3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
         <native-maven-plugin.version>1.0-alpha-8</native-maven-plugin.version>
         <maven-enforcer-plugin.version>1.3.1</maven-enforcer-plugin.version>
 
-        <hadoop.version>2.6.0</hadoop.version>
+        <hadoop.version>2.7.3</hadoop.version>
         <guava.version>11.0.2</guava.version>
         <thrift.path>thrift</thrift.path>
         <thrift.version>0.9.2</thrift.version>
@@ -225,6 +225,24 @@
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest_${scala.major.version}</artifactId>
                 <version>${scalatest.version}</version>
+                <scope>${spark-scope}</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-client</artifactId>
+                <version>${hadoop.version}</version>
+                <scope>${spark-scope}</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-common</artifactId>
+                <version>${hadoop.version}</version>
                 <scope>${spark-scope}</scope>
             </dependency>
         </dependencies>

--- a/spark/dl/pom.xml
+++ b/spark/dl/pom.xml
@@ -39,14 +39,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
-            <version>2.7.1</version>
             <scope>${spark-scope}</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
If you look at `mvn dependency:tree` you'll see that Hadoop 2.2.0 and Hadoop 2.7.1 artifacts are being included. This despite the build says `hadoop.version` is 2.6.0. This change harmonizes all Hadoop deps on 2.7.3