### PR TITLE
Add backward and forward for module and criterion

### DIFF
--- a/pyspark/dl/nn/criterion.py
+++ b/pyspark/dl/nn/criterion.py
@@ -20,6 +20,7 @@ import sys
 from util.common import JavaValue
 from util.common import callBigDlFunc
 from util.common import JTensor
+from nn.layer import Model
 import numpy as np
 
 if sys.version >= '3':
@@ -36,6 +37,37 @@ class Criterion(JavaValue):
         self.value = jvalue if jvalue else callBigDlFunc(
             bigdl_type, JavaValue.jvm_class_constructor(self), *args)
         self.bigdl_type = bigdl_type
+
+    def forward(self, input, target):
+        """
+        NB: It's for debug only, please use optimizer.optimize() in production.
+        Takes an input object, and computes the corresponding loss of the criterion,
+        compared with `target`
+        :param input: ndarray or list of ndarray
+        :param target: ndarray or list of ndarray
+        :return: value of loss
+        """
+        output = callBigDlFunc(self.bigdl_type,
+                               "criterionForward",
+                               self.value,
+                               Model.check_input(input),
+                               Model.check_input(target))
+        return output
+
+    def backward(self, input, target):
+        """
+        NB: It's for debug only, please use optimizer.optimize() in production.
+        Performs a back-propagation step through the criterion, with respect to the given input.
+        :param input: ndarray or list of ndarray
+        :param target: ndarray or list of ndarray
+        :return: ndarray
+        """
+        output = callBigDlFunc(self.bigdl_type,
+                               "criterionBackward",
+                               self.value,
+                               Model.check_input(input),
+                               Model.check_input(target))
+        return Model.convert_output(output)
 
     @classmethod
     def of(cls, jcriterion, bigdl_type="float"):

--- a/pyspark/dl/nn/layer.py
+++ b/pyspark/dl/nn/layer.py
@@ -82,6 +82,58 @@ class Model(JavaValue):
             return "float32"
         else:
             return "float64"
