### PR TITLE
[Issue 864] save module weights, load (all / part) module weights

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -464,7 +464,7 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag,
   def loadWeights(weightPath: String, matchAll: Boolean = true): this.type = {
     val srcParameter = File.load[Table](weightPath)
     val targetParameter = getParametersTable()
-    copyWeights(targetParameter, srcParameter)
+    copyWeights(targetParameter, srcParameter, matchAll)
     this
   }
 
@@ -475,13 +475,13 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag,
    * @return current module
    */
   def loadModelWeights(srcModel: Module[Float], matchAll: Boolean = true): this.type = {
-    val srcParameters = srcModel.getParametersTable()
-    val parameterTable = getParametersTable()
-    copyWeights(parameterTable, srcParameters, matchAll)
+    val srcParameter = srcModel.getParametersTable()
+    val targetParameter = getParametersTable()
+    copyWeights(targetParameter, srcParameter, matchAll)
     this
   }
 
-  private def copyWeights(target: Table, src: Table, matchAll: Boolean = true): Unit = {
+  private def copyWeights(target: Table, src: Table, matchAll: Boolean): Unit = {
     target.foreach {
       case (name: String, targetParams: Table) =>
         if (src.contains(name)) {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/AbstractModuleSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/AbstractModuleSpec.scala
@@ -172,4 +172,37 @@ class AbstractModuleSpec extends FlatSpec with Matchers {
 
     module.parameters()._1 should be(module2.parameters()._1)
   }
+
+  "loadModelWeights" should "work properly" in {
+    val module = Sequential()
+
+    module.add(SpatialConvolution(1, 6, 5, 5).setName("conv1"))
+    module.add(Tanh())
+    module.add(SpatialMaxPooling(2, 2, 2, 2))
+    // stage 2 : filter bank -> squashing -> max pooling
+    module.add(SpatialConvolution(6, 12, 5, 5).setName("conv2"))
+    module.add(Tanh())
+    module.add(SpatialMaxPooling(2, 2, 2, 2))
+    // stage 3 : standard 2-layer neural network
+    module.add(Reshape(Array(12 * 5 * 5)))
+    module.add(Linear(12 * 5 * 5, 100).setName("l1"))
+    module.add(Tanh())
+    module.add(Linear(100, 6).setName("l2"))
+    module.add(LogSoftMax())
+
+    val module2 = Sequential()
+
+    module2.add(SpatialConvolution(1, 6, 5, 5).setName("conv1"))
+    module2.add(SpatialMaxPooling(2, 2, 2, 2))
+    // stage 2 : filter bank -> squashing -> max pooling
+    module2.add(SpatialConvolution(6, 12, 5, 5).setName("conv2"))
+    module2.add(SpatialMaxPooling(2, 2, 2, 2))
+    // stage 3 : standard 2-layer neural network
+    module2.add(Reshape(Array(12 * 5 * 5)))
+    module2.add(Linear(12 * 5 * 5, 100).setName("l1"))
+    module2.add(Linear(100, 6).setName("l2"))
+    module.loadModelWeights(module2)
+
+    module.parameters()._1 should be(module2.parameters()._1)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/AbstractModuleSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/AbstractModuleSpec.scala
@@ -15,6 +15,7 @@
  */
 package com.intel.analytics.bigdl.nn
 
+import com.intel.analytics.bigdl._
 import org.scalatest.{FlatSpec, Matchers}
 import com.intel.analytics.bigdl.numeric.NumericFloat
 
@@ -70,5 +71,105 @@ class AbstractModuleSpec extends FlatSpec with Matchers {
     intercept[IllegalArgumentException] {
       s("module").get
     }
+  }
+
+  "weights save and load" should "work properly" in {
+    val tmpFile = java.io.File.createTempFile("module", "obj")
+    val absolutePath = tmpFile.getAbsolutePath
+    val module = Sequential()
+
+    module.add(SpatialConvolution(1, 6, 5, 5).setName("conv1"))
+    module.add(Tanh())
+    module.add(SpatialMaxPooling(2, 2, 2, 2))
+    // stage 2 : filter bank -> squashing -> max pooling
+    module.add(SpatialConvolution(6, 12, 5, 5).setName("conv2"))
+    module.add(Tanh())
+    module.add(SpatialMaxPooling(2, 2, 2, 2))
+    // stage 3 : standard 2-layer neural network
+    module.add(Reshape(Array(12 * 5 * 5)))
+    module.add(Linear(12 * 5 * 5, 100).setName("l1"))
+    module.add(Tanh())
+    module.add(Linear(100, 6).setName("l2"))
+    module.add(LogSoftMax())
+
+    val module2 = Sequential()
+
+    module2.add(SpatialConvolution(1, 6, 5, 5).setName("conv1"))
+    module2.add(Tanh())
+    module2.add(SpatialMaxPooling(2, 2, 2, 2))
+    // stage 2 : filter bank -> squashing -> max pooling
+    module2.add(SpatialConvolution(6, 12, 5, 5).setName("conv2"))
+    module2.add(Tanh())
+    module2.add(SpatialMaxPooling(2, 2, 2, 2))
+    // stage 3 : standard 2-layer neural network
+    module2.add(Reshape(Array(12 * 5 * 5)))
+    module2.add(Linear(12 * 5 * 5, 100).setName("l1"))
+    module2.add(Tanh())
+    module2.add(Linear(100, 6).setName("l2"))
+    module2.add(LogSoftMax())
+
+    module.saveWeights(absolutePath, true)
+
+    module2.loadWeights(absolutePath)
+
+    module.parameters()._1 should be(module2.parameters()._1)
+  }
+
+  "weights save and load with different model definition" should "work properly" in {
+    val tmpFile = java.io.File.createTempFile("module", "obj")
+    val absolutePath = tmpFile.getAbsolutePath
+    val module = Sequential()
+
+    module.add(SpatialConvolution(1, 6, 5, 5).setName("conv1"))
+    module.add(Tanh())
+    module.add(SpatialMaxPooling(2, 2, 2, 2))
+    // stage 2 : filter bank -> squashing -> max pooling
+    module.add(SpatialConvolution(6, 12, 5, 5).setName("conv2"))
+    module.add(Tanh())
+    module.add(SpatialMaxPooling(2, 2, 2, 2))
+    // stage 3 : standard 2-layer neural network
+    module.add(Reshape(Array(12 * 5 * 5)))
+    module.add(Linear(12 * 5 * 5, 100).setName("l1"))
+    module.add(Tanh())
+    module.add(Linear(100, 6).setName("l2"))
+    module.add(LogSoftMax())
+
+    val module2 = Sequential()
+
+    module2.add(SpatialConvolution(1, 6, 5, 5).setName("conv1"))
+    module2.add(SpatialMaxPooling(2, 2, 2, 2))
+    // stage 2 : filter bank -> squashing -> max pooling
+    module2.add(SpatialConvolution(6, 12, 5, 5).setName("conv2"))
+    module2.add(SpatialMaxPooling(2, 2, 2, 2))
+    // stage 3 : standard 2-layer neural network
+    module2.add(Reshape(Array(12 * 5 * 5)))
+    module2.add(Linear(12 * 5 * 5, 100).setName("l1"))
+    module2.add(Linear(100, 6).setName("l2"))
+
+    module.saveWeights(absolutePath, true)
+
+    module2.loadWeights(absolutePath)
+
+    module.parameters()._1 should be(module2.parameters()._1)
+  }
+
+  "weights save and load with only weight or bias" should "work properly" in {
+    val tmpFile = java.io.File.createTempFile("module", "obj")
+    val absolutePath = tmpFile.getAbsolutePath
+    val module = Sequential()
+
+    module.add(CMul(Array(1, 4, 1, 1)).setName("cmul"))
+    module.add(CAdd(Array(1, 4, 1, 1)).setName("cadd"))
+
+    val module2 = Sequential()
+
+    module2.add(CMul(Array(1, 4, 1, 1)).setName("cmul"))
+    module2.add(CAdd(Array(1, 4, 1, 1)).setName("cadd"))
+
+    module.saveWeights(absolutePath, true)
+
+    module2.loadWeights(absolutePath)
+
+    module.parameters()._1 should be(module2.parameters()._1)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

load and save weights.

This is useful for finetuning, If you need to load weights into a different architecture (with some layers in common), for instance for fine-tuning or transfer-learning, you can load weights by layer name.

## How was this patch tested?

unit test

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/864

