### PR TITLE
Add isTensor and isTable method in Activity with additional test cases

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/Activity.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/Activity.scala
@@ -33,6 +33,10 @@ trait Activity {
   def toTensor[D](implicit ev: TensorNumeric[D]): Tensor[D]
 
   def toTable: Table
+
+  def isTensor: Boolean
+
+  def isTable: Boolean
 }
 
 object Activity {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
@@ -614,6 +614,19 @@ trait Tensor[T] extends Serializable with TensorMath[T] with Activity {
 
   override def toTable: Table =
     throw new IllegalArgumentException("Tensor cannot be cast to Table")
+
+  /**
+    * Return true because it's a Tensor implemented from [[Activity]]
+    * @return true
+    */
+  override def isTensor: Boolean = true
+
+
+  /**
+    * Return false because it's not a Table
+    * @return
+    */
+  override def isTable: Boolean = false
 }
 
 /**

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
@@ -616,16 +616,18 @@ trait Tensor[T] extends Serializable with TensorMath[T] with Activity {
     throw new IllegalArgumentException("Tensor cannot be cast to Table")
 
   /**
-    * Return true because it's a Tensor implemented from [[Activity]]
-    * @return true
-    */
+   * Return true because it's a Tensor implemented from [[Activity]]
+   *
+   * @return true
+   */
   override def isTensor: Boolean = true
 
 
   /**
-    * Return false because it's not a Table
-    * @return
-    */
+   * Return false because it's not a Table
+   *
+   * @return false
+   */
   override def isTable: Boolean = false
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
@@ -46,15 +46,17 @@ class Table private[bigdl](
   }
 
   /**
-    * Return false because it's not a Tensor
-    * @return
-    */
+   * Return false because it's not a Tensor
+   *
+   * @return false
+   */
   override def isTensor: Boolean = false
 
   /**
-    * Return true because it's a Table implemented from [[Activity]]
-    * @return
-    */
+   * Return true because it's a Table implemented from [[Activity]]
+   *
+   * @return true
+   */
   override def isTable: Boolean = true
 
   private[bigdl] def getState(): ImmutableMap[Any, Any] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
@@ -45,6 +45,18 @@ class Table private[bigdl](
     }
   }
 
+  /**
+    * Return false because it's not a Tensor
+    * @return
+    */
+  override def isTensor: Boolean = false
+
+  /**
+    * Return true because it's a Table implemented from [[Activity]]
+    * @return
+    */
+  override def isTable: Boolean = true
+
   private[bigdl] def getState(): ImmutableMap[Any, Any] = {
     return state.toMap
   }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
@@ -18,8 +18,9 @@ package com.intel.analytics.bigdl.optim
 
 import com.intel.analytics.bigdl.nn.{ConcatTable, Linear}
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.bigdl.utils.T
+import com.intel.analytics.bigdl.utils.{T, Table}
 import org.scalatest.{FlatSpec, Matchers}
+
 import scala.util.Properties
 
 @com.intel.analytics.bigdl.tags.Parallel
@@ -40,6 +41,12 @@ class TableSpec extends FlatSpec with Matchers {
     t1.hashCode() should not equal t3.hashCode()
     t3.hashCode() should equal (t4.hashCode())
     t4.hashCode() should not equal t5.hashCode()
+  }
+
+  "Test type of Activity" should "be correct" in {
+    val t: Table = T()
+    t.isTensor should be(false)
+    t.isTable should be(true)
   }
 
   "equals()" should "behave correctly" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DenseTensorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DenseTensorSpec.scala
@@ -31,6 +31,12 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     t.nDimension should be(0)
   }
 
+  "Test type of Activity" should "be correct" in {
+    val t: Tensor[Double] = new DenseTensor[Double]()
+    t.isTensor should be(true)
+    t.isTable should be(false)
+  }
+
   "Construct with dimension list" should "return correct value" in {
     val t: Tensor[Double] = new DenseTensor[Double](1, 2, 3)
     t.nDimension should be(3)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `isTensor` and `isTable` method to `Activity` with additional test cases.
Override two methods in `Tensor` and `Table` to return corresponding value.

## How was this patch tested?

unit test with additional test cases in `TableSpec` and `DenseTensorSpec`

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/597

