### PR TITLE
fix lookupTable python api

### DIFF
--- a/pyspark/dl/nn/layer.py
+++ b/pyspark/dl/nn/layer.py
@@ -1479,7 +1479,7 @@ class LookupTable(Model):
     def __init__(self,
                  n_index,
                  n_output,
-                 padding_value=0,
+                 padding_value=0.0,
                  max_norm=DOUBLEMAX,
                  norm_type=2.0,
                  should_scale_grad_by_freq=False,


### PR DESCRIPTION
## What changes were proposed in this pull request?

fix LookupTable python api, otherwise python will interpret the `padding_value` as a integer and a MethodNotFoundException will be thrown.


