### PR TITLE
add unit test for revision in TimeDistributed Layer

### DIFF
--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/TimeDistributedSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/TimeDistributedSpec.scala
@@ -21,6 +21,27 @@ import com.intel.analytics.bigdl.utils.RandomGenerator._
 import org.scalatest.{FlatSpec, Matchers}
 
 class TimeDistributedSpec extends FlatSpec with Matchers {
+  "A TimeDistributed Module" should " reset correctly" in {
+    RNG.setSeed(100)
+    val batchSize = 5
+    val times = 5
+    val inputDim = 3
+    val outputDim = 4
+    val timeDim = 1
+    val input = Tensor[Float](Array(batchSize, times, inputDim)).randn()
+    val gradOutput = Tensor[Float](Array(batchSize, times, outputDim)).randn()
+    val linear = Linear[Float](inputDim, outputDim)
+    val model = TimeDistributed[Float](linear)
+
+    val output = model.forward(input)
+    val gradInput = model.backward(input, gradOutput)
+
+    model.reset()
+
+    gradOutput should not be (null)
+    gradInput should not be (null)
+  }
+
   "A TimeDistributed Module" should " hash code correctly" in {
     RNG.setSeed(100)
     val batchSize = 5


### PR DESCRIPTION
## What changes were proposed in this pull request?
add unit test for TimeDistributed layer on reset method.

## How was this patch tested?
Unit Test

The gradOutput and gradInput should not be bound to the buffer inside this layer.

