### PR TITLE
Check if conf file exists or not before parsing the content

### DIFF
--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -258,10 +258,10 @@ def get_bigdl_conf():
                     "#" not in line and line.strip())
 
     for p in sys.path:
-        if bigdl_conf_file in p:
+        if bigdl_conf_file in p and os.path.isfile(p):
             with open(p) if sys.version_info < (3,) else open(p, encoding='latin-1') as conf_file: # noqa
                 return load_conf(conf_file.read())
-        if bigdl_python_wrapper in p:
+        if bigdl_python_wrapper in p and os.path.isfile(p):
             import zipfile
             with zipfile.ZipFile(p, 'r') as zip_conf:
                 content = zip_conf.read(bigdl_conf_file)

--- a/pyspark/test/simple_integration_test.py
+++ b/pyspark/test/simple_integration_test.py
@@ -111,6 +111,7 @@ class TestWorkFlow(unittest.TestCase):
         import sys
         sys.path = [path for path in sys.path if "spark-bigdl.conf" not in path]
         sys.path.insert(0, os.path.join(os.path.split(__file__)[0], "resources/conf/python-api.zip"))  # noqa
+        sys.path.insert(0, os.path.join(os.path.split(__file__)[0], "resources/conf/invalid-python-api.zip"))  # noqa
         result = get_bigdl_conf()
         self.assertTrue(result.get("spark.executorEnv.OMP_WAIT_POLICY"), "passive")
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Check if conf file exists or not before parsing the content. Ignore the non-existing path instead of throw exception.

## How was this patch tested?

unittest


