### PR TITLE
Remove *.txt from gitignore as it matched versioned files; rearrange entries and standardize entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,29 +1,33 @@
+# Compile products
 *.pyc
 *.class
-*.log
-dl/src/main/python/.idea/
+target/
+dist/
 
-# sbt specific
+# SBT, Maven specific
 .cache
 .history
 .lib/
-dist/*
-target/
 lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+dependency-reduced-pom.xml
 
-# Scala-IDE specific
+# IDE specific
 .scala_dependencies
 .worksheet
 *.iml
 .idea/
 
-# other
-*.txt
+# macOS specific
+.DS_Store
+
+# data files
 *.csv
-nohup.out
 model*.[0-9]*
 state*.[0-9]*
-spark/dl/dependency-reduced-pom.xml
+
+# other
+nohup.out
+*.log


### PR DESCRIPTION
## What changes were proposed in this pull request?

The only real change here is to not match `*.txt*` in `.gitignore` because that matches `requirements.txt`, which is versioned, and generates a warning. The rest of the changes are just rearranging and rationalizing the entries a bit.

## How was this patch tested?

Existing tests