### PR TITLE
remove init_method from python constructor to be compatible with scala api

### DIFF
--- a/docs/docs/APIdocs/layers/nn/Convolution Layers/SpatialConvolution.md
+++ b/docs/docs/APIdocs/layers/nn/Convolution Layers/SpatialConvolution.md
@@ -6,7 +6,7 @@ val m = SpatialConvolution(nInputPlane,nOutputPlane,kernelW,kernelH,strideW=1,st
 ```
 **Python:**
 ```python
-m = SpatialConvolution(n_input_plane,n_output_plane,kernel_w,kernel_h,stride_w=1,stride_h=1,pad_w=0,pad_h=0,n_group=1,propagate_back=True,init_method="default")
+m = SpatialConvolution(n_input_plane,n_output_plane,kernel_w,kernel_h,stride_w=1,stride_h=1,pad_w=0,pad_h=0,n_group=1,propagate_back=True,wRegularizer=None,bRegularizer=None,init_weight=None,init_bias=None,init_grad_weight=None,init_grad_bias=None)
 ```
 
 SpatialConvolution is a module that applies a 2D convolution over an input image.

--- a/docs/docs/APIdocs/layers/nn/Loss Functions/DiceCoefficientCriterion.md
+++ b/docs/docs/APIdocs/layers/nn/Loss Functions/DiceCoefficientCriterion.md
@@ -6,7 +6,7 @@ val loss = DiceCoefficientCriterion(sizeAverage=true, epsilon=1.0f)
 ```
 **Python:**
 ```python
-loss = DiceCoefficientCriterion(size_average,epsilon)
+loss = DiceCoefficientCriterion(size_average=True,epsilon=1.0)
 ```
 
 DiceCoefficientCriterion is the Dice-Coefficient objective function. 

--- a/docs/docs/APIdocs/layers/nn/Simple Layers/Linear.md
+++ b/docs/docs/APIdocs/layers/nn/Simple Layers/Linear.md
@@ -21,7 +21,11 @@ module = Linear(
   init_method="default",
   with_bias=True,
   wRegularizer=None,
-  bRegularizer=None)
+  bRegularizer=None,
+  init_weight=None,
+  init_bias=None,
+  init_grad_weight=None,
+  init_grad_bias=None)
 ```
 
 The `Linear` module applies a linear transformation to the input data,

--- a/docs/docs/APIdocs/layers/nn/Simple Layers/Mean.md
+++ b/docs/docs/APIdocs/layers/nn/Simple Layers/Mean.md
@@ -6,7 +6,7 @@ val m = Mean(dimension=1, nInputDims=-1, squeeze=true)
 ```
 **Python:**
 ```python
-m = Mean(dimension=1,n_input_dims=-1)
+m = Mean(dimension=1,n_input_dims=-1, squeeze=True)
 ```
 
 Mean is a module that simply applies a mean operation over the given dimension - specified by `dimension` (starting from 1).

--- a/docs/docs/APIdocs/layers/nn/Simple Layers/Sum.md
+++ b/docs/docs/APIdocs/layers/nn/Simple Layers/Sum.md
@@ -6,7 +6,7 @@ val m = Sum(dimension=1,nInputDims=-1,sizeAverage=false,squeeze=true)
 ```
 **Python:**
 ```python
