### PR TITLE
Make ClassNLL can process -1 label for padding, not update the model.

### DIFF
--- a/docs/docs/APIdocs/Losses/ClassNLLCriterion.md
+++ b/docs/docs/APIdocs/Losses/ClassNLLCriterion.md
@@ -28,7 +28,7 @@ criterion expects a class index (1 to the number of class) as target when callin
  calculating losses in non-batch mode.
 
  Note that if the target is `-1`, the training process will skip this sample.
- In other will, the forward process will return zero output and the backward process
+ In other words, the forward process will return zero output and the backward process
  will also return zero `gradInput`.
 
  By default, the losses are averaged over observations for each minibatch. However, if the field

--- a/docs/docs/APIdocs/Losses/ClassNLLCriterion.md
+++ b/docs/docs/APIdocs/Losses/ClassNLLCriterion.md
@@ -27,6 +27,10 @@ criterion expects a class index (1 to the number of class) as target when callin
  Due to the behaviour of the backend code, it is necessary to set sizeAverage to false when
  calculating losses in non-batch mode.
 
+ Note that if the target is `-1`, the training process will skip this sample.
+ In other will, the forward process will return zero output and the backward process
+ will also return zero `gradInput`.
+
  By default, the losses are averaged over observations for each minibatch. However, if the field
  `sizeAverage` is set to false, the losses are instead summed for each minibatch.
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterion.scala
@@ -45,7 +45,7 @@ import com.intel.analytics.bigdl.utils.Engine
  * calculating losses in non-batch mode.
  *
  * Note that if the target is `-1`, the training process will skip this sample.
- * In other will, the forward process will return zero output and the backward process
+ * In other words, the forward process will return zero output and the backward process
  * will also return zero `gradInput`.
  *
  * By default, the losses are averaged over observations for each minibatch. However, if the field

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterion.scala
@@ -44,6 +44,10 @@ import com.intel.analytics.bigdl.utils.Engine
  * Due to the behaviour of the backend code, it is necessary to set sizeAverage to false when
  * calculating losses in non-batch mode.
  *
+ * Note that if the target is `-1`, the training process will skip this sample.
+ * In other will, the forward process will return zero output and the backward process
+ * will also return zero `gradInput`.
+ *
  * By default, the losses are averaged over observations for each minibatch. However, if the field
  * sizeAverage is set to false, the losses are instead summed for each minibatch.
  *
@@ -73,10 +77,11 @@ class ClassNLLCriterion[@specialized(Float, Double) T: ClassTag]
         "ClassNLLCriterion: " + ErrorInfo.constrainInputDimSameAsTarget +
           s" Input dimension is: ${ input.dim() } , target dimension is: ${ target.dim() }")
       val curTarget = ev.toType[Int](target.valueAt(1))
-      assert(curTarget >= 1 && curTarget <= nClasses,
+      assert(curTarget >= 1 && curTarget <= nClasses || curTarget == -1,
         s"curTarget ${curTarget} is out of range, should be 1 to ${nClasses}")
       total_weight = if (weights != null) weights(Array(curTarget)) else ev.fromType[Int](1)
-      output = ev.times(ev.negative(input.valueAt(curTarget)), total_weight)
+      output = if (curTarget == -1) ev.zero
+      else ev.times(ev.negative(input.valueAt(curTarget)), total_weight)
     } else if (input.dim() == 2) {
       val batchSize = input.size(1)
       val targetSize = target.size()
@@ -93,10 +98,13 @@ class ClassNLLCriterion[@specialized(Float, Double) T: ClassTag]
         val _i = i
         results(_i - 1) = Engine.model.invoke( () => {
           val curTarget = ev.toType[Int](target.valueAt(_i))
-          assert(curTarget >= 1 && curTarget <= nClasses,
+          assert(curTarget >= 1 && curTarget <= nClasses || curTarget == -1,
             s"curTarget ${curTarget} is out of range 1 to ${nClasses}")
-          val curWeight = if (weights != null) weights.valueAt(curTarget) else ev.fromType[Int](1)
-          (ev.times(input.valueAt(_i, curTarget), curWeight), curWeight)
+          if (curTarget == -1) (ev.zero, ev.one)
+          else {
+            val curWeight = if (weights != null) weights.valueAt(curTarget) else ev.fromType[Int](1)
+            (ev.times(input.valueAt(_i, curTarget), curWeight), curWeight)
+          }
         })
         i += 1
       }
@@ -128,6 +136,7 @@ class ClassNLLCriterion[@specialized(Float, Double) T: ClassTag]
         "ClassNLLCriterion: " + ErrorInfo.constrainInputDimSameAsTarget +
           s" Input dimension is: ${ input.dim() } , target dimension is: ${ target.dim() }")
       val curTarget = ev.toType[Int](target.valueAt(1))