+    @staticmethod
+    def check_input(input):
+        if type(input) is list:
+            if len(input) == 0:
+                raise Exception('Error when checking: empty input')
+            if not hasattr(input[0], 'shape'):
+                raise Exception(
+                    'Error when checking: expecting list of ndarray')
+            return [JTensor.from_ndarray(i) for i in input]
+        else:
+            if not hasattr(input, 'shape'):
+                raise Exception(
+                    'Error when checking: expecting list of ndarray')
+            return [JTensor.from_ndarray(input)]
+
+    @staticmethod
+    def convert_output(output):
+        if type(output) is JTensor:
+            return output.to_ndarray()
+        else:
+            return map(lambda x: x.to_ndarray(), output)
+
+    def forward(self, input):
+        """
+        NB: It's for debug only, please use optimizer.optimize() in production.
+        Takes an input object, and computes the corresponding output of the module
+        :param input: ndarray or list of ndarray
+        :return: ndarray or list of ndarray
+        """
+        output = callBigDlFunc(self.bigdl_type,
+                               "modelForward",
+                               self.value,
+                               self.check_input(input))
+        return self.convert_output(output)
+
+    def backward(self, input, grad_output):
+        """
+        NB: It's for debug only, please use optimizer.optimize() in production.
+        Performs a back-propagation step through the module, with respect to the given input. In
+        general this method makes the assumption forward(input) has been called before, with the same
+        input. This is necessary for optimization reasons. If you do not respect this rule, backward()
+        will compute incorrect gradients.
+        :param input: ndarray or list of ndarray
+        :param grad_output: ndarray or list of ndarray
+        :return: ndarray or list of ndarray
+        """
+        output = callBigDlFunc(self.bigdl_type,
+                               "modelBackward",
+                               self.value,
+                               self.check_input(input),
+                               self.check_input(grad_output))
+        return self.convert_output(output)
 
     def reset(self):
         """

--- a/pyspark/dl/util/common.py
+++ b/pyspark/dl/util/common.py
@@ -176,7 +176,7 @@ class RNG():
         callBigDlFunc(self.bigdl_type, "setModelSeed", seed)
 
     def uniform(self, a, b, size):
-        return callBigDlFunc(self.bigdl_type, "uniform", a, b, size)
+        return callBigDlFunc(self.bigdl_type, "uniform", a, b, size).to_ndarray() # noqa
 
 
 _picklable_classes = [

--- a/pyspark/test/simple_integration_test.py
+++ b/pyspark/test/simple_integration_test.py
@@ -139,6 +139,27 @@ class TestWorkFlow(unittest.TestCase):
         grad_output = mse.backward(output, rng.uniform(0.0, 1.0, [5]))
         l_grad_output = linear.backward(input, grad_output)
 
+    def test_forward_multiple(self):
+        from nn.layer import Linear
+        rng = RNG()
+        rng.set_seed(100)
+
+        input = [rng.uniform(0.0, 0.1, [2]),
+                 rng.uniform(0.0, 0.1, [2]) + 0.2]
+
+        grad_output = [rng.uniform(0.0, 0.1, [3]),
+                       rng.uniform(0.0, 0.1, [3]) + 0.2]
+
+        linear1 = Linear(2, 3)
+        linear2 = Linear(2, 3)
+
+        module = ParallelTable()
+        module.add(linear1)
+        module.add(linear2)
+        module.forward(input)
+        module.backward(input, grad_output)
+
+
     def test_predict(self):
         np.random.seed(100)
         total_length = 6

--- a/pyspark/test/simple_integration_test.py
+++ b/pyspark/test/simple_integration_test.py
@@ -159,7 +159,6 @@ class TestWorkFlow(unittest.TestCase):
         module.forward(input)
         module.backward(input, grad_output)
 
-
     def test_predict(self):
         np.random.seed(100)
         total_length = 6

--- a/pyspark/test/simple_integration_test.py
+++ b/pyspark/test/simple_integration_test.py
@@ -117,6 +117,28 @@ class TestWorkFlow(unittest.TestCase):
         for test_result in test_results:
             print(test_result)
 
+    def test_forward_backward(self):
+        from nn.layer import Linear
+        rng = RNG()
+        rng.set_seed(100)
+
+        linear = Linear(4, 5)
+        input = rng.uniform(0.0, 1.0, [4])
+        output = linear.forward(input)
+        self.assertTrue(np.allclose(output,
+                                    np.array([0.41366524,
+                                              0.009532653,
+                                              -0.677581,
+                                              0.07945433,
+                                              -0.5742568]),
+                                    atol=1e-6, rtol=0))
+        mse = MSECriterion()
+        target = rng.uniform(0.0, 1.0, [5])
+        loss = mse.forward(output, target)
+        print("loss: " + str(loss))
+        grad_output = mse.backward(output, rng.uniform(0.0, 1.0, [5]))
+        l_grad_output = linear.backward(input, grad_output)
+
     def test_predict(self):
         np.random.seed(100)
         total_length = 6
@@ -138,14 +160,14 @@ class TestWorkFlow(unittest.TestCase):
         result = rng.uniform(0.1, 0.2, [2, 3])
         ground_label = np.array([[0.15434049, 0.16711557, 0.12783694],
                                  [0.14120464, 0.14245176, 0.15263824]])
-        self.assertTrue(result.shape == [2, 3])
-        data = result.to_ndarray()
+        self.assertTrue(result.shape == (2, 3))
+        data = result
         for i in range(0, 2):
             self.assertTrue(np.allclose(data[i], ground_label[i], atol=1e-6, rtol=0))
 
         rng.set_seed(100)
         result2 = rng.uniform(0.1, 0.2, [2, 3])
-        data2 = result2.to_ndarray()
+        data2 = result2
         for i in range(0, 2):
             self.assertTrue(np.allclose(data[i], data2[i]))
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
@@ -23,7 +23,7 @@ import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.optim.SGD
 import com.intel.analytics.bigdl.optim.Trigger
-import com.intel.analytics.bigdl.utils.Engine
+import com.intel.analytics.bigdl.utils.{Engine, T}
 import com.intel.analytics.bigdl.visualization.{TrainSummary, ValidationSummary}
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.SparkContext
@@ -34,6 +34,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 
 import scala.util.Random
+import scala.collection.JavaConverters._
 
 
 class PythonSpec extends FlatSpec with Matchers with BeforeAndAfter {
@@ -54,6 +55,28 @@ class PythonSpec extends FlatSpec with Matchers with BeforeAndAfter {
     }
   }
 
+  "model forward and backward with sigle tensor input" should "be test" in {
+    val linear = Linear[Float](4, 5)
+    val input: Tensor[Float] = Tensor[Float](4).apply1(_ => Random.nextFloat())
+    val target: Tensor[Float] = Tensor[Float](5).apply1(_ => Random.nextFloat())
+    val pythonBigDL = PythonBigDL.ofFloat()
+    val mse = new MSECriterion[Float]
+    val joutput = pythonBigDL.modelForward(linear,
+      List(pythonBigDL.toJTensor(input)).asJava
+    ).iterator().next()
+    val expectedOutput = linear.forward(input)
+    require(pythonBigDL.toTensor(joutput) == expectedOutput, "forward output should be the same")
+
+    // test backward for linear
+    val mseGradOutput = mse.backward(pythonBigDL.toTensor(joutput), target).toTensor[Float]
+    val expectedLinearGradOutput = linear.backward(input, mseGradOutput)
+    val jLinearGradOutput = pythonBigDL.modelBackward(linear,
+      List(pythonBigDL.toJTensor(input)).asJava,
+      List(pythonBigDL.toJTensor(mseGradOutput)).asJava
+    ).iterator().next()
+    require(pythonBigDL.toTensor(jLinearGradOutput) == expectedLinearGradOutput,
+      "backward output should be the same")
+  }
 
   "to jtensor" should "be test" in {
     val pythonBigDL = PythonBigDL.ofFloat()


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add backward and forward python api for module and criterion. 
These API would not as efficient as the scala version as it introduce some data conversion overhead, so you may want to use ``` optimizer.optimize()``` in production.

## How was this patch tested?
unittest

