### PR TITLE
Refactor DLEstimator and DLClassifier for Spark Pipeline compatibility

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/MLPipeline/DLEstimatorLeNet.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/MLPipeline/DLEstimatorLeNet.scala
@@ -27,11 +27,8 @@ import com.intel.analytics.bigdl.utils.{Engine, LoggerFilter}
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.SparkContext
 import org.apache.spark.ml.{DLEstimator, DLModel}
-import org.apache.spark.ml.linalg.DenseVector
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SQLContext
-
-import scala.collection.mutable.ArrayBuffer
 
 /**
  * An example to show how to use DLEstimator fit to be compatible with ML Pipeline
@@ -70,7 +67,7 @@ object DLEstimatorLeNet {
 
       val model = LeNet5(classNum = 10)
       val criterion = ClassNLLCriterion[Float]()
-      var featureSize = Array(28, 28)
+      val featureSize = Array(28, 28)
       val estimator = new DLEstimator[Float](model, criterion, featureSize, Array(1))
         .setFeaturesCol(inputs(0))
         .setLabelCol(inputs(1))
@@ -94,5 +91,4 @@ object DLEstimatorLeNet {
   }
 }
 
-private case class DenseVectorData(denseVector : DenseVector)
 private case class Data[T](featureData : Array[T], labelData : Array[T])

--- a/spark/dl/src/main/scala/org/apache/spark/ml/DLClassifier.scala
+++ b/spark/dl/src/main/scala/org/apache/spark/ml/DLClassifier.scala
@@ -15,93 +15,103 @@
  */
 package org.apache.spark.ml
 
+import scala.reflect.ClassTag
+
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.models.utils.ModelBroadcast
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
-import org.apache.spark.ml.param.shared.{HasInputCol, HasOutputCol}
 import org.apache.spark.ml.param.{ParamMap, _}
-import org.apache.spark.mllib.linalg.DenseVector
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row}
 
-import scala.reflect.ClassTag
+// TODO: override transformSchema to change label and prediction type
+class DLClassifier[@specialized(Float, Double) T: ClassTag] (
+    override val model: Module[T],
+    featureSize : Array[Int],
+    override val uid: String = "DLClassifier"
+  ) (implicit ev: TensorNumeric[T]) extends DLModel[T](model, featureSize) {
+
+}
 
 /**
- * A general Classifier to classify the input data in inputCol, and write the results to outputCol.
- * Use setInputCol to set inputCol name, and use setOutputCol to set outputCol name.
+ * [[DLModel]] helps embedding a BigDL model into a Spark Transformer, thus Spark users can
+ * conveniently merge BigDL into Spark ML pipeline. The features column holds the storage
+ * (Vector, float array or double array) of the feature data, and user should specify the
+ * tensor size (dimensions) via featureSize. (e.g. an image may be with featureSize = 28 * 28).
  *
- * DLClassifier is compatible with both spark 1.5-plus and 2.0 by extending MLTransform.
+ * Internally the feature data are converted to BigDL tensors with batch acceleration, and
+ * further predict with a BigDL model.
+ *
+ * [[DLModel]] is compatible with both spark 1.5-plus and 2.0 by extending ML Transformer.
  */
-class DLClassifier[@specialized(Float, Double) T: ClassTag]
-  (override val uid: String = "DLClassifier")(implicit ev: TensorNumeric[T]) extends DLTransformer
-  with HasInputCol with HasOutputCol with DataParams[T] {
+class DLModel[@specialized(Float, Double) T: ClassTag](
+    val model: Module[T],
+    var featureSize : Array[Int],
+    override val uid: String = "DLModel"
+  )(implicit ev: TensorNumeric[T]) extends DLTransformerBase with DLParams with HasBatchSize {
 
-  /**
-   * Set the input column name
-   * @param inputColName the name of the input column
-   * @return this.
-   */
-  def setInputCol(inputColName: String): this.type = set(inputCol, inputColName)
+  def setFeaturesCol(featuresColName: String): this.type = set(featuresCol, featuresColName)
 
-  /**
-   * Set the output column name, should not existed in the DataFrame.
-   * @param outputColName the name of the output column
-   * @return this.
-   */
-  def setOutputCol(outputColName: String): this.type = set(outputCol, outputColName)
+  def setPredictionCol(value: String): this.type = set(predictionCol, value)
 
-  def validateParameters(): Unit = {
-    val params = this.extractParamMap()
-    require(null != params.getOrElse(modelTrain, null),
-      "DLClassifier: model for predict must not be null")
-    require(null != params.getOrElse(batchShape, null),
-      "DLClassifier: batchSize for predict must not be null")
-    require(null != params.getOrElse(inputCol, null),
-      "DLClassifier: inputCol must not be null")
-    require(null != params.getOrElse(outputCol, null),
-      "DLClassifier: inputCol must not be null")
+  def setFeatureSize(value: Array[Int]): this.type = {
+    this.featureSize = value
+    this
   }
+
+  def setBatchSize(value: Int): this.type = set(batchSize, value)
+
+  def getFeatureSize: Array[Int] = this.featureSize
 
   /**
    * Perform a prediction on inputCol, and write result to the outputCol.
    * @param dataset input DataFrame
    * @return output DataFrame
    */
-  override def process(dataset: DataFrame): DataFrame = {
-    this.validateParameters()
-    DLClassifier.process[T]($(batchShape), $(modelTrain), $(inputCol), $(outputCol), dataset)
+  protected override def internalTransform(dataset: DataFrame): DataFrame = {
+    val featureArrayCol = if (dataset.schema($(featuresCol)).dataType.isInstanceOf[ArrayType]) {
+      $(featuresCol)
+    } else {
+      getFeatureArrayCol
+    }
+
+    process[T](featureSize, model, featureArrayCol, $(predictionCol), dataset)
   }
 
-  override def copy(extra: ParamMap): DLClassifier[T] = {
-    copyValues(new DLClassifier(uid), extra)
-  }
-}
+  private[DLModel] def process[@specialized(Float, Double) T: ClassTag](
+      featureSize: Array[Int],
+      modelTrain: Module[T],
+      featuresArrayCol: String,
+      predictionCol: String,
+      dataset: DataFrame)(implicit ev: TensorNumeric[T]): DataFrame = {
 
-object DLClassifier{
-  private[DLClassifier] def process[@specialized(Float, Double) T: ClassTag](
-    batchSize: Array[Int],
-    modelTrain: Module[T],
-    inputCol: String,
-    outputCol: String,
-    dataset: DataFrame)(implicit ev: TensorNumeric[T]) : DataFrame = {
     val model = modelTrain.evaluate()
-
     val modelBroadCast = ModelBroadcast[T].broadcast(dataset.sqlContext.sparkContext, model)
+    val featureColIndex = dataset.schema.fieldIndex(featuresArrayCol)
 
-    val predictRdd = dataset.rdd.mapPartitions{ rows =>
+    val featureType = dataset.schema(featuresArrayCol).dataType.asInstanceOf[ArrayType].elementType
+    def featureToTensor = featureType match {
+      case DoubleType =>
+        (row: Row, index: Int) =>
+          Tensor(Storage(row.getSeq[Double](featureColIndex).toArray.map(ev.fromType(_))))
+      case FloatType =>
+        (row: Row, index: Int) =>
+          Tensor(Storage(row.getSeq[Float](featureColIndex).toArray.map(ev.fromType(_))))
+    }
+
+    val predictRdd = dataset.rdd.mapPartitions { rows =>
       val localModel = modelBroadCast.value()
-      val tensorBuffer = Tensor[T](batchSize)
-      val batches = rows.grouped(batchSize(0))
+      val tensorBuffer = Tensor[T](Array($(batchSize)) ++ featureSize)
+      val batches = rows.grouped($(batchSize))
 
-      val results = batches.flatMap{ batch =>
+      val results = batches.flatMap { batch =>
         val batchResult = new Array[Row](batch.length)
         var i = 1
-        // Notice: if the last batch is smaller than the batchSize(0), we still continue
+        // Notice: if the last batch is smaller than the batchSize, we still continue
         // to use this tensorBuffer, but only add the meaningful parts to the result Array.
-        batch.foreach{ row =>
-          tensorBuffer.select(1, i).copy(
-            Tensor(Storage(row.getAs[DenseVector](inputCol).toArray.map(ev.fromType(_)))))
+        batch.foreach { row =>
+          tensorBuffer.select(1, i).copy(featureToTensor(row, featureColIndex))
           i += 1
         }
         val output = localModel.forward(tensorBuffer).toTensor[T]
@@ -114,8 +124,9 @@ object DLClassifier{
         }
 
         i = 0
-        batch.foreach{ row =>
-          batchResult(i) = Row.fromSeq(row.toSeq ++ Array[Int](ev.toType[Int](predict(i))))
+        batch.foreach { row =>
+          batchResult(i) = Row.fromSeq(
+            row.toSeq ++ Seq(Array[Double](ev.toType[Double](predict(i)))))
           i += 1
         }
 
@@ -124,29 +135,27 @@ object DLClassifier{
 
       results
     }
-    val predictSchema = dataset.schema.add(outputCol, IntegerType)
+    val predictSchema = dataset.schema.add(predictionCol, new ArrayType(DoubleType, false))
     dataset.sqlContext.createDataFrame(predictRdd, predictSchema)
+  }
+
+  override def copy(extra: ParamMap): DLModel[T] = {
+    val copied = new DLModel(model, featureSize, uid).setParent(parent)
+    copyValues(copied, extra).asInstanceOf[DLModel[T]]
   }
 }
 
-/**
- * parameters passed to DLClassifier
- * @tparam T data type
- */
-trait DataParams[@specialized(Float, Double) T] extends Params {
-  final val modelTrain = new Param[Module[T]](this, "module factory", "network model")
-  final val batchShape = new Param[Array[Int]](this, "batch size", "batch size for input")
+// TODO, add save/load
+object DLModel {
 
-  /**
-   * get the model
-   * @return modelTrain
-   */
-  final def getModel: Module[T] = $(modelTrain)
 
-  /**
-   * get the batch shape
-   * @return batchShape
-   */
-  final def getBatchSize: Array[Int] = $(batchShape)
 }
 
+
+trait HasBatchSize extends Params {
+
+  final val batchSize: Param[Int] = new Param[Int](this, "batchSize", "batchSize")
+  setDefault(batchSize -> 1)
+
+  final def getBatchSize: Int = $(batchSize)
+}

--- a/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
+++ b/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
@@ -31,9 +31,9 @@ import org.apache.spark.sql.types._
  * thus Spark users can conveniently fit BigDL into Spark ML pipeline.
  *
  * The feature column holds the storage (Spark Vectors or array of Floats or Doubles) of
- * the feature data, and user should specify the tensor size(dimensions) via the featureSize.
+ * the feature data, and user should specify the tensor size(dimensions) via param featureSize.
  * The label column holds the storage (Spark Vectors, array of Floats or Doubles, or Double) of
- * the label data, and user should specify the tensor size(dimensions) via the labelSize.
+ * the label data, and user should specify the tensor size(dimensions) via param labelSize.
  * Internally the feature and label data are converted to BigDL tensors, to further train a
  * BigDL model efficiently.
  *

--- a/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
+++ b/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
@@ -14,110 +14,129 @@
  * limitations under the License.
  */
 package org.apache.spark.ml
+
+import scala.reflect.ClassTag
 import com.intel.analytics.bigdl.dataset.{DataSet, MiniBatch}
 import com.intel.analytics.bigdl.{Criterion, Module}
 import com.intel.analytics.bigdl.optim.Optimizer
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
-import org.apache.spark.ml.param.shared.{HasFeaturesCol, HasInputCols, HasLabelCol}
-import org.apache.spark.ml.param.{Param, ParamMap, Params}
+import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.types.{ArrayType, StructType}
-
-import scala.collection.mutable
-import scala.reflect.ClassTag
+import org.apache.spark.sql.types._
 
 /**
- * A wrapper of Optimizer to support fit() in ML Pipelines as an Estimator
- * feature column name and label column name should be provided in training Dataframe
- * Model to be trained, Feature size, label size, batch shap must also be provided
+ * [[DLEstimator]] helps to train a BigDL Model with the Spark ML Estimator/Transfomer pattern,
+ * thus Spark users can conveniently fit BigDL into Spark ML pipeline.
+ *
+ * The feature column holds the storage (Spark Vectors or array of Floats or Doubles) of
+ * the feature data, and user should specify the tensor size(dimensions) via the featureSize.
+ * The label column holds the storage (Spark Vectors, array of Floats or Doubles, or Double) of
+ * the label data, and user should specify the tensor size(dimensions) via the labelSize.
+ * Internally the feature and label data are converted to BigDL tensors, to further train a
+ * BigDL model efficiently.
+ *
  * For details usage, please refer to example :
  * [[com.intel.analytics.bigdl.example.MLPipeline.DLEstimatorLeNet]]
  *
- * @param modelTrain module to be optimized
+ * @param model module to be optimized
  * @param criterion  criterion method
- * @param batchShape batch shape for DLClassifier transformation input
+ * @param featureSize The size (Tensor dimensions) of the feature data.
+ * @param labelSize The size (Tensor dimensions) of the label data.
  */
-class DLEstimator[@specialized(Float, Double) T: ClassTag]
-(val modelTrain : Module[T], val criterion : Criterion[T], val batchShape : Array[Int],
- override val uid: String = "DLEstimator")
-(implicit ev: TensorNumeric[T])
-  extends DLEstimatorBase with HasFeaturesCol with HasLabelCol with DLDataParams[T] {
+class DLEstimator[@specialized(Float, Double) T: ClassTag](
+    val model: Module[T],
+    val criterion : Criterion[T],
+    val featureSize : Array[Int],
+    val labelSize : Array[Int],
+    override val uid: String = "DLEstimator"
+  )(implicit ev: TensorNumeric[T]) extends DLEstimatorBase with DLParams with HasBatchSize {
 
   def setFeaturesCol(featuresColName: String): this.type = set(featuresCol, featuresColName)
 
   def setLabelCol(labelColName : String) : this.type = set(labelCol, labelColName)
 
-  private def validateInput(schema : StructType): Unit = {
-    require(isDefined(featuresCol),
-      "DLEstimator: features data must not be null")
-    require(isDefined(featureSize),
-      "DLEstimator: features size col must not be null")
-    require(isDefined(labelCol),
-      "DLEstimator: label data must not be null")
-    require(isDefined(labelSize),
-      "DLEstimator: label size must not be null")
-    val featureIndex = schema.fieldIndex($(featuresCol))
-    val featureField = schema.fields(featureIndex)
-    require(featureField.dataType.isInstanceOf[ArrayType], "Feature data should be of array type")
-    val labelIndex = schema.fieldIndex($(labelCol))
-    val labelField = schema.fields(labelIndex)
-    require(labelField.dataType.isInstanceOf[ArrayType], "Label data should be of array type")
+  def setPredictionCol(value: String): this.type = set(predictionCol, value)
+
+  def setBatchSize(value: Int): this.type = set(batchSize, value)
+
+  override def transformSchema(schema : StructType): StructType = {
+    validateAndTransformSchema(schema)
   }
 
-  override protected def process(dataFrame: DataFrame): DLTransformer = {
-
-    validateInput(dataFrame.schema)
+  protected override def internalFit(dataFrame: DataFrame): DLTransformerBase = {
+    dataFrame.show()
 
     val batches = toMiniBatch(dataFrame)
-
     val dataset = DataSet.rdd(batches)
 
-    val optimizer = Optimizer(modelTrain, dataset, criterion)
+    val optimizer = Optimizer(model, dataset, criterion)
+    val optimizedModel = optimizer.optimize()
 
-    var optimizedModule = modelTrain
-
-    optimizedModule = optimizer.optimize()
-
-    var classifier = new DLClassifier[T]()
-
-    val paramsTrans = ParamMap(
-      classifier.modelTrain -> optimizedModule,
-      classifier.batchShape -> batchShape)
-
-    classifier = classifier.copy(paramsTrans)
-
-    classifier
+    val dlModel = new DLModel[T](optimizedModel, featureSize)
+    copyValues(dlModel.setParent(this))
   }
 
+  /**
+   * Extract and reassemble data according to batchSize
+   */
   private def toMiniBatch(dataFrame: DataFrame) : RDD[MiniBatch[T]] = {
+    val featureArrayCol = if (dataFrame.schema($(featuresCol)).dataType.isInstanceOf[ArrayType]) {
+      $(featuresCol)
+    } else {
+      getFeatureArrayCol
+    }
+    val featureColIndex = dataFrame.schema.fieldIndex(featureArrayCol)
 
-    val data = dataFrame.rdd
-    val batchs = data.map(row => {
-      val featureData = row.getAs[mutable.WrappedArray[T]]($(featuresCol)).toArray
-      val labelData = row.getAs[mutable.WrappedArray[T]]($(labelCol)).toArray
-      MiniBatch[T](Tensor(featureData, $(featureSize)), Tensor(labelData, $(labelSize)))
-    })
-    batchs
+    val labelArrayCol = if (dataFrame.schema($(labelCol)).dataType.isInstanceOf[ArrayType]) {
+      $(labelCol)
+    } else {
+      getLabelArrayCol
+    }
+    val labelColIndex = dataFrame.schema.fieldIndex(labelArrayCol)
+
+    val featureType = dataFrame.schema(featureArrayCol).dataType.asInstanceOf[ArrayType].elementType
+    val labelType = dataFrame.schema(labelArrayCol).dataType.asInstanceOf[ArrayType].elementType
+
+    /**
+     * since model data type (float or double) and feature data element type does not necessarily
+     * comply, we need to extract data from feature column and convert according to model type.
+     */
+    val featureAndLabelData = dataFrame.rdd.map { row =>
+      val featureData = featureType match {
+        case DoubleType =>
+          row.getSeq[Double](featureColIndex).toArray.map(ev.fromType(_))
+        case FloatType =>
+          row.getSeq[Float](featureColIndex).toArray.map(ev.fromType(_))
+      }
+      require(featureData.length == featureSize.product, s"Data length mismatch:" +
+        s" feature data length ${featureData.length}, featureSize: ${featureSize.mkString(", ")}")
+
+      val labelData = labelType match {
+        case DoubleType =>
+          row.getSeq[Double](labelColIndex).toArray.map(ev.fromType(_))
+        case FloatType =>
+          row.getSeq[Float](labelColIndex).toArray.map(ev.fromType(_))
+      }
+      require(featureData.length == featureSize.product, s"Data length mismatch:" +
+        s" label data length ${featureData.length}, labelSize: ${featureSize.mkString(", ")}")
+      (featureData, labelData)
+    }
+
+    featureAndLabelData.mapPartitions { rows =>
+      val batches = rows.grouped($(batchSize)).map { batch =>
+        val featureData = batch.flatMap(_._1).toArray
+        val labelData = batch.flatMap(_._2).toArray
+        MiniBatch[T](
+          Tensor(featureData, Array(batch.length) ++ featureSize),
+          Tensor(labelData, Array(batch.length) ++ labelSize))
+      }
+      batches
+    }
   }
 
   override def copy(extra: ParamMap): DLEstimator[T] = {
-    copyValues(new DLEstimator(modelTrain, criterion, batchShape), extra)
+    copyValues(new DLEstimator(model, criterion, featureSize, labelSize), extra)
   }
 }
-
-private[ml] trait DLDataParams[@specialized(Float, Double) T] extends Params {
-
-  final val featureSize = new Param[Array[Int]](this, "feature size", "feature input size")
-
-  final val labelSize = new Param[Array[Int]](this, "label size", "label input size")
-
-  final def getFeatureSize : Array[Int] = $(featureSize)
-
-  final def getLabelSize : Array[Int] = $(labelSize)
-
-}
-
-
-

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLEstimatorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLEstimatorSpec.scala
@@ -16,7 +16,8 @@
 
 package com.intel.analytics.bigdl.optim
 
-import com.intel.analytics.bigdl.dataset.MiniBatch
+import scala.util.Random
+
 import com.intel.analytics.bigdl.models.lenet.LeNet5
 import com.intel.analytics.bigdl.nn.{ClassNLLCriterion, Linear, Sequential}
 import com.intel.analytics.bigdl.tensor.Tensor
@@ -24,19 +25,21 @@ import com.intel.analytics.bigdl.utils.Engine
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric.NumericFloat
 import org.apache.log4j.{Level, Logger}
-import org.apache.spark.SparkContext
-import org.apache.spark.ml._
-import org.apache.spark.ml.param.ParamMap
-import org.apache.spark.mllib.linalg.DenseVector
+import org.apache.spark.{SparkContext, SparkException}
+import org.apache.spark.ml.{DLClassifier, DLEstimator, DLModel}
 import org.apache.spark.sql.{DataFrame, SQLContext}
-
-import scala.collection.mutable.ArrayBuffer
-import scala.util.Random
 
 class DLEstimatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
   val model = new Sequential[Float]()
   var sc : SparkContext = null
-  var sQLContext : SQLContext = null
+  var sqlContext : SQLContext = null
+
+  before {
+    val conf = Engine.createSparkConf().setAppName("Test DLEstimator").setMaster("local[1]")
+    sc = SparkContext.getOrCreate(conf)
+    sqlContext = new SQLContext(sc)
+    Engine.init
+  }
 
   after{
     if (sc != null) {
@@ -45,192 +48,88 @@ class DLEstimatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
   }
 
   "An Estimator" should "works properly" in {
-    val conf = Engine.createSparkConf().setAppName("Test DLEstimator").setMaster("local[1]")
-    sc = SparkContext.getOrCreate(conf)
-    sQLContext = new SQLContext(sc)
-    Engine.init
-
-    val inputs = Array[String]("Feature data", "Label data")
 
     val model = Linear[Float](10, 1)
-
     val criterion = ClassNLLCriterion[Float]()
+    val inputs = Array[String]("Feature data", "Label data")
+    var estimator = new DLEstimator[Float](model, criterion, Array(10), Array(1))
+      .setBatchSize(2)
+      .setFeaturesCol(inputs(0))
+      .setLabelCol(inputs(1))
 
-    var estimator = new DLEstimator[Float](model, criterion, Array(2, 10))
-      .setFeaturesCol(inputs(0)).setLabelCol(inputs(1))
-
-    val featureData = Tensor(2, 10)
-    val labelData = Tensor(2, 1).fill(1.0f)
-
-    val batch = MiniBatch(featureData, labelData)
-
+    val featureData = Tensor(10)
+    val labelData = Tensor(1).fill(1.0f)
     val miniBatch = sc.parallelize(Seq(
-      MinibatchData[Float](featureData.storage().array(),
-        labelData.storage().array())
+      MinibatchData[Float](featureData.storage().array(), labelData.storage().array())
     ))
-
-    val paramsTrans = ParamMap(
-      estimator.featureSize -> Array(2, 10),
-      estimator.labelSize -> Array(2, 1))
-
-    estimator = estimator.copy(paramsTrans)
-
-    var trainingDF: DataFrame = sQLContext.createDataFrame(miniBatch).toDF(inputs: _*)
+    var trainingDF: DataFrame = sqlContext.createDataFrame(miniBatch).toDF(inputs: _*)
 
     val res = estimator.fit(trainingDF)
-
-    res.isInstanceOf[DLTransformer] should be(true)
+    res.isInstanceOf[DLModel[_]] should be(true)
   }
 
   "An Estimator" should "throws exception without correct inputs" in {
-    val conf = Engine.createSparkConf().setAppName("Test DLEstimator").setMaster("local[1]")
-    sc = new SparkContext(conf)
-    sQLContext = new SQLContext(sc)
-    Engine.init
-
-    val inputs = Array[String]("Feature data", "Label data")
 
     val model = Linear[Float](10, 1)
-
     val criterion = ClassNLLCriterion[Float]()
-
-    var estimator = new DLEstimator[Float](model, criterion, Array(2, 10)).
+    val inputs = Array[String]("Feature data", "Label data")
+    var estimator = new DLEstimator[Float](model, criterion, Array(10), Array(2, 1)).
       setFeaturesCol(inputs(0)).setLabelCol(inputs(1))
 
     val featureData = Tensor(2, 10)
     val labelData = Tensor(2, 1)
-    val batch = MiniBatch(featureData, labelData)
-
     val miniBatch = sc.parallelize(Seq(
-      MinibatchData[Float](featureData.storage().array(),
-        labelData.storage().array())
+      MinibatchData[Float](featureData.storage().array(), labelData.storage().array())
     ))
+    var df: DataFrame = sqlContext.createDataFrame(miniBatch).toDF(inputs: _*)
 
-    var df: DataFrame = sQLContext.createDataFrame(miniBatch).toDF(inputs: _*)
-    intercept[IllegalArgumentException] {
-      val res = estimator.fit(df)
+    // Spark 1.6 and 2.0 throws different exception here
+    intercept[Exception] {
+      estimator.fit(df)
     }
   }
 
-  "An Estimator" should "has same transformate result as Classifier" in {
-    val conf = Engine.createSparkConf().setAppName("Test DLEstimator").setMaster("local[1]")
-    sc = new SparkContext(conf)
-    sQLContext = new SQLContext(sc)
-    Engine.init
+  "An Estimator" should "has same transform result as Classifier" in {
 
     Logger.getLogger("org").setLevel(Level.WARN)
     Logger.getLogger("akka").setLevel(Level.WARN)
 
-    val tensorBuffer = new ArrayBuffer[ClassifierDenseVector]()
-
-    val batchSize = 10
+    val batchSize = 2
     val inputs = Array[String]("Feature data", "Label data")
+    val featureSize = Array(28, 28)
 
     val model = LeNet5(5)
-
-    val batchShape = Array(10, 28, 28)
-
     val criterion = ClassNLLCriterion[Float]()
+    var estimator = new DLEstimator[Float](model, criterion, featureSize, Array(1))
+      .setFeaturesCol(inputs(0))
+      .setLabelCol(inputs(1))
+      .setBatchSize(batchSize)
 
-    var estimator = new DLEstimator[Float](model, criterion, batchShape).
-      setFeaturesCol(inputs(0)).setLabelCol(inputs(1))
+    val optimizerInput = Tensor[Float](28, 28).apply1(e => Random.nextFloat())
+    val optimizerTarget = model.forward(optimizerInput).toTensor[Float]
+    val optimizerTargetArr = optimizerTarget.max(1)._2.squeeze().storage().array()
+    val miniBatch = sc.parallelize( Seq(
+      MinibatchData(optimizerInput.storage().array(), optimizerTargetArr),
+      MinibatchData(optimizerInput.storage().array(), optimizerTargetArr)
+    ))
+    val df = sqlContext.createDataFrame(miniBatch).toDF(inputs: _*)
 
-    var m = 0
-
-    var transformer: DLClassifier[Float] = null
-
-    while (m < 10) {
-
-      val optimizerInput = Tensor[Float](10, 28, 28).apply1(e => Random.nextFloat())
-
-      val optimizerTarget = model.forward(optimizerInput).toTensor[Float]
-
-      val optimizerInputArr = optimizerInput.storage().array()
-
-      val optimizerTargetArr = optimizerTarget.max(2)._2.squeeze().storage().array()
-
-      val paramsTrans = ParamMap(
-        estimator.featureSize -> Array(10, 28, 28),
-        estimator.labelSize -> Array(10))
-
-      estimator = estimator.copy(paramsTrans)
-
-      val miniBatch = sc.parallelize(Seq(
-        MinibatchData(optimizerInput.storage().array(), optimizerTargetArr)
-      ))
-
-      val df = sQLContext.createDataFrame(miniBatch).toDF(inputs: _*)
-
-      transformer = estimator.fit(df).asInstanceOf[DLClassifier[Float]]
-
-      m += 1
-    }
-
-    transformer.setInputCol("features")
-      .setOutputCol("predict")
-
-    val optimizedModel = transformer.getModel
-
-    val transInput = Tensor[Float](10, 28, 28).apply1(e => Random.nextFloat())
-
-    val classifierInput = Tensor[Float]()
-
-    classifierInput.resizeAs(transInput).copy(transInput)
-
-    val transInputDataArr = transInput.storage().array()
-
-    var i = 0
-    while (i < batchSize) {
-      tensorBuffer.append(new ClassifierDenseVector(
-        new DenseVector(transInputDataArr.slice(i * 28 * 28, (i + 1) * 28 * 28).map(_.toDouble))))
-      i += 1
-    }
-
-    val transRDD = sc.parallelize(tensorBuffer)
-    val transDataFrame = sQLContext.createDataFrame(transRDD)
-
-    val transPredicts = transformer.transform(transDataFrame).
-      select("predict").collect().map(
-      row => {
-        row.getAs[Int](0)
+    val dlModel = estimator.fit(df).asInstanceOf[DLModel[Float]]
+    val transPredicts = dlModel.transform(df).select("prediction").collect().map { row =>
+        row.getSeq[Double](0).head
       }
-    )
 
-    tensorBuffer.clear()
-
-    var classifier = new DLClassifier[Float]()
-      .setInputCol("features")
-      .setOutputCol("predict")
-
-    val classifierParams = ParamMap(
-      classifier.modelTrain -> optimizedModel,
-      classifier.batchShape -> batchShape)
-    classifier = classifier.copy(classifierParams)
-
-    val classifierInputArr = classifierInput.storage().array()
-
-    i = 0
-    while (i < batchSize) {
-      tensorBuffer.append(new ClassifierDenseVector(
-        new DenseVector(classifierInputArr.slice(i * 28 * 28, (i + 1) * 28 * 28).
-          map(_.toDouble))))
-      i += 1
-    }
-
-    val classifierRDD = sc.parallelize(tensorBuffer)
-    val classifierDataFrame = sQLContext.createDataFrame(classifierRDD)
-
-    val classifierPredicts = classifier.transform(classifierDataFrame).
-      select("predict").collect().map(
+    val classifier = new DLClassifier[Float](dlModel.model, featureSize)
+      .setFeaturesCol(inputs(0))
+      .setBatchSize(batchSize)
+    val classifierPredicts = classifier.transform(df).
+      select("prediction").collect().map(
       row => {
-        row.getAs[Int](0)
+        row.getSeq[Double](0).head
       }
     )
     transPredicts should be(classifierPredicts)
   }
-
 }
-
-private case class ClassifierDenseVector( val features : DenseVector)
 
 private case class MinibatchData[T](featureData : Array[T], labelData : Array[T])

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLEstimatorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLEstimatorSpec.scala
@@ -56,6 +56,7 @@ class DLEstimatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
       .setBatchSize(2)
       .setFeaturesCol(inputs(0))
       .setLabelCol(inputs(1))
+      .setMaxEpoch(2)
 
     val featureData = Tensor(10)
     val labelData = Tensor(1).fill(1.0f)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/DLClassifierSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/DLClassifierSpec.scala
@@ -16,30 +16,19 @@
 
 package com.intel.analytics.bigdl.utils
 
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.util.Random
 import com.intel.analytics.bigdl.models.lenet.LeNet5
 import com.intel.analytics.bigdl.tensor.Tensor
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.{SparkConf, SparkContext}
-import org.apache.spark.ml.DLClassifier
-import org.apache.spark.ml.param.ParamMap
-import org.apache.spark.mllib.linalg.DenseVector
-import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.ml.{DLClassifier, DLModel}
 import org.apache.spark.sql.{Row, SQLContext}
 import org.scalatest.{FlatSpec, Matchers}
 
-import scala.collection.mutable.ArrayBuffer
-import scala.util.Random
-
 @com.intel.analytics.bigdl.tags.Parallel
-class DLClassifierSpec extends FlatSpec with Matchers{
-
-  private def processPath(path: String): String = {
-    if (path.contains(":")) {
-      path.substring(1)
-    } else {
-      path
-    }
-  }
+class DLClassifierSpec extends FlatSpec with Matchers {
 
   "DLClassifier" should "get good result" in {
     Logger.getLogger("org").setLevel(Level.WARN)
@@ -52,41 +41,38 @@ class DLClassifierSpec extends FlatSpec with Matchers{
     val model = LeNet5(10)
 
     // init
-    val valTrans = new DLClassifier[Float]().setInputCol("features").setOutputCol("predict")
-    val paramsTrans = ParamMap(valTrans.modelTrain -> model,
-      valTrans.batchShape -> Array(10, 28, 28))
+    val valTrans = new DLModel[Float](model, Array(28, 28))
+      .setFeaturesCol("features")
+      .setPredictionCol("predict")
+      .setBatchSize(10)
 
-    val tensorBuffer = new ArrayBuffer[LabeledPoint]()
+    val tensorBuffer = new ArrayBuffer[Data]()
     var m = 0
-    while (m < 10) {
-      // generate test data
-      val input = Tensor[Float](10, 28, 28).apply1(e => Random.nextFloat())
-      val target = model.forward(input).toTensor[Float]
+    // generate test data
+    val input = Tensor[Float](10, 28, 28).apply1(e => Random.nextFloat())
+    val target = model.forward(input).toTensor[Float]
 
-      val inputArr = input.storage().array()
-      val targetArr = target.max(2)._2.squeeze().storage().array()
+    val inputArr = input.storage().array()
+    val targetArr = target.max(2)._2.squeeze().storage().array()
 
-      var i = 0
-      while (i < batchSize) {
-        tensorBuffer.append(new LabeledPoint(targetArr(i),
-          new DenseVector(inputArr.slice(i * 28 * 28, (i + 1) * 28 * 28).map(_.toDouble))))
-        i += 1
+    (0 until batchSize).foreach(i =>
+      tensorBuffer.append(
+        Data(targetArr(i), inputArr.slice(i * 28 * 28, (i + 1) * 28 * 28).map(_.toDouble))))
+
+    val rowRDD = sc.parallelize(tensorBuffer)
+    val testData = sqlContext.createDataFrame(rowRDD)
+
+    valTrans.transform(testData)
+      .select("label", "predict")
+      .collect()
+      .foreach { case Row(label: Double, predict: mutable.WrappedArray[Double]) =>
+        label should be(predict.head)
       }
 
-      val rowRDD = sc.parallelize(tensorBuffer)
-      val testData = sqlContext.createDataFrame(rowRDD)
-
-      valTrans.transform(testData, paramsTrans)
-        .select("label", "predict")
-        .collect()
-        .foreach { case Row(label: Double, predict: Int) =>
-          label.toInt should be(predict)
-        }
-
-      tensorBuffer.clear()
-      m += 1
-    }
+    tensorBuffer.clear()
     sc.stop()
   }
 }
+
+case class Data(label: Double, features: Array[Double])
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/DLClassifierSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/DLClassifierSpec.scala
@@ -23,7 +23,7 @@ import com.intel.analytics.bigdl.models.lenet.LeNet5
 import com.intel.analytics.bigdl.tensor.Tensor
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.{SparkConf, SparkContext}
-import org.apache.spark.ml.{DLClassifier, DLModel}
+import org.apache.spark.ml.DLModel
 import org.apache.spark.sql.{Row, SQLContext}
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -47,7 +47,6 @@ class DLClassifierSpec extends FlatSpec with Matchers {
       .setBatchSize(10)
 
     val tensorBuffer = new ArrayBuffer[Data]()
-    var m = 0
     // generate test data
     val input = Tensor[Float](10, 28, 28).apply1(e => Random.nextFloat())
     val target = model.forward(input).toTensor[Float]

--- a/spark/spark-version/1.5-plus/src/main/scala/org/apache/spark/ml/DLEstimatorBase.scala
+++ b/spark/spark-version/1.5-plus/src/main/scala/org/apache/spark/ml/DLEstimatorBase.scala
@@ -35,10 +35,10 @@ private[ml] trait DLParams extends HasFeaturesCol with HasPredictionCol {
       new VectorUDT)
 
     // TODO use SchemaUtils.checkColumnTypes after convert to 2.0
-      val actualDataType = schema($(featuresCol)).dataType
-      require(dataTypes.exists(actualDataType.equals),
-        s"Column ${$(featuresCol)} must be of type equal to one of the following types: " +
-          s"${dataTypes.mkString("[", ", ", "]")} but was actually of type $actualDataType.")
+    val actualDataType = schema($(featuresCol)).dataType
+    require(dataTypes.exists(actualDataType.equals),
+      s"Column ${$(featuresCol)} must be of type equal to one of the following types: " +
+        s"${dataTypes.mkString("[", ", ", "]")} but was actually of type $actualDataType.")
 
     SchemaUtils.appendColumn(schema, $(predictionCol), new ArrayType(DoubleType, false))
   }
@@ -107,8 +107,10 @@ private[ml] abstract class DLEstimatorBase
    * validate both feature and label columns
    */
   protected override def validateAndTransformSchema(schema: StructType): StructType = {
+    // validate feature column
     super.validateAndTransformSchema(schema)
 
+    // validate label column
     val dataTypes = Seq(
       new ArrayType(DoubleType, false),
       new ArrayType(FloatType, false),
@@ -116,10 +118,10 @@ private[ml] abstract class DLEstimatorBase
       DoubleType)
 
     // TODO use SchemaUtils.checkColumnTypes after convert to 2.0
-      val actualDataType = schema($(labelCol)).dataType
-      require(dataTypes.exists(actualDataType.equals),
-        s"Column ${$(labelCol)} must be of type equal to one of the following types: " +
-          s"${dataTypes.mkString("[", ", ", "]")} but was actually of type $actualDataType.")
+    val actualDataType = schema($(labelCol)).dataType
+    require(dataTypes.exists(actualDataType.equals),
+      s"Column ${$(labelCol)} must be of type equal to one of the following types: " +
+        s"${dataTypes.mkString("[", ", ", "]")} but was actually of type $actualDataType.")
 
     SchemaUtils.appendColumn(schema, $(predictionCol), new ArrayType(DoubleType, false))
   }

--- a/spark/spark-version/1.5-plus/src/main/scala/org/apache/spark/ml/DLEstimatorBase.scala
+++ b/spark/spark-version/1.5-plus/src/main/scala/org/apache/spark/ml/DLEstimatorBase.scala
@@ -14,19 +14,118 @@
  * limitations under the License.
  */
 package org.apache.spark.ml
+
+import org.apache.spark.mllib.linalg.{Vector, VectorUDT}
 import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.ml.param.shared.{HasFeaturesCol, HasLabelCol, HasPredictionCol}
+import org.apache.spark.ml.util.SchemaUtils
+import org.apache.spark.sql.functions.{col, udf}
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{ArrayType, DoubleType, FloatType, StructType}
+
+private[ml] trait DLParams extends HasFeaturesCol with HasPredictionCol {
+
+  /**
+   * only validate feature columns here
+   */
+  protected def validateAndTransformSchema(schema: StructType): StructType = {
+    val dataTypes = Seq(
+      new ArrayType(DoubleType, false),
+      new ArrayType(FloatType, false),
+      new VectorUDT)
+
+    // TODO use SchemaUtils.checkColumnTypes after convert to 2.0
+      val actualDataType = schema($(featuresCol)).dataType
+      require(dataTypes.exists(actualDataType.equals),
+        s"Column ${$(featuresCol)} must be of type equal to one of the following types: " +
+          s"${dataTypes.mkString("[", ", ", "]")} but was actually of type $actualDataType.")
+
+    SchemaUtils.appendColumn(schema, $(predictionCol), new ArrayType(DoubleType, false))
+  }
+
+  /**
+   * convert feature columns to array columns
+   */
+  protected def toArrayType(dataset: DataFrame): DataFrame = {
+    val toArray = udf { (vector: Vector) => vector.toArray }
+    var converted = dataset
+    if (converted.schema($(featuresCol)).dataType.sameType(new VectorUDT)) {
+      val newFeatureCol = getFeatureArrayCol
+      converted = converted.withColumn(newFeatureCol, toArray(col($(featuresCol))))
+    }
+
+    converted
+  }
+
+  protected def getFeatureArrayCol: String = $(featuresCol) + "_Array"
+
+}
+
+
 /**
  *A wrapper from org.apache.spark.ml.Estimator
  * Extends MLEstimator and override process to gain compatibility with
  * both spark 1.5 and spark 2.0.
  */
-abstract class DLEstimatorBase extends Estimator[DLTransformer]{
-  protected def process(dataset: DataFrame): DLTransformer
-  override def fit(dataset : org.apache.spark.sql.DataFrame) : DLTransformer = {
-    process(dataset)
+private[ml] abstract class DLEstimatorBase
+  extends Estimator[DLTransformerBase] with DLParams with HasLabelCol{
+
+  protected def getLabelArrayCol: String = $(labelCol) + "_Array"
+
+  protected def internalFit(dataset: DataFrame): DLTransformerBase
+
+  override def fit(dataset: DataFrame): DLTransformerBase = {
+    transformSchema(dataset.schema, logging = true)
+    internalFit(toArrayType(dataset))
   }
-  override def transformSchema(schema: StructType): StructType = schema
+
+  override def transformSchema(schema : StructType): StructType = {
+    validateAndTransformSchema(schema)
+  }
+
+  /**
+   * convert feature and label columns to array columns
+   */
+  protected override def toArrayType(dataset: DataFrame): DataFrame = {
+    var converted = super.toArrayType(dataset)
+
+    // convert label column to array type
+    val vec2Array = udf { (vector: Vector) => vector.toArray }
+    val num2Array = udf { (d: Double) => Array(d) }
+    val labelType = converted.schema($(labelCol)).dataType
+    val newLabelCol = getLabelArrayCol
+
+    if (labelType.sameType(new VectorUDT)) {
+      converted = converted.withColumn(newLabelCol, vec2Array(col($(labelCol))))
+    } else if (labelType.sameType(DoubleType)) {
+      converted = converted.withColumn(newLabelCol, num2Array(col($(labelCol))))
+    }
+    converted
+  }
+
+  /**
+   * validate both feature and label columns
+   */
+  protected override def validateAndTransformSchema(schema: StructType): StructType = {
+    super.validateAndTransformSchema(schema)
+
+    val dataTypes = Seq(
+      new ArrayType(DoubleType, false),
+      new ArrayType(FloatType, false),
+      new VectorUDT,
+      DoubleType)
+
+    // TODO use SchemaUtils.checkColumnTypes after convert to 2.0
+      val actualDataType = schema($(labelCol)).dataType
+      require(dataTypes.exists(actualDataType.equals),
+        s"Column ${$(labelCol)} must be of type equal to one of the following types: " +
+          s"${dataTypes.mkString("[", ", ", "]")} but was actually of type $actualDataType.")
+
+    SchemaUtils.appendColumn(schema, $(predictionCol), new ArrayType(DoubleType, false))
+  }
+
   override def copy(extra: ParamMap): DLEstimatorBase = defaultCopy(extra)
 }
+
+
+

--- a/spark/spark-version/2.0/src/main/scala/org/apache/spark/ml/DLEstimatorBase.scala
+++ b/spark/spark-version/2.0/src/main/scala/org/apache/spark/ml/DLEstimatorBase.scala
@@ -14,20 +14,115 @@
  * limitations under the License.
  */
 package org.apache.spark.ml
+
+import org.apache.spark.ml.linalg.{Vector, VectorUDT}
 import org.apache.spark.ml.param.ParamMap
-import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.Dataset
+import org.apache.spark.ml.param.shared.{HasFeaturesCol, HasLabelCol, HasPredictionCol}
+import org.apache.spark.ml.util.SchemaUtils
+import org.apache.spark.sql.functions.{col, udf}
+import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.types.{ArrayType, DoubleType, FloatType, StructType}
+
+private[ml] trait DLParams extends HasFeaturesCol with HasPredictionCol {
+
+  /**
+   * validate feature columns data format
+   */
+  protected def validateAndTransformSchema(schema: StructType): StructType = {
+    val dataTypes = Seq(
+      new ArrayType(DoubleType, false),
+      new ArrayType(FloatType, false),
+      new VectorUDT)
+
+    // TODO use SchemaUtils.checkColumnTypes after convert to 2.0
+      val actualDataType = schema($(featuresCol)).dataType
+      require(dataTypes.exists(actualDataType.equals),
+        s"Column ${$(featuresCol)} must be of type equal to one of the following types: " +
+          s"${dataTypes.mkString("[", ", ", "]")} but was actually of type $actualDataType.")
+
+    SchemaUtils.appendColumn(schema, $(predictionCol), new ArrayType(DoubleType, false))
+  }
+
+  /**
+   * convert feature columns to array columns if necessary
+   */
+  protected def toArrayType(dataset: DataFrame): DataFrame = {
+    val toArray = udf { (vector: Vector) => vector.toArray }
+    var converted = dataset
+    if (converted.schema($(featuresCol)).dataType.sameType(new VectorUDT)) {
+      val newFeatureCol = getFeatureArrayCol
+      converted = converted.withColumn(newFeatureCol, toArray(col($(featuresCol))))
+    }
+
+    converted
+  }
+
+  protected def getFeatureArrayCol: String = $(featuresCol) + "_Array"
+
+}
+
+
 /**
- *A wrapper from org.apache.spark.ml.Estimator
+ * A wrapper from org.apache.spark.ml.Estimator
  * Extends MLEstimator and override process to gain compatibility with
  * both spark 1.5 and spark 2.0.
-  */
-abstract class DLEstimatorBase extends Estimator[DLTransformer]{
-  protected def process(dataset: DataFrame): DLTransformer
-  override def fit(dataset: Dataset[_]): DLTransformer = {
-    process(dataset.toDF())
+ */
+private[ml] abstract class DLEstimatorBase
+  extends Estimator[DLTransformerBase] with DLParams with HasLabelCol{
+
+  protected def getLabelArrayCol: String = $(labelCol) + "_Array"
+
+  protected def internalFit(dataset: DataFrame): DLTransformerBase
+
+  override def fit(dataset: Dataset[_]): DLTransformerBase = {
+    transformSchema(dataset.schema, logging = true)
+    internalFit(toArrayType(dataset.toDF()))
   }
-  override def transformSchema(schema: StructType): StructType = schema
+
+  override def transformSchema(schema : StructType): StructType = {
+    validateAndTransformSchema(schema)
+  }
+
+  /**
+   * convert feature and label columns to array columns
+   */
+  protected override def toArrayType(dataset: DataFrame): DataFrame = {
+    var converted = super.toArrayType(dataset)
+
+    // convert label column to array type
+    val vec2Array = udf { (vector: Vector) => vector.toArray }
+    val num2Array = udf { (d: Double) => Array(d) }
+    val labelType = converted.schema($(labelCol)).dataType
+    val newLabelCol = getLabelArrayCol
+
+    if (labelType.sameType(new VectorUDT)) {
+      converted = converted.withColumn(newLabelCol, vec2Array(col($(labelCol))))
+    } else if (labelType.sameType(DoubleType)) {
+      converted = converted.withColumn(newLabelCol, num2Array(col($(labelCol))))
+    }
+    converted
+  }
+
+  /**
+   * validate both feature and label columns
+   */
+  protected override def validateAndTransformSchema(schema: StructType): StructType = {
+    super.validateAndTransformSchema(schema)
+
+    val dataTypes = Seq(
+      new ArrayType(DoubleType, false),
+      new ArrayType(FloatType, false),
+      new VectorUDT,
+      DoubleType)
+
+    // TODO use SchemaUtils.checkColumnTypes after convert to 2.0
+      val actualDataType = schema($(labelCol)).dataType
+      require(dataTypes.exists(actualDataType.equals),
+        s"Column ${$(labelCol)} must be of type equal to one of the following types: " +
+          s"${dataTypes.mkString("[", ", ", "]")} but was actually of type $actualDataType.")
+
+    SchemaUtils.appendColumn(schema, $(predictionCol), new ArrayType(DoubleType, false))
+  }
+
   override def copy(extra: ParamMap): DLEstimatorBase = defaultCopy(extra)
 }

--- a/spark/spark-version/2.0/src/main/scala/org/apache/spark/ml/DLEstimatorBase.scala
+++ b/spark/spark-version/2.0/src/main/scala/org/apache/spark/ml/DLEstimatorBase.scala
@@ -35,10 +35,10 @@ private[ml] trait DLParams extends HasFeaturesCol with HasPredictionCol {
       new VectorUDT)
 
     // TODO use SchemaUtils.checkColumnTypes after convert to 2.0
-      val actualDataType = schema($(featuresCol)).dataType
-      require(dataTypes.exists(actualDataType.equals),
-        s"Column ${$(featuresCol)} must be of type equal to one of the following types: " +
-          s"${dataTypes.mkString("[", ", ", "]")} but was actually of type $actualDataType.")
+    val actualDataType = schema($(featuresCol)).dataType
+    require(dataTypes.exists(actualDataType.equals),
+      s"Column ${$(featuresCol)} must be of type equal to one of the following types: " +
+        s"${dataTypes.mkString("[", ", ", "]")} but was actually of type $actualDataType.")
 
     SchemaUtils.appendColumn(schema, $(predictionCol), new ArrayType(DoubleType, false))
   }
@@ -107,8 +107,10 @@ private[ml] abstract class DLEstimatorBase
    * validate both feature and label columns
    */
   protected override def validateAndTransformSchema(schema: StructType): StructType = {
+    // validate feature column
     super.validateAndTransformSchema(schema)
 
+    // validate label column
     val dataTypes = Seq(
       new ArrayType(DoubleType, false),
       new ArrayType(FloatType, false),
@@ -116,10 +118,10 @@ private[ml] abstract class DLEstimatorBase
       DoubleType)
 
     // TODO use SchemaUtils.checkColumnTypes after convert to 2.0
-      val actualDataType = schema($(labelCol)).dataType
-      require(dataTypes.exists(actualDataType.equals),
-        s"Column ${$(labelCol)} must be of type equal to one of the following types: " +
-          s"${dataTypes.mkString("[", ", ", "]")} but was actually of type $actualDataType.")
+    val actualDataType = schema($(labelCol)).dataType
+    require(dataTypes.exists(actualDataType.equals),
+      s"Column ${$(labelCol)} must be of type equal to one of the following types: " +
+        s"${dataTypes.mkString("[", ", ", "]")} but was actually of type $actualDataType.")
 
     SchemaUtils.appendColumn(schema, $(predictionCol), new ArrayType(DoubleType, false))
   }

--- a/spark/spark-version/2.0/src/main/scala/org/apache/spark/ml/DLTransformerBase.scala
+++ b/spark/spark-version/2.0/src/main/scala/org/apache/spark/ml/DLTransformerBase.scala
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 package org.apache.spark.ml
+
 import org.apache.spark.ml.param.ParamMap
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.{DataFrame, Dataset}
 import org.apache.spark.sql.types.StructType
 
 /**
@@ -23,16 +24,20 @@ import org.apache.spark.sql.types.StructType
  * Extends MlTransformer and override process to gain compatibility with
  * both spark 1.5 and spark 2.0.
  */
-abstract class DLTransformer extends Model[DLTransformer]{
+private[ml] abstract class DLTransformerBase
+  extends Model[DLTransformerBase] with DLParams {
 
-  def process(dataset: DataFrame): DataFrame
+  protected def internalTransform(dataset: DataFrame): DataFrame
 
-  override def transform(dataset: DataFrame): DataFrame = {
-    process(dataset)
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    transformSchema(dataset.schema, logging = true)
+    internalTransform(toArrayType(dataset.toDF()))
   }
 
-  override def transformSchema(schema: StructType): StructType = schema
+  override def transformSchema(schema : StructType): StructType = {
+    validateAndTransformSchema(schema)
+  }
 
-  override def copy(extra: ParamMap): DLTransformer = defaultCopy(extra)
+  override def copy(extra: ParamMap): DLTransformerBase = defaultCopy(extra)
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

major changes.
1. Support Spark ML Vector, MLlib Vector, Array[Float], Array[Double] as feature and label column format. Also support label column of Double type. Set prediction col datatype to array[Double] for now.
2. Create a new class `DLModel` to be consistent with `DLEstimator`, and `DLClassifier` extends `DLModel`. `DLModel` and `DLEstimator` both use `HasFeatureCol` and `HasPredictionCol`. `DLClassifier` may simplify the prediction data type to Double in the future.
3. Implement `transformSchema` to allow schema validation before pipeline execution.
4. Reorganize the hierarchy so that `DLEstimator` and `DLModel` extends the same DLParams.
5. Remove the `process` method. Replace it with protected `internalFit` and `internalTransform` respectively.
6. Add HasBatchSize trait. Feature size now does not include batch size. 

## How was this patch tested?
existing unit test.

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/941

