### PR TITLE
Enable local http server for doc site

### DIFF
--- a/docs/gen_site.py
+++ b/docs/gen_site.py
@@ -17,11 +17,11 @@ def run_cmd(cmds, err_msg, s=False):
         p.communicate()
         if p.returncode != 0:
             print err_msg
-            sys.exit()
+            sys.exit(1)
     except OSError as e:
         print err_msg
         print e.strerror
-        sys.exit()
+        sys.exit(1)
 
 parser = argparse.ArgumentParser(description='Process BigDL docs.')
 parser.add_argument('-s', '--scaladocs',

--- a/docs/gen_site.py
+++ b/docs/gen_site.py
@@ -30,7 +30,10 @@ parser.add_argument('-s', '--scaladocs',
 parser.add_argument('-p', '--pythondocs',
     dest='pythondocsflag', action='store_true',
     help='Add python doc to site')
-parser.add_argument('-m', '--startmkdocserve',
+parser.add_argument('-m', '--startserver',
+    dest='port', type=int,
+    help='Start server at PORT after building')
+parser.add_argument('-d', '--startmkdocserve',
     dest='mkdocserveflag', action='store_true',
     help=argparse.SUPPRESS)
 
@@ -92,8 +95,17 @@ if pythondocs:
 
 os.chdir(dir_name)
 
+if mkdoc_serve and args.port != None:
+    print 'Cannot start http server in debug mode'
+    sys.exit()
+
 if mkdoc_serve:
     print 'start mkdoc server'
     run_cmd(['mkdocs', 'serve'], 
         'mkdocs start serve error')
+
+if args.port != None:
+    os.chdir(dir_name + '/site')
+    run_cmd(['python', '-m', 'SimpleHTTPServer', '{}'.format(args.port)],
+        'start http server error')
    


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use `SimpleHTTPServer` to enable local http server for doc site.

## How was this patch tested?

manual tests

