### PR TITLE
Add default spark config

### DIFF
--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -277,7 +277,14 @@ def create_spark_conf():
     return sparkConf
 
 
-def get_spark_context(conf = SparkConf()):
+def get_spark_context(conf = None):
+    """
+    Get the current active spark context and create one if no active instance
+    :param conf: combining bigdl configs into spark conf
+    :return: SparkContext
+    """
+    if not conf:
+        conf = create_spark_conf()
     if "getOrCreate" in SparkContext.__dict__:
         return SparkContext.getOrCreate(conf)
     else:


### PR DESCRIPTION
## What changes were proposed in this pull request?
Previously we use ``` SparkConf()``` as the default value, but actually the correct one should be ``` create_spark_conf()``` which would combining bigdl config into the default spark conf