### PR TITLE
BatchNormalization accepts default values

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BatchNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BatchNormalization.scala
@@ -60,10 +60,6 @@ class BatchNormalization[@specialized(Float, Double) T: ClassTag](
 
   require(nOutput > 0)
 
-  def this(affine: Option[Int])(implicit ev: TensorNumeric[T]) {
-    this(nOutput = affine.getOrElse(1), affine = affine.isDefined)
-  }
-
   val nDim = 2
   val runningMean = if (affine) Tensor[T](nOutput) else Tensor[T]()
   val runningVar = if (affine) Tensor[T](nOutput).fill(ev.fromType[Int](1)) else Tensor[T]()
@@ -746,6 +742,6 @@ object BatchNormalization {
   }
   def apply[@specialized(Float, Double) T: ClassTag](
     affine: Option[Int])(implicit ev: TensorNumeric[T]): BatchNormalization[T] = {
-    new BatchNormalization[T](affine)
+    new BatchNormalization[T](nOutput = affine.getOrElse(1), affine = affine.isDefined)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BatchNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BatchNormalization.scala
@@ -60,6 +60,10 @@ class BatchNormalization[@specialized(Float, Double) T: ClassTag](
 
   require(nOutput > 0)
 
+  def this(affine: Option[Int])(implicit ev: TensorNumeric[T]) {
+    this(nOutput = affine.getOrElse(1), affine = affine.isDefined)
+  }
+
   val nDim = 2
   val runningMean = Tensor[T](nOutput)
   val runningVar = Tensor[T](nOutput).fill(ev.fromType[Int](1))
@@ -732,5 +736,9 @@ object BatchNormalization {
     initGradBias: Tensor[T] = null)(implicit ev: TensorNumeric[T]): BatchNormalization[T] = {
     new BatchNormalization[T](
       nOutput, eps, momentum, affine, initWeight, initBias, initGradWeight, initGradBias)
+  }
+  def apply[@specialized(Float, Double) T: ClassTag](
+    affine: Option[Int])(implicit ev: TensorNumeric[T]): BatchNormalization[T] = {
+    new BatchNormalization[T](affine)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/BatchNormalizationSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/BatchNormalizationSpec.scala
@@ -16,13 +16,43 @@
 
 package com.intel.analytics.bigdl.nn
 
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import com.intel.analytics.bigdl.utils.T
 import org.scalatest.{FlatSpec, Matchers}
 
 @com.intel.analytics.bigdl.tags.Parallel
 class BatchNormalizationSpec extends FlatSpec with Matchers {
+  "A BatchNormalization" should "generate correct output using default arguments" in {
+    val bn = BatchNormalization[Double](None)
+    val input = Tensor[Double](3, 3)
+
+    var i = 0
+    input.apply1(e => {
+      i += 1; i
+    })
+    val output = bn.forward(input)
+
+    val mean = Tensor[Double](Storage[Double](Array(4.0, 5.0, 6.0)))
+    val std = Tensor(Storage(Array(0.3333, 0.3333, 0.3333)))
+    val output1 = Tensor[Double](3, 3)
+    for (i <- 1 to 3) {
+      for (j <- 1 to 3) {
+        output1.setValue(i, j, (input(Array(i, j)) - mean(Array(j))) / std(Array(j)))
+      }
+    }
+
+    output.nDimension() should be(2)
+    output.size(1) should be(3)
+    output.size(2) should be(3)
+
+    output.map(output1, (a, b) => {
+      a should be (b)
+      a
+    })
+  }
+
   "A BatchNormalization" should "generate correct output" in {
+
     val bn = new BatchNormalization[Double](3)
     bn.weight(1) = 0.1
     bn.weight(2) = 0.2

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/BatchNormalizationSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/BatchNormalizationSpec.scala
@@ -33,11 +33,11 @@ class BatchNormalizationSpec extends FlatSpec with Matchers {
     val output = bn.forward(input)
 
     val mean = Tensor[Double](Storage[Double](Array(4.0, 5.0, 6.0)))
-    val std = Tensor(Storage(Array(0.3333, 0.3333, 0.3333)))
+    val std = Tensor(Storage(Array(0.4082479, 0.4082479, 0.4082479)))
     val output1 = Tensor[Double](3, 3)
     for (i <- 1 to 3) {
       for (j <- 1 to 3) {
-        output1.setValue(i, j, (input(Array(i, j)) - mean(Array(j))) / std(Array(j)))
+        output1.setValue(i, j, (input(Array(i, j)) - mean(Array(j))) * std(Array(j)))
       }
     }
 
@@ -46,7 +46,7 @@ class BatchNormalizationSpec extends FlatSpec with Matchers {
     output.size(2) should be(3)
 
     output.map(output1, (a, b) => {
-      a should be (b)
+      a should be (b +- 0.0001)
       a
     })
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a constructor without nOutput

`val bn = BatchNormalization[Double](None)`

## How was this patch tested?
Unit Test

