### PR TITLE
fix ConcatTable.clearState() don't clear gradInput when gradInput is table

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ConcatTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ConcatTable.scala
@@ -160,6 +160,15 @@ class ConcatTable[T : ClassTag]
     }
   }
 
+  override def clearState(): ConcatTable.this.type = {
+    super.clearState()
+    modules.foreach(_.clearState())
+    if (gradInput.isInstanceOf[Table]) {
+      gradInput.toTable.clear()
+    }
+    this
+  }
+
   override def toString(): String = {
     val tab = "\t"
     val line = "\n"

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ConcatTableSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ConcatTableSpec.scala
@@ -17,6 +17,7 @@
 package com.intel.analytics.bigdl.nn
 
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
+import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.utils.T
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -53,5 +54,21 @@ class ConcatTableSpec extends FlatSpec with Matchers {
         Tensor(Storage[Float](Array(0.8f, 0.6f, 0.4f, 0.2f)))
       )
     ))
+  }
+
+  "ConcatTable" should "work properly after clearState()" in {
+    val model = Sequential[Float]()
+    model.add(ConcatTable().add(Identity()).add(Identity()))
+    model.add(ParallelTable().add(Reshape(Array(3, 2))).add(Reshape(Array(3, 2))))
+    model.add(ConcatTable().add(Identity()))
+    val input = Tensor[Float](2, 3)
+    model.forward(input)
+    model.backward(input, model.output)
+
+    model.clearState()
+    model.modules(2).clearState()
+    val input2 = Tensor[Float](2, 3)
+    model.forward(input2)
+    model.backward(input2, model.output)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

fix ConcatTable.clearState() don't clear gradInput when gradInput is table

## How was this patch tested?

unit tests

## Related links or issues (optional)
fixed #929 

