### PR TITLE
[backport to branch-0.1] add profile for spark2.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -538,6 +538,16 @@
             </properties>
         </profile>
         <profile>
+            <id>spark_2.1.1</id>
+            <properties>
+                <spark-version.project>2.0</spark-version.project>
+                <spark.version>2.1.1</spark.version>
+                <scala.major.version>2.11</scala.major.version>
+                <scala.version>2.11.8</scala.version>
+                <scala.macros.version>2.1.0</scala.macros.version>
+            </properties>
+        </profile>
+        <profile>
             <id>scala_2.11</id>
             <properties>
                 <scala.major.version>2.11</scala.major.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is backport PR for branch-0.1 of PR #895

In Spark 2.1.1, the Blockmanager API putBytes is changed. An optional parameter is added. This won't break the code which invoke it, but will break the compiled package. So if you want your application run on Spark 2.1.1, you need to recompile against spark-core 2.1.1 version.

To compatible with spark 2.1.1, this profile is added.

## How was this patch tested?

manual test and existing unit test


