### PR TITLE
Make top 1 Accuracy support binary input (labels)

### DIFF
--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
@@ -56,7 +56,7 @@ class LinearSpec extends FlatSpec with Matchers {
     weights2.copy(weights1.clone())
     grad2.copy(grad1.clone())
 
-    
+
     val sgd = new SGD[Double]
 
     def feval1(x: Tensor[Double]): (Double, Tensor[Double]) = {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
@@ -56,6 +56,7 @@ class LinearSpec extends FlatSpec with Matchers {
     weights2.copy(weights1.clone())
     grad2.copy(grad1.clone())
 
+    
     val sgd = new SGD[Double]
 
     def feval1(x: Tensor[Double]): (Double, Tensor[Double]) = {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
@@ -56,7 +56,6 @@ class LinearSpec extends FlatSpec with Matchers {
     weights2.copy(weights1.clone())
     grad2.copy(grad1.clone())
 
-
     val sgd = new SGD[Double]
 
     def feval1(x: Tensor[Double]): (Double, Tensor[Double]) = {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/ValidationSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/ValidationSpec.scala
@@ -50,6 +50,36 @@ class ValidationSpec extends FlatSpec with Matchers {
     result should be(test)
   }
 
+
+  "top1 accuracy" should "be correct on 2d tensor for binary inputs" in {
+    val output = Tensor(Storage(Array[Double](
+      0,
+      0,
+      1,
+      0,
+      1,
+      0,
+      0,
+      0
+    )), 1, Array(8, 1))
+
+    val target = Tensor(Storage(Array[Double](
+      1,
+      0,
+      1,
+      1,
+      0,
+      0,
+      1,
+      1
+    )))
+
+    val validation = new Top1Accuracy[Double]()
+    val result = validation(output, target)
+    val test = new AccuracyResult(3, 8)
+    result should be(test)
+  }
+
   it should "be correct on 1d tensor" in {
     val output = Tensor(Storage(Array[Double](
       0, 0, 0, 1


### PR DESCRIPTION
## What changes were proposed in this pull request?
Make top 1 Accuracy support binary input (labels), eg. the labels are 0, 1, 0, 0, 1, ...

## How was this patch tested?
Unit test

