### PR TITLE
Use reflection to call BlockManager.putBytes in Spark 2.x to handle different method signatures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,9 @@ matrix:
  include:
    # Covers Java 7, Spark 1.x
    - jdk: openjdk7
-     env: SPARK=-Pspark_1.6
    # Covers Java 8, Spark 2.x
    - jdk: oraclejdk8
-     env: SPARK=-Pspark_2.1
+     env: SPARK=-Pspark_2.x
 cache:
   directories:
     - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -525,8 +525,12 @@
     </reporting>
 
     <profiles>
+        <!-- no-op profile for backwards-compatibility with build scripts, for now -->
         <profile>
-            <id>spark_2.0</id>
+            <id>spark_1.6</id>
+        </profile>
+        <profile>
+            <id>spark_2.x</id>
             <properties>
                 <spark-version.project>2.0</spark-version.project>
                 <spark.version>2.0.0</spark.version>
@@ -543,7 +547,7 @@
                 <scala.macros.version>2.1.0</scala.macros.version>
             </properties>
         </profile>
-        <!-- put this profile after spark_2.0 profile -->
+        <!-- put this profile after spark_2.x profile -->
         <profile>
             <id>scala_2.10</id>
             <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -526,40 +526,10 @@
 
     <profiles>
         <profile>
-            <id>spark_1.6</id>
-            <properties>
-                <spark-version.project>1.5-plus</spark-version.project>
-                <spark.version>1.6.0</spark.version>
-                <scala.major.version>2.10</scala.major.version>
-                <scala.version>2.10.5</scala.version>
-                <scala.macros.version>2.0.1</scala.macros.version>
-            </properties>
-        </profile>
-        <profile>
             <id>spark_2.0</id>
             <properties>
                 <spark-version.project>2.0</spark-version.project>
                 <spark.version>2.0.0</spark.version>
-                <scala.major.version>2.11</scala.major.version>
-                <scala.version>2.11.8</scala.version>
-                <scala.macros.version>2.1.0</scala.macros.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>spark_2.1</id>
-            <properties>
-                <spark-version.project>2.0</spark-version.project>
-                <spark.version>2.1.0</spark.version>
-                <scala.major.version>2.11</scala.major.version>
-                <scala.version>2.11.8</scala.version>
-                <scala.macros.version>2.1.0</scala.macros.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>spark_2.1.1</id>
-            <properties>
-                <spark-version.project>2.0</spark-version.project>
-                <spark.version>2.1.1</spark.version>
                 <scala.major.version>2.11</scala.major.version>
                 <scala.version>2.11.8</scala.version>
                 <scala.macros.version>2.1.0</scala.macros.version>
@@ -581,22 +551,6 @@
                 <scala.version>2.10.5</scala.version>
                 <scala.macros.version>2.0.1</scala.macros.version>
             </properties>
-        </profile>
-        <profile>
-            <id>cloudera</id>
-            <properties>
-                <spark-version.project>2.0</spark-version.project>
-                <spark.version>2.0.0.cloudera2</spark.version>
-                <scala.major.version>2.11</scala.major.version>
-                <scala.version>2.11.8</scala.version>
-                <scala.macros.version>2.1.0</scala.macros.version>
-            </properties>
-            <repositories>
-                <repository>
-                    <id>cloudera</id>
-                    <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
-                </repository>
-            </repositories>
         </profile>
         <profile>
             <id>all-in-one</id>

