### PR TITLE
stop SparkContext at the end

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/MLPipeline/DLEstimatorLeNet.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/MLPipeline/DLEstimatorLeNet.scala
@@ -123,6 +123,7 @@ object DLEstimatorLeNet {
         .foreach { case Row(data: DenseVector, predict: Int) =>
             println(data + "=>" + predict)
         }
+      sc.stop()
     })
 
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/loadmodel/ModelValidator.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/loadmodel/ModelValidator.scala
@@ -138,6 +138,7 @@ object ModelValidator {
       result.foreach(r => {
         logger.info(s"${ r._2 } is ${ r._1 }")
       })
+      sc.stop()
     })
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/udfpredictor/DataframePredictor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/udfpredictor/DataframePredictor.scala
@@ -116,6 +116,7 @@ object DataframePredictor {
         .sql("SELECT filename, textClassifier(text) AS textType_sql, text " +
           "FROM textTable WHERE textClassifier(text) = 9")
       filteredDF2.show()
+      sc.stop()
     }
 
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/udfpredictor/StructuredStreamPredictor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/udfpredictor/StructuredStreamPredictor.scala
@@ -143,6 +143,7 @@ object  StructuredStreamPredictor {
       aggQuery.awaitTermination()
       classifyQuery2.awaitTermination()
       filteredQuery2.awaitTermination()
+      sc.stop()
     }
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/autoencoder/Train.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/autoencoder/Train.scala
@@ -90,6 +90,7 @@ object Train {
         .setOptimMethod(optimMethod)
         .setEndWhen(Trigger.maxEpoch(param.maxEpoch))
         .optimize()
+      sc.stop()
     })
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/inception/Test.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/inception/Test.scala
@@ -59,6 +59,7 @@ object Test {
         Array(new Top1Accuracy[Float], new Top5Accuracy[Float]), param.batchSize)
 
       result.foreach(r => println(s"${r._2} is ${r._1}"))
+      sc.stop()
     }
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/inception/Train.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/inception/Train.scala
@@ -106,6 +106,7 @@ object TrainInceptionV1 {
           valSet, Array(new Top1Accuracy[Float], new Top5Accuracy[Float]))
         .setEndWhen(endTrigger)
         .optimize()
+      sc.stop()
     })
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/lenet/Test.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/lenet/Test.scala
@@ -56,6 +56,7 @@ object Test {
         Array(new Top1Accuracy[Float]), Some(param.batchSize))
 
       result.foreach(r => println(s"${r._2} is ${r._1}"))
+      sc.stop()
     }
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/resnet/Train.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/resnet/Train.scala
@@ -92,6 +92,7 @@ object Train {
           validateSet, Array(new Top1Accuracy[Float]))
         .setEndWhen(Trigger.maxEpoch(maxEpoch))
         .optimize()
+      sc.stop()
 
     })
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Test.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Test.scala
@@ -92,6 +92,7 @@ object Test {
 
       val results = flow.map(x => x.map(t => vocab.getWord(t)))
       results.foreach(x => logger.info(x.mkString(" ")))
+      sc.stop()
     }
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Train.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Train.scala
@@ -128,6 +128,7 @@ object Train {
         .setOptimMethod(optimMethod)
         .setEndWhen(Trigger.maxEpoch(param.nEpochs))
         .optimize()
+      sc.stop()
     })
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/DistriOptimizerPerf.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/DistriOptimizerPerf.scala
@@ -124,6 +124,7 @@ object DistriOptimizerPerf {
       criterion
     )
     optimizer.setEndWhen(Trigger.maxEpoch(param.maxEpoch)).optimize()
+    sc.stop()
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/Test.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/Test.scala
@@ -49,6 +49,7 @@ object Test {
       val result = model.evaluate(evaluationSet,
         Array(new Top1Accuracy[Float]), Some(param.batchSize))
       result.foreach(r => println(s"${r._2} is ${r._1}"))
+      sc.stop()
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Stop SparkContext ( sc.stop() ) at the end of each example and model

## How was this patch tested?

unit tests

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/565
