### PR TITLE
remove tf layers from python api

### DIFF
--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -3223,55 +3223,17 @@ class SpatialSubtractiveNormalization(Layer):
                                                               n_input_plane,
                                                               JTensor.from_ndarray(kernel))
 
-class Const(Model):
-    '''
-    Return a constant tensor defined by value when forward
-    '''
 
-    def __init__(self, value, bigdl_type="float"):
-        super(Const, self).__init__(None, bigdl_type, JTensor.from_ndarray(value))
-
-class Fill(Model):
-    '''
-    Return a constant tensor defined by value when forward
-    '''
-
-    def __init__(self, value, bigdl_type="float"):
-        super(Fill, self).__init__(None, bigdl_type, value)
-
-class Pack(Model):
+class Pack(Layer):
     '''
     Stacks a list of n-dimensional tensors into one (n+1)-dimensional tensor.
+    
+    >>> layer = Pack(1)
+    creating: createPack
     '''
 
     def __init__(self, dimension, bigdl_type="float"):
         super(Pack, self).__init__(None, bigdl_type, dimension)
-
-class Shape(Model):
-    '''
-    Given input, return the shape of this input as a 1-D tensor
-    '''
-
-    def __init__(self, bigdl_type="float"):
-        super(Shape, self).__init__(None, bigdl_type)
-
-class SplitAndSelect(Model):
-    '''
-    First split the tensor along the [[dimension]] into [[numSplit]] sub tensors,
-    then select the [[index]]th one
-    '''
-
-    def __init__(self, dimension, index, num_split, bigdl_type="float"):
-        super(SplitAndSelect, self).__init__(None, bigdl_type, dimension, index, num_split)
-
-class StrideSlice(Model):
-    '''
-    Extracts a strided slice from a tensor.
-    '''
-
-    def __init__(self):
-        raise Exception('StrideSlice is not supported in python yet')
-
 
 
 def _test():

--- a/pyspark/test/dev/diff.py
+++ b/pyspark/test/dev/diff.py
@@ -28,7 +28,8 @@ scala_to_python = {"Graph": "Model"}
 
 
 def extract_scala_class(class_path):
-    exclude_key_words = set(["*", "abstract"])
+    exclude_key_words = set(["*", "abstract", "Const", "Fill", "Shape",
+                             "SplitAndSelect", "StrideSlice"])
     include_key_words = set(["Module", "Criterion", "Container", "Cell", "TensorNumeric"])  # noqa
     content = "\n".join([line for line in open(class_path).readlines() if all([key not in line for key in exclude_key_words])])  # noqa
     match = re.search(r"class ([\w]+)[^{]+", content)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -1223,24 +1223,8 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
     SoftmaxWithCriterion[T](labelToIgnore, normM)
   }
 
-  def createConst(value: JTensor): Const[T] = {
-    Const(toTensor(value))
-  }
-
-  def createFill(value: Double): Fill[T] = {
-    Fill(value)
-  }
-
   def createPack(dimension: Int): Pack[T] = {
     Pack(dimension)
-  }
-
-  def createShape(): Shape[T] = {
-    Shape()
-  }
-
-  def createSplitAndSelect(dimension: Int, index: Int, numSplit: Int): SplitAndSelect[T] = {
-    SplitAndSelect(dimension, index, numSplit)
   }
 
   def setModelSeed(seed: Long): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Const, Fill, SplitAndSelect, Shape

The above layers are created to match the tf counterparts and should not be used by user directly. Remove them from python api. 

## How was this patch tested?
add unit tests, modify existing tests
