### PR TITLE
share memory in CAddTable for LSTM, GRU, SimpleRNN

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BiRecurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BiRecurrent.scala
@@ -47,7 +47,7 @@ class BiRecurrent[T : ClassTag] (
           .add(Reverse[T](timeDim))
           .add(revLayer)
           .add(Reverse[T](timeDim))))
-    if (merge == null) birnn.add(CAddTable[T]())
+    if (merge == null) birnn.add(CAddTable[T](true))
     else birnn.add(merge)
 
   override def add(module: AbstractModule[_ <: Activity, _ <: Activity, T]):

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GRU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GRU.scala
@@ -135,7 +135,8 @@ class GRU[T : ClassTag] (
             bRegularizer = bRegularizer)))
         .add(Sequential()
           .add(Dropout(p))
-          .add(Linear(outputSize, outputSize, withBias = false))))
+          .add(Linear(outputSize, outputSize, withBias = false,
+            wRegularizer = uRegularizer))))
       .add(CAddTable(true))
       .add(Tanh())
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GRU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GRU.scala
@@ -103,7 +103,7 @@ class GRU[T : ClassTag] (
       .add(ParallelTable()
         .add(i2g)
         .add(h2g))
-      .add(CAddTable())
+      .add(CAddTable(true))
       .add(Reshape(Array(2, outputSize)))
       .add(SplitTable(1, 2))
       .add(ParallelTable()
@@ -135,9 +135,8 @@ class GRU[T : ClassTag] (
             bRegularizer = bRegularizer)))
         .add(Sequential()
           .add(Dropout(p))
-          .add(Linear(outputSize, outputSize, withBias = false,
-            wRegularizer = uRegularizer))))
-      .add(CAddTable())
+          .add(Linear(outputSize, outputSize, withBias = false))))
+      .add(CAddTable(true))
       .add(Tanh())
 
     gru
@@ -155,7 +154,7 @@ class GRU[T : ClassTag] (
             .add(SelectTable(2))
             .add(SelectTable(4)))
           .add(CMulTable())))
-      .add(CAddTable())
+      .add(CAddTable(true))
       .add(ConcatTable()
         .add(Identity[T]())
         .add(Identity[T]()))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LSTM.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LSTM.scala
@@ -117,7 +117,7 @@ class LSTM[T : ClassTag] (
       .add(ParallelTable()
         .add(i2g)
         .add(h2g))
-      .add(CAddTable())
+      .add(CAddTable(true))
       .add(Reshape(Array(4, hiddenSize)))
       .add(SplitTable(1, 2))
       .add(ParallelTable()
@@ -150,7 +150,7 @@ class LSTM[T : ClassTag] (
             .add(SelectTable(3))
             .add(SelectTable(5)))
           .add(CMulTable())))
