### PR TITLE
add py3.5 support (lenet5 tested)

### DIFF
--- a/pyspark/dl/dataset/mnist.py
+++ b/pyspark/dl/dataset/mnist.py
@@ -20,7 +20,7 @@ import gzip
 
 import numpy
 
-import base
+from . import base
 
 SOURCE_URL = 'http://yann.lecun.com/exdb/mnist/'
 

--- a/pyspark/dl/dataset/news20.py
+++ b/pyspark/dl/dataset/news20.py
@@ -1,5 +1,5 @@
 import tarfile
-import base
+from . import base
 import os
 import sys
 
@@ -70,10 +70,10 @@ def get_glove_w2v(source_dir="/tmp/news20/", dim=100):
     :return: A dict mapping from word to vector
     """
     w2v_dir = download_glove_w2v(source_dir)
-    with open(os.path.join(w2v_dir, "glove.6B.%sd.txt" % dim)) as w2v_f:
+    with open(os.path.join(w2v_dir, "glove.6B.%sd.txt" % dim), 'rb') as w2v_f:
         pre_w2v = {}
         for line in w2v_f.readlines():
-            items = line.split(" ")
+            items = line.split(b" ")
             pre_w2v[items[0]] = [float(i) for i in items[1:]]
         return pre_w2v
 

--- a/pyspark/dl/models/lenet/README.md
+++ b/pyspark/dl/models/lenet/README.md
@@ -36,7 +36,6 @@ We would train a LeNet model in spark local mode with the following commands and
         --driver-cores 2  \
         --driver-memory 2g  \
         --total-executor-cores 2  \
-        --num-executors 4 \
         --executor-cores 2  \
         --executor-memory 4g \
         --conf spark.akka.frameSize=64 \

--- a/pyspark/dl/models/lenet/README.md
+++ b/pyspark/dl/models/lenet/README.md
@@ -34,11 +34,12 @@ We would train a LeNet model in spark local mode with the following commands and
     ${SPARK_HOME}/bin/spark-submit \
         --master ${MASTER} \
         --driver-cores 2  \
-       --driver-memory 2g  \
-       --total-executor-cores 2  \
-       --executor-cores 2  \
-       --executor-memory 4g \
-       --conf spark.akka.frameSize=64 \
+        --driver-memory 2g  \
+        --total-executor-cores 2  \
+        --num-executors 4 \
+        --executor-cores 2  \
+        --executor-memory 4g \
+        --conf spark.akka.frameSize=64 \
         --py-files ${PYTHON_API_ZIP_PATH},${BigDL_HOME}/pyspark/dl/models/lenet/lenet5.py  \
         --properties-file ${BigDL_HOME}/dist/conf/spark-bigdl.conf \
         --jars ${BigDL_JAR_PATH} \

--- a/pyspark/dl/models/lenet/lenet5.py
+++ b/pyspark/dl/models/lenet/lenet5.py
@@ -55,8 +55,8 @@ def get_minst(sc, data_type="train", location="/tmp/mnist"):
     images = sc.parallelize(images)
     labels = sc.parallelize(labels)
     # Target start from 1 in BigDL
-    record = images.zip(labels).map(lambda args:
-                                    Sample.from_ndarray(args[0], args[1] + 1))
+    record = images.zip(labels).map(lambda features_label:
+                                    Sample.from_ndarray(features_label[0], features_label[1] + 1))
     return record
 
 

--- a/pyspark/dl/models/lenet/lenet5.py
+++ b/pyspark/dl/models/lenet/lenet5.py
@@ -55,13 +55,12 @@ def get_minst(sc, data_type="train", location="/tmp/mnist"):
     images = sc.parallelize(images)
     labels = sc.parallelize(labels)
     # Target start from 1 in BigDL
-    record = images.zip(labels).map(lambda (features, label):
-                                    Sample.from_ndarray(features, label + 1))
+    record = images.zip(labels).map(lambda args:
+                                    Sample.from_ndarray(args[0], args[1] + 1))
     return record
 
 
 if __name__ == "__main__":
-
     parser = OptionParser()
     parser.add_option("-a", "--action", dest="action", default="train")
     parser.add_option("-b", "--batchSize", dest="batchSize", default="128")
@@ -103,4 +102,4 @@ if __name__ == "__main__":
         model = Model.from_path("/tmp/lenet5/lenet-model.470")
         results = model.test(test_data, 32, ["Top1Accuracy"])
         for result in results:
-            print result
+            print(result)

--- a/pyspark/dl/models/textclassifier/README.md
+++ b/pyspark/dl/models/textclassifier/README.md
@@ -17,8 +17,8 @@ or [20 Newsgroup dataset](http://www.cs.cmu.edu/afs/cs.cmu.edu/project/theo-20/w
 ```{r, engine='sh'}
 $ [/tmp/news20]$ tree . -L 1
   .
-  ├── 20_newsgroup
-  └── glove.6B
+  ├── 20news-19997.tar.gz
+  └── glove.6B.zip
 ```
 
 then running the flowing script would automatically download the data during the first run.
@@ -26,6 +26,7 @@ then running the flowing script would automatically download the data during the
 bigdl.sh would setup the essential environment for you and it would accept a spark-submit command as an input parameter.
 
 ```{r, engine='sh'}
+        PYTHONHASHSEED=...
         BigDL_HOME=...
         SPARK_HOME=...
         MASTER=...
@@ -39,6 +40,7 @@ bigdl.sh would setup the essential environment for you and it would accept a spa
             --driver-cores 4  \
             --driver-memory 10g  \
             --total-executor-cores 4  \
+            --num-executors 4 \
             --executor-cores 4  \
             --executor-memory 20g \
             --conf spark.akka.frameSize=64 \
@@ -46,6 +48,7 @@ bigdl.sh would setup the essential environment for you and it would accept a spa
             --jars ${BigDL_JAR_PATH} \
             --conf spark.driver.extraClassPath=${BigDL_JAR_PATH} \
             --conf spark.executor.extraClassPath=bigdl-VERSION-jar-with-dependencies.jar \
+            --conf spark.executorEnv.PYTHONHASHSEED=${PYTHONHASHSEED} \
             ${BigDL_HOME}/pyspark/dl/models/textclassifier/textclassifier.py \
              --max_epoch 3
              --model cnn

--- a/pyspark/dl/models/textclassifier/README.md
+++ b/pyspark/dl/models/textclassifier/README.md
@@ -40,7 +40,6 @@ bigdl.sh would setup the essential environment for you and it would accept a spa
             --driver-cores 4  \
             --driver-memory 10g  \
             --total-executor-cores 4  \
-            --num-executors 4 \
             --executor-cores 4  \
             --executor-memory 20g \
             --conf spark.akka.frameSize=64 \

--- a/pyspark/dl/models/textclassifier/textclassifier.py
+++ b/pyspark/dl/models/textclassifier/textclassifier.py
@@ -35,10 +35,13 @@ def text_to_words(review_text):
 
 
 def analyze_texts(data_rdd):
+    def index(w_c_i):
+        ((w, c), i) = w_c_i
+        return (w, (i + 1, c))
     return data_rdd.flatMap(lambda text_label: text_to_words(text_label[0])) \
         .map(lambda word: (word, 1)).reduceByKey(lambda a, b: a + b) \
         .sortBy(lambda w_c: - w_c[1]).zipWithIndex() \
-        .map(lambda w_c__i: (w_c__i[0][0], (w_c__i[1] + 1, w_c__i[0][1]))).collect()
+        .map(lambda w_c_i: index(w_c_i)).collect()
 
 
 # pad([1, 2, 3, 4, 5], 0, 6)

--- a/pyspark/dl/nn/layer.py
+++ b/pyspark/dl/nn/layer.py
@@ -103,10 +103,10 @@ class Model(JavaValue):
             return {
                 param_name: np.array(values[0],
                                      dtype=self.get_dtype()).reshape(
-                    values[1]) for param_name, values in params.iteritems()}
+                    values[1]) for param_name, values in params.items()}
 
         return {layer_name: to_ndarray(params) for layer_name, params in
-                name_to_params.iteritems()}
+                name_to_params.items()}
 
     def predict(self, data_rdd):
         """