--- a/pyspark/dl/README.md
+++ b/pyspark/dl/README.md
@@ -11,8 +11,8 @@ This Python binding has been tested with Python 2.7 and Spark 1.6.0 / Spark 2.0.
 ## Installing on Ubuntu
 1. Build BigDL
 [Build Page](https://github.com/intel-analytics/BigDL/wiki/Build-Page)
-    * With Spark1.6: ```  $BIGDL_HOME/make-dist.sh ``` 
-    * With Spark2.0: ``` $BIGDL_HOME/make-dist.sh -P spark_2.0 ```
+    * With Spark 1.6: ```  $BIGDL_HOME/make-dist.sh ``` 
+    * With Spark 2.0 or later: ``` $BIGDL_HOME/make-dist.sh -P spark_2.x ```
 
 2. Install python dependensies(if you're running cluster mode, you need to install them on client and each worker node):
   * Installing Numpy: 

--- a/scripts/run.example.sh
+++ b/scripts/run.example.sh
@@ -47,7 +47,7 @@ eval set -- "$options"
 while true; do
 	case $1 in
 		-p|--spark)
-			if [ "$2" == "spark_2.0" ]; then
+			if [ "$2" == "spark_2.x" ]; then
 				SPARK_DIR=$SPARK2_DIR
 				SPARK_LINK=$SPARK2_LINK
 				BIGDL_JAR=$BIGDL2_JAR

--- a/spark/dl/pom.xml
+++ b/spark/dl/pom.xml
@@ -248,13 +248,7 @@
 
     <profiles>
         <profile>
-            <id>spark_2.0</id>
-            <properties>
-                <filesToExclude>""</filesToExclude> <!-- we do not want exclude anything here -->
-            </properties>
-        </profile>
-        <profile>
-            <id>spark_2.1</id>
+            <id>spark_2.x</id>
             <properties>
                 <filesToExclude>""</filesToExclude> <!-- we do not want exclude anything here -->
             </properties>

--- a/spark/dl/src/test/integration-test.robot
+++ b/spark/dl/src/test/integration-test.robot
@@ -41,13 +41,13 @@ Build SparkJar
    Log To Console    build jar finished
 
 Spark2.0 Test Suite
-   Build SparkJar                   spark_2.0 
+   Build SparkJar                   spark_2.x 
    Set Environment Variable         SPARK_HOME     /opt/work/spark-2.0.0-bin-hadoop2.7  
    ${submit}=                       Catenate       SEPARATOR=/    /opt/work/spark-2.0.0-bin-hadoop2.7/bin    spark-submit
    Run Shell                        ${submit} --master ${spark_200_3_master} --conf "spark.serializer=org.apache.spark.serializer.JavaSerializer" --driver-memory 150g --executor-cores 28 --total-executor-cores 84 --class com.intel.analytics.bigdl.models.lenet.Train ${jar_path} -f ${mnist_data_source} -b 336 -e 3
 
 Spark2.1 Test Suite
-   Build SparkJar                   spark_2.1
+   Build SparkJar                   spark_2.x
    Set Environment Variable         SPARK_HOME     /opt/work/spark-2.1.0-bin-hadoop2.7
    ${submit}=                       Catenate       SEPARATOR=/    /opt/work/spark-2.1.0-bin-hadoop2.7/bin    spark-submit
    Run Shell                        ${submit} --master ${spark_210_3_master} --conf "spark.serializer=org.apache.spark.serializer.JavaSerializer" --driver-memory 150g --executor-cores 28 --total-executor-cores 84 --class com.intel.analytics.bigdl.models.lenet.Train ${jar_path} -f ${mnist_data_source} -b 336 -e 3
@@ -56,7 +56,7 @@ Hdfs Test Suite
    Run Shell      mvn clean test -Dsuites=com.intel.analytics.bigdl.integration.HdfsSpec -DhdfsMaster=${hdfs_264_3_master} -Dmnist=${mnist_data_source} -P integration-test -DforkMode=never
 
 Yarn Test Suite
-   Build SparkJar                   spark_2.0 
+   Build SparkJar                   spark_2.x 
    Set Environment Variable         SPARK_HOME               /opt/work/spark-2.0.0-bin-hadoop2.7  
    Set Environment Variable         http_proxy               http://child-prc.intel.com:913
    Set Environment Variable         https_proxy              https://child-prc.intel.com:913
@@ -69,7 +69,7 @@ Yarn Test Suite
 
 
 TensorFlow Spark2.1 Test Suite
-   Build SparkJar                   spark_2.1
+   Build SparkJar                   spark_2.x
    Set Environment Variable         SPARK_HOME     /opt/work/spark-2.1.0-bin-hadoop2.7
    ${submit}=                       Catenate       SEPARATOR=/    /opt/work/spark-2.1.0-bin-hadoop2.7/bin    spark-submit
    Run Shell                        ${submit} --master ${spark_tf_210_3_master} --conf "spark.serializer=org.apache.spark.serializer.JavaSerializer" --driver-memory 150g --executor-cores 28 --total-executor-cores 56 --py-files ${curdir}/dist/lib/bigdl-0.2.0-SNAPSHOT-python-api.zip --jars ${jar_path} --properties-file ${curdir}/dist/conf/spark-bigdl.conf ${curdir}/pyspark/dl/models/lenet/lenet5.py -b 224

--- a/spark/spark-version/2.0/src/main/scala/org/apache/spark/storage/BlockManagerWrapper.scala
+++ b/spark/spark-version/2.0/src/main/scala/org/apache/spark/storage/BlockManagerWrapper.scala
@@ -16,10 +16,13 @@
 
 package org.apache.spark.storage
 
+import java.lang.{Boolean => JBoolean}
 import java.nio.ByteBuffer
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.util.io.ChunkedByteBuffer
+
+import scala.reflect.ClassTag
 
 object BlockManagerWrapper {
 
@@ -29,7 +32,7 @@ object BlockManagerWrapper {
     require(bytes != null, "Bytes is null")
     val blockManager = SparkEnv.get.blockManager
     blockManager.removeBlock(blockId)
-    blockManager.putBytes(blockId, new ChunkedByteBuffer(bytes), level)
+    doPutBytes(blockId, new ChunkedByteBuffer(bytes), level)
   }
 
   def getLocal(blockId: BlockId): Option[BlockResult] = {
@@ -57,4 +60,48 @@ object BlockManagerWrapper {
       blockInfoManager.unlock(blockId)
     }
   }
+
+  private val putBytesMethod = {
+    val bmClass = classOf[BlockManager]
+    // Spark 2.0.0 - 2.1.0, and 2.2.0+ (as of this writing), declare the method:
+    // def putBytes[T: ClassTag](
+    //   blockId: BlockId,
+    //   bytes: ChunkedByteBuffer,
+    //   level: StorageLevel,
+    //   tellMaster: Boolean = true): Boolean
+    try {
+      bmClass.getMethod("putBytes",
+        classOf[BlockId], classOf[ChunkedByteBuffer], classOf[StorageLevel],
+        classOf[Boolean], classOf[ClassTag[_]])
+    } catch {
+      case _: NoSuchMethodException =>
+        // But Spark 2.1.1 and distros like Cloudera 2.0.0 / 2.1.0 had an extra boolean
+        // param:
+        //   def putBytes[T: ClassTag](
+        //     blockId: BlockId,
+        //     bytes: ChunkedByteBuffer,
+        //     level: StorageLevel,
+        //     tellMaster: Boolean = true,
+        //     encrypt: Boolean = false): Boolean
+        bmClass.getMethod("putBytes",
+          classOf[BlockId], classOf[ChunkedByteBuffer], classOf[StorageLevel],
+          classOf[Boolean], classOf[Boolean], classOf[ClassTag[_]])
+    }
+  }
+  private val putBytesArgCount = putBytesMethod.getParameterTypes.length
+
+  private def doPutBytes(
+      blockId: BlockId,
+      bytes: ChunkedByteBuffer,
+      level: StorageLevel): Unit = {
+    putBytesArgCount match {
+      case 5 =>
+        putBytesMethod.invoke(SparkEnv.get.blockManager,
+          blockId, bytes, level, JBoolean.TRUE, null)
+      case 6 =>
+        putBytesMethod.invoke(SparkEnv.get.blockManager,
+          blockId, bytes, level, JBoolean.TRUE, JBoolean.FALSE, null)
+    }
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use reflection to call `BlockManager.putBytes` in Spark 2.x to handle different method signatures.
This also removes the profiles, which only set versions now, which could be done on the command line. The profiles don't have to be removed, strictly, but won't be necessary to produce published Maven builds.

## How was this patch tested?

Existing tests pass with `-Pspark_2.0`. The same build works on Cloudera's distribution of Spark 2.1.0, which has a differing signature for `BlockManager.putBytes`

## Related links or issues (optional)

fixed https://github.com/intel-analytics/BigDL/issues/900

