### PR TITLE
remove unnecessary contiguous check in volumetricconvolution

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricConvolution.scala
@@ -265,7 +265,7 @@ class VolumetricConvolution[T: ClassTag](
         val gradInputT = gradInput.select(1, t)
         val gradOutputT = gradOutput.select(1, t)
         val fGradInputT = fGradInput.select(1, t)
-        require(gradOutputT.isContiguous())
+        require(gradOutputT.isContiguous(), "each batch of gradOutput should be contiguous")
         updateGradInputFrame(gradInputT, gradOutputT, weightMM.transpose(1, 2), fGradInputT,
           kT, kW, kH,
           dT, dW, dH,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricConvolution.scala
@@ -250,11 +250,10 @@ class VolumetricConvolution[T: ClassTag](
   override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
     require(input.dim() == 4 || input.dim() == 5,
       s"4D or 5D (batch mode) tensor expected for input, but got: ${ input.dim() }d")
-    require(input.isContiguous(), "input should be contiguous")
-    require(gradOutput.isContiguous(), "gradOutput should be contiguous")
     gradInput.resizeAs(input)
     fGradInput.resizeAs(fInput).zero()
     if (input.dim() == 4) {
+      require(gradOutput.isContiguous(), "gradOutput should be contiguous")
       updateGradInputFrame(gradInput, gradOutput, weightMM.transpose(1, 2), fGradInput,
         kT, kW, kH,
         dT, dW, dH,
@@ -266,6 +265,7 @@ class VolumetricConvolution[T: ClassTag](
         val gradInputT = gradInput.select(1, t)
         val gradOutputT = gradOutput.select(1, t)
         val fGradInputT = fGradInput.select(1, t)
+        require(gradOutputT.isContiguous())
         updateGradInputFrame(gradInputT, gradOutputT, weightMM.transpose(1, 2), fGradInputT,
           kT, kW, kH,
           dT, dW, dH,
@@ -303,7 +303,6 @@ class VolumetricConvolution[T: ClassTag](
   }
 
   override def accGradParameters(input: Tensor[T], gradOutput: Tensor[T]): Unit = {
-    require(input.isContiguous(), "input should be contiguous")
     require(gradOutput.isContiguous(), "gradOutput should be contiguous")
     if (gradWeightMM == null || gradWeightMM.storage().isEmpty) {
       gradWeightMM = gradWeight.view(nOutputPlane, nInputPlane * kT * kH * kW)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Looks like input is not used for calculation in updateGradInput and accGradParameters, I think we don't require it's contiguous. And if input.dim==5, in updateGradInput, we require sliced gradOutputT is contiguous but looks like we don't need gradOutput is contiguous. 

## How was this patch tested?
ut
