### PR TITLE
[Issue #1033 #450] Disable backpropagation for general layers

### DIFF
--- a/docs/docs/APIGuide/Module.md
+++ b/docs/docs/APIGuide/Module.md
@@ -151,13 +151,15 @@ val preductResult = model.predict(predictSet)
 To "freeze" a module means to exclude some layers of model from training.
 
 ```scala
-layer.setTrainable(false)
+layer.freeze()
+layer.unFreeze()
 model.freeze(Array("layer1", "layer2"))
 model.unFreeze()
 model.stopGradient(Array("layer1"))
 ```
-* A single layer can be "freezed" by calling ```setTrainable(false)```. If a layer is freezed,
+* A single layer can be "freezed" by calling ```freeze()```. If a layer is freezed,
 its parameters(weight/bias, if exists) are not changed in training process
+* A single layer can be "unFreezed" by calling ```unFreeze()```.
 * User can set freeze of list of layers in model by calling ```freeze```
 * User can unfreeze all layers by calling ```unFreeze```
 * stop the input gradient of layers that match the given names. Their input gradient are not computed.
@@ -165,7 +167,8 @@ And they will not contributed to the input gradient computation of layers that d
 
 **Python**
 ```python
-layer.set_trainable(false)
+layer.freeze()
+layer.unfreeze()
 model.freeze(["layer1", "layer2"])
 model.unfreeze()
 model.stop_gradient(["layer1"])

--- a/docs/docs/APIGuide/Module.md
+++ b/docs/docs/APIGuide/Module.md
@@ -152,13 +152,13 @@ To "freeze" a module means to exclude some layers of model from training.
 
 ```scala
 layer.setTrainable(false)
-model.setFreeze(Array("layer1", "layer2"))
+model.freeze(Array("layer1", "layer2"))
 model.unFreeze()
-model.setStopGradient(Array("layer1"))
+model.stopGradient(Array("layer1"))
 ```
 * A single layer can be "freezed" by calling ```setTrainable(false)```. If a layer is freezed,
 its parameters(weight/bias, if exists) are not changed in training process
-* User can set freeze of list of layers in model by calling ```setFreeze```
+* User can set freeze of list of layers in model by calling ```freeze```
 * User can unfreeze all layers by calling ```unFreeze```
 * stop the input gradient of layers that match the given names. Their input gradient are not computed.
 And they will not contributed to the input gradient computation of layers that depend on them.
@@ -166,9 +166,9 @@ And they will not contributed to the input gradient computation of layers that d
 **Python**
 ```python
 layer.set_trainable(false)
-model.set_freeze(["layer1", "layer2"])
+model.freeze(["layer1", "layer2"])
 model.unfreeze()
-model.set_stop_gradient(["layer1"])
+model.stop_gradient(["layer1"])
 ```
 
 **Scala**
@@ -216,7 +216,7 @@ println("fc2 weight \n", fc2.element.parameters()._1(0))
 fc1.element.getParameters()._1.apply1(_ => 1.0f)
 fc2.element.getParameters()._1.apply1(_ => 2.0f)
 model.zeroGradParameters()
-model.setFreeze(Array("fc2"))
+model.freeze(Array("fc2"))
 println("output2: \n", model.forward(input))
 model.backward(input, gradOutput)
 model.updateParameters(1)
@@ -269,7 +269,7 @@ println("fc2 weight \n", fc2.element.parameters()._1(0))
 ```scala
 fc1.element.getParameters()._1.apply1(_ => 1.0f)
 fc2.element.getParameters()._1.apply1(_ => 2.0f)
-model.setStopGradient(Array("cadd"))
+model.stopGradient(Array("cadd"))
 model.zeroGradParameters()
 println("output4: \n", model.forward(input))
 model.backward(input, gradOutput)
@@ -344,7 +344,7 @@ print "fc2 weight \n", fc2.element().parameters()['fc2']['weight']
 ```
 fc1.element().set_weights([np.array([[1,1,1,1],[1,1,1,1]]), np.array([1,1])])
 fc2.element().set_weights([np.array([[2,2,2,2],[2,2,2,2]]), np.array([2,2])])
-m3 = model.set_freeze(["fc2"])
+m3 = model.freeze(["fc2"])
 model.zero_grad_parameters()
 output = model.forward(input)
 print "output2 ", output
@@ -384,7 +384,7 @@ print "fc2 weight \n", fc2.element().parameters()['fc2']['weight']
 ```
 
 ```
-m3 = model.set_stop_gradient(["cadd"])
+m3 = model.stop_gradient(["cadd"])
 model.zero_grad_parameters()
 output = model.forward(input)
 print "output4 ", output

--- a/docs/docs/APIGuide/Module.md
+++ b/docs/docs/APIGuide/Module.md
@@ -147,3 +147,209 @@ val preductResult = model.predict(predictSet)
  preductResult = model.predict(predictSet)
 ```
 
+## Module Freeze
+To "freeze" a module means to exclude some part of model from training.
+Note that it only takes effect in BigDL graph model.
+
+```scala
+layer.setTrainable(false)
+model.setFreeze(Array("layer1", "layer2"))
+model.setTrainable(Array("layer3", "layer4"))
+model.unFreeze()
+```
+* A single layer can be "freezed" by calling ```setTrainable```
+* User can set freeze of list of layers in model by calling ```setFreeze```
+* User can set a list of trainable layers and keep the remaining layers freezed by calling ```setTrainable```
+* User can unfreeze all layers by calling ```unFreeze```
+**Python**
+```python
+layer.set_trainable(false)
+model.set_freeze(["layer1", "layer2"])
+model.set_trainable(["layer1", "layer2"])
+model.unfreeze()
+```
+
+**Scala**
+```scala
+val reshape = Reshape(Array(4)).inputs()
+val fc1_1 = Linear(4, 2).setName("fc1_1").inputs()
+val fc2_1 = Linear(4, 2).setName("fc2_1").setTrainable(false).inputs(reshape)
+val cadd_1 = CAddTable().inputs(fc1_1, fc2_1)
+val output1_1 = ReLU().inputs(cadd_1)
+val output2_1 = Threshold(10.0).inputs(cadd_1)
+
+val model = Graph(Array(reshape, fc1_1), Array(output1_1, output2_1))
+
+fc1_1.element.getParameters()._1.apply1(_ => 1.0f)
+fc2_1.element.getParameters()._1.apply1(_ => 2.0f)
+
+val input = T(Tensor(T(0.1f, 0.2f, -0.3f, -0.4f)),
+  Tensor(T(0.5f, 0.4f, -0.2f, -0.1f)))
+val gradOutput = T(Tensor(T(1.0f, 2.0f)), Tensor(T(3.0f, 4.0f)))
+
+println("output1: \n", model.forward(input))
+println("gradInput1: \n", model.backward(input, gradOutput))
+
+model.unFreeze()
+println("output2: \n", model.forward(input))
+println("gradInput2: \n", model.backward(input, gradOutput))
+
+model.setFreeze(Array("fc2_1"))
+println("output3: \n", model.forward(input))
+println("gradInput3: \n", model.backward(input, gradOutput))
+
+model.unFreeze()
+model.setTrainable(Array("fc1_1"))
+println("output4: \n", model.forward(input))
+println("gradInput4: \n", model.backward(input, gradOutput))
+```
+
+```
+(output1: 
+, {
+	2: 0.0
+	   0.0
+	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 2]
+	1: 2.8
+	   2.8
+	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 2]
+ })
+(gradInput1: 
+, {
+	2: 3.0
+	   3.0
+	   3.0
+	   3.0
+	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 4]
+	1: [com.intel.analytics.bigdl.tensor.DenseTensor with no dimension]
+ })
+(output2: 
+, {
+	2: 0.0
+	   0.0
+	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 2]
+	1: 3.6
+	   3.6
+	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 2]
+ })
+(gradInput2: 
+, {
+	2: 3.0
+	   3.0
+	   3.0
+	   3.0
+	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 4]
+	1: 6.0
+	   6.0
+	   6.0
+	   6.0
+	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 4]
+ })
+(output3: 
+, {
+	2: 0.0
+	   0.0
+	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 2]
+	1: 3.6
+	   3.6
+	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 2]
+ })
+(gradInput3: 
+, {
+	2: 3.0
+	   3.0
+	   3.0
+	   3.0
+	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 4]
+	1: [com.intel.analytics.bigdl.tensor.DenseTensor with no dimension]
+ })
+(output4: 
+, {
+	2: 0.0
+	   0.0
+	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 2]
+	1: 3.6
+	   3.6
+	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 2]
+ })
+(gradInput4: 
+, {
+	2: 3.0
+	   3.0
+	   3.0
+	   3.0
+	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 4]
+	1: [com.intel.analytics.bigdl.tensor.DenseTensor with no dimension]
+ })
+```
+
+
+
+**Python**
+```python
+from bigdl.nn.layer import *
+import numpy as np
+
+reshape = Reshape([4])()
+fc1_1 = Linear(4, 2).set_name("fc1_1")()
+# set fc2_1 to non-trainable
+fc2_1 = Linear(4, 2).set_name("fc2_1").set_trainable(False)(reshape)
+cadd_1 = CAddTable()([fc1_1, fc2_1])
+output1_1 = ReLU()(cadd_1)
+output2_1 = Threshold(10.0)(cadd_1)
+model = Model([reshape, fc1_1], [output1_1, output2_1])
+
+input = [
+    np.array([0.1, 0.2, -0.3, -0.4]),
+    np.array([0.5, 0.4, -0.2, -0.1])]
+gradOutput = [
+    np.array([1.0, 2.0]), np.array([3.0, 4.0])]
+
+output = model.forward(input)
+print "output1: \n", output
+gradInput = model.backward(input, gradOutput)
+print "gradInput1 \n", gradInput
+
+# unfreeze all layers in model
+model.unfreeze()
+output = model.forward(input)
+print "output2 \n", output
+gradInput = model.backward(input, gradOutput)
+print "gradInput2 \n", gradInput
+
+# set fc2_1 to non-trainable in model API
+m3 = model.set_freeze(["fc2_1"])
+output = model.forward(input)
+print "output3 \n", output
+gradInput = model.backward(input, gradOutput)
+print "gradInput3 \n", gradInput
+
+model.unfreeze()
+# set only fc1_1 to trainable in model API
+m3 = model.set_trainable(["fc1_1"])
+output = model.forward(input)
+print "output4 \n", output
+gradInput = model.backward(input, gradOutput)
+print "gradInput4 \n", gradInput
+```
+
+```
+output1: 
+[array([ 0.        ,  0.58186555], dtype=float32), array([ 0.,  0.], dtype=float32)]
+gradInput1 
+[array([], dtype=float32), array([ 0.510382  ,  0.85159016, -0.55450386, -0.54459006], dtype=float32)]
+output2 
+[array([ 0.        ,  0.58186555], dtype=float32), array([ 0.,  0.], dtype=float32)]
+gradInput2 
+[array([ 0.04848308, -0.04261303,  0.04275261, -0.94517899], dtype=float32), array([ 0.510382  ,  0.85159016, -0.55450386, -0.54459006], dtype=float32)]
+output3 
+[array([ 0.        ,  0.58186555], dtype=float32), array([ 0.,  0.], dtype=float32)]
+gradInput3 
+[array([], dtype=float32), array([ 0.510382  ,  0.85159016, -0.55450386, -0.54459006], dtype=float32)]
+output4 
+[array([ 0.        ,  0.58186555], dtype=float32), array([ 0.,  0.], dtype=float32)]
+gradInput4 
+[array([], dtype=float32), array([ 0.510382  ,  0.85159016, -0.55450386, -0.54459006], dtype=float32)]
+```
+
+

--- a/docs/docs/APIGuide/Module.md
+++ b/docs/docs/APIGuide/Module.md
@@ -148,64 +148,55 @@ val preductResult = model.predict(predictSet)
 ```
 
 ## Module Freeze
-To "freeze" a module means to exclude some part of model from training.
-Note that it only takes effect in BigDL graph model.
+To "freeze" a module means to exclude some layers of model from training.
 
 ```scala
 layer.setTrainable(false)
 model.setFreeze(Array("layer1", "layer2"))
-model.setTrainable(Array("layer3", "layer4"))
 model.unFreeze()
+model.setStopGradient(Array("layer1"))
 ```
-* A single layer can be "freezed" by calling ```setTrainable```
+* A single layer can be "freezed" by calling ```setTrainable(false)```. If a layer is freezed,
+its parameters(weight/bias, if exists) are not changed in training process
 * User can set freeze of list of layers in model by calling ```setFreeze```
-* User can set a list of trainable layers and keep the remaining layers freezed by calling ```setTrainable```
 * User can unfreeze all layers by calling ```unFreeze```
+* stop the input gradient of layers that match the given names. Their input gradient are not computed.
+And they will not contributed to the input gradient computation of layers that depend on them.
+
 **Python**
 ```python
 layer.set_trainable(false)
 model.set_freeze(["layer1", "layer2"])
-model.set_trainable(["layer1", "layer2"])
 model.unfreeze()
+model.set_stop_gradient(["layer1"])
 ```
 
 **Scala**
+Original model without "freeze" or "stop gradient"
 ```scala
 val reshape = Reshape(Array(4)).inputs()
-val fc1_1 = Linear(4, 2).setName("fc1_1").inputs()
-val fc2_1 = Linear(4, 2).setName("fc2_1").setTrainable(false).inputs(reshape)
-val cadd_1 = CAddTable().inputs(fc1_1, fc2_1)
+val fc1 = Linear(4, 2).setName("fc1").inputs()
+val fc2 = Linear(4, 2).setName("fc2").inputs(reshape)
+val cadd_1 = CAddTable().setName("cadd").inputs(fc1, fc2)
 val output1_1 = ReLU().inputs(cadd_1)
 val output2_1 = Threshold(10.0).inputs(cadd_1)
 
-val model = Graph(Array(reshape, fc1_1), Array(output1_1, output2_1))
-
-fc1_1.element.getParameters()._1.apply1(_ => 1.0f)
-fc2_1.element.getParameters()._1.apply1(_ => 2.0f)
+val model = Graph(Array(reshape, fc1), Array(output1_1, output2_1))
 
 val input = T(Tensor(T(0.1f, 0.2f, -0.3f, -0.4f)),
   Tensor(T(0.5f, 0.4f, -0.2f, -0.1f)))
 val gradOutput = T(Tensor(T(1.0f, 2.0f)), Tensor(T(3.0f, 4.0f)))
 
+fc1.element.getParameters()._1.apply1(_ => 1.0f)
+fc2.element.getParameters()._1.apply1(_ => 2.0f)
+model.zeroGradParameters()
 println("output1: \n", model.forward(input))
-println("gradInput1: \n", model.backward(input, gradOutput))
-
-model.unFreeze()
-println("output2: \n", model.forward(input))
-println("gradInput2: \n", model.backward(input, gradOutput))
-
-model.setFreeze(Array("fc2_1"))
-println("output3: \n", model.forward(input))
-println("gradInput3: \n", model.backward(input, gradOutput))
-
-model.unFreeze()
-model.setTrainable(Array("fc1_1"))
-println("output4: \n", model.forward(input))
-println("gradInput4: \n", model.backward(input, gradOutput))
+model.backward(input, gradOutput)
+model.updateParameters(1)
+println("fc2 weight \n", fc2.element.parameters()._1(0))
 ```
-
 ```
-(output1: 
+(output1:
 , {
 	2: 0.0
 	   0.0
@@ -214,73 +205,97 @@ println("gradInput4: \n", model.backward(input, gradOutput))
 	   2.8
 	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 2]
  })
-(gradInput1: 
-, {
-	2: 3.0
-	   3.0
-	   3.0
-	   3.0
-	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 4]
-	1: [com.intel.analytics.bigdl.tensor.DenseTensor with no dimension]
- })
-(output2: 
-, {
-	2: 0.0
-	   0.0
-	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 2]
-	1: 3.6
-	   3.6
-	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 2]
- })
-(gradInput2: 
-, {
-	2: 3.0
-	   3.0
-	   3.0
-	   3.0
-	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 4]
-	1: 6.0
-	   6.0
-	   6.0
-	   6.0
-	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 4]
- })
-(output3: 
+(fc2 weight
+,1.9	1.8	2.3	2.4
+1.8	1.6	2.6	2.8
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x4])
+```
+
+"Freeze" ```fc2```, the parameters of ```fc2``` is not changed.
+```scala
+fc1.element.getParameters()._1.apply1(_ => 1.0f)
+fc2.element.getParameters()._1.apply1(_ => 2.0f)
+model.zeroGradParameters()
+model.setFreeze(Array("fc2"))
+println("output2: \n", model.forward(input))
+model.backward(input, gradOutput)
+model.updateParameters(1)
+println("fc2 weight \n", fc2.element.parameters()._1(0))
+```
+
+```
+(output2:
 , {
 	2: 0.0
 	   0.0
 	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 2]
-	1: 3.6
-	   3.6
+	1: 2.8
+	   2.8
 	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 2]
  })
