### PR TITLE
TemporalConvolutionSpec should use TorchSpec to avoid failing the build on non-Torch machines

### DIFF
--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/TemporalConvolutionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/TemporalConvolutionSpec.scala
@@ -21,18 +21,13 @@ import com.intel.analytics.bigdl.nn.TemporalConvolution
 import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator._
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
-class TemporalConvolutionSpec extends FlatSpec with BeforeAndAfter with Matchers {
-  before {
-    if (!TH.hasTorch()) {
-      cancel("Torch is not installed")
-    }
-  }
+class TemporalConvolutionSpec extends TorchSpec {
 
   "A TemporalConvolution with 2d input" should "generate correct output" in {
+    torchCheck()
     val seed = 100
     RNG.setSeed(seed)
 
@@ -74,6 +69,7 @@ class TemporalConvolutionSpec extends FlatSpec with BeforeAndAfter with Matchers
   }
 
   "A TemporalConvolution" should "generate correct output" in {
+    torchCheck()
     val seed = 100
     RNG.setSeed(seed)
 


### PR DESCRIPTION

## What changes were proposed in this pull request?

TemporalConvolutionSpec should use TorchSpec to avoid failing the build on non-Torch machines. Right now, `mvn package` will fail instead of just marking this suite as cancelled.

## How was this patch tested?

Existing tests