### PR TITLE
add a property to control the blockmanger behavior

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
@@ -273,11 +273,11 @@ object Engine {
 
     // For spark 1.5, we observe nio block manager has better performance than netty block manager
     // So we will force set block manager to nio. If user don't want this, he/she can set
-    // bigdl.nio.force == false to customize it. This configuration/blcok manager setting won't
+    // bigdl.network.nio == false to customize it. This configuration/blcok manager setting won't
     // take affect on newer spark version as the nio block manger has been removed
     lines.map(_.split("\\s+")).map(d => (d(0), d(1))).toSeq
       .filter(_._1 != "spark.shuffle.blockTransferService" ||
-        System.getProperty("bigdl.nio.force", "true").toBoolean)
+        System.getProperty("bigdl.network.nio", "true").toBoolean)
   }
 
   /**

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
@@ -270,7 +270,14 @@ object Engine {
     val stream : InputStream = getClass.getResourceAsStream("/spark-bigdl.conf")
     val lines = scala.io.Source.fromInputStream(stream)
       .getLines.filter(_.startsWith("spark")).toArray
+
+    // For spark 1.5, we observe nio block manager has better performance than netty block manager
+    // So we will force set block manager to nio. If user don't want this, he/she can set
+    // bigdl.nio.force == false to customize it. This configuration/blcok manager setting won't
+    // take affect on newer spark version as the nio block manger has been removed
     lines.map(_.split("\\s+")).map(d => (d(0), d(1))).toSeq
+      .filter(_._1 != "spark.shuffle.blockTransferService" ||
+        System.getProperty("bigdl.nio.force", "true").toBoolean)
   }
 
   /**

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/EngineSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/EngineSpec.scala
@@ -141,6 +141,20 @@ class EngineSpec extends FlatSpec with Matchers with BeforeAndAfter {
     })
   }
 
+  "readConf" should "skip blockTransferService if bigdl.nio.force is set to false" in {
+    System.setProperty("bigdl.nio.force", "false")
+    val conf = Engine.readConf
+    val target = Map(
+      "spark.shuffle.reduceLocality.enabled" -> "false",
+      "spark.scheduler.minRegisteredResourcesRatio" -> "1.0"
+    )
+    conf.length should be(target.keys.size)
+    conf.foreach(s => {
+      s._2 should be(target(s._1))
+    })
+    System.clearProperty("bigdl.nio.force")
+  }
+
   "LocalMode" should "false if onSpark" in {
     intercept[IllegalArgumentException] {
       System.setProperty("bigdl.localMode", "true")

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/EngineSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/EngineSpec.scala
@@ -141,8 +141,8 @@ class EngineSpec extends FlatSpec with Matchers with BeforeAndAfter {
     })
   }
 
-  "readConf" should "skip blockTransferService if bigdl.nio.force is set to false" in {
-    System.setProperty("bigdl.nio.force", "false")
+  "readConf" should "skip blockTransferService if bigdl.network.nio is set to false" in {
+    System.setProperty("bigdl.network.nio", "false")
     val conf = Engine.readConf
     val target = Map(
       "spark.shuffle.reduceLocality.enabled" -> "false",
@@ -152,7 +152,7 @@ class EngineSpec extends FlatSpec with Matchers with BeforeAndAfter {
     conf.foreach(s => {
       s._2 should be(target(s._1))
     })
-    System.clearProperty("bigdl.nio.force")
+    System.clearProperty("bigdl.network.nio")
   }
 
   "LocalMode" should "false if onSpark" in {


### PR DESCRIPTION
## What changes were proposed in this pull request?
For spark 1.5, we observe nio block manager has better performance than netty block manager. So we will force set block manager to nio. But some user want to control this behavior.

In this PR a new property ```bigdl.nio.force``` is added . The default value is true. User can set it to force to customize the blockmanager choice.

## How was this patch tested?
Add new unit test
