### PR TITLE
Changes to SpatialConvolution.scala to avoid divide by 0 error

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialConvolution.scala
@@ -130,8 +130,8 @@ class SpatialConvolution[T: ClassTag](
     val inputWidth = input.size(dimWidth)
     val inputHeight = input.size(dimHeight)
 
-    val outputWidth = (inputWidth + 2 * padW - kernelW) / strideW + 1
-    val outputHeight = (inputHeight + 2 * padH - kernelH) / strideH + 1
+    val outputWidth = (inputWidth + 2 * padW - kernelW) / (strideW + 1)
+    val outputHeight = (inputHeight + 2 * padH - kernelH) / (strideH + 1)
 
     require(outputWidth >= 1 && outputHeight >= 1,
       s"output size is too small. outputWidth: $outputWidth, outputHeight: $outputHeight")


### PR DESCRIPTION
## What changes were proposed in this pull request?
On line #133, when the strideW or strideH is 0 the existing logic causes the application to fail. See below:

Caused by: java.lang.ArithmeticException: / by zero
	at com.intel.analytics.bigdl.nn.SpatialConvolution.updateOutput(SpatialConvolution.scala:133)
	at com.intel.analytics.bigdl.nn.SpatialConvolution.updateOutput(SpatialConvolution.scala:42)
	at com.intel.analytics.bigdl.nn.abstractnn.AbstractModule.forward(AbstractModule.scala:168)
	at com.intel.analytics.bigdl.nn.Sequential.updateOutput(Sequential.scala:37)
	at com.intel.analytics.bigdl.nn.abstractnn.AbstractModule.forward(AbstractModule.scala:168)
	at com.intel.analytics.bigdl.optim.DistriOptimizer$$anonfun$4$$anonfun$5$$anonfun$apply$2.apply$mcI$sp(DistriOptimizer.scala:198)
	at com.intel.analytics.bigdl.optim.DistriOptimizer$$anonfun$4$$anonfun$5$$anonfun$apply$2.apply(DistriOptimizer.scala:191)
	at com.intel.analytics.bigdl.optim.DistriOptimizer$$anonfun$4$$anonfun$5$$anonfun$apply$2.apply(DistriOptimizer.scala:191)
	at com.intel.analytics.bigdl.utils.ThreadPool$$anonfun$1$$anon$4.call(ThreadPool.scala:112)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)

(Please fill in changes proposed in this patch)
Using parenthesis would help avoid this error even when the values of strideW and strideH are 0
## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If it is possible, please attach a screenshot; otherwise, remove this)

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