+      if (curTarget == -1) return gradInput
       gradInput.setValue(curTarget, if (weights != null) ev.times(ev.fromType[Int](-1),
         weights.valueAt(curTarget))
       else ev.fromType[Int](-1))
@@ -147,11 +156,13 @@ class ClassNLLCriterion[@specialized(Float, Double) T: ClassTag]
         val _i = i
         resultsBackward(_i - 1) = Engine.model.invoke(() => {
           val curTarget = ev.toType[Int](target.valueAt(_i))
-          gradInput.setValue(_i, curTarget, if (weights != null) ev.times(ev.fromType[Int](-1),
-            weights.valueAt(curTarget))
-          else ev.fromType[Int](-1))
-          if (sizeAverage) gradInput.setValue(_i, curTarget, ev.divide(gradInput.valueAt(_i,
-            curTarget), total_weight))
+          if (curTarget != -1) {
+            gradInput.setValue(_i, curTarget, if (weights != null) ev.times(ev.fromType[Int](-1),
+              weights.valueAt(curTarget))
+            else ev.fromType[Int](-1))
+            if (sizeAverage) gradInput.setValue(_i, curTarget, ev.divide(gradInput.valueAt(_i,
+              curTarget), total_weight))
+          }
         })
         i += 1
       }
@@ -169,8 +180,8 @@ class ClassNLLCriterion[@specialized(Float, Double) T: ClassTag]
 
 object ClassNLLCriterion {
   def apply[@specialized(Float, Double) T: ClassTag](
-      weights: Tensor[T] = null,
-      sizeAverage: Boolean = true)(implicit ev: TensorNumeric[T]) : ClassNLLCriterion[T] = {
+    weights: Tensor[T] = null,
+    sizeAverage: Boolean = true)(implicit ev: TensorNumeric[T]) : ClassNLLCriterion[T] = {
     new ClassNLLCriterion[T](weights, sizeAverage)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterionSpec.scala
@@ -23,6 +23,42 @@ import scala.math._
 
 @com.intel.analytics.bigdl.tags.Parallel
 class ClassNLLCriterionSpec extends FlatSpec with Matchers {
+  "A ClassNLL Criterion with -1 label " should "generate correct output and grad" in {
+    val criterion = new ClassNLLCriterion[Double]()
+    val input = Tensor[Double](3, 3)
+    input(Array(1, 1)) = -1.0262627674932
+    input(Array(1, 2)) = -1.2412600935171
+    input(Array(1, 3)) = -1.0423174168648
+    input(Array(2, 1)) = -0.90330565804228
+    input(Array(2, 2)) = -1.3686840144413
+    input(Array(2, 3)) = -1.0778380454479
+    input(Array(3, 1)) = -0.99131220658219
+    input(Array(3, 2)) = -1.0559142847536
+    input(Array(3, 3)) = -1.2692712660404
+    val target = Tensor[Double](3)
+    target(Array(1)) = -1
+    target(Array(2)) = 2
+    target(Array(3)) = 3
+    val expectedOutput = 0.8793184268272333
+    val expectedGrad = Tensor[Double](3, 3)
+    expectedGrad(Array(1, 1)) = 0
+    expectedGrad(Array(1, 2)) = 0
+    expectedGrad(Array(1, 3)) = 0
+    expectedGrad(Array(2, 1)) = 0
+    expectedGrad(Array(2, 2)) = -0.33333333333333
+    expectedGrad(Array(2, 3)) = 0
+    expectedGrad(Array(3, 1)) = 0
+    expectedGrad(Array(3, 2)) = 0
+    expectedGrad(Array(3, 3)) = -0.33333333333333
+    val output = criterion.forward(input, target)
+    val gradInput = criterion.backward(input, target)
+    assert(abs(expectedOutput - output) < 1e-6)
+    expectedGrad.map(gradInput, (v1, v2) => {
+      assert(abs(v1 - v2) < 1e-6);
+      v1
+    })
+  }
+
   "A ClassNLL Criterion " should "generate correct output and grad" in {
     val criterion = new ClassNLLCriterion[Double]()
     val input = Tensor[Double](3, 3)


### PR DESCRIPTION
## What changes were proposed in this pull request?
 If the target is `-1`, the training process will skip this sample.
 In other words, the forward process will return zero output and the backward process
 will also return zero `gradInput`.

## How was this patch tested?
Unit tests