--- a/pyspark/dl/util/common.py
+++ b/pyspark/dl/util/common.py
@@ -201,8 +201,6 @@ def get_bigdl_conf():
     bigdl_python_wrapper = "python-api.zip"
 
     def load_conf(conf_str):
-        if isinstance(conf_str, bytes):
-            conf_str = conf_str.decode()
         return dict(line.split() for line in conf_str.split("\n") if
                     "#" not in line and line.strip())
 
@@ -213,7 +211,7 @@ def get_bigdl_conf():
         if bigdl_python_wrapper in p:
             import zipfile
             with zipfile.ZipFile(p, 'r') as zip_conf:
-                return load_conf(zip_conf.read(bigdl_conf_file))
+                return load_conf(str(zip_conf.read(bigdl_conf_file)))
     raise Exception("Cannot find spark-bigdl.conf.Pls add it to PYTHONPATH.")
 
 

--- a/pyspark/dl/util/common.py
+++ b/pyspark/dl/util/common.py
@@ -201,6 +201,8 @@ def get_bigdl_conf():
     bigdl_python_wrapper = "python-api.zip"
 
     def load_conf(conf_str):
+        if isinstance(conf_str, bytes):
+            conf_str = conf_str.decode()
         return dict(line.split() for line in conf_str.split("\n") if
                     "#" not in line and line.strip())
 
@@ -299,7 +301,7 @@ def _py2java(sc, obj):
                                       sc._gateway._gateway_client)
     elif isinstance(obj, dict):
         result = {}
-        for (key, value) in obj.iteritems():
+        for (key, value) in obj.items():
             result[key] = _py2java(sc, value) if isinstance(value, JavaValue) else value  # noqa
         obj = result
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

**Modify the codes to support Python 3.5**

1. lambda function.
Python3.5 doesn't support something like 'lamda (x,y): f(x,y)'. It only supports something like 'lambda x:f(x[0], x[1])'.

2. print function.
Python3.5 use 'print' as a function

3. bytes and str.
Python3.5 provides a new data type called 'bytes'. 'bytes' object need to be decoded to 'str' type, so that it is compatible.

4. iteritems
Python3.5 removes 'dict.iteritems' method. It only supports 'dict.items'

**Modify the LeNet5 README.md**

- --num-executors need to be specified

**Modify dataset/mnist.py**
change 'import base' to 'from . import base'
Otherwise in yarn-client mode, 'base' cannot be found.

## How was this patch tested?

passed with spark 1.6 or 2.0
