### PR TITLE
Remove unnecessary varialbe in Recurrent object construtor

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/SimpleRNN.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/SimpleRNN.scala
@@ -26,7 +26,7 @@ object SimpleRNN {
   outputSize: Int)
   : Module[Float] = {
     val model = Sequential[Float]()
-    model.add(Recurrent[Float](hiddenSize)
+    model.add(Recurrent[Float]()
       .add(RnnCell[Float](inputSize, hiddenSize, Tanh[Float]())))
       .add(TimeDistributed[Float](Linear[Float](hiddenSize, outputSize)))
     model

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -298,8 +298,7 @@ class Recurrent[T : ClassTag]()
 }
 
 object Recurrent {
-  def apply[@specialized(Float, Double) T: ClassTag](
-    hiddenSize: Int = 3)
+  def apply[@specialized(Float, Double) T: ClassTag]
     (implicit ev: TensorNumeric[T]) : Recurrent[T] = {
     new Recurrent[T]()
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -298,7 +298,7 @@ class Recurrent[T : ClassTag]()
 }
 
 object Recurrent {
-  def apply[@specialized(Float, Double) T: ClassTag]
+  def apply[@specialized(Float, Double) T: ClassTag]()
     (implicit ev: TensorNumeric[T]) : Recurrent[T] = {
     new Recurrent[T]()
   }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
@@ -56,6 +56,7 @@ class LinearSpec extends FlatSpec with Matchers {
     weights2.copy(weights1.clone())
     grad2.copy(grad1.clone())
 
+
     val sgd = new SGD[Double]
 
     def feval1(x: Tensor[Double]): (Double, Tensor[Double]) = {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
@@ -56,7 +56,6 @@ class LinearSpec extends FlatSpec with Matchers {
     weights2.copy(weights1.clone())
     grad2.copy(grad1.clone())
 
-
     val sgd = new SGD[Double]
 
     def feval1(x: Tensor[Double]): (Double, Tensor[Double]) = {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
@@ -37,7 +37,7 @@ class RecurrentSpec extends FlatSpec with Matchers {
     RNG.setSeed(seed)
 
     val model = Sequential[Double]()
-      .add(Recurrent[Double](hiddenSize)
+      .add(Recurrent[Double]()
         .add(RnnCell[Double](inputSize, hiddenSize, Tanh[Double]())))
       .add(Select(1, 1))
       .add(Linear[Double](hiddenSize, outputSize))
@@ -94,7 +94,7 @@ class RecurrentSpec extends FlatSpec with Matchers {
     RNG.setSeed(seed)
 
     val model = Sequential[Double]()
-      .add(Recurrent[Double](hiddenSize)
+      .add(Recurrent[Double]()
         .add(RnnCell[Double](inputSize, hiddenSize, Tanh())))
       .add(Select(2, nWords))
       .add(Linear[Double](hiddenSize, outputSize))
@@ -151,7 +151,7 @@ class RecurrentSpec extends FlatSpec with Matchers {
     RNG.setSeed(seed)
 
     val model = Sequential[Double]()
-      .add(Recurrent[Double](hiddenSize)
+      .add(Recurrent[Double]()
         .add(RnnCell[Double](inputSize, hiddenSize, Tanh())))
       .add(Select(1, 1))
       .add(Linear[Double](hiddenSize, outputSize))
@@ -192,7 +192,7 @@ class RecurrentSpec extends FlatSpec with Matchers {
 
     println(input)
     val gru = GRU[Double](inputSize, hiddenSize, 0.2)
-    val model = Recurrent[Double](hiddenSize).add(gru)
+    val model = Recurrent[Double]().add(gru)
 
     val field = model.getClass.getDeclaredField("cells")
     field.setAccessible(true)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/GRUSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/GRUSpec.scala
@@ -66,8 +66,8 @@ class GRUSpec  extends TorchSpec {
     }
 
     println(input)
-    val rec1 = Recurrent[Double](hiddenSize)
-    val rec2 = Recurrent[Double](hiddenSize)
+    val rec1 = Recurrent[Double]()
+    val rec2 = Recurrent[Double]()
 
     val model1 = Sequential[Double]()
       .add(rec1
@@ -152,7 +152,7 @@ class GRUSpec  extends TorchSpec {
     }
 
     println(input)
-    val rec = Recurrent[Double](hiddenSize)
+    val rec = Recurrent[Double]()
 
     val model = Sequential[Double]()
       .add(rec
@@ -321,7 +321,7 @@ class GRUSpec  extends TorchSpec {
 
     println(input)
     // RNG.setSeed(seed)
-    val rec = Recurrent[Double](hiddenSize)
+    val rec = Recurrent[Double]()
 
     val model = Sequential[Double]()
       .add(rec
@@ -387,7 +387,7 @@ class GRUSpec  extends TorchSpec {
     }
 
     println(input)
-    val rec = Recurrent[Double](hiddenSize)
+    val rec = Recurrent[Double]()
 
     val model = Sequential[Double]()
       .add(rec
@@ -545,7 +545,7 @@ class GRUSpec  extends TorchSpec {
     }
 
     println(input)
-    val rec = Recurrent[Double](hiddenSize)
+    val rec = Recurrent[Double]()
 
     val model = Sequential[Double]()
       .add(rec
@@ -597,7 +597,7 @@ class GRUSpec  extends TorchSpec {
     RNG.setSeed(seed)
 
     val model = Sequential[Double]()
-      .add(Recurrent[Double](hiddenSize)
+      .add(Recurrent[Double]()
         .add(GRU[Double](inputSize, hiddenSize)))
       .add(Select(1, 1))
       .add(Linear[Double](hiddenSize, outputSize))

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/LSTMPeepholeSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/LSTMPeepholeSpec.scala
@@ -69,7 +69,7 @@ class LSTMPeepholeSpec  extends TorchSpec {
     }
 
     println(input)
-    val rec = Recurrent[Double](hiddenSize)
+    val rec = Recurrent[Double]()
 
     val model = Sequential[Double]()
       .add(rec
@@ -239,7 +239,7 @@ class LSTMPeepholeSpec  extends TorchSpec {
     }
 
     println(input)
-    val rec = Recurrent[Double](hiddenSize)
+    val rec = Recurrent[Double]()
 
     val model = Sequential[Double]()
       .add(rec
@@ -306,7 +306,7 @@ class LSTMPeepholeSpec  extends TorchSpec {
     }
 
     println(input)
-    val rec = Recurrent(hiddenSize)
+    val rec = Recurrent()
 
     val model = Sequential()
       .add(rec
@@ -477,7 +477,7 @@ class LSTMPeepholeSpec  extends TorchSpec {
     }
 
     println(input)
-    val rec = Recurrent[Double](hiddenSize)
+    val rec = Recurrent[Double]()
 
     val model = Sequential[Double]()
       .add(rec
@@ -529,7 +529,7 @@ class LSTMPeepholeSpec  extends TorchSpec {
     RNG.setSeed(seed)
 
     val model = Sequential[Double]()
-      .add(Recurrent[Double](hiddenSize)
+      .add(Recurrent[Double]()
         .add(LSTMPeephole[Double](inputSize, hiddenSize)))
       .add(Select(1, 1))
       .add(Linear[Double](hiddenSize, outputSize))

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/LSTMSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/LSTMSpec.scala
@@ -64,8 +64,8 @@ class LSTMSpec  extends TorchSpec {
     }
 
     println(input)
-    val rec1 = Recurrent[Double](hiddenSize)
-    val rec2 = Recurrent[Double](hiddenSize)
+    val rec1 = Recurrent[Double]()
+    val rec2 = Recurrent[Double]()
 
     val model1 = Sequential[Double]()
       .add(rec1
@@ -150,7 +150,7 @@ class LSTMSpec  extends TorchSpec {
     }
 
 //    println(input)
-    val rec = Recurrent[Double](hiddenSize)
+    val rec = Recurrent[Double]()
 
     val model = Sequential[Double]()
       .add(rec
@@ -320,7 +320,7 @@ class LSTMSpec  extends TorchSpec {
         labels.setValue(b, i, rdmLabel)
       }
     }
-    val rec = Recurrent[Double](hiddenSize)
+    val rec = Recurrent[Double]()
 
     val model = Sequential[Double]()
       .add(rec
@@ -473,7 +473,7 @@ class LSTMSpec  extends TorchSpec {
 
     println(input)
     RNG.setSeed(seed)
-    val rec = Recurrent[Double](hiddenSize)
+    val rec = Recurrent[Double]()
 
     val model = Sequential[Double]()
       .add(rec
@@ -538,7 +538,7 @@ class LSTMSpec  extends TorchSpec {
     }
 
     println(input)
-    val rec = Recurrent[Double](hiddenSize)
+    val rec = Recurrent[Double]()
 
     val model = Sequential[Double]()
       .add(rec


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove unnecessary varialbe in Recurrent object construtor

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/1097

