### PR TITLE
fix: preload libjmkl.so (#848)

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
@@ -19,6 +19,7 @@ package com.intel.analytics.bigdl.tensor
 import java.io.Serializable
 
 import breeze.linalg.{DenseMatrix => BrzDenseMatrix, DenseVector => BrzDenseVector}
+import com.intel.analytics.bigdl.mkl.MKL
 import com.intel.analytics.bigdl.nn.abstractnn.Activity
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.{File, Table}
@@ -625,6 +626,11 @@ object DoubleType extends TensorDataType
 object FloatType extends TensorDataType
 
 object Tensor {
+
+  // pre-load MKL library. If we do not do it here,
+  // libjmkl.so will be loaded when one of the methods of in MKL is called.
+  MKL.isMKLLoaded
+
   /**
    * Returns an empty tensor.
    *


### PR DESCRIPTION
* fix: preload libjmkl.so by hand.

* fix: move preload libjmkl.so in Tensor object.

It will run method isMKLLoad every time when using `Tensor`/`new
DenseTensor`. And the `DenseTensor` is not public out of BigDL.