-(gradInput3: 
-, {
-	2: 3.0
-	   3.0
-	   3.0
-	   3.0
-	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 4]
-	1: [com.intel.analytics.bigdl.tensor.DenseTensor with no dimension]
- })
-(output4: 
+(fc2 weight
+,2.0	2.0	2.0	2.0
+2.0	2.0	2.0	2.0
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x4])
+```
+"unFreeze" ```fc2```, the parameters of ```fc2``` will be updated.
+```scala
+fc1.element.getParameters()._1.apply1(_ => 1.0f)
+fc2.element.getParameters()._1.apply1(_ => 2.0f)
+model.zeroGradParameters()
+model.unFreeze()
+println("output3: \n", model.forward(input))
+model.backward(input, gradOutput)
+model.updateParameters(1)
+println("fc2 weight \n", fc2.element.parameters()._1(0))
+```
+```
+(output3:
 , {
 	2: 0.0
 	   0.0
 	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 2]
-	1: 3.6
-	   3.6
+	1: 2.8
+	   2.8
 	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 2]
  })
-(gradInput4: 
+(fc2 weight
+,1.9	1.8	2.3	2.4
+1.8	1.6	2.6	2.8
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x4])
+```
+
+"stop gradient" at ```cadd```, the parameters of ```fc1``` and ```fc2``` are not changed.
+```scala
+fc1.element.getParameters()._1.apply1(_ => 1.0f)
+fc2.element.getParameters()._1.apply1(_ => 2.0f)
+model.setStopGradient(Array("cadd"))
+model.zeroGradParameters()
+println("output4: \n", model.forward(input))
+model.backward(input, gradOutput)
+model.updateParameters(1)
+println("fc1 weight \n", fc1.element.parameters()._1(0))
+println("fc2 weight \n", fc2.element.parameters()._1(0))
+```
+
+```
+(output4:
 , {
-	2: 3.0
-	   3.0
-	   3.0
-	   3.0
-	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 4]
-	1: [com.intel.analytics.bigdl.tensor.DenseTensor with no dimension]
+	2: 0.0
+	   0.0
+	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 2]
+	1: 2.8
+	   2.8
+	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 2]
  })
+(fc1 weight
+,1.0	1.0	1.0	1.0
+1.0	1.0	1.0	1.0
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x4])
+(fc2 weight
+,2.0	2.0	2.0	2.0
+2.0	2.0	2.0	2.0
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x4])
 ```
 
 
@@ -290,14 +305,16 @@ println("gradInput4: \n", model.backward(input, gradOutput))
 from bigdl.nn.layer import *
 import numpy as np
 
+from bigdl.nn.layer import *
+import numpy as np
+
 reshape = Reshape([4])()
-fc1_1 = Linear(4, 2).set_name("fc1_1")()
-# set fc2_1 to non-trainable
-fc2_1 = Linear(4, 2).set_name("fc2_1").set_trainable(False)(reshape)
-cadd_1 = CAddTable()([fc1_1, fc2_1])
-output1_1 = ReLU()(cadd_1)
-output2_1 = Threshold(10.0)(cadd_1)
-model = Model([reshape, fc1_1], [output1_1, output2_1])
+fc1 = Linear(4, 2).set_name("fc1")()
+fc2 = Linear(4, 2).set_name("fc2")(reshape)
+cadd = CAddTable().set_name("cadd")([fc1, fc2])
+output1 = ReLU()(cadd)
+output2 = Threshold(10.0)(cadd)
+model = Model([reshape, fc1], [output1, output2])
 
 input = [
     np.array([0.1, 0.2, -0.3, -0.4]),
@@ -305,51 +322,87 @@ input = [
 gradOutput = [
     np.array([1.0, 2.0]), np.array([3.0, 4.0])]
 
+fc1.element().set_weights([np.array([[1,1,1,1],[1,1,1,1]]), np.array([1,1])])
+fc2.element().set_weights([np.array([[2,2,2,2],[2,2,2,2]]), np.array([2,2])])
+model.zero_grad_parameters()
 output = model.forward(input)
-print "output1: \n", output
+print "output1: ", output
 gradInput = model.backward(input, gradOutput)
-print "gradInput1 \n", gradInput
-
-# unfreeze all layers in model
-model.unfreeze()
-output = model.forward(input)
-print "output2 \n", output
-gradInput = model.backward(input, gradOutput)
-print "gradInput2 \n", gradInput
-
-# set fc2_1 to non-trainable in model API
-m3 = model.set_freeze(["fc2_1"])
-output = model.forward(input)
-print "output3 \n", output
-gradInput = model.backward(input, gradOutput)
-print "gradInput3 \n", gradInput
-
-model.unfreeze()
-# set only fc1_1 to trainable in model API
-m3 = model.set_trainable(["fc1_1"])
-output = model.forward(input)
-print "output4 \n", output
-gradInput = model.backward(input, gradOutput)
-print "gradInput4 \n", gradInput
+model.update_parameters(1.0)
+print "fc2 weight \n", fc2.element().parameters()['fc2']['weight']
 ```
 
 ```
-output1: 
-[array([ 0.        ,  0.58186555], dtype=float32), array([ 0.,  0.], dtype=float32)]
-gradInput1 
-[array([], dtype=float32), array([ 0.510382  ,  0.85159016, -0.55450386, -0.54459006], dtype=float32)]
-output2 
-[array([ 0.        ,  0.58186555], dtype=float32), array([ 0.,  0.], dtype=float32)]
-gradInput2 
-[array([ 0.04848308, -0.04261303,  0.04275261, -0.94517899], dtype=float32), array([ 0.510382  ,  0.85159016, -0.55450386, -0.54459006], dtype=float32)]
-output3 
-[array([ 0.        ,  0.58186555], dtype=float32), array([ 0.,  0.], dtype=float32)]
-gradInput3 
-[array([], dtype=float32), array([ 0.510382  ,  0.85159016, -0.55450386, -0.54459006], dtype=float32)]
-output4 
-[array([ 0.        ,  0.58186555], dtype=float32), array([ 0.,  0.], dtype=float32)]
-gradInput4 
-[array([], dtype=float32), array([ 0.510382  ,  0.85159016, -0.55450386, -0.54459006], dtype=float32)]
+> output1
+[array([ 2.79999995,  2.79999995], dtype=float32), array([ 0.,  0.], dtype=float32)]
+
+> fc2 weight
+[[ 1.89999998  1.79999995  2.29999995  2.4000001 ]
+ [ 1.79999995  1.60000002  2.5999999   2.79999995]]
 ```
 
+```
+fc1.element().set_weights([np.array([[1,1,1,1],[1,1,1,1]]), np.array([1,1])])
+fc2.element().set_weights([np.array([[2,2,2,2],[2,2,2,2]]), np.array([2,2])])
+m3 = model.set_freeze(["fc2"])
+model.zero_grad_parameters()
+output = model.forward(input)
+print "output2 ", output
+gradInput = model.backward(input, gradOutput)
+model.update_parameters(1.0)
+print "fc2 weight \n", fc2.element().parameters()['fc2']['weight']
+```
 
+```
+> output2
+[array([ 2.79999995,  2.79999995], dtype=float32), array([ 0.,  0.], dtype=float32)]
+
+> fc2 weight
+[[ 2.  2.  2.  2.]
+ [ 2.  2.  2.  2.]]
+```
+
+```
+fc1.element().set_weights([np.array([[1,1,1,1],[1,1,1,1]]), np.array([1,1])])
+fc2.element().set_weights([np.array([[2,2,2,2],[2,2,2,2]]), np.array([2,2])])
+m3 = model.unfreeze()
+model.zero_grad_parameters()
+output = model.forward(input)
+print "output3 ", output
+gradInput = model.backward(input, gradOutput)
+model.update_parameters(1.0)
+print "fc2 weight \n", fc2.element().parameters()['fc2']['weight']
+```
+
+```
+> output3
+[array([ 2.79999995,  2.79999995], dtype=float32), array([ 0.,  0.], dtype=float32)]
+
+> fc2 weight
+[[ 1.89999998  1.79999995  2.29999995  2.4000001 ]
+ [ 1.79999995  1.60000002  2.5999999   2.79999995]]
+```
+
+```
+m3 = model.set_stop_gradient(["cadd"])
+model.zero_grad_parameters()
+output = model.forward(input)
+print "output4 ", output
+gradInput = model.backward(input, gradOutput)
+model.update_parameters(1.0)
+print "fc1 weight \n", fc1.element().parameters()['fc1']['weight']
+print "fc2 weight \n", fc2.element().parameters()['fc2']['weight']
+```
+
+```
+> output4
+[array([ 2.79999995,  2.79999995], dtype=float32), array([ 0.,  0.], dtype=float32)]
+
+> fc1 weight
+[[ 1.  1.  1.  1.]
+ [ 1.  1.  1.  1.]]
+
+> fc2 weight
+[[ 2.  2.  2.  2.]
+ [ 2.  2.  2.  2.]]
+```

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -376,6 +376,16 @@ class Layer(JavaValue):
         '''
         self.value.bRegularizer = bRegularizer.value
 
+    def set_trainable(self, trainable):
+        '''
+        set trainable
+        :param trainable: whether this layer is trainable
+        '''
+        callBigDlFunc(self.bigdl_type,
+                        "setLayerTrainable", self.value, trainable)
+        return self
+
+
 
 class Container(Layer):
     '''
@@ -490,6 +500,36 @@ class Model(Container):
         """
         jmodel = callBigDlFunc(bigdl_type, "loadTF", path, inputs, outputs, byte_order)
         return Model.of(jmodel)
+
+    def set_freeze(self, freeze_layers, bigdl_type="float"):
+        """
+        set an array of layers to be freezed, the rest of layers are trainable
+        :param freeze_layers: an array of layer names
+        :param bigdl_type:
+        :return:
+        """
+        callBigDlFunc(bigdl_type, "setFreeze", self.value, freeze_layers)
+        return self
+
+    def set_trainable(self, trainable_layers, bigdl_type="float"):
+        """
+        set an array of layers to be trainable, the rest of layers are freezed
+        :param trainable_layers:  an array of layer names
+        :param bigdl_type:
+        :return:
+        """
+        callBigDlFunc(bigdl_type, "setTrainable", self.value, trainable_layers)
+        return self
+
+    def unfreeze(self, bigdl_type="float"):
+        """
+        set all layers to be trainable
+        :param bigdl_type:
+        :return:
+        """
+        callBigDlFunc(bigdl_type, "unFreeze", self.value)
+        return self
+
 
 
 class Linear(Layer):

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -385,17 +385,6 @@ class Layer(JavaValue):
                         "setLayerTrainable", self.value, trainable)
         return self
 
-    def set_stop_gradient(self, stop_gradient):
-        '''
-        set stop gradient. If isStopGradient is true, its input gradient
-        is not computed. And it will not contributed to the input gradient computation of
-        layers that depend on this layer.
-        :param stop_gradient: whether stop gradient
-        '''
-        callBigDlFunc(self.bigdl_type,
-                        "setLayerStopGradient", self.value, stop_gradient)
-        return self
-
 
 
 class Container(Layer):

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -376,14 +376,20 @@ class Layer(JavaValue):
         '''
         self.value.bRegularizer = bRegularizer.value
 
-    def set_trainable(self, trainable):
+    def freeze(self):
         '''
-        set trainable
-        :param trainable: whether this layer is trainable
+        freeze layer
         '''
         callBigDlFunc(self.bigdl_type,
-                        "setLayerTrainable", self.value, trainable)
+                        "setLayerFreeze", self.value)
         return self
+
+    def unfreeze(self):
+        '''
+        unfreeze layer
+        '''
+        callBigDlFunc(self.bigdl_type,
+                        "setLayerUnFreeze", self.value)
 
 
 

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -385,6 +385,17 @@ class Layer(JavaValue):
                         "setLayerTrainable", self.value, trainable)
         return self
 
+    def set_stop_gradient(self, stop_gradient):
+        '''
+        set stop gradient. If isStopGradient is true, its input gradient
+        is not computed. And it will not contributed to the input gradient computation of
+        layers that depend on this layer.
+        :param stop_gradient: whether stop gradient
+        '''
+        callBigDlFunc(self.bigdl_type,
+                        "setLayerStopGradient", self.value, stop_gradient)
+        return self
+
 
 
 class Container(Layer):
@@ -503,22 +514,12 @@ class Model(Container):
 
     def set_freeze(self, freeze_layers, bigdl_type="float"):
         """
