### PR TITLE
add preTopology to boost performance of rnn

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cell.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cell.scala
@@ -60,6 +60,8 @@ abstract class Cell[T : ClassTag](
    */
   var cell: AbstractModule[Activity, Activity, T]
 
+  def preTopology: AbstractModule[Activity, Activity, T] = null
+
   /**
    * resize the hidden parameters wrt the batch size, hiddens shapes.
    *

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cell.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cell.scala
@@ -60,6 +60,17 @@ abstract class Cell[T : ClassTag](
    */
   var cell: AbstractModule[Activity, Activity, T]
 
+  /**
+   * The preTopology defines operations to pre-process the input when it is not dependent
+   * on the time dimension. For example, the i2h in SimpleRNN Cell can be calculated before
+   * the recurrence since all the input slices are independent.
+   *
+   * This is particular useful to boost the performance of the recurrent layer.
+   *
+   * Please define your own preTopology according to your Cell structure.
+   * Please refer to SimpleRNN or LSTM for reference.
+   * @return
+   */
   def preTopology: AbstractModule[Activity, Activity, T] = null
 
   /**

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/RNN.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/RNN.scala
@@ -56,7 +56,7 @@ class RnnCell[T : ClassTag] (
   val parallelTable = ParallelTable[T]()
   val i2h = Identity[T]()
   val h2h = Linear[T](hiddenSize, hiddenSize,
-    wRegularizer = uRegularizer).setName("h2h")
+    wRegularizer = uRegularizer)
   parallelTable.add(i2h)
   parallelTable.add(h2h)
   val cAddTable = CAddTable[T](false)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/RNN.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/RNN.scala
@@ -19,8 +19,10 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, TensorModule}
 import com.intel.analytics.bigdl.nn.abstractnn.TensorModule
 import com.intel.analytics.bigdl.optim.Regularizer
+import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.RandomGenerator._
+import com.intel.analytics.bigdl.utils.Table
 
 import scala.reflect.ClassTag
 
@@ -52,13 +54,20 @@ class RnnCell[T : ClassTag] (
   extends Cell[T](Array(hiddenSize)) {
 
   val parallelTable = ParallelTable[T]()
-  val i2h = Linear[T](inputSize, hiddenSize,
-    wRegularizer = wRegularizer, bRegularizer = bRegularizer)
+  val i2h = Identity[T]()
   val h2h = Linear[T](hiddenSize, hiddenSize,
-    wRegularizer = uRegularizer)
+    wRegularizer = uRegularizer).setName("h2h")
   parallelTable.add(i2h)
   parallelTable.add(h2h)
-  val cAddTable = CAddTable[T](true)
+  val cAddTable = CAddTable[T](false)
+
+  override def preTopology: AbstractModule[Activity, Activity, T] =
+    TimeDistributed[T](
+      Linear[T](inputSize,
+        hiddenSize,
+        wRegularizer = wRegularizer,
+        bRegularizer = bRegularizer))
+    .asInstanceOf[AbstractModule[Activity, Activity, T]]
 
   override var cell: AbstractModule[Activity, Activity, T] =
     Sequential[T]()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -37,6 +37,8 @@ class Recurrent[T : ClassTag]()
   private var hiddenShape: Array[Int] = null
   private val currentInput = T()
   private val currentGradOutput = T()
+  private val gradInputCell = Tensor[T]()
+  private var outputCell = Tensor[T]()
   private val _input = T()
   private val batchDim = 1
   private val timeDim = 2
@@ -44,13 +46,20 @@ class Recurrent[T : ClassTag]()
   private val hidDim = 2
   private var cellAppendStartIdx = 0
   private var (batchSize, times) = (0, 0)
+  private var topology: Cell[T] = null
+  private var preTopology: AbstractModule[Activity, Activity, T] = null
   private val dropouts: ArrayBuffer[Array[Dropout[T]]] =
     new ArrayBuffer[Array[Dropout[T]]]
 
   override def add(module: AbstractModule[_ <: Activity, _ <: Activity, T]): Recurrent.this.type = {
     require(module.isInstanceOf[Cell[T]],
       "Recurrent: contained module should be Cell type")
-    modules += module.asInstanceOf[Cell[T]]
+    topology = module.asInstanceOf[Cell[T]]
+    preTopology = topology.preTopology
+    if (preTopology != null) {
+      modules += preTopology
+    }
+    modules += topology
     this
   }
 
@@ -66,11 +75,12 @@ class Recurrent[T : ClassTag]()
    */
   private def extend(times: Int, batchSize: Int, hiddenSize: Int): Unit = {
     if (hidden == null) {
-      require(modules != null && modules.length == 1,
-        "Recurrent extend: should contain only one cell")
+      require(topology != null && modules != null && modules.length <= 2,
+        "Recurrent extend: should contain only one cell or plus a pre-topology" +
+          " to process input")
 
       cells.clear()
-      cells += modules.head.asInstanceOf[Cell[T]]
+      cells += topology
       val cell = cells.head
 
       // The cell will help initialize or resize the hidden variable.
@@ -173,10 +183,16 @@ class Recurrent[T : ClassTag]()
       "Recurrent: input should be a 3D Tensor, e.g [batch, times, nDim], " +
         s"current input.dim = ${input.dim}")
 
-    batchSize = input.size(batchDim)
-    times = input.size(timeDim)
+    outputCell = if (preTopology != null) {
+      preTopology.updateOutput(input).toTensor[T]
+    } else {
+      input
+    }
 
-    val hiddenSize = modules.last.asInstanceOf[Cell[T]].hiddensShape(0)
+    batchSize = outputCell.size(batchDim)
+    times = outputCell.size(timeDim)
+
+    val hiddenSize = topology.hiddensShape(0)
     output.resize(batchSize, times, hiddenSize)
 
     // Clone N modules along the sequence dimension.
@@ -192,7 +208,7 @@ class Recurrent[T : ClassTag]()
     currentInput(hidDim) = hidden
     var i = 1
     while (i <= times) {
-      currentInput(inputDim) = input.select(timeDim, i)
+      currentInput(inputDim) = outputCell.select(timeDim, i)
       cells(i - 1).updateOutput(currentInput)
       currentInput(hidDim) = cells(i - 1).output.toTable(hidDim)
       i += 1
@@ -219,12 +235,13 @@ class Recurrent[T : ClassTag]()
      * of Cell(i)
      * The first module in the cells array accepts zero hidden parameter.
      */
+
     var i = times
     while (i >= 1) {
       currentGradOutput(inputDim) = gradOutput.select(timeDim, i)
       _input(hidDim) = if (i > 1) cells(i - 2).output.toTable(hidDim)
         else hidden
-      _input(inputDim) = input.select(timeDim, i)
+      _input(inputDim) = outputCell.select(timeDim, i)
       if (i == 1) {
         cells(i - 1).regluarized(true)
       } else {
@@ -234,17 +251,26 @@ class Recurrent[T : ClassTag]()
       currentGradOutput(hidDim) = cells(i - 1).gradInput.toTable(hidDim)
       i -= 1
     }
+    if (preTopology != null) {
+      preTopology.accGradParameters(input, gradInputCell)
+    }
   }
 
   override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
-    gradInput.resizeAs(input)
+
+    gradInput = if (preTopology != null) {
+      preTopology.gradInput.toTensor[T]
+    } else {
+      gradInputCell
+    }
+    gradInputCell.resizeAs(outputCell)
     currentGradOutput(hidDim) = gradHidden
     var i = times
     while (i >= 1) {
       currentGradOutput(inputDim) = gradOutput.select(timeDim, i)
       _input(hidDim) = if (i > 1) cells(i - 2).output.toTable(hidDim)
         else hidden
-      _input(inputDim) = input.select(timeDim, i)
+      _input(inputDim) = outputCell.select(timeDim, i)
       cells(i - 1).updateGradInput(_input, currentGradOutput)
       currentGradOutput(hidDim) = cells(i - 1).gradInput.toTable(hidDim)
       i -= 1
@@ -252,8 +278,11 @@ class Recurrent[T : ClassTag]()
     if (cellAppendStartIdx == 0 || cellAppendStartIdx < times) {
       set(cells.slice(cellAppendStartIdx, times)
         .map(x => x.gradInput.toTable[Tensor[T]](inputDim)),
-        gradInput,
+        gradInputCell,
         cellAppendStartIdx)
+    }
+    if (preTopology != null) {
+      gradInput = preTopology.updateGradInput(input, gradInputCell).toTensor[T]
     }
     gradInput
   }
@@ -271,9 +300,10 @@ class Recurrent[T : ClassTag]()
   }
 
   override def reset(): Unit = {
-    require(modules != null && modules.length == 1,
-      "Recurrent extend: should contain only one cell")
-    require(modules.head.isInstanceOf[Cell[T]],
+    require(topology != null && modules != null && modules.length <= 2,
+      "Recurrent extend: should contain only one cell or plus a pre-topology" +
+        " to process input.")
+    require(topology.isInstanceOf[Cell[T]],
       "Recurrent: should contain module with Cell type")
 
     modules.foreach(_.reset())

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -51,6 +51,17 @@ class Recurrent[T : ClassTag]()
   private val dropouts: ArrayBuffer[Array[Dropout[T]]] =
     new ArrayBuffer[Array[Dropout[T]]]
 
+  /**
+   *
+   *  modules: -- preTopology
+   *           |- topology (cell)
+   *
+   * The topology (or cell) will be cloned for N times w.r.t the time dimension.
+   * The preTopology will be execute only once before the recurrence.
+   *
+   * @param module module to be add
+   * @return this container
+   */
   override def add(module: AbstractModule[_ <: Activity, _ <: Activity, T]): Recurrent.this.type = {
     require(module.isInstanceOf[Cell[T]],
       "Recurrent: contained module should be Cell type")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -75,7 +75,8 @@ class Recurrent[T : ClassTag]()
    */
   private def extend(times: Int, batchSize: Int, hiddenSize: Int): Unit = {
     if (hidden == null) {
-      require(topology != null && modules != null && modules.length <= 2,
+      require((preTopology != null && modules.length == 1) ||
+        (topology != null && modules != null && modules.length <= 2),
         "Recurrent extend: should contain only one cell or plus a pre-topology" +
           " to process input")
 
@@ -300,7 +301,8 @@ class Recurrent[T : ClassTag]()
   }
 
   override def reset(): Unit = {
-    require(topology != null && modules != null && modules.length <= 2,
+    require((preTopology != null && modules.length == 1) ||
+      (topology != null && modules != null && modules.length <= 2),
       "Recurrent extend: should contain only one cell or plus a pre-topology" +
         " to process input.")
     require(topology.isInstanceOf[Cell[T]],

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -75,8 +75,8 @@ class Recurrent[T : ClassTag]()
    */
   private def extend(times: Int, batchSize: Int, hiddenSize: Int): Unit = {
     if (hidden == null) {
-      require((preTopology != null && modules.length == 1) ||
-        (topology != null && modules != null && modules.length <= 2),
+      require((preTopology == null && modules.length == 1) ||
+        (topology != null && preTopology != null && modules.length == 2),
         "Recurrent extend: should contain only one cell or plus a pre-topology" +
           " to process input")
 
@@ -301,8 +301,8 @@ class Recurrent[T : ClassTag]()
   }
 
   override def reset(): Unit = {
-    require((preTopology != null && modules.length == 1) ||
-      (topology != null && modules != null && modules.length <= 2),
+    require((preTopology == null && modules.length == 1) ||
+      (topology != null && preTopology != null && modules.length == 2),
       "Recurrent extend: should contain only one cell or plus a pre-topology" +
         " to process input.")
     require(topology.isInstanceOf[Cell[T]],


### PR DESCRIPTION
## What changes were proposed in this pull request?

Revise Cell.
Add pre-topology for RNN to boost the performance.
For example, i2h for input can be pre-calculated before recurrence.

## How was this patch tested?
Unit Test.
The fast mode cannot influence the correctness of the model.


