### PR TITLE
Remove hard code spark version as 2.0 in pom

### DIFF
--- a/spark/spark-version/2.0/pom.xml
+++ b/spark/spark-version/2.0/pom.xml
@@ -17,13 +17,13 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.major.version}</artifactId>
-            <version>2.0.0</version>
+            <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-mllib_${scala.major.version}</artifactId>
-            <version>2.0.0</version>
+            <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Remove hard code spark version as 2.0 in pom

## How was this patch tested?
manual run lenet with spark 2.1.1 and spark 2.1.0