-        set an array of layers to be freezed, the rest of layers are trainable
+        set an array of layers to be freezed
         :param freeze_layers: an array of layer names
         :param bigdl_type:
         :return:
         """
         callBigDlFunc(bigdl_type, "setFreeze", self.value, freeze_layers)
-        return self
-
-    def set_trainable(self, trainable_layers, bigdl_type="float"):
-        """
-        set an array of layers to be trainable, the rest of layers are freezed
-        :param trainable_layers:  an array of layer names
-        :param bigdl_type:
-        :return:
-        """
-        callBigDlFunc(bigdl_type, "setTrainable", self.value, trainable_layers)
         return self
 
     def unfreeze(self, bigdl_type="float"):
@@ -528,6 +529,19 @@ class Model(Container):
         :return:
         """
         callBigDlFunc(bigdl_type, "unFreeze", self.value)
+        return self
+
+    def set_stop_gradient(self, stop_layers, bigdl_type="float"):
+        """
+        stop the input gradient of layers that match the given ```names```
+        their input gradient are not computed.
+        And they will not contributed to the input gradient computation of
+        layers that depend on them.
+        :param stop_layers:  an array of layer names
+        :param bigdl_type:
+        :return:
+        """
+        callBigDlFunc(bigdl_type, "setStopGradient", self.value, stop_layers)
         return self
 
 

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -501,7 +501,7 @@ class Model(Container):
         jmodel = callBigDlFunc(bigdl_type, "loadTF", path, inputs, outputs, byte_order)
         return Model.of(jmodel)
 
-    def set_freeze(self, freeze_layers, bigdl_type="float"):
+    def freeze(self, freeze_layers, bigdl_type="float"):
         """
         set an array of layers to be freezed
         :param freeze_layers: an array of layer names
@@ -520,7 +520,7 @@ class Model(Container):
         callBigDlFunc(bigdl_type, "unFreeze", self.value)
         return self
 
-    def set_stop_gradient(self, stop_layers, bigdl_type="float"):
+    def stop_gradient(self, stop_layers, bigdl_type="float"):
         """
         stop the input gradient of layers that match the given ```names```
         their input gradient are not computed.

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
@@ -16,6 +16,7 @@
 
 package com.intel.analytics.bigdl.nn
 
+import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.tensor.Tensor
@@ -201,5 +202,23 @@ abstract class Container[A <: Activity : ClassTag,
         None
       }
     }
+  }
+
+  /**
+    * get all submodules map, use the module name as key
+    */
+  def getSubModules(): Map[String, Module[T]] = {
+    val nameToSubModules = Utils.getNamedModules(this)
+    nameToSubModules
+  }
+
+  /**
+    * get submodule by module name
+    */
+  def getSubModule(name: String): Option[Module[T]] = {
+    val subModules = getSubModules()
+    if (subModules.contains(name)) {
+      Some(subModules(name))
+    } else None
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
@@ -203,22 +203,4 @@ abstract class Container[A <: Activity : ClassTag,
       }
     }
   }
-
-  /**
-   * get all submodules map, use the module name as key
-   */
-  def getSubModules(): Map[String, Module[T]] = {
-    val nameToSubModules = Utils.getNamedModules(this)
-    nameToSubModules
-  }
-
-  /**
-   * get submodule by module name
-   */
-  def getSubModule(name: String): Option[Module[T]] = {
-    val subModules = getSubModules()
-    if (subModules.contains(name)) {
-      Some(subModules(name))
-    } else None
-  }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
@@ -16,7 +16,6 @@
 
 package com.intel.analytics.bigdl.nn
 
