### PR TITLE
optimize GRU by pre-calculating three linear operations

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GRU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GRU.scala
@@ -65,10 +65,8 @@ class GRU[T : ClassTag] (
   var i2g: AbstractModule[_, _, T] = _
   var h2g: AbstractModule[_, _, T] = _
   var gates: AbstractModule[_, _, T] = _
-  val timeDim = 2
+  val featDim = 2
   override var cell: AbstractModule[Activity, Activity, T] = buildGRU()
-
-  var linear: AbstractModule[Activity, Activity, T] = null
 
   override def preTopology: AbstractModule[Activity, Activity, T] =
     if (p != 0) {
@@ -107,7 +105,7 @@ class GRU[T : ClassTag] (
             wRegularizer = uRegularizer)))
         .add(JoinTable(1, 1))
     } else {
-      i2g = Narrow[T](timeDim, 1, 2 * outputSize)
+      i2g = Narrow[T](featDim, 1, 2 * outputSize)
       h2g = Linear(outputSize, 2 * outputSize, withBias = false,
         wRegularizer = uRegularizer)
     }
@@ -139,7 +137,7 @@ class GRU[T : ClassTag] (
       .add(ConcatTable()
         .add(Sequential()
           .add(SelectTable(1))
-          .add(Narrow(timeDim, 1 + 2 * outputSize, outputSize)))
+          .add(Narrow(featDim, 1 + 2 * outputSize, outputSize)))
         .add(Sequential()
         .add(NarrowTable(2, 2))
         .add(CMulTable())))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GRU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GRU.scala
