### PR TITLE
Support some layers working only in evaluate mode

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Sequential.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Sequential.scala
@@ -61,9 +61,7 @@ class Sequential[T: ClassTag]
   }
 
   override def updateGradInput(input: Activity, nextError: Activity): Activity = {
-    if (evaluateOnly && isTraining()) {
-      gradInput = nextError
-    } else {
+    if (!evaluateOnly || !isTraining()) {
       var i = modules.length - 1
       var error = nextError.asInstanceOf[Activity]
       while (i > 0) {
@@ -74,6 +72,8 @@ class Sequential[T: ClassTag]
       error = modules(0).updateGradInput(input, error)
 
       this.gradInput = error
+    } else {
+      gradInput = nextError
     }
 
     gradInput
@@ -100,9 +100,7 @@ class Sequential[T: ClassTag]
   }
 
   override def backward(input: Activity, nextError: Activity): Activity = {
-    if (evaluateOnly && isTraining()) {
-      gradInput = nextError
-    } else {
+    if (!evaluateOnly || !isTraining()) {
       var i = modules.length - 1
       var error = nextError.asInstanceOf[Activity]
       while (i > 0) {
@@ -113,6 +111,8 @@ class Sequential[T: ClassTag]
       error = modules(0).backward(input, error)
 
       this.gradInput = error
+    } else {
+      gradInput = nextError
     }
 
     gradInput

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Sequential.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Sequential.scala
@@ -33,8 +33,10 @@ class Sequential[T: ClassTag]
   private var evaluateOnly = false
 
   /**
-   * If evaluateOnly = true, then this sequential only works in evaluate mode, and not work in
-   * training mode
+   * If evaluateOnly = true,
+   * in training mode, the submodules will be skipped and input directly be passed to output;
+   * in evaluation mode, the modules will process the input tensors.
+   * If evaluateOnly = false, the modules will process the data in both mode.
    * @param status contral evaluateOnly
    * @return this
    */


### PR DESCRIPTION
## What changes were proposed in this pull request?
Support some layers working only in evaluate mode

A->B->C->D

If I only want B C to work in evaluate mode(when do model validation),
then we can wrap B->C to a sequential and setEvaluateOnly(true)

## How was this patch tested?

unit test