-import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.tensor.Tensor

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
@@ -205,16 +205,16 @@ abstract class Container[A <: Activity : ClassTag,
   }
 
   /**
-    * get all submodules map, use the module name as key
-    */
+   * get all submodules map, use the module name as key
+   */
   def getSubModules(): Map[String, Module[T]] = {
     val nameToSubModules = Utils.getNamedModules(this)
     nameToSubModules
   }
 
   /**
-    * get submodule by module name
-    */
+   * get submodule by module name
+   */
   def getSubModule(name: String): Option[Module[T]] = {
     val subModules = getSubModules()
     if (subModules.contains(name)) {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
@@ -345,19 +345,6 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
     this
   }
 
-  /**
-   * "unfreeze" all layers, i.e. make the layer parameters(weight/bias, if exists)
-   * to be trained(updated) in training process
-   */
-  def unFreeze(): this.type = {
-    modules.foreach(layer => {
-      layer.setScaleW(1)
-      layer.setScaleB(1)
-    })
-    this
-  }
-
-
   private var stopGradientLayers: util.HashSet[String] = _
 
   /**

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
@@ -417,9 +417,9 @@ object Graph extends ContainerSerializable {
    * @param output output node
    * @return a graph container
    */
-  def apply[T: ClassTag](input: Array[ModuleNode[T]], output: Array[ModuleNode[T]],
-                         variables: Option[(Array[Tensor[T]], Array[Tensor[T]])] = None)
-                        (implicit ev: TensorNumeric[T]): Graph[T] = {
+  def apply[T: ClassTag](input : Array[ModuleNode[T]], output : Array[ModuleNode[T]],
+      variables: Option[(Array[Tensor[T]], Array[Tensor[T]])] = None)
+      (implicit ev: TensorNumeric[T]) : Graph[T] = {
     new Graph[T](input, output, variables)
   }
 
@@ -429,8 +429,8 @@ object Graph extends ContainerSerializable {
    * @param output output nodes
    * @return a graph container
    */
-  def apply[T: ClassTag](input: ModuleNode[T], output: Array[ModuleNode[T]])
-                        (implicit ev: TensorNumeric[T]): Graph[T] = {
+  def apply[T: ClassTag](input : ModuleNode[T], output : Array[ModuleNode[T]])
+    (implicit ev: TensorNumeric[T]) : Graph[T] = {
     new Graph[T](Array(input), output)
   }
 
@@ -440,8 +440,8 @@ object Graph extends ContainerSerializable {
    * @param output output node
    * @return a graph container
    */
-  def apply[T: ClassTag](input: Array[ModuleNode[T]], output: ModuleNode[T])
-                        (implicit ev: TensorNumeric[T]): Graph[T] = {
+  def apply[T: ClassTag](input : Array[ModuleNode[T]], output : ModuleNode[T])
+    (implicit ev: TensorNumeric[T]) : Graph[T] = {
     new Graph[T](input, Array(output))
   }
 
@@ -451,8 +451,8 @@ object Graph extends ContainerSerializable {
    * @param output output nodes
    * @return a graph container
    */
-  def apply[T: ClassTag](input: ModuleNode[T], output: ModuleNode[T])
-                        (implicit ev: TensorNumeric[T]): Graph[T] = {
+  def apply[T: ClassTag](input : ModuleNode[T], output : ModuleNode[T])
+    (implicit ev: TensorNumeric[T]) : Graph[T] = {
     new Graph[T](Array(input), Array(output))
   }
 
@@ -510,7 +510,7 @@ object Graph extends ContainerSerializable {
     val graph = module.module.asInstanceOf[Graph[T]]
     val inputsNames = graph.inputs.map(_.element.getName).toArray
     val outputsNames = graph.outputs.map(_.element.getName).toArray
-    graph.getExecutions.foreach(execution => {
+    graph.getForwardExecutions.foreach(execution => {
       val preNodes = execution.prevNodes.map(_.element.getName)
       val nextNodes = execution.nextNodes.map(_.element.getName)
       val currNode = execution.element
@@ -545,6 +545,5 @@ object Graph extends ContainerSerializable {
 private[bigdl] class Dummy[T: ClassTag]()(implicit ev: TensorNumeric[T])
   extends AbstractModule[Activity, Tensor[T], T] {
   override def updateOutput(input: Activity): Tensor[T] = null
-
   override def updateGradInput(input: Activity, gradOutput: Tensor[T]): Activity = null
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
@@ -335,7 +335,7 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
    * @param names an array of layer names
    * @return current graph model
    */
-  def setFreeze(names: Array[String]): this.type = {
+  def freeze(names: Array[String]): this.type = {
     names.foreach(name => {
       val layer = this (name)
       require(layer.isDefined, s"cannot find layer match ${name}")
@@ -358,14 +358,14 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
   }
 
 
-  private var stopGradientLayers: util.HashSet[AbstractModule[_ <: Activity, _ <: Activity, T]] = _
+  private var stopGradientLayers: util.HashSet[String] = _
 
   /**
    * whether stop propagating gradInput back
    * @return
    */
   private def isStopGradient(module: AbstractModule[_ <: Activity, _ <: Activity, T]): Boolean = {
-    null != stopGradientLayers && stopGradientLayers.contains(module)
+    null != stopGradientLayers && stopGradientLayers.contains(module.getName())
   }
 
   /**
@@ -376,13 +376,13 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
    * @param names an array of layer names
    * @return current graph model
    */
-  def setStopGradient(names: Array[String]): this.type = {
+  def stopGradient(names: Array[String]): this.type = {
     names.foreach(name => {
       val layer = this (name)
       require(layer.isDefined, s"cannot find layer match ${name}")
       if (stopGradientLayers == null) stopGradientLayers =
-        new util.HashSet[AbstractModule[_ <: Activity, _ <: Activity, T]]()
-      stopGradientLayers.add(layer.get)
+        new util.HashSet[String]()
+      stopGradientLayers.add(layer.get.getName())
     })
     build()
     this

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
@@ -390,7 +390,7 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
 
 
   override def reset(): Unit = {
-    stopGradientLayers.clear()
+    if (null != stopGradientLayers) stopGradientLayers.clear()
     unFreeze()
     build()
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
@@ -15,6 +15,8 @@
  */
 package com.intel.analytics.bigdl.nn
 
+import java.util
+
 import scala.collection.JavaConverters._
 import com.intel.analytics.bigdl.nn.Graph.ModuleNode
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, TensorModule}
@@ -24,6 +26,7 @@ import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.serializer.{ContainerSerializable, DataConverter, ModuleData, ModuleSerializer}
 import com.intel.analytics.bigdl.utils.{Node, T, Table}
 import serialization.Bigdl.{AttrValue, BigDLModule}
+import com.intel.analytics.bigdl.utils.{DirectedGraph, Node, T, Table}
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -70,16 +73,17 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
 
   override def updateOutput(input: Activity): Activity = {
     var i = 0
-    while(i < executions.length) {
-      val node = executions(i)
-      inputsBP(i) = if (node.prevNodes.isEmpty && !node.element.isInstanceOf[WithoutInput]) {
+    while(i < forwardExecutions.length) {
+      val node = forwardExecutions(i)
+      val nodeInput = if (node.prevNodes.isEmpty && !node.element.isInstanceOf[WithoutInput]) {
         inputData(node, input)
       } else if (node.prevNodes.length == 1) {
         node.prevNodes.head.element.output.toTensor[T]
       } else {
         seqToTable(node.prevNodes.map(_.element.output))
       }
-      node.element.forward(inputsBP(i))
+      node.element.forward(nodeInput)
+      inputsBP.put(node.element.getName(), nodeInput)
       i += 1
     }
 
@@ -93,11 +97,13 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
 
   override def backward(input: Activity, gradOutput: Activity): Activity = {
     val before = System.nanoTime()
-    dummyOutput.element.gradInput = gradOutput
-    var i = executions.length - 1
-    while(i >= 0) {
-      val curNode = executions(i)
+    dummyOutputGrad.element.gradInput = gradOutput
+
+    var i = 0
+    while (i < backwardExecutions.length) {
+      val curNode = backwardExecutions(i)
       var curGradOutput : Tensor[T] = null
+
       curNode.nextNodes.foreach(n => {
         val nextGradOutput = if (n.prevNodes.length == 1) {
           n.element.gradInput.toTensor
@@ -114,9 +120,14 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
       })
 
       gradOutputBP(i) = curGradOutput
-      curNode.element.backward(inputsBP(i), curGradOutput)
-      i -= 1
+      if (!curNode.element.isStopGrad()) {
+        curNode.element.backward(inputsBP.get(curNode.element.getName()), curGradOutput)
+      } else {
+        curNode.element.accGradParameters(inputsBP.get(curNode.element.getName()), curGradOutput)
+      }
+      i += 1
     }
+
     gradInput = if (inputs.length == 1) {
       inputs(0).element.gradInput
     } else {
@@ -151,11 +162,13 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
   }
 
   override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
-    dummyOutput.element.gradInput = gradOutput
-    var i = executions.length - 1
-    while(i >= 0) {
-      val curNode = executions(i)
+    dummyOutputGrad.element.gradInput = gradOutput
+
+    var i = 0
+    while (i < backwardExecutions.length) {
+      val curNode = backwardExecutions(i)
       var curGradOutput : Tensor[T] = null
+
       curNode.nextNodes.foreach(n => {
         val nextGradOutput = if (n.prevNodes.length == 1) {
           n.element.gradInput.toTensor
@@ -172,8 +185,11 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
       })
 
       gradOutputBP(i) = curGradOutput
-      curNode.element.updateGradInput(inputsBP(i), curGradOutput)
-      i -= 1
+
+      if (!curNode.element.isStopGrad()) {
+        curNode.element.updateGradInput(inputsBP.get(curNode.element.getName()), curGradOutput)
+      }
+      i += 1
     }
 
     gradInput = if (inputs.length == 1) {
@@ -186,11 +202,11 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
   }
 
   override def accGradParameters(input: Activity, gradOutput: Activity): Unit = {
-    var i = executions.length - 1
-    while(i >= 0) {
-      val curNode = executions(i)
-      curNode.element.accGradParameters(inputsBP(i), gradOutputBP(i))
-      i -= 1
+    var i = 0
+    while (i < backwardExecutions.length) {
+      val curNode = backwardExecutions(i)
+      curNode.element.accGradParameters(inputsBP.get(curNode.element.getName()), gradOutputBP(i))
+      i += 1
     }
   }
 
@@ -209,27 +225,52 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
   // Add a dummy output node, to get an one end graph. So the nodes that are not dependent by
   // the outputs will be excluded
   private val dummyOutput = new ModuleNode[T](new Dummy[T]())
+  // Add a dummy output node for backward graph,
+  // dummyOutputGrad has the same function as dummyOutput
+  // used to construct a backward graph
+  private var dummyOutputGrad: ModuleNode[T] = null
   outputs.foreach(_ -> dummyOutput)
 
   /**
    * Computing backgraph
    */
-  val backGraph = dummyOutput.graph(reverse = true)
+  private val backGraph = dummyOutput.graph(reverse = true)
+  private var gradGraph: DirectedGraph[AbstractModule[Activity, Tensor[T], T]] = null
 
   /**
    * Execution plan
    */
-  val executions = backGraph.topologySort.filter(!_.element.isInstanceOf[Dummy[T]]).reverse
-  modules.appendAll(executions.map(_.element.asInstanceOf[AbstractModule[Activity, Activity, T]]))
+  private val forwardExecutions = backGraph.topologySort
+    .filter(!_.element.isInstanceOf[Dummy[T]]).reverse
+  private var backwardExecutions: Array[Node[AbstractModule[Activity, Tensor[T], T]]] = null
+
+  modules.appendAll(forwardExecutions.map(
+    _.element.asInstanceOf[AbstractModule[Activity, Activity, T]]))
+
+  /**
+    * build is needed when the stopGrad is changed
+    */
+  def build(): this.type = {
+    val gradGraph = backGraph.cloneGraph()
+    dummyOutputGrad = gradGraph.source
+    val nodes = gradGraph.DFS
+    nodes.filter(_.element.isStopGrad()).foreach(_.removePrev())
+    backwardExecutions = gradGraph.topologySort.filter(!_.element.isInstanceOf[Dummy[T]])
+    clearState()
+    this
+  }
+
+
+  private val inputsBP = new util.HashMap[String, Activity]()
 
   // Check all inputs of the graph should be passed in
   checkRoots
+  build
 
-  private val inputsBP = new Array[Activity](executions.length)
-  private val gradOutputBP = new Array[Tensor[T]](executions.length)
+  private val gradOutputBP = new Array[Tensor[T]](forwardExecutions.length)
 
   private def checkRoots : Unit = {
-    val roots = executions.filter(_.prevNodes.size == 0)
+    val roots = forwardExecutions.filter(_.prevNodes.size == 0)
       .filter(node => !node.element.isInstanceOf[WithoutInput])
     require(roots.size == inputs.length,
       s"There're ${inputs.length} inputs, but graph has ${roots.size} roots")
@@ -288,8 +329,39 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
     }
   }
 
-  def getExecutions : Array[Node[AbstractModule[Activity, Tensor[T], T]]] = {
-    return executions
+  /**
+   * set an array of layers to be freezed, which means their parameters are not changed
+   * @param names an array of layer names
+   * @return
+   */
+  def setFreeze(names: Array[String]): this.type = {
+    names.foreach(name => {
+      val layer = getSubModule(name)
+      require(layer.isDefined, s"cannot find layer match ${name}")
+      layer.get.setScaleW(0)
+      layer.get.setScaleB(0)
+    })
+    this
+  }
+
+  /**
+   * set all layers to be trainable
+   */
+  def unFreeze(): this.type = {
+    modules.foreach(layer => {
+      layer.setScaleW(1)
+      layer.setScaleB(1)
+    })
+    this
+  }
+
+  override def reset(): Unit = {
+    modules.foreach(_.setStopGrad(false))
+    unFreeze()
+  }
+
+  def getForwardExecutions : Array[Node[AbstractModule[Activity, Tensor[T], T]]] = {
+    forwardExecutions
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
@@ -228,7 +228,7 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
   // Add a dummy output node for backward graph,
   // dummyOutputGrad has the same function as dummyOutput
   // used to construct a backward graph
-  private var dummyOutputGrad: ModuleNode[T] = null
+  private var dummyOutputGrad: ModuleNode[T] = _
   outputs.foreach(_ -> dummyOutput)
 
   /**

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Reshape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Reshape.scala
@@ -51,6 +51,8 @@ class Reshape[@specialized(Float, Double) T: ClassTag](
     nElement *= size(i - 1)
   }
 
+  // whether share the storage between input and output
+  // in this layer, if input is contiguous, inplace is true. otherwise, inplace is false
   private var inplace: Boolean = true
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -206,15 +206,22 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag,
   }
 
   /**
-   * set trainable. If trainable is false, its parameters(weight/bias, if exists)
+   * freeze the layer, its parameters(weight/bias, if exists)
    * are not changed in training process
-   * @param trainable whether this layer is trainable
    */
-  def setTrainable(trainable: Boolean): this.type = {
-    if (!trainable) {
-      setScaleW(0)
-      setScaleB(0)
-    }
+  def freeze(): this.type = {
+    setScaleW(0)
+    setScaleB(0)
+    this
+  }
+
+  /**
+   * "unfreeze" layer, i.e. make the layer parameters(weight/bias, if exists)
+   * to be trained(updated) in training process
+   */
+  def unFreeze(): this.type = {
+    setScaleW(1)
+    setScaleB(1)
     this
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -23,6 +23,7 @@ import com.intel.analytics.bigdl.tensor.{Tensor, TensorDataType}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils._
 import com.intel.analytics.bigdl.nn.{Graph, InitializationMethod, Module, Zeros}
+import com.intel.analytics.bigdl.nn.{Module, Utils}
 import com.intel.analytics.bigdl.utils.TorchObject.TYPE_MODULE
 import org.apache.commons.lang3.SerializationUtils
 import org.apache.spark.rdd.RDD
@@ -202,6 +203,29 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag,
   def resetTimes(): Unit = {
     forwardTime = 0
     backwardTime = 0
+  }
+
+  /**
+   * set trainable
+   * @param trainable whether this layer is trainable
+   */
+  def setTrainable(trainable: Boolean): this.type = {
+    if (!trainable) {
+      scaleW = 0
+      scaleB = 0
+    }
+    this
+  }
+
+  private var _stopGrad: Boolean = false
+
+  def isStopGrad(): Boolean = {
+    _stopGrad
+  }
+
+  def setStopGrad(isStop: Boolean = true): this.type = {
+    _stopGrad = isStop
+    this
   }
 
   /**

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -206,7 +206,8 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag,
   }
 
   /**
-   * set trainable
+   * set trainable. If trainable is false, its parameters(weight/bias, if exists)
+   * are not changed in training process
    * @param trainable whether this layer is trainable
    */
   def setTrainable(trainable: Boolean): this.type = {
@@ -217,14 +218,25 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag,
     this
   }
 
-  private var _stopGrad: Boolean = false
+  private var _stopGradient: Boolean = false
 
-  def isStopGrad(): Boolean = {
-    _stopGrad
+  /**
+   * whether stop propagating gradInput back
+   * @return
+   */
+  def isStopGradient(): Boolean = {
+    _stopGradient
   }
 
-  def setStopGrad(isStop: Boolean = true): this.type = {
-    _stopGrad = isStop
+  /**
+   * set stop gradient. If isStopGradient is true, its input gradient
+   * is not computed. And it will not contributed to the input gradient computation of
+   * layers that depend on this layer.
+   * @param isStopGradient default is true.
+   * @return
+   */
+  def setStopGradient(isStopGradient: Boolean = true): this.type = {
+    _stopGradient = isStopGradient
     this
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -218,28 +218,6 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag,
     this
   }
 
-  private var _stopGradient: Boolean = false
-
-  /**
-   * whether stop propagating gradInput back
-   * @return
-   */
-  def isStopGradient(): Boolean = {
-    _stopGradient
-  }
-
-  /**
-   * set stop gradient. If isStopGradient is true, its input gradient
-   * is not computed. And it will not contributed to the input gradient computation of
-   * layers that depend on this layer.
-   * @param isStopGradient default is true.
-   * @return
-   */
-  def setStopGradient(isStopGradient: Boolean = true): this.type = {
-    _stopGradient = isStopGradient
-    this
-  }
-
   /**
    * Takes an input object, and computes the corresponding output of the module. After a forward,
    * the output state variable should have been updated to the new value.

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -212,8 +212,8 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag,
    */
   def setTrainable(trainable: Boolean): this.type = {
     if (!trainable) {
-      scaleW = 0
-      scaleB = 0
+      setScaleW(0)
+      setScaleB(0)
     }
     this
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -1868,7 +1868,7 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   }
 
   def setFreeze(model: Graph[T], freezeLayers: JList[String]): Graph[T] = {
-    model.setFreeze(freezeLayers.asScala.toArray)
+    model.freeze(freezeLayers.asScala.toArray)
   }
 
   def unFreeze(model: Graph[T]): Graph[T] = {
@@ -1876,6 +1876,6 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   }
 
   def setStopGradient(model: Graph[T], layers: JList[String]): Graph[T] = {
-    model.setStopGradient(layers.asScala.toArray)
+    model.stopGradient(layers.asScala.toArray)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -1867,11 +1867,6 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
     model.setTrainable(trainable)
   }
 
-  def setLayerStopGradient(model: AbstractModule[Activity, Activity, T], stopGradient: Boolean)
-  : AbstractModule[Activity, Activity, T] = {
-    model.setStopGradient(stopGradient)
-  }
-
   def setFreeze(model: Graph[T], freezeLayers: JList[String]): Graph[T] = {
     model.setFreeze(freezeLayers.asScala.toArray)
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -1862,9 +1862,14 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
     rec.setState(stateActivity)
   }
 
-  def setLayerTrainable(model: AbstractModule[Activity, Activity, T], trainable: Boolean)
+  def setLayerFreeze(model: AbstractModule[Activity, Activity, T])
   : AbstractModule[Activity, Activity, T] = {
-    model.setTrainable(trainable)
+    model.freeze()
+  }
+
+  def setLayerUnFreeze(model: AbstractModule[Activity, Activity, T])
+  : AbstractModule[Activity, Activity, T] = {
+    model.unFreeze()
   }
 
   def setFreeze(model: Graph[T], freezeLayers: JList[String]): Graph[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -1867,11 +1867,20 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
     model.setTrainable(trainable)
   }
 
+  def setLayerStopGradient(model: AbstractModule[Activity, Activity, T], stopGradient: Boolean)
+  : AbstractModule[Activity, Activity, T] = {
+    model.setStopGradient(stopGradient)
+  }
+
   def setFreeze(model: Graph[T], freezeLayers: JList[String]): Graph[T] = {
     model.setFreeze(freezeLayers.asScala.toArray)
   }
 
   def unFreeze(model: Graph[T]): Graph[T] = {
     model.unFreeze()
+  }
+
+  def setStopGradient(model: Graph[T], layers: JList[String]): Graph[T] = {
+    model.setStopGradient(layers.asScala.toArray)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -129,9 +129,13 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   def toJTensor(tensor: Tensor[T]): JTensor = {
     // clone here in case the the size of storage larger then the size of tensor.
     require(tensor != null, "tensor cannot be null")
-    val cloneTensor = tensor.clone()
-    JTensor(cloneTensor.storage().toList.map(_.asInstanceOf[Any]).asJava,
-      cloneTensor.size().toList.asJava, typeName)
+    if (tensor.nElement() == 0) {
+      JTensor(new JArrayList[Any](0), List(0).asJava, typeName)
+    } else {
+      val cloneTensor = tensor.clone()
+      JTensor(cloneTensor.storage().toList.map(_.asInstanceOf[Any]).asJava,
+        cloneTensor.size().toList.asJava, typeName)
+    }
   }
 
   def testTensor(jTensor: JTensor): JTensor = {
@@ -1856,5 +1860,18 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   def setState(rec: Recurrent[T], state: JList[JTensor], isTable: Boolean): Unit = {
     val stateActivity = jTensorsToActivity(state, isTable)
     rec.setState(stateActivity)
+  }
+
+  def setLayerTrainable(model: AbstractModule[Activity, Activity, T], trainable: Boolean)
+  : AbstractModule[Activity, Activity, T] = {
+    model.setTrainable(trainable)
+  }
+
+  def setFreeze(model: Graph[T], freezeLayers: JList[String]): Graph[T] = {
+    model.setFreeze(freezeLayers.asScala.toArray)
+  }
+
+  def unFreeze(model: Graph[T]): Graph[T] = {
+    model.unFreeze()
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
@@ -203,10 +203,10 @@ class Node[T](val element: T) extends Serializable {
   }
 
   /**
-    * remove all previous nodes
+    * remove edges that connect previous nodes
     * @return current node
     */
-  def removePrev(): Node[T] = {
+  def removePrevEdges(): Node[T] = {
     prevs.foreach(_.nexts.-=(this))
     prevs.clear()
     this

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
@@ -124,19 +124,27 @@ class DirectedGraph[T](val source : Node[T], val reverse : Boolean = false) exte
   }
 
   /**
-   * Clone the graph structure, will not change the node element
+   * Clone the graph structure, will not clone the node element
    * @return new graph
    */
   def cloneGraph(): DirectedGraph[T] = {
     val oldToNew = new util.HashMap[Node[T], Node[T]]()
+//    BFS.foreach(node => {
+//      oldToNew.put(node, new Node[T](node.element))
+//    })
+//    BFS.foreach(node => {
+//      node.prevNodes.foreach(prev => {
+//        oldToNew.get(prev) -> oldToNew.get(node)
+//      })
+//    })
     val oldNodes = new util.LinkedList[Node[T]]()
     oldNodes.add(source)
-    oldToNew.put(source, source.cloneNode())
+    oldToNew.put(source, new Node[T](source.element))
     while (!oldNodes.isEmpty) {
       val cur = oldNodes.remove()
       cur.prevNodes.foreach(prev => {
         if (!oldToNew.containsKey(prev)) {
-          oldToNew.put(prev, prev.cloneNode())
+          oldToNew.put(prev, new Node[T](prev.element))
           oldNodes.add(prev)
         }
         oldToNew.get(prev) -> oldToNew.get(cur)
@@ -225,10 +233,6 @@ class Node[T](val element: T) extends Serializable {
 
   private val nexts = new ArrayBuffer[Node[T]]()
   private val prevs = new ArrayBuffer[Node[T]]()
-
-  def cloneNode(): Node[T] = {
-    new Node[T](element)
-  }
 }
 
 object Node {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
@@ -129,27 +129,15 @@ class DirectedGraph[T](val source : Node[T], val reverse : Boolean = false) exte
    */
   def cloneGraph(): DirectedGraph[T] = {
     val oldToNew = new util.HashMap[Node[T], Node[T]]()
-//    BFS.foreach(node => {
-//      oldToNew.put(node, new Node[T](node.element))
-//    })
-//    BFS.foreach(node => {
-//      node.prevNodes.foreach(prev => {
-//        oldToNew.get(prev) -> oldToNew.get(node)
-//      })
-//    })
-    val oldNodes = new util.LinkedList[Node[T]]()
-    oldNodes.add(source)
-    oldToNew.put(source, new Node[T](source.element))
-    while (!oldNodes.isEmpty) {
-      val cur = oldNodes.remove()
-      cur.prevNodes.foreach(prev => {
-        if (!oldToNew.containsKey(prev)) {
-          oldToNew.put(prev, new Node[T](prev.element))
-          oldNodes.add(prev)
-        }
-        oldToNew.get(prev) -> oldToNew.get(cur)
+    val bfs = BFS.toArray
+    bfs.foreach(node => {
+      oldToNew.put(node, new Node[T](node.element))
+    })
+    bfs.foreach(node => {
+      node.prevNodes.foreach(prev => {
+        oldToNew.get(prev) -> oldToNew.get(node)
       })
-    }
+    })
     new DirectedGraph[T](oldToNew.get(source), reverse)
   }
 
@@ -233,6 +221,10 @@ class Node[T](val element: T) extends Serializable {
 
   private val nexts = new ArrayBuffer[Node[T]]()
   private val prevs = new ArrayBuffer[Node[T]]()
+
+  def cloneNode(): Node[T] = {
+    new Node[T](element)
+  }
 }
 
 object Node {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
@@ -221,10 +221,6 @@ class Node[T](val element: T) extends Serializable {
 
   private val nexts = new ArrayBuffer[Node[T]]()
   private val prevs = new ArrayBuffer[Node[T]]()
-
-  def cloneNode(): Node[T] = {
-    new Node[T](element)
-  }
 }
 
 object Node {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
@@ -124,9 +124,9 @@ class DirectedGraph[T](val source : Node[T], val reverse : Boolean = false) exte
   }
 
   /**
-    * Clone the graph structure, will not change the node element
-    * @return new graph
-    */
+   * Clone the graph structure, will not change the node element
+   * @return new graph
+   */
   def cloneGraph(): DirectedGraph[T] = {
     val oldToNew = new util.HashMap[Node[T], Node[T]]()
     val oldNodes = new util.LinkedList[Node[T]]()
@@ -203,9 +203,9 @@ class Node[T](val element: T) extends Serializable {
   }
 
   /**
-    * remove edges that connect previous nodes
-    * @return current node
-    */
+   * remove edges that connect previous nodes
+   * @return current node
+   */
   def removePrevEdges(): Node[T] = {
     prevs.foreach(_.nexts.-=(this))
     prevs.clear()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/caffe/CaffePersister.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/caffe/CaffePersister.scala
@@ -77,7 +77,7 @@ class CaffePersister[T: ClassTag](val prototxtPath: String,
     val graph = toGraph()
     val top2Layers = new mutable.HashMap[String, String]()
     val layers = new mutable.HashMap[String, GeneratedMessage]()
-    val executions = graph.getExecutions
+    val executions = graph.getForwardExecutions
     netparam.setName(module.getName)
     executions.foreach(execution => {
       val preModules = execution.prevNodes

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/TensorflowSaver.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/TensorflowSaver.scala
@@ -59,7 +59,7 @@ object TensorflowSaver {
     val graphBuilder = GraphDef.newBuilder()
     inputs.foreach(graphBuilder.addNode(_))
 
-    model.executions.foreach(n => {
+    model.getForwardExecutions.foreach(n => {
       val nodeDefs = maps(n.element.getClass.getName).toTFDef(n.element, inputNodeCache(n.element),
         byteOrder)
       nodeDefs.foreach(nDef => {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/InceptionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/InceptionSpec.scala
@@ -840,7 +840,21 @@ class InceptionSpec extends TorchSpec {
     val gradInput2 = graphModel.backward(input, gradOutput).toTensor[Float]
     gradInput1 should be(gradInput2)
 
-    model.getParametersTable().equals(graphModel.getParametersTable()) should be (true)
+    val table1 = model.getParametersTable()
+    val table2 = graphModel.getParametersTable()
+    table1.keySet.foreach(key => {
+      table1(key).asInstanceOf[Table]("weight").asInstanceOf[Tensor[Float]] should be
+      table2(key).asInstanceOf[Table]("weight").asInstanceOf[Tensor[Float]]
+
+      table1(key).asInstanceOf[Table]("bias").asInstanceOf[Tensor[Float]] should be
+      table2(key).asInstanceOf[Table]("bias").asInstanceOf[Tensor[Float]]
+
+      table1(key).asInstanceOf[Table]("gradWeight").asInstanceOf[Tensor[Float]] should be
+      table2(key).asInstanceOf[Table]("gradWeight").asInstanceOf[Tensor[Float]]
+
+      table1(key).asInstanceOf[Table]("gradBias").asInstanceOf[Tensor[Float]] should be
+      table2(key).asInstanceOf[Table]("gradBias").asInstanceOf[Tensor[Float]]
+    })
   }
 
   "Inception_v1 graph" should "be correct" in {
@@ -882,7 +896,21 @@ class InceptionSpec extends TorchSpec {
     val gradInput2 = graphModel.backward(input, gradOutput).toTensor[Float]
     gradInput1 should be(gradInput2)
 
-    model.getParametersTable().equals(graphModel.getParametersTable()) should be (true)
+    val table1 = model.getParametersTable()
+    val table2 = graphModel.getParametersTable()
+    table1.keySet.foreach(key => {
+      table1(key).asInstanceOf[Table]("weight").asInstanceOf[Tensor[Float]] should be
+      table2(key).asInstanceOf[Table]("weight").asInstanceOf[Tensor[Float]]
+
+      table1(key).asInstanceOf[Table]("bias").asInstanceOf[Tensor[Float]] should be
+      table2(key).asInstanceOf[Table]("bias").asInstanceOf[Tensor[Float]]
+
+      table1(key).asInstanceOf[Table]("gradWeight").asInstanceOf[Tensor[Float]] should be
+      table2(key).asInstanceOf[Table]("gradWeight").asInstanceOf[Tensor[Float]]
+
+      table1(key).asInstanceOf[Table]("gradBias").asInstanceOf[Tensor[Float]] should be
+      table2(key).asInstanceOf[Table]("gradBias").asInstanceOf[Tensor[Float]]
+    })
   }
 
   "Inception_v2_NoAuxClassifier graph" should "be correct" in {
@@ -903,7 +931,21 @@ class InceptionSpec extends TorchSpec {
     val gradInput2 = graphModel.backward(input, gradOutput).toTensor[Float]
     gradInput1 should be(gradInput2)
 
-    model.getParametersTable().equals(graphModel.getParametersTable()) should be (true)
+    val table1 = model.getParametersTable()
+    val table2 = graphModel.getParametersTable()
+    table1.keySet.foreach(key => {
+      table1(key).asInstanceOf[Table]("weight").asInstanceOf[Tensor[Float]] should be
+      table2(key).asInstanceOf[Table]("weight").asInstanceOf[Tensor[Float]]
+
+      table1(key).asInstanceOf[Table]("bias").asInstanceOf[Tensor[Float]] should be
+      table2(key).asInstanceOf[Table]("bias").asInstanceOf[Tensor[Float]]
+
+      table1(key).asInstanceOf[Table]("gradWeight").asInstanceOf[Tensor[Float]] should be
+      table2(key).asInstanceOf[Table]("gradWeight").asInstanceOf[Tensor[Float]]
+
+      table1(key).asInstanceOf[Table]("gradBias").asInstanceOf[Tensor[Float]] should be
+      table2(key).asInstanceOf[Table]("gradBias").asInstanceOf[Tensor[Float]]
+    })
   }
 
   "Inception_v2 graph" should "be correct" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GraphSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GraphSpec.scala
@@ -682,7 +682,7 @@ class GraphSpec extends FlatSpec with Matchers {
     val funcModelNoBack = Graph(input, output)
     val funcModelOriginal = Graph(input2, output_2)
 
-    funcModelNoBack.setStopGradient(Array("reshape"))
+    funcModelNoBack.stopGradient(Array("reshape"))
 
     val inputData = Tensor(4, 28 * 28).rand()
     val outputData1 = funcModelOriginal.forward(inputData) // warm up
@@ -741,7 +741,7 @@ class GraphSpec extends FlatSpec with Matchers {
     val output_2 = LogSoftMax().inputs(fc2_2)
 
     val funcModelNoBack = Graph(input, output)
-    funcModelNoBack.setStopGradient(Array("pool1"))
+    funcModelNoBack.stopGradient(Array("pool1"))
     val funcModelOriginal = Graph(input2, output_2)
 
     val inputData = Tensor(4, 28 * 28).rand()
@@ -782,7 +782,7 @@ class GraphSpec extends FlatSpec with Matchers {
     val output2_1 = Threshold(10.0).inputs(cadd_1)
 
     val graphNoBack = Graph(Array(fc2_1, fc1_1), Array(output1_1, output2_1))
-    graphNoBack.setStopGradient(Array("relu"))
+    graphNoBack.stopGradient(Array("relu"))
 
     RandomGenerator.RNG.setSeed(1000)
     val fc1_2 = Linear(4, 2).inputs()
@@ -835,7 +835,7 @@ class GraphSpec extends FlatSpec with Matchers {
     val output2_1 = Threshold(10.0).inputs(cadd_1)
 
     val graphNoBack = Graph(Array(fc2_1, fc1_1), Array(output1_1, output2_1))
-    graphNoBack.setStopGradient(Array("fc2_1"))
+    graphNoBack.stopGradient(Array("fc2_1"))
 
     fc1.element.getParameters()._1.apply1(_ => 1.0f)
     fc2.element.getParameters()._1.apply1(_ => 2.0f)
@@ -875,7 +875,7 @@ class GraphSpec extends FlatSpec with Matchers {
     val output2_1 = Threshold(10.0).inputs(cadd_1)
 
     val graphNoBack = Graph(Array(reshape, fc1_1), Array(output1_1, output2_1))
-    graphNoBack.setStopGradient(Array("fc2_1"))
+    graphNoBack.stopGradient(Array("fc2_1"))
     fc1.element.getParameters()._1.apply1(_ => 1.0f)
     fc2.element.getParameters()._1.apply1(_ => 2.0f)
     fc1_1.element.getParameters()._1.apply1(_ => 1.0f)
@@ -914,7 +914,7 @@ class GraphSpec extends FlatSpec with Matchers {
     val output2_1 = Threshold(10.0).inputs(cadd_1)
 
     val graphNoBack = Graph(Array(fc2_1, fc1_1), Array(output1_1, output2_1))
-    graphNoBack.setStopGradient(Array("fc2_1"))
+    graphNoBack.stopGradient(Array("fc2_1"))
 
     fc1.element.getParameters()._1.apply1(_ => 1.0f)
     fc2.element.getParameters()._1.apply1(_ => 2.0f)
@@ -976,7 +976,7 @@ class GraphSpec extends FlatSpec with Matchers {
     fc1.element.getParameters()._1.apply1(_ => 1.0f)
     fc2.element.getParameters()._1.apply1(_ => 2.0f)
     model.zeroGradParameters()
-    model.setFreeze(Array("fc2"))
+    model.freeze(Array("fc2"))
     println("output2: \n", model.forward(input))
     model.backward(input, gradOutput)
     model.updateParameters(1)
@@ -993,7 +993,7 @@ class GraphSpec extends FlatSpec with Matchers {
 
     fc1.element.getParameters()._1.apply1(_ => 1.0f)
     fc2.element.getParameters()._1.apply1(_ => 2.0f)
-    model.setStopGradient(Array("cadd"))
+    model.stopGradient(Array("cadd"))
     model.zeroGradParameters()
     println("output4: \n", model.forward(input))
     model.backward(input, gradOutput)
@@ -1019,7 +1019,7 @@ class GraphSpec extends FlatSpec with Matchers {
     val output2_1 = Threshold(10.0).inputs(cadd_1)
 
     val graphNoBack = Graph(Array(reshape, fc1_1), Array(output1_1, output2_1))
-    graphNoBack.setStopGradient(Array("fc2_1"))
+    graphNoBack.stopGradient(Array("fc2_1"))
 
     fc1.element.getParameters()._1.apply1(_ => 1.0f)
     fc2.element.getParameters()._1.apply1(_ => 2.0f)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GraphSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GraphSpec.scala
@@ -15,6 +15,7 @@
  */
 package com.intel.analytics.bigdl.nn
 
+import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.example.loadmodel.AlexNet_OWT
 import com.intel.analytics.bigdl.models.autoencoder.Autoencoder
@@ -28,10 +29,12 @@ import org.scalatest.{FlatSpec, Matchers}
 import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import com.intel.analytics.bigdl.utils.RandomGenerator._
+import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.{RandomGenerator, T, Table}
 
 import scala.reflect.ClassTag
 import scala.util.Random
+import org.scalatest.{FlatSpec, Matchers}
 
 @com.intel.analytics.bigdl.tags.Parallel
 class GraphSpec extends FlatSpec with Matchers {
@@ -408,7 +411,7 @@ class GraphSpec extends FlatSpec with Matchers {
     val seqModel = ModelUntils.ResNet.basicBlockSeq(16, 16, 1, "A")
     RandomGenerator.RNG.setSeed(1000)
     val input = Input()
-    val output = ModelUntils.ResNet.basicBlockFunc(16, 16, 1, "A")(input)
+    val output = ModelUntils.ResNet.basicBlockSeq(16, 16, 1, "A").inputs(input)
     val funcModel = Graph(input, output)
 
     println(seqModel)
@@ -646,6 +649,423 @@ class GraphSpec extends FlatSpec with Matchers {
     gradInput1 should be(gradInput2)
     model.getParameters().equals(graphModel.getParameters()) should be(true)
   }
+
+  "Graph backward sequential with propagateBack false in the first" should "work properly" in {
+    RandomGenerator.RNG.setSeed(1000)
+    val input = Reshape(Array(1, 28, 28)).setStopGrad().inputs()
+    val conv1 = SpatialConvolution(1, 6, 5, 5).setName("conv1").inputs(input)
+    val tanh1 = Tanh().inputs(conv1)
+    val pool1 = SpatialMaxPooling(2, 2, 2, 2).inputs(tanh1)
+    val tanh2 = Tanh().inputs(pool1)
+    val conv2 = SpatialConvolution(6, 12, 5, 5).inputs(tanh2)
+    val pool2 = SpatialMaxPooling(2, 2, 2, 2).inputs(conv2)
+    val reshape = Reshape(Array(12 * 4 * 4)).inputs(pool2)
+    val fc1 = Linear(12 * 4 * 4, 100).inputs(reshape)
+    val tanh3 = Tanh().inputs(fc1)
+    val fc2 = Linear(100, 10).inputs(tanh3)
+    val output = LogSoftMax().inputs(fc2)
+
+    RandomGenerator.RNG.setSeed(1000)
+    val input2 = Reshape(Array(1, 28, 28)).inputs()
+    val conv1_2 = SpatialConvolution(1, 6, 5, 5).setName("conv1").inputs(input2)
+    val tanh1_2 = Tanh().inputs(conv1_2)
+    val pool1_2 = SpatialMaxPooling(2, 2, 2, 2).inputs(tanh1_2)
+    val tanh2_2 = Tanh().inputs(pool1_2)
+    val conv2_2 = SpatialConvolution(6, 12, 5, 5).inputs(tanh2_2)
+    val pool2_2 = SpatialMaxPooling(2, 2, 2, 2).inputs(conv2_2)
+    val reshape_2 = Reshape(Array(12 * 4 * 4)).inputs(pool2_2)
+    val fc1_2 = Linear(12 * 4 * 4, 100).inputs(reshape_2)
+    val tanh3_2 = Tanh().inputs(fc1_2)
+    val fc2_2 = Linear(100, 10).inputs(tanh3_2)
+    val output_2 = LogSoftMax().inputs(fc2_2)
+
+    val funcModelNoBack = Graph(input, output)
+    val funcModelOriginal = Graph(input2, output_2)
+
+    val inputData = Tensor(4, 28 * 28).rand()
+    val outputData1 = funcModelOriginal.forward(inputData) // warm up
+    var start = System.nanoTime()
+    funcModelOriginal.forward(inputData)
+    println(s"seq model forward time is ${ (System.nanoTime() - start) / 1e6 }ms")
+    start = System.nanoTime()
+    val outputData2 = funcModelNoBack.forward(inputData)
+    println(s"funcModel model forward time is ${ (System.nanoTime() - start) / 1e6 }ms")
+
+    outputData1 should be(outputData2)
+
+    val gradient = Tensor(4, 10).rand()
+    start = System.nanoTime()
+    val gradientBPOriginal = funcModelOriginal.backward(inputData, gradient)
+    println(s"seq model backward time is ${ (System.nanoTime() - start) / 1e6 }ms")
+    start = System.nanoTime()
+    val gradientBPNoBack = funcModelNoBack.backward(inputData, gradient)
+    println(s"funcModel model backward time is ${ (System.nanoTime() - start) / 1e6 }ms")
+
+    gradientBPNoBack.toTensor.nElement() should be(0)
+    val namedModule1 = funcModelOriginal.getParametersTable()
+    val namedModule2 = funcModelNoBack.getParametersTable()
+    namedModule1("conv1").asInstanceOf[Table] should
+      equal(namedModule2("conv1").asInstanceOf[Table])
+    funcModelOriginal.getParameters()._2 should be(funcModelNoBack.getParameters()._2)
+  }
+
+  "Graph backward propagateBack false in the middle" should "work properly in sequential lenet" in {
+    RandomGenerator.RNG.setSeed(1000)
+    val input = Reshape(Array(1, 28, 28)).setName("r1").inputs()
+    val conv1 = SpatialConvolution(1, 6, 5, 5).setName("conv1").inputs(input)
+    val tanh1 = Tanh().setName("tanh1").inputs(conv1)
+    val pool1 = SpatialMaxPooling(2, 2, 2, 2).setName("pool1").setStopGrad().inputs(tanh1)
+    val tanh2 = Tanh().setName("tanh2").inputs(pool1)
+    val conv2 = SpatialConvolution(6, 12, 5, 5).setName("conv2").inputs(tanh2)
+    val pool2 = SpatialMaxPooling(2, 2, 2, 2).inputs(conv2)
+    val reshape = Reshape(Array(12 * 4 * 4)).inputs(pool2)
+    val fc1 = Linear(12 * 4 * 4, 100).inputs(reshape)
+    val tanh3 = Tanh().inputs(fc1)
+    val fc2 = Linear(100, 10).inputs(tanh3)
+    val output = LogSoftMax().inputs(fc2)
+
+    RandomGenerator.RNG.setSeed(1000)
+    val input2 = Reshape(Array(1, 28, 28)).setName("r1").inputs()
+    val conv1_2 = SpatialConvolution(1, 6, 5, 5).setName("conv1").inputs(input2)
+    val tanh1_2 = Tanh().setName("tanh1").inputs(conv1_2)
+    val pool1_2 = SpatialMaxPooling(2, 2, 2, 2).setName("pool1").inputs(tanh1_2)
+    val tanh2_2 = Tanh().setName("tanh2").inputs(pool1_2)
+    val conv2_2 = SpatialConvolution(6, 12, 5, 5).inputs(tanh2_2)
+    val pool2_2 = SpatialMaxPooling(2, 2, 2, 2).inputs(conv2_2)
+    val reshape_2 = Reshape(Array(12 * 4 * 4)).inputs(pool2_2)
+    val fc1_2 = Linear(12 * 4 * 4, 100).inputs(reshape_2)
+    val tanh3_2 = Tanh().inputs(fc1_2)
+    val fc2_2 = Linear(100, 10).inputs(tanh3_2)
+    val output_2 = LogSoftMax().inputs(fc2_2)
+
+    val funcModelNoBack = Graph(input, output)
+    val funcModelOriginal = Graph(input2, output_2)
+
+    val inputData = Tensor(4, 28 * 28).rand()
+    val outputData1 = funcModelOriginal.forward(inputData)
+    val outputData2 = funcModelNoBack.forward(inputData)
+    outputData1 should be(outputData2)
+
+    val gradient = Tensor(4, 10).rand()
+    val gradientBPOriginal = funcModelOriginal.backward(inputData, gradient)
+    val gradientBPNoBack = funcModelNoBack.backward(inputData, gradient)
+
+    gradientBPNoBack.toTensor.nElement() should be(0)
+    val namedModule1 = Utils.getNamedModules(funcModelOriginal)
+    val namedModule2 = Utils.getNamedModules(funcModelNoBack)
+    namedModule2("r1").gradInput.toTensor.nElement() should be(0)
+    namedModule2("conv1").gradInput.toTensor.nElement() should be(0)
+    namedModule2("tanh1").gradInput.toTensor.nElement() should be(0)
+    namedModule2("pool1").gradInput.toTensor.nElement() should be(0)
+
+    namedModule2("conv2").asInstanceOf[SpatialConvolution[Float]].parameters()._2 should be(
+      namedModule2("conv2").asInstanceOf[SpatialConvolution[Float]].parameters()._2)
+  }
+
+  "graph propagate false in subpath" should "work properly" in {
+    RandomGenerator.RNG.setSeed(1000)
+    val fc1 = Linear(4, 2).inputs()
+    val fc2 = Linear(4, 2).inputs()
+    val cadd = CAddTable().inputs(fc1, fc2)
+    val output1 = ReLU().inputs(cadd)
+    val output2 = Threshold(10.0).inputs(cadd)
+
+    val graph = Graph(Array(fc2, fc1), Array(output1, output2))
+    RandomGenerator.RNG.setSeed(1000)
+    val fc1_1 = Linear(4, 2).inputs()
+    val fc2_1 = Linear(4, 2).inputs()
+    val cadd_1 = CAddTable().inputs(fc1_1, fc2_1)
+    val output1_1 = ReLU().setStopGrad().inputs(cadd_1)
+    val output2_1 = Threshold(10.0).inputs(cadd_1)
+
+    val graphNoBack = Graph(Array(fc2_1, fc1_1), Array(output1_1, output2_1))
+
+    RandomGenerator.RNG.setSeed(1000)
+    val fc1_2 = Linear(4, 2).inputs()
+    val fc2_2 = Linear(4, 2).inputs()
+    val cadd_2 = CAddTable().inputs(fc1_2, fc2_2)
+    val output2_2 = Threshold(10.0).inputs(cadd_2)
+
+    val graphNoBackExpect = Graph(Array(fc2_2, fc1_2), Array(output2_2))
+
+    fc1.element.getParameters()._1.apply1(_ => 1.0f)
+    fc2.element.getParameters()._1.apply1(_ => 2.0f)
+    fc1_1.element.getParameters()._1.apply1(_ => 1.0f)
+    fc2_1.element.getParameters()._1.apply1(_ => 2.0f)
+    fc1_2.element.getParameters()._1.apply1(_ => 1.0f)
+    fc2_2.element.getParameters()._1.apply1(_ => 2.0f)
+
+    val input = T(Tensor(T(0.1f, 0.2f, -0.3f, -0.4f)),
+      Tensor(T(0.5f, 0.4f, -0.2f, -0.1f)))
+    graph.forward(input) should be (graphNoBack.forward(input))
+
+
+    val gradOutput = T(Tensor(T(1.0f, 2.0f)), Tensor(T(3.0f, 4.0f)))
+    val gradInput = graph.backward(input, gradOutput)
+
+    graph.backward(input, gradOutput)
+    graphNoBack.backward(input, gradOutput)
+    graphNoBackExpect.forward(input)
+    graphNoBackExpect.backward(input, Tensor(T(3.0f, 4.0f)))
+    output1_1.element.gradInput.toTensor.nElement() should be (0)
+    cadd_2.element.gradInput should be (cadd_1.element.gradInput)
+    fc1_2.element.gradInput should be (fc1_1.element.gradInput)
+    fc2_2.element.gradInput should be (fc2_1.element.gradInput)
+    output2.element.gradInput should be (output2_1.element.gradInput)
+  }
+
+  "graph propagate false in concat subpath" should "work properly" in {
+    RandomGenerator.RNG.setSeed(1000)
+    val fc1 = Linear(4, 2).inputs()
+    val fc2 = Linear(4, 2).inputs()
+    val cadd = CAddTable().inputs(fc1, fc2)
+    val output1 = ReLU().inputs(cadd)
+    val output2 = Threshold(10.0).inputs(cadd)
+
+    val graph = Graph(Array(fc2, fc1), Array(output1, output2))
+    RandomGenerator.RNG.setSeed(1000)
+    val fc1_1 = Linear(4, 2).inputs()
+    val fc2_1 = Linear(4, 2).setStopGrad().inputs()
+    val cadd_1 = CAddTable().inputs(fc1_1, fc2_1)
+    val output1_1 = ReLU().inputs(cadd_1)
+    val output2_1 = Threshold(10.0).inputs(cadd_1)
+
+    val graphNoBack = Graph(Array(fc2_1, fc1_1), Array(output1_1, output2_1))
+
+    fc1.element.getParameters()._1.apply1(_ => 1.0f)
+    fc2.element.getParameters()._1.apply1(_ => 2.0f)
+    fc1_1.element.getParameters()._1.apply1(_ => 1.0f)
+    fc2_1.element.getParameters()._1.apply1(_ => 2.0f)
+
+    val input = T(Tensor(T(0.1f, 0.2f, -0.3f, -0.4f)),
+      Tensor(T(0.5f, 0.4f, -0.2f, -0.1f)))
+    graph.forward(input) should be (graphNoBack.forward(input))
+
+
+    val gradOutput = T(Tensor(T(1.0f, 2.0f)), Tensor(T(3.0f, 4.0f)))
+
+    graph.backward(input, gradOutput)
+    graphNoBack.backward(input, gradOutput)
+    fc2_1.element.gradInput.toTensor.nElement() should be (0)
+    output2.element.gradInput should be (output2_1.element.gradInput)
+    fc1_1.element.gradInput should be (fc1.element.gradInput)
+    fc1_1.element.parameters()._2 should be (fc1.element.parameters()._2)
+  }
+
+  "graph propagate false in concat subpath with longer edge" should "work properly" in {
+    RandomGenerator.RNG.setSeed(1000)
+    val fc1 = Linear(4, 2).inputs()
+    val fc2 = Linear(4, 2).inputs()
+    val cadd = CAddTable().inputs(fc1, fc2)
+    val output1 = ReLU().inputs(cadd)
+    val output2 = Threshold(10.0).inputs(cadd)
+
+    val graph = Graph(Array(fc2, fc1), Array(output1, output2))
+    RandomGenerator.RNG.setSeed(1000)
+    val reshape = Reshape(Array(4)).inputs()
+    val fc1_1 = Linear(4, 2).inputs()
+    val fc2_1 = Linear(4, 2).setStopGrad().inputs(reshape)
+    val cadd_1 = CAddTable().inputs(fc1_1, fc2_1)
+    val output1_1 = ReLU().inputs(cadd_1)
+    val output2_1 = Threshold(10.0).inputs(cadd_1)
+
+    val graphNoBack = Graph(Array(reshape, fc1_1), Array(output1_1, output2_1))
+
+    fc1.element.getParameters()._1.apply1(_ => 1.0f)
+    fc2.element.getParameters()._1.apply1(_ => 2.0f)
+    fc1_1.element.getParameters()._1.apply1(_ => 1.0f)
+    fc2_1.element.getParameters()._1.apply1(_ => 2.0f)
+
+    val input = T(Tensor(T(0.1f, 0.2f, -0.3f, -0.4f)),
+      Tensor(T(0.5f, 0.4f, -0.2f, -0.1f)))
+    graph.forward(input) should be (graphNoBack.forward(input))
+
+
+    val gradOutput = T(Tensor(T(1.0f, 2.0f)), Tensor(T(3.0f, 4.0f)))
+
+    graph.backward(input, gradOutput)
+    graphNoBack.backward(input, gradOutput)
+    fc2_1.element.gradInput.toTensor.nElement() should be (0)
+    output2.element.gradInput should be (output2_1.element.gradInput)
+    fc1_1.element.gradInput should be (fc1.element.gradInput)
+    fc1_1.element.parameters()._2 should be (fc1.element.parameters()._2)
+    reshape.element.gradInput.toTensor.nElement() should be (0)
+  }
+
+  "graph propagate false reset to true" should "work properly" in {
+    RandomGenerator.RNG.setSeed(1000)
+    val fc1 = Linear(4, 2).inputs()
+    val fc2 = Linear(4, 2).inputs()
+    val cadd = CAddTable().inputs(fc1, fc2)
+    val output1 = ReLU().inputs(cadd)
+    val output2 = Threshold(10.0).inputs(cadd)
+
+    val graph = Graph(Array(fc2, fc1), Array(output1, output2))
+    RandomGenerator.RNG.setSeed(1000)
+    val fc1_1 = Linear(4, 2).inputs()
+    val fc2_1 = Linear(4, 2).setStopGrad().inputs()
+    val cadd_1 = CAddTable().inputs(fc1_1, fc2_1)
+    val output1_1 = ReLU().inputs(cadd_1)
+    val output2_1 = Threshold(10.0).inputs(cadd_1)
+
+    val graphNoBack = Graph(Array(fc2_1, fc1_1), Array(output1_1, output2_1))
+
+    fc1.element.getParameters()._1.apply1(_ => 1.0f)
+    fc2.element.getParameters()._1.apply1(_ => 2.0f)
+    fc1_1.element.getParameters()._1.apply1(_ => 1.0f)
+    fc2_1.element.getParameters()._1.apply1(_ => 2.0f)
+
+    val input = T(Tensor(T(0.1f, 0.2f, -0.3f, -0.4f)),
+      Tensor(T(0.5f, 0.4f, -0.2f, -0.1f)))
+    graph.forward(input) should be (graphNoBack.forward(input))
+
+
+    val gradOutput = T(Tensor(T(1.0f, 2.0f)), Tensor(T(3.0f, 4.0f)))
+
+    graph.backward(input, gradOutput)
+    graphNoBack.backward(input, gradOutput)
+    fc2_1.element.gradInput.toTensor.nElement() should be (0)
+    output2.element.gradInput should be (output2_1.element.gradInput)
+    fc1_1.element.gradInput should be (fc1.element.gradInput)
+    fc1_1.element.parameters()._2 should be (fc1.element.parameters()._2)
+
+    // reset propagateBack
+    fc2_1.element.setStopGrad(false)
+    graphNoBack.build()
+    graphNoBack.zeroGradParameters()
+    graphNoBack.forward(input) should be (graph.forward(input))
+    graphNoBack.backward(input, gradOutput)
+
+    graphNoBack.parameters()._1 should be (graph.parameters()._1)
+
+    graphNoBack.parameters()._2 should be (graph.parameters()._2)
+  }
+
+//  "graph setFreeze" should "work properly" in {
+//    RandomGenerator.RNG.setSeed(1000)
+//    val fc1 = Linear(4, 2).inputs()
+//    val fc2 = Linear(4, 2).inputs()
+//    val cadd = CAddTable().inputs(fc1, fc2)
+//    val output1 = ReLU().inputs(cadd)
+//    val output2 = Threshold(10.0).inputs(cadd)
+//
+//    val graph = Graph(Array(fc2, fc1), Array(output1, output2))
+//    RandomGenerator.RNG.setSeed(1000)
+//    val reshape = Reshape(Array(4)).inputs()
+//    val fc1_1 = Linear(4, 2).inputs()
+//    val fc2_1 = Linear(4, 2).setName("fc2_1").inputs(reshape)
+//    val cadd_1 = CAddTable().inputs(fc1_1, fc2_1)
+//    val output1_1 = ReLU().inputs(cadd_1)
+//    val output2_1 = Threshold(10.0).inputs(cadd_1)
+//
+//    val graphNoBack = Graph(Array(reshape, fc1_1), Array(output1_1, output2_1))
+//    graphNoBack.setFreeze(Array("fc2_1"))
+//
+//    fc1.element.getParameters()._1.apply1(_ => 1.0f)
+//    fc2.element.getParameters()._1.apply1(_ => 2.0f)
+//    fc1_1.element.getParameters()._1.apply1(_ => 1.0f)
+//    fc2_1.element.getParameters()._1.apply1(_ => 2.0f)
+//
+//    val input = T(Tensor(T(0.1f, 0.2f, -0.3f, -0.4f)),
+//      Tensor(T(0.5f, 0.4f, -0.2f, -0.1f)))
+//    graph.forward(input) should be (graphNoBack.forward(input))
+//
+//
+//    val gradOutput = T(Tensor(T(1.0f, 2.0f)), Tensor(T(3.0f, 4.0f)))
+//
+//    graph.backward(input, gradOutput)
+//    graphNoBack.backward(input, gradOutput)
+//    fc2_1.element.gradInput.toTensor.nElement() should be (0)
+//    output2.element.gradInput should be (output2_1.element.gradInput)
+//    fc1_1.element.gradInput should be (fc1.element.gradInput)
+//    fc1_1.element.parameters()._2 should be (fc1.element.parameters()._2)
+//    reshape.element.gradInput.toTensor.nElement() should be (0)
+//  }
+
+//  "graph setTrainable" should "work properly" in {
+//    RandomGenerator.RNG.setSeed(1000)
+//    val fc1 = Linear(4, 2).inputs()
+//    val fc2 = Linear(4, 2).inputs()
+//    val cadd = CAddTable().inputs(fc1, fc2)
+//    val output1 = ReLU().inputs(cadd)
+//    val output2 = Threshold(10.0).inputs(cadd)
+//
+//    val graph = Graph(Array(fc2, fc1), Array(output1, output2))
+//    RandomGenerator.RNG.setSeed(1000)
+//    val reshape = Reshape(Array(4)).inputs()
+//    val fc1_1 = Linear(4, 2).setName("fc1_1").inputs()
+//    val fc2_1 = Linear(4, 2).setName("fc2_1").inputs(reshape)
+//    val cadd_1 = CAddTable().inputs(fc1_1, fc2_1)
+//    val output1_1 = ReLU().inputs(cadd_1)
+//    val output2_1 = Threshold(10.0).inputs(cadd_1)
+//
+//    val graphNoBack = Graph(Array(reshape, fc1_1), Array(output1_1, output2_1))
+//    graphNoBack.setTrainable(Array("fc1_1"))
+//
+//    fc1.element.getParameters()._1.apply1(_ => 1.0f)
+//    fc2.element.getParameters()._1.apply1(_ => 2.0f)
+//    fc1_1.element.getParameters()._1.apply1(_ => 1.0f)
+//    fc2_1.element.getParameters()._1.apply1(_ => 2.0f)
+//
+//    val input = T(Tensor(T(0.1f, 0.2f, -0.3f, -0.4f)),
+//      Tensor(T(0.5f, 0.4f, -0.2f, -0.1f)))
+//    graph.forward(input) should be (graphNoBack.forward(input))
+//
+//
+//    val gradOutput = T(Tensor(T(1.0f, 2.0f)), Tensor(T(3.0f, 4.0f)))
+//
+//    graph.backward(input, gradOutput)
+//    graphNoBack.backward(input, gradOutput)
+//    fc2_1.element.gradInput.toTensor.nElement() should be (0)
+//    output2.element.gradInput should be (output2_1.element.gradInput)
+//    fc1_1.element.gradInput should be (fc1.element.gradInput)
+//    fc1_1.element.parameters()._2 should be (fc1.element.parameters()._2)
+//    reshape.element.gradInput.toTensor.nElement() should be (0)
+//  }
+
+//  "graph unfreeze" should "work properly" in {
+//    RandomGenerator.RNG.setSeed(1000)
+//    val fc1 = Linear(4, 2).inputs()
+//    val fc2 = Linear(4, 2).inputs()
+//    val cadd = CAddTable().inputs(fc1, fc2)
+//    val output1 = ReLU().inputs(cadd)
+//    val output2 = Threshold(10.0).inputs(cadd)
+//
+//    val graph = Graph(Array(fc2, fc1), Array(output1, output2))
+//    RandomGenerator.RNG.setSeed(1000)
+//    val reshape = Reshape(Array(4)).inputs()
+//    val fc1_1 = Linear(4, 2).setName("fc1_1").inputs()
+//    val fc2_1 = Linear(4, 2).setName("fc2_1").inputs(reshape)
+//    val cadd_1 = CAddTable().inputs(fc1_1, fc2_1)
+//    val output1_1 = ReLU().inputs(cadd_1)
+//    val output2_1 = Threshold(10.0).inputs(cadd_1)
+//
+//    val graphNoBack = Graph(Array(reshape, fc1_1), Array(output1_1, output2_1))
+//    graphNoBack.setTrainable(Array("fc1_1"))
+//    graphNoBack.unFreeze()
+//
+//    fc1.element.getParameters()._1.apply1(_ => 1.0f)
+//    fc2.element.getParameters()._1.apply1(_ => 2.0f)
+//    fc1_1.element.getParameters()._1.apply1(_ => 1.0f)
+//    fc2_1.element.getParameters()._1.apply1(_ => 2.0f)
+//
+//    val input = T(Tensor(T(0.1f, 0.2f, -0.3f, -0.4f)),
+//      Tensor(T(0.5f, 0.4f, -0.2f, -0.1f)))
+//    graph.forward(input) should be (graphNoBack.forward(input))
+//
+//
+//    val gradOutput = T(Tensor(T(1.0f, 2.0f)), Tensor(T(3.0f, 4.0f)))
+//
+//    graph.backward(input, gradOutput)
+//    graphNoBack.zeroGradParameters()
+//    graphNoBack.forward(input) should be (graph.forward(input))
+//    graphNoBack.backward(input, gradOutput)
+//
+//    graphNoBack.parameters()._1 should be (graph.parameters()._1)
+//
+//    graphNoBack.parameters()._2 should be (graph.parameters()._2)
+//  }
+
 }
 
 object ModelUntils {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GraphSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GraphSpec.scala
@@ -1013,7 +1013,7 @@ class GraphSpec extends FlatSpec with Matchers {
     val output2_1 = Threshold(10.0).inputs(cadd_1)
 
     val graphNoBack = Graph(Array(reshape, fc1_1), Array(output1_1, output2_1))
-    graphNoBack.setFreeze(Array("fc2_1"))
+    graphNoBack.setStopGradient(Array("fc2_1"))
 
     fc1.element.getParameters()._1.apply1(_ => 1.0f)
     fc2.element.getParameters()._1.apply1(_ => 2.0f)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GraphSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GraphSpec.scala
@@ -652,7 +652,7 @@ class GraphSpec extends FlatSpec with Matchers {
 
   "Graph backward sequential with propagateBack false in the first" should "work properly" in {
     RandomGenerator.RNG.setSeed(1000)
-    val input = Reshape(Array(1, 28, 28)).setStopGrad().inputs()
+    val input = Reshape(Array(1, 28, 28)).setStopGradient().inputs()
     val conv1 = SpatialConvolution(1, 6, 5, 5).setName("conv1").inputs(input)
     val tanh1 = Tanh().inputs(conv1)
     val pool1 = SpatialMaxPooling(2, 2, 2, 2).inputs(tanh1)
@@ -714,7 +714,7 @@ class GraphSpec extends FlatSpec with Matchers {
     val input = Reshape(Array(1, 28, 28)).setName("r1").inputs()
     val conv1 = SpatialConvolution(1, 6, 5, 5).setName("conv1").inputs(input)
     val tanh1 = Tanh().setName("tanh1").inputs(conv1)
-    val pool1 = SpatialMaxPooling(2, 2, 2, 2).setName("pool1").setStopGrad().inputs(tanh1)
+    val pool1 = SpatialMaxPooling(2, 2, 2, 2).setName("pool1").setStopGradient().inputs(tanh1)
     val tanh2 = Tanh().setName("tanh2").inputs(pool1)
     val conv2 = SpatialConvolution(6, 12, 5, 5).setName("conv2").inputs(tanh2)
     val pool2 = SpatialMaxPooling(2, 2, 2, 2).inputs(conv2)
@@ -775,7 +775,7 @@ class GraphSpec extends FlatSpec with Matchers {
     val fc1_1 = Linear(4, 2).inputs()
     val fc2_1 = Linear(4, 2).inputs()
     val cadd_1 = CAddTable().inputs(fc1_1, fc2_1)
-    val output1_1 = ReLU().setStopGrad().inputs(cadd_1)
+    val output1_1 = ReLU().setStopGradient().inputs(cadd_1)
     val output2_1 = Threshold(10.0).inputs(cadd_1)
 
     val graphNoBack = Graph(Array(fc2_1, fc1_1), Array(output1_1, output2_1))
@@ -825,7 +825,7 @@ class GraphSpec extends FlatSpec with Matchers {
     val graph = Graph(Array(fc2, fc1), Array(output1, output2))
     RandomGenerator.RNG.setSeed(1000)
     val fc1_1 = Linear(4, 2).inputs()
-    val fc2_1 = Linear(4, 2).setStopGrad().inputs()
+    val fc2_1 = Linear(4, 2).setStopGradient().inputs()
     val cadd_1 = CAddTable().inputs(fc1_1, fc2_1)
     val output1_1 = ReLU().inputs(cadd_1)
     val output2_1 = Threshold(10.0).inputs(cadd_1)
@@ -864,7 +864,7 @@ class GraphSpec extends FlatSpec with Matchers {
     RandomGenerator.RNG.setSeed(1000)
     val reshape = Reshape(Array(4)).inputs()
     val fc1_1 = Linear(4, 2).inputs()
-    val fc2_1 = Linear(4, 2).setStopGrad().inputs(reshape)
+    val fc2_1 = Linear(4, 2).setStopGradient().inputs(reshape)
     val cadd_1 = CAddTable().inputs(fc1_1, fc2_1)
     val output1_1 = ReLU().inputs(cadd_1)
     val output2_1 = Threshold(10.0).inputs(cadd_1)
@@ -903,7 +903,7 @@ class GraphSpec extends FlatSpec with Matchers {
     val graph = Graph(Array(fc2, fc1), Array(output1, output2))
     RandomGenerator.RNG.setSeed(1000)
     val fc1_1 = Linear(4, 2).inputs()
-    val fc2_1 = Linear(4, 2).setStopGrad().inputs()
+    val fc2_1 = Linear(4, 2).setStopGradient().inputs()
     val cadd_1 = CAddTable().inputs(fc1_1, fc2_1)
     val output1_1 = ReLU().inputs(cadd_1)
     val output2_1 = Threshold(10.0).inputs(cadd_1)
@@ -930,7 +930,7 @@ class GraphSpec extends FlatSpec with Matchers {
     fc1_1.element.parameters()._2 should be (fc1.element.parameters()._2)
 
     // reset propagateBack
-    fc2_1.element.setStopGrad(false)
+    fc2_1.element.setStopGradient(false)
     graphNoBack.build()
     graphNoBack.zeroGradParameters()
     graphNoBack.forward(input) should be (graph.forward(input))
@@ -941,131 +941,100 @@ class GraphSpec extends FlatSpec with Matchers {
     graphNoBack.parameters()._2 should be (graph.parameters()._2)
   }
 
-//  "graph setFreeze" should "work properly" in {
-//    RandomGenerator.RNG.setSeed(1000)
-//    val fc1 = Linear(4, 2).inputs()
-//    val fc2 = Linear(4, 2).inputs()
-//    val cadd = CAddTable().inputs(fc1, fc2)
-//    val output1 = ReLU().inputs(cadd)
-//    val output2 = Threshold(10.0).inputs(cadd)
-//
-//    val graph = Graph(Array(fc2, fc1), Array(output1, output2))
-//    RandomGenerator.RNG.setSeed(1000)
-//    val reshape = Reshape(Array(4)).inputs()
-//    val fc1_1 = Linear(4, 2).inputs()
-//    val fc2_1 = Linear(4, 2).setName("fc2_1").inputs(reshape)
-//    val cadd_1 = CAddTable().inputs(fc1_1, fc2_1)
-//    val output1_1 = ReLU().inputs(cadd_1)
-//    val output2_1 = Threshold(10.0).inputs(cadd_1)
-//
-//    val graphNoBack = Graph(Array(reshape, fc1_1), Array(output1_1, output2_1))
-//    graphNoBack.setFreeze(Array("fc2_1"))
-//
-//    fc1.element.getParameters()._1.apply1(_ => 1.0f)
-//    fc2.element.getParameters()._1.apply1(_ => 2.0f)
-//    fc1_1.element.getParameters()._1.apply1(_ => 1.0f)
-//    fc2_1.element.getParameters()._1.apply1(_ => 2.0f)
-//
-//    val input = T(Tensor(T(0.1f, 0.2f, -0.3f, -0.4f)),
-//      Tensor(T(0.5f, 0.4f, -0.2f, -0.1f)))
-//    graph.forward(input) should be (graphNoBack.forward(input))
-//
-//
-//    val gradOutput = T(Tensor(T(1.0f, 2.0f)), Tensor(T(3.0f, 4.0f)))
-//
-//    graph.backward(input, gradOutput)
-//    graphNoBack.backward(input, gradOutput)
-//    fc2_1.element.gradInput.toTensor.nElement() should be (0)
-//    output2.element.gradInput should be (output2_1.element.gradInput)
-//    fc1_1.element.gradInput should be (fc1.element.gradInput)
-//    fc1_1.element.parameters()._2 should be (fc1.element.parameters()._2)
-//    reshape.element.gradInput.toTensor.nElement() should be (0)
-//  }
 
-//  "graph setTrainable" should "work properly" in {
-//    RandomGenerator.RNG.setSeed(1000)
-//    val fc1 = Linear(4, 2).inputs()
-//    val fc2 = Linear(4, 2).inputs()
-//    val cadd = CAddTable().inputs(fc1, fc2)
-//    val output1 = ReLU().inputs(cadd)
-//    val output2 = Threshold(10.0).inputs(cadd)
-//
-//    val graph = Graph(Array(fc2, fc1), Array(output1, output2))
-//    RandomGenerator.RNG.setSeed(1000)
-//    val reshape = Reshape(Array(4)).inputs()
-//    val fc1_1 = Linear(4, 2).setName("fc1_1").inputs()
-//    val fc2_1 = Linear(4, 2).setName("fc2_1").inputs(reshape)
-//    val cadd_1 = CAddTable().inputs(fc1_1, fc2_1)
-//    val output1_1 = ReLU().inputs(cadd_1)
-//    val output2_1 = Threshold(10.0).inputs(cadd_1)
-//
-//    val graphNoBack = Graph(Array(reshape, fc1_1), Array(output1_1, output2_1))
-//    graphNoBack.setTrainable(Array("fc1_1"))
-//
-//    fc1.element.getParameters()._1.apply1(_ => 1.0f)
-//    fc2.element.getParameters()._1.apply1(_ => 2.0f)
-//    fc1_1.element.getParameters()._1.apply1(_ => 1.0f)
-//    fc2_1.element.getParameters()._1.apply1(_ => 2.0f)
-//
-//    val input = T(Tensor(T(0.1f, 0.2f, -0.3f, -0.4f)),
-//      Tensor(T(0.5f, 0.4f, -0.2f, -0.1f)))
-//    graph.forward(input) should be (graphNoBack.forward(input))
-//
-//
-//    val gradOutput = T(Tensor(T(1.0f, 2.0f)), Tensor(T(3.0f, 4.0f)))
-//
-//    graph.backward(input, gradOutput)
-//    graphNoBack.backward(input, gradOutput)
-//    fc2_1.element.gradInput.toTensor.nElement() should be (0)
-//    output2.element.gradInput should be (output2_1.element.gradInput)
-//    fc1_1.element.gradInput should be (fc1.element.gradInput)
-//    fc1_1.element.parameters()._2 should be (fc1.element.parameters()._2)
-//    reshape.element.gradInput.toTensor.nElement() should be (0)
-//  }
+  "markdown test" should "work" in {
+    val reshape = Reshape(Array(4)).inputs()
+    val fc1 = Linear(4, 2).setName("fc1").inputs()
+    val fc2 = Linear(4, 2).setName("fc2").inputs(reshape)
+    val cadd_1 = CAddTable().setName("cadd").inputs(fc1, fc2)
+    val output1_1 = ReLU().inputs(cadd_1)
+    val output2_1 = Threshold(10.0).inputs(cadd_1)
 
-//  "graph unfreeze" should "work properly" in {
-//    RandomGenerator.RNG.setSeed(1000)
-//    val fc1 = Linear(4, 2).inputs()
-//    val fc2 = Linear(4, 2).inputs()
-//    val cadd = CAddTable().inputs(fc1, fc2)
-//    val output1 = ReLU().inputs(cadd)
-//    val output2 = Threshold(10.0).inputs(cadd)
-//
-//    val graph = Graph(Array(fc2, fc1), Array(output1, output2))
-//    RandomGenerator.RNG.setSeed(1000)
-//    val reshape = Reshape(Array(4)).inputs()
-//    val fc1_1 = Linear(4, 2).setName("fc1_1").inputs()
-//    val fc2_1 = Linear(4, 2).setName("fc2_1").inputs(reshape)
-//    val cadd_1 = CAddTable().inputs(fc1_1, fc2_1)
-//    val output1_1 = ReLU().inputs(cadd_1)
-//    val output2_1 = Threshold(10.0).inputs(cadd_1)
-//
-//    val graphNoBack = Graph(Array(reshape, fc1_1), Array(output1_1, output2_1))
-//    graphNoBack.setTrainable(Array("fc1_1"))
-//    graphNoBack.unFreeze()
-//
-//    fc1.element.getParameters()._1.apply1(_ => 1.0f)
-//    fc2.element.getParameters()._1.apply1(_ => 2.0f)
-//    fc1_1.element.getParameters()._1.apply1(_ => 1.0f)
-//    fc2_1.element.getParameters()._1.apply1(_ => 2.0f)
-//
-//    val input = T(Tensor(T(0.1f, 0.2f, -0.3f, -0.4f)),
-//      Tensor(T(0.5f, 0.4f, -0.2f, -0.1f)))
-//    graph.forward(input) should be (graphNoBack.forward(input))
-//
-//
-//    val gradOutput = T(Tensor(T(1.0f, 2.0f)), Tensor(T(3.0f, 4.0f)))
-//
-//    graph.backward(input, gradOutput)
-//    graphNoBack.zeroGradParameters()
-//    graphNoBack.forward(input) should be (graph.forward(input))
-//    graphNoBack.backward(input, gradOutput)
-//
-//    graphNoBack.parameters()._1 should be (graph.parameters()._1)
-//
-//    graphNoBack.parameters()._2 should be (graph.parameters()._2)
-//  }
+    val model = Graph(Array(reshape, fc1), Array(output1_1, output2_1))
 
+
+
+    val input = T(Tensor(T(0.1f, 0.2f, -0.3f, -0.4f)),
+      Tensor(T(0.5f, 0.4f, -0.2f, -0.1f)))
+    val gradOutput = T(Tensor(T(1.0f, 2.0f)), Tensor(T(3.0f, 4.0f)))
+
+    fc1.element.getParameters()._1.apply1(_ => 1.0f)
+    fc2.element.getParameters()._1.apply1(_ => 2.0f)
+    model.zeroGradParameters()
+    println("output1: \n", model.forward(input))
+    model.backward(input, gradOutput)
+    model.updateParameters(1)
+    println("fc2 weight \n", fc2.element.parameters()._1(0))
+
+
+    fc1.element.getParameters()._1.apply1(_ => 1.0f)
+    fc2.element.getParameters()._1.apply1(_ => 2.0f)
+    model.zeroGradParameters()
+    model.setFreeze(Array("fc2"))
+    println("output2: \n", model.forward(input))
+    model.backward(input, gradOutput)
+    model.updateParameters(1)
+    println("fc2 weight \n", fc2.element.parameters()._1(0))
+
+    fc1.element.getParameters()._1.apply1(_ => 1.0f)
+    fc2.element.getParameters()._1.apply1(_ => 2.0f)
+    model.zeroGradParameters()
+    model.unFreeze()
+    println("output3: \n", model.forward(input))
+    model.backward(input, gradOutput)
+    model.updateParameters(1)
+    println("fc2 weight \n", fc2.element.parameters()._1(0))
+
+    fc1.element.getParameters()._1.apply1(_ => 1.0f)
+    fc2.element.getParameters()._1.apply1(_ => 2.0f)
+    model.setStopGradient(Array("cadd"))
+    model.zeroGradParameters()
+    println("output4: \n", model.forward(input))
+    model.backward(input, gradOutput)
+    model.updateParameters(1)
+    println("fc1 weight \n", fc1.element.parameters()._1(0))
+    println("fc2 weight \n", fc2.element.parameters()._1(0))
+  }
+  "graph setFreeze" should "work properly" in {
+    RandomGenerator.RNG.setSeed(1000)
+    val fc1 = Linear(4, 2).inputs()
+    val fc2 = Linear(4, 2).inputs()
+    val cadd = CAddTable().inputs(fc1, fc2)
+    val output1 = ReLU().inputs(cadd)
+    val output2 = Threshold(10.0).inputs(cadd)
+
+    val graph = Graph(Array(fc2, fc1), Array(output1, output2))
+    RandomGenerator.RNG.setSeed(1000)
+    val reshape = Reshape(Array(4)).inputs()
+    val fc1_1 = Linear(4, 2).inputs()
+    val fc2_1 = Linear(4, 2).setName("fc2_1").inputs(reshape)
+    val cadd_1 = CAddTable().inputs(fc1_1, fc2_1)
+    val output1_1 = ReLU().inputs(cadd_1)
+    val output2_1 = Threshold(10.0).inputs(cadd_1)
+
+    val graphNoBack = Graph(Array(reshape, fc1_1), Array(output1_1, output2_1))
+    graphNoBack.setFreeze(Array("fc2_1"))
+
+    fc1.element.getParameters()._1.apply1(_ => 1.0f)
+    fc2.element.getParameters()._1.apply1(_ => 2.0f)
+    fc1_1.element.getParameters()._1.apply1(_ => 1.0f)
+    fc2_1.element.getParameters()._1.apply1(_ => 2.0f)
+
+    val input = T(Tensor(T(0.1f, 0.2f, -0.3f, -0.4f)),
+      Tensor(T(0.5f, 0.4f, -0.2f, -0.1f)))
+    graph.forward(input) should be (graphNoBack.forward(input))
+
+
+    val gradOutput = T(Tensor(T(1.0f, 2.0f)), Tensor(T(3.0f, 4.0f)))
+
+    graph.backward(input, gradOutput)
+    graphNoBack.backward(input, gradOutput)
+    fc2_1.element.gradInput.toTensor.nElement() should be (0)
+    output2.element.gradInput should be (output2_1.element.gradInput)
+    fc1_1.element.gradInput should be (fc1.element.gradInput)
+    fc1_1.element.parameters()._2 should be (fc1.element.parameters()._2)
+    reshape.element.gradInput.toTensor.nElement() should be (0)
+  }
 }
 
 object ModelUntils {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
@@ -138,6 +138,15 @@ class PythonSpec extends FlatSpec with Matchers with BeforeAndAfter {
     require(output == expectedResult)
   }
 
+  "to jtensor with empty tensor" should "be test" in {
+    val pythonBigDL = PythonBigDL.ofFloat()
+    val tensor: Tensor[Float] = Tensor[Float]()
+    val jTensor = pythonBigDL.toJTensor(tensor)
+    println(jTensor.shape)
+    val tensorBack = pythonBigDL.toTensor(jTensor)
+    require(tensorBack == tensor)
+  }
+
   "Double prototype" should "be test" in {
     TestUtils.cancelOnWindows()
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

User can freeze some layers in the training process, or unfreeze afterwards.

```
val graph = Graph(Array(input1, input2), Array(output1, output2))
// set an array of layers to be trainable, the rest of layers are freezed
graph.setTrainable(Array("fc1_1", "conv1"))
// set an array of layers to be freezed, the rest of layers are trainable
graph.setFreeze(Array("fc2_1"))
// unfreeze and set all layers to be trainable
graph.unFreeze()
// or freeze certain layer
layer.setTrainable(false)
```

## How was this patch tested?

unit test

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/1033
https://github.com/intel-analytics/BigDL/issues/450

