### PR TITLE
Add a DependencyReducedPom back to get a fine pom to install/deploy

### DIFF
--- a/make-dist.sh
+++ b/make-dist.sh
@@ -30,11 +30,16 @@ else
     exit 1
 fi
 
+export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m"
+
 if [[ "$_java" ]]; then
     version=$("$_java" -version 2>&1 | awk -F '"' '/version/ {print $2}')
     if [[ "$version" < "1.7" ]]; then
         echo Require a java version not lower than 1.7
         exit 1
+    fi
+    if [[ "$version" < "1.8" ]]; then
+        export MAVEN_OPTS="$MAVEN_OPTS -XX:MaxPermSize=1G"
     fi
 fi
 

--- a/make-dist.sh
+++ b/make-dist.sh
@@ -30,7 +30,7 @@ else
     exit 1
 fi
 
-export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=512m"
+MVN_OPTS_LIST="-Xmx2g -XX:ReservedCodeCacheSize=512m"
 
 if [[ "$_java" ]]; then
     version=$("$_java" -version 2>&1 | awk -F '"' '/version/ {print $2}')
@@ -38,10 +38,13 @@ if [[ "$_java" ]]; then
         echo Require a java version not lower than 1.7
         exit 1
     fi
+    # For jdk7
     if [[ "$version" < "1.8" ]]; then
-        export MAVEN_OPTS="$MAVEN_OPTS -XX:MaxPermSize=1G"
+        MVN_OPTS_LIST="$MVN_OPTS_LIST -XX:MaxPermSize=1G"
     fi
 fi
+
+export MAVEN_OPTS=${MAVEN_OPTS:-"$MVN_OPTS_LIST"}
 
 # Check if mvn installed
 MVN_INSTALL=$(which mvn 2>/dev/null | grep mvn | wc -l)

--- a/spark/dl/pom.xml
+++ b/spark/dl/pom.xml
@@ -152,42 +152,6 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.0.0</version>
-                <configuration>
-                    <createDependencyReducedPom>false</createDependencyReducedPom>
-                    <artifactSet>
-                        <includes>
-                            <include>com.google.protobuf</include>
-                        </includes>
-                    </artifactSet>
-                    <filters>
-                        <filter>
-                            <artifact>com.google.protobuf</artifact>
-                            <excludes>
-                                <exclude>META-INF/maven/com.google.protobuf/protobuf-java/*</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
-                    <relocations>
-                        <relocation>
-                            <pattern>com.google.protobuf</pattern>
-                            <shadedPattern>com.intel.analytics.bigdl.shaded.protobuf</shadedPattern>
-                        </relocation>
-                    </relocations>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -18,4 +18,60 @@
         <module>spark-version</module>
         <module>dist</module>
     </modules>
+
+    <dependencies>
+        <!--
+          This is a dummy dependency that is used to trigger the maven-shade plugin so that BigDL's
+          published POMs are flattened and do not contain variables. Without this dependency, some
+          subprojects' published POMs would contain variables like ${spark.version} that will
+          be substituted according to the default properties instead of the ones determined by the
+          profiles that were active during publishing. By ensuring that maven-shade runs for all
+          subprojects, we eliminate this problem because the substitutions are baked into the final POM.
+        -->
+        <dependency>
+            <groupId>org.spark-project.spark</groupId>
+            <artifactId>unused</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <artifactSet>
+                        <includes>
+                            <include>org.spark-project.spark:unused</include>
+                            <include>com.google.protobuf</include>
+                        </includes>
+                    </artifactSet>
+                    <filters>
+                        <filter>
+                            <artifact>com.google.protobuf</artifact>
+                            <excludes>
+                                <exclude>META-INF/maven/com.google.protobuf/protobuf-java/*</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                    <relocations>
+                        <relocation>
+                            <pattern>com.google.protobuf</pattern>
+                            <shadedPattern>com.intel.analytics.bigdl.shaded.protobuf</shadedPattern>
+                        </relocation>
+                    </relocations>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -27,6 +27,8 @@
           be substituted according to the default properties instead of the ones determined by the
           profiles that were active during publishing. By ensuring that maven-shade runs for all
           subprojects, we eliminate this problem because the substitutions are baked into the final POM.
+
+          Here we 'borrow' the spark dummy project. So we needn't to publish one to maven central.
         -->
         <dependency>
             <groupId>org.spark-project.spark</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the snapshot published pom, the properties in the pom dependency are not replaced by the value we specified in the building. This will cause problem when user use the published artifacts in maven. But the published 0.1.0 artifacts doesn't have the problem.

The root cause is we disable DependencyReducedPom when shading the bigdl artifact later in the master branch. When generating DependencyReducedPom, the property will be replaced in the generated pom. That's why 0.1.0 published pom is fine but master published pom has problem.

This PR will fix this issue by bringing back the DependencyReducedPom. And it will also bring the shade to the parent project and add a dummy project dependency in the parent project. So all the project will be shaded and all the pom will be processed to replace the property with its value.

This is how spark deal with this problem. See https://github.com/apache/spark/blob/master/pom.xml#L246

## How was this patch tested?

Unit test

## Related links or issues (optional)
This PR is related with #874

