### PR TITLE
Recurrent supports BatchNormalization

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cell.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cell.scala
@@ -82,6 +82,8 @@ abstract class Cell[T : ClassTag](
    */
   def preTopology: AbstractModule[Activity, Activity, T] = null
 
+  def hiddenSizeOfPreTopo: Int = hiddensShape(0)
+
   /**
    * resize the hidden parameters wrt the batch size, hiddens shapes.
    *

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cell.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cell.scala
@@ -83,17 +83,6 @@ abstract class Cell[T : ClassTag](
   def preTopology: AbstractModule[Activity, Activity, T] = null
 
   /**
-   * A method that returns the nOutput of the preToplogy sequential
-   * for BatchNormalization.
-   * @return
-   */
-  def getPreTopologyNOutput: Int = if (hiddensShape.length == 0) {
-    0
-  } else {
-    hiddensShape(0)
-  }
-
-  /**
    * resize the hidden parameters wrt the batch size, hiddens shapes.
    *
    * e.g. RnnCell contains 1 hidden parameter (H), thus it will return Tensor(size)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cell.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cell.scala
@@ -83,6 +83,17 @@ abstract class Cell[T : ClassTag](
   def preTopology: AbstractModule[Activity, Activity, T] = null
 
   /**
+   * A method that returns the nOutput of the preToplogy sequential
+   * for BatchNormalization.
+   * @return
+   */
+  def getPreTopologyNOutput: Int = if (hiddensShape.length == 0) {
+    0
+  } else {
+    hiddensShape(0)
+  }
+
+  /**
    * resize the hidden parameters wrt the batch size, hiddens shapes.
    *
    * e.g. RnnCell contains 1 hidden parameter (H), thus it will return Tensor(size)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GRU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GRU.scala
@@ -76,6 +76,8 @@ class GRU[T : ClassTag] (
         wRegularizer = wRegularizer, bRegularizer = bRegularizer))
     }
 
+  override def hiddenSizeOfPreTopo: Int = 3 * outputSize
+
   def buildGates()(input1: ModuleNode[T], input2: ModuleNode[T])
   : (ModuleNode[T], ModuleNode[T]) = {
     if (p != 0) {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LSTM.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LSTM.scala
@@ -77,6 +77,8 @@ class LSTM[T : ClassTag] (
       wRegularizer = wRegularizer, bRegularizer = bRegularizer))
   }
 
+  override def hiddenSizeOfPreTopo: Int = 4 * hiddenSize
+
   def buildGates()(input1: ModuleNode[T], input2: ModuleNode[T])
   : (ModuleNode[T], ModuleNode[T], ModuleNode[T], ModuleNode[T]) = {
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LSTMPeephole.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LSTMPeephole.scala
@@ -81,6 +81,8 @@ class LSTMPeephole[T : ClassTag] (
     .add(TimeDistributed(Linear(inputSize, hiddenSize * 4, wRegularizer = wRegularizer,
       bRegularizer = bRegularizer)))
 
+  override def hiddenSizeOfPreTopo: Int = hiddenSize * 4
+
   def buildGate(dimension: Int, offset: Int, length: Int)
                (input1: ModuleNode[T], input2: ModuleNode[T], input3: ModuleNode[T])
   : ModuleNode[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -356,9 +356,7 @@ class Recurrent[T : ClassTag]()
     copy(cells.map(x => x.gradInput.toTable[Tensor[T]](inputDim)),
         gradInputCell, 0)
     if (preTopology != null) {
-      preTopology.updateGradInput(input, gradInputCell)
-      gradInput = preTopology.gradInput.toTensor[T]
-      // gradInput = preTopology.updateGradInput(input, gradInputCell).toTensor[T]
+      gradInput = preTopology.updateGradInput(input, gradInputCell).toTensor[T]
     }
     gradInput
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -93,10 +93,11 @@ class Recurrent[T : ClassTag]()
         }
       case module: AbstractModule[Activity, Activity, T] =>
         val sequential = Sequential[T]()
+        sequential.add(module)
         if (layer != null) {
           sequential.add(layer)
         }
-        sequential.add(module)
+        sequential
       case _ => null
     }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -524,7 +524,7 @@ object Recurrent extends ContainerSerializable {
 
     if (flag) {
       val bnormEpsAttr = attrMap.get("bnormEps")
-      recurrent.batchNormParams.momentum =
+      recurrent.batchNormParams.eps =
         DataConverter.getAttributeValue(bnormEpsAttr)
           .asInstanceOf[Double]
 
@@ -617,6 +617,7 @@ object Recurrent extends ContainerSerializable {
       flag, universe.typeOf[Boolean])
     recurrentBuilder.putAttr("bnorm", bNormBuilder.build)
 
+    createSerializeBigDLModule(recurrentBuilder, module)
     recurrentBuilder.build
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -618,7 +618,6 @@ object Recurrent extends ContainerSerializable {
     recurrentBuilder.putAttr("bnorm", bNormBuilder.build)
 
     createSerializeBigDLModule(recurrentBuilder, module)
-    recurrentBuilder.build
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -16,6 +16,7 @@
 
 package com.intel.analytics.bigdl.nn
 
+
 import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, TensorModule}
 import com.intel.analytics.bigdl.tensor.Tensor
@@ -24,7 +25,8 @@ import com.intel.analytics.bigdl.utils.serializer.{ContainerSerializable, DataCo
 import com.intel.analytics.bigdl.utils.{T, Table}
 import serialization.Bigdl.{AttrValue, BigDLModule}
 
-import scala.collection.mutable
+import scala.reflect.runtime.universe
+import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 
@@ -32,7 +34,7 @@ import scala.reflect.ClassTag
  * [[Recurrent]] module is a container of rnn cells
  * Different types of rnn cells can be added using add() function
  */
-class Recurrent[T : ClassTag](batchNormParams: BatchNormParams[T] = null)
+class Recurrent[T : ClassTag](var batchNormParams: BatchNormParams[T] = null)
   (implicit ev: TensorNumeric[T]) extends Container[Tensor[T], Tensor[T], T] {
 
   private var hidden: Activity = null
@@ -496,8 +498,16 @@ object Recurrent extends ContainerSerializable {
   override def doLoadModule[T: ClassTag](model : BigDLModule)
     (implicit ev: TensorNumeric[T]) : AbstractModule[Activity, Activity, T] = {
 
-    val recurrent = super.doLoadModule(model).asInstanceOf[Recurrent[T]]
     val attrMap = model.getAttrMap
+
+    val flag = DataConverter
+      .getAttributeValue(attrMap.get("bnorm"))
+      .asInstanceOf[Boolean]
+    val recurrent = if (flag) {
+      Recurrent[T](BatchNormParams[T]())
+    } else {
+      Recurrent[T]()
+    }
 
     val topologyAttr = attrMap.get("topology")
     recurrent.topology = DataConverter.getAttributeValue(topologyAttr).
@@ -507,6 +517,44 @@ object Recurrent extends ContainerSerializable {
     recurrent.preTopology = DataConverter.getAttributeValue(preTopologyAttr).
       asInstanceOf[AbstractModule[Activity, Activity, T]]
 
+    if (recurrent.preTopology != null) {
+      recurrent.modules.append(recurrent.preTopology)
+    }
+    recurrent.modules.append(recurrent.topology)
+
+    if (flag) {
+      val bnormEpsAttr = attrMap.get("bnormEps")
+      recurrent.batchNormParams.momentum =
+        DataConverter.getAttributeValue(bnormEpsAttr)
+          .asInstanceOf[Double]
+
+      val bnormMomentumAttr = attrMap.get("bnormMomentum")
+      recurrent.batchNormParams.momentum =
+        DataConverter.getAttributeValue(bnormMomentumAttr)
+          .asInstanceOf[Double]
+
+      val bnormInitWeightAttr = attrMap.get("bnormInitWeight")
+      recurrent.batchNormParams.initWeight =
+        DataConverter.getAttributeValue(bnormInitWeightAttr)
+          .asInstanceOf[Tensor[T]]
+
+      val bnormInitBiasAttr = attrMap.get("bnormInitBias")
+      recurrent.batchNormParams.initBias =
+        DataConverter.getAttributeValue(bnormInitBiasAttr)
+          .asInstanceOf[Tensor[T]]
+
+      val bnormInitGradWeightAttr = attrMap.get("bnormInitGradWeight")
+      recurrent.batchNormParams.initGradWeight =
+        DataConverter.getAttributeValue(bnormInitGradWeightAttr)
+          .asInstanceOf[Tensor[T]]
+
+      val bnormInitGradBiasAttr = attrMap.get("bnormInitGradBias")
+      recurrent.batchNormParams.initGradBias =
+        DataConverter.getAttributeValue(bnormInitGradBiasAttr)
+          .asInstanceOf[Tensor[T]]
+    }
+
+    createBigDLModule(model, recurrent)
     recurrent
   }
 
@@ -527,13 +575,56 @@ object Recurrent extends ContainerSerializable {
       recurrent.preTopology, ModuleSerializer.abstractModuleType)
     recurrentBuilder.putAttr("preTopology", preTopologyBuilder.build)
 
+    val flag = if (recurrent.batchNormParams != null) {
+
+      val bnormEpsBuilder = AttrValue.newBuilder
+      DataConverter.setAttributeValue(bnormEpsBuilder,
+        recurrent.batchNormParams.eps, universe.typeOf[Double])
+      recurrentBuilder.putAttr("bnormEps", bnormEpsBuilder.build)
+
+      val bnormMomentumBuilder = AttrValue.newBuilder
+      DataConverter.setAttributeValue(bnormMomentumBuilder,
+        recurrent.batchNormParams.momentum, universe.typeOf[Double])
+      recurrentBuilder.putAttr("bnormMomentum", bnormMomentumBuilder.build)
+
+      val bnormInitWeightBuilder = AttrValue.newBuilder
+      DataConverter.setAttributeValue(bnormInitWeightBuilder,
+        recurrent.batchNormParams.initWeight, ModuleSerializer.tensorType)
+      recurrentBuilder.putAttr("bnormInitWeight", bnormInitWeightBuilder.build)
+
+      val bnormInitBiasBuilder = AttrValue.newBuilder
+      DataConverter.setAttributeValue(bnormInitBiasBuilder,
+        recurrent.batchNormParams.initBias, ModuleSerializer.tensorType)
+      recurrentBuilder.putAttr("bnormInitBias", bnormInitBiasBuilder.build)
+
+      val bnormInitGradWeightBuilder = AttrValue.newBuilder
+      DataConverter.setAttributeValue(bnormInitGradWeightBuilder,
+        recurrent.batchNormParams.initGradWeight, ModuleSerializer.tensorType)
+      recurrentBuilder.putAttr("bnormInitGradWeight", bnormInitGradWeightBuilder.build)
+
+      val bnormInitGradBiasBuilder = AttrValue.newBuilder
+      DataConverter.setAttributeValue(bnormInitGradBiasBuilder,
+        recurrent.batchNormParams.initGradBias, ModuleSerializer.tensorType)
+      recurrentBuilder.putAttr("bnormInitGradBias", bnormInitGradBiasBuilder.build)
+
+      true
+    } else {
+      false
+    }
+
+    val bNormBuilder = AttrValue.newBuilder
+    DataConverter.setAttributeValue(bNormBuilder,
+      flag, universe.typeOf[Boolean])
+    recurrentBuilder.putAttr("bnorm", bNormBuilder.build)
+
+    recurrentBuilder.build
   }
 }
 
 case class BatchNormParams[T : ClassTag](
-             val eps: Double = 1e-5, // avoid divde zero
-             val momentum: Double = 0.1, // momentum for weight update
-             val initWeight: Tensor[T] = null,
-             val initBias: Tensor[T] = null,
-             val initGradWeight: Tensor[T] = null,
-             val initGradBias: Tensor[T] = null)(implicit ev: TensorNumeric[T])
+             var eps: Double = 1e-5, // avoid divde zero
+             var momentum: Double = 0.1, // momentum for weight update
+             var initWeight: Tensor[T] = null,
+             var initBias: Tensor[T] = null,
+             var initGradWeight: Tensor[T] = null,
+             var initGradBias: Tensor[T] = null)(implicit ev: TensorNumeric[T])

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -79,7 +79,7 @@ class Recurrent[T : ClassTag](batchNormParams: BatchNormParams[T] = null)
       throw new IllegalArgumentException(
         s"${topology.getName} does not support BatchNormalization." +
           s" Please add preTopology for it. You can simply using: " +
-          s"override def preTopology: AbstractModule[Activity, Activity, T] = Sequential()")
+          s"override def preTopology: AbstractModule[Activity, Activity, T] = Identity()")
     }
 
     if (batchNormParams != null) {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -83,11 +83,7 @@ class Recurrent[T : ClassTag](batchNormParams: BatchNormParams[T] = null)
     }
 
     if (batchNormParams != null) {
-      require(topology.getPreTopologyNOutput > 0,
-        s"In ${topology.getName}, def getPreTopologyNOutput = 0. Please override this method")
-      layer = batchNormalization(
-        topology.getPreTopologyNOutput,
-        batchNormParams)
+      layer = batchNormalization(batchNormParams)
     }
 
     preTopology = preTopology match {
@@ -116,12 +112,12 @@ class Recurrent[T : ClassTag](batchNormParams: BatchNormParams[T] = null)
     this
   }
 
