### PR TITLE
Pyspark test

### DIFF
--- a/pyspark/test/dev/comment.py
+++ b/pyspark/test/dev/comment.py
@@ -24,11 +24,13 @@ def _process_docstring(filepath, lines):
     param_re = re.compile(r'^\s*:?@?\s*(?:param\s+|return:?).*$')
     blank_re = re.compile(r'\s*$')
     prmpt_re = re.compile(r'\s*>>>.*$')
+    liter_re = re.compile(r'\s*```\s*$')
 
     quote_flag = False
     param_flag = False
     blank_flag = False
     prmpt_flag = False
+    liter_flag = False
 
     param_rules = [(re.compile(x), y) for x,y in [
             ('^\s*.{0,2}(?<!:)(?:param\s+|return:?).*$', 'A colon is required to be attached just before \'param\', and no blank gap is allowed. For example, \':param\', not \': param\' or \'@param\'. For \'return\', a colon is also required, like \':return\'.' ),
@@ -42,12 +44,25 @@ def _process_docstring(filepath, lines):
             blank_flag = False
             param_flag = False
             prmpt_flag = False
+            liter_flag = False
         elif quote_flag and quote_re.match(line):
             quote_flag = False
             param_flag = False
             blank_flag = False
             prmpt_flag = False
+            liter_flag = False
         elif quote_flag:
+            if not liter_flag and liter_re.match(line):
+                liter_flag = True
+                continue
+            elif liter_flag and liter_re.match(line):
+                blank_flag = True
+                liter_flag = False
+                continue
+
+            if liter_flag:
+                continue
+
             for param_rule in param_rules:
                 rule_re, err_mes = param_rule
                 if rule_re.match(line):

--- a/pyspark/test/dev/comment.py
+++ b/pyspark/test/dev/comment.py
@@ -34,7 +34,7 @@ def _process_docstring(filepath, lines):
 
     param_rules = [(re.compile(x), y) for x,y in [
             ('^\s*.{0,2}(?<!:)(?:param\s+|return:?).*$', 'A colon is required to be attached just before \'param\', and no blank gap is allowed. For example, \':param\', not \': param\' or \'@param\'. For \'return\', a colon is also required, like \':return\'.' ),
-            ('^\s*:(?:param\s+\S+(?<!:)|return)\s+?.*$', 'A colon is required to be attached just after \':param xx\', and no blank gap is allowed. For example, \':param xx:\', not \':param xx :\' or \':param xx\'. For \'return\', a colon is also required, lik \':return:\'.')]]
+            ('^\s*:(?:param\s+\S+(?<!:)|return)\s+?.*$', 'A colon is required to be attached just after \':param xx\', and no blank gap is allowed. For example, \':param xx:\', not \':param xx :\' or \':param xx\'. For \'return\', a colon is also required, like \':return:\'.')]]
 
     for i in range(len(lines)):
         line = lines[i][:-1]

