### PR TITLE
Touch up gitignore to only exclude root /dist dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.pyc
 *.class
 target/
-dist/
+/dist/
 
 # SBT, Maven specific
 .cache


### PR DESCRIPTION
## What changes were proposed in this pull request?

I made an error in https://github.com/intel-analytics/BigDL/pull/849 and this still doesn't only gitignore the root /dist directory.

## How was this patch tested?

N/A

## Related links or issues (optional)

https://github.com/intel-analytics/BigDL/pull/849
