### PR TITLE
Add setup file for python distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ nohup.out
 *.log
 *.un~
 .ipynb_checkpoints/
+pyspark/dist/
+pyspark/build/
+

--- a/pyspark/MANIFEST.in
+++ b/pyspark/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include bigdl/share *

--- a/pyspark/bigdl/models/lenet/lenet5.py
+++ b/pyspark/bigdl/models/lenet/lenet5.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
         parameters = trained_model.parameters()
     elif options.action == "test":
         # Load a pre-trained model and then validate it through top1 accuracy.
-        test_data = get_minst(sc, "test").map(
+        test_data = get_mnist(sc, "test").map(
             normalizer(mnist.TEST_MEAN, mnist.TEST_STD))
         model = Model.load(options.modelPath)
         results = model.test(test_data, options.batchSize, ["Top1Accuracy"])

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
+import os
 import sys
+import glob
 from py4j.protocol import Py4JJavaError
 from py4j.java_gateway import JavaObject
 from py4j.java_collections import ListConverter, JavaArray, JavaList, JavaMap
@@ -26,6 +28,7 @@ from pyspark.mllib.common import callJavaFunc
 from pyspark import SparkConf
 import numpy as np
 import threading
+from bigdl.util.engine import prepare_env
 
 INTMAX = 2147483647
 INTMIN = -2147483648
@@ -162,7 +165,7 @@ class JTensor(object):
         Utility method to flatten a ndarray
 
         :return: (storage, shape)
-        
+
         >>> from bigdl.util.common import JTensor
         >>> np.random.seed(123)
         >>> data = np.random.uniform(0, 1, (2, 3))
@@ -287,15 +290,10 @@ def get_spark_context(conf = None):
     :param conf: combining bigdl configs into spark conf
     :return: SparkContext
     """
-    if not conf:
-        conf = create_spark_conf()
-    if "getOrCreate" in SparkContext.__dict__:
-        return SparkContext.getOrCreate(conf)
-    else:
-        with SparkContext._lock: # Compatible with Spark1.5.1
-            if SparkContext._active_spark_context is None:
-                SparkContext(conf)
-            return SparkContext._active_spark_context
+    with SparkContext._lock:  # Compatible with Spark1.5.1
+        if SparkContext._active_spark_context is None:
+            SparkContext(conf=conf or create_spark_conf())
+        return SparkContext._active_spark_context
 
 
 def get_spark_sql_context(sc):

--- a/pyspark/bigdl/util/engine.py
+++ b/pyspark/bigdl/util/engine.py
@@ -1,0 +1,62 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+import os
+import glob
+
+def __prepare_spark_env():
+    modules = sys.modules
+    if "pyspark" not in modules or "py4j" not in modules:
+        spark_home = os.environ.get('SPARK_HOME', None)
+        if not spark_home:
+            raise ValueError(
+                """Could not find Spark. Pls make sure SPARK_HOME env is set:
+                   export SPARK_HOME=path to your spark home directory""")
+        py4j = glob.glob(os.path.join(spark_home, 'python/lib', 'py4j-*.zip'))[0]
+        pyspark = glob.glob(os.path.join(spark_home, 'python/lib', 'pyspark*.zip'))[0]
+        sys.path.insert(0, py4j)
+        sys.path.insert(0, pyspark)
+
+
+def __prepare_bigdl_env():
+    import bigdl.nn.layer
+    jar_dir = os.path.abspath(bigdl.nn.layer.__file__ + "/../../")
+    jar_paths = glob.glob(os.path.join(jar_dir, "share/lib/*.jar"))
+    conf_paths = glob.glob(os.path.join(jar_dir, "share/conf/*.conf"))
+
+    def append_path(env_var_name, path):
+        try:
+            os.environ[env_var_name] = path + ":" + os.environ[
+                env_var_name]  # noqa
+        except KeyError:
+            os.environ[env_var_name] = path
+
+    if conf_paths and conf_paths:
+        assert len(conf_paths) == 1, "Expecting one jar: %s" % len(jar_paths)
+        assert len(conf_paths) == 1, "Expecting one conf: %s" % len(conf_paths)
+        print("Adding %s to spark.driver.extraClassPath" % jar_paths[0])
+        print("Adding %s to spark.executor.extraClassPath" % jar_paths[0])
+        append_path("spark.driver.extraClassPath", jar_paths[0])
+        append_path("spark.executor.extraClassPath", jar_paths[0])
+        append_path("SPARK_CLASSPATH", jar_paths[0])
+        print("Prepending %s to sys.path" % conf_paths[0])
+        sys.path.insert(0, conf_paths[0])
+
+
+def prepare_env():
+    __prepare_spark_env()
+    __prepare_bigdl_env()

--- a/pyspark/bigdl/version.py
+++ b/pyspark/bigdl/version.py
@@ -14,5 +14,4 @@
 # limitations under the License.
 #
 
-from bigdl.util.engine import prepare_env
-prepare_env()
+__version__ = "0.2.0.dev2"

--- a/pyspark/setup.cfg
+++ b/pyspark/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+description-file = README.md

--- a/pyspark/setup.py
+++ b/pyspark/setup.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import sys
+from shutil import copyfile, copytree, rmtree
+
+from setuptools import setup
+
+TEMP_PATH = "bigdl/share"
+bigdl_home = os.path.abspath(__file__ + "/../../")
+
+try:
+    exec(open('bigdl/version.py').read())
+except IOError:
+    print("Failed to load Bigdl version file for packaging. You must be in Bigdl's pyspark dir.")
+    sys.exit(-1)
+
+VERSION = __version__
+
+building_error_msg = """
+If you are packing python API from BigDL source, you must build BigDL first
+and run sdist.
+    To build BigDL with maven you can run:
+      cd $BigDL_HOME
+      ./make-dist.sh
+    Building the source dist is done in the Python directory:
+      cd pyspark
+      python setup.py sdist
+      pip install dist/*.tar.gz"""
+
+def build_from_source():
+    code_path = bigdl_home + "/pyspark/bigdl/util/common.py"
+    print("Checking: %s to see if build from source" % code_path)
+    if os.path.exists(code_path):
+        return True
+    return False
+
+
+def init_env():
+    if build_from_source():
+        print("Start to build distributed package")
+        print("HOME OF BIGDL: " + bigdl_home)
+        dist_source = bigdl_home + "/dist"
+        if not os.path.exists(dist_source):
+            print(building_error_msg)
+            sys.exit(-1)
+        if os.path.exists(TEMP_PATH):
+            rmtree(TEMP_PATH)
+        copytree(dist_source, TEMP_PATH)
+        copyfile(bigdl_home + "/pyspark/bigdl/nn/__init__.py", TEMP_PATH + "/__init__.py")
+    else:
+        print("Do nothing for release installation")
+
+
+def setup_package():
+    metadata = dict(
+        name='BigDL',
+        version=VERSION,
+        description='Distributed Deep Learning Library for Apache Spark',
+        author='BigDL Authors',
+        author_email='bigdl-user-group@googlegroups.com',
+        license='Apache License, Version 2.0',
+        url='https://github.com/intel-analytics/Bigdl',
+        packages=['bigdl',
+                  'bigdl.dataset',
+                  'bigdl.nn',
+                  'bigdl.optim',
+                  'bigdl.util',
+                  'bigdl.share'],
+        install_requires=['numpy>=1.7'],
+        dependency_links=['https://d3kbcqa49mib13.cloudfront.net/spark-2.0.0-bin-hadoop2.7.tgz'],
+        include_package_data=True,
+        package_data={"bigdl.share": ['bigdl/share/lib', 'bigdl/share/conf', 'bigdl/share/bin']},
+        classifiers=[
+            'License :: OSI Approved :: Apache Software License',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.4',
+            'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: Implementation :: CPython'],
+        platforms=['mac', 'linux']
+    )
+
+    setup(**metadata)
+
+
+if __name__ == '__main__':
+    try:
+        init_env()
+        setup_package()
+    except Exception as e:
+        raise e
+    finally:
+        if build_from_source() and os.path.exists(TEMP_PATH):
+             rmtree(TEMP_PATH)
+


### PR DESCRIPTION
## What changes were proposed in this pull request?

In general, python project would contain a setup file for packaging or distributing. This PR aims to fulfill this and provide a pip installable BigDL package.

You can install BigDL via pip very soon.

- export SPARK_HOME=path to spark2.x. (This step can be skip if we can install spark via pip.)
i.e:  export SPARK_HOME=/home/zhichao/ spark-2.0.0-bin-hadoop2.6/

- pip install BigDL

- Launch python
```
from bigdl.util.common import *
from bigdl.nn.layer import *
init_engine()
linear = Linear(2, 3)
```
- Verify the bigdl version in case the older version is installed:
```
>>> import bigdl.version
>>> bigdl.version.__version__
'0.2.0.dev2'
```


## How was this patch tested?
manual test