@@ -77,12 +77,12 @@ class GRU[T : ClassTag] (
           .add(Dropout(p))
           .add(Dropout(p)))
         .add(ParallelTable()
-          .add(Linear(inputSize, outputSize,
-            wRegularizer = wRegularizer, bRegularizer = bRegularizer))
-          .add(Linear(inputSize, outputSize,
-            wRegularizer = wRegularizer, bRegularizer = bRegularizer))
-          .add(Linear(inputSize, outputSize,
+          .add(TimeDistributed(Linear(inputSize, outputSize,
             wRegularizer = wRegularizer, bRegularizer = bRegularizer)))
+          .add(TimeDistributed(Linear(inputSize, outputSize,
+            wRegularizer = wRegularizer, bRegularizer = bRegularizer)))
+          .add(TimeDistributed(Linear(inputSize, outputSize,
+            wRegularizer = wRegularizer, bRegularizer = bRegularizer))))
         .add(JoinTable(3, 1))
     } else {
       TimeDistributed[T](Linear(inputSize, 3 * outputSize,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GRU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GRU.scala
@@ -57,9 +57,7 @@ class GRU[T : ClassTag] (
   val p: Double = 0,
   var wRegularizer: Regularizer[T] = null,
   var uRegularizer: Regularizer[T] = null,
-  var bRegularizer: Regularizer[T] = null
-)
-  (implicit ev: TensorNumeric[T])
+  var bRegularizer: Regularizer[T] = null)(implicit ev: TensorNumeric[T])
   extends Cell[T](
     hiddensShape = Array(outputSize),
     regularizers = Array(wRegularizer, uRegularizer, bRegularizer)
@@ -69,18 +67,33 @@ class GRU[T : ClassTag] (
   var gates: AbstractModule[_, _, T] = _
   override var cell: AbstractModule[Activity, Activity, T] = buildGRU()
 
-  def buildGates(): AbstractModule[Activity, Activity, T] = {
+  var linear: AbstractModule[Activity, Activity, T] = null
+
+  override def preTopology: AbstractModule[Activity, Activity, T] =
     if (p != 0) {
-      i2g = Sequential()
+      Sequential()
         .add(ConcatTable()
+          .add(Dropout(p))
           .add(Dropout(p))
           .add(Dropout(p)))
         .add(ParallelTable()
           .add(Linear(inputSize, outputSize,
             wRegularizer = wRegularizer, bRegularizer = bRegularizer))
           .add(Linear(inputSize, outputSize,
+            wRegularizer = wRegularizer, bRegularizer = bRegularizer))
+          .add(Linear(inputSize, outputSize,
             wRegularizer = wRegularizer, bRegularizer = bRegularizer)))
-        .add(JoinTable(1, 1))
+        .add(JoinTable(3, 1))
+    } else {
+      TimeDistributed[T](Linear(inputSize, 3 * outputSize,
+        wRegularizer = wRegularizer, bRegularizer = bRegularizer))
+    }
+
+  def buildGates(): AbstractModule[Activity, Activity, T] = {
+    if (p != 0) {
+      i2g = Sequential()
+        .add(Narrow[T](2, 1, 2 * outputSize))
+        .add(Reshape(Array(2, outputSize)))
 
       h2g = Sequential()
         .add(ConcatTable()
@@ -93,8 +106,7 @@ class GRU[T : ClassTag] (
             wRegularizer = uRegularizer)))
         .add(JoinTable(1, 1))
     } else {
-      i2g = Linear(inputSize, 2 * outputSize,
-        wRegularizer = wRegularizer, bRegularizer = bRegularizer)
+      i2g = Narrow[T](2, 1, 2 * outputSize)
       h2g = Linear(outputSize, 2 * outputSize, withBias = false,
         wRegularizer = uRegularizer)
     }
@@ -124,19 +136,18 @@ class GRU[T : ClassTag] (
 
     val h_hat = Sequential()
       .add(ConcatTable()
-        .add(SelectTable(1))
         .add(Sequential()
-          .add(NarrowTable(2, 2))
-          .add(CMulTable())))
+          .add(SelectTable(1))
+          .add(Narrow(2, 1 + 2 * outputSize, outputSize)))
+        .add(Sequential()
+        .add(NarrowTable(2, 2))
+        .add(CMulTable())))
       .add(ParallelTable()
+        .add(Identity())
         .add(Sequential()
-          .add(Dropout(p))
-          .add(Linear(inputSize, outputSize, wRegularizer = wRegularizer,
-            bRegularizer = bRegularizer)))
-        .add(Sequential()
-          .add(Dropout(p))
-          .add(Linear(outputSize, outputSize, withBias = false,
-            wRegularizer = uRegularizer))))
+         .add(Dropout(p))
+         .add(Linear(outputSize, outputSize, withBias = false,
+           wRegularizer = uRegularizer))))
       .add(CAddTable(true))
       .add(Tanh())
 
@@ -189,9 +200,7 @@ object GRU {
     p: Double = 0,
     wRegularizer: Regularizer[T] = null,
     uRegularizer: Regularizer[T] = null,
-    bRegularizer: Regularizer[T] = null
-  )
-    (implicit ev: TensorNumeric[T]): GRU[T] = {
+    bRegularizer: Regularizer[T] = null)(implicit ev: TensorNumeric[T]): GRU[T] = {
     new GRU[T](inputSize, outputSize, p, wRegularizer, uRegularizer, bRegularizer)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GRU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GRU.scala
@@ -65,6 +65,7 @@ class GRU[T : ClassTag] (
   var i2g: AbstractModule[_, _, T] = _
   var h2g: AbstractModule[_, _, T] = _
   var gates: AbstractModule[_, _, T] = _
+  val timeDim = 2
   override var cell: AbstractModule[Activity, Activity, T] = buildGRU()
 
   var linear: AbstractModule[Activity, Activity, T] = null
@@ -106,7 +107,7 @@ class GRU[T : ClassTag] (
             wRegularizer = uRegularizer)))
         .add(JoinTable(1, 1))
     } else {
-      i2g = Narrow[T](2, 1, 2 * outputSize)
+      i2g = Narrow[T](timeDim, 1, 2 * outputSize)
       h2g = Linear(outputSize, 2 * outputSize, withBias = false,
         wRegularizer = uRegularizer)
     }
@@ -138,7 +139,7 @@ class GRU[T : ClassTag] (
       .add(ConcatTable()
         .add(Sequential()
           .add(SelectTable(1))
-          .add(Narrow(2, 1 + 2 * outputSize, outputSize)))
+          .add(Narrow(timeDim, 1 + 2 * outputSize, outputSize)))
         .add(Sequential()
         .add(NarrowTable(2, 2))
         .add(CMulTable())))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LSTMPeephole.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LSTMPeephole.scala
@@ -67,30 +67,13 @@ class LSTMPeephole[T : ClassTag] (
   var cellLayer: Sequential[T] = _
   override var cell: AbstractModule[Activity, Activity, T] = buildLSTM()
 
-  override def preTopology: AbstractModule[Activity, Activity, T] =
-    Sequential()
-      .add(ConcatTable()
-        .add(Identity())
-        .add(Sequential()
-          .add(Dropout(p))
-          .add(TimeDistributed[T](Linear(inputSize, hiddenSize, wRegularizer = wRegularizer,
-            bRegularizer = bRegularizer)))))
-      .add(JoinTable(3, 1))
-
-  def buildGate(dimension: Int, offset: Int, length: Int, preTopo: Boolean = true):
-  Sequential[T] = {
+  def buildGate(): Sequential[T] = {
     val gate = Sequential()
 
     val i2g = Sequential()
-    if (preTopo) {
-      i2g.add(Narrow(dimension, offset, length))
-    } else {
-      i2g
-        .add(Narrow(dimension, offset, length))
-        .add(Dropout(p))
-        .add(Linear(inputSize, hiddenSize, wRegularizer = wRegularizer,
-          bRegularizer = bRegularizer))
-    }
+      .add(Dropout(p))
+      .add(Linear(inputSize, hiddenSize, wRegularizer = wRegularizer,
+        bRegularizer = bRegularizer))
     val h2g = Sequential()
       .add(Dropout(p))
       .add(Linear(hiddenSize, hiddenSize,
@@ -106,17 +89,17 @@ class LSTMPeephole[T : ClassTag] (
   }
 
   def buildInputGate(): Sequential[T] = {
-    inputGate = buildGate(2, 1, inputSize, false)
+    inputGate = buildGate()
     inputGate
   }
 
   def buildForgetGate(): Sequential[T] = {
-    forgetGate = buildGate(2, 1 + inputSize, hiddenSize, true)
+    forgetGate = buildGate()
     forgetGate
   }
 
   def buildOutputGate(): Sequential[T] = {
-    outputGate = buildGate(2, 1, inputSize, false)
+    outputGate = buildGate()
     outputGate
   }
 
@@ -125,7 +108,6 @@ class LSTMPeephole[T : ClassTag] (
       .add(NarrowTable(1, 2))
 
     val i2h = Sequential()
-      .add(Narrow(2, 1, inputSize))
       .add(Dropout(p))
       .add(Linear(inputSize, hiddenSize, wRegularizer = wRegularizer,
         bRegularizer = bRegularizer))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -271,7 +271,11 @@ class Recurrent[T : ClassTag]()
   override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
 
     gradInput = if (preTopology != null) {
-      if (preTopology.isInstanceOf[Sequential[T]]) {
+      /**
+       * if preTopology is Sequential, it has not created gradInput.
+       * Thus, it needs to create a new Tensor.
+       */
+      if (preTopology.gradInput == null) {
         preTopology.gradInput = Tensor[T]()
       }
       preTopology.gradInput.toTensor[T]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -271,6 +271,9 @@ class Recurrent[T : ClassTag]()
   override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
 
     gradInput = if (preTopology != null) {
+      if (preTopology.gradInput == null) {
+        preTopology.gradInput = Tensor[T]()
+      }
       preTopology.gradInput.toTensor[T]
     } else {
       gradInputCell

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -271,7 +271,7 @@ class Recurrent[T : ClassTag]()
   override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
 
     gradInput = if (preTopology != null) {
-      if (preTopology.gradInput == null) {
+      if (preTopology.isInstanceOf[Sequential[T]]) {
         preTopology.gradInput = Tensor[T]()
       }
       preTopology.gradInput.toTensor[T]

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/GRUSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/GRUSpec.scala
@@ -48,6 +48,41 @@ class GRUSpec  extends TorchSpec {
     }
   }
 
+  "A GRU" should " be fast" in {
+    val inputSize = 1000
+    val hiddenSize = 1000
+    val batchSize = 12
+    val time = 200
+    val seed = 100
+    RNG.setSeed(seed)
+    val input = Tensor[Float](batchSize, time, inputSize).rand
+    val gradOutput = Tensor[Float](batchSize, time, hiddenSize).rand
+
+    val model = Recurrent[Float]()
+      .add(GRU[Float](inputSize, hiddenSize))
+
+    var startTime = System.nanoTime()
+    var duration = (System.nanoTime() - startTime) / 1e9
+    var sum = 0.0
+
+    println("warmup ..")
+    for (i <- 1 to 5) {
+      model.forward(input)
+      model.backward(input, gradOutput)
+    }
+
+    val n = 5
+    for (i <- 1 to n) {
+      startTime = System.nanoTime()
+      model.forward(input)
+      model.backward(input, gradOutput)
+      duration = (System.nanoTime() - startTime) / 1e9
+      sum += duration
+      println(s"iteration-${i} = ${duration}")
+    }
+    println(s"average = ${sum / n}")
+  }
+
   "A LSTM L2 regularizer" should "works correctly" in {
     import com.intel.analytics.bigdl.numeric.NumericDouble
     val hiddenSize = 4


### PR DESCRIPTION
## What changes were proposed in this pull request?
define preTopology in GRU

## How was this patch tested?
Unit Test.

Since the structure of GRU in BigDL and Torch are different, I revised the Unit Test by rearrange the parameters in copy operation.




The speed:

I set batchSize = 12, inputSize = 1000, hiddenSize = 1000, and time = 200.
Running on my Desktop.
```
elapsed time | before    | after
------------------------------------------
1                | 3.22405 | 2.91554
2                | 3.26716 | 2.94787
3                | 3.17547 | 2.96847
4                | 3.15196 | 2.99957
5                | 3.16941 | 2.93977
------------------------------------------
average        | 3.19761 | 2.95424
------------------------------------------
throughput    | 3.7528  | 4.06195 
```
Thus, the revised version will give a ~8.24% throughput improvement.
With larger batchSize, inputSize and hiddenSize, the improvement will be more salient.