### PR TITLE
Some new Sample/MiniBatch implements, and SampleToMiniBatch transformer

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/DataSet.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/DataSet.scala
@@ -393,7 +393,7 @@ object DataSet {
     if (isInOrder) {
       require(classTag[T] == classTag[Sample[_]],
         "DataSet.sortData: Only support sort for sample input")
-      data.sortBy(a => a.asInstanceOf[Sample[_]].featureLength())
+      data.sortBy(a => a.asInstanceOf[Sample[_]].featureLength()(0))
     } else {
       data
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/DataSet.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/DataSet.scala
@@ -393,7 +393,7 @@ object DataSet {
     if (isInOrder) {
       require(classTag[T] == classTag[Sample[_]],
         "DataSet.sortData: Only support sort for sample input")
-      data.sortBy(a => a.asInstanceOf[Sample[_]].featureLength()(0))
+      data.sortBy(a => a.asInstanceOf[Sample[_]].featureLength(0))
     } else {
       data
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
@@ -18,9 +18,8 @@ package com.intel.analytics.bigdl.dataset
 
 import com.intel.analytics.bigdl.nn.abstractnn.Activity
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.{T, Table}
 
-import scala.reflect.ClassTag
 
 /**
  * A interface for MiniBatch.
@@ -100,9 +99,102 @@ class TensorMiniBatch[T](
   }
 }
 
+/**
+ * A MiniBatch with [[com.intel.analytics.bigdl.utils.Table]] input and [[Tensor]] target.
+ * The size of first dimension in input and target should be the mini-batch size.
+ *b
+ * @param input input Table
+ * @param target target Tensor
+ * @tparam T Numeric type
+ */
+class ArrayTensorMiniBatch[T](
+      val input: Table,
+      val target: Tensor[T]) extends MiniBatch[T]{
+
+  override def size(): Int = {
+    input[Tensor[T]](1).size(1)
+  }
+
+  override def slice(offset: Int, length: Int): MiniBatch[T] = {
+    val t = T()
+    var b = 1
+    while(b <= input.length()) {
+      t(b) = input[Tensor[T]](b).narrow(1, offset, length)
+      b += 1
+    }
+    MiniBatch(t, target.narrow(1, offset, length))
+  }
+
+  override def getInput(): Activity = {
+    input
+  }
+
+  override def getTarget(): Activity = {
+    target
+  }
+}
+
+class UnlabeledTensorMiniBatch[T](
+      val input: Tensor[T]) extends MiniBatch[T]{
+
+  override def size(): Int = {
+    input.size(1)
+  }
+
+  override def slice(offset: Int, length: Int): MiniBatch[T] = {
+    MiniBatch(input.narrow(1, offset, length))
+  }
+
+  override def getInput(): Activity = {
+    input
+  }
+
+  override def getTarget(): Activity = {
+    throw new UnsupportedOperationException("UnlabeledTensorMiniBatch: no target in this MiniBatch")
+  }
+}
+
+class UnlabeledArrayTensorMiniBatch[T](
+      val input: Table) extends MiniBatch[T]{
+
+  override def size(): Int = {
+    input[Tensor[T]](1).size(1)
+  }
+
+  override def slice(offset: Int, length: Int): MiniBatch[T] = {
+    val t = T()
+    var b = 1
+    while(b <= input.length()) {
+      t(b) = input[Tensor[T]](b).narrow(1, offset, length)
+      b += 1
+    }
+    MiniBatch(t)
+  }
+
+  override def getInput(): Activity = {
+    input
+  }
+
+  override def getTarget(): Activity = {
+    throw new UnsupportedOperationException("No target in this UnlabeledArrayTensorMiniBatch")
+  }
+}
+
 object MiniBatch {
   def apply[T](input: Tensor[T], target: Tensor[T]): MiniBatch[T] = {
     new TensorMiniBatch[T](input, target)
+  }
+
+  def apply[T](input: Table, target: Tensor[T]): MiniBatch[T] = {
+    new ArrayTensorMiniBatch[T](input, target)
+  }
+
+  def apply[T](input: Tensor[T]): MiniBatch[T] = {
+    new UnlabeledTensorMiniBatch[T](input)
+  }
+
+  def apply[T](input: Table): MiniBatch[T] = {
+    new UnlabeledArrayTensorMiniBatch[T](input)
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
@@ -18,6 +18,9 @@ package com.intel.analytics.bigdl.dataset
 
 import com.intel.analytics.bigdl.nn.abstractnn.Activity
 import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+
+import scala.reflect.ClassTag
 
 /**
  * A interface for MiniBatch.

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
@@ -101,8 +101,8 @@ class TensorMiniBatch[T](
 
 /**
  * A MiniBatch with [[com.intel.analytics.bigdl.utils.Table]] input and [[Tensor]] target.
- * The size of first dimension in input and target should be the mini-batch size.
- *b
+ * The size of first dimension in input's first tensor and target is the mini-batch size.
+ *
  * @param input input Table
  * @param target target Tensor
  * @tparam T Numeric type
@@ -134,6 +134,11 @@ class ArrayTensorMiniBatch[T](
   }
 }
 
+/**
+ * TensorMiniBatch without target.
+ * @param input input tensor of this MiniBatch
+ * @tparam T Numeric type
+ */
 class UnlabeledTensorMiniBatch[T](
       val input: Tensor[T]) extends MiniBatch[T]{
 
@@ -154,6 +159,11 @@ class UnlabeledTensorMiniBatch[T](
   }
 }
 
+/**
+ * ArrayTensorMiniBatch without target.
+ * @param input input table of this MiniBatch
+ * @tparam T Numeric type
+ */
 class UnlabeledArrayTensorMiniBatch[T](
       val input: Table) extends MiniBatch[T]{
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
@@ -17,8 +17,11 @@
 package com.intel.analytics.bigdl.dataset
 
 import com.intel.analytics.bigdl.nn.abstractnn.Activity
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.{DoubleType, FloatType, Tensor}
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.{T, Table}
+
+import scala.reflect.ClassTag
 
 
 /**
@@ -67,6 +70,8 @@ trait MiniBatch[T] extends Serializable{
       " Only support TensorMiniBatch.")
     this.asInstanceOf[TensorMiniBatch[T]].input
   }
+
+  def setValue(samples: Array[Sample[T]])(implicit ev: TensorNumeric[T]): this.type
 }
 
 /**
@@ -77,7 +82,7 @@ trait MiniBatch[T] extends Serializable{
  * @param target target Tensor
  * @tparam T Numeric type
  */
-class TensorMiniBatch[T](
+class TensorMiniBatch[T: ClassTag](
       val input: Tensor[T],
       val target: Tensor[T]) extends MiniBatch[T]{
   require(input.size(1) == target.size(1))
@@ -97,32 +102,66 @@ class TensorMiniBatch[T](
   override def getTarget(): Activity = {
     target
   }
+
+  override def setValue(samples: Array[Sample[T]])(implicit ev: TensorNumeric[T]): this.type = {
+    // todo
+    throw new UnsupportedOperationException("unimplemented")
+  }
+
 }
 
 /**
  * A MiniBatch with [[com.intel.analytics.bigdl.utils.Table]] input and [[Tensor]] target.
  * The size of first dimension in input's first tensor and target is the mini-batch size.
  *
- * @param input input Table
- * @param target target Tensor
+ * @param inputData input Table
+ * @param targetData target Tensor
  * @tparam T Numeric type
+ * @since 0.2.0
  */
-class ArrayTensorMiniBatch[T](
-      val input: Table,
-      val target: Tensor[T]) extends MiniBatch[T]{
+class ArrayTensorMiniBatch[T: ClassTag](
+    val inputData: Array[Tensor[T]],
+    val targetData: Array[Tensor[T]],
+    featurePadding: Option[Array[Tensor[T]]] = None,
+    featureFixedLength: Option[Array[Int]] = None,
+    featureIncrement: Option[Array[Int]] = None,
+    labelPadding: Option[Array[T]] = None,
+    labelFixedLength: Option[Array[Int]] = None,
+    labelIncrement: Option[Array[Int]] = None) extends MiniBatch[T]{
+  require(inputData.length > 0, "Input data in MiniBatch is empty.")
+  val input: Activity = if (inputData.length == 1) {
+    inputData(0)
+  } else {
+    T.array(inputData.map(_.asInstanceOf[Any]))
+  }
+
+  val target: Activity = if (targetData.length == 0) {
+    null
+  } else if (targetData.length == 1) {
+    targetData(0)
+  } else {
+    T.array(targetData.map(_.asInstanceOf[Any]))
+  }
 
   override def size(): Int = {
-    input[Tensor[T]](1).size(1)
+    inputData(0).size(1)
   }
 
   override def slice(offset: Int, length: Int): MiniBatch[T] = {
-    val t = T()
+    val is = new Array[Tensor[T]](inputData.length)
+    val ts = new Array[Tensor[T]](targetData.length)
     var b = 1
-    while(b <= input.length()) {
-      t(b) = input[Tensor[T]](b).narrow(1, offset, length)
+    while(b <= inputData.size) {
+      is(b) = inputData(b).narrow(1, offset, length)
       b += 1
     }
-    MiniBatch(t, target.narrow(1, offset, length))
+    b = 1
+    while(b <= targetData.size) {
+      ts(b) = inputData(b).narrow(1, offset, length)
+      b += 1
+    }
+
+    MiniBatch(is, ts)
   }
 
   override def getInput(): Activity = {
@@ -132,79 +171,276 @@ class ArrayTensorMiniBatch[T](
   override def getTarget(): Activity = {
     target
   }
-}
 
-/**
- * TensorMiniBatch without target.
- * @param input input tensor of this MiniBatch
- * @tparam T Numeric type
- */
-class UnlabeledTensorMiniBatch[T](
-      val input: Tensor[T]) extends MiniBatch[T]{
+  def setValue(samples: Array[Sample[T]])(implicit ev: TensorNumeric[T]): this.type = {
+    require(samples.length > 0)
+    require(samples(0).isInstanceOf[ArraySample[T]],
+      "ArrayTensorMiniBatch: Only support ArraySample")
+    val s = samples.map(_.asInstanceOf[ArraySample[T]])
 
-  override def size(): Int = {
-    input.size(1)
-  }
+    val longestFeature = MiniBatch.findLongestFeatures(samples)
+    val longestLabel = MiniBatch.findLongestLabels(samples)
 
-  override def slice(offset: Int, length: Int): MiniBatch[T] = {
-    MiniBatch(input.narrow(1, offset, length))
-  }
-
-  override def getInput(): Activity = {
-    input
-  }
-
-  override def getTarget(): Activity = {
-    throw new UnsupportedOperationException("UnlabeledTensorMiniBatch: no target in this MiniBatch")
-  }
-}
-
-/**
- * ArrayTensorMiniBatch without target.
- * @param input input table of this MiniBatch
- * @tparam T Numeric type
- */
-class UnlabeledArrayTensorMiniBatch[T](
-      val input: Table) extends MiniBatch[T]{
-
-  override def size(): Int = {
-    input[Tensor[T]](1).size(1)
-  }
-
-  override def slice(offset: Int, length: Int): MiniBatch[T] = {
-    val t = T()
-    var b = 1
-    while(b <= input.length()) {
-      t(b) = input[Tensor[T]](b).narrow(1, offset, length)
-      b += 1
-    }
-    MiniBatch(t)
-  }
-
-  override def getInput(): Activity = {
-    input
-  }
-
-  override def getTarget(): Activity = {
-    throw new UnsupportedOperationException("No target in this UnlabeledArrayTensorMiniBatch")
+    MiniBatch.arraySampleToMiniBatch(s, this, longestFeature, longestLabel, featurePadding,
+      featureFixedLength, featureIncrement, labelPadding, labelFixedLength, labelIncrement)
+    this
   }
 }
 
 object MiniBatch {
-  def apply[T](input: Tensor[T], target: Tensor[T]): MiniBatch[T] = {
-    new TensorMiniBatch[T](input, target)
+  def apply[T: ClassTag](
+    nInputs: Int,
+    nTargets: Int,
+    featurePadding: Option[Array[Tensor[T]]],
+    featureFixedLength: Option[Array[Int]],
+    featureIncrement: Option[Array[Int]],
+    labelPadding: Option[Array[T]],
+    labelFixedLength: Option[Array[Int]],
+    labelIncrement: Option[Array[Int]])(
+    implicit ev: TensorNumeric[T]): MiniBatch[T] = {
+
+    new ArrayTensorMiniBatch[T](Array.tabulate(nInputs)(_ => Tensor[T]()),
+      Array.tabulate(nTargets)(_ => Tensor[T]()),
+      featurePadding, featureFixedLength, featureIncrement,
+      labelPadding, labelFixedLength, labelIncrement)
   }
 
-  def apply[T](input: Table, target: Tensor[T]): MiniBatch[T] = {
+  def apply[T: ClassTag](input: Tensor[T], target: Tensor[T]): MiniBatch[T] = {
+    MiniBatch[T](Array(input), Array(target))
+  }
+
+  def apply[T: ClassTag](input: Array[Tensor[T]], target: Tensor[T]): MiniBatch[T] = {
+    MiniBatch[T](input, Array(target))
+  }
+
+  def apply[T: ClassTag](input: Array[Tensor[T]], target: Array[Tensor[T]]): MiniBatch[T] = {
     new ArrayTensorMiniBatch[T](input, target)
   }
 
-  def apply[T](input: Tensor[T]): MiniBatch[T] = {
-    new UnlabeledTensorMiniBatch[T](input)
+  def apply[T: ClassTag](input: Tensor[T]): MiniBatch[T] = {
+    MiniBatch[T](Array(input), new Array[Tensor[T]](0))
   }
 
-  def apply[T](input: Table): MiniBatch[T] = {
-    new UnlabeledArrayTensorMiniBatch[T](input)
+  def apply[T: ClassTag](input: Array[Tensor[T]]): MiniBatch[T] = {
+    MiniBatch[T](input, new Array[Tensor[T]](0))
+  }
+
+  private def resizeData[T: ClassTag](
+        data: Array[Tensor[T]],
+        sampleSize: Array[Array[Array[Int]]],
+        longestData: Array[Int],
+        dataFixedLength: Option[Array[Int]] = None,
+        dataIncrement: Option[Array[Int]] = None): Unit = {
+    val inputSize = new Array[Array[Int]](longestData.length)
+    var ii = 0
+    while (ii < inputSize.length) {
+      inputSize(ii) = Array(sampleSize.length) ++ sampleSize(longestData(ii))(ii)
+      ii += 1
+    }
+
+    var i = 0
+    while (i < inputSize.length) {
+      if (dataFixedLength.isDefined) {
+        val fixedLength = dataFixedLength.get(i)
+        require(fixedLength >= inputSize(i)(1),
+          s"${i}th FixedLength=${fixedLength} is smaller than its FeatureLength=${inputSize(i)(1)}")
+        inputSize(i)(1) = fixedLength
+      } else if (dataIncrement.isDefined) {
+        val increment = dataIncrement.get(i)
+        inputSize(i)(1) += increment
+      }
+      data(i).resize(inputSize(i))
+      i += 1
+    }
+
+  }
+
+  def arraySampleToMiniBatch[T: ClassTag](
+      samples: Array[ArraySample[T]],
+      miniBatch: ArrayTensorMiniBatch[T],
+      longestFeature: Array[Int],
+      longestLabel: Array[Int],
+      featurePadding: Option[Array[Tensor[T]]] = None,
+      featureFixedLength: Option[Array[Int]] = None,
+      featureIncrement: Option[Array[Int]] = None,
+      labelPadding: Option[Array[T]] = None,
+      labelFixedLength: Option[Array[Int]] = None,
+      labelIncrement: Option[Array[Int]] = None
+      )(implicit ev: TensorNumeric[T]): MiniBatch[T] = {
+    val inputs = miniBatch.inputData
+    val target = miniBatch.targetData
+
+    val featureSizes = samples.map(_.getFeatureSize())
+    val labelSizes = samples.map(_.getLabelSize())
+    val unlabeled = if (labelSizes.flatMap(_.flatMap(_.toIterator)).product == 0) true else false
+    resizeData(inputs, featureSizes,
+      longestFeature, featureFixedLength, featureIncrement)
+    if (!unlabeled) {
+      resizeData(target, labelSizes,
+        longestLabel, labelFixedLength, labelIncrement)
+    }
+
+    if (featurePadding.isDefined) {
+      // check if featurePadding is right.
+      var i = 0
+      while (i < inputs.length) {
+        require(featurePadding.get.length == inputs.length, s"Number of tensor padding should " +
+          s"equals to Number of feature tensor in Sample. Excepted ${inputs.length}," +
+          s" but got ${featurePadding.get.length}")
+        if (inputs(i).dim() == 2) {
+          require(featurePadding.get(i).nElement() == 1, s"${i}thFeature is 1D, featurePadding " +
+            s"should have only one element, but got ${featurePadding.get(i)}")
+        } else {
+          require(featurePadding.get(i).dim() == inputs(i).dim() - 2,
+            s"${i}thFeature's featurePadding should have the " +
+            s"same dimension with the feature in sample. Excepted: ${inputs(i).dim() - 2}, " +
+            s"but got ${featurePadding.get(i).dim()}")
+        }
+        require(featurePadding.get(i).isContiguous(), "featurePadding should be contiguous")
+        i += 1
+      }
+    }
+
+    // init input and target
+    if (labelPadding.isDefined) {
+      // fill target with labelPadding first.
+      var l = 0
+      while(l < target.length) {
+        target(l).fill(labelPadding.get(l))
+        l += 1
+      }
+    } else {
+      target.foreach(_.zero())
+    }
+    if (!featurePadding.isDefined) {
+      inputs.foreach(_.zero())
+    }
+
+    // Copy sample data to miniBatch
+    var s = 0
+    while (s < samples.length) {
+      var f = 0
+      var offset = 0
+      val featureSize = featureSizes(s)
+      while (f < inputs.length) {
+        val length = featureSize(f).product
+        if (featurePadding.isDefined) {
+          // copy data
+          copy(samples(s).getData(), offset,
+            length, inputs(f)(s + 1), featurePadding.get(f))
+        } else {
+          // copy data without padding.
+          copy(samples(s).getData(), offset,
+            length, inputs(f)(s + 1))
+        }
+        f += 1
+        offset += length
+      }
+
+      if (!unlabeled) {
+        var l = 0
+        val labelSize = labelSizes(s)
+        while (l < target.length) {
+          val length = labelSize(l).product
+          copy(samples(s).getData(), offset,
+            length, target(l)(s + 1))
+          l += 1
+          offset += length
+        }
+      }
+
+      s += 1
+    }
+
+    miniBatch
+  }
+
+  /**
+   * Find Sample in Array[Sample] who has the biggest featureLength
+   */
+  def findLongestFeatures[T: ClassTag](
+        samples: Array[Sample[T]])(implicit ev: TensorNumeric[T]): Array[Int] = {
+    val featureIndices =
+      new Array[Int](samples(0).featureLength().length).map(_ => 0)
+    var i = 1
+    while (i < samples.length) {
+      var j = 0
+      while (j < featureIndices.length) {
+        if (samples(i).featureLength()(j) > samples(featureIndices(j)).featureLength()(j)) {
+          featureIndices(j) = i
+        }
+        j += 1
+      }
+      i += 1
+    }
+    featureIndices
+  }
+
+  /**
+   * Find Sample in Array[Sample] who has the biggest labelLength
+   */
+  def findLongestLabels[T: ClassTag](
+        samples: Array[Sample[T]])(implicit ev: TensorNumeric[T]): Array[Int] = {
+    val labelIndices =
+      new Array[Int](samples(0).labelLength().length).map(_ => 0)
+    var i = 1
+    while (i < samples.length) {
+      var j = 0
+      while (j < labelIndices.length) {
+        if (samples(i).labelLength()(j) > samples(labelIndices(j)).labelLength()(j)) {
+          labelIndices(j) = i
+        }
+        j += 1
+      }
+      i += 1
+    }
+    labelIndices
+  }
+
+  /**
+   * Copy tensor src to tensor dest with a padding tensor.
+   */
+  private def copy[T: ClassTag](
+      src: Array[T],
+      offset: Int,
+      length: Int,
+      dest: Tensor[T],
+      paddingTensor: Tensor[T] = null)(implicit ev: TensorNumeric[T]): Unit = {
+    arrayCopy(src,
+      offset,
+      dest.storage().array(),
+      dest.storageOffset() - 1,
+      length)
+    if (null != paddingTensor) {
+      var j = length
+      while (j < dest.nElement()) {
+        arrayCopy(paddingTensor.storage().array(), paddingTensor.storageOffset() - 1,
+          dest.storage().array(), dest.storageOffset() - 1 + j, paddingTensor.nElement())
+        j += paddingTensor.nElement()
+      }
+    }
+  }
+
+  /**
+   * A wrapper for System.arraycopy
+   */
+  private def arrayCopy[T: ClassTag](
+      src: AnyRef,
+      srcPos: Int,
+      dest: AnyRef,
+      destPos: Int,
+      length: Int)(implicit ev: TensorNumeric[T]): Unit = {
+    ev.getType() match {
+      case DoubleType => Array.copy(src
+        .asInstanceOf[Array[Double]],
+        srcPos, dest
+          .asInstanceOf[Array[Double]], destPos, length)
+      case FloatType => System.arraycopy(src
+        .asInstanceOf[Array[Float]],
+        srcPos, dest
+          .asInstanceOf[Array[Float]], destPos, length)
+      case _ => throw new UnsupportedOperationException(s"Only Float/Double supported")
+    }
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
@@ -71,6 +71,11 @@ trait MiniBatch[T] extends Serializable{
     this.asInstanceOf[TensorMiniBatch[T]].input
   }
 
+  /**
+   * Set values to this miniBatch with a set of Sample.
+   * @param samples a set of Sample
+   * @return self
+   */
   def setValue(samples: Array[Sample[T]])(implicit ev: TensorNumeric[T]): this.type
 }
 
@@ -119,7 +124,7 @@ class TensorMiniBatch[T: ClassTag](
  * @tparam T Numeric type
  * @since 0.2.0
  */
-class ArrayTensorMiniBatch[T: ClassTag](
+private[bigdl] class ArrayTensorMiniBatch[T: ClassTag](
     val inputData: Array[Tensor[T]],
     val targetData: Array[Tensor[T]],
     featurePadding: Option[Array[Tensor[T]]] = None,
@@ -242,9 +247,11 @@ object MiniBatch {
     while (i < inputSize.length) {
       if (dataFixedLength.isDefined) {
         val fixedLength = dataFixedLength.get(i)
-        require(fixedLength >= inputSize(i)(1),
+        require(fixedLength >= inputSize(i)(1) || fixedLength < 0,
           s"${i}th FixedLength=${fixedLength} is smaller than its FeatureLength=${inputSize(i)(1)}")
-        inputSize(i)(1) = fixedLength
+        if (fixedLength >= inputSize(i)(1)) {
+          inputSize(i)(1) = fixedLength
+        }
       } else if (dataIncrement.isDefined) {
         val increment = dataIncrement.get(i)
         inputSize(i)(1) += increment
@@ -255,7 +262,7 @@ object MiniBatch {
 
   }
 
-  def arraySampleToMiniBatch[T: ClassTag](
+  private[bigdl] def arraySampleToMiniBatch[T: ClassTag](
       samples: Array[ArraySample[T]],
       miniBatch: ArrayTensorMiniBatch[T],
       longestFeature: Array[Int],

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
@@ -83,13 +83,10 @@ trait MiniBatch[T] extends Serializable{
  * `targetData` store the target tensors, if `targetData.length == 1`, `getTarget()` will return
  * a tensor; If `targetData.length > 1`, `getTarget()` will return a table.
  *
- * Notice: a feature is a input tensor of model.
- * featureFixedLength's priority is higher than featureIncrement. Also
- * labelFixedLength and featureIncrement.
- *
  * @param inputData a set of input tensor
  * @param targetData a set of target tensor
- * @param paddingParam padding parameter
+ * @param paddingParam padding strategy, see [[com.intel.analytics.bigdl.dataset.PaddingParam]]
+ *                     for details.
  * @tparam T Numeric type
  * @since 0.2.0
  */

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
@@ -406,7 +406,7 @@ object MiniBatch {
       length: Int,
       dest: Tensor[T],
       paddingTensor: Tensor[T] = null)(implicit ev: TensorNumeric[T]): Unit = {
-    arrayCopy(src,
+    ev.arraycopy(src,
       offset,
       dest.storage().array(),
       dest.storageOffset() - 1,
@@ -414,32 +414,10 @@ object MiniBatch {
     if (null != paddingTensor) {
       var j = length
       while (j < dest.nElement()) {
-        arrayCopy(paddingTensor.storage().array(), paddingTensor.storageOffset() - 1,
+        ev.arraycopy(paddingTensor.storage().array(), paddingTensor.storageOffset() - 1,
           dest.storage().array(), dest.storageOffset() - 1 + j, paddingTensor.nElement())
         j += paddingTensor.nElement()
       }
-    }
-  }
-
-  /**
-   * A wrapper for System.arraycopy
-   */
-  private def arrayCopy[T: ClassTag](
-      src: AnyRef,
-      srcPos: Int,
-      dest: AnyRef,
-      destPos: Int,
-      length: Int)(implicit ev: TensorNumeric[T]): Unit = {
-    ev.getType() match {
-      case DoubleType => Array.copy(src
-        .asInstanceOf[Array[Double]],
-        srcPos, dest
-          .asInstanceOf[Array[Double]], destPos, length)
-      case FloatType => System.arraycopy(src
-        .asInstanceOf[Array[Float]],
-        srcPos, dest
-          .asInstanceOf[Array[Float]], destPos, length)
-      case _ => throw new UnsupportedOperationException(s"Only Float/Double supported")
     }
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
@@ -181,7 +181,7 @@ private[bigdl] class ArrayTensorMiniBatch[T: ClassTag](
     require(batchSize == 0 || samples.length <= batchSize, "setValue: samples's size doesn't " +
       s"match mini batch size, excepted ${size()} got ${samples.length}")
     val resize = batchSize != samples.length || featurePaddingParam.isDefined ||
-      labelPaddingParam.isDefined
+      labelPaddingParam.isDefined || size() != samples.length
     if (batchSize == 0) {
       batchSize = samples.length // set a batchSize when set data.
       unlabeled = samples.head.numLabel() == 0

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
@@ -32,6 +32,13 @@ import scala.reflect.ClassTag
  */
 trait MiniBatch[T] extends Serializable{
   /**
+   * Set a batchSize of this miniBatch.
+   * @param batchSize batch Size
+   * @return this
+   */
+  def setBatchSize(batchSize: Int): this.type
+
+  /**
    * Get the number of samples in this MiniBatch
    * @return size How many samples in this MiniBatch
    */
@@ -57,22 +64,32 @@ trait MiniBatch[T] extends Serializable{
    */
   def getTarget(): Activity
 
-  @deprecated("Old interface", "0.2.0")
+  /**
+   * An deprecated function for single-input/single-target MiniBatch.
+   * You don't need to override this, because we have add
+   * a default implement to throw exception.
+   */
+  @deprecated("Old interface, use getInput instead", "0.2.0")
   def data(): Tensor[T] = {
     throw new UnsupportedOperationException("MiniBatch.data(): unimplemented deprecated method")
   }
 
-  @deprecated("Old interface", "0.2.0")
+  /**
+   * An deprecated function for single-input/single-target MiniBatch.
+   * You don't need to override this, because we have add
+   * a default implement to throw exception.
+   */
+  @deprecated("Old interface, use getTarget instead", "0.2.0")
   def labels(): Tensor[T] = {
     throw new UnsupportedOperationException("MiniBatch.labels(): unimplemented deprecated method")
   }
 
   /**
-   * Set values to this miniBatch with a set of Sample.
+   * Replace the original content of the miniBatch with a set of Sample.
    * @param samples a set of Sample
    * @return self
    */
-  def setValue(samples: Array[Sample[T]])(implicit ev: TensorNumeric[T]): this.type
+  def setValue(samples: Seq[Sample[T]])(implicit ev: TensorNumeric[T]): this.type
 }
 
 /**
@@ -85,23 +102,47 @@ trait MiniBatch[T] extends Serializable{
  *
  * @param inputData a set of input tensor
  * @param targetData a set of target tensor
- * @param paddingParam padding strategy, see [[com.intel.analytics.bigdl.dataset.PaddingParam]]
- *                     for details.
+ * @param featurePaddingParam feature padding strategy, see
+ *                       [[com.intel.analytics.bigdl.dataset.FeaturePaddingParam]] for details.
+ * @param labelPaddingParam   label padding strategy, see
+ *                       [[com.intel.analytics.bigdl.dataset.LabelPaddingParam]] for details.
  * @tparam T Numeric type
  * @since 0.2.0
  */
 private[bigdl] class ArrayTensorMiniBatch[T: ClassTag](
-    val inputData: Array[Tensor[T]],
-    val targetData: Array[Tensor[T]],
-    paddingParam: Option[PaddingParam[T]] = None) extends MiniBatch[T]{
+      val inputData: Array[Tensor[T]],
+      val targetData: Array[Tensor[T]],
+      featurePaddingParam: Option[FeaturePaddingParam[T]] = None,
+      labelPaddingParam: Option[LabelPaddingParam[T]] = None) extends MiniBatch[T]{
   require(inputData.length > 0, "Input data in MiniBatch is empty.")
-  private lazy val input: Activity = if (inputData.length == 1) {
+  private var batchSize = 0
+
+  def setBatchSize(batchSize: Int): this.type = {
+    require(batchSize > 0, s"Illegal batch size ${batchSize}")
+    this.batchSize = batchSize
+    this
+  }
+
+  val (featurePadding, featurePaddingStrategy) = if (featurePaddingParam.isDefined) {
+    (featurePaddingParam.get.paddingTensor, featurePaddingParam.get.paddingStrategy)
+  } else {
+    (None, None)
+  }
+
+  val (labelPadding, labelPaddingStrategy) = if (labelPaddingParam.isDefined) {
+    (labelPaddingParam.get.paddingValue, labelPaddingParam.get.paddingStrategy)
+  } else {
+    (None, None)
+  }
+
+
+  private val input: Activity = if (inputData.length == 1) {
     inputData(0)
   } else {
     T.array(inputData.map(_.asInstanceOf[Any]))
   }
 
-  private lazy val target: Activity = if (targetData.length == 0) {
+  private val target: Activity = if (targetData.length == 0) {
     null
   } else if (targetData.length == 1) {
     targetData(0)
@@ -110,24 +151,28 @@ private[bigdl] class ArrayTensorMiniBatch[T: ClassTag](
   }
 
   override def size(): Int = {
-    inputData(0).size(1)
+    if (inputData(0).nElement() == 0) {
+      0
+    } else {
+      inputData(0).size(1)
+    }
   }
 
   override def slice(offset: Int, length: Int): MiniBatch[T] = {
-    val is = new Array[Tensor[T]](inputData.length)
-    val ts = new Array[Tensor[T]](targetData.length)
+    val inputs = new Array[Tensor[T]](inputData.length)
+    val targets = new Array[Tensor[T]](targetData.length)
     var b = 0
     while(b < inputData.size) {
-      is(b) = inputData(b).narrow(1, offset, length)
+      inputs(b) = inputData(b).narrow(1, offset, length)
       b += 1
     }
     b = 0
     while(b < targetData.size) {
-      ts(b) = targetData(b).narrow(1, offset, length)
+      targets(b) = targetData(b).narrow(1, offset, length)
       b += 1
     }
 
-    MiniBatch(is, ts)
+    MiniBatch(inputs, targets)
   }
 
   override def getInput(): Activity = {
@@ -138,20 +183,20 @@ private[bigdl] class ArrayTensorMiniBatch[T: ClassTag](
     target
   }
 
-  override def setValue(samples: Array[Sample[T]])(implicit ev: TensorNumeric[T]): this.type = {
-    require(samples.length > 0)
-    samples.foreach(s => require(s.isInstanceOf[ArraySample[T]],
-      "ArrayTensorMiniBatch: Only support ArraySample"))
-    val s = samples.map(_.asInstanceOf[ArraySample[T]])
+  override def setValue(samples: Seq[Sample[T]])(implicit ev: TensorNumeric[T]): this.type = {
+    require(samples.length > 0, "samples is empty")
+    require(batchSize == 0 || samples.length <= batchSize, "setValue: samples's size doesn't " +
+      s"match mini batch size, excepted ${size()} got ${samples.length}")
 
-    val longestFeature = MiniBatch.findLongestFeatures(samples)
-    val longestLabel = MiniBatch.findLongestLabels(samples)
+    if (featurePaddingParam.isDefined || labelPaddingParam.isDefined) {
+      val longestFeature = MiniBatch.findLongestFeatures(samples)
+      val longestLabel = MiniBatch.findLongestLabels(samples)
 
-    if (paddingParam.isDefined) {
-      val padding = paddingParam.get
-      MiniBatch.arraySampleToMiniBatch(s, this, longestFeature, longestLabel,
-        padding.featurePadding, padding.featureFixedLength, padding.featureIncrement,
-        padding.labelPadding, padding.labelFixedLength, padding.labelIncrement)
+      MiniBatch.arraySampleToMiniBatch[T](samples, this,
+        Some(longestFeature), Some(longestLabel),
+        featurePadding, featurePaddingStrategy, labelPadding, labelPaddingStrategy)
+    } else {
+      MiniBatch.arraySampleToMiniBatch[T](samples, this)
     }
     this
   }
@@ -179,13 +224,14 @@ object MiniBatch {
    * @return
    */
   def apply[T: ClassTag](
-    nInputs: Int,
-    nTargets: Int,
-    paddingParam: Option[PaddingParam[T]] = None)(
+        nInputs: Int,
+        nTargets: Int,
+        featurePaddingParam: Option[FeaturePaddingParam[T]] = None,
+        labelPaddingParam: Option[LabelPaddingParam[T]] = None)(
     implicit ev: TensorNumeric[T]): MiniBatch[T] = {
     new ArrayTensorMiniBatch[T](Array.tabulate(nInputs)(_ => Tensor[T]()),
       Array.tabulate(nTargets)(_ => Tensor[T]()),
-      paddingParam)
+      featurePaddingParam, labelPaddingParam)
   }
 
   def apply[T: ClassTag](input: Tensor[T], target: Tensor[T]): MiniBatch[T] = {
@@ -210,58 +256,68 @@ object MiniBatch {
 
   private def resizeData[T: ClassTag](
         data: Array[Tensor[T]],
-        sampleSize: Array[Array[Array[Int]]],
-        longestData: Array[Int],
-        dataFixedLength: Option[Array[Int]] = None,
-        dataIncrement: Option[Array[Int]] = None): Unit = {
-    val inputSize = new Array[Array[Int]](longestData.length)
-    var ii = 0
-    while (ii < inputSize.length) {
-      inputSize(ii) = Array(sampleSize.length) ++ sampleSize(longestData(ii))(ii)
-      ii += 1
+        // 1st Seq is batchSize, 2nd Array is number of features, 3th Array is feature size
+        sampleSize: Seq[Array[Array[Int]]],
+        longestData: Option[Array[Int]],
+        paddingStrategy: Option[PaddingStrategy] = None): Unit = {
+    // Size of input data. 1st Array is number of input, 2nd Array is input size.
+    val finalSizes = if (longestData.isDefined) {
+      val longest = longestData.get
+      val sizes = new Array[Array[Int]](longest.length)
+
+      var i = 0
+      while (i < sizes.length) {
+        // Set i-th input's size
+        sizes(i) = Array(sampleSize.length) ++ sampleSize(longest(i))(i)
+        i += 1
+      }
+
+      if (paddingStrategy.isDefined) {
+        paddingStrategy.get.padding(sizes)
+      }
+      sizes
+    } else {
+      val sizes = new Array[Array[Int]](sampleSize(0).length)
+      var i = 0
+      while (i < sizes.length) {
+        // Set i-th input's size
+        sizes(i) = Array(sampleSize.length) ++ sampleSize(0)(i)
+        i += 1
+      }
+      sizes
+
     }
 
+    // resize
     var i = 0
-    while (i < inputSize.length) {
-      if (dataFixedLength.isDefined) {
-        val fixedLength = dataFixedLength.get(i)
-        require(fixedLength >= inputSize(i)(1) || fixedLength < 0,
-          s"${i}th FixedLength=${fixedLength} is smaller than its FeatureLength=${inputSize(i)(1)}")
-        if (fixedLength >= inputSize(i)(1)) {
-          inputSize(i)(1) = fixedLength
-        }
-      } else if (dataIncrement.isDefined) {
-        val increment = dataIncrement.get(i)
-        inputSize(i)(1) += increment
-      }
-      data(i).resize(inputSize(i))
+    while (i < finalSizes.length) {
+      data(i).resize(finalSizes(i))
       i += 1
     }
+
   }
 
   private[bigdl] def arraySampleToMiniBatch[T: ClassTag](
-      samples: Array[ArraySample[T]],
+      samples: Seq[Sample[T]],
       miniBatch: ArrayTensorMiniBatch[T],
-      longestFeature: Array[Int],
-      longestLabel: Array[Int],
+      longestFeature: Option[Array[Int]] = None,
+      longestLabel: Option[Array[Int]] = None,
       featurePadding: Option[Array[Tensor[T]]] = None,
-      featureFixedLength: Option[Array[Int]] = None,
-      featureIncrement: Option[Array[Int]] = None,
+      featurePaddingStrategy: Option[PaddingStrategy] = None,
       labelPadding: Option[Array[T]] = None,
-      labelFixedLength: Option[Array[Int]] = None,
-      labelIncrement: Option[Array[Int]] = None
+      labelPaddingStrategy: Option[PaddingStrategy] = None
       )(implicit ev: TensorNumeric[T]): MiniBatch[T] = {
     val inputs = miniBatch.inputData
-    val target = miniBatch.targetData
+    val targets = miniBatch.targetData
 
     val featureSizes = samples.map(_.getFeatureSize())
     val labelSizes = samples.map(_.getLabelSize())
     val unlabeled = if (labelSizes.flatMap(_.flatMap(_.toIterator)).product == 0) true else false
     resizeData(inputs, featureSizes,
-      longestFeature, featureFixedLength, featureIncrement)
+      longestFeature, featurePaddingStrategy)
     if (!unlabeled) {
-      resizeData(target, labelSizes,
-        longestLabel, labelFixedLength, labelIncrement)
+      resizeData(targets, labelSizes,
+        longestLabel, labelPaddingStrategy)
     }
 
     if (featurePadding.isDefined) {
@@ -289,12 +345,12 @@ object MiniBatch {
     if (labelPadding.isDefined) {
       // fill target with labelPadding first.
       var l = 0
-      while(l < target.length) {
-        target(l).fill(labelPadding.get(l))
+      while(l < targets.length) {
+        targets(l).fill(labelPadding.get(l))
         l += 1
       }
     } else {
-      target.foreach(_.zero())
+      targets.foreach(_.zero())
     }
     if (!featurePadding.isDefined) {
       inputs.foreach(_.zero())
@@ -324,10 +380,10 @@ object MiniBatch {
       if (!unlabeled) {
         var l = 0
         val labelSize = labelSizes(s)
-        while (l < target.length) {
+        while (l < targets.length) {
           val length = labelSize(l).product
           copy(samples(s).getData(), offset,
-            length, target(l)(s + 1))
+            length, targets(l)(s + 1))
           l += 1
           offset += length
         }
@@ -343,14 +399,14 @@ object MiniBatch {
    * Find Sample in Array[Sample] who has the biggest featureLength
    */
   private[bigdl] def findLongestFeatures[T: ClassTag](
-        samples: Array[Sample[T]])(implicit ev: TensorNumeric[T]): Array[Int] = {
+        samples: Seq[Sample[T]])(implicit ev: TensorNumeric[T]): Array[Int] = {
     val featureIndices =
-      new Array[Int](samples(0).featureLength().length).map(_ => 0)
+      new Array[Int](samples(0).numFeature())
     var i = 1
     while (i < samples.length) {
       var j = 0
       while (j < featureIndices.length) {
-        if (samples(i).featureLength()(j) > samples(featureIndices(j)).featureLength()(j)) {
+        if (samples(i).featureLength(j) > samples(featureIndices(j)).featureLength(j)) {
           featureIndices(j) = i
         }
         j += 1
@@ -364,14 +420,14 @@ object MiniBatch {
    * Find Sample in Array[Sample] who has the biggest labelLength
    */
   private[bigdl] def findLongestLabels[T: ClassTag](
-        samples: Array[Sample[T]])(implicit ev: TensorNumeric[T]): Array[Int] = {
+        samples: Seq[Sample[T]])(implicit ev: TensorNumeric[T]): Array[Int] = {
     val labelIndices =
-      new Array[Int](samples(0).labelLength().length).map(_ => 0)
+      new Array[Int](samples(0).numLabel())
     var i = 1
     while (i < samples.length) {
       var j = 0
       while (j < labelIndices.length) {
-        if (samples(i).labelLength()(j) > samples(labelIndices(j)).labelLength()(j)) {
+        if (samples(i).labelLength(j) > samples(labelIndices(j)).labelLength(j)) {
           labelIndices(j) = i
         }
         j += 1
@@ -407,29 +463,126 @@ object MiniBatch {
 }
 
 /**
- * Padding param for ArrayTensorMiniBatch.
- * Notice: featureFixedLength's priority is higher than featureIncrement. Also
- * labelFixedLength and featureIncrement.
+ * Feature Padding param for MiniBatch.
  *
- * @param featurePadding feature paddings for each input tensor(by default None,
- *                       meaning zero padding)
- * @param featureFixedLength it specifies the length of each input after padding (by default
- *                           None, meaning using the longest input length in the mini Batch)
- * @param featureIncrement it specifies adding an constant length to the longest length
- *                         of each target in each MiniBatch.
- *                         (by default None, meaning no increment)
- * @param labelPadding feature paddings for each target (by default None, meaning zero padding)
- * @param labelFixedLength it specifies the length of each target after padding (by default
- *                         None, meaning using the longest target length in the mini Batch)
- * @param labelIncrement it specifies adding an constant length to the longest length
- *                       of each target in each MiniBatch.
- *                       (by default None, meaning no increment)
+ * For constructing a mini batch, we need to make sure all samples' feature and label
+ * in this mini batch have the same size. If the size is different, we will pad them
+ * to the same size.
+ *
+ * By default, we will pad the first dimension to the longest size with zero in the MiniBatch.
+ * If you want to specify the padding values, you can set `paddingTensor`; If you want to specify
+ * the padding length, you can use `PaddingLongest` or `FixedLength`.
+ *
+ * For example, your feature size is n*m*k,
+ *                       you should provide a 2D tensor in a size of m*k.
+ *                       If your feature is 1D, you can provide a one-element 1D tensor.
+ *
+ * For example, we have 3 Sample, and convert them into a MiniBatch.
+ * Sample1's feature is a 2*3 tensor {1, 2, 3,
+ *                                    4, 5, 6}
+ *
+ * Sample2's feature is a 1*3 tensor {7, 8, 9}
+ *
+ * Sample3's feature is a 3*3 tensor {10, 11, 12,
+ *                                    13, 14, 15,
+ *                                    16, 17, 18}
+ *
+ * And the paddingTensor is {-1, -2, -3}, use `FixedLength(Array(4))`, the MiniBatch will be
+ * a tensor of 3*4*3:
+ * {1, 2, 3,
+ *  4, 5, 6,
+ *  -1, -2, -3,
+ *  -1, -2, -3
+ *
+ *  7, 8, 9,
+ *  -1, -2, -3,
+ *  -1, -2, -3,
+ *  -1, -2, -3
+ *
+ *  10, 11, 12,
+ *  13, 14, 15,
+ *  16, 17, 18
+ *  -1, -2, -3}
+ *
+ * @param paddingTensor paddings tensor for the first dimension(by default None,
+ *                       meaning zero padding).
+ * @param paddingStrategy See [[PaddingLongest]], [[FixedLength]]
  * @tparam T numeric type
  */
-case class PaddingParam[T: ClassTag](
-      featurePadding: Option[Array[Tensor[T]]] = None,
-      featureFixedLength: Option[Array[Int]] = None,
-      featureIncrement: Option[Array[Int]] = None,
-      labelPadding: Option[Array[T]] = None,
-      labelFixedLength: Option[Array[Int]] = None,
-      labelIncrement: Option[Array[Int]] = None)
+case class FeaturePaddingParam[T: ClassTag](
+      paddingTensor: Option[Array[Tensor[T]]] = None,
+      paddingStrategy: Option[PaddingStrategy] = None)
+
+/**
+ * Label Padding param for MiniBatch.
+ *
+ * For constructing a mini batch, we need to make sure all samples' feature and label
+ * in this mini batch have the same size. If the size is different, we will pad them
+ * to the same size.
+ *
+ * By default, we will pad the first dimension to the longest size with zero in the MiniBatch.
+ * If you want to specify the padding values, you can set `paddingValue`; If you want to specify
+ * the padding length, you can use `PaddingLongest` or `FixedLength`.
+ *
+ * For example, we have 3 Sample, and convert them into a MiniBatch.
+ * Sample1's label is a tensor {1}
+ *
+ * Sample2's label is a tensor {2, 3}
+ *
+ * Sample3's feature is a tensor {4, 5, 6}
+ *
+ * And the paddingValue is `0`, fixedLength is 4, the MiniBatch will be
+ * a tensor of 3*4:
+ * {1, 0, 0, 0
+ *  2, 3, 0, 0
+ *  4, 5, 6, 0}
+ *
+ * @param paddingValue padding value
+ * @param paddingStrategy padding strategy
+ */
+case class LabelPaddingParam[T: ClassTag](
+      paddingValue: Option[Array[T]] = None,
+      paddingStrategy: Option[PaddingStrategy] = None)
+
+abstract class PaddingStrategy {
+  def padding(sizes: Seq[Array[Int]]): Seq[Array[Int]]
+}
+
+/**
+ * Add an constant length to longest feature in the first dimension
+ * @param paddingLength
+ */
+case class PaddingLongest(
+      paddingLength: Array[Int]) extends PaddingStrategy {
+    def padding(sizes: Seq[Array[Int]]): Seq[Array[Int]] = {
+      var i = 0
+      while (i < sizes.length) {
+          // Add an constant length to the first dimension's length(besides mini batch size).
+          val increment = paddingLength(i)
+          sizes(i)(1) += increment
+        i += 1
+      }
+      sizes
+  }
+}
+
+/**
+ * Set the first dimension's length to fixed length.
+ * @param fixedLength fixed length
+ */
+case class FixedLength(fixedLength: Array[Int]) extends PaddingStrategy {
+  def padding(sizes: Seq[Array[Int]]): Seq[Array[Int]] = {
+    var i = 0
+    while (i < sizes.length) {
+        // Set the first dimension's length(besides mini batch size) to fixed length.
+        val fixed = fixedLength(i)
+        require(fixed >= sizes(i)(1) || fixed < 0,
+          s"${i}th FixedLength=${fixed} is smaller than its FeatureLength=${sizes(i)(1)}")
+        if (fixed >= sizes(i)(1)) {
+          sizes(i)(1) = fixed
+        }
+      i += 1
+    }
+    sizes
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
@@ -521,9 +521,9 @@ object MiniBatch {
  */
 case class PaddingParam[T: ClassTag](
       paddingTensor: Option[Array[Tensor[T]]] = None,
-      paddingStrategy: PaddingStrategy = new DefaultPadding)
+      paddingStrategy: PaddingStrategy = new DefaultPadding) extends Serializable
 
-abstract class PaddingStrategy {
+abstract class PaddingStrategy extends Serializable {
   def paddingSize(sizes: Seq[Array[Int]]): Seq[Array[Int]]
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
@@ -318,11 +318,11 @@ object MiniBatch {
     val targets = miniBatch.targetData
 
     val featureSizes = samples.map(_.getFeatureSize())
-    val labelSizes = samples.map(_.getLabelSize())
-    val unlabeled = if (labelSizes.flatMap(_.flatMap(_.toIterator)).product == 0) true else false
+    val unlabeled = samples.head.numLabel() == 0
     resizeData(inputs, featureSizes,
       longestFeature, featurePaddingStrategy, featurePaddingTensor)
     if (!unlabeled) {
+      val labelSizes = samples.map(_.getLabelSize())
       resizeData(targets, labelSizes,
         longestLabel, labelPaddingStrategy, labelPaddingTensor)
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
@@ -129,13 +129,13 @@ class ArrayTensorMiniBatch[T: ClassTag](
     labelFixedLength: Option[Array[Int]] = None,
     labelIncrement: Option[Array[Int]] = None) extends MiniBatch[T]{
   require(inputData.length > 0, "Input data in MiniBatch is empty.")
-  val input: Activity = if (inputData.length == 1) {
+  private lazy val input: Activity = if (inputData.length == 1) {
     inputData(0)
   } else {
     T.array(inputData.map(_.asInstanceOf[Any]))
   }
 
-  val target: Activity = if (targetData.length == 0) {
+  private lazy val target: Activity = if (targetData.length == 0) {
     null
   } else if (targetData.length == 1) {
     targetData(0)
@@ -150,14 +150,14 @@ class ArrayTensorMiniBatch[T: ClassTag](
   override def slice(offset: Int, length: Int): MiniBatch[T] = {
     val is = new Array[Tensor[T]](inputData.length)
     val ts = new Array[Tensor[T]](targetData.length)
-    var b = 1
-    while(b <= inputData.size) {
+    var b = 0
+    while(b < inputData.size) {
       is(b) = inputData(b).narrow(1, offset, length)
       b += 1
     }
-    b = 1
-    while(b <= targetData.size) {
-      ts(b) = inputData(b).narrow(1, offset, length)
+    b = 0
+    while(b < targetData.size) {
+      ts(b) = targetData(b).narrow(1, offset, length)
       b += 1
     }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Sample.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Sample.scala
@@ -221,6 +221,21 @@ class ArrayTensorSample[T: ClassTag](
   def numFeature(): Int = features.length
 
   def numLabel(): Int = 1
+
+  def canEqual(other: Any): Boolean = other.isInstanceOf[ArrayTensorSample[T]]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: ArrayTensorSample[T] =>
+      (that canEqual this) &&
+        features == that.features &&
+        labels == that.labels
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    val state = Seq(features, labels)
+    state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
+  }
 }
 
 /**
@@ -291,6 +306,20 @@ class UnlabeledArrayTensorSample[T: ClassTag](
   def numFeature(): Int = features.length
 
   def numLabel(): Int = 0
+
+  def canEqual(other: Any): Boolean = other.isInstanceOf[UnlabeledArrayTensorSample[T]]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: UnlabeledArrayTensorSample[T] =>
+      (that canEqual this) &&
+        features == that.features
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    val state = Seq(features)
+    state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
+  }
 }
 
 object Sample {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Sample.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Sample.scala
@@ -143,6 +143,12 @@ class TensorSample[T: ClassTag](
   }
 }
 
+/**
+ * A kind of sample. Feature is a tensor, and label is a double/float.
+ * @param featureTensor feature tensor
+ * @param labelValue label
+ * @tparam T numeric type
+ */
 class TensorTSample[T: ClassTag](
     val featureTensor: Tensor[T],
     var labelValue: T) extends Sample[T]{
@@ -182,6 +188,12 @@ class TensorTSample[T: ClassTag](
   }
 }
 
+/**
+ * A kind of sample. Feature is an Array[Tensor], and label is a tensor too.
+ * @param features array of tensor
+ * @param labels label tensor
+ * @tparam T numeric type
+ */
 class ArrayTensorSample[T: ClassTag](
     val features: Array[Tensor[T]],
     val labels: Tensor[T]) extends Sample[T] {
@@ -211,6 +223,11 @@ class ArrayTensorSample[T: ClassTag](
   def numLabel(): Int = 1
 }
 
+/**
+ * A kind of sample doesn't contain label. Feature is a Tensor.
+ * @param featureTensor feature tensor
+ * @tparam T numeric type
+ */
 class UnlabeledTensorSample[T: ClassTag](
       val featureTensor: Tensor[T]) extends Sample[T]{
   override def featureLength(): Int = {
@@ -245,6 +262,11 @@ class UnlabeledTensorSample[T: ClassTag](
   }
 }
 
+/**
+ * A kind of sample doesn't contain label. Feature is an Array[Tensor].
+ * @param features array of tensor
+ * @tparam T numeric type
+ */
 class UnlabeledArrayTensorSample[T: ClassTag](
       val features: Array[Tensor[T]]) extends Sample[T] {
   override def featureLength(): Int = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Sample.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Sample.scala
@@ -123,6 +123,7 @@ private[bigdl] class ArraySample[T: ClassTag](
       private val data: Array[T],
       private val featureSize: Array[Array[Int]],
       private val labelSize: Array[Array[Int]]) extends Sample[T] {
+  require(featureSize != null, "Feature couldn't be empty")
 
   override def getData(): Array[T] = data
 
@@ -132,10 +133,10 @@ private[bigdl] class ArraySample[T: ClassTag](
   }
 
   override def labelLength(index: Int): Int = {
-    if (null == labelSize) {
-      0
-    } else {
+    if (null != labelSize) {
       labelSize(index)(0)
+    } else {
+      0
     }
   }
 
@@ -144,11 +145,8 @@ private[bigdl] class ArraySample[T: ClassTag](
   }
 
   override def getLabelSize(): Array[Array[Int]] = {
-    if (null != labelSize) {
-      labelSize
-    } else {
-      Array(Array(0))
-    }
+    require(null != labelSize, "Sample doesn't have label")
+    labelSize
   }
 
   override def numFeature(): Int = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Sample.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Sample.scala
@@ -80,12 +80,28 @@ abstract class Sample[T: ClassTag] extends Serializable {
   override def clone(): this.type =
     SerializationUtils.clone(this)
 
+  /**
+   * Get feature tensor, for one feature Sample only.
+   * @return feature tensor
+   */
   @deprecated("Old interface", "0.2.0")
   def feature()(implicit ev: TensorNumeric[T]): Tensor[T]
 
+  /**
+   * Get label tensor, for one label Sample only.
+   * @return label tensor
+   */
   @deprecated("Old interface", "0.2.0")
   def label()(implicit ev: TensorNumeric[T]): Tensor[T]
 
+  /**
+   * Set data of feature and label.
+   * @param featureData
+   * @param labelData
+   * @param featureSize
+   * @param labelSize
+   * @return
+   */
   @deprecated("Old interface", "0.2.0")
   def set(
         featureData: Array[T],
@@ -93,14 +109,21 @@ abstract class Sample[T: ClassTag] extends Serializable {
         featureSize: Array[Int],
         labelSize: Array[Int])(implicit ev: TensorNumeric[T]): Sample[T]
 
+  /**
+   * Set sample's data with a set of features and labels.
+   * @param features a set of features
+   * @param labels a set of labels
+   * @return this
+   */
   def set(features: Array[Tensor[T]], labels: Array[Tensor[T]]
          )(implicit ev: TensorNumeric[T]): Sample[T]
 }
 
 
 /**
+ * A kind of sample who use only one array
  */
-class ArraySample[T: ClassTag](
+private[bigdl] class ArraySample[T: ClassTag](
       private var data: Array[T],
       private var featureSize: Array[Int],
       private var numberFeature: Int,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Transformer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Transformer.scala
@@ -347,7 +347,13 @@ class SampleToMiniBatch[T: ClassTag](
           if (null == targetBuffer && sampleData(0).numLabel() > 0) {
             targetBuffer = Array.tabulate(sampleData(0).numLabel())(_ => Tensor[T]())
           }
-          toMiniBatch(sampleData, inputBuffer, targetBuffer)
+
+          if (i == batchSize) {
+            toMiniBatch(sampleData, inputBuffer, targetBuffer)
+          } else {
+            // Deal with number Sample is smaller than batchSize.
+            toMiniBatch(sampleData.slice(0, i), inputBuffer, targetBuffer)
+          }
         } else {
           null
         }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Transformer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Transformer.scala
@@ -307,11 +307,11 @@ class SampleToBatch[T: ClassTag]
  * Convert a sequence of [[Sample]] to a sequence of [[MiniBatch]] through function toMiniBatch.
  */
 private[bigdl] class SampleToMiniBatch[T: ClassTag](
-                                                     totalBatch: Int,
-                                                     miniBatch: Option[MiniBatch[T]] = None,
-                                                     featurePaddingParam: Option[PaddingParam[T]] = None,
-                                                     labelPaddingParam: Option[PaddingParam[T]] = None,
-                                                     partitionNum: Option[Int] = None)
+      totalBatch: Int,
+      miniBatch: Option[MiniBatch[T]] = None,
+      featurePaddingParam: Option[PaddingParam[T]] = None,
+      labelPaddingParam: Option[PaddingParam[T]] = None,
+      partitionNum: Option[Int] = None)
     (implicit ev: TensorNumeric[T]) extends Transformer[Sample[T], MiniBatch[T]] {
 
   private val batchPerPartition = Utils.getBatchSize(totalBatch, partitionNum)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Transformer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Transformer.scala
@@ -37,6 +37,7 @@ import scala.reflect.ClassTag
  * pre-process steps. User needn't write them every time, but can reuse others work.
  *
  * Transformer can be used with RDD(rdd.mapPartition), iterator and DataSet.
+ *
  * @tparam A
  * @tparam B
  */
@@ -58,6 +59,7 @@ trait Transformer[A, B] extends Serializable {
 
   /**
    * Apply this transformer to rdd
+   *
    * @param dataset
    */
   def apply(dataset: RDD[A])(implicit evidence: ClassTag[B]): RDD[B] = {
@@ -74,6 +76,7 @@ trait Transformer[A, B] extends Serializable {
 /**
  * A transformer chain two transformer together. The output type of the first transformer should be
  * same with the input type of the second transformer.
+ *
  * @param first first transformer
  * @param last last transformer
  * @tparam A input type of the first transformer
@@ -195,6 +198,7 @@ class SampleToBatch[T: ClassTag]
 
   /**
    * compare a and b, then return the larger one's index
+   *
    * @param i the index of a
    * @param j the index of b
    */
@@ -303,11 +307,11 @@ class SampleToBatch[T: ClassTag]
  * Convert a sequence of [[Sample]] to a sequence of [[MiniBatch]] through function toMiniBatch.
  */
 private[bigdl] class SampleToMiniBatch[T: ClassTag](
-    totalBatch: Int,
-    miniBatch: Option[MiniBatch[T]] = None,
-    featurePaddingParam: Option[FeaturePaddingParam[T]] = None,
-    labelPaddingParam: Option[LabelPaddingParam[T]] = None,
-    partitionNum: Option[Int] = None)
+                                                     totalBatch: Int,
+                                                     miniBatch: Option[MiniBatch[T]] = None,
+                                                     featurePaddingParam: Option[PaddingParam[T]] = None,
+                                                     labelPaddingParam: Option[PaddingParam[T]] = None,
+                                                     partitionNum: Option[Int] = None)
     (implicit ev: TensorNumeric[T]) extends Transformer[Sample[T], MiniBatch[T]] {
 
   private val batchPerPartition = Utils.getBatchSize(totalBatch, partitionNum)
@@ -335,9 +339,9 @@ private[bigdl] class SampleToMiniBatch[T: ClassTag](
           }
 
           if (i < batchSize) {
-            miniBatchBuffer.setValue(sampleData.slice(0, i))
+            miniBatchBuffer.set(sampleData.slice(0, i))
           } else {
-            miniBatchBuffer.setValue(sampleData)
+            miniBatchBuffer.set(sampleData)
           }
         } else {
           null
@@ -353,16 +357,16 @@ object SampleToMiniBatch {
    *
    * @param batchSize           total batch size
    * @param featurePaddingParam feature padding strategy, see
-   *                       [[com.intel.analytics.bigdl.dataset.FeaturePaddingParam]] for details.
+   *                            [[com.intel.analytics.bigdl.dataset.PaddingParam]] for details.
    * @param labelPaddingParam   label padding strategy, see
-   *                       [[com.intel.analytics.bigdl.dataset.LabelPaddingParam]] for details.
+   *                            [[com.intel.analytics.bigdl.dataset.PaddingParam]] for details.
    * @return
    */
   def apply[T: ClassTag](
-       batchSize : Int,
-       featurePaddingParam: Option[FeaturePaddingParam[T]] = None,
-       labelPaddingParam: Option[LabelPaddingParam[T]] = None,
-       partitionNum: Option[Int] = None
+                          batchSize : Int,
+                          featurePaddingParam: Option[PaddingParam[T]] = None,
+                          labelPaddingParam: Option[PaddingParam[T]] = None,
+                          partitionNum: Option[Int] = None
         )(implicit ev: TensorNumeric[T]): SampleToMiniBatch[T] = {
     new SampleToMiniBatch[T](batchSize, None, featurePaddingParam, labelPaddingParam, partitionNum)
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Transformer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Transformer.scala
@@ -308,7 +308,7 @@ class SampleToBatch[T: ClassTag]
  *
  * @param totalBatch total batch size
  * @param partitionNum partition number of dataset, default means partitionNum
- *                     equals Engine.nodeNumber()
+ *                     equals executor number.
  * @param toMiniBatch toMiniBatch is an function convert an Array[Sample] to a MiniBatch[T], defined
  *                    as (Array[Sample[T]], Array[Tensor[T]], Array[Tensor[T]]) => MiniBatch[T]).
  *                    The two array[Tensor] are input buffers and target buffers, their lengths

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/BGRImgToSample.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/BGRImgToSample.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.dataset.image
 
-import com.intel.analytics.bigdl.dataset.{Sample, TensorSample, Transformer}
+import com.intel.analytics.bigdl.dataset.{Sample, Transformer}
 import com.intel.analytics.bigdl.tensor.Tensor
 
 import scala.collection.Iterator

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/BGRImgToSample.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/BGRImgToSample.scala
@@ -32,20 +32,18 @@ object BGRImgToSample {
  */
 class BGRImgToSample(toRGB: Boolean = true) extends Transformer[LabeledBGRImage, Sample[Float]] {
 
-  private val featureBuffer = Array(Tensor[Float]())
-  private val labelBuffer = Array(Tensor[Float](1))
-  private val buffer = Sample[Float]()
+  private val featureBuffer = Tensor[Float]()
+  private val labelBuffer = Tensor[Float](1)
 
   override def apply(prev: Iterator[LabeledBGRImage]): Iterator[Sample[Float]] = {
     prev.map(img => {
-      labelBuffer(0).storage.array()(0) = img.label()
-      if (featureBuffer(0).nElement() != 3 * img.height() * img.width()) {
-        featureBuffer(0).resize(3, img.height(), img.width())
+      labelBuffer.storage.array()(0) = img.label()
+      if (featureBuffer.nElement() != 3 * img.height() * img.width()) {
+        featureBuffer.resize(3, img.height(), img.width())
       }
 
-      img.copyTo(featureBuffer(0).storage().array(), 0, toRGB)
-      buffer.set(featureBuffer, labelBuffer)
-      buffer
+      img.copyTo(featureBuffer.storage().array(), 0, toRGB)
+      Sample(featureBuffer, labelBuffer)
     })
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/BGRImgToSample.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/BGRImgToSample.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.dataset.image
 
-import com.intel.analytics.bigdl.dataset.{Sample, Transformer}
+import com.intel.analytics.bigdl.dataset.{Sample, TensorSample, Transformer}
 import com.intel.analytics.bigdl.tensor.Tensor
 
 import scala.collection.Iterator
@@ -32,18 +32,19 @@ object BGRImgToSample {
  */
 class BGRImgToSample(toRGB: Boolean = true) extends Transformer[LabeledBGRImage, Sample[Float]] {
 
-  private val featureBuffer = Tensor[Float]()
-  private val labelBuffer = Tensor[Float](1)
-  private val buffer = Sample[Float](featureBuffer, labelBuffer)
+  private val featureBuffer = Array(Tensor[Float]())
+  private val labelBuffer = Array(Tensor[Float](1))
+  private val buffer = Sample[Float]()
 
   override def apply(prev: Iterator[LabeledBGRImage]): Iterator[Sample[Float]] = {
     prev.map(img => {
-      labelBuffer.storage.array()(0) = img.label()
-      if (featureBuffer.nElement() != 3 * img.height() * img.width()) {
-        featureBuffer.resize(3, img.height(), img.width())
+      labelBuffer(0).storage.array()(0) = img.label()
+      if (featureBuffer(0).nElement() != 3 * img.height() * img.width()) {
+        featureBuffer(0).resize(3, img.height(), img.width())
       }
 
-      img.copyTo(featureBuffer.storage().array(), 0, toRGB)
+      img.copyTo(featureBuffer(0).storage().array(), 0, toRGB)
+      buffer.set(featureBuffer, labelBuffer)
       buffer
     })
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/GreyImgToSample.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/GreyImgToSample.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.dataset.image
 
-import com.intel.analytics.bigdl.dataset.{Sample, TensorSample, Transformer}
+import com.intel.analytics.bigdl.dataset.{Sample, Transformer}
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 
 import scala.collection.Iterator

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/GreyImgToSample.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/GreyImgToSample.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.dataset.image
 
-import com.intel.analytics.bigdl.dataset.{Sample, Transformer}
+import com.intel.analytics.bigdl.dataset.{Sample, TensorSample, Transformer}
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 
 import scala.collection.Iterator
@@ -32,19 +32,19 @@ object GreyImgToSample {
  */
 class GreyImgToSample() extends Transformer[LabeledGreyImage, Sample[Float]] {
 
-  private val featureBuffer = Tensor[Float]()
-  private val labelBuffer = Tensor[Float](1)
+  private val featureBuffer = Array(Tensor[Float]())
+  private val labelBuffer = Array(Tensor[Float](1))
   private val featureSize = new Array[Int](2)
-  private val buffer = Sample[Float](featureBuffer, labelBuffer)
+  private val buffer = Sample[Float]()
 
   override def apply(prev: Iterator[LabeledGreyImage]): Iterator[Sample[Float]] = {
     prev.map(img => {
-      labelBuffer.storage.array()(0) = img.label()
+      labelBuffer(0).storage.array()(0) = img.label()
       featureSize(0) = img.height()
       featureSize(1) = img.width()
-      featureBuffer.set(Storage(img.content), sizes = featureSize)
+      featureBuffer(0).set(Storage(img.content), sizes = featureSize)
 
-      buffer
+      buffer.set(featureBuffer, labelBuffer)
     })
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/GreyImgToSample.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/GreyImgToSample.scala
@@ -32,19 +32,18 @@ object GreyImgToSample {
  */
 class GreyImgToSample() extends Transformer[LabeledGreyImage, Sample[Float]] {
 
-  private val featureBuffer = Array(Tensor[Float]())
-  private val labelBuffer = Array(Tensor[Float](1))
+  private val featureBuffer = Tensor[Float]()
+  private val labelBuffer = Tensor[Float](1)
   private val featureSize = new Array[Int](2)
-  private val buffer = Sample[Float]()
 
   override def apply(prev: Iterator[LabeledGreyImage]): Iterator[Sample[Float]] = {
     prev.map(img => {
-      labelBuffer(0).storage.array()(0) = img.label()
+      labelBuffer.storage.array()(0) = img.label()
       featureSize(0) = img.height()
       featureSize(1) = img.width()
-      featureBuffer(0).set(Storage(img.content), sizes = featureSize)
+      featureBuffer.set(Storage(img.content), sizes = featureSize)
 
-      buffer.set(featureBuffer, labelBuffer)
+      Sample(featureBuffer, labelBuffer)
     })
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/text/LabeledSentenceToSample.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/text/LabeledSentenceToSample.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.dataset.text
 
-import com.intel.analytics.bigdl.dataset.{Sample, Transformer}
+import com.intel.analytics.bigdl.dataset.{Sample, TensorSample, Transformer}
 
 import scala.collection.Iterator
 import java.util
@@ -61,7 +61,6 @@ class LabeledSentenceToSample[T: ClassTag](vocabLength: Int,
 
   private val feature: Tensor[T] = Tensor()
   private val label: Tensor[T] = Tensor()
-  private val buffer = Sample[T](feature, label)
 
   override def apply(prev: Iterator[LabeledSentence[T]]): Iterator[Sample[T]] = {
     prev.map(sentence => {
@@ -116,7 +115,7 @@ class LabeledSentenceToSample[T: ClassTag](vocabLength: Int,
         i += 1
       }
 
-      buffer
+      Sample[T](feature, label)
     })
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/text/LabeledSentenceToSample.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/text/LabeledSentenceToSample.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.dataset.text
 
-import com.intel.analytics.bigdl.dataset.{Sample, TensorSample, Transformer}
+import com.intel.analytics.bigdl.dataset.{Sample, Transformer}
 
 import scala.collection.Iterator
 import java.util

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/MLPipeline/DLClassifierLeNet.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/MLPipeline/DLClassifierLeNet.scala
@@ -58,7 +58,7 @@ object DLClassifierLeNet {
         BytesToGreyImg(28, 28) -> GreyImgNormalizer(trainMean, trainStd) -> GreyImgToBatch(1)
 
       val trainingRDD : RDD[Data[Float]] = trainSet.
-        asInstanceOf[DistributedDataSet[TensorMiniBatch[Float]]].data(false).map(batch => {
+        asInstanceOf[DistributedDataSet[MiniBatch[Float]]].data(false).map(batch => {
           val feature = batch.getInput().asInstanceOf[Tensor[Float]]
           val label = batch.getTarget().asInstanceOf[Tensor[Float]]
           Data[Float](feature.storage().array(), label.storage().array())

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/utils/TextClassifier.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/utils/TextClassifier.scala
@@ -223,7 +223,7 @@ class TextClassifier(param: AbstractTextClassificationParams) extends Serializab
       Sample(
         featureTensor = Tensor(input.flatten, Array(sequenceLen, embeddingDim))
           .transpose(1, 2).contiguous(),
-        labelTensor = Tensor(Array(label), Array(1)))
+        label = label)
     }
 
     val Array(trainingRDD, valRDD) = sampleRDD.randomSplit(
@@ -255,14 +255,14 @@ class TextClassifier(param: AbstractTextClassificationParams) extends Serializab
       Sample(
         featureTensor = Tensor(input.flatten, Array(param.maxSequenceLength, param.embeddingDim))
           .transpose(1, 2).contiguous(),
-        labelTensor = Tensor(Array(label), Array(1)))
+        label = label)
     }
 
     val valRDD = rdds(1).map { case (input: Array[Array[Float]], label: Float) =>
       Sample(
         featureTensor = Tensor(input.flatten, Array(param.maxSequenceLength, param.embeddingDim))
           .transpose(1, 2).contiguous(),
-        labelTensor = Tensor(Array(label), Array(1)))
+        label = label)
     }
 
     // train

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/autoencoder/Train.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/autoencoder/Train.scala
@@ -30,11 +30,13 @@ import com.intel.analytics.bigdl.utils.{Engine, T, Table}
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.SparkContext
 
+import scala.reflect.ClassTag
+
 object toAutoencoderBatch {
   def apply(): toAutoencoderBatch[Float] = new toAutoencoderBatch[Float]()
 }
 
-class toAutoencoderBatch[T](implicit ev: TensorNumeric[T]
+class toAutoencoderBatch[T: ClassTag](implicit ev: TensorNumeric[T]
       )extends Transformer[MiniBatch[T], MiniBatch[T]] {
   override def apply(prev: Iterator[MiniBatch[T]]): Iterator[MiniBatch[T]] = {
     prev.map(batch => {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Test.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Test.scala
@@ -17,7 +17,7 @@
 package com.intel.analytics.bigdl.models.rnn
 
 
-import com.intel.analytics.bigdl.dataset.{DataSet, LocalDataSet, MiniBatch, SampleToBatch}
+import com.intel.analytics.bigdl.dataset.{DataSet, LocalDataSet, MiniBatch, SampleToMiniBatch}
 import com.intel.analytics.bigdl.dataset.text.{Dictionary, LabeledSentence, LabeledSentenceToSample}
 import com.intel.analytics.bigdl.nn.{Concat, Identity, LogSoftMax, Module}
 import com.intel.analytics.bigdl.tensor.Tensor
@@ -64,7 +64,7 @@ object Test {
       val rdd = sc.parallelize(labeledInput).mapPartitions(iter =>
         LabeledSentenceToSample[Float](vocabSize).apply(iter)
       ).mapPartitions(iter =>
-        SampleToBatch[Float](batchSize).apply(iter)
+        SampleToMiniBatch[Float](batchSize).apply(iter)
       )
 
       val flow = rdd.mapPartitions(iter => {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Train.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Train.scala
@@ -17,7 +17,7 @@
 package com.intel.analytics.bigdl.models.rnn
 
 import com.intel.analytics.bigdl._
-import com.intel.analytics.bigdl.dataset.{DataSet, FixedLength, FeaturePaddingParam, SampleToMiniBatch}
+import com.intel.analytics.bigdl.dataset.{DataSet, FixedLength, PaddingParam, SampleToMiniBatch}
 import com.intel.analytics.bigdl.dataset.text.LabeledSentenceToSample
 import com.intel.analytics.bigdl.dataset.text._
 import com.intel.analytics.bigdl.dataset.text.utils.SentenceToken
@@ -71,17 +71,14 @@ object Train {
       val padFeature = Tensor[Float]().resize(totalVocabLength)
       padFeature.setValue(endIdx + 1, 1.0f)
       val padLabel = startIdx
-      val featurePadding = FeaturePaddingParam(Some(Array(padFeature)),
-        Some(FixedLength(Array(maxTrainLength))))
+      val featurePadding = PaddingParam(Some(Array(padFeature)),
+        FixedLength(Array(maxTrainLength)))
 
       val trainSet = DataSet.rdd(tokens)
         .transform(TextToLabeledSentence[Float](dictionary))
         .transform(LabeledSentenceToSample[Float](totalVocabLength))
         .transform(SampleToMiniBatch[Float](param.batchSize,
           Some(featurePadding), None))
-//          featurePadding = Some(padFeature),
-//          labelPadding = Some(padLabel),
-//          fixedLength = Some(maxTrainLength)))
 
       val validationSet = DataSet.rdd(valtokens)
         .transform(TextToLabeledSentence[Float](dictionary))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Train.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Train.scala
@@ -17,7 +17,7 @@
 package com.intel.analytics.bigdl.models.rnn
 
 import com.intel.analytics.bigdl._
-import com.intel.analytics.bigdl.dataset.{DataSet, SampleToBatch}
+import com.intel.analytics.bigdl.dataset.{DataSet, SampleToMiniBatch}
 import com.intel.analytics.bigdl.dataset.text.LabeledSentenceToSample
 import com.intel.analytics.bigdl.dataset.text._
 import com.intel.analytics.bigdl.dataset.text.utils.SentenceToken
@@ -75,7 +75,7 @@ object Train {
       val trainSet = DataSet.rdd(tokens)
         .transform(TextToLabeledSentence[Float](dictionary))
         .transform(LabeledSentenceToSample[Float](totalVocabLength))
-        .transform(SampleToBatch[Float](batchSize = param.batchSize,
+        .transform(SampleToMiniBatch(batchSize = param.batchSize,
           featurePadding = Some(padFeature),
           labelPadding = Some(padLabel),
           fixedLength = Some(maxTrainLength)))
@@ -83,7 +83,7 @@ object Train {
       val validationSet = DataSet.rdd(valtokens)
         .transform(TextToLabeledSentence[Float](dictionary))
         .transform(LabeledSentenceToSample[Float](totalVocabLength))
-        .transform(SampleToBatch[Float](batchSize = param.batchSize,
+        .transform(SampleToMiniBatch(batchSize = param.batchSize,
           featurePadding = Some(padFeature),
           labelPadding = Some(padLabel),
           fixedLength = Some(maxValLength)))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Evaluator.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Evaluator.scala
@@ -17,7 +17,7 @@
 package com.intel.analytics.bigdl.optim
 
 import com.intel.analytics.bigdl._
-import com.intel.analytics.bigdl.dataset.{Sample, SampleToBatch}
+import com.intel.analytics.bigdl.dataset.{Sample, SampleToMiniBatch}
 import com.intel.analytics.bigdl.models.utils.ModelBroadcast
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import org.apache.spark.rdd.RDD
@@ -53,7 +53,7 @@ class Evaluator[T: ClassTag] private[optim](model: Module[T])(implicit ev: Tenso
     val partitionNum = dataset.partitions.length
 
     val totalBatch = batchSize.getOrElse(batchPerPartition * partitionNum)
-    val otherBroad = dataset.sparkContext.broadcast(vMethods, SampleToBatch(
+    val otherBroad = dataset.sparkContext.broadcast(vMethods, SampleToMiniBatch(
       batchSize = totalBatch, None, None, None, partitionNum = Some(partitionNum)))
 
     dataset.mapPartitions(partition => {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Evaluator.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Evaluator.scala
@@ -54,7 +54,7 @@ class Evaluator[T: ClassTag] private[optim](model: Module[T])(implicit ev: Tenso
 
     val totalBatch = batchSize.getOrElse(batchPerPartition * partitionNum)
     val otherBroad = dataset.sparkContext.broadcast(vMethods, SampleToMiniBatch(
-      batchSize = totalBatch, partitionNum = Some(partitionNum)))
+      batchSize = totalBatch))
 
     dataset.mapPartitions(partition => {
       val localModel = modelBroad.value()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Evaluator.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Evaluator.scala
@@ -54,7 +54,7 @@ class Evaluator[T: ClassTag] private[optim](model: Module[T])(implicit ev: Tenso
 
     val totalBatch = batchSize.getOrElse(batchPerPartition * partitionNum)
     val otherBroad = dataset.sparkContext.broadcast(vMethods, SampleToMiniBatch(
-      batchSize = totalBatch))
+      batchSize = totalBatch, partitionNum = Some(partitionNum)))
 
     dataset.mapPartitions(partition => {
       val localModel = modelBroad.value()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Evaluator.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Evaluator.scala
@@ -54,7 +54,7 @@ class Evaluator[T: ClassTag] private[optim](model: Module[T])(implicit ev: Tenso
 
     val totalBatch = batchSize.getOrElse(batchPerPartition * partitionNum)
     val otherBroad = dataset.sparkContext.broadcast(vMethods, SampleToMiniBatch(
-      batchSize = totalBatch, None, None, None, partitionNum = Some(partitionNum)))
+      batchSize = totalBatch, partitionNum = Some(partitionNum)))
 
     dataset.mapPartitions(partition => {
       val localModel = modelBroad.value()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Optimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Optimizer.scala
@@ -118,7 +118,7 @@ abstract class Optimizer[T: ClassTag, D](
   : this.type = {
     this.validationTrigger = Some(trigger)
     val dataSet =
-      (DataSet.rdd(sampleRDD) -> SampleToBatch(batchSize))
+      (DataSet.rdd(sampleRDD) -> SampleToMiniBatch(batchSize))
         .asInstanceOf[DistributedDataSet[MiniBatch[T]]]
     this.validationDataSet = Some(dataSet)
     this.validationMethods = Some(vMethods)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Predictor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Predictor.scala
@@ -17,7 +17,7 @@
 package com.intel.analytics.bigdl.optim
 
 import com.intel.analytics.bigdl._
-import com.intel.analytics.bigdl.dataset.{MiniBatch, Sample, SampleToBatch, Utils, DataSet => _}
+import com.intel.analytics.bigdl.dataset.{MiniBatch, Sample, SampleToMiniBatch, Utils, DataSet => _}
 import com.intel.analytics.bigdl.models.utils.ModelBroadcast
 import com.intel.analytics.bigdl.nn.abstractnn.Activity
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
@@ -51,7 +51,7 @@ class Predictor[T: ClassTag] private[optim](
   def predict(dataSet: RDD[Sample[T]]): RDD[Activity] = {
     val modelBroad = ModelBroadcast[T].broadcast(dataSet.sparkContext, model.evaluate())
     val partitionNum = dataSet.partitions.length
-    val otherBroad = dataSet.sparkContext.broadcast(SampleToBatch(
+    val otherBroad = dataSet.sparkContext.broadcast(SampleToMiniBatch(
       batchSize = batchPerPartition * partitionNum, None, None, None,
       partitionNum = Some(partitionNum)))
     dataSet.mapPartitions { partition =>

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Predictor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Predictor.scala
@@ -52,7 +52,7 @@ class Predictor[T: ClassTag] private[optim](
     val modelBroad = ModelBroadcast[T].broadcast(dataSet.sparkContext, model.evaluate())
     val partitionNum = dataSet.partitions.length
     val otherBroad = dataSet.sparkContext.broadcast(SampleToMiniBatch(
-      batchSize = batchPerPartition * partitionNum))
+      batchSize = batchPerPartition * partitionNum, partitionNum = Some(partitionNum)))
     dataSet.mapPartitions { partition =>
       val localModel = modelBroad.value()
       val localTransformer = otherBroad.value.cloneTransformer()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Predictor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Predictor.scala
@@ -52,8 +52,7 @@ class Predictor[T: ClassTag] private[optim](
     val modelBroad = ModelBroadcast[T].broadcast(dataSet.sparkContext, model.evaluate())
     val partitionNum = dataSet.partitions.length
     val otherBroad = dataSet.sparkContext.broadcast(SampleToMiniBatch(
-      batchSize = batchPerPartition * partitionNum, None, None, None,
-      partitionNum = Some(partitionNum)))
+      batchSize = batchPerPartition * partitionNum))
     dataSet.mapPartitions { partition =>
       val localModel = modelBroad.value()
       val localTransformer = otherBroad.value.cloneTransformer()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -170,7 +170,7 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   private def batching(rdd: RDD[Sample], batchSize: Int)
   : DistributedDataSet[MiniBatch[T]] = {
     val recordRDD = rdd.map(toSample(_))
-    (DataSet.rdd(recordRDD) -> new SampleToBatch[T](batchSize))
+    (DataSet.rdd(recordRDD) -> SampleToMiniBatch[T](batchSize))
       .asInstanceOf[DistributedDataSet[MiniBatch[T]]]
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/TensorNumeric.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/TensorNumeric.scala
@@ -130,6 +130,9 @@ object TensorNumericMath {
 
     def sum(n: Int, a: Array[T], aOffset: Int, stride: Int): T
 
+    def arraycopy(src: Array[T], srcPos: Int,
+                  dest: Array[T], destPos: Int, length: Int): Unit
+
     def getType(): TensorDataType
   }
 
@@ -339,6 +342,15 @@ object TensorNumericMath {
         }
         r
       }
+
+      override def arraycopy(
+            src: Array[Float],
+            srcPos: Int,
+            dest: Array[Float],
+            destPos: Int,
+            length: Int): Unit = {
+        System.arraycopy(src, srcPos, dest, destPos, length)
+      }
     }
 
     implicit object NumericDouble extends TensorNumeric[Double] {
@@ -531,6 +543,15 @@ object TensorNumericMath {
           i += 1
         }
         r
+      }
+
+      override def arraycopy(
+            src: Array[Double],
+            srcPos: Int,
+            dest: Array[Double],
+            destPos: Int,
+            length: Int): Unit = {
+        System.arraycopy(src, srcPos, dest, destPos, length)
       }
     }
   }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/BatchPaddingSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/BatchPaddingSpec.scala
@@ -55,7 +55,7 @@ class BatchPaddingSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val trainData =
       Array[Sample[Float]](sample1, sample2, sample3, sample3, sample3, sample3)
     val trainSet = DataSet.array(trainData)
-      .transform(SampleToBatch[Float](batchSize, Some(featurePadding), Some(10.0f)))
+      .transform(SampleToMiniBatch[Float](batchSize, Some(featurePadding), Some(10.0f)))
 
     val iter = trainSet.toLocal().data(train = false)
 
@@ -105,7 +105,7 @@ class BatchPaddingSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val trainData =
       Array[Sample[Float]](sample1, sample2, sample3, sample3, sample3, sample3)
     val trainSet = DataSet.array(trainData).transform(
-      SampleToBatch[Float](batchSize, Some(featurePadding), Some(80.0f), Some(10)))
+      SampleToMiniBatch[Float](batchSize, Some(featurePadding), Some(80.0f), Some(10)))
 
     val iter = trainSet.toLocal().data(train = false)
 
@@ -146,7 +146,7 @@ class BatchPaddingSpec extends FlatSpec with Matchers with BeforeAndAfter {
     data should be (tensorInput2)
   }
 
-  "SampleToBatchPadding " should "be same to SampleToBatch when no padding" in {
+  "SampleToBatchPadding " should "be same to SampleToMiniBatch when no padding" in {
     val batchSize = 3
     val totalCount = 100
     val trainData = new Array[Sample[Float]](totalCount)
@@ -158,7 +158,7 @@ class BatchPaddingSpec extends FlatSpec with Matchers with BeforeAndAfter {
       i += 1
     }
     val trainSet1 = DataSet.array(trainData)
-      .transform(SampleToBatch[Float](batchSize))
+      .transform(SampleToMiniBatch[Float](batchSize))
     val trainSet2 = DataSet.array(trainData)
       .transform(SampleToBatchNoPadding(batchSize))
 
@@ -175,7 +175,7 @@ class BatchPaddingSpec extends FlatSpec with Matchers with BeforeAndAfter {
     data2.hasNext should be (false)
   }
 
-  "SampleToBatchPadding " should "be same to LabeledSentenceToSample and SampleToBatch " +
+  "SampleToBatchPadding " should "be same to LabeledSentenceToSample and SampleToMiniBatch " +
     "when padding" in {
     val batchSize = 3
     val totalCount = 9
@@ -196,8 +196,8 @@ class BatchPaddingSpec extends FlatSpec with Matchers with BeforeAndAfter {
     featurePadding(4000) = 1
     val trainSet1 = DataSet.array(trainData)
       .transform(LabeledSentenceToSample(dictionaryLength))
-      .transform(SampleToBatch[Float]
-        (batchSize, Some(featurePadding), Some(3999), Some(trainMaxLength)))
+      .transform(SampleToMiniBatch(batchSize, Some(featurePadding),
+        Some(3999), Some(trainMaxLength)))
 
     val trainSet2 = DataSet.array(trainData)
       .transform(LabeledSentenceToSample(dictionaryLength,

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/BatchPaddingSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/BatchPaddingSpec.scala
@@ -52,12 +52,14 @@ class BatchPaddingSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     val featurePadding = Tensor[Float](dictionaryLength).fill(100.0f)
 
+    val featurePaddingParam = FeaturePaddingParam(Some(Array(featurePadding)))
+    val labelPaddingParam = LabelPaddingParam[Float](Some(Array(10.0f)))
+
     val trainData =
       Array[Sample[Float]](sample1, sample2, sample3, sample3, sample3, sample3)
     val trainSet = DataSet.array(trainData)
       .transform(SampleToMiniBatch[Float](batchSize,
-        featurePadding = Some(featurePadding),
-        labelPadding = Some(10.0f)))
+        Some(featurePaddingParam), Some(labelPaddingParam)))
 
     val iter = trainSet.toLocal().data(train = false)
 
@@ -102,12 +104,18 @@ class BatchPaddingSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val sample2 = Sample[Float](input2, target2)
     val sample3 = Sample[Float](input3, target3)
 
-    val featurePadding = Tensor[Float](dictionaryLength).fill(100.0f)
+    val featurePadding = Tensor[Float](dictionaryLength).fill(100f)
+
+    val featurePaddingParam = FeaturePaddingParam(Some(Array(featurePadding)),
+      Some(FixedLength(Array(10))))
+    val labelPaddingParam = LabelPaddingParam[Float](Some(Array(80f)),
+    Some(FixedLength(Array(10))))
 
     val trainData =
       Array[Sample[Float]](sample1, sample2, sample3, sample3, sample3, sample3)
     val trainSet = DataSet.array(trainData).transform(
-      SampleToMiniBatch[Float](batchSize, Some(featurePadding), Some(80.0f), Some(10)))
+      SampleToMiniBatch[Float](batchSize,
+        Some(featurePaddingParam), Some(labelPaddingParam)))
 
     val iter = trainSet.toLocal().data(train = false)
 
@@ -199,10 +207,16 @@ class BatchPaddingSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val trainMaxLength = 10
     val featurePadding = Tensor[Float](dictionaryLength).fill(0.0f)
     featurePadding(4000) = 1
+
+    val featurePaddingParam = FeaturePaddingParam(Some(Array(featurePadding)),
+      Some(FixedLength(Array(trainMaxLength))))
+    val labelPaddingParam = LabelPaddingParam[Float](Some(Array(3999f)),
+      Some(FixedLength(Array(trainMaxLength))))
+
     val trainSet1 = DataSet.array(trainData)
       .transform(LabeledSentenceToSample(dictionaryLength))
-      .transform(SampleToMiniBatch(batchSize, Some(featurePadding),
-        Some(3999), Some(trainMaxLength)))
+      .transform(SampleToMiniBatch[Float](batchSize,
+        Some(featurePaddingParam), Some(labelPaddingParam)))
 
     val trainSet2 = DataSet.array(trainData)
       .transform(LabeledSentenceToSample(dictionaryLength,

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/BatchPaddingSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/BatchPaddingSpec.scala
@@ -52,8 +52,8 @@ class BatchPaddingSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     val featurePadding = Tensor[Float](dictionaryLength).fill(100.0f)
 
-    val featurePaddingParam = FeaturePaddingParam(Some(Array(featurePadding)))
-    val labelPaddingParam = LabelPaddingParam[Float](Some(Array(10.0f)))
+    val featurePaddingParam = PaddingParam(Some(Array(featurePadding)))
+    val labelPaddingParam = PaddingParam[Float](Some(Array(Tensor[Float](1).fill(10.0f))))
 
     val trainData =
       Array[Sample[Float]](sample1, sample2, sample3, sample3, sample3, sample3)
@@ -106,10 +106,10 @@ class BatchPaddingSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     val featurePadding = Tensor[Float](dictionaryLength).fill(100f)
 
-    val featurePaddingParam = FeaturePaddingParam(Some(Array(featurePadding)),
-      Some(FixedLength(Array(10))))
-    val labelPaddingParam = LabelPaddingParam[Float](Some(Array(80f)),
-    Some(FixedLength(Array(10))))
+    val featurePaddingParam = PaddingParam(Some(Array(featurePadding)),
+      FixedLength(Array(10)))
+    val labelPaddingParam = PaddingParam[Float](Some(Array(Tensor[Float](1).fill(80f))),
+      FixedLength(Array(10)))
 
     val trainData =
       Array[Sample[Float]](sample1, sample2, sample3, sample3, sample3, sample3)
@@ -208,10 +208,10 @@ class BatchPaddingSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val featurePadding = Tensor[Float](dictionaryLength).fill(0.0f)
     featurePadding(4000) = 1
 
-    val featurePaddingParam = FeaturePaddingParam(Some(Array(featurePadding)),
-      Some(FixedLength(Array(trainMaxLength))))
-    val labelPaddingParam = LabelPaddingParam[Float](Some(Array(3999f)),
-      Some(FixedLength(Array(trainMaxLength))))
+    val featurePaddingParam = PaddingParam(Some(Array(featurePadding)),
+      FixedLength(Array(trainMaxLength)))
+    val labelPaddingParam = PaddingParam[Float](Some(Array(Tensor[Float](1).fill(3999f))),
+      FixedLength(Array(trainMaxLength)))
 
     val trainSet1 = DataSet.array(trainData)
       .transform(LabeledSentenceToSample(dictionaryLength))

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/BatchPaddingSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/BatchPaddingSpec.scala
@@ -55,7 +55,9 @@ class BatchPaddingSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val trainData =
       Array[Sample[Float]](sample1, sample2, sample3, sample3, sample3, sample3)
     val trainSet = DataSet.array(trainData)
-      .transform(SampleToMiniBatch[Float](batchSize, Some(featurePadding), Some(10.0f)))
+      .transform(SampleToMiniBatch[Float](batchSize,
+        featurePadding = Some(featurePadding),
+        labelPadding = Some(10.0f)))
 
     val iter = trainSet.toLocal().data(train = false)
 
@@ -168,6 +170,9 @@ class BatchPaddingSpec extends FlatSpec with Matchers with BeforeAndAfter {
     while (data1.hasNext && data2.hasNext) {
       val batch1 = data1.next()
       val batch2 = data2.next()
+      if (batch1.getInput() != batch2.getInput()) {
+        println
+      }
       batch1.getInput should be (batch2.getInput)
       batch1.getTarget should be (batch2.getTarget)
     }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/DataSetSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/DataSetSpec.scala
@@ -345,7 +345,7 @@ class DataSetSpec extends FlatSpec with Matchers with BeforeAndAfter {
       groupSize
     )
 
-    val dataSet = dataSet1.transform(SampleToBatch(batchSize))
+    val dataSet = dataSet1.transform(SampleToMiniBatch(batchSize))
     val rdd = dataSet.toDistributed().data(train = true)
     rdd.partitions.size should be (partitionNum)
     val rddData = rdd.mapPartitions(iter => {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/MiniBatchSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/MiniBatchSpec.scala
@@ -53,7 +53,7 @@ class MiniBatchSpec extends FlatSpec with Matchers {
     val a1 = Tensor[Float](3, 4).range(1, 12, 1)
     val a2 = Tensor[Float](3, 2).range(1, 6, 1)
     val b = Tensor[Float](3).range(1, 3, 1)
-    val miniBatch = MiniBatch(T(a1, a2), b)
+    val miniBatch = MiniBatch(Array(a1, a2), b)
     miniBatch.size() should be (3)
   }
 
@@ -61,7 +61,7 @@ class MiniBatchSpec extends FlatSpec with Matchers {
     val a1 = Tensor[Float](3, 4).range(1, 12, 1)
     val a2 = Tensor[Float](3, 2).range(1, 6, 1)
     val b = Tensor[Float](3).range(1, 3, 1)
-    val miniBatch = MiniBatch(T(a1, a2), b)
+    val miniBatch = MiniBatch(Array(a1, a2), b)
     miniBatch.getInput() should be (T(a1, a2))
     miniBatch.getTarget() should be (b)
   }
@@ -70,7 +70,7 @@ class MiniBatchSpec extends FlatSpec with Matchers {
     val a1 = Tensor[Float](3, 2, 2).range(1, 12, 1)
     val a2 = Tensor[Float](3, 2).range(1, 6, 1)
     val b = Tensor[Float](3).range(1, 3, 1)
-    val miniBatch = MiniBatch(T(a1, a2), b)
+    val miniBatch = MiniBatch(Array(a1, a2), b)
 
     miniBatch.slice(1, 1).getInput() should be (T(Tensor[Float](1, 2, 2).range(1, 4, 1),
       Tensor[Float](1, 2).range(1, 2, 1)))

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/MiniBatchSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/MiniBatchSpec.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.dataset
+
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.T
+import org.scalatest.{FlatSpec, Matchers}
+
+class MiniBatchSpec extends FlatSpec with Matchers {
+  "TensorMiniBatch size" should "return right result" in {
+    val a = Tensor[Float](3, 4).range(1, 12, 1)
+    val b = Tensor[Float](3).range(1, 3, 1)
+    val miniBatch = MiniBatch(a, b)
+    miniBatch.size() should be (3)
+  }
+
+  "TensorMiniBatch getInput/target" should "return right result" in {
+    val a = Tensor[Float](3, 4).range(1, 12, 1)
+    val b = Tensor[Float](3).range(1, 3, 1)
+    val miniBatch = MiniBatch(a, b)
+    miniBatch.getInput() should be (a)
+    miniBatch.getTarget() should be (b)
+  }
+
+  "TensorMiniBatch slice" should "return right result" in {
+    val a = Tensor[Float](3, 4).range(1, 12, 1)
+    val b = Tensor[Float](3).range(1, 3, 1)
+    val miniBatch = MiniBatch(a, b)
+
+    miniBatch.slice(1, 1).getInput() should be (Tensor[Float](1, 4).range(1, 4, 1))
+    miniBatch.slice(2, 1).getInput() should be (Tensor[Float](1, 4).range(5, 8, 1))
+    miniBatch.slice(3, 1).getInput() should be (Tensor[Float](1, 4).range(9, 12, 1))
+    miniBatch.slice(1, 1).getTarget() should be (Tensor[Float](1).fill(1))
+    miniBatch.slice(2, 1).getTarget() should be (Tensor[Float](1).fill(2))
+    miniBatch.slice(3, 1).getTarget() should be (Tensor[Float](1).fill(3))
+  }
+
+  "ArrayTensorMiniBatch size" should "return right result" in {
+    val a1 = Tensor[Float](3, 4).range(1, 12, 1)
+    val a2 = Tensor[Float](3, 2).range(1, 6, 1)
+    val b = Tensor[Float](3).range(1, 3, 1)
+    val miniBatch = MiniBatch(T(a1, a2), b)
+    miniBatch.size() should be (3)
+  }
+
+  "ArrayTensorMiniBatch getInput/target" should "return right result" in {
+    val a1 = Tensor[Float](3, 4).range(1, 12, 1)
+    val a2 = Tensor[Float](3, 2).range(1, 6, 1)
+    val b = Tensor[Float](3).range(1, 3, 1)
+    val miniBatch = MiniBatch(T(a1, a2), b)
+    miniBatch.getInput() should be (T(a1, a2))
+    miniBatch.getTarget() should be (b)
+  }
+
+  "ArrayTensorMiniBatch slice" should "return right result" in {
+    val a1 = Tensor[Float](3, 2, 2).range(1, 12, 1)
+    val a2 = Tensor[Float](3, 2).range(1, 6, 1)
+    val b = Tensor[Float](3).range(1, 3, 1)
+    val miniBatch = MiniBatch(T(a1, a2), b)
+
+    miniBatch.slice(1, 1).getInput() should be (T(Tensor[Float](1, 2, 2).range(1, 4, 1),
+      Tensor[Float](1, 2).range(1, 2, 1)))
+    miniBatch.slice(2, 1).getInput() should be (T(Tensor[Float](1, 2, 2).range(5, 8, 1),
+      Tensor[Float](1, 2).range(3, 4, 1)))
+    miniBatch.slice(3, 1).getInput() should be (T(Tensor[Float](1, 2, 2).range(9, 12, 1),
+      Tensor[Float](1, 2).range(5, 6, 1)))
+    miniBatch.slice(1, 1).getTarget() should be (Tensor[Float](1).fill(1))
+    miniBatch.slice(2, 1).getTarget() should be (Tensor[Float](1).fill(2))
+    miniBatch.slice(3, 1).getTarget() should be (Tensor[Float](1).fill(3))
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SampleSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SampleSpec.scala
@@ -56,10 +56,121 @@ class SampleSpec extends FlatSpec with Matchers {
     tensorLabel1.rand()
     val sample = Sample[Float]()
     sample.set(tensorInput1.storage().array(),
-        tensorLabel1.storage().array(),
-        tensorInput1.size,
-        tensorLabel1.size)
-    sample.feature() should be (tensorInput1)
-    sample.label() should be (tensorLabel1)
+      tensorLabel1.storage().array(),
+      tensorInput1.size,
+      tensorLabel1.size)
+    sample.feature() should be(tensorInput1)
+    sample.label() should be(tensorLabel1)
+  }
+
+  "Array[Sample] toMiniBatch" should "return right result" in {
+    lazy val buf1 = Array(Tensor[Float]())
+    lazy val buf2 = Array(Tensor[Float]())
+    val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
+    samples(0) = Sample[Float](Tensor[Float](2, 3).range(1, 6, 1), Tensor[Float](1).fill(1))
+    samples(1) = Sample[Float](Tensor[Float](2, 3).range(7, 12, 1), Tensor[Float](1).fill(2))
+    samples(2) = Sample[Float](Tensor[Float](2, 3).range(13, 18, 1), Tensor[Float](1).fill(3))
+    val result = SampleToMiniBatch.toMiniBatch(samples, buf1, buf2)
+    val exceptedInput = Tensor[Float](3, 2, 3).range(1, 18, 1)
+    val exceptedTarget = Tensor[Float](3, 1).range(1, 3, 1)
+
+    result.getInput() should be (exceptedInput)
+    result.getTarget() should be (exceptedTarget)
+  }
+
+  "Array[Sample] toMiniBatch with feature padding" should "return right result" in {
+    lazy val buf1 = Array(Tensor[Float]())
+    lazy val buf2 = Array(Tensor[Float]())
+    val featurePadding = Some(Tensor[Float](Storage(Array(-1f, -2f, -3f))))
+    val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
+    samples(0) = Sample[Float](Tensor[Float](1, 3).range(1, 3, 1), Tensor[Float](1).fill(1))
+    samples(1) = Sample[Float](Tensor[Float](2, 3).range(10, 15, 1), Tensor[Float](1).fill(2))
+    samples(2) = Sample[Float](Tensor[Float](3, 3).range(19, 27, 1), Tensor[Float](1).fill(3))
+    val result = SampleToMiniBatch.toMiniBatch[Float](samples, buf1, buf2, featurePadding)
+    val exceptedInput = Tensor[Float](Storage(Array[Float](
+      1, 2, 3,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      10, 11, 12,
+      13, 14, 15,
+      -1f, -2f, -3f,
+
+      19, 20, 21,
+      22, 23, 24,
+      25, 26, 27
+    )), 1, Array(3, 3, 3))
+    val exceptedTarget = Tensor[Float](Storage(Array[Float](1, 2, 3)), 1, Array(3, 1))
+
+    result.getInput() should be (exceptedInput)
+    result.getTarget() should be (exceptedTarget)
+  }
+
+  "Array[Sample] toMiniBatch with padding" should "return right result" in {
+    lazy val buf1 = Array(Tensor[Float]())
+    lazy val buf2 = Array(Tensor[Float]())
+    val featurePadding = Some(Tensor[Float](Storage(Array(-1f, -2f, -3f))))
+    val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
+    samples(0) = Sample[Float](Tensor[Float](1, 3).range(1, 3, 1), Tensor[Float](1).fill(1))
+    samples(1) = Sample[Float](Tensor[Float](2, 3).range(10, 15, 1), Tensor[Float](2).fill(2))
+    samples(2) = Sample[Float](Tensor[Float](3, 3).range(19, 27, 1), Tensor[Float](3).fill(3))
+    val result = SampleToMiniBatch.toMiniBatch[Float](samples, buf1, buf2, featurePadding, Some(-1))
+    val exceptedInput = Tensor[Float](Storage(Array[Float](
+      1, 2, 3,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      10, 11, 12,
+      13, 14, 15,
+      -1f, -2f, -3f,
+
+      19, 20, 21,
+      22, 23, 24,
+      25, 26, 27
+    )), 1, Array(3, 3, 3))
+    val exceptedTarget = Tensor[Float](Storage(Array[Float](
+      1, -1, -1,
+      2, 2, -1,
+      3, 3, 3
+    )), 1, Array(3, 3))
+
+    result.getInput() should be (exceptedInput)
+    result.getTarget() should be (exceptedTarget)
+  }
+
+  "Array[Sample] toMiniBatch with fixedlength" should "return right result" in {
+    lazy val buf1 = Array(Tensor[Float]())
+    lazy val buf2 = Array(Tensor[Float]())
+    val featurePadding = Some(Tensor[Float](Storage(Array(-1f, -2f, -3f))))
+    val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
+    samples(0) = Sample[Float](Tensor[Float](1, 3).range(1, 3, 1), Tensor[Float](1).fill(1))
+    samples(1) = Sample[Float](Tensor[Float](2, 3).range(10, 15, 1), Tensor[Float](2).fill(2))
+    samples(2) = Sample[Float](Tensor[Float](3, 3).range(19, 27, 1), Tensor[Float](3).fill(3))
+    val result = SampleToMiniBatch.toMiniBatch[Float](
+      samples, buf1, buf2, featurePadding, Some(-1), Some(4))
+    val exceptedInput = Tensor[Float](Storage(Array[Float](
+      1, 2, 3,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      10, 11, 12,
+      13, 14, 15,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      19, 20, 21,
+      22, 23, 24,
+      25, 26, 27,
+      -1f, -2f, -3f
+    )), 1, Array(3, 4, 3))
+    val exceptedTarget = Tensor[Float](Storage(Array[Float](
+      1, -1, -1,
+      2, 2, -1,
+      3, 3, 3
+    )), 1, Array(3, 3))
+
+    result.getInput() should be (exceptedInput)
+    result.getTarget() should be (exceptedTarget)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SampleSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SampleSpec.scala
@@ -167,10 +167,10 @@ class SampleSpec extends FlatSpec with Matchers {
       -1f, -2f, -3f
     )), 1, Array(3, 4, 3))
     val exceptedTarget = Tensor[Float](Storage(Array[Float](
-      1, -1, -1,
-      2, 2, -1,
-      3, 3, 3
-    )), 1, Array(3, 3))
+      1, -1, -1, -1,
+      2, 2, -1, -1,
+      3, 3, 3, -1
+    )), 1, Array(3, 4))
 
     result.getInput() should be (exceptedInput)
     result.getTarget() should be (exceptedTarget)
@@ -378,10 +378,10 @@ class SampleSpec extends FlatSpec with Matchers {
     exceptedInput[Tensor[Float]](2)(2).fill(2)
     exceptedInput[Tensor[Float]](2)(3).fill(3)
     val exceptedTarget = Tensor[Float](Storage(Array[Float](
-      1, -1, -1,
-      2, 2, -1,
-      3, 3, 3
-    )), 1, Array(3, 3))
+      1, -1, -1, -1,
+      2, 2, -1, -1,
+      3, 3, 3, -1
+    )), 1, Array(3, 4))
 
     result.getInput() should be (exceptedInput)
     result.getTarget() should be (exceptedTarget)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SampleSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SampleSpec.scala
@@ -18,6 +18,7 @@ package com.intel.analytics.bigdl.dataset
 
 import com.intel.analytics.bigdl.dataset.image.LabeledBGRImage
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
+import com.intel.analytics.bigdl.utils.T
 import org.scalatest.{FlatSpec, Matchers}
 
 @com.intel.analytics.bigdl.tags.Parallel
@@ -63,14 +64,14 @@ class SampleSpec extends FlatSpec with Matchers {
     sample.label() should be(tensorLabel1)
   }
 
-  "Array[Sample] toMiniBatch" should "return right result" in {
+  "Array[TensorSample] toMiniBatch" should "return right result" in {
     lazy val buf1 = Array(Tensor[Float]())
     lazy val buf2 = Array(Tensor[Float]())
     val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
     samples(0) = Sample[Float](Tensor[Float](2, 3).range(1, 6, 1), Tensor[Float](1).fill(1))
     samples(1) = Sample[Float](Tensor[Float](2, 3).range(7, 12, 1), Tensor[Float](1).fill(2))
     samples(2) = Sample[Float](Tensor[Float](2, 3).range(13, 18, 1), Tensor[Float](1).fill(3))
-    val result = SampleToMiniBatch.toMiniBatch(samples, buf1, buf2)
+    val result = SampleToMiniBatch.samplesToMiniBatch(samples, buf1, buf2)
     val exceptedInput = Tensor[Float](3, 2, 3).range(1, 18, 1)
     val exceptedTarget = Tensor[Float](3, 1).range(1, 3, 1)
 
@@ -78,7 +79,7 @@ class SampleSpec extends FlatSpec with Matchers {
     result.getTarget() should be (exceptedTarget)
   }
 
-  "Array[Sample] toMiniBatch with feature padding" should "return right result" in {
+  "Array[TensorSample] toMiniBatch with feature padding" should "return right result" in {
     lazy val buf1 = Array(Tensor[Float]())
     lazy val buf2 = Array(Tensor[Float]())
     val featurePadding = Some(Tensor[Float](Storage(Array(-1f, -2f, -3f))))
@@ -86,7 +87,7 @@ class SampleSpec extends FlatSpec with Matchers {
     samples(0) = Sample[Float](Tensor[Float](1, 3).range(1, 3, 1), Tensor[Float](1).fill(1))
     samples(1) = Sample[Float](Tensor[Float](2, 3).range(10, 15, 1), Tensor[Float](1).fill(2))
     samples(2) = Sample[Float](Tensor[Float](3, 3).range(19, 27, 1), Tensor[Float](1).fill(3))
-    val result = SampleToMiniBatch.toMiniBatch[Float](samples, buf1, buf2, featurePadding)
+    val result = SampleToMiniBatch.samplesToMiniBatch[Float](samples, buf1, buf2, featurePadding)
     val exceptedInput = Tensor[Float](Storage(Array[Float](
       1, 2, 3,
       -1f, -2f, -3f,
@@ -106,15 +107,16 @@ class SampleSpec extends FlatSpec with Matchers {
     result.getTarget() should be (exceptedTarget)
   }
 
-  "Array[Sample] toMiniBatch with padding" should "return right result" in {
+  "Array[TensorSample] toMiniBatch with padding" should "return right result" in {
     lazy val buf1 = Array(Tensor[Float]())
     lazy val buf2 = Array(Tensor[Float]())
     val featurePadding = Some(Tensor[Float](Storage(Array(-1f, -2f, -3f))))
     val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
-    samples(0) = Sample[Float](Tensor[Float](1, 3).range(1, 3, 1), Tensor[Float](1).fill(1))
+    samples(0) = Sample[Float](Tensor[Float](1, 3).range(1, 3, 1), Tensor[Float](3).fill(1))
     samples(1) = Sample[Float](Tensor[Float](2, 3).range(10, 15, 1), Tensor[Float](2).fill(2))
-    samples(2) = Sample[Float](Tensor[Float](3, 3).range(19, 27, 1), Tensor[Float](3).fill(3))
-    val result = SampleToMiniBatch.toMiniBatch[Float](samples, buf1, buf2, featurePadding, Some(-1))
+    samples(2) = Sample[Float](Tensor[Float](3, 3).range(19, 27, 1), Tensor[Float](1).fill(3))
+    val result = SampleToMiniBatch.samplesToMiniBatch[Float](samples, buf1, buf2,
+      featurePadding, Some(-1))
     val exceptedInput = Tensor[Float](Storage(Array[Float](
       1, 2, 3,
       -1f, -2f, -3f,
@@ -129,16 +131,16 @@ class SampleSpec extends FlatSpec with Matchers {
       25, 26, 27
     )), 1, Array(3, 3, 3))
     val exceptedTarget = Tensor[Float](Storage(Array[Float](
-      1, -1, -1,
+      1, 1, 1,
       2, 2, -1,
-      3, 3, 3
+      3, -1, -1
     )), 1, Array(3, 3))
 
     result.getInput() should be (exceptedInput)
     result.getTarget() should be (exceptedTarget)
   }
 
-  "Array[Sample] toMiniBatch with fixedlength" should "return right result" in {
+  "Array[TensorSample] toMiniBatch with fixedlength" should "return right result" in {
     lazy val buf1 = Array(Tensor[Float]())
     lazy val buf2 = Array(Tensor[Float]())
     val featurePadding = Some(Tensor[Float](Storage(Array(-1f, -2f, -3f))))
@@ -146,7 +148,7 @@ class SampleSpec extends FlatSpec with Matchers {
     samples(0) = Sample[Float](Tensor[Float](1, 3).range(1, 3, 1), Tensor[Float](1).fill(1))
     samples(1) = Sample[Float](Tensor[Float](2, 3).range(10, 15, 1), Tensor[Float](2).fill(2))
     samples(2) = Sample[Float](Tensor[Float](3, 3).range(19, 27, 1), Tensor[Float](3).fill(3))
-    val result = SampleToMiniBatch.toMiniBatch[Float](
+    val result = SampleToMiniBatch.samplesToMiniBatch[Float](
       samples, buf1, buf2, featurePadding, Some(-1), Some(4))
     val exceptedInput = Tensor[Float](Storage(Array[Float](
       1, 2, 3,
@@ -172,5 +174,370 @@ class SampleSpec extends FlatSpec with Matchers {
 
     result.getInput() should be (exceptedInput)
     result.getTarget() should be (exceptedTarget)
+  }
+
+  "Array[TensorTSample] toMiniBatch" should "return right result" in {
+    lazy val buf1 = Array(Tensor[Float]())
+    lazy val buf2 = Array(Tensor[Float]())
+    val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
+    samples(0) = Sample[Float](Tensor[Float](2, 3).range(1, 6, 1), 1)
+    samples(1) = Sample[Float](Tensor[Float](2, 3).range(7, 12, 1), 2)
+    samples(2) = Sample[Float](Tensor[Float](2, 3).range(13, 18, 1), 3)
+    val result = SampleToMiniBatch.samplesToMiniBatch(samples, buf1, buf2)
+    val exceptedInput = Tensor[Float](3, 2, 3).range(1, 18, 1)
+    val exceptedTarget = Tensor[Float](3).range(1, 3, 1)
+
+    result.getInput() should be (exceptedInput)
+    result.getTarget() should be (exceptedTarget)
+  }
+
+  "Array[TensorTSample] toMiniBatch with feature padding" should "return right result" in {
+    lazy val buf1 = Array(Tensor[Float]())
+    lazy val buf2 = Array(Tensor[Float]())
+    val featurePadding = Some(Tensor[Float](Storage(Array(-1f, -2f, -3f))))
+    val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
+    samples(0) = Sample[Float](Tensor[Float](1, 3).range(1, 3, 1), 1)
+    samples(1) = Sample[Float](Tensor[Float](2, 3).range(10, 15, 1), 2)
+    samples(2) = Sample[Float](Tensor[Float](3, 3).range(19, 27, 1), 3)
+    val result = SampleToMiniBatch.samplesToMiniBatch[Float](samples, buf1, buf2, featurePadding)
+    val exceptedInput = Tensor[Float](Storage(Array[Float](
+      1, 2, 3,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      10, 11, 12,
+      13, 14, 15,
+      -1f, -2f, -3f,
+
+      19, 20, 21,
+      22, 23, 24,
+      25, 26, 27
+    )), 1, Array(3, 3, 3))
+    val exceptedTarget = Tensor[Float](Storage(Array[Float](1, 2, 3)), 1, Array(3))
+
+    result.getInput() should be (exceptedInput)
+    result.getTarget() should be (exceptedTarget)
+  }
+
+  "Array[TensorTSample] toMiniBatch with fixedlength" should "return right result" in {
+    lazy val buf1 = Array(Tensor[Float]())
+    lazy val buf2 = Array(Tensor[Float]())
+    val featurePadding = Some(Tensor[Float](Storage(Array(-1f, -2f, -3f))))
+    val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
+    samples(0) = Sample[Float](Tensor[Float](1, 3).range(1, 3, 1), 1)
+    samples(1) = Sample[Float](Tensor[Float](2, 3).range(10, 15, 1), 2)
+    samples(2) = Sample[Float](Tensor[Float](3, 3).range(19, 27, 1), 3)
+    val result = SampleToMiniBatch.samplesToMiniBatch[Float](
+      samples, buf1, buf2, featurePadding, Some(-1), Some(4))
+    val exceptedInput = Tensor[Float](Storage(Array[Float](
+      1, 2, 3,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      10, 11, 12,
+      13, 14, 15,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      19, 20, 21,
+      22, 23, 24,
+      25, 26, 27,
+      -1f, -2f, -3f
+    )), 1, Array(3, 4, 3))
+    val exceptedTarget = Tensor[Float](Storage(Array[Float](1, 2, 3 )), 1, Array(3))
+
+    result.getInput() should be (exceptedInput)
+    result.getTarget() should be (exceptedTarget)
+  }
+
+  "Array[ArrayTensorSample] toMiniBatch" should "return right result" in {
+    lazy val buf1 = Array(Tensor[Float](), Tensor[Float]())
+    lazy val buf2 = Array(Tensor[Float]())
+    val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
+    samples(0) = Sample[Float](Array(Tensor[Float](2, 3).range(1, 6, 1),
+      Tensor[Float](3).fill(1)), Tensor[Float](1).fill(1))
+    samples(1) = Sample[Float](Array(Tensor[Float](2, 3).range(7, 12, 1),
+      Tensor[Float](3).fill(2)), Tensor[Float](1).fill(2))
+    samples(2) = Sample[Float](Array(Tensor[Float](2, 3).range(13, 18, 1),
+      Tensor[Float](3).fill(3)), Tensor[Float](1).fill(3))
+    val result = SampleToMiniBatch.samplesToMiniBatch(samples, buf1, buf2)
+    val exceptedInput = T(Tensor[Float](3, 2, 3).range(1, 18, 1), Tensor[Float](3, 3))
+    exceptedInput[Tensor[Float]](2)(1).fill(1)
+    exceptedInput[Tensor[Float]](2)(2).fill(2)
+    exceptedInput[Tensor[Float]](2)(3).fill(3)
+    val exceptedTarget = Tensor[Float](3, 1).range(1, 3, 1)
+
+    result.getInput() should be (exceptedInput)
+    result.getTarget() should be (exceptedTarget)
+  }
+
+  "Array[ArrayTensorSample] toMiniBatch with feature padding" should "return right result" in {
+    lazy val buf1 = Array(Tensor[Float](), Tensor[Float]())
+    lazy val buf2 = Array(Tensor[Float]())
+    val featurePadding = Some(Tensor[Float](Storage(Array(-1f, -2f, -3f))))
+    val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
+    samples(0) = Sample[Float](Array(Tensor[Float](1, 3).range(1, 3, 1),
+      Tensor[Float](3).fill(1)), Tensor[Float](1).fill(1))
+    samples(1) = Sample[Float](Array(Tensor[Float](2, 3).range(10, 15, 1),
+      Tensor[Float](3).fill(2)), Tensor[Float](1).fill(2))
+    samples(2) = Sample[Float](Array(Tensor[Float](3, 3).range(19, 27, 1),
+      Tensor[Float](3).fill(3)), Tensor[Float](1).fill(3))
+    val result = SampleToMiniBatch.samplesToMiniBatch[Float](samples, buf1, buf2, featurePadding)
+    val exceptedInput = T(Tensor[Float](Storage(Array[Float](
+      1, 2, 3,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      10, 11, 12,
+      13, 14, 15,
+      -1f, -2f, -3f,
+
+      19, 20, 21,
+      22, 23, 24,
+      25, 26, 27
+    )), 1, Array(3, 3, 3)), Tensor[Float](3, 3))
+    exceptedInput[Tensor[Float]](2)(1).fill(1)
+    exceptedInput[Tensor[Float]](2)(2).fill(2)
+    exceptedInput[Tensor[Float]](2)(3).fill(3)
+    val exceptedTarget = Tensor[Float](Storage(Array[Float](1, 2, 3)), 1, Array(3, 1))
+
+    result.getInput() should be (exceptedInput)
+    result.getTarget() should be (exceptedTarget)
+  }
+
+  "Array[ArrayTensorSample] toMiniBatch with padding" should "return right result" in {
+    lazy val buf1 = Array(Tensor[Float](), Tensor[Float]())
+    lazy val buf2 = Array(Tensor[Float]())
+    val featurePadding = Some(Tensor[Float](Storage(Array(-1f, -2f, -3f))))
+    val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
+    samples(0) = Sample[Float](Array(Tensor[Float](1, 3).range(1, 3, 1),
+      Tensor[Float](3).fill(1)), Tensor[Float](1).fill(1))
+    samples(1) = Sample[Float](Array(Tensor[Float](2, 3).range(10, 15, 1),
+      Tensor[Float](3).fill(2)), Tensor[Float](2).fill(2))
+    samples(2) = Sample[Float](Array(Tensor[Float](3, 3).range(19, 27, 1),
+      Tensor[Float](3).fill(3)), Tensor[Float](3).fill(3))
+    val result = SampleToMiniBatch.samplesToMiniBatch[Float](samples, buf1, buf2,
+      featurePadding, Some(-1))
+    val exceptedInput = T(Tensor[Float](Storage(Array[Float](
+      1, 2, 3,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      10, 11, 12,
+      13, 14, 15,
+      -1f, -2f, -3f,
+
+      19, 20, 21,
+      22, 23, 24,
+      25, 26, 27
+    )), 1, Array(3, 3, 3)), Tensor[Float](3, 3))
+    exceptedInput[Tensor[Float]](2)(1).fill(1)
+    exceptedInput[Tensor[Float]](2)(2).fill(2)
+    exceptedInput[Tensor[Float]](2)(3).fill(3)
+    val exceptedTarget = Tensor[Float](Storage(Array[Float](
+      1, -1, -1,
+      2, 2, -1,
+      3, 3, 3
+    )), 1, Array(3, 3))
+
+    result.getInput() should be (exceptedInput)
+    result.getTarget() should be (exceptedTarget)
+  }
+
+  "Array[ArrayTensorSample] toMiniBatch with fixedlength" should "return right result" in {
+    lazy val buf1 = Array(Tensor[Float](), Tensor[Float]())
+    lazy val buf2 = Array(Tensor[Float]())
+    val featurePadding = Some(Tensor[Float](Storage(Array(-1f, -2f, -3f))))
+    val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
+    samples(0) = Sample[Float](Array(Tensor[Float](1, 3).range(1, 3, 1),
+      Tensor[Float](3).fill(1)), Tensor[Float](1).fill(1))
+    samples(1) = Sample[Float](Array(Tensor[Float](2, 3).range(10, 15, 1),
+      Tensor[Float](3).fill(2)), Tensor[Float](2).fill(2))
+    samples(2) = Sample[Float](Array(Tensor[Float](3, 3).range(19, 27, 1),
+      Tensor[Float](3).fill(3)), Tensor[Float](3).fill(3))
+    val result = SampleToMiniBatch.samplesToMiniBatch[Float](
+      samples, buf1, buf2, featurePadding, Some(-1), Some(4))
+    val exceptedInput = T(Tensor[Float](Storage(Array[Float](
+      1, 2, 3,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      10, 11, 12,
+      13, 14, 15,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      19, 20, 21,
+      22, 23, 24,
+      25, 26, 27,
+      -1f, -2f, -3f
+    )), 1, Array(3, 4, 3)), Tensor[Float](3, 3))
+    exceptedInput[Tensor[Float]](2)(1).fill(1)
+    exceptedInput[Tensor[Float]](2)(2).fill(2)
+    exceptedInput[Tensor[Float]](2)(3).fill(3)
+    val exceptedTarget = Tensor[Float](Storage(Array[Float](
+      1, -1, -1,
+      2, 2, -1,
+      3, 3, 3
+    )), 1, Array(3, 3))
+
+    result.getInput() should be (exceptedInput)
+    result.getTarget() should be (exceptedTarget)
+  }
+
+  "Array[UnlabledTensorSample] toMiniBatch" should "return right result" in {
+    lazy val buf1 = Array(Tensor[Float]())
+    val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
+    samples(0) = Sample[Float](Tensor[Float](2, 3).range(1, 6, 1))
+    samples(1) = Sample[Float](Tensor[Float](2, 3).range(7, 12, 1))
+    samples(2) = Sample[Float](Tensor[Float](2, 3).range(13, 18, 1))
+    val result = SampleToMiniBatch.samplesToMiniBatch(samples, buf1)
+    val exceptedInput = Tensor[Float](3, 2, 3).range(1, 18, 1)
+
+    result.getInput() should be (exceptedInput)
+  }
+
+  "Array[UnlabledTensorSample] toMiniBatch with feature padding" should "return right result" in {
+    lazy val buf1 = Array(Tensor[Float]())
+    val featurePadding = Some(Tensor[Float](Storage(Array(-1f, -2f, -3f))))
+    val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
+    samples(0) = Sample[Float](Tensor[Float](1, 3).range(1, 3, 1))
+    samples(1) = Sample[Float](Tensor[Float](2, 3).range(10, 15, 1))
+    samples(2) = Sample[Float](Tensor[Float](3, 3).range(19, 27, 1))
+    val result = SampleToMiniBatch.samplesToMiniBatch[Float](samples, buf1,
+      featurePadding = featurePadding)
+    val exceptedInput = Tensor[Float](Storage(Array[Float](
+      1, 2, 3,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      10, 11, 12,
+      13, 14, 15,
+      -1f, -2f, -3f,
+
+      19, 20, 21,
+      22, 23, 24,
+      25, 26, 27
+    )), 1, Array(3, 3, 3))
+
+    result.getInput() should be (exceptedInput)
+  }
+
+  "Array[UnlabledTensorSample] toMiniBatch with fixedlength" should "return right result" in {
+    lazy val buf1 = Array(Tensor[Float]())
+    val featurePadding = Some(Tensor[Float](Storage(Array(-1f, -2f, -3f))))
+    val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
+    samples(0) = Sample[Float](Tensor[Float](1, 3).range(1, 3, 1))
+    samples(1) = Sample[Float](Tensor[Float](2, 3).range(10, 15, 1))
+    samples(2) = Sample[Float](Tensor[Float](3, 3).range(19, 27, 1))
+    val result = SampleToMiniBatch.samplesToMiniBatch[Float](
+      samples, buf1,
+      featurePadding = featurePadding,
+      fixedLength = Some(4))
+    val exceptedInput = Tensor[Float](Storage(Array[Float](
+      1, 2, 3,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      10, 11, 12,
+      13, 14, 15,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      19, 20, 21,
+      22, 23, 24,
+      25, 26, 27,
+      -1f, -2f, -3f
+    )), 1, Array(3, 4, 3))
+
+    result.getInput() should be (exceptedInput)
+  }
+
+  "Array[UnlabeledArrayTensorSample] toMiniBatch" should "return right result" in {
+    lazy val buf1 = Array(Tensor[Float](), Tensor[Float]())
+    val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
+    samples(0) = Sample[Float](Array(Tensor[Float](2, 3).range(1, 6, 1),
+      Tensor[Float](3).fill(1)))
+    samples(1) = Sample[Float](Array(Tensor[Float](2, 3).range(7, 12, 1),
+      Tensor[Float](3).fill(2)))
+    samples(2) = Sample[Float](Array(Tensor[Float](2, 3).range(13, 18, 1),
+      Tensor[Float](3).fill(3)))
+    val result = SampleToMiniBatch.samplesToMiniBatch(samples, buf1)
+    val exceptedInput = T(Tensor[Float](3, 2, 3).range(1, 18, 1), Tensor[Float](3, 3))
+    exceptedInput[Tensor[Float]](2)(1).fill(1)
+    exceptedInput[Tensor[Float]](2)(2).fill(2)
+    exceptedInput[Tensor[Float]](2)(3).fill(3)
+
+    result.getInput() should be (exceptedInput)
+  }
+
+  "Array[UnlabeledArrayTensorSample] toMiniBatch with padding" should "return right result" in {
+    lazy val buf1 = Array(Tensor[Float](), Tensor[Float]())
+    lazy val buf2 = Array(Tensor[Float]())
+    val featurePadding = Some(Tensor[Float](Storage(Array(-1f, -2f, -3f))))
+    val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
+    samples(0) = Sample[Float](Array(Tensor[Float](1, 3).range(1, 3, 1),
+      Tensor[Float](3).fill(1)))
+    samples(1) = Sample[Float](Array(Tensor[Float](2, 3).range(10, 15, 1),
+      Tensor[Float](3).fill(2)))
+    samples(2) = Sample[Float](Array(Tensor[Float](3, 3).range(19, 27, 1),
+      Tensor[Float](3).fill(3)))
+    val result = SampleToMiniBatch.samplesToMiniBatch[Float](samples, buf1, buf2, featurePadding)
+    val exceptedInput = T(Tensor[Float](Storage(Array[Float](
+      1, 2, 3,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      10, 11, 12,
+      13, 14, 15,
+      -1f, -2f, -3f,
+
+      19, 20, 21,
+      22, 23, 24,
+      25, 26, 27
+    )), 1, Array(3, 3, 3)), Tensor[Float](3, 3))
+    exceptedInput[Tensor[Float]](2)(1).fill(1)
+    exceptedInput[Tensor[Float]](2)(2).fill(2)
+    exceptedInput[Tensor[Float]](2)(3).fill(3)
+
+    result.getInput() should be (exceptedInput)
+  }
+
+  "Array[UnlabeledArrayTensorSample] toMiniBatch with fixedlength" should "return right result" in {
+    lazy val buf1 = Array(Tensor[Float](), Tensor[Float]())
+    val featurePadding = Some(Tensor[Float](Storage(Array(-1f, -2f, -3f))))
+    val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
+    samples(0) = Sample[Float](Array(Tensor[Float](1, 3).range(1, 3, 1),
+      Tensor[Float](3).fill(1)))
+    samples(1) = Sample[Float](Array(Tensor[Float](2, 3).range(10, 15, 1),
+      Tensor[Float](3).fill(2)))
+    samples(2) = Sample[Float](Array(Tensor[Float](3, 3).range(19, 27, 1),
+      Tensor[Float](3).fill(3)))
+    val result = SampleToMiniBatch.samplesToMiniBatch[Float](
+      samples, buf1, featurePadding = featurePadding, fixedLength = Some(4))
+    val exceptedInput = T(Tensor[Float](Storage(Array[Float](
+      1, 2, 3,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      10, 11, 12,
+      13, 14, 15,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      19, 20, 21,
+      22, 23, 24,
+      25, 26, 27,
+      -1f, -2f, -3f
+    )), 1, Array(3, 4, 3)), Tensor[Float](3, 3))
+    exceptedInput[Tensor[Float]](2)(1).fill(1)
+    exceptedInput[Tensor[Float]](2)(2).fill(2)
+    exceptedInput[Tensor[Float]](2)(3).fill(3)
+
+    result.getInput() should be (exceptedInput)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SampleSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SampleSpec.scala
@@ -48,9 +48,9 @@ class SampleSpec extends FlatSpec with Matchers {
     val tensorLabel1 = Tensor[Float](Storage[Float](label1.content), 1, Array(3, 32, 32))
     tensorInput1.rand()
     tensorLabel1.rand()
-    val sample = new TensorSample[Float](tensorInput1, tensorLabel1)
-    sample.featureTensor should be (tensorInput1)
-    sample.labelTensor should be (tensorLabel1)
+    val sample = Sample[Float](tensorInput1, tensorLabel1)
+    sample.feature should be (tensorInput1)
+    sample.label should be (tensorLabel1)
   }
 
   "TensorSample" should "clone well" in {
@@ -60,10 +60,10 @@ class SampleSpec extends FlatSpec with Matchers {
     val tensorLabel1 = Tensor[Float](Storage[Float](label1.content), 1, Array(3, 32, 32))
     tensorInput1.rand()
     tensorLabel1.rand()
-    val sample = new TensorSample[Float](tensorInput1, tensorLabel1)
+    val sample = Sample[Float](tensorInput1, tensorLabel1)
     val otherSample = sample.clone()
-    sample.featureTensor should be (otherSample.featureTensor)
-    sample.labelTensor should be (otherSample.labelTensor)
+    sample.feature should be (otherSample.feature)
+    sample.label should be (otherSample.label)
   }
 
   "SampleSpec with Float Tensor input and Tensor label" should "set well" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SampleSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SampleSpec.scala
@@ -159,7 +159,7 @@ class SampleSpec extends FlatSpec with Matchers {
     samples(1) = Sample[Float](Tensor[Float](2, 3).range(10, 15, 1), Tensor[Float](2).fill(2))
     samples(2) = Sample[Float](Tensor[Float](3, 3).range(19, 27, 1), Tensor[Float](3).fill(3))
     val result = newMiniBatch[Float](samples, featurePadding = featurePadding,
-      featureFixedLength = Some(Array(4, 3)), labelPadding = Some(Array(-1)),
+      featureFixedLength = Some(Array(4)), labelPadding = Some(Array(-1)),
       labelFixedLength = Some(Array(4)))
     val exceptedInput = Tensor[Float](Storage(Array[Float](
       1, 2, 3,
@@ -177,6 +177,44 @@ class SampleSpec extends FlatSpec with Matchers {
       25, 26, 27,
       -1f, -2f, -3f
     )), 1, Array(3, 4, 3))
+    val exceptedTarget = Tensor[Float](Storage(Array[Float](
+      1, -1, -1, -1,
+      2, 2, -1, -1,
+      3, 3, 3, -1
+    )), 1, Array(3, 4))
+
+    result.getInput() should be (exceptedInput)
+    result.getTarget() should be (exceptedTarget)
+  }
+
+  "Array[TensorSample] toMiniBatch with increment" should "return right result" in {
+    val featurePadding = Some(Array(Tensor[Float](Storage(Array(-1f, -2f, -3f)))))
+    val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
+    samples(0) = Sample[Float](Tensor[Float](1, 3).range(1, 3, 1), Tensor[Float](1).fill(1))
+    samples(1) = Sample[Float](Tensor[Float](2, 3).range(10, 15, 1), Tensor[Float](2).fill(2))
+    samples(2) = Sample[Float](Tensor[Float](3, 3).range(19, 27, 1), Tensor[Float](3).fill(3))
+    val result = newMiniBatch[Float](samples, featurePadding = featurePadding,
+      featureIncrement = Some(Array(2)), labelPadding = Some(Array(-1)),
+      labelIncrement = Some(Array(1)))
+    val exceptedInput = Tensor[Float](Storage(Array[Float](
+      1, 2, 3,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      10, 11, 12,
+      13, 14, 15,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      19, 20, 21,
+      22, 23, 24,
+      25, 26, 27,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f
+    )), 1, Array(3, 5, 3))
     val exceptedTarget = Tensor[Float](Storage(Array[Float](
       1, -1, -1, -1,
       2, 2, -1, -1,
@@ -388,6 +426,52 @@ class SampleSpec extends FlatSpec with Matchers {
       2, 2, -1, -1,
       3, 3, 3, -1
     )), 1, Array(3, 4))
+
+    result.getInput() should be (exceptedInput)
+    result.getTarget() should be (exceptedTarget)
+  }
+
+  "Array[ArrayTensorSample] toMiniBatch with fixedlength(4, -1)" should "return right result" in {
+    val featurePadding = Some(Array(Tensor[Float](Storage(Array(-1f, -2f, -3f))),
+      Tensor[Float](1)))
+    val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
+    samples(0) = Sample[Float](Array(Tensor[Float](1, 3).range(1, 3, 1),
+      Tensor[Float](3).fill(1)), Tensor[Float](1).fill(1))
+    samples(1) = Sample[Float](Array(Tensor[Float](2, 3).range(10, 15, 1),
+      Tensor[Float](3).fill(2)), Tensor[Float](2).fill(2))
+    samples(2) = Sample[Float](Array(Tensor[Float](3, 3).range(19, 27, 1),
+      Tensor[Float](3).fill(3)), Tensor[Float](3).fill(3))
+    val result = newMiniBatch[Float](
+      samples, featurePadding,
+      Some(Array(4, -1)),
+      None,
+      Some(Array(-1)),
+      Some(Array(-1))
+    )
+    val exceptedInput = T(Tensor[Float](Storage(Array[Float](
+      1, 2, 3,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      10, 11, 12,
+      13, 14, 15,
+      -1f, -2f, -3f,
+      -1f, -2f, -3f,
+
+      19, 20, 21,
+      22, 23, 24,
+      25, 26, 27,
+      -1f, -2f, -3f
+    )), 1, Array(3, 4, 3)), Tensor[Float](3, 3))
+    exceptedInput[Tensor[Float]](2)(1).fill(1)
+    exceptedInput[Tensor[Float]](2)(2).fill(2)
+    exceptedInput[Tensor[Float]](2)(3).fill(3)
+    val exceptedTarget = Tensor[Float](Storage(Array[Float](
+      1, -1, -1,
+      2, 2, -1,
+      3, 3, 3
+    )), 1, Array(3, 3))
 
     result.getInput() should be (exceptedInput)
     result.getTarget() should be (exceptedTarget)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SampleSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SampleSpec.scala
@@ -82,6 +82,35 @@ class SampleSpec extends FlatSpec with Matchers {
     sample.label() should be(tensorLabel1)
   }
 
+  "Sample.equals" should "return right result" in {
+    val sample1 = Sample[Float](Tensor[Float](2, 3).range(1, 6, 1), Tensor[Float](1).fill(1))
+    val sample2 = Sample[Float](Tensor[Float](2, 3).range(1, 6, 1), Tensor[Float](1).fill(1))
+    sample1.equals(sample2) should be (true)
+
+    val sample3 = Sample[Float](Tensor[Float](3, 3).range(1, 9, 1), Tensor[Float](1).fill(10))
+    val sample4 = Sample[Float](Tensor[Float](2, 3).range(1, 6, 1),
+      Tensor[Float](4).range(7, 10, 1))
+    sample3.equals(sample4) should be (false)
+  }
+
+  "Sample.copy" should "return right result" in {
+    val sample1 = Sample[Float](Tensor[Float](2, 3).range(1, 6, 1), Tensor[Float](1).fill(1))
+    val sample2 = Sample[Float](Tensor[Float](3, 3), Tensor[Float](1))
+    sample2.copy(sample1)
+    sample1.equals(sample2) should be (true)
+
+    val sample3 = Sample[Float](
+      Array(Tensor[Float](3, 3).range(1, 9, 1),
+        Tensor[Float](3, 3).range(1, 9, 1),
+        Tensor[Float](3, 3).range(1, 9, 1)), Tensor[Float](1).fill(10))
+    val sample4 = Sample[Float](
+      Array(Tensor[Float](1, 3).range(1, 3, 1),
+        Tensor[Float](2, 3).range(1, 6, 1),
+        Tensor[Float](3, 3).range(1, 9, 1)), Tensor[Float](1).fill(10))
+    sample4.copy(sample3)
+    sample3.equals(sample4) should be (true)
+  }
+
   "Array[TensorSample] toMiniBatch" should "return right result" in {
     val samples: Array[Sample[Float]] = new Array[Sample[Float]](3)
     samples(0) = Sample[Float](Tensor[Float](2, 3).range(1, 6, 1), Tensor[Float](1).fill(1))

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SampleSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SampleSpec.scala
@@ -36,23 +36,29 @@ class SampleSpec extends FlatSpec with Matchers {
         labelIncrement: Option[Array[Int]] = None)(
         implicit ev: TensorNumeric[T]): MiniBatch[T] = {
     val featureParam = if (featureFixedLength.isDefined) {
-      FeaturePaddingParam(featurePadding, Some(FixedLength(featureFixedLength.get)))
+      PaddingParam(featurePadding, FixedLength(featureFixedLength.get))
     } else if (featureIncrement.isDefined) {
-      FeaturePaddingParam(featurePadding, Some(PaddingLongest(featureIncrement.get)))
+      PaddingParam(featurePadding, PaddingLongest(featureIncrement.get))
     } else {
-      FeaturePaddingParam(featurePadding)
+      PaddingParam(featurePadding)
+    }
+
+    val newLabelPadding = if (labelPadding.isDefined) {
+      Some(labelPadding.get.map(v => Tensor[T](1).fill(v)))
+    } else {
+      None
     }
 
     val labelParam = if (labelFixedLength.isDefined) {
-      LabelPaddingParam(labelPadding, Some(FixedLength(labelFixedLength.get)))
+      PaddingParam(newLabelPadding, FixedLength(labelFixedLength.get))
     } else if (labelIncrement.isDefined) {
-      LabelPaddingParam(labelPadding, Some(PaddingLongest(labelIncrement.get)))
+      PaddingParam(newLabelPadding, PaddingLongest(labelIncrement.get))
     } else {
-      LabelPaddingParam(labelPadding)
+      PaddingParam(newLabelPadding)
     }
 
     MiniBatch[T](samples(0).numFeature(), samples(0).numLabel(),
-      Some(featureParam), Some(labelParam)).setValue(samples)
+      Some(featureParam), Some(labelParam)).set(samples)
   }
 
   "SampleSpec with Float Tensor input and Tensor label" should "initialize well" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SampleSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/SampleSpec.scala
@@ -37,8 +37,8 @@ class SampleSpec extends FlatSpec with Matchers {
         implicit ev: TensorNumeric[T]): MiniBatch[T] = {
 
     MiniBatch[T](samples(0).numFeature(), samples(0).numLabel(),
-      featurePadding, featureFixedLength, featureIncrement,
-      labelPadding, labelFixedLength, labelIncrement).setValue(samples)
+      Some(PaddingParam(featurePadding, featureFixedLength, featureIncrement,
+      labelPadding, labelFixedLength, labelIncrement))).setValue(samples)
   }
 
   "SampleSpec with Float Tensor input and Tensor label" should "initialize well" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/TransformersSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/TransformersSpec.scala
@@ -1068,7 +1068,7 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val image3 = new LabeledBGRImage(data, 32, 32, 3.0f)
 
     val image = Array(image1, image2, image3)
-    val toSample = BGRImgToSample() -> SampleToBatch(1)
+    val toSample = BGRImgToSample() -> SampleToMiniBatch(1)
     val miniBatch1 = toSample(image.toIterator)
     val miniBatch2 = BGRImgToBatch(1).apply(image.toIterator)
 
@@ -1104,7 +1104,7 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val image3 = new LabeledGreyImage(data, 32, 32, 3.0f)
 
     val image = Array(image1, image2, image3)
-    val toSample = GreyImgToSample() -> SampleToBatch(1)
+    val toSample = GreyImgToSample() -> SampleToMiniBatch(1)
     val miniBatch1 = toSample(image.toIterator)
     val miniBatch2 = GreyImgToBatch(1).apply(image.toIterator)
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/TransformersSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/TransformersSpec.scala
@@ -925,6 +925,138 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     batch2.target should be (batch2Label)
   }
 
+  "SampleToMiniBatchSpec" should "be good with TensorBatch1 Double" in {
+    Engine.setNodeAndCore(1, 1)
+    val tensorInput1 = Tensor[Double](Storage(
+      Array(0.0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0)), 1, Array(3, 5))
+    val tensorInput2 = Tensor[Double](Storage(
+      Array(0.0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0)), 1, Array(3, 5))
+    val tensorInput3 = Tensor[Double](Storage(
+      Array(1.0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)), 1, Array(3, 5))
+    val tensorTarget1 = Tensor[Double](Storage(
+      Array(3.0, 4, 5)), 1, Array(3))
+    val tensorTarget2 = Tensor[Double](Storage(
+      Array(2.0, 1, 5)), 1, Array(3))
+    val tensorTarget3 = Tensor[Double](Storage(
+      Array(5.0, 2, 1)), 1, Array(3))
+    val sample1 = Sample[Double](tensorInput1, tensorTarget1)
+    val sample2 = Sample[Double](tensorInput2, tensorTarget2)
+    val sample3 = Sample[Double](tensorInput3, tensorTarget3)
+
+    val dataSet = new LocalArrayDataSet[Sample[Double]](Array(sample1,
+      sample2, sample3))
+    val sampleToBatch = SampleToMiniBatch[Double](2)
+    val sampleDataSet = dataSet -> sampleToBatch
+    val iter = sampleDataSet.toLocal().data(train = false)
+
+    val batch1 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+
+    val batch1Data = Tensor[Double](Array(2, 3, 5))
+    batch1Data(1).resizeAs(tensorInput1).copy(tensorInput1)
+    batch1Data(2).resizeAs(tensorInput2).copy(tensorInput2)
+    val batch1Label = Tensor[Double](Array(2, 3))
+    batch1Label(1).resizeAs(tensorTarget1).copy(tensorTarget1)
+    batch1Label(2).resizeAs(tensorTarget2).copy(tensorTarget2)
+    batch1.input should be (batch1Data)
+    batch1.target should be (batch1Label)
+
+    val batch2 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+    val batch2Data = Tensor[Double](Array(1, 3, 5))
+    batch2Data(1).resizeAs(tensorInput3).copy(tensorInput3)
+    val batch2Label = Tensor[Double](Array(1, 3))
+    batch2Label(1).resizeAs(tensorTarget3).copy(tensorTarget3)
+    batch2.input should be (batch2Data)
+    batch2.target should be (batch2Label)
+  }
+  "SampleToMiniBatchSpec" should "be good with TensorBatch1" in {
+    Engine.setNodeAndCore(1, 1)
+    val tensorInput1 = Tensor[Float](Storage(
+      Array(0.0f, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0)), 1, Array(3, 5))
+    val tensorInput2 = Tensor[Float](Storage(
+      Array(0.0f, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0)), 1, Array(3, 5))
+    val tensorInput3 = Tensor[Float](Storage(
+      Array(1.0f, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)), 1, Array(3, 5))
+    val tensorTarget1 = Tensor[Float](Storage(
+      Array(3.0f, 4, 5)), 1, Array(3))
+    val tensorTarget2 = Tensor[Float](Storage(
+      Array(2.0f, 1, 5)), 1, Array(3))
+    val tensorTarget3 = Tensor[Float](Storage(
+      Array(5.0f, 2, 1)), 1, Array(3))
+    val sample1 = Sample[Float](tensorInput1, tensorTarget1)
+    val sample2 = Sample[Float](tensorInput2, tensorTarget2)
+    val sample3 = Sample[Float](tensorInput3, tensorTarget3)
+
+    val dataSet = new LocalArrayDataSet[Sample[Float]](Array(sample1,
+      sample2, sample3))
+    val sampleToBatch = SampleToMiniBatch[Float](2)
+    val sampleDataSet = dataSet -> sampleToBatch
+    val iter = sampleDataSet.toLocal().data(train = false)
+
+    val batch1 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+
+    val batch1Data = Tensor[Float](Array(2, 3, 5))
+    batch1Data(1).resizeAs(tensorInput1).copy(tensorInput1)
+    batch1Data(2).resizeAs(tensorInput2).copy(tensorInput2)
+    val batch1Label = Tensor[Float](Array(2, 3))
+    batch1Label(1).resizeAs(tensorTarget1).copy(tensorTarget1)
+    batch1Label(2).resizeAs(tensorTarget2).copy(tensorTarget2)
+    batch1.input should be (batch1Data)
+    batch1.target should be (batch1Label)
+
+    val batch2 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+    val batch2Data = Tensor[Float](Array(1, 3, 5))
+    batch2Data(1).resizeAs(tensorInput3).copy(tensorInput3)
+    val batch2Label = Tensor[Float](Array(1, 3))
+    batch2Label(1).resizeAs(tensorTarget3).copy(tensorTarget3)
+    batch2.input should be (batch2Data)
+    batch2.target should be (batch2Label)
+  }
+  "SampleToMiniBatchSpec" should "be good with TensorBatch2" in {
+    Engine.setNodeAndCore(1, 1)
+    val tensorInput1 = Tensor[Float](Storage(
+      Array(0.0f, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0)), 1, Array(3, 5))
+    val tensorInput2 = Tensor[Float](Storage(
+      Array(0.0f, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0)), 1, Array(3, 5))
+    val tensorInput3 = Tensor[Float](Storage(
+      Array(1.0f, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1)), 1, Array(3, 5))
+    val tensorTarget1 = Tensor[Float](Storage(
+      Array(3.0f, 4, 5)), 1, Array(3))
+    val tensorTarget2 = Tensor[Float](Storage(
+      Array(2.0f, 1, 5)), 1, Array(3))
+    val tensorTarget3 = Tensor[Float](Storage(
+      Array(5.0f, 2, 1)), 1, Array(3))
+    val sample1 = Sample[Float](tensorInput1, tensorTarget1)
+    val sample2 = Sample[Float](tensorInput2, tensorTarget2)
+    val sample3 = Sample[Float](tensorInput3, tensorTarget3)
+
+    val dataSet = new LocalArrayDataSet[Sample[Float]](Array(sample1,
+      sample2, sample3))
+    val sampleToBatch = SampleToMiniBatch[Float](2)
+    val sampleDataSet = dataSet -> sampleToBatch
+    val iter = sampleDataSet.toLocal().data(train = true)
+
+    val batch1 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+
+    val batch1Data = Tensor[Float](Array(2, 3, 5))
+    batch1Data(1).resizeAs(tensorInput1).copy(tensorInput1)
+    batch1Data(2).resizeAs(tensorInput2).copy(tensorInput2)
+    val batch1Label = Tensor[Float](Array(2, 3))
+    batch1Label(1).resizeAs(tensorTarget1).copy(tensorTarget1)
+    batch1Label(2).resizeAs(tensorTarget2).copy(tensorTarget2)
+    batch1.input should be (batch1Data)
+    batch1.target should be (batch1Label)
+
+    val batch2 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+    val batch2Data = Tensor[Float](Array(2, 3, 5))
+    batch2Data(1).resizeAs(tensorInput3).copy(tensorInput3)
+    batch2Data(2).resizeAs(tensorInput1).copy(tensorInput1)
+    val batch2Label = Tensor[Float](Array(2, 3))
+    batch2Label(1).resizeAs(tensorTarget3).copy(tensorTarget3)
+    batch2Label(2).resizeAs(tensorTarget1).copy(tensorTarget1)
+    batch2.input should be (batch2Data)
+    batch2.target should be (batch2Label)
+  }
+
   "BRGImgToSample" should "be correct" in {
     RNG.setSeed(100)
     var data = new Array[Float](3 * 32 * 32)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/TransformersSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/TransformersSpec.scala
@@ -101,11 +101,12 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val toTensor = new GreyImgToBatch(2)
     val tensorDataSet = dataSet -> toTensor
     val iter = tensorDataSet.toLocal().data(train = true)
-    val batch = iter.next().asInstanceOf[TensorMiniBatch[Float]]
-    batch.input.size(1) should be(2)
-    batch.input.size(2) should be(32)
-    batch.input.size(3) should be(32)
-    val testData1 = batch.input.storage().array()
+    val batch = iter.next()
+    val input = batch.getInput().toTensor[Float]
+    input.size(1) should be(2)
+    input.size(2) should be(32)
+    input.size(3) should be(32)
+    val testData1 = input.storage().array()
     val content1 = image1.content
     var i = 0
     while (i < content1.length) {
@@ -118,11 +119,12 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
       testData1(i + 32 * 32) should be(content2(i))
       i += 1
     }
-    val batch2 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+    val batch2 = iter.next()
+    val input2 = batch.getInput().toTensor[Float]
     val content3 = image3.content
-    batch2.input.size(1) should be(2)
-    batch2.input.size(2) should be(32)
-    batch2.input.size(3) should be(32)
+    input2.size(1) should be(2)
+    input2.size(2) should be(32)
+    input2.size(3) should be(32)
     i = 0
     while (i < content3.length) {
       testData1(i) should be(content3(i))
@@ -242,97 +244,99 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val toTensor = new BGRImgToBatch(2)
     val tensorDataSet = dataSet -> toTensor
     val iter = tensorDataSet.toLocal().data(train = true)
-    val batch1 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
-    batch1.input.size(1) should be(2)
-    batch1.input.size(2) should be(3)
-    batch1.input.size(3) should be(32)
-    batch1.input.size(4) should be(32)
+    val batch1 = iter.next()
+    val input1 = batch1.getInput().toTensor[Float]
+    input1.size(1) should be(2)
+    input1.size(2) should be(3)
+    input1.size(3) should be(32)
+    input1.size(4) should be(32)
     val content1 = image1.content
     var i = 0
-    batch1.input.select(1, 1).select(1, 1).apply1(e => {
+    input1.select(1, 1).select(1, 1).apply1(e => {
       e should be(content1(i * 3 + 2))
       i += 1
       e
     })
 
     i = 0
-    batch1.input.select(1, 1).select(1, 2).apply1(e => {
+    input1.select(1, 1).select(1, 2).apply1(e => {
       e should be(content1(i * 3 + 1))
       i += 1
       e
     })
 
     i = 0
-    batch1.input.select(1, 1).select(1, 3).apply1(e => {
+    input1.select(1, 1).select(1, 3).apply1(e => {
       e should be(content1(i * 3))
       i += 1
       e
     })
     val content2 = image2.content
     i = 0
-    batch1.input.select(1, 2).select(1, 1).apply1(e => {
+    input1.select(1, 2).select(1, 1).apply1(e => {
       e should be(content2(i * 3 + 2))
       i += 1
       e
     })
 
     i = 0
-    batch1.input.select(1, 2).select(1, 2).apply1(e => {
+    input1.select(1, 2).select(1, 2).apply1(e => {
       e should be(content2(i * 3 + 1))
       i += 1
       e
     })
 
     i = 0
-    batch1.input.select(1, 2).select(1, 3).apply1(e => {
+    input1.select(1, 2).select(1, 3).apply1(e => {
       e should be(content2(i * 3))
       i += 1
       e
     })
 
-    val batch = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+    val batch = iter.next()
+    val input = batch.getInput().toTensor[Float]
     val content3 = image3.content
-    batch.input.size(1) should be(2)
-    batch.input.size(2) should be(3)
-    batch.input.size(3) should be(32)
-    batch.input.size(4) should be(32)
+    input.size(1) should be(2)
+    input.size(2) should be(3)
+    input.size(3) should be(32)
+    input.size(4) should be(32)
 
     i = 0
-    batch.input.select(1, 1).select(1, 1).apply1(e => {
+    input.select(1, 1).select(1, 1).apply1(e => {
       e should be(content3(i * 3 + 2))
       i += 1
       e
     })
 
     i = 0
-    batch.input.select(1, 1).select(1, 2).apply1(e => {
+    input.select(1, 1).select(1, 2).apply1(e => {
       e should be(content3(i * 3 + 1))
       i += 1
       e
     })
 
     i = 0
-    batch.input.select(1, 1).select(1, 3).apply1(e => {
+    input.select(1, 1).select(1, 3).apply1(e => {
       e should be(content3(i * 3))
       i += 1
       e
     })
     i = 0
-    batch.input.select(1, 2).select(1, 1).apply1(e => {
+    input.select(1, 2).select(1, 1).apply1(e => {
       e should be(content1(i * 3 + 2))
       i += 1
       e
     })
 
     i = 0
-    batch.input.select(1, 2).select(1, 2).apply1(e => {
+    input.select(1, 2).select(1, 2).apply1(e => {
       e should be(content1(i * 3 + 1))
       i += 1
       e
     })
 
     i = 0
-    batch.input.select(1, 2).select(1, 3).apply1(e => {
+    input.select(1, 2).select(1, 3).apply1(e => {
       e should be(content1(i * 3))
       i += 1
       e
@@ -359,97 +363,99 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     )
     val tensorDataSet = dataSet -> toTensor
     val iter = tensorDataSet.toLocal().data(train = true)
-    val batch = iter.next().asInstanceOf[TensorMiniBatch[Float]]
-    batch.input.size(1) should be(2)
-    batch.input.size(2) should be(3)
-    batch.input.size(3) should be(32)
-    batch.input.size(4) should be(32)
+    val batch = iter.next()
+    val input = batch.getInput().toTensor[Float]
+    input.size(1) should be(2)
+    input.size(2) should be(3)
+    input.size(3) should be(32)
+    input.size(4) should be(32)
     val content1 = image1.content
     var i = 0
-    batch.input.select(1, 1).select(1, 1).apply1(e => {
+    input.select(1, 1).select(1, 1).apply1(e => {
       e should be(content1(i * 3 + 2))
       i += 1
       e
     })
 
     i = 0
-    batch.input.select(1, 1).select(1, 2).apply1(e => {
+    input.select(1, 1).select(1, 2).apply1(e => {
       e should be(content1(i * 3 + 1))
       i += 1
       e
     })
 
     i = 0
-    batch.input.select(1, 1).select(1, 3).apply1(e => {
+    input.select(1, 1).select(1, 3).apply1(e => {
       e should be(content1(i * 3))
       i += 1
       e
     })
     val content2 = image2.content
     i = 0
-    batch.input.select(1, 2).select(1, 1).apply1(e => {
+    input.select(1, 2).select(1, 1).apply1(e => {
       e should be(content2(i * 3 + 2))
       i += 1
       e
     })
 
     i = 0
-    batch.input.select(1, 2).select(1, 2).apply1(e => {
+    input.select(1, 2).select(1, 2).apply1(e => {
       e should be(content2(i * 3 + 1))
       i += 1
       e
     })
 
     i = 0
-    batch.input.select(1, 2).select(1, 3).apply1(e => {
+    input.select(1, 2).select(1, 3).apply1(e => {
       e should be(content2(i * 3))
       i += 1
       e
     })
 
-    val batch2 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+    val batch2 = iter.next()
+    val input2 = batch.getInput().toTensor[Float]
     val content3 = image3.content
-    batch2.input.size(1) should be(2)
-    batch2.input.size(2) should be(3)
-    batch2.input.size(3) should be(32)
-    batch2.input.size(4) should be(32)
+    input2.size(1) should be(2)
+    input2.size(2) should be(3)
+    input2.size(3) should be(32)
+    input2.size(4) should be(32)
 
     i = 0
-    batch2.input.select(1, 1).select(1, 1).apply1(e => {
+    input2.select(1, 1).select(1, 1).apply1(e => {
       e should be(content3(i * 3 + 2))
       i += 1
       e
     })
 
     i = 0
-    batch2.input.select(1, 1).select(1, 2).apply1(e => {
+    input2.select(1, 1).select(1, 2).apply1(e => {
       e should be(content3(i * 3 + 1))
       i += 1
       e
     })
 
     i = 0
-    batch2.input.select(1, 1).select(1, 3).apply1(e => {
+    input2.select(1, 1).select(1, 3).apply1(e => {
       e should be(content3(i * 3))
       i += 1
       e
     })
     i = 0
-    batch2.input.select(1, 2).select(1, 1).apply1(e => {
+    input2.select(1, 2).select(1, 1).apply1(e => {
       e should be(content1(i * 3 + 2))
       i += 1
       e
     })
 
     i = 0
-    batch2.input.select(1, 2).select(1, 2).apply1(e => {
+    input2.select(1, 2).select(1, 2).apply1(e => {
       e should be(content1(i * 3 + 1))
       i += 1
       e
     })
 
     i = 0
-    batch2.input.select(1, 2).select(1, 3).apply1(e => {
+    input2.select(1, 2).select(1, 3).apply1(e => {
       e should be(content1(i * 3))
       i += 1
       e
@@ -589,16 +595,16 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val sample3 = Sample[Float](tensorInput3, tensorTarget3)
 
     val batch1 = iter.next()
-    batch1.asInstanceOf[TensorSample[Float]].featureTensor should be (tensorInput1)
-    batch1.asInstanceOf[TensorSample[Float]].labelTensor should be (tensorTarget1)
+    batch1.feature() should be (tensorInput1)
+    batch1.label() should be (tensorTarget1)
 
     val batch2 = iter.next()
-    batch2.asInstanceOf[TensorSample[Float]].featureTensor should be (tensorInput2)
-    batch2.asInstanceOf[TensorSample[Float]].labelTensor should be (tensorTarget2)
+    batch2.feature should be (tensorInput2)
+    batch2.label should be (tensorTarget2)
 
     val batch3 = iter.next()
-    batch3.asInstanceOf[TensorSample[Float]].featureTensor should be (tensorInput3)
-    batch3.asInstanceOf[TensorSample[Float]].labelTensor should be (tensorTarget3)
+    batch3.feature should be (tensorInput3)
+    batch3.label should be (tensorTarget3)
   }
   "LabeledSentence toSample" should "transform correctly for single label Double" in {
     val input1 = Array(1.0, 2.0, 3.0)
@@ -637,16 +643,16 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val sample3 = Sample[Double](tensorInput3, tensorTarget3)
 
     val batch1 = iter.next()
-    batch1.asInstanceOf[TensorSample[Float]].featureTensor should be (tensorInput1)
-    batch1.asInstanceOf[TensorSample[Float]].labelTensor should be (tensorTarget1)
+    batch1.feature should be (tensorInput1)
+    batch1.label should be (tensorTarget1)
 
     val batch2 = iter.next()
-    batch2.asInstanceOf[TensorSample[Float]].featureTensor should be (tensorInput2)
-    batch2.asInstanceOf[TensorSample[Float]].labelTensor should be (tensorTarget2)
+    batch2.feature should be (tensorInput2)
+    batch2.label should be (tensorTarget2)
 
     val batch3 = iter.next()
-    batch3.asInstanceOf[TensorSample[Float]].featureTensor should be (tensorInput3)
-    batch3.asInstanceOf[TensorSample[Float]].labelTensor should be (tensorTarget3)
+    batch3.feature should be (tensorInput3)
+    batch3.label should be (tensorTarget3)
   }
   "LabeledSentence toSample" should "transform correctly for padding sentences single label" in {
     val input1 = Array(1.0f, 2.0f, 3.0f)
@@ -685,16 +691,16 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val sample3 = Sample[Float](tensorInput3, tensorTarget3)
 
     val batch1 = iter.next()
-    batch1.asInstanceOf[TensorSample[Float]].featureTensor should be (tensorInput1)
-    batch1.asInstanceOf[TensorSample[Float]].labelTensor should be (tensorTarget1)
+    batch1.feature should be (tensorInput1)
+    batch1.label should be (tensorTarget1)
 
     val batch2 = iter.next()
-    batch2.asInstanceOf[TensorSample[Float]].featureTensor should be (tensorInput2)
-    batch2.asInstanceOf[TensorSample[Float]].labelTensor should be (tensorTarget2)
+    batch2.feature should be (tensorInput2)
+    batch2.label should be (tensorTarget2)
 
     val batch3 = iter.next()
-    batch3.asInstanceOf[TensorSample[Float]].featureTensor should be (tensorInput3)
-    batch3.asInstanceOf[TensorSample[Float]].labelTensor should be (tensorTarget3)
+    batch3.feature should be (tensorInput3)
+    batch3.label should be (tensorTarget3)
   }
   "LabeledSentence toSample" should "transform correctly for language model label" in {
     val input1 = Array(0.0f, 2.0f, 3.0f)
@@ -733,16 +739,16 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val sample3 = Sample[Float](tensorInput3, tensorTarget3)
 
     val batch1 = iter.next()
-    batch1.asInstanceOf[TensorSample[Float]].featureTensor should be (tensorInput1)
-    batch1.asInstanceOf[TensorSample[Float]].labelTensor should be (tensorTarget1)
+    batch1.feature should be (tensorInput1)
+    batch1.label should be (tensorTarget1)
 
     val batch2 = iter.next()
-    batch2.asInstanceOf[TensorSample[Float]].featureTensor should be (tensorInput2)
-    batch2.asInstanceOf[TensorSample[Float]].labelTensor should be (tensorTarget2)
+    batch2.feature should be (tensorInput2)
+    batch2.label should be (tensorTarget2)
 
     val batch3 = iter.next()
-    batch3.asInstanceOf[TensorSample[Float]].featureTensor should be (tensorInput3)
-    batch3.asInstanceOf[TensorSample[Float]].labelTensor should be (tensorTarget3)
+    batch3.feature should be (tensorInput3)
+    batch3.label should be (tensorTarget3)
   }
   "LabeledSentence toSample" should "transform correctly" +
     " for language model label padding sentences" in {
@@ -782,16 +788,16 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val sample3 = Sample[Float](tensorInput3, tensorTarget3)
 
     val batch1 = iter.next()
-    batch1.asInstanceOf[TensorSample[Float]].featureTensor should be (tensorInput1)
-    batch1.asInstanceOf[TensorSample[Float]].labelTensor should be (tensorTarget1)
+    batch1.feature should be (tensorInput1)
+    batch1.label should be (tensorTarget1)
 
     val batch2 = iter.next()
-    batch2.asInstanceOf[TensorSample[Float]].featureTensor should be (tensorInput2)
-    batch2.asInstanceOf[TensorSample[Float]].labelTensor should be (tensorTarget2)
+    batch2.feature should be (tensorInput2)
+    batch2.label should be (tensorTarget2)
 
     val batch3 = iter.next()
-    batch3.asInstanceOf[TensorSample[Float]].featureTensor should be (tensorInput3)
-    batch3.asInstanceOf[TensorSample[Float]].labelTensor should be (tensorTarget3)
+    batch3.feature should be (tensorInput3)
+    batch3.label should be (tensorTarget3)
   }
   "SampleToBatchSpec" should "be good with TensorBatch1 Double" in {
     Engine.setNodeAndCore(1, 1)
@@ -807,9 +813,9 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
       Array(2.0, 1, 5)), 1, Array(3))
     val tensorTarget3 = Tensor[Double](Storage(
       Array(5.0, 2, 1)), 1, Array(3))
-    val sample1 = Sample[Double](tensorInput1, tensorTarget1)
-    val sample2 = Sample[Double](tensorInput2, tensorTarget2)
-    val sample3 = Sample[Double](tensorInput3, tensorTarget3)
+    val sample1 = new TensorSample[Double](tensorInput1, tensorTarget1)
+    val sample2 = new TensorSample[Double](tensorInput2, tensorTarget2)
+    val sample3 = new TensorSample[Double](tensorInput3, tensorTarget3)
 
     val dataSet = new LocalArrayDataSet[Sample[Double]](Array(sample1,
       sample2, sample3))
@@ -817,7 +823,7 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val sampleDataSet = dataSet -> sampleToBatch
     val iter = sampleDataSet.toLocal().data(train = false)
 
-    val batch1 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+    val batch1 = iter.next()
 
     val batch1Data = Tensor[Double](Array(2, 3, 5))
     batch1Data(1).resizeAs(tensorInput1).copy(tensorInput1)
@@ -825,16 +831,16 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val batch1Label = Tensor[Double](Array(2, 3))
     batch1Label(1).resizeAs(tensorTarget1).copy(tensorTarget1)
     batch1Label(2).resizeAs(tensorTarget2).copy(tensorTarget2)
-    batch1.input should be (batch1Data)
-    batch1.target should be (batch1Label)
+    batch1.getInput should be (batch1Data)
+    batch1.getTarget should be (batch1Label)
 
-    val batch2 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+    val batch2 = iter.next()
     val batch2Data = Tensor[Double](Array(1, 3, 5))
     batch2Data(1).resizeAs(tensorInput3).copy(tensorInput3)
     val batch2Label = Tensor[Double](Array(1, 3))
     batch2Label(1).resizeAs(tensorTarget3).copy(tensorTarget3)
-    batch2.input should be (batch2Data)
-    batch2.target should be (batch2Label)
+    batch2.getInput should be (batch2Data)
+    batch2.getTarget should be (batch2Label)
   }
   "SampleToBatchSpec" should "be good with TensorBatch1" in {
     Engine.setNodeAndCore(1, 1)
@@ -949,7 +955,7 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val sampleDataSet = dataSet -> sampleToBatch
     val iter = sampleDataSet.toLocal().data(train = false)
 
-    val batch1 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+    val batch1 = iter.next()
 
     val batch1Data = Tensor[Double](Array(2, 3, 5))
     batch1Data(1).resizeAs(tensorInput1).copy(tensorInput1)
@@ -957,16 +963,16 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val batch1Label = Tensor[Double](Array(2, 3))
     batch1Label(1).resizeAs(tensorTarget1).copy(tensorTarget1)
     batch1Label(2).resizeAs(tensorTarget2).copy(tensorTarget2)
-    batch1.input should be (batch1Data)
-    batch1.target should be (batch1Label)
+    batch1.getInput should be (batch1Data)
+    batch1.getTarget should be (batch1Label)
 
-    val batch2 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+    val batch2 = iter.next()
     val batch2Data = Tensor[Double](Array(1, 3, 5))
     batch2Data(1).resizeAs(tensorInput3).copy(tensorInput3)
     val batch2Label = Tensor[Double](Array(1, 3))
     batch2Label(1).resizeAs(tensorTarget3).copy(tensorTarget3)
-    batch2.input should be (batch2Data)
-    batch2.target should be (batch2Label)
+    batch2.getInput should be (batch2Data)
+    batch2.getTarget should be (batch2Label)
   }
   "SampleToMiniBatchSpec" should "be good with TensorBatch1" in {
     Engine.setNodeAndCore(1, 1)
@@ -992,7 +998,7 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val sampleDataSet = dataSet -> sampleToBatch
     val iter = sampleDataSet.toLocal().data(train = false)
 
-    val batch1 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+    val batch1 = iter.next()
 
     val batch1Data = Tensor[Float](Array(2, 3, 5))
     batch1Data(1).resizeAs(tensorInput1).copy(tensorInput1)
@@ -1000,16 +1006,16 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val batch1Label = Tensor[Float](Array(2, 3))
     batch1Label(1).resizeAs(tensorTarget1).copy(tensorTarget1)
     batch1Label(2).resizeAs(tensorTarget2).copy(tensorTarget2)
-    batch1.input should be (batch1Data)
-    batch1.target should be (batch1Label)
+    batch1.getInput should be (batch1Data)
+    batch1.getTarget should be (batch1Label)
 
-    val batch2 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+    val batch2 = iter.next()
     val batch2Data = Tensor[Float](Array(1, 3, 5))
     batch2Data(1).resizeAs(tensorInput3).copy(tensorInput3)
     val batch2Label = Tensor[Float](Array(1, 3))
     batch2Label(1).resizeAs(tensorTarget3).copy(tensorTarget3)
-    batch2.input should be (batch2Data)
-    batch2.target should be (batch2Label)
+    batch2.getInput should be (batch2Data)
+    batch2.getTarget should be (batch2Label)
   }
   "SampleToMiniBatchSpec" should "be good with TensorBatch2" in {
     Engine.setNodeAndCore(1, 1)
@@ -1035,7 +1041,7 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val sampleDataSet = dataSet -> sampleToBatch
     val iter = sampleDataSet.toLocal().data(train = true)
 
-    val batch1 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+    val batch1 = iter.next()
 
     val batch1Data = Tensor[Float](Array(2, 3, 5))
     batch1Data(1).resizeAs(tensorInput1).copy(tensorInput1)
@@ -1043,18 +1049,18 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val batch1Label = Tensor[Float](Array(2, 3))
     batch1Label(1).resizeAs(tensorTarget1).copy(tensorTarget1)
     batch1Label(2).resizeAs(tensorTarget2).copy(tensorTarget2)
-    batch1.input should be (batch1Data)
-    batch1.target should be (batch1Label)
+    batch1.getInput should be (batch1Data)
+    batch1.getTarget should be (batch1Label)
 
-    val batch2 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+    val batch2 = iter.next()
     val batch2Data = Tensor[Float](Array(2, 3, 5))
     batch2Data(1).resizeAs(tensorInput3).copy(tensorInput3)
     batch2Data(2).resizeAs(tensorInput1).copy(tensorInput1)
     val batch2Label = Tensor[Float](Array(2, 3))
     batch2Label(1).resizeAs(tensorTarget3).copy(tensorTarget3)
     batch2Label(2).resizeAs(tensorTarget1).copy(tensorTarget1)
-    batch2.input should be (batch2Data)
-    batch2.target should be (batch2Label)
+    batch2.getInput should be (batch2Data)
+    batch2.getTarget should be (batch2Label)
   }
 
   "BRGImgToSample" should "be correct" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/TransformersSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/TransformersSpec.scala
@@ -866,7 +866,7 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val sampleDataSet = dataSet -> sampleToBatch
     val iter = sampleDataSet.toLocal().data(train = false)
 
-    val batch1 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+    val batch1 = iter.next()
 
     val batch1Data = Tensor[Float](Array(2, 3, 5))
     batch1Data(1).resizeAs(tensorInput1).copy(tensorInput1)
@@ -874,16 +874,16 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val batch1Label = Tensor[Float](Array(2, 3))
     batch1Label(1).resizeAs(tensorTarget1).copy(tensorTarget1)
     batch1Label(2).resizeAs(tensorTarget2).copy(tensorTarget2)
-    batch1.input should be (batch1Data)
-    batch1.target should be (batch1Label)
+    batch1.getInput should be (batch1Data)
+    batch1.getTarget should be (batch1Label)
 
-    val batch2 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+    val batch2 = iter.next()
     val batch2Data = Tensor[Float](Array(1, 3, 5))
     batch2Data(1).resizeAs(tensorInput3).copy(tensorInput3)
     val batch2Label = Tensor[Float](Array(1, 3))
     batch2Label(1).resizeAs(tensorTarget3).copy(tensorTarget3)
-    batch2.input should be (batch2Data)
-    batch2.target should be (batch2Label)
+    batch2.getInput should be (batch2Data)
+    batch2.getTarget should be (batch2Label)
   }
   "SampleToBatchSpec" should "be good with TensorBatch2" in {
     Engine.setNodeAndCore(1, 1)
@@ -909,7 +909,7 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val sampleDataSet = dataSet -> sampleToBatch
     val iter = sampleDataSet.toLocal().data(train = true)
 
-    val batch1 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+    val batch1 = iter.next()
 
     val batch1Data = Tensor[Float](Array(2, 3, 5))
     batch1Data(1).resizeAs(tensorInput1).copy(tensorInput1)
@@ -917,18 +917,18 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val batch1Label = Tensor[Float](Array(2, 3))
     batch1Label(1).resizeAs(tensorTarget1).copy(tensorTarget1)
     batch1Label(2).resizeAs(tensorTarget2).copy(tensorTarget2)
-    batch1.input should be (batch1Data)
-    batch1.target should be (batch1Label)
+    batch1.getInput should be (batch1Data)
+    batch1.getTarget should be (batch1Label)
 
-    val batch2 = iter.next().asInstanceOf[TensorMiniBatch[Float]]
+    val batch2 = iter.next()
     val batch2Data = Tensor[Float](Array(2, 3, 5))
     batch2Data(1).resizeAs(tensorInput3).copy(tensorInput3)
     batch2Data(2).resizeAs(tensorInput1).copy(tensorInput1)
     val batch2Label = Tensor[Float](Array(2, 3))
     batch2Label(1).resizeAs(tensorTarget3).copy(tensorTarget3)
     batch2Label(2).resizeAs(tensorTarget1).copy(tensorTarget1)
-    batch2.input should be (batch2Data)
-    batch2.target should be (batch2Label)
+    batch2.getInput should be (batch2Data)
+    batch2.getTarget should be (batch2Label)
   }
 
   "SampleToMiniBatchSpec" should "be good with TensorBatch1 Double" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/TransformersSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/TransformersSpec.scala
@@ -813,9 +813,9 @@ class TransformersSpec extends FlatSpec with Matchers with BeforeAndAfter {
       Array(2.0, 1, 5)), 1, Array(3))
     val tensorTarget3 = Tensor[Double](Storage(
       Array(5.0, 2, 1)), 1, Array(3))
-    val sample1 = new TensorSample[Double](tensorInput1, tensorTarget1)
-    val sample2 = new TensorSample[Double](tensorInput2, tensorTarget2)
-    val sample3 = new TensorSample[Double](tensorInput3, tensorTarget3)
+    val sample1 = Sample[Double](tensorInput1, tensorTarget1)
+    val sample2 = Sample[Double](tensorInput2, tensorTarget2)
+    val sample3 = Sample[Double](tensorInput3, tensorTarget3)
 
     val dataSet = new LocalArrayDataSet[Sample[Double]](Array(sample1,
       sample2, sample3))

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/EvaluatorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/EvaluatorSpec.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.optim
 
-import com.intel.analytics.bigdl.dataset.{DataSet, Sample, SampleToBatch}
+import com.intel.analytics.bigdl.dataset.{DataSet, Sample}
 import com.intel.analytics.bigdl.models.lenet.LeNet5
 import com.intel.analytics.bigdl.nn.CrossEntropyCriterion
 import com.intel.analytics.bigdl.tensor.Tensor

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/PredictorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/PredictorSpec.scala
@@ -57,12 +57,12 @@ class PredictorSpec extends FlatSpec with Matchers with BeforeAndAfter{
     val result = model.predict(dataSet)
 
     val prob = result.map(_.toTensor[Float].clone()).collect()
-    prob(0) should be (model.forward(data(0).asInstanceOf[TensorSample[Float]].featureTensor))
-    prob(11) should be (model.forward(data(11).asInstanceOf[TensorSample[Float]].featureTensor))
-    prob(31) should be (model.forward(data(31).asInstanceOf[TensorSample[Float]].featureTensor))
-    prob(51) should be (model.forward(data(51).asInstanceOf[TensorSample[Float]].featureTensor))
-    prob(71) should be (model.forward(data(71).asInstanceOf[TensorSample[Float]].featureTensor))
-    prob(91) should be (model.forward(data(91).asInstanceOf[TensorSample[Float]].featureTensor))
+    prob(0) should be (model.forward(data(0).feature))
+    prob(11) should be (model.forward(data(11).feature))
+    prob(31) should be (model.forward(data(31).feature))
+    prob(51) should be (model.forward(data(51).feature))
+    prob(71) should be (model.forward(data(71).feature))
+    prob(91) should be (model.forward(data(91).feature))
   }
 
   "model.predictClass" should "be correct" in {
@@ -82,22 +82,22 @@ class PredictorSpec extends FlatSpec with Matchers with BeforeAndAfter{
 
     val prob = result.collect()
     prob(0) should be
-    (model.forward(data(0).asInstanceOf[TensorSample[Float]].featureTensor
+    (model.forward(data(0).feature
     ).toTensor[Float].max(1)._2.valueAt(1).toInt)
     prob(11) should be
-    (model.forward(data(11).asInstanceOf[TensorSample[Float]].featureTensor
+    (model.forward(data(11).feature
     ).toTensor[Float].max(1)._2.valueAt(1).toInt)
     prob(31) should be
-    (model.forward(data(31).asInstanceOf[TensorSample[Float]].featureTensor
+    (model.forward(data(31).feature
     ).toTensor[Float].max(1)._2.valueAt(1).toInt)
     prob(51) should be
-    (model.forward(data(51).asInstanceOf[TensorSample[Float]].featureTensor
+    (model.forward(data(51).feature
     ).toTensor[Float].max(1)._2.valueAt(1).toInt)
     prob(71) should be
-    (model.forward(data(71).asInstanceOf[TensorSample[Float]].featureTensor
+    (model.forward(data(71).feature
     ).toTensor[Float].max(1)._2.valueAt(1).toInt)
     prob(91) should be
-    (model.forward(data(91).asInstanceOf[TensorSample[Float]].featureTensor
+    (model.forward(data(91).feature
     ).toTensor[Float].max(1)._2.valueAt(1).toInt)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/PredictorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/PredictorSpec.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.optim
 
-import com.intel.analytics.bigdl.dataset.{Sample, TensorSample}
+import com.intel.analytics.bigdl.dataset.Sample
 import com.intel.analytics.bigdl.models.lenet.LeNet5
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Engine

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/ValidatorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/ValidatorSpec.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.optim
 
-import com.intel.analytics.bigdl.dataset.{DataSet, Sample, SampleToBatch}
+import com.intel.analytics.bigdl.dataset.{DataSet, Sample, SampleToMiniBatch}
 import com.intel.analytics.bigdl.models.lenet.LeNet5
 import com.intel.analytics.bigdl.nn.CrossEntropyCriterion
 import com.intel.analytics.bigdl.tensor.Tensor
@@ -64,7 +64,7 @@ class ValidatorSpec extends FlatSpec with Matchers with BeforeAndAfter{
       i += 1
     }
     val model = LeNet5(classNum = 10)
-    val dataSet = DataSet.array(tmp, sc).transform(SampleToBatch(1))
+    val dataSet = DataSet.array(tmp, sc).transform(SampleToMiniBatch(1))
     val validator = Validator(model, dataSet)
 
     val result = validator.test(Array(new Top1Accuracy[Float](), new Top5Accuracy[Float](),
@@ -89,7 +89,7 @@ class ValidatorSpec extends FlatSpec with Matchers with BeforeAndAfter{
       i += 1
     }
     val model = LeNet5(classNum = 10)
-    val dataSet = DataSet.array(tmp).transform(SampleToBatch(1))
+    val dataSet = DataSet.array(tmp).transform(SampleToMiniBatch(1))
     val validator = Validator(model, dataSet)
 
     val result = validator.test(Array(new Top1Accuracy[Float](), new Top5Accuracy[Float](),

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
@@ -20,7 +20,6 @@ import java.util
 import java.util.{List => JList, Map => JMap}
 
 import com.intel.analytics.bigdl._
-import com.intel.analytics.bigdl.dataset.TensorSample
 import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.optim.{Loss, SGD, Top1Accuracy, Trigger}
 import com.intel.analytics.bigdl.utils.{Engine, T}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
@@ -210,20 +210,16 @@ class PythonSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     val localData = data.collect()
     pp.toTensor(preResult.get(0)) should be
-    (trainedModel.forward(pp.toSample(localData(0))
-      .asInstanceOf[TensorSample[Float]].featureTensor))
+    (trainedModel.forward(pp.toSample(localData(0)).feature))
 
     pp.toTensor(preResult.get(25)) should be
-    (trainedModel.forward(pp.toSample(localData(25))
-      .asInstanceOf[TensorSample[Float]].featureTensor))
+    (trainedModel.forward(pp.toSample(localData(25)).feature))
 
     pp.toTensor(preResult.get(55)) should be
-    (trainedModel.forward(pp.toSample(localData(55))
-      .asInstanceOf[TensorSample[Float]].featureTensor))
+    (trainedModel.forward(pp.toSample(localData(55)).feature))
 
     pp.toTensor(preResult.get(75)) should be
-    (trainedModel.forward(pp.toSample(localData(75))
-      .asInstanceOf[TensorSample[Float]].featureTensor))
+    (trainedModel.forward(pp.toSample(localData(75)).feature))
 
     // TODO: verify the parameters result
     val parameters = pp.modelGetParameters(trainedModel)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/LoggerFilterSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/LoggerFilterSpec.scala
@@ -21,7 +21,7 @@ import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.numeric.NumericDouble
 import com.intel.analytics.bigdl.optim.{Optimizer, SGD, Trigger}
 import com.intel.analytics.bigdl.nn.{Linear, MSECriterion, Sequential}
-import com.intel.analytics.bigdl.dataset.{DataSet, MiniBatch, Sample, SampleToBatch}
+import com.intel.analytics.bigdl.dataset.{DataSet, MiniBatch, Sample, SampleToMiniBatch}
 
 import scala.io.Source
 import java.io.StringWriter
@@ -88,7 +88,7 @@ class LoggerFilterSpec extends FlatSpec with BeforeAndAfter with Matchers {
       Sample[Double](featureTensor, labelTensor)
     }
 
-    val trainSet = DataSet.rdd(data).transform(SampleToBatch(recordSize/2))
+    val trainSet = DataSet.rdd(data).transform(SampleToMiniBatch(recordSize/2))
 
     val state =
       T(


### PR DESCRIPTION
## What changes were proposed in this pull request?
Use an uniform Sample, ArraySample,  to store all Sample Data.

Use an ArrayTensorMiniBatch to host single/multi input data.
Add an SampleToMiniBatch transformer to transform Sample to miniBatch.  

## How was this patch tested?
unit tests

Fixed #392 


