### PR TITLE
Refine model name

### DIFF
--- a/pyspark/dl/nn/criterion.py
+++ b/pyspark/dl/nn/criterion.py
@@ -38,6 +38,9 @@ class Criterion(JavaValue):
             bigdl_type, JavaValue.jvm_class_constructor(self), *args)
         self.bigdl_type = bigdl_type
 
+    def __str__(self):
+        return self.value.toString()
+
     def forward(self, input, target):
         """
         NB: It's for debug only, please use optimizer.optimize() in production.

--- a/pyspark/dl/nn/layer.py
+++ b/pyspark/dl/nn/layer.py
@@ -44,6 +44,15 @@ class Model(JavaValue):
             bigdl_type, JavaValue.jvm_class_constructor(self), *args)
         self.bigdl_type = bigdl_type
 
+    def __str__(self):
+        """
+        >>> conv2 = SpatialConvolution(6, 12, 5, 5).set_name("conv2")
+        creating: createSpatialConvolution
+        >>> print(conv2)
+        conv2(6 -> 12, 5 x 5, 1, 1, 0, 0)
+        """
+        return self.value.toString()
+
     @classmethod
     def of(cls, jmodel, bigdl_type="float"):
         """
@@ -159,6 +168,7 @@ class Model(JavaValue):
 
         return {layer_name: to_ndarray(params) for layer_name, params in
                 name_to_params.items()}
+
 
     def predict(self, data_rdd):
         """

--- a/pyspark/dl/nn/layer.py
+++ b/pyspark/dl/nn/layer.py
@@ -49,7 +49,7 @@ class Model(JavaValue):
         >>> conv2 = SpatialConvolution(6, 12, 5, 5).set_name("conv2")
         creating: createSpatialConvolution
         >>> print(conv2)
-        conv2(6 -> 12, 5 x 5, 1, 1, 0, 0)
+        SpatialConvolution[conv2](6 -> 12, 5 x 5, 1, 1, 0, 0)
         """
         return self.value.toString()
 

--- a/pyspark/dl/util/common.py
+++ b/pyspark/dl/util/common.py
@@ -68,6 +68,7 @@ class JavaCreator(SingletonMixin):
         else:
             raise Exception("Not supported bigdl_type: %s" % bigdl_type)
 
+
 class JavaValue(object):
     def jvm_class_constructor(self):
         name = "create" + self.__class__.__name__
@@ -78,6 +79,9 @@ class JavaValue(object):
         self.value = jvalue if jvalue else callBigDlFunc(
             bigdl_type, self.jvm_class_constructor(), *args)
         self.bigdl_type = bigdl_type
+
+    def __str__(self):
+        return self.value.toString()
 
 
 class TestResult():

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Abs.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Abs.scala
@@ -68,10 +68,6 @@ class Abs[T: ClassTag]
     val state = Seq(super.hashCode())
     state.map(getHashCode).foldLeft(0)((a, b) => 31 * a + b)
   }
-
-  override def toString(): String = {
-    s"nn.Abs"
-  }
 }
 
 object Abs {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/AbsCriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/AbsCriterion.scala
@@ -78,10 +78,6 @@ class AbsCriterion[@specialized(Float, Double) T: ClassTag](val sizeAverage: Boo
     val state = Seq(super.hashCode(), sizeAverage)
     state.map(getHashCode).foldLeft(0)((a, b) => 31 * a + b)
   }
-
-  override def toString(): String = {
-    s"nn.AbsCriterion"
-  }
 }
 
 object AbsCriterion {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Add.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Add.scala
@@ -101,7 +101,7 @@ class Add[T: ClassTag](val inputSize: Int
   }
 
   override def toString(): String = {
-    s"${getName}($inputSize)"
+    s"${getPrintName}($inputSize)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Add[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Add.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Add.scala
@@ -101,7 +101,7 @@ class Add[T: ClassTag](val inputSize: Int
   }
 
   override def toString(): String = {
-    s"nn.Add ($inputSize)"
+    s"${getName}($inputSize)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Add[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/AddConstant.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/AddConstant.scala
@@ -56,7 +56,7 @@ class AddConstant[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.AddConstant ($constant_scalar, $inplace)"
+    s"${getName}($constant_scalar, $inplace)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[AddConstant[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/AddConstant.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/AddConstant.scala
@@ -56,7 +56,7 @@ class AddConstant[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($constant_scalar, $inplace)"
+    s"${getPrintName}($constant_scalar, $inplace)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[AddConstant[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BiRecurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BiRecurrent.scala
@@ -117,7 +117,7 @@ class BiRecurrent[T : ClassTag] (
     this
   }
 
-  override def toString(): String = s"BiRecurrent($timeDim, $birnn)"
+  override def toString(): String = s"${getName}($timeDim, $birnn)"
 
   override def equals(other: Any): Boolean = other match {
     case that: BiRecurrent[T] =>

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BiRecurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BiRecurrent.scala
@@ -117,7 +117,7 @@ class BiRecurrent[T : ClassTag] (
     this
   }
 
-  override def toString(): String = s"${getName}($timeDim, $birnn)"
+  override def toString(): String = s"${getPrintName}($timeDim, $birnn)"
 
   override def equals(other: Any): Boolean = other match {
     case that: BiRecurrent[T] =>

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Bilinear.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Bilinear.scala
@@ -212,7 +212,7 @@ class Bilinear[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.Bilinear($inputSize1, $inputSize2, $outputSize, $biasRes)"
+    s"${getName}($inputSize1, $inputSize2, $outputSize, $biasRes)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Bilinear[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Bilinear.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Bilinear.scala
@@ -212,7 +212,7 @@ class Bilinear[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($inputSize1, $inputSize2, $outputSize, $biasRes)"
+    s"${getPrintName}($inputSize1, $inputSize2, $outputSize, $biasRes)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Bilinear[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Bottle.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Bottle.scala
@@ -105,7 +105,7 @@ class Bottle[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($module, $nInputDim, $nOutputDim1)"
+    s"${getPrintName}($module, $nInputDim, $nOutputDim1)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Bottle[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Bottle.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Bottle.scala
@@ -105,7 +105,7 @@ class Bottle[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.Bottle ($module, $nInputDim, $nOutputDim1)"
+    s"${getName}($module, $nInputDim, $nOutputDim1)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Bottle[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CAdd.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CAdd.scala
@@ -176,7 +176,7 @@ class CAdd[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}(${java.util.Arrays.toString(size)})"
+    s"${getPrintName}(${java.util.Arrays.toString(size)})"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CAdd.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CAdd.scala
@@ -176,7 +176,7 @@ class CAdd[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.CAdd(${java.util.Arrays.toString(size)})"
+    s"${getName}(${java.util.Arrays.toString(size)})"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CAddTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CAddTable.scala
@@ -65,10 +65,6 @@ class CAddTable[T: ClassTag](val inplace: Boolean = false)(
     }
     gradInput
   }
-
-  override def toString() : String = {
-    "nn.CAddTable"
-  }
 }
 
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CDivTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CDivTable.scala
@@ -52,10 +52,6 @@ class CDivTable[T: ClassTag](implicit ev: TensorNumeric[T])
     gradInput
   }
 
-  override def toString() : String = {
-    "nn.CDivTable"
-  }
-
   override def canEqual(other: Any): Boolean = other.isInstanceOf[CDivTable[T]]
 
   override def equals(other: Any): Boolean = other match {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CMaxTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CMaxTable.scala
@@ -78,10 +78,6 @@ class CMaxTable[T: ClassTag](implicit ev: TensorNumeric[T])
     gradInput
   }
 
-  override def toString() : String = {
-    "nn.CMaxTable"
-  }
-
   override def canEqual(other: Any): Boolean = other.isInstanceOf[CMaxTable[T]]
 
   override def equals(other: Any): Boolean = other match {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CMinTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CMinTable.scala
@@ -93,11 +93,6 @@ class CMinTable[T: ClassTag](implicit ev: TensorNumeric[T])
     val state = Seq(super.hashCode())
     state.map(getHashCode).foldLeft(0)((a, b) => 31 * a + b)
   }
-
-  override def toString() : String = {
-    "nn.CMinTable"
-  }
-
 }
 
 object CMinTable {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CMul.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CMul.scala
@@ -197,7 +197,7 @@ class CMul[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}(${java.util.Arrays.toString(size)})"
+    s"${getPrintName}(${java.util.Arrays.toString(size)})"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CMul.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CMul.scala
@@ -197,7 +197,7 @@ class CMul[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.CMul(${java.util.Arrays.toString(size)})"
+    s"${getName}(${java.util.Arrays.toString(size)})"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CMulTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CMulTable.scala
@@ -54,10 +54,6 @@ class CMulTable[T: ClassTag]()(
     gradInput
   }
 
-  override def toString() : String = {
-    "nn.CMulTable"
-  }
-
   override def canEqual(other: Any): Boolean = other.isInstanceOf[CMulTable[T]]
 
   override def equals(other: Any): Boolean = other match {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CSubTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CSubTable.scala
@@ -45,10 +45,6 @@ class CSubTable[T: ClassTag]()(
     gradInput
   }
 
-  override def toString(): String = {
-    s"nn.CSubTable"
-  }
-
   override def canEqual(other: Any): Boolean = other.isInstanceOf[CSubTable[T]]
 
   override def equals(other: Any): Boolean = other match {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Concat.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Concat.scala
@@ -305,7 +305,7 @@ class Concat[T: ClassTag](val dimension: Int)(
     val last = "   ... -> "
     val ext = "  |    "
     val extlast = "       "
-    s"nn.Concat {$line${tab}input$line${
+    s"${getName}{$line${tab}input$line${
       modules.zipWithIndex
         .map { case (model: AbstractModule[Activity, Activity, T], index: Int)
         => s"$tab$next(${index + 1}): ${

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Concat.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Concat.scala
@@ -305,7 +305,7 @@ class Concat[T: ClassTag](val dimension: Int)(
     val last = "   ... -> "
     val ext = "  |    "
     val extlast = "       "
-    s"${getName}{$line${tab}input$line${
+    s"${getPrintName}{$line${tab}input$line${
       modules.zipWithIndex
         .map { case (model: AbstractModule[Activity, Activity, T], index: Int)
         => s"$tab$next(${index + 1}): ${

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ConcatTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ConcatTable.scala
@@ -168,7 +168,7 @@ class ConcatTable[T : ClassTag]
     val ext = "  |    "
     val extlast = "       "
     val last = "   ... -> "
-    var str = s"${getName}"
+    var str = s"${getPrintName}"
     str = str + " {" + line + tab + "input"
     var i = 1
     while (i <= modules.length) {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ConcatTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ConcatTable.scala
@@ -168,7 +168,7 @@ class ConcatTable[T : ClassTag]
     val ext = "  |    "
     val extlast = "       "
     val last = "   ... -> "
-    var str = "nn.ConcatTable"
+    var str = s"${getName}"
     str = str + " {" + line + tab + "input"
     var i = 1
     while (i <= modules.length) {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cosine.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cosine.scala
@@ -187,7 +187,7 @@ class Cosine[T: ClassTag](val inputSize : Int, val outputSize : Int)(
   }
 
   override def toString(): String = {
-    s"${getName}($inputSize, $outputSize)"
+    s"${getPrintName}($inputSize, $outputSize)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Contiguous[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cosine.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cosine.scala
@@ -187,7 +187,7 @@ class Cosine[T: ClassTag](val inputSize : Int, val outputSize : Int)(
   }
 
   override def toString(): String = {
-    s"nn.Cosine($inputSize, $outputSize)"
+    s"${getName}($inputSize, $outputSize)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Contiguous[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CosineDistance.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CosineDistance.scala
@@ -119,10 +119,6 @@ class CosineDistance[T: ClassTag](
     gradInput
   }
 
-  override def toString(): String = {
-    s"nn.CosineDistance"
-  }
-
   override def canEqual(other: Any): Boolean = other.isInstanceOf[CosineDistance[T]]
 
   override def equals(other: Any): Boolean = other match {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Dropout.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Dropout.scala
@@ -202,7 +202,7 @@ class Dropout[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.Dropout($p)"
+    s"${getName}($p)"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Dropout.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Dropout.scala
@@ -202,7 +202,7 @@ class Dropout[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($p)"
+    s"${getPrintName}($p)"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Echo.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Echo.scala
@@ -40,10 +40,6 @@ class Echo[T: ClassTag] (implicit ev: TensorNumeric[T])
     println(s"${getName()} : Gradient size is ${gradOutput.size().mkString("x")}")
     this.gradInput
   }
-
-  override def toString(): String = {
-    s"nn.Echo"
-  }
 }
 
 object Echo {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Echo.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Echo.scala
@@ -32,12 +32,12 @@ class Echo[T: ClassTag] (implicit ev: TensorNumeric[T])
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
     this.output = input
-    println(s"${getName()} : Activation size is ${input.size().mkString("x")}")
+    println(s"${getPrintName} : Activation size is ${input.size().mkString("x")}")
     this.output
   }
   override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
     this.gradInput = gradOutput
-    println(s"${getName()} : Gradient size is ${gradOutput.size().mkString("x")}")
+    println(s"${getPrintName} : Gradient size is ${gradOutput.size().mkString("x")}")
     this.gradInput
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Euclidean.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Euclidean.scala
@@ -136,7 +136,7 @@ class Euclidean[T: ClassTag](val inputSize: Int, val outputSize: Int,
   }
 
   override def toString(): String = {
-    s"${getName}($inputSize, $outputSize)"
+    s"${getPrintName}($inputSize, $outputSize)"
   }
 
   override def zeroGradParameters(): Unit = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Euclidean.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Euclidean.scala
@@ -136,7 +136,7 @@ class Euclidean[T: ClassTag](val inputSize: Int, val outputSize: Int,
   }
 
   override def toString(): String = {
-    s"nn.Euclidean($inputSize, $outputSize)"
+    s"${getName}($inputSize, $outputSize)"
   }
 
   override def zeroGradParameters(): Unit = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Exp.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Exp.scala
@@ -37,10 +37,6 @@ class Exp[@specialized(Float, Double) T: ClassTag] (implicit ev: TensorNumeric[T
       .resizeAs(gradOutput)
       .cmul(output, gradOutput)
   }
-
-  override def toString(): String = {
-    s"nn.Exp"
-  }
 }
 
 object Exp {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GradientReversal.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GradientReversal.scala
@@ -51,10 +51,6 @@ class GradientReversal[T: ClassTag](var lambda: Double = 1) (implicit ev: Tensor
       .copy(gradOutput)
       .mul(ev.negative(ev.fromType[Double](lambda)))
   }
-
-  override def toString(): String = {
-    s"nn.GradientReversal"
-  }
 }
 
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/HardShrink.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/HardShrink.scala
@@ -66,10 +66,6 @@ class HardShrink[T: ClassTag](lambda: Double = 0.5)
     DenseTensorApply.apply3[T](gradInput, gradOutput, input, func)
     gradInput
   }
-
-  override def toString(): String = {
-    s"nn.HardShrink"
-  }
 }
 
 object HardShrink {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Index.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Index.scala
@@ -68,7 +68,7 @@ class Index[T: ClassTag](dimension: Int)(implicit ev: TensorNumeric[T])
   }
 
   override def toString(): String = {
-    s"${getName}($dimension)"
+    s"${getPrintName}($dimension)"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Index.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Index.scala
@@ -68,7 +68,7 @@ class Index[T: ClassTag](dimension: Int)(implicit ev: TensorNumeric[T])
   }
 
   override def toString(): String = {
-    s"nn.Index($dimension)"
+    s"${getName}($dimension)"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/InferReshape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/InferReshape.scala
@@ -143,7 +143,7 @@ class InferReshape[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.InferReshape(${
+    s"${getName}(${
       size.mkString("x")
     })"
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/InferReshape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/InferReshape.scala
@@ -143,7 +143,7 @@ class InferReshape[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}(${
+    s"${getPrintName}(${
       size.mkString("x")
     })"
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/L1Penalty.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/L1Penalty.scala
@@ -76,7 +76,7 @@ class L1Penalty[T: ClassTag]
   }
 
   override def toString(): String = {
-    s"${getName}($l1weight, $sizeAverage, $provideOutput)"
+    s"${getPrintName}($l1weight, $sizeAverage, $provideOutput)"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/L1Penalty.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/L1Penalty.scala
@@ -76,7 +76,7 @@ class L1Penalty[T: ClassTag]
   }
 
   override def toString(): String = {
-    s"nn.L1Penalty ($l1weight, $sizeAverage, $provideOutput)"
+    s"${getName}($l1weight, $sizeAverage, $provideOutput)"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LeakyReLU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LeakyReLU.scala
@@ -95,10 +95,6 @@ class LeakyReLU[T: ClassTag](
     }
     gradInput
   }
-
-  override def toString(): String = {
-    s"nn.LeakyReLU"
-  }
 }
 
 object LeakyReLU {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Linear.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Linear.scala
@@ -218,7 +218,7 @@ class Linear[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($inputSize -> $outputSize)"
+    s"${getPrintName}($inputSize -> $outputSize)"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Linear.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Linear.scala
@@ -218,7 +218,7 @@ class Linear[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.Linear($inputSize -> $outputSize)"
+    s"${getName}($inputSize -> $outputSize)"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Log.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Log.scala
@@ -42,10 +42,6 @@ class Log[T: ClassTag] (implicit ev: TensorNumeric[T])
 
     gradInput
   }
-
-  override def toString(): String = {
-    s"nn.Log"
-  }
 }
 
 object Log {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSigmoid.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSigmoid.scala
@@ -71,10 +71,6 @@ class LogSigmoid[T: ClassTag] (implicit ev: TensorNumeric[T])
 
     gradInput
   }
-
-  override def toString(): String = {
-    s"nn.LogSigmoid"
-  }
 }
 
 object LogSigmoid {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSoftMax.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSoftMax.scala
@@ -125,10 +125,6 @@ class LogSoftMax[T: ClassTag](
 
     gradInput
   }
-
-  override def toString(): String = {
-    s"nn.LogSoftMax"
-  }
 }
 
 object LogSoftMax {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LookupTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LookupTable.scala
@@ -234,7 +234,7 @@ class LookupTable[T: ClassTag]
   }
 
   override def toString(): String = {
-    s"${getName}($nIndex, $nOutput, $paddingValue, $maxNorm, $normType)"
+    s"${getPrintName}($nIndex, $nOutput, $paddingValue, $maxNorm, $normType)"
   }
 
   override def zeroGradParameters(): Unit = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LookupTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LookupTable.scala
@@ -234,7 +234,7 @@ class LookupTable[T: ClassTag]
   }
 
   override def toString(): String = {
-    s"nn.LookupTable($nIndex, $nOutput, $paddingValue, $maxNorm, $normType)"
+    s"${getName}($nIndex, $nOutput, $paddingValue, $maxNorm, $normType)"
   }
 
   override def zeroGradParameters(): Unit = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MapTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MapTable.scala
@@ -104,7 +104,7 @@ class MapTable[T: ClassTag](
     val tab = "  "
     val extlast = "       "
     val line = "\n"
-    var str = s"${getName}"
+    var str = s"${getPrintName}"
     if (module != null) {
       str += s"{$line$tab$module$line}"
     } else {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MapTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MapTable.scala
@@ -104,7 +104,7 @@ class MapTable[T: ClassTag](
     val tab = "  "
     val extlast = "       "
     val line = "\n"
-    var str = "nn.MapTable"
+    var str = s"${getName}"
     if (module != null) {
       str += s"{$line$tab$module$line}"
     } else {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MaskedSelect.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MaskedSelect.scala
@@ -72,10 +72,6 @@ class MaskedSelect[T: ClassTag]
     this
   }
 
-  override def toString(): String = {
-    s"nn.MaskedSelect"
-  }
-
   override def canEqual(other: Any): Boolean = other.isInstanceOf[MaskedSelect[T]]
 
   override def equals(other: Any): Boolean = other match {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Max.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Max.scala
@@ -77,7 +77,7 @@ class Max[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.Max($dim${if (numInputDims != Int.MinValue) ", " + numInputDims else ""})"
+    s"${getName}($dim${if (numInputDims != Int.MinValue) ", " + numInputDims else ""})"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Max[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Max.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Max.scala
@@ -77,7 +77,7 @@ class Max[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($dim${if (numInputDims != Int.MinValue) ", " + numInputDims else ""})"
+    s"${getPrintName}($dim${if (numInputDims != Int.MinValue) ", " + numInputDims else ""})"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Max[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Min.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Min.scala
@@ -77,7 +77,7 @@ class Min[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.Min($dim${if (numInputDims != Int.MinValue) ", " + numInputDims else ""})"
+    s"${getName}($dim${if (numInputDims != Int.MinValue) ", " + numInputDims else ""})"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Min[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Min.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Min.scala
@@ -77,7 +77,7 @@ class Min[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($dim${if (numInputDims != Int.MinValue) ", " + numInputDims else ""})"
+    s"${getPrintName}($dim${if (numInputDims != Int.MinValue) ", " + numInputDims else ""})"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Min[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MixtureTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MixtureTable.scala
@@ -192,7 +192,7 @@ class MixtureTable[T: ClassTag](var dim: Int = Int.MaxValue)
   }
 
   override def toString(): String = {
-    s"${getName}($dim)"
+    s"${getPrintName}($dim)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[MixtureTable[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MixtureTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MixtureTable.scala
@@ -192,7 +192,7 @@ class MixtureTable[T: ClassTag](var dim: Int = Int.MaxValue)
   }
 
   override def toString(): String = {
-    s"nn.MixtureTable($dim)"
+    s"${getName}($dim)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[MixtureTable[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Mul.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Mul.scala
@@ -88,10 +88,6 @@ class Mul[T: ClassTag](implicit ev: TensorNumeric[T]) extends TensorModule[T] {
     val state = Seq(super.hashCode(), weight, gradWeight)
     state.map(getHashCode).foldLeft(0)((a, b) => 31 * a + b)
   }
-
-  override def toString(): String = {
-    s"nn.Mul"
-  }
 }
 
 object Mul {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MulConstant.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MulConstant.scala
@@ -59,7 +59,7 @@ class MulConstant[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($scalar, $inplace)"
+    s"${getPrintName}($scalar, $inplace)"
   }
 
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MulConstant.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MulConstant.scala
@@ -59,7 +59,7 @@ class MulConstant[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.MulConstant($scalar, $inplace)"
+    s"${getName}($scalar, $inplace)"
   }
 
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Narrow.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Narrow.scala
@@ -45,7 +45,7 @@ class Narrow[T: ClassTag](dimension: Int, offset: Int, length: Int = 1)
     gradInput
   }
   override def toString(): String = {
-    s"${getName}($dimension, $offset, $length)"
+    s"${getPrintName}($dimension, $offset, $length)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Narrow[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Narrow.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Narrow.scala
@@ -45,7 +45,7 @@ class Narrow[T: ClassTag](dimension: Int, offset: Int, length: Int = 1)
     gradInput
   }
   override def toString(): String = {
-    s"nn.Narrow($dimension, $offset, $length)"
+    s"${getName}($dimension, $offset, $length)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Narrow[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/NarrowTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/NarrowTable.scala
@@ -76,7 +76,7 @@ class NarrowTable[T: ClassTag](var offset: Int, val length: Int = 1)
   }
 
   override def toString(): String = {
-    s"${getName}($offset, $length)"
+    s"${getPrintName}($offset, $length)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[NarrowTable[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/NarrowTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/NarrowTable.scala
@@ -76,7 +76,7 @@ class NarrowTable[T: ClassTag](var offset: Int, val length: Int = 1)
   }
 
   override def toString(): String = {
-    s"nn.NarrowTable($offset, $length)"
+    s"${getName}($offset, $length)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[NarrowTable[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Normalize.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Normalize.scala
@@ -144,7 +144,7 @@ class Normalize[T: ClassTag](val p: Double, val eps: Double = 1e-10
   }
 
   override def toString(): String = {
-    s"${getName}($p, $eps)"
+    s"${getPrintName}($p, $eps)"
   }
 
   override def clearState() : this.type = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Normalize.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Normalize.scala
@@ -144,7 +144,7 @@ class Normalize[T: ClassTag](val p: Double, val eps: Double = 1e-10
   }
 
   override def toString(): String = {
-    s"nn.Normalize($p, $eps)"
+    s"${getName}($p, $eps)"
   }
 
   override def clearState() : this.type = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/PReLU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/PReLU.scala
@@ -287,7 +287,7 @@ class PReLU[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.PReLU($nOutputPlane)"
+    s"${getName}($nOutputPlane)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[PReLU[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/PReLU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/PReLU.scala
@@ -287,7 +287,7 @@ class PReLU[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($nOutputPlane)"
+    s"${getPrintName}($nOutputPlane)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[PReLU[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Padding.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Padding.scala
@@ -91,7 +91,7 @@ class Padding[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($dim, $pad, $nInputDim, $value, $nIndex)"
+    s"${getPrintName}($dim, $pad, $nInputDim, $value, $nIndex)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Padding[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Padding.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Padding.scala
@@ -91,7 +91,7 @@ class Padding[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.Padding ($dim, $pad, $nInputDim, $value, $nIndex)"
+    s"${getName}($dim, $pad, $nInputDim, $value, $nIndex)"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Padding[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Power.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Power.scala
@@ -99,7 +99,7 @@ class Power[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.Power($power, $scale, $shift)"
+    s"${getName}($power, $scale, $shift)"
   }
 
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Power.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Power.scala
@@ -99,7 +99,7 @@ class Power[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($power, $scale, $shift)"
+    s"${getPrintName}($power, $scale, $shift)"
   }
 
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/RNN.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/RNN.scala
@@ -69,11 +69,6 @@ class RnnCell[T : ClassTag] (
       .add(Identity[T]())
       .add(Identity[T]()))
 
-  override def toString(): String = {
-    val str = "nn.RnnCell"
-    str
-  }
-
   /**
    * Clear cached activities to save storage space or network bandwidth. Note that we use
    * Tensor.set to keep some information like tensor share

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ReLU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ReLU.scala
@@ -31,10 +31,6 @@ import scala.reflect.ClassTag
 @SerialVersionUID(1208478077576570643L)
 class ReLU[T: ClassTag](ip: Boolean = false)(
   implicit ev: TensorNumeric[T]) extends Threshold[T](0, 0, ip) {
-
-  override def toString(): String = {
-    s"nn.ReLU"
-  }
 }
 
 object ReLU {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ReLU6.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ReLU6.scala
@@ -39,10 +39,6 @@ class ReLU6[T: ClassTag](inplace: Boolean = false)
   override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
     super.updateGradInput(input, gradOutput)
   }
-
-  override def toString(): String = {
-    s"nn.ReLU6"
-  }
 }
 
 object ReLU6 {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -252,11 +252,6 @@ class Recurrent[T : ClassTag]()
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Recurrent[T]]
 
-  override def toString(): String = {
-    val str = "nn.Recurrent"
-    str
-  }
-
   override def equals(other: Any): Boolean = other match {
     case that: Recurrent[T] =>
       super.equals(that) &&

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Replicate.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Replicate.scala
@@ -80,7 +80,7 @@ class Replicate[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($nFeatures, $dim${if (nDim != Int.MaxValue) ", " + nDim else ""})"
+    s"${getPrintName}($nFeatures, $dim${if (nDim != Int.MaxValue) ", " + nDim else ""})"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Replicate.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Replicate.scala
@@ -80,7 +80,7 @@ class Replicate[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.Replicate($nFeatures, $dim${if (nDim != Int.MaxValue) ", " + nDim else ""})"
+    s"${getName}($nFeatures, $dim${if (nDim != Int.MaxValue) ", " + nDim else ""})"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Reshape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Reshape.scala
@@ -119,7 +119,7 @@ class Reshape[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.Reshape(${size.mkString("x")})"
+    s"${getName}(${size.mkString("x")})"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Reshape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Reshape.scala
@@ -119,7 +119,7 @@ class Reshape[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}(${size.mkString("x")})"
+    s"${getPrintName}(${size.mkString("x")})"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Sequential.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Sequential.scala
@@ -133,7 +133,7 @@ class Sequential[T: ClassTag]
   override def toString(): String = {
     val tab = "  "
 
-    s"nn.Sequential {${line + tab}[input -> ${
+    s"${getName}{${line + tab}[input -> ${
       modules.zipWithIndex.map {
         case (m: AbstractModule[Activity, Activity, T], i: Int) => "(" + (i + 1) + ")"
       }.

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Sequential.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Sequential.scala
@@ -133,7 +133,7 @@ class Sequential[T: ClassTag]
   override def toString(): String = {
     val tab = "  "
 
-    s"${getName}{${line + tab}[input -> ${
+    s"${getPrintName}{${line + tab}[input -> ${
       modules.zipWithIndex.map {
         case (m: AbstractModule[Activity, Activity, T], i: Int) => "(" + (i + 1) + ")"
       }.

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Sigmoid.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Sigmoid.scala
@@ -44,10 +44,6 @@ class Sigmoid[@specialized(Float, Double) T: ClassTag](
     gradInput.map(output, (g, z) => ev.times(ev.times(g, ev.minus(ev.fromType[Int](1), z)), z))
     gradInput
   }
-
-  override def toString(): String = {
-    s"nn.Sigmoid"
-  }
 }
 
 object Sigmoid {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftMax.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftMax.scala
@@ -61,10 +61,6 @@ class SoftMax[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends TensorModule
     SoftMax.updateGradInput[T](input, gradOutput, gradInput, output, results)
     gradInput
   }
-
-  override def toString(): String = {
-    s"nn.SoftMax"
-  }
 }
 
 object SoftMax{

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftMin.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftMin.scala
@@ -66,10 +66,6 @@ class SoftMin[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends TensorModule
     gradInput.mul(ev.fromType[Int](-1))
     gradInput
   }
-
-  override def toString(): String = {
-    s"nn.SoftMin"
-  }
 }
 
 object SoftMin {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftPlus.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftPlus.scala
@@ -79,10 +79,6 @@ class SoftPlus[T: ClassTag](
 
     gradInput
   }
-
-  override def toString(): String = {
-    s"nn.SoftPlus"
-  }
 }
 
 object SoftPlus {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftShrink.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftShrink.scala
@@ -73,10 +73,6 @@ class SoftShrink[T: ClassTag](
 
     gradInput
   }
-
-  override def toString(): String = {
-    s"nn.SoftShrink"
-  }
 }
 
 object SoftShrink {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftSign.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftSign.scala
@@ -54,10 +54,6 @@ class SoftSign[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends TensorModul
     gradInput.resizeAs(input).copy(gradOutput).cdiv(tempGrad)
     gradInput
   }
-
-  override def toString(): String = {
-    s"nn.SoftSign"
-  }
 }
 
 object SoftSign {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialAveragePooling.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialAveragePooling.scala
@@ -468,7 +468,7 @@ class SpatialAveragePooling[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($kW, $kH, $dW, $dH, $padW, $padH)"
+    s"${getPrintName}($kW, $kH, $dW, $dH, $padW, $padH)"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialAveragePooling.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialAveragePooling.scala
@@ -468,7 +468,7 @@ class SpatialAveragePooling[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.SpatialAveragePooling($kW, $kH, $dW, $dH, $padW, $padH)"
+    s"${getName}($kW, $kH, $dW, $dH, $padW, $padH)"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialBatchNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialBatchNormalization.scala
@@ -43,7 +43,7 @@ class SpatialBatchNormalization[T: ClassTag](
   override val nDim = 4
 
   override def toString(): String = {
-    s"nn.SpatialBatchNormalization[${ev.getType()}]($nOutput, $eps, $momentum, $affine)"
+    s"${getName}[${ev.getType()}]($nOutput, $eps, $momentum, $affine)"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialBatchNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialBatchNormalization.scala
@@ -43,7 +43,7 @@ class SpatialBatchNormalization[T: ClassTag](
   override val nDim = 4
 
   override def toString(): String = {
-    s"${getName}[${ev.getType()}]($nOutput, $eps, $momentum, $affine)"
+    s"${getPrintName}[${ev.getType()}]($nOutput, $eps, $momentum, $affine)"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialContrastiveNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialContrastiveNormalization.scala
@@ -63,7 +63,7 @@ class SpatialContrastiveNormalization[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"SpatialContrastiveNormalization($nInputPlane, kernelTensor, $threshold, $thresval)"
+    s"${getName}($nInputPlane, kernelTensor, $threshold, $thresval)"
   }
 
   override def canEqual(other: Any): Boolean = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialContrastiveNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialContrastiveNormalization.scala
@@ -63,7 +63,7 @@ class SpatialContrastiveNormalization[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($nInputPlane, kernelTensor, $threshold, $thresval)"
+    s"${getPrintName}($nInputPlane, kernelTensor, $threshold, $thresval)"
   }
 
   override def canEqual(other: Any): Boolean = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialConvolution.scala
@@ -422,7 +422,7 @@ class SpatialConvolution[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName()}($nInputPlane -> $nOutputPlane, $kernelW x" +
+    s"${getPrintName}($nInputPlane -> $nOutputPlane, $kernelW x" +
       s" $kernelH, $strideW, $strideH, $padW, $padH)"
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialConvolution.scala
@@ -422,7 +422,7 @@ class SpatialConvolution[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.SpatialConvolution($nInputPlane -> $nOutputPlane, $kernelW x" +
+    s"${getName()}($nInputPlane -> $nOutputPlane, $kernelW x" +
       s" $kernelH, $strideW, $strideH, $padW, $padH)"
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialCrossMapLRN.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialCrossMapLRN.scala
@@ -89,7 +89,7 @@ class SpatialCrossMapLRN[@specialized(Float, Double) T: ClassTag]
   }
 
   override def toString(): String = {
-    s"${getName}($size, $alpha, $beta, $k)"
+    s"${getPrintName}($size, $alpha, $beta, $k)"
   }
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialCrossMapLRN.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialCrossMapLRN.scala
@@ -89,7 +89,7 @@ class SpatialCrossMapLRN[@specialized(Float, Double) T: ClassTag]
   }
 
   override def toString(): String = {
-    s"nn.LocalResponseNormalizationAcrossChannels($size, $alpha, $beta, $k)"
+    s"${getName}($size, $alpha, $beta, $k)"
   }
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialDilatedConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialDilatedConvolution.scala
@@ -549,7 +549,7 @@ class SpatialDilatedConvolution[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($nInputPlane -> $nOutputPlane, " +
+    s"${getPrintName}($nInputPlane -> $nOutputPlane, " +
       s"$kW x $kH, $dW, $dH, $padW, $padH, $dilationH, $dilationW)"
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialDilatedConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialDilatedConvolution.scala
@@ -549,7 +549,7 @@ class SpatialDilatedConvolution[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.SpatialDilatedConvolution($nInputPlane -> $nOutputPlane, " +
+    s"${getName}($nInputPlane -> $nOutputPlane, " +
       s"$kW x $kH, $dW, $dH, $padW, $padH, $dilationH, $dilationW)"
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialDivisiveNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialDivisiveNormalization.scala
@@ -171,7 +171,7 @@ class SpatialDivisiveNormalization[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($nInputPlane, kernelTensor, $threshold, $thresval)"
+    s"${getPrintName}($nInputPlane, kernelTensor, $threshold, $thresval)"
   }
 
   override def canEqual(other: Any): Boolean = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialDivisiveNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialDivisiveNormalization.scala
@@ -171,7 +171,7 @@ class SpatialDivisiveNormalization[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"SpatialDivisiveNormalization($nInputPlane, kernelTensor, $threshold, $thresval)"
+    s"${getName}($nInputPlane, kernelTensor, $threshold, $thresval)"
   }
 
   override def canEqual(other: Any): Boolean = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolution.scala
@@ -776,7 +776,7 @@ class SpatialFullConvolution[A <: Activity : ClassTag, T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($nInputPlane -> $nOutputPlane, " +
+    s"${getPrintName}($nInputPlane -> $nOutputPlane, " +
       s"$kW x $kH, $dW, $dH, $padW, $padH, $adjW, $adjH)"
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolution.scala
@@ -776,7 +776,7 @@ class SpatialFullConvolution[A <: Activity : ClassTag, T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.SpatialFullConvolution($nInputPlane -> $nOutputPlane, " +
+    s"${getName}($nInputPlane -> $nOutputPlane, " +
       s"$kW x $kH, $dW, $dH, $padW, $padH, $adjW, $adjH)"
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialMaxPooling.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialMaxPooling.scala
@@ -276,7 +276,7 @@ class SpatialMaxPooling[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.SpatialMaxPooling($kW, $kH, $dW, $dH, $padW, $padH)"
+    s"${getName}($kW, $kH, $dW, $dH, $padW, $padH)"
   }
 
   override def clearState(): this.type = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialMaxPooling.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialMaxPooling.scala
@@ -276,7 +276,7 @@ class SpatialMaxPooling[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($kW, $kH, $dW, $dH, $padW, $padH)"
+    s"${getPrintName}($kW, $kH, $dW, $dH, $padW, $padH)"
   }
 
   override def clearState(): this.type = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialShareConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialShareConvolution.scala
@@ -331,7 +331,7 @@ class SpatialShareConvolution[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.SpatialShareConvolution($nInputPlane -> $nOutputPlane, $kernelW x" +
+    s"${getName}($nInputPlane -> $nOutputPlane, $kernelW x" +
       s" $kernelH, $strideW, $strideH, $padW, $padH)"
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialShareConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialShareConvolution.scala
@@ -331,7 +331,7 @@ class SpatialShareConvolution[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($nInputPlane -> $nOutputPlane, $kernelW x" +
+    s"${getPrintName}($nInputPlane -> $nOutputPlane, $kernelW x" +
       s" $kernelH, $strideW, $strideH, $padW, $padH)"
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialSubtractiveNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialSubtractiveNormalization.scala
@@ -144,7 +144,7 @@ class SpatialSubtractiveNormalization[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"SpatialSubtractiveNormalization($nInputPlane, kernelTensor)"
+    s"${getName}($nInputPlane, kernelTensor)"
   }
 
   override def canEqual(other: Any): Boolean = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialSubtractiveNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialSubtractiveNormalization.scala
@@ -144,7 +144,7 @@ class SpatialSubtractiveNormalization[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($nInputPlane, kernelTensor)"
+    s"${getPrintName}($nInputPlane, kernelTensor)"
   }
 
   override def canEqual(other: Any): Boolean = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialZeroPadding.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialZeroPadding.scala
@@ -170,7 +170,7 @@ class SpatialZeroPadding[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}(l=$padLeft, r=$padRight, t=$padTop, b=$padBottom)"
+    s"${getPrintName}(l=$padLeft, r=$padRight, t=$padTop, b=$padBottom)"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialZeroPadding.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialZeroPadding.scala
@@ -170,7 +170,7 @@ class SpatialZeroPadding[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.SpatialZeroPadding(l=$padLeft, r=$padRight, t=$padTop, b=$padBottom)"
+    s"${getName}(l=$padLeft, r=$padRight, t=$padTop, b=$padBottom)"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Sqrt.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Sqrt.scala
@@ -25,10 +25,6 @@ import scala.reflect.ClassTag
 
 @SerialVersionUID(223597921741020277L)
 class Sqrt[T: ClassTag](implicit ev: TensorNumeric[T]) extends Power[T](0.5, 1, 0) {
-
-  override def toString(): String = {
-    s"nn.Sqrt"
-  }
 }
 
 object Sqrt {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Square.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Square.scala
@@ -25,10 +25,6 @@ import scala.reflect.ClassTag
 
 @SerialVersionUID(5169592189338322411L)
 class Square[T: ClassTag](implicit ev: TensorNumeric[T]) extends Power[T](2, 1, 0) {
-
-  override def toString(): String = {
-    s"nn.Square"
-  }
 }
 
 object Square {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Squeeze.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Squeeze.scala
@@ -67,7 +67,7 @@ class Squeeze[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.Squeeze(${if (dims != null) dims.mkString(",") + ", " else ""}" +
+    s"${getName}(${if (dims != null) dims.mkString(",") + ", " else ""}" +
       s"${if (batchMode) "batch" else ""})"
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Squeeze.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Squeeze.scala
@@ -67,7 +67,7 @@ class Squeeze[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}(${if (dims != null) dims.mkString(",") + ", " else ""}" +
+    s"${getPrintName}(${if (dims != null) dims.mkString(",") + ", " else ""}" +
       s"${if (batchMode) "batch" else ""})"
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Tanh.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Tanh.scala
@@ -44,10 +44,6 @@ class Tanh[@specialized(Float, Double) T: ClassTag](
       gradValue, ev.minus(ev.fromType[Int](1), ev.times(outputValue, outputValue))))
     gradInput
   }
-
-  override def toString(): String = {
-    s"nn.Tanh"
-  }
 }
 
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Threshold.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Threshold.scala
@@ -396,7 +396,7 @@ class Threshold[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.Threshold($th, $v)"
+    s"${getName}($th, $v)"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Threshold.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Threshold.scala
@@ -396,7 +396,7 @@ class Threshold[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($th, $v)"
+    s"${getPrintName}($th, $v)"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributed.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributed.scala
@@ -189,11 +189,6 @@ class TimeDistributed[T : ClassTag] (layer: TensorModule[T])
     this
   }
 
-  override def toString(): String = {
-    val str = "nn.TimeDistributed"
-    str
-  }
-
   override def canEqual(other: Any): Boolean = other.isInstanceOf[TimeDistributed[T]]
 
   override def equals(other: Any): Boolean = other match {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Transpose.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Transpose.scala
@@ -55,7 +55,7 @@ class Transpose[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.Transpose(${
+    s"${getName}(${
       permutations.map {
         case (from: Int, to: Int) => s"$from -> $to"
       }.mkString(", ")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Transpose.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Transpose.scala
@@ -55,7 +55,7 @@ class Transpose[@specialized(Float, Double) T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}(${
+    s"${getPrintName}(${
       permutations.map {
         case (from: Int, to: Int) => s"$from -> $to"
       }.mkString(", ")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Unsqueeze.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Unsqueeze.scala
@@ -68,7 +68,7 @@ class Unsqueeze[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.Unsqueeze($pos${if (numInputDims != Int.MinValue) ", " + numInputDims else ""})"
+    s"${getName}($pos${if (numInputDims != Int.MinValue) ", " + numInputDims else ""})"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Unsqueeze[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Unsqueeze.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Unsqueeze.scala
@@ -68,7 +68,7 @@ class Unsqueeze[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($pos${if (numInputDims != Int.MinValue) ", " + numInputDims else ""})"
+    s"${getPrintName}($pos${if (numInputDims != Int.MinValue) ", " + numInputDims else ""})"
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Unsqueeze[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/View.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/View.scala
@@ -124,7 +124,7 @@ class View[T: ClassTag](sizes: Array[Int])(
   }
 
   override def toString(): String = {
-    s"nn.View(${sizes.mkString("x")})"
+    s"${getName}(${sizes.mkString("x")})"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/View.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/View.scala
@@ -124,7 +124,7 @@ class View[T: ClassTag](sizes: Array[Int])(
   }
 
   override def toString(): String = {
-    s"${getName}(${sizes.mkString("x")})"
+    s"${getPrintName}(${sizes.mkString("x")})"
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricMaxPooling.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricMaxPooling.scala
@@ -325,7 +325,7 @@ class VolumetricMaxPooling[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"nn.VolumetricMaxPooling($kT, $kW, $kH, $dT, $dW, $dH, $padT, $padW, $padH)"
+    s"${getName}($kT, $kW, $kH, $dT, $dW, $dH, $padT, $padW, $padH)"
   }
 
   override def clearState(): this.type = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricMaxPooling.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricMaxPooling.scala
@@ -325,7 +325,7 @@ class VolumetricMaxPooling[T: ClassTag](
   }
 
   override def toString(): String = {
-    s"${getName}($kT, $kW, $kH, $dT, $dW, $dH, $padT, $padW, $padH)"
+    s"${getPrintName}($kT, $kW, $kH, $dT, $dW, $dH, $padT, $padW, $padH)"
   }
 
   override def clearState(): this.type = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -131,7 +131,17 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag,
     }
   }
 
-  override def toString(): String = getName()
+  def getPrintName(): String = {
+    val postfix = if (name == null) {
+      namePostfix
+    } else {
+      name
+    }
+    s"${this.getClass.getSimpleName}[${postfix}]"
+
+  }
+
+  override def toString(): String =getPrintName
 
   protected var forwardTime = 0L
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -125,11 +125,13 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag,
    */
   def getName() : String = {
     if (this.name == null) {
-      s"${this.getClass.getName}@${namePostfix}"
+      s"${this.getClass.getSimpleName}@${namePostfix}"
     } else {
       this.name
     }
   }
+
+  override def toString(): String = getName()
 
   protected var forwardTime = 0L
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -131,7 +131,7 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag,
     }
   }
 
-  def getPrintName(): String = {
+  protected def getPrintName(): String = {
     val postfix = if (name == null) {
       namePostfix
     } else {
@@ -141,7 +141,7 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag,
 
   }
 
-  override def toString(): String =getPrintName
+  override def toString(): String = getPrintName
 
   protected var forwardTime = 0L
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Previously the name of module is hardcode and cannot reflect the user input.
After the changes: 
```
        >>> conv2 = SpatialConvolution(6, 12, 5, 5).set_name("conv2")
        >>> print(conv2)
        conv2(6 -> 12, 5 x 5, 1, 1, 0, 0)
```

and use simple class name for the default value: ie. ``` com.intel.analytics.bigdl.nn.SoftMax@4df4dc0``` -> ``` SoftMax@4df4dc0```

## How was this patch tested?
manual

https://github.com/intel-analytics/BigDL/issues/893

