### PR TITLE
Optimize LSTMPeephole by pre-calculating the input2hidden linear

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LSTMPeephole.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LSTMPeephole.scala
@@ -65,7 +65,7 @@ class LSTMPeephole[T : ClassTag] (
   var outputGate: Sequential[T] = _
   var hiddenLayer: Sequential[T] = _
   var cellLayer: Sequential[T] = _
-  val timeDim = 2
+  val featDim = 2
   override var cell: AbstractModule[Activity, Activity, T] = buildLSTM()
 
   override def preTopology: AbstractModule[Activity, Activity, T] =
@@ -93,17 +93,17 @@ class LSTMPeephole[T : ClassTag] (
   }
 
   def buildInputGate(): Sequential[T] = {
-    inputGate = buildGate(timeDim, 1, hiddenSize)
+    inputGate = buildGate(featDim, 1, hiddenSize)
     inputGate
   }
 
   def buildForgetGate(): Sequential[T] = {
-    forgetGate = buildGate(timeDim, 1 + hiddenSize, hiddenSize)
+    forgetGate = buildGate(featDim, 1 + hiddenSize, hiddenSize)
     forgetGate
   }
 
   def buildOutputGate(): Sequential[T] = {
-    outputGate = buildGate(timeDim, 1 + 3 * hiddenSize, hiddenSize)
+    outputGate = buildGate(featDim, 1 + 3 * hiddenSize, hiddenSize)
     outputGate
   }
 
@@ -111,7 +111,7 @@ class LSTMPeephole[T : ClassTag] (
     val hidden = Sequential()
       .add(NarrowTable(1, 2))
 
-    val i2h = Narrow(timeDim, 1 + 2 * hiddenSize, hiddenSize)
+    val i2h = Narrow(featDim, 1 + 2 * hiddenSize, hiddenSize)
 
     val h2h = Sequential()
       .add(Dropout(p))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LSTMPeephole.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LSTMPeephole.scala
@@ -65,6 +65,7 @@ class LSTMPeephole[T : ClassTag] (
   var outputGate: Sequential[T] = _
   var hiddenLayer: Sequential[T] = _
   var cellLayer: Sequential[T] = _
+  val timeDim = 2
   override var cell: AbstractModule[Activity, Activity, T] = buildLSTM()
 
   override def preTopology: AbstractModule[Activity, Activity, T] =
@@ -92,17 +93,17 @@ class LSTMPeephole[T : ClassTag] (
   }
 
   def buildInputGate(): Sequential[T] = {
-    inputGate = buildGate(2, 1, hiddenSize)
+    inputGate = buildGate(timeDim, 1, hiddenSize)
     inputGate
   }
 
   def buildForgetGate(): Sequential[T] = {
-    forgetGate = buildGate(2, 1 + hiddenSize, hiddenSize)
+    forgetGate = buildGate(timeDim, 1 + hiddenSize, hiddenSize)
     forgetGate
   }
 
   def buildOutputGate(): Sequential[T] = {
-    outputGate = buildGate(2, 1 + 3 * hiddenSize, hiddenSize)
+    outputGate = buildGate(timeDim, 1 + 3 * hiddenSize, hiddenSize)
     outputGate
   }
 
@@ -110,7 +111,7 @@ class LSTMPeephole[T : ClassTag] (
     val hidden = Sequential()
       .add(NarrowTable(1, 2))
 
-    val i2h = Narrow(2, 1 + 2 * hiddenSize, hiddenSize)
+    val i2h = Narrow(timeDim, 1 + 2 * hiddenSize, hiddenSize)
 
     val h2h = Sequential()
       .add(Dropout(p))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LSTMPeephole.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LSTMPeephole.scala
@@ -71,21 +71,16 @@ class LSTMPeephole[T : ClassTag] (
     Sequential()
     .add(Dropout(p))
     .add(TimeDistributed(Linear(inputSize, hiddenSize * 4, wRegularizer = wRegularizer,
-      bRegularizer = bRegularizer).setName("i2g1234")))
+      bRegularizer = bRegularizer)))
 
-  def buildGate(dimension: Int, offset: Int, length: Int, name: String): Sequential[T] = {
+  def buildGate(dimension: Int, offset: Int, length: Int): Sequential[T] = {
     val gate = Sequential()
 
     val i2g = Narrow(dimension, offset, length)
-//      Sequential()
-//      .add(Dropout(p))
-//      .add(Linear(inputSize, hiddenSize, wRegularizer = wRegularizer,
-//        bRegularizer = bRegularizer))
-
     val h2g = Sequential()
       .add(Dropout(p))
       .add(Linear(hiddenSize, hiddenSize,
-        withBias = false, wRegularizer = uRegularizer).setName(name))
+        withBias = false, wRegularizer = uRegularizer))
 
     gate
       .add(ParallelTable()
@@ -97,17 +92,17 @@ class LSTMPeephole[T : ClassTag] (
   }
 
   def buildInputGate(): Sequential[T] = {
-    inputGate = buildGate(2, 1, hiddenSize, "inputGate")
+    inputGate = buildGate(2, 1, hiddenSize)
     inputGate
   }
 
   def buildForgetGate(): Sequential[T] = {
-    forgetGate = buildGate(2, 1 + hiddenSize, hiddenSize, "forgetGate")
+    forgetGate = buildGate(2, 1 + hiddenSize, hiddenSize)
     forgetGate
   }
 
   def buildOutputGate(): Sequential[T] = {
-    outputGate = buildGate(2, 1 + 3 * hiddenSize, hiddenSize, "outputGate")
+    outputGate = buildGate(2, 1 + 3 * hiddenSize, hiddenSize)
     outputGate
   }
 
@@ -116,15 +111,11 @@ class LSTMPeephole[T : ClassTag] (
       .add(NarrowTable(1, 2))
 
     val i2h = Narrow(2, 1 + 2 * hiddenSize, hiddenSize)
-//      Sequential()
-//      .add(Dropout(p))
-//      .add(Linear(inputSize, hiddenSize, wRegularizer = wRegularizer,
-//        bRegularizer = bRegularizer))
 
     val h2h = Sequential()
       .add(Dropout(p))
       .add(Linear(hiddenSize, hiddenSize, withBias = false,
-        wRegularizer = uRegularizer).setName("hiddenGate"))
+        wRegularizer = uRegularizer))
 
     hidden
       .add(ParallelTable()

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/LSTMPeepholeSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/LSTMPeepholeSpec.scala
@@ -24,6 +24,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 import com.intel.analytics.bigdl.utils.T
 
+import scala.collection.mutable.ArrayBuffer
 import scala.sys.process._
 
 @com.intel.analytics.bigdl.tags.Serial
@@ -84,6 +85,47 @@ class LSTMPeepholeSpec  extends TorchSpec {
     val logSoftMax = TimeDistributed[Double](LogSoftMax[Double]())
 
     val (weights, grad) = model.getParameters()
+
+    /*
+     * Since we changed the structure of LSTMPeephole, we have to rearrange the parameters.
+     */
+    val (weightsArray, gradArray) = model.parameters()
+    val weightsArrayTorch = weightsArray.clone
+
+    val weightsTorch = new ArrayBuffer[Tensor[Double]]()
+
+    val i2g2 = weightsArrayTorch(0).narrow(1, 1 + hiddenSize, hiddenSize)
+    weightsTorch += Tensor().resizeAs(i2g2).copy(i2g2)
+    val i2g2bias = weightsArrayTorch(1).narrow(1, 1 + hiddenSize, hiddenSize)
+    weightsTorch += Tensor().resizeAs(i2g2bias).copy(i2g2bias)
+    weightsTorch += Tensor().resizeAs(weightsArrayTorch(2)).copy(weightsArrayTorch(2))
+    weightsTorch += Tensor().resizeAs(weightsArrayTorch(3)).copy(weightsArrayTorch(3))
+    val i2g1 = weightsArrayTorch(0).narrow(1, 1, hiddenSize)
+    weightsTorch += Tensor().resizeAs(i2g1).copy(i2g1)
+    val i2g1bias = weightsArrayTorch(1).narrow(1, 1, hiddenSize)
+    weightsTorch += Tensor().resizeAs(i2g1bias).copy(i2g1bias)
+    weightsTorch += Tensor().resizeAs(weightsArrayTorch(4)).copy(weightsArrayTorch(4))
+    weightsTorch += Tensor().resizeAs(weightsArrayTorch(5)).copy(weightsArrayTorch(5))
+
+    val i2g3 = weightsArrayTorch(0).narrow(1, 1 + 2 * hiddenSize, hiddenSize)
+    weightsTorch += Tensor().resizeAs(i2g3).copy(i2g3)
+    val i2g3bias = weightsArrayTorch(1).narrow(1, 1 + 2 * hiddenSize, hiddenSize)
+    weightsTorch += Tensor().resizeAs(i2g3bias).copy(i2g3bias)
+
+    weightsTorch += Tensor().resizeAs(weightsArrayTorch(6)).copy(weightsArrayTorch(6))
+
+    val i2g4 = weightsArrayTorch(0).narrow(1, 1 + 3 * hiddenSize, hiddenSize)
+    weightsTorch += Tensor().resizeAs(i2g4).copy(i2g4)
+    val i2g4bias = weightsArrayTorch(1).narrow(1, 1 + 3 * hiddenSize, hiddenSize)
+    weightsTorch += Tensor().resizeAs(i2g4bias).copy(i2g4bias)
+
+    weightsTorch += Tensor().resizeAs(weightsArrayTorch(7)).copy(weightsArrayTorch(7))
+    weightsTorch += Tensor().resizeAs(weightsArrayTorch(8)).copy(weightsArrayTorch(8))
+    weightsTorch += Tensor().resizeAs(weightsArrayTorch(9)).copy(weightsArrayTorch(9))
+    weightsTorch += Tensor().resizeAs(weightsArrayTorch(10)).copy(weightsArrayTorch(10))
+
+    val (weights2Torch, grad2Torch) =
+      (Module.flatten[Double](weightsTorch.toArray), Module.flatten[Double](gradArray))
 
     val code =
       s"""
@@ -159,7 +201,7 @@ class LSTMPeepholeSpec  extends TorchSpec {
     """.stripMargin
 
     val (luaTime, torchResult) = TH.run(code,
-      Map("input" -> input.transpose(1, 2), "weights" -> weights,
+      Map("input" -> input.transpose(1, 2), "weights" -> weights2Torch,
         "labels" -> SplitTable[Double](1).forward(labels.t())),
       Array("output", "err", "parameters", "gradParameters", "output2", "gradInput", "err2"))
 
@@ -319,6 +361,48 @@ class LSTMPeepholeSpec  extends TorchSpec {
 
     val (weights, grad) = model.getParameters()
 
+
+    /*
+     * Since we changed the structure of LSTMPeephole, we have to rearrange the parameters.
+     */
+    val (weightsArray, gradArray) = model.parameters()
+    val weightsArrayTorch = weightsArray.clone
+
+    val weightsTorch = new ArrayBuffer[Tensor[Float]]()
+
+    val i2g2 = weightsArrayTorch(0).narrow(1, 1 + hiddenSize, hiddenSize)
+    weightsTorch += Tensor().resizeAs(i2g2).copy(i2g2)
+    val i2g2bias = weightsArrayTorch(1).narrow(1, 1 + hiddenSize, hiddenSize)
+    weightsTorch += Tensor().resizeAs(i2g2bias).copy(i2g2bias)
+    weightsTorch += Tensor().resizeAs(weightsArrayTorch(2)).copy(weightsArrayTorch(2))
+    weightsTorch += Tensor().resizeAs(weightsArrayTorch(3)).copy(weightsArrayTorch(3))
+    val i2g1 = weightsArrayTorch(0).narrow(1, 1, hiddenSize)
+    weightsTorch += Tensor().resizeAs(i2g1).copy(i2g1)
+    val i2g1bias = weightsArrayTorch(1).narrow(1, 1, hiddenSize)
+    weightsTorch += Tensor().resizeAs(i2g1bias).copy(i2g1bias)
+    weightsTorch += Tensor().resizeAs(weightsArrayTorch(4)).copy(weightsArrayTorch(4))
+    weightsTorch += Tensor().resizeAs(weightsArrayTorch(5)).copy(weightsArrayTorch(5))
+
+    val i2g3 = weightsArrayTorch(0).narrow(1, 1 + 2 * hiddenSize, hiddenSize)
+    weightsTorch += Tensor().resizeAs(i2g3).copy(i2g3)
+    val i2g3bias = weightsArrayTorch(1).narrow(1, 1 + 2 * hiddenSize, hiddenSize)
+    weightsTorch += Tensor().resizeAs(i2g3bias).copy(i2g3bias)
+
+    weightsTorch += Tensor().resizeAs(weightsArrayTorch(6)).copy(weightsArrayTorch(6))
+
+    val i2g4 = weightsArrayTorch(0).narrow(1, 1 + 3 * hiddenSize, hiddenSize)
+    weightsTorch += Tensor().resizeAs(i2g4).copy(i2g4)
+    val i2g4bias = weightsArrayTorch(1).narrow(1, 1 + 3 * hiddenSize, hiddenSize)
+    weightsTorch += Tensor().resizeAs(i2g4bias).copy(i2g4bias)
+
+    weightsTorch += Tensor().resizeAs(weightsArrayTorch(7)).copy(weightsArrayTorch(7))
+    weightsTorch += Tensor().resizeAs(weightsArrayTorch(8)).copy(weightsArrayTorch(8))
+    weightsTorch += Tensor().resizeAs(weightsArrayTorch(9)).copy(weightsArrayTorch(9))
+    weightsTorch += Tensor().resizeAs(weightsArrayTorch(10)).copy(weightsArrayTorch(10))
+
+    val (weights2Torch, grad2Torch) =
+      (Module.flatten[Float](weightsTorch.toArray), Module.flatten[Float](gradArray))
+
     val code =
       s"""
          |
@@ -385,7 +469,7 @@ class LSTMPeepholeSpec  extends TorchSpec {
     scala.Seq
 
     val (luaTime, torchResult) = TH.run(code,
-      Map("input" -> input.transpose(1, 2), "weights" -> weights,
+      Map("input" -> input.transpose(1, 2), "weights" -> weights2Torch,
         "labels" -> SplitTable[Double](1).forward(labels.t())),
       Array("output", "err", "parameters", "gradParameters", "output2", "gradInput", "err2"))
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/LSTMPeepholeSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/LSTMPeepholeSpec.scala
@@ -45,6 +45,41 @@ class LSTMPeepholeSpec  extends TorchSpec {
     }
   }
 
+  "A LSTMPeephole" should " be fast" in {
+    val inputSize = 300
+    val hiddenSize = 300
+    val batchSize = 12
+    val time = 200
+    val seed = 100
+    RNG.setSeed(seed)
+    val input = Tensor[Float](batchSize, time, inputSize).rand
+    val gradOutput = Tensor[Float](batchSize, time, hiddenSize).rand
+
+    val model = Recurrent[Float]()
+        .add(LSTMPeephole[Float](inputSize, hiddenSize))
+
+    var startTime = System.nanoTime()
+    var duration = (System.nanoTime() - startTime) / 1e9
+    var sum = 0.0
+
+    println("warmup ..")
+    for (i <- 1 to 5) {
+      model.forward(input)
+      model.backward(input, gradOutput)
+    }
+
+    val n = 5
+    for (i <- 1 to n) {
+      startTime = System.nanoTime()
+      model.forward(input)
+      model.backward(input, gradOutput)
+      duration = (System.nanoTime() - startTime) / 1e9
+      sum += duration
+      println(s"iteration-${i}, elapsed time = ${duration}")
+    }
+    println(s"average elapsed time = ${sum / n}")
+  }
+
   "A LSTMPeepwhole " should "has same loss as torch rnn" in {
     torchCheck()
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
add preTopology in LSTMPeephole to boost the performance

## How was this patch tested?
Unit Test.

The structure of LSTMPeephole in BigDL and Torch are different. So I rearrange the weights in copy operation.


The speed:

I set batchSize = 12, inputSize = 300, hiddenSize = 300, and time = 200.
Running on my Desktop.
```
elapsed time | before    | after
------------------------------------------
1                | 1.25213 | 1.11945
2                | 1.25913 | 1.13069
3                | 1.27919 | 1.22337
4                | 1.27735 | 1.18582
5                | 1.23374 | 1.16419
------------------------------------------
average        | 1.26031 | 1.16470
------------------------------------------
throughput    | 9.5214   | 10.303 
```
Thus, the revised version will give a ~8.2% throughput improvement.
With larger batchSize, inputSize and hiddenSize, the improvement will be more salient.
