### PR TITLE
fix mkl-java version

### DIFF
--- a/spark/dl/pom.xml
+++ b/spark/dl/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.intel.analytics.bigdl.native</groupId>
             <artifactId>${mkl-java-os-version}</artifactId>
-            <version>${project.version}</version>
+            <version>0.1.0</version>
             <exclusions>
                 <!-- We already copy the dynamic lib files of this project to mkl-java, so we
                 need not the dependency, which will break assembly step.


### PR DESCRIPTION
## What changes were proposed in this pull request?

BigDL-core is much stable than BigDL. We won't upgrade its version as frequently as BigDL. So make the dependency of mkl-java to a fixed version instead of same of BigDL project version.

## How was this patch tested?

unit test
