### PR TITLE
Move references to BlockManager from AllReduceParameter into BlockMan…

### DIFF
--- a/spark/spark-version/1.5-plus/src/main/scala/org/apache/spark/storage/BlockManagerWrapper.scala
+++ b/spark/spark-version/1.5-plus/src/main/scala/org/apache/spark/storage/BlockManagerWrapper.scala
@@ -45,8 +45,14 @@ object BlockManagerWrapper {
     SparkEnv.get.blockManager.getLocal(blockId)
   }
 
-  def byteBufferConvert(byteBuffer: ByteBuffer): ByteBuffer = {
-    byteBuffer
+  def getLocalOrRemoteBytes(blockId: BlockId): Option[ByteBuffer] = {
+    val bm = SparkEnv.get.blockManager
+    val maybeLocalBytes = bm.getLocalBytes(blockId)
+    if (maybeLocalBytes.isDefined) {
+      maybeLocalBytes
+    } else {
+      bm.getRemoteBytes(blockId)
+    }
   }
 
   def unlock(blockId : BlockId): Unit = {}


### PR DESCRIPTION


## What changes were proposed in this pull request?

Move references to BlockManager from AllReduceParameter into BlockManagerWrapper. Offer new getLocalOrRemoteBytes method instead. Use reflection internally to be compatible with Spark 2.2 but also earlier Spark 2.

## How was this patch tested?

Built vs Spark 1.5, 1.6, 2.0, 2.1, 2.2.
I believe full tests need to be run to verify the change.

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/1292

