### PR TITLE
record forward time in Graph correctly

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
@@ -72,7 +72,7 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
       } else {
         seqToTable(node.prevNodes.map(_.element.output))
       }
-      node.element.updateOutput(inputsBP(i))
+      node.element.forward(inputsBP(i))
       i += 1
     }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GraphSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GraphSpec.scala
@@ -335,6 +335,24 @@ class GraphSpec extends FlatSpec with Matchers {
     gradient should be(T(Tensor(T(-1.0f, 1.0f)), Tensor(T(-1.0f, 1.0f))))
   }
 
+  "Graph forward/backward time" should "be recorded" in {
+    val input1 = Input()
+    val input2 = Input()
+    val add = CAddTable().inputs(input1, input2)
+    val add2 = AddConstant(2.0f).inputs(add)
+    val relu = ReLU().inputs(add2)
+    val graph = Graph[Float](Array(input1, input2), Array(add, relu))
+
+    val input = T(Tensor(T(1.0f, 2.0f)), Tensor(T(-2.0f, -1.0f)))
+    graph.forward(input)
+    graph.backward(input, T(Tensor(T(1.0f, 2.0f)), Tensor(T(-2.0f, -1.0f))))
+    graph.getTimes().foreach {
+      case (_, forward, backward) =>
+        forward should not be(0.0)
+        backward should not be(0.0)
+    }
+  }
+
   "lenet" should "be same with sequential model" in {
     RandomGenerator.RNG.setSeed(1000)
     val seqModel = Sequential().add(Reshape(Array(1, 28, 28)))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bug fix: use `model.forward` instead of `model.updateOutput` in `Graph` to record model forward time.
Add unit test to test the forward/backward time recording.

## How was this patch tested?

unit tests