-      .add(CAddTable())
+      .add(CAddTable(true))
 
     lstm
       .add(ConcatTable()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/RNN.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/RNN.scala
@@ -58,7 +58,7 @@ class RnnCell[T : ClassTag] (
     wRegularizer = uRegularizer)
   parallelTable.add(i2h)
   parallelTable.add(h2h)
-  val cAddTable = CAddTable[T]()
+  val cAddTable = CAddTable[T](true)
 
   override var cell: AbstractModule[Activity, Activity, T] =
     Sequential[T]()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Reverse.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Reverse.scala
@@ -28,7 +28,7 @@ import scala.reflect.ClassTag
  * @param ev
  * @tparam T Numeric type. Only support float/double now
  */
-class Reverse[T: ClassTag](dim: Int = 1, isInplace: Boolean = true)
+class Reverse[T: ClassTag](dim: Int = 1, isInplace: Boolean = false)
   (implicit ev: TensorNumeric[T])
   extends TensorModule[T] {
 
@@ -117,7 +117,7 @@ class Reverse[T: ClassTag](dim: Int = 1, isInplace: Boolean = true)
 
 object Reverse {
   def apply[@specialized(Float, Double) T: ClassTag](
-    dimension: Int = 1, isInplace: Boolean = true)
+    dimension: Int = 1, isInplace: Boolean = false)
     (implicit ev: TensorNumeric[T]) : Reverse[T] = {
     new Reverse[T](dimension, isInplace)
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Reverse.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Reverse.scala
@@ -59,9 +59,9 @@ class Reverse[T: ClassTag](dim: Int = 1, isInplace: Boolean = true)
   }
 
   /**
-   * reverse the src Tensor and write it to target w.r.t given dim.
+   * reverse the src Tensor given dim in-place.
    * E.g. src: (1,2,3; 4,5,6) and dim = 1
-   *      target: (4,5,6; 1,2,3)
+   *      => src: (4,5,6; 1,2,3)
    * @param src
    * @param dim
    * @return

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Reverse.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Reverse.scala
@@ -28,9 +28,11 @@ import scala.reflect.ClassTag
  * @param ev
  * @tparam T Numeric type. Only support float/double now
  */
-class Reverse[T: ClassTag](dim: Int = 1)
+class Reverse[T: ClassTag](dim: Int = 1, isInplace: Boolean = true)
   (implicit ev: TensorNumeric[T])
   extends TensorModule[T] {
+
+  var buffer: Tensor[T] = null
 
   /**
    * reverse the src Tensor and write it to target w.r.t given dim.
@@ -56,14 +58,51 @@ class Reverse[T: ClassTag](dim: Int = 1)
     target
   }
 
+  /**
+   * reverse the src Tensor and write it to target w.r.t given dim.
+   * E.g. src: (1,2,3; 4,5,6) and dim = 1
+   *      target: (4,5,6; 1,2,3)
+   * @param src
+   * @param dim
+   * @return
+   */
+  private def reverseTensor(src: Tensor[T], dim: Int): Tensor[T] = {
+    require(dim > 0 && dim <= src.dim,
+      s"Reverse: the designated dimension ${dim} to reverse input Tensor" +
+        s" is out of index. The input.dim = ${src.dim}")
+    if (buffer == null) buffer = Tensor[T]()
+
+    val time = src.size(dim)
+    val half = time >> 1
+    buffer.resizeAs(src.select(dim, 1))
+    var i = 1
+    while (i <= half) {
+      buffer.copy(src.select(dim, time - i + 1))
+      src.select(dim, time - i + 1).copy(src.select(dim, i))
+      src.select(dim, i).copy(buffer)
+      i += 1
+    }
+    src
+  }
+
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
-    if (output == null) output = Tensor[T]()
-    reverseTensor(input.toTensor[T], output.toTensor[T], dim)
+    if (isInplace) {
+      output = reverseTensor(input.toTensor[T], dim)
+    } else {
+      if (output == null) output = Tensor[T]()
+      reverseTensor(input.toTensor[T], output.toTensor[T], dim)
+    }
+    output
   }
 
   override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
-    if (gradInput == null) gradInput = Tensor[T]()
-    reverseTensor(gradOutput.toTensor[T], gradInput.toTensor[T], dim)
+    if (isInplace) {
+      gradInput = reverseTensor(gradOutput.toTensor[T], dim)
+    } else {
+      if (gradInput == null) gradInput = Tensor[T]()
+      reverseTensor(gradOutput.toTensor[T], gradInput.toTensor[T], dim)
+    }
+    gradInput
   }
 
   override def toString: String = s"nn.Reverse"
@@ -78,7 +117,8 @@ class Reverse[T: ClassTag](dim: Int = 1)
 
 object Reverse {
   def apply[@specialized(Float, Double) T: ClassTag](
-    dimension: Int = 1)(implicit ev: TensorNumeric[T]) : Reverse[T] = {
-    new Reverse[T](dimension)
+    dimension: Int = 1, isInplace: Boolean = true)
+    (implicit ev: TensorNumeric[T]) : Reverse[T] = {
+    new Reverse[T](dimension, isInplace)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ReverseSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ReverseSpec.scala
@@ -24,6 +24,34 @@ import scala.collection.mutable
 @com.intel.analytics.bigdl.tags.Serial
 class ReverseSpec extends FlatSpec with Matchers {
 
+  "A Reverse()" should "generate correct output and grad for Tensor input dim1 inplace" in {
+    def randomn(): Double = RandomGenerator.RNG.uniform(-10, 10)
+    val layer = new Reverse[Double](1)
+
+    val input = Tensor[Double](4, 3)
+    input.apply1(x => randomn())
+    val expectedOutput = Tensor[Double]().resizeAs(input)
+    expectedOutput.select(1, 1).copy(input(4))
+    expectedOutput.select(1, 2).copy(input(3))
+    expectedOutput.select(1, 3).copy(input(2))
+    expectedOutput.select(1, 4).copy(input(1))
+
+    val gradOutput = Tensor[Double](4, 3)
+    gradOutput.apply1(x => randomn())
+    val expectedGradInput = Tensor[Double]().resizeAs(gradOutput)
+    expectedGradInput(1).copy(gradOutput(4))
+    expectedGradInput(2).copy(gradOutput(3))
+    expectedGradInput(3).copy(gradOutput(2))
+    expectedGradInput(4).copy(gradOutput(1))
+
+    val output = layer.forward(input)
+    val gradInput = layer.backward(input, gradOutput)
+
+    output should be (expectedOutput)
+    gradInput should be (expectedGradInput)
+
+  }
+
   "A Reverse()" should "generate correct output and grad for Tensor input dim1" in {
     def randomn(): Double = RandomGenerator.RNG.uniform(-10, 10)
     val layer = new Reverse[Double](1)


### PR DESCRIPTION
## What changes were proposed in this pull request?

share memory in CAddTable for LSTM, GRU, SimpleRNN;
share memory for Reverse layer.

## How was this patch tested?

Unit Tests
## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