-m = Sum(dimension=1,n_input_dims=-1,size_average=False)
+m = Sum(dimension=1,n_input_dims=-1,size_average=False,squeeze=True)
 ```
 
 Sum is a module that simply applies a sum operation over the given dimension - specified by the argument `dimension` (starting from 1). 

--- a/pyspark/bigdl/nn/criterion.py
+++ b/pyspark/bigdl/nn/criterion.py
@@ -686,11 +686,13 @@ class DiceCoefficientCriterion(Criterion):
 
     >>> diceCoefficientCriterion = DiceCoefficientCriterion(size_average = True, epsilon = 1.0)
     creating: createDiceCoefficientCriterion
+    >>> diceCoefficientCriterion = DiceCoefficientCriterion()
+    creating: createDiceCoefficientCriterion
     '''
 
     def __init__(self,
-                 size_average,
-                 epsilon,
+                 size_average=True,
+                 epsilon=1.0,
                  bigdl_type="float"):
         super(DiceCoefficientCriterion, self).__init__(None, bigdl_type,
                                                        size_average,

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -443,25 +443,33 @@ class Linear(Layer):
 
     :param input_size the size the each input sample
     :param output_size the size of the module output of each sample
-    :param init_method: two initialized methods are supported here, which are [[Default]]and [[Xavier]], where [[Xavier]] set bias to zero here. For moredetailed information about `initMethod`, please refer to[[InitializationMethod]]
     :param wRegularizer: instance of [[Regularizer]](eg. L1 or L2 regularization), applied to the input weights matrices.
     :param bRegularizer: instance of [[Regularizer]]applied to the bias.
+    :param init_weight: the optional initial value for the weight
+    :param init_bias: the optional initial value for the bias
+    :param init_grad_weight: the optional initial value for the grad_weight
+    :param init_grad_bias: the optional initial value for the grad_bias
 
 
-    >>> linear = Linear(100, 10, "Xavier", True, L1Regularizer(0.5), L1Regularizer(0.5))
+    >>> linear = Linear(100, 10, True, L1Regularizer(0.5), L1Regularizer(0.5))
     creating: createL1Regularizer
     creating: createL1Regularizer
     creating: createLinear
     '''
 
-    def __init__(self, input_size, output_size, init_method="default", with_bias=True, wRegularizer=None, bRegularizer=None,
-                 bigdl_type="float"):
+    def __init__(self, input_size, output_size, with_bias=True, wRegularizer=None, bRegularizer=None,
+                 init_weight=None, init_bias=None, init_grad_weight=None, init_grad_bias=None, bigdl_type="float"):
         super(Linear, self).__init__(None, bigdl_type, input_size, output_size,
-                                     init_method, with_bias, wRegularizer, bRegularizer)
+                                     with_bias, wRegularizer, bRegularizer,
+                                     JTensor.from_ndarray(init_weight),
+                                     JTensor.from_ndarray(init_bias),
+                                     JTensor.from_ndarray(init_grad_weight),
+                                     JTensor.from_ndarray(init_grad_bias))
 
     def set_init_method(self, weight_init_method = None, bias_init_method = None):
         callBigDlFunc(self.bigdl_type, "setInitMethod", self.value,
                                    weight_init_method, bias_init_method)
+        return self
 
 
 class ReLU(Layer):
@@ -568,9 +576,12 @@ class SpatialConvolution(Layer):
     :param pad_h The additional zeros added per height to the input planes.
     :param n_group Kernel group number
     :param propagate_back Propagate gradient back
-    :param init_method Initialization method to initialize bias and weight
     :param wRegularizer: instance of [[Regularizer]](eg. L1 or L2 regularization), applied to the input weights matrices.
     :param bRegularizer: instance of [[Regularizer]]applied to the bias.
+    :param init_weight: the optional initial value for the weight
+    :param init_bias: the optional initial value for the bias
+    :param init_grad_weight: the optional initial value for the grad_weight
+    :param init_grad_bias: the optional initial value for the grad_bias
 
     >>> spatialConvolution = SpatialConvolution(6, 12, 5, 5)
     creating: createSpatialConvolution
@@ -594,6 +605,10 @@ class SpatialConvolution(Layer):
                  init_method="default",
                  wRegularizer=None,
                  bRegularizer=None,
+                 init_weight=None,
+                 init_bias=None,
+                 init_grad_weight=None,
+                 init_grad_bias=None,
                  bigdl_type="float"):
         super(SpatialConvolution, self).__init__(None, bigdl_type,
                                                  n_input_plane,
@@ -608,10 +623,15 @@ class SpatialConvolution(Layer):
                                                  propagate_back,
                                                  init_method,
                                                  wRegularizer,
-                                                 bRegularizer)
+                                                 bRegularizer,
+                                                 JTensor.from_ndarray(init_weight),
+                                                 JTensor.from_ndarray(init_bias),
+                                                 JTensor.from_ndarray(init_grad_weight),
+                                                 JTensor.from_ndarray(init_grad_bias))
     def set_init_method(self, weight_init_method = None, bias_init_method = None):
         callBigDlFunc(self.bigdl_type, "setInitMethod", self.value,
                   weight_init_method, bias_init_method)
+        return self
 
 
 class SpatialMaxPooling(Layer):
@@ -943,6 +963,7 @@ class SpatialBatchNormalization(Layer):
     def set_init_method(self, weight_init_method = None, bias_init_method = None):
         callBigDlFunc(self.bigdl_type, "setInitMethod", self.value,
                       weight_init_method, bias_init_method)
+        return self
 
 
 class SpatialCrossMapLRN(Layer):
@@ -1071,6 +1092,7 @@ class Add(Layer):
     def set_init_method(self, weight_init_method = None, bias_init_method = None):
         callBigDlFunc(self.bigdl_type, "setInitMethod", self.value,
                       weight_init_method, bias_init_method)
+        return self
 
 
 class AddConstant(Layer):
@@ -1140,6 +1162,7 @@ class BatchNormalization(Layer):
     def set_init_method(self, weight_init_method = None, bias_init_method = None):
         callBigDlFunc(self.bigdl_type, "setInitMethod", self.value,
                       weight_init_method, bias_init_method)
+        return self
 
 
 class Bilinear(Layer):
@@ -1179,6 +1202,7 @@ class Bilinear(Layer):
     def set_init_method(self, weight_init_method = None, bias_init_method = None):
         callBigDlFunc(self.bigdl_type, "setInitMethod", self.value,
                       weight_init_method, bias_init_method)
+        return self
 
 
 class Bottle(Container):
@@ -1236,6 +1260,7 @@ class CAdd(Layer):
     def set_init_method(self, weight_init_method = None, bias_init_method = None):
         callBigDlFunc(self.bigdl_type, "setInitMethod", self.value,
                       weight_init_method, bias_init_method)
+        return self
 
 
 class CAddTable(Layer):
@@ -1326,6 +1351,7 @@ class CMul(Layer):
     def set_init_method(self, weight_init_method = None, bias_init_method = None):
         callBigDlFunc(self.bigdl_type, "setInitMethod", self.value,
                       weight_init_method, bias_init_method)
+        return self
 
 
 class CMulTable(Layer):
@@ -1427,6 +1453,7 @@ class Cosine(Layer):
     def set_init_method(self, weight_init_method = None, bias_init_method = None):
         callBigDlFunc(self.bigdl_type, "setInitMethod", self.value,
                       weight_init_method, bias_init_method)
+        return self
 
 
 class CosineDistance(Layer):
@@ -1510,6 +1537,7 @@ class Euclidean(Layer):
     def set_init_method(self, weight_init_method = None, bias_init_method = None):
         callBigDlFunc(self.bigdl_type, "setInitMethod", self.value,
                       weight_init_method, bias_init_method)
+        return self
 
 
 class Exp(Layer):
@@ -1833,6 +1861,7 @@ class LookupTable(Layer):
     def set_init_method(self, weight_init_method = None, bias_init_method = None):
         callBigDlFunc(self.bigdl_type, "setInitMethod", self.value,
                       weight_init_method, bias_init_method)
+        return self
 
 
 class MM(Layer):
@@ -1948,19 +1977,21 @@ class Mean(Layer):
 
     :param dimension: the dimension to be applied mean operation
     :param n_input_dims: specify the number of dimensions that this module will receiveIf it is more than the dimension of input tensors, the first dimension would be consideredas batch size
+    :param squeeze: default is true, which will squeeze the sum dimension; set it to false to keep the sum dimension 
 
-
-    >>> mean = Mean(1, 1)
+    >>> mean = Mean(1, 1, True)
     creating: createMean
     '''
 
     def __init__(self,
                  dimension=1,
                  n_input_dims=-1,
+                 squeeze=True,
                  bigdl_type="float"):
         super(Mean, self).__init__(None, bigdl_type,
                                    dimension,
-                                   n_input_dims)
+                                   n_input_dims,
+                                   squeeze)
 
 
 class Min(Layer):
@@ -2025,6 +2056,7 @@ class Mul(Layer):
     def set_init_method(self, weight_init_method = None, bias_init_method = None):
         callBigDlFunc(self.bigdl_type, "setInitMethod", self.value,
                       weight_init_method, bias_init_method)
+        return self
 
 
 class MulConstant(Layer):
@@ -2151,6 +2183,7 @@ class PReLU(Layer):
     def set_init_method(self, weight_init_method = None, bias_init_method = None):
         callBigDlFunc(self.bigdl_type, "setInitMethod", self.value,
                       weight_init_method, bias_init_method)
+        return self
 
 
 class Padding(Layer):
@@ -2629,6 +2662,7 @@ class SpatialDilatedConvolution(Layer):
     def set_init_method(self, weight_init_method = None, bias_init_method = None):
         callBigDlFunc(self.bigdl_type, "setInitMethod", self.value,
                       weight_init_method, bias_init_method)
+        return self
 
 
 class SpatialFullConvolution(Layer):
@@ -2712,6 +2746,7 @@ class SpatialFullConvolution(Layer):
     def set_init_method(self, weight_init_method = None, bias_init_method = None):
         callBigDlFunc(self.bigdl_type, "setInitMethod", self.value,
                       weight_init_method, bias_init_method)
+        return self
 
 
 class SpatialShareConvolution(Layer):
@@ -2750,6 +2785,7 @@ class SpatialShareConvolution(Layer):
     def set_init_method(self, weight_init_method = None, bias_init_method = None):
         callBigDlFunc(self.bigdl_type, "setInitMethod", self.value,
                       weight_init_method, bias_init_method)
+        return self
 
 
 class VolumetricConvolution(Layer):
@@ -2810,6 +2846,7 @@ class VolumetricConvolution(Layer):
     def set_init_method(self, weight_init_method = None, bias_init_method = None):
         callBigDlFunc(self.bigdl_type, "setInitMethod", self.value,
                       weight_init_method, bias_init_method)
+        return self
 
 
 class VolumetricMaxPooling(Layer):
@@ -2987,9 +3024,10 @@ class Sum(Layer):
     :param dimension: the dimension to be applied sum operation
     :param n_input_dims: specify the number of dimensions that this module will receiveIf it is more than the dimension of input tensors, the first dimensionwould be considered as batch size
     :param size_average: default is false, if it is true, it will return the mean instead
+    :param squeeze: default is true, which will squeeze the sum dimension; set it to false to keep the sum dimension
 
 
-    >>> sum = Sum(1, 1, True)
+    >>> sum = Sum(1, 1, True, True)
     creating: createSum
     '''
 

--- a/pyspark/test/simple_integration_test.py
+++ b/pyspark/test/simple_integration_test.py
@@ -16,6 +16,7 @@
 # Still in experimental stage!
 
 from bigdl.nn.layer import *
+from bigdl.nn.initialization_method import *
 from bigdl.nn.criterion import *
 from bigdl.optim.optimizer import *
 from bigdl.util.common import *
@@ -116,8 +117,10 @@ class TestWorkFlow(unittest.TestCase):
         self.assertTrue(result.get("spark.executorEnv.OMP_WAIT_POLICY"), "passive")
 
     def test_set_seed(self):
-        l1 = Linear(10, 20, "Xavier").set_name("linear1").set_seed(1234).reset()  # noqa
-        l2 = Linear(10, 20, "Xavier").set_name("linear2").set_seed(1234).reset()  # noqa
+        w_init = Xavier()
+        b_init = Zeros()
+        l1 = Linear(10, 20).set_init_method(w_init, b_init).set_name("linear1").set_seed(1234).reset()  # noqa
+        l2 = Linear(10, 20).set_init_method(w_init, b_init).set_name("linear2").set_seed(1234).reset()  # noqa
         p1 = l1.parameters()
         p2 = l2.parameters()
         self.assertTrue((p1["linear1"]["weight"] == p2["linear2"]["weight"]).all())  # noqa
@@ -137,13 +140,14 @@ class TestWorkFlow(unittest.TestCase):
             lambda i: gen_rand_sample())
 
         model_test = Sequential()
-        l1_test = Linear(FEATURES_DIM, 1, "Xavier").set_name("linear1_test")
+        l1_test = Linear(FEATURES_DIM, 1).set_init_method(Xavier(), Zeros())\
+            .set_name("linear1_test")
         self.assertEqual("linear1_test", l1_test.name())
         model_test.add(l1_test)
         model_test.add(Sigmoid())
 
         model = Sequential()
-        l1 = Linear(FEATURES_DIM, 1, "Xavier").set_name("linear1")
+        l1 = Linear(FEATURES_DIM, 1).set_init_method(Xavier(), Zeros()).set_name("linear1")
         self.assertEqual("linear1", l1.name())
         model.add(l1)
 
@@ -305,7 +309,8 @@ class TestWorkFlow(unittest.TestCase):
         label = (features).sum() + 0.4
         predict_data = self.sc.parallelize(range(0, total_length)).map(
             lambda i: Sample.from_ndarray(features[i], label))
-        model = Linear(2, 1, "Xavier").set_name("linear1").set_seed(1234).reset()
+        model = Linear(2, 1).set_init_method(Xavier(), Zeros())\
+            .set_name("linear1").set_seed(1234).reset()
         predict_result = model.predict(predict_data)
         p = predict_result.take(6)
         ground_label = np.array([[-0.47596836], [-0.37598032], [-0.00492062],

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -205,15 +205,15 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   }
 
   def createLinear(inputSize: Int, outputSize: Int,
-                   initMethod: String, withBias: Boolean,
+                   withBias: Boolean,
                    wRegularizer: Regularizer[T] = null,
-                   bRegularizer: Regularizer[T] = null): Linear[T] = {
-    val l = Linear[T](inputSize, outputSize, withBias, wRegularizer, bRegularizer)
-    if (initMethod != "default") {
-      l.setInitMethod(weightInitMethod = PythonBigDL.getInitMethod(initMethod),
-      biasInitMethod = Zeros)
-    }
-    l
+                   bRegularizer: Regularizer[T] = null,
+                   initWeight: Tensor[T] = null,
+                   initBias: Tensor[T] = null,
+                   initGradWeight: Tensor[T] = null,
+                   initGradBias: Tensor[T] = null): Linear[T] = {
+    Linear[T](inputSize, outputSize, withBias, wRegularizer, bRegularizer,
+      initWeight, initBias, initGradWeight, initGradBias)
   }
 
   def createReLU(ip: Boolean = false): ReLU[T] = {
@@ -314,9 +314,14 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
                                propagateBack: Boolean = true,
                                initMethod: String = "default",
                                wRegularizer: Regularizer[T] = null,
-                               bRegularizer: Regularizer[T] = null)
+                               bRegularizer: Regularizer[T] = null,
+                               initWeight: Tensor[T] = null,
+                               initBias: Tensor[T] = null,
+                               initGradWeight: Tensor[T] = null,
+                               initGradBias: Tensor[T] = null
+                              )
   : SpatialConvolution[T] = {
-    val s = SpatialConvolution[T](nInputPlane,
+    SpatialConvolution[T](nInputPlane,
       nOutputPlane,
       kernelW,
       kernelH,
@@ -327,12 +332,12 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
       nGroup,
       propagateBack,
       wRegularizer,
-      bRegularizer)
-    if (initMethod != "default") {
-      s.setInitMethod(weightInitMethod = PythonBigDL.getInitMethod(initMethod),
-        biasInitMethod = Zeros)
-    }
-    s
+      bRegularizer,
+      initWeight,
+      initBias,
+      initGradWeight,
+      initGradBias
+    )
   }
 
   def createReshape(size: JList[Int], batchMode: JBoolean = null): Reshape[T] = {
@@ -656,10 +661,12 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   }
 
   def createMean(dimension: Int = 1,
-                 nInputDims: Int = -1)
+                 nInputDims: Int = -1,
+                 squeeze: Boolean = true)
   : Mean[T] = {
     Mean[T](dimension,
-      nInputDims)
+      nInputDims,
+      squeeze)
   }
 
   def createMin(dim: Int = 1,


### PR DESCRIPTION
## What changes were proposed in this pull request?

remove init_method from python constructor to be compatible with scala api

## How was this patch tested?

existing tests

## Related links or issues (optional)
fixed #1056 #1029 

