### PR TITLE
fix convLSTMpeephole

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ConvLSTMPeephole.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ConvLSTMPeephole.scala
@@ -177,10 +177,9 @@ class ConvLSTMPeephole[T : ClassTag] (
             .add(outputGate)
             .add(Sequential()
               .add(SelectTable(3))
-              .add(Tanh())
-            )
-          )
-          .add(CMulTable()))
+              .add(Tanh())))
+          .add(CMulTable())
+          .add(Contiguous()))
         .add(SelectTable(3)))
 
       .add(ConcatTable()

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ConvLSTMPeepholeSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ConvLSTMPeepholeSpec.scala
@@ -26,6 +26,33 @@ import scala.math._
 
 @com.intel.analytics.bigdl.tags.Parallel
 class ConvLSTMPeepholeSpec extends FlatSpec with BeforeAndAfter with Matchers {
+
+  "A convLstm" should " work in BatchMode" in {
+    val hiddenSize = 5
+    val inputSize = 3
+    val seqLength = 4
+    val batchSize = 2
+    val kernalW = 3
+    val kernalH = 3
+    val rec = Recurrent[Double]()
+    val model = Sequential[Double]()
+      .add(rec
+        .add(ConvLSTMPeephole[Double](
+            inputSize,
+            hiddenSize,
+            kernalW, kernalH,
+            1,
+            withPeephole = false)))
+     .add(View(hiddenSize * kernalH * kernalW))
+
+    val input = Tensor[Double](batchSize, seqLength, inputSize, kernalW, kernalH).rand
+    val output = model.forward(input).toTensor[Double]
+    for (i <- 1 to 3) {
+      val output = model.forward(input)
+      model.backward(input, output)
+    }
+  }
+
   "A ConvLSTMPeepwhole " should "generate corrent output" in {
     val hiddenSize = 5
     val inputSize = 3


### PR DESCRIPTION
## What changes were proposed in this pull request?
ConvLSTMPeephole's output will be set to Recurrent's output.
Thus, the output of ConvLSTMPeephole will be incontiguous which will 
throw an error in SpatialConvolution since it requires a contiguous input.

Add Contiguous layer inside ConvLSTMPeephole network.

## How was this patch tested?
Unit Test