### PR TITLE
Add nn graph support

### DIFF
--- a/pyspark/dl/util/common.py
+++ b/pyspark/dl/util/common.py
@@ -259,6 +259,12 @@ def get_bigdl_conf():
     raise Exception("Cannot find spark-bigdl.conf.Pls add it to PYTHONPATH.")
 
 
+def to_list(a):
+    if type(a) is list:
+        return a
+    return [a]
+
+
 def create_spark_conf():
     bigdl_conf = get_bigdl_conf()
     sparkConf = SparkConf()


### PR DESCRIPTION
## What changes were proposed in this pull request?
Original API design can be found from
https://github.com/intel-analytics/BigDL/pull/777
Example of define a simple model via DAG:
```
        fc1 = Linear(4, 2)()
        fc2 = Linear(4, 2)()
        cadd = CAddTable()([fc1, fc2])
        output1 = ReLU()(cadd)
        output2 = Threshold(10.0)(cadd)
        graph = Graph([fc1, fc2], [output1, output2])
        output = graph.forward([np.array([0.1, 0.2, -0.3, -0.4]),
                                np.array([0.5, 0.4, -0.2, -0.1])])
        gradInput = graph.backward([np.array([0.1, 0.2, -0.3, -0.4]),
                                    np.array([0.5, 0.4, -0.2, -0.1])],
                                   [np.array([1.0, 2.0]),
                                    np.array([3.0, 4.0])])
```
User can inspect parameters in this way:
```
        fc1.element().get_weights()
        fc1.element().set_weights([np.ones((4, 2)), np.ones((2, ))])
```

## How was this patch tested?
unittest