--- a/pyspark/test/dev/comment.py
+++ b/pyspark/test/dev/comment.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import re
+import os
+
+def _process_docstring(filepath, lines):
+    quote_re = re.compile(r'\s*["\']{3}(?:.(?<!["\']{3}))*$')
+    param_re = re.compile(r'^\s*:?@?\s*(?:param\s+|return:?).*$')
+    blank_re = re.compile(r'\s*$')
+    prmpt_re = re.compile(r'\s*>>>.*$')
+
+    quote_flag = False
+    param_flag = False
+    blank_flag = False
+    prmpt_flag = False
+
+    param_rules = [(re.compile(x), y) for x,y in [
+            ('^\s*.{0,2}(?<!:)(?:param\s+|return:?).*$', 'A colon is required to be attached just before \'param\', and no blank gap is allowed. For example, \':param\', not \': param\' or \'@param\'. For \'return\', a colon is also required, like \':return\'.' ),
+            ('^\s*:(?:param\s+\S+(?<!:)|return)\s+?.*$', 'A colon is required to be attached just after \':param xx\', and no blank gap is allowed. For example, \':param xx:\', not \':param xx :\' or \':param xx\'. For \'return\', a colon is also required, lik \':return:\'.')]]
+
+    for i in range(len(lines)):
+        line = lines[i][:-1]
+        ln = i+1
+        if not quote_flag and quote_re.match(line):
+            quote_flag = True
+            blank_flag = False
+            param_flag = False
+            prmpt_flag = False
+        elif quote_flag and quote_re.match(line):
+            quote_flag = False
+            param_flag = False
+            blank_flag = False
+            prmpt_flag = False
+        elif quote_flag:
+            for param_rule in param_rules:
+                rule_re, err_mes = param_rule
+                if rule_re.match(line):
+                    raise Exception('line {0}, in {3}:\n {1}\n{2}'.format(ln, line, err_mes, filepath))
+            # blank line
+            if blank_re.match(line):
+                param_flag = False
+                blank_flag = True
+                prmpt_flag = False
+            # first param line with no head blank line
+            elif not param_flag and not blank_flag and param_re.match(line):
+                param_flag = True
+                blank_flag = False
+                prmpt_falg = False
+                err_mes = 'A blank line preceding the first parameter line is required. Try adding a blank line before it.'
+                raise Exception('line {0}, in {3}:\n {1}\n{2}'.format(ln, line , err_mes, filepath))
+            # normal param line
+            elif param_re.match(line):
+                param_flag = True
+                blank_flag = False
+                prmpt_flag = False
+            # fisrt prompt line with no head blank line 
+            elif not prmpt_flag and not blank_flag and prmpt_re.match(line):
+                param_falg = False
+                blank_flag = False
+                prmpt_flag = True
+                err_mes = 'A blank line preceding the first prompt line is required. Try adding a blank line before it.'
+                raise Exception('line {0}, in {3}:\n {1}\n{2}'.format(ln, line , err_mes, filepath))
+            # normal param line
+            elif prmpt_re.match(line):
+                param_flag = False
+                blank_flag = False
+                prmpt_flag = True
+            # regular line with head prmpt line
+            elif prmpt_flag: 
+                param_flag = False
+                blank_flag = False
+                prmpt_flag = True
+            # regular line with head param line
+            elif param_flag:
+                param_flag = True
+                blank_flag = False
+                prmpt_flag = False
+                err_mes = 'Add a blank line before it to make it as a new paragraph. Or append it to the previous parameter line. You have to write the parameter definition in one line.'
+                raise Exception('line {0}, in {3}:\n {1}\n{2}'.format(ln, line , err_mes, filepath))
+            # regualr line
+            else:
+                param_flag = False
+                blank_flag = False
+                prmpt_flag = False
+
+if __name__ == '__main__':
+    python_nn_root = "./pyspark/dl/"
+    for dirpath, dirnames, filenames in os.walk(python_nn_root):
+        for filename in filenames:
+            filepath = os.path.join(dirpath, filename)
+            _process_docstring(filepath, open(filepath).readlines())
+

--- a/pyspark/test/dev/diff.py
+++ b/pyspark/test/dev/diff.py
@@ -71,5 +71,6 @@ for name in python_layers:
     if name not in scala_layers:
         print name,
 
-if len(scala_layers - python_layers) > 0:
+# check the difference between two sets
+if not len(scala_layers ^ python_layers) == 0:
     raise Exception("There are difference between python and scala")

--- a/pyspark/test/dev/run-comment
+++ b/pyspark/test/dev/run-comment
@@ -15,6 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-BASE="$(cd "`dirname $0`"; pwd)"
 
-$BASE/run-comment $BASE/run-diff && $BASE/lint-python && $BASE/run-tests
+DL_PYTHON_HOME="$(cd "`dirname $0`"/../..; pwd)"
+
+BIGDL_HOME="$(cd "`dirname $0`"/../../..; pwd)"
+
+cd $BIGDL_HOME
+exec $DL_PYTHON_HOME/test/dev/comment.py


### PR DESCRIPTION
## What changes were proposed in this pull request?

This test is used in Jenkins. It can test comments style in python files. All blocks wrapped by ''' will be parsed. Literal blocks wrapped by ``` will be skipped. The rules for comments are:

line strating with '>>>' means a prompt line.
line starting with :?@?\s*(?:param|return) means a parameter line.

It will check whether there is a blank line before the first prompt line/ parameter line or not, check whether a parametet line is a single line or multiple line, check the format of ':param xx:' and ':return:' is right or not.

## How was this patch tested?

Exception: line 156, in /home/yuchao/BigDL/pyspark/dl/util/common.py:
         :return (storage, shape)
A colon is required to be attached just after ':param xx', and no blank gap is allowed. For example, ':param xx:', not ':param xx :' or ':param xx'. For 'return', a colon is also required, like ':return:'.

Exception: line 110, in /home/yuchao/BigDL/pyspark/dl/optim/optimizer.py:
            every "n" iterations
Add a blank line before it to make it as a new paragraph. Or append it to the previous parameter line. You have to write the parameter definition in one line.

Exception: line 1413, in /home/yuchao/BigDL/pyspark/dl/nn/layer.py:
     :param min_value: minValue in f(x), default is -1.
A blank line preceding the first parameter line is required. Try adding a blank line before it.


## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