-  private def batchNormalization(nOutput: Int, batchNormParams: BatchNormParams[T]) =
+  private def batchNormalization(batchNormParams: BatchNormParams[T]) =
     TimeDistributed[T](BatchNormalization[T](
-      nOutput,
+      nOutput = 1,
       batchNormParams.eps,
       batchNormParams.momentum,
-      batchNormParams.affine,
+      affine = false,
       batchNormParams.initWeight,
       batchNormParams.initBias,
       batchNormParams.initGradWeight,
@@ -553,7 +549,6 @@ object Recurrent extends ContainerSerializable {
 case class BatchNormParams[T : ClassTag](
              val eps: Double = 1e-5, // avoid divde zero
              val momentum: Double = 0.1, // momentum for weight update
-             val affine: Boolean = true, // affine operation on output or not
              val initWeight: Tensor[T] = null,
              val initBias: Tensor[T] = null,
              val initGradWeight: Tensor[T] = null,

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ConvLSTMPeephole3DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ConvLSTMPeephole3DSpec.scala
@@ -60,7 +60,7 @@ class ConvLSTMPeephole3DSpec extends FlatSpec with BeforeAndAfter with Matchers 
     val batchSize = 2
     val kernalW = 3
     val kernalH = 3
-    val model = Recurrent[Double]
+    val model = Recurrent[Double]()
         .add(ConvLSTMPeephole3D[Double](
           inputSize,
           hiddenSize,

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
@@ -97,9 +97,10 @@ class RecurrentSpec extends FlatSpec with Matchers {
 
     val model = Sequential[Double]()
       .add(Recurrent[Double]()
+
         .add(LSTM[Double](inputSize, hiddenSize)))
       .add(Select(2, 1))
-//      .add(Linear[Double](hiddenSize, outputSize))
+    //      .add(Linear[Double](hiddenSize, outputSize))
 
     val input = Tensor[Double](Array(batchSize1, time, inputSize)).rand
     val gradOutput = Tensor[Double](batchSize1, outputSize).rand
@@ -140,6 +141,34 @@ class RecurrentSpec extends FlatSpec with Matchers {
 
     assert(abs((etaForward - forwardSum) / etaForward) < 0.1)
     assert(abs((etaBackward - backwardSum) / etaBackward) < 0.1)
+  }
+
+  "A Recurrent with SimpleRNN cell " should " add batchNormalization correctly" in {
+    val hiddenSize = 4
+    val inputSize = 5
+    val outputSize = 5
+    val batchSize = 4
+    val time = 2
+    val batchSize1 = 5
+    val batchSize2 = 8
+    val seed = 100
+    RNG.setSeed(seed)
+
+    val model = Sequential[Double]()
+      .add(Recurrent[Double]()
+        .addPreprocessInputLayer(TimeDistributed[Double](BatchNormalization[Double](inputSize)))
+        .add(RnnCell[Double](inputSize, hiddenSize, Tanh[Double]())))
+      .add(TimeDistributed[Double](Linear[Double](hiddenSize, outputSize)))
+
+    println(model)
+
+    val input = Tensor[Double](batchSize, time, inputSize)
+    val gradOutput = Tensor[Double](batchSize, time, outputSize)
+
+    val output = model.forward(input)
+    val gradInput = model.backward(input, gradOutput)
+
+    println("add normalization")
   }
 
   "A Recurrent" should " converge when batchSize changes" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
@@ -156,7 +156,7 @@ class RecurrentSpec extends FlatSpec with Matchers {
 
     val model = Sequential[Double]()
       .add(Recurrent[Double]()
-        .addPreprocessInputLayer(TimeDistributed[Double](BatchNormalization[Double](inputSize)))
+        .addPreprocessInputLayer(TimeDistributed[Double](BatchNormalization[Double](hiddenSize)))
         .add(RnnCell[Double](inputSize, hiddenSize, Tanh[Double]())))
       .add(TimeDistributed[Double](Linear[Double](hiddenSize, outputSize)))
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
@@ -143,6 +143,81 @@ class RecurrentSpec extends FlatSpec with Matchers {
     assert(abs((etaBackward - backwardSum) / etaBackward) < 0.1)
   }
 
+  "A Recurrent with LSTMPeephole cell " should " add batchNormalization correctly" in {
+    val hiddenSize = 4
+    val inputSize = 5
+    val outputSize = 5
+    val batchSize = 4
+    val time = 2
+    val seed = 100
+    RNG.setSeed(seed)
+
+    val model = Sequential[Double]()
+      .add(Recurrent[Double](BatchNormParams())
+        .add(LSTMPeephole[Double](inputSize, hiddenSize)))
+      .add(TimeDistributed[Double](Linear[Double](hiddenSize, outputSize)))
+
+    println(model)
+
+    val input = Tensor[Double](batchSize, time, inputSize)
+    val gradOutput = Tensor[Double](batchSize, time, outputSize)
+
+    val output = model.forward(input)
+    val gradInput = model.backward(input, gradOutput)
+
+    println("add normalization")
+  }
+
+  "A Recurrent with GRU cell " should " add batchNormalization correctly" in {
+    val hiddenSize = 4
+    val inputSize = 5
+    val outputSize = 5
+    val batchSize = 4
+    val time = 2
+    val seed = 100
+    RNG.setSeed(seed)
+
+    val model = Sequential[Double]()
+      .add(Recurrent[Double](BatchNormParams())
+        .add(GRU[Double](inputSize, hiddenSize)))
+      .add(TimeDistributed[Double](Linear[Double](hiddenSize, outputSize)))
+
+    println(model)
+
+    val input = Tensor[Double](batchSize, time, inputSize)
+    val gradOutput = Tensor[Double](batchSize, time, outputSize)
+
+    val output = model.forward(input)
+    val gradInput = model.backward(input, gradOutput)
+
+    println("add normalization")
+  }
+
+  "A Recurrent with LSTM cell " should " add batchNormalization correctly" in {
+    val hiddenSize = 4
+    val inputSize = 5
+    val outputSize = 5
+    val batchSize = 4
+    val time = 2
+    val seed = 100
+    RNG.setSeed(seed)
+
+    val model = Sequential[Double]()
+      .add(Recurrent[Double](BatchNormParams())
+        .add(LSTM[Double](inputSize, hiddenSize)))
+      .add(TimeDistributed[Double](Linear[Double](hiddenSize, outputSize)))
+
+    println(model)
+
+    val input = Tensor[Double](batchSize, time, inputSize)
+    val gradOutput = Tensor[Double](batchSize, time, outputSize)
+
+    val output = model.forward(input)
+    val gradInput = model.backward(input, gradOutput)
+
+    println("add normalization")
+  }
+
   "A Recurrent with SimpleRNN cell " should " add batchNormalization correctly" in {
     val hiddenSize = 4
     val inputSize = 5
@@ -155,8 +230,7 @@ class RecurrentSpec extends FlatSpec with Matchers {
     RNG.setSeed(seed)
 
     val model = Sequential[Double]()
-      .add(Recurrent[Double]()
-        .addPreprocessInputLayer(TimeDistributed[Double](BatchNormalization[Double](hiddenSize)))
+      .add(Recurrent[Double](BatchNormParams())
         .add(RnnCell[Double](inputSize, hiddenSize, Tanh[Double]())))
       .add(TimeDistributed[Double](Linear[Double](hiddenSize, outputSize)))
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
add a method that can support BatchNormalization

Usage:

```
Recurrent[Double](BatchNormParams())
        .add(RnnCell[Double](inputSize, hiddenSize, Tanh[Double]()))
```



## How was this patch tested?

Unit Test
The programme can run added BatchNormalization correctly.

