### PR TITLE
RNN cells do not execute preTopology in Dropout mode

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -195,14 +195,14 @@ class Recurrent[T : ClassTag]()
       "Recurrent: input should be a 3D Tensor, e.g [batch, times, nDim], " +
         s"current input.dim = ${input.dim}")
 
+    batchSize = input.size(batchDim)
+    times = input.size(timeDim)
+
     outputCell = if (preTopology != null) {
       preTopology.updateOutput(input).toTensor[T]
     } else {
       input
     }
-
-    batchSize = outputCell.size(batchDim)
-    times = outputCell.size(timeDim)
 
     val hiddenSize = topology.hiddensShape(0)
     output.resize(batchSize, times, hiddenSize)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/LSTMSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/LSTMSpec.scala
@@ -45,6 +45,19 @@ class LSTMSpec  extends TorchSpec {
     }
   }
 
+  "A LSTM dropout " should "works correctly" in {
+    val inputSize = 6
+    val hiddenSize = 5
+    val batchSize = 2
+    val time = 2
+    RNG.setSeed(100)
+    val input = Tensor[Float](batchSize, time, inputSize)
+    println(s"input = ${input}")
+    val model = Recurrent[Float]().add(LSTM[Float](inputSize, hiddenSize, p = 0.1))
+    val output = model.forward(input)
+    println(s"output = ${output}")
+  }
+
   "A LSTM L2 regularizer" should "works correctly" in {
     import com.intel.analytics.bigdl.numeric.NumericDouble
     val hiddenSize = 4


### PR DESCRIPTION
## What changes were proposed in this pull request?
LSTM, GRU do not calculate preTopology in Dropout mode.
(considering the convergence)

## How was this patch tested?
Unit Test


