### PR TITLE
fix set bugs for fInput and fGradOutput in TimeDistributed layer

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributed.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributed.scala
@@ -34,10 +34,8 @@ import scala.reflect.ClassTag
  */
 
 class TimeDistributed[T : ClassTag] (layer: TensorModule[T])
-(implicit ev: TensorNumeric[T]) extends TensorModule[T] {
+  (implicit ev: TensorNumeric[T]) extends TensorModule[T] {
 
-  private val fInput: Tensor[T] = Tensor[T]()
-  private val fGradOutput: Tensor[T] = Tensor[T]()
   private var inputSize: Array[Int] = _
   private var gradOutputSize: Array[Int] = _
   private var outputSize: Array[Int] = _
@@ -62,8 +60,8 @@ class TimeDistributed[T : ClassTag] (layer: TensorModule[T])
         s" Current src.length = ${src.length}" +
         s" Current target.length = ${target.length}")
     require(dim1 * dim2 == src(0),
-    "TimeDistributed: split method requires dim1 * dim2 == src(0), " +
-      s"Current dim1 = ${dim1}, dim2 = ${dim2}, src(0) = ${src(0)}")
+      "TimeDistributed: split method requires dim1 * dim2 == src(0), " +
+        s"Current dim1 = ${dim1}, dim2 = ${dim2}, src(0) = ${src(0)}")
 
     target(0) = dim1
     target(1) = dim2
@@ -90,25 +88,41 @@ class TimeDistributed[T : ClassTag] (layer: TensorModule[T])
      * combine: [B, T, D] => [B * T, D]
      * split:   [B * T, D] => [B, T, D]
      */
-    combine(input.size, inputSize)
-    fInput.set(input).resize(inputSize)
-    val _output = layer.updateOutput(fInput).toTensor[T]
-    split(_output.size, outputSize, input.size(1), input.size(2))
+
+    val _inputSize = input.size
+    combine(_inputSize, inputSize)
+    input.resize(inputSize)
+    val _output = layer.updateOutput(input).toTensor[T]
+    split(_output.size, outputSize, _inputSize(0), _inputSize(1))
+    input.resize(_inputSize)
     output.set(_output).resize(outputSize)
     output
   }
 
   override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
-    gradOutputSize = inputSize
-    combine(gradOutput.size, gradOutputSize)
-    fGradOutput.set(gradOutput).resize(gradOutputSize)
-    val _gradInput = layer.updateGradInput(fInput, fGradOutput).toTensor[T]
-    gradInput.set(_gradInput).resize(input.size)
+    if (gradOutputSize == null) {
+      gradOutputSize = new Array[Int](gradOutput.size.length - 1)
+    }
+    val _inputSize = input.size
+    val _gradOutputSize = gradOutput.size
+    combine(_gradOutputSize, gradOutputSize)
+    input.resize(inputSize)
+    gradOutput.resize(gradOutputSize)
+    val _gradInput = layer.updateGradInput(input, gradOutput).toTensor[T]
+    gradInput.set(_gradInput).resize(_inputSize)
+    input.resize(_inputSize)
+    gradOutput.resize(_gradOutputSize)
     gradInput
   }
 
   override def accGradParameters(input: Tensor[T], gradOutput: Tensor[T]): Unit = {
-    layer.accGradParameters(fInput, fGradOutput)
+    val _inputSize = input.size
+    val _gradOutputSize = gradOutput.size
+    input.resize(inputSize)
+    gradOutput.resize(gradOutputSize)
+    layer.accGradParameters(input, gradOutput)
+    input.resize(_inputSize)
+    gradOutput.resize(_gradOutputSize)
   }
 
   /**
@@ -180,8 +194,6 @@ class TimeDistributed[T : ClassTag] (layer: TensorModule[T])
   override def clearState(): TimeDistributed.this.type = {
     super.clearState()
     layer.clearState()
-    fInput.set()
-    fGradOutput.set()
     inputSize = null
     gradOutputSize = null
     outputSize = null
@@ -194,9 +206,7 @@ class TimeDistributed[T : ClassTag] (layer: TensorModule[T])
     case that: TimeDistributed[T] =>
       super.equals(that) &&
         (that canEqual this) &&
-      layer.equals(layer) &&
-        fInput == that.fInput &&
-        fGradOutput == that.fGradOutput &&
+        layer.equals(layer) &&
         inputSize == that.inputSize &&
         gradOutputSize == that.gradOutputSize &&
         outputSize == that.outputSize
@@ -205,14 +215,14 @@ class TimeDistributed[T : ClassTag] (layer: TensorModule[T])
 
   override def hashCode(): Int = {
     val state = Seq(super.hashCode(),
-      layer, fInput, fGradOutput, inputSize, gradOutputSize, outputSize)
+      layer, inputSize, gradOutputSize, outputSize)
     state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
   }
 }
 
 object TimeDistributed {
   def apply[@specialized(Float, Double) T: ClassTag](layer: TensorModule[T])
-  (implicit ev: TensorNumeric[T]): TimeDistributed[T] = {
+    (implicit ev: TensorNumeric[T]): TimeDistributed[T] = {
     new TimeDistributed[T](layer)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
fInput should not be set to the same storage as input
fGradOutput should not be set to the same storage as gradOutput

## How was this patch tested?
Unit Test


