### PR TITLE
optimize logsoftmax

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSoftMax.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSoftMax.scala
@@ -16,8 +16,11 @@
 
 package com.intel.analytics.bigdl.nn
 
+import java.util
+
+import com.intel.analytics.bigdl.mkl.MKL
 import com.intel.analytics.bigdl.nn.abstractnn.TensorModule
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.{DoubleType, FloatType, Storage, Tensor}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.Engine
 
@@ -39,11 +42,16 @@ class LogSoftMax[T: ClassTag](
   implicit ev: TensorNumeric[T]) extends TensorModule[T] {
   @transient
   private var results: Array[Future[Unit]] = null
+  @transient
+  private var buffer1: Array[T] = null
+  @transient
+  private var buffer2: Array[T] = null
+
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
     require(input.dim() == 1 || input.dim() == 2,
       "LogSoftMax: " + ErrorInfo.constrainInputAsVectorOrBatch)
-    output.resizeAs(input)
+    output.resizeAs(input).copy(input)
     val (nframe, dim) =
       if (input.nDimension() == 1) (1, input.size(1)) else (input.size(1), input.size(2))
 
@@ -68,63 +76,158 @@ class LogSoftMax[T: ClassTag](
   }
 
   private def updateOutputFrame(in: Tensor[T], out: Tensor[T]): Unit = {
-    var logsum = ev.fromType[Int](0)
-    val maxInput = in.max()
-    in.apply1(v => {
-      logsum = ev.plus(logsum, ev.exp(ev.minus(v, maxInput))); v
-    })
-    logsum = ev.plus(maxInput, ev.log(logsum))
+    if (buffer1 == null || buffer1.length < in.nElement) {
+      buffer1 = Array.fill(in.nElement)(ev.fromType[Int](1))
+    }
+    if (buffer2 == null || buffer2.length < in.nElement) {
+      buffer2 = new Array[T](in.nElement)
+    }
+    ev.getType match {
+      case FloatType =>
 
-    out.map(in, (outData, inData) => {
-      ev.minus(inData, logsum)
-    })
+        MKL.vsExp(in.nElement,
+          in.storage.asInstanceOf[Storage[Float]].array,
+          in.storageOffset - 1,
+          buffer2.asInstanceOf[Array[Float]],
+          0)
+
+        val dot = MKL.vsdot(in.nElement,
+          buffer2.asInstanceOf[Array[Float]],
+          0,
+          1,
+          buffer1.asInstanceOf[Array[Float]],
+          0,
+          1)
+        val sum = ev.negative(
+          ev.log(ev.fromType[Float](dot)))
+
+        MKL.vsaxpy(in.nElement,
+          ev.toType[Float](sum),
+          buffer1.asInstanceOf[Array[Float]],
+          0,
+          1,
+          out.storage.asInstanceOf[Storage[Float]].array,
+          out.storageOffset - 1,
+          1)
+
+      case DoubleType =>
+
+        MKL.vdExp(in.nElement,
+          in.storage.asInstanceOf[Storage[Double]].array,
+          in.storageOffset - 1,
+          buffer2.asInstanceOf[Array[Double]],
+          0)
+
+        val dot = MKL.vddot(in.nElement,
+          buffer2.asInstanceOf[Array[Double]],
+          0,
+          1,
+          buffer1.asInstanceOf[Array[Double]],
+          0,
+          1)
+        val sum = ev.negative(
+          ev.log(ev.fromType[Double](dot)))
+
+        MKL.vdaxpy(in.nElement,
+          ev.toType[Double](sum),
+          buffer1.asInstanceOf[Array[Double]],
+          0,
+          1,
+          out.storage.asInstanceOf[Storage[Double]].array,
+          out.storageOffset - 1,
+          1)
+      case _ => throw new UnsupportedOperationException(s"Only Float/Double supported")
+    }
+    out
   }
 
   override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
     require(output.nDimension() == 1 || output.nDimension() == 2, "vector or matrix expected")
     require(gradOutput.dim() == input.dim(), "LogSoftMax: input and gradOutput shapes do not " +
       "match, input_dim: " + input.dim() + ", gradOutput_dim: " + gradOutput.dim())
-    gradInput.resizeAs(input)
+    gradInput.resizeAs(input).copy(gradOutput)
     val (nframe, dim) =
       if (output.nDimension() == 1) (1, output.size(1)) else (output.size(1), output.size(2))
 
-    if (results == null || results.length != nframe) {
-      results = new Array[Future[Unit]](nframe)
+
+    if (nframe == 1) {
+      updateGradInputFrame(output, gradInput)
+    } else {
+      if (results == null || results.length != nframe) {
+        results = new Array[Future[Unit]](nframe)
+      }
+      var t = 1
+      while (t <= nframe) {
+        val _t = t
+        results(_t - 1) = Engine.model.invoke(() => {
+          updateGradInputFrame(output.select(1, _t), gradInput.select(1, _t))
+        })
+        t += 1
+      }
+      Engine.model.sync(results)
     }
-
-    var t = 1
-    while (t <= nframe) {
-      val _t = t
-      results(_t - 1) = Engine.model.invoke(() => {
-        var sum = 0.0
-        var d = 1
-        while (d <= dim) {
-          if (gradOutput.dim() == 1) {
-            sum += ev.toType[Double](gradOutput.valueAt(d))
-          } else {
-            sum += ev.toType[Double](gradOutput.valueAt(_t, d))
-          }
-          d += 1
-        }
-
-        d = 1
-        while (d <= dim) {
-          if (input.dim() == 1) {
-            gradInput.setValue(d, ev.minus(gradOutput.valueAt(d),
-              ev.times(ev.exp(output.valueAt(d)), ev.fromType[Double](sum))))
-          } else {
-            gradInput.setValue(_t, d, ev.minus(gradOutput.valueAt(_t, d),
-              ev.times(ev.exp(output.valueAt(_t, d)), ev.fromType[Double](sum))))
-          }
-          d += 1
-        }
-      })
-      t += 1
-    }
-    Engine.model.sync(results)
-
     gradInput
   }
+
+  private def updateGradInputFrame(out: Tensor[T], gradOut: Tensor[T]): Unit = {
+    ev.getType match {
+       case FloatType =>
+
+         MKL.vsExp(out.nElement,
+           out.storage.asInstanceOf[Storage[Float]].array,
+           out.storageOffset - 1,
+           buffer2.asInstanceOf[Array[Float]],
+           0)
+
+         val dot = MKL.vsdot(gradOut.nElement,
+           gradOut.storage.asInstanceOf[Storage[Float]].array,
+           gradOut.storageOffset - 1,
+           1,
+           buffer1.asInstanceOf[Array[Float]],
+           0,
+           1)
+         val sum = ev.negative(
+           ev.fromType[Float](dot))
+
+         MKL.vsaxpy(gradOut.nElement,
+           ev.toType[Float](sum),
+           buffer2.asInstanceOf[Array[Float]],
+           0,
+           1,
+           gradOut.storage.asInstanceOf[Storage[Float]].array,
+           gradOut.storageOffset - 1,
+           1)
+
+      case DoubleType =>
+
+        MKL.vdExp(out.nElement,
+          out.storage.asInstanceOf[Storage[Double]].array,
+          out.storageOffset - 1,
+          buffer2.asInstanceOf[Array[Double]],
+          0)
+
+        val dot = MKL.vddot(gradOut.nElement,
+          gradOut.storage.asInstanceOf[Storage[Double]].array,
+          gradOut.storageOffset - 1,
+          1,
+          buffer1.asInstanceOf[Array[Double]],
+          0,
+          1)
+        val sum = ev.negative(
+          ev.fromType[Double](dot))
+
+        MKL.vdaxpy(gradOut.nElement,
+          ev.toType[Double](sum),
+          buffer2.asInstanceOf[Array[Double]],
+          0,
+          1,
+          gradOut.storage.asInstanceOf[Storage[Double]].array,
+          gradOut.storageOffset - 1,
+          1)
+      case _ => throw new UnsupportedOperationException(s"Only Float/Double supported")
+    }
+  }
+
 }
 
 object LogSoftMax {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSoftMax.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSoftMax.scala
@@ -166,9 +166,9 @@ class LogSoftMax[T: ClassTag](
 
   override def clearState() : this.type = {
     super.clearState()
-    if (buffer1 != null) buffer1 = null
-    if (buffer2 != null) buffer2 = null
-    if (results != null) results = null
+    buffer1 = null
+    buffer2 = null
+    results = null
     this
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/InceptionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/InceptionSpec.scala
@@ -774,7 +774,7 @@ class InceptionSpec extends TorchSpec {
     val loss = criterion.forward(output, labels)
 
     // since we already set the seed, the loss should match exactly
-    loss should be (6.901158f)
+    loss should be (6.9011583f)
   }
 
   "Inception_Layer_V1 graph" should "be correct" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/ModelGraientCheckSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/ModelGraientCheckSpec.scala
@@ -67,7 +67,7 @@ class ModelGraientCheckSpec extends FlatSpec with BeforeAndAfter with Matchers {
     val output = model.forward(input)
     val loss = criterion.forward(output, labels)
 
-    loss should be (6.9059443926654875)
+    loss should be (6.905944392665487)
   }
 
   "GoogleNet_v2 model in batch mode" should "be good in gradient check for input" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LogSoftMaxSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LogSoftMaxSpec.scala
@@ -28,6 +28,29 @@ class LogSoftMaxSpec extends FlatSpec with Matchers with BeforeAndAfter {
   }
 
 
+  "A LogSoftMax Module" should " be fast using MKL" in {
+    val layer = LogSoftMax[Float]()
+    val batchSize = 20
+    val input = Tensor[Float](batchSize, 10000)
+    val gradOutput = Tensor[Float](batchSize, 10000)
+    var startTime = System.nanoTime()
+    var duration = (System.nanoTime() - startTime) / 1e9
+    var sum = 0.0
+    for (i <- 1 to 5) {
+      layer.forward(input)
+      layer.backward(input, gradOutput)
+    }
+    for (i <- 1 to 5) {
+      startTime = System.nanoTime()
+      layer.forward(input)
+      layer.backward(input, gradOutput)
+      duration = (System.nanoTime() - startTime) / 1e9
+      println(s"speed: = ${duration} seconds")
+      sum += duration
+    }
+    println(s"avg speed: = ${sum / 5}")
+  }
+
   "A LogSoftMax Module " should "generate correct output" in {
     val module = new LogSoftMax[Double]()
     val input = Tensor[Double](2)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LogSoftMaxSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LogSoftMaxSpec.scala
@@ -30,6 +30,7 @@ class LogSoftMaxSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
   "A LogSoftMax Module" should " be fast using MKL" in {
     val layer = LogSoftMax[Float]()
+    layer.clearState()
     val batchSize = 20
     val input = Tensor[Float](batchSize, 10000)
     val gradOutput = Tensor[Float](batchSize, 10000)
@@ -49,6 +50,7 @@ class LogSoftMaxSpec extends FlatSpec with Matchers with BeforeAndAfter {
       sum += duration
     }
     println(s"avg speed: = ${sum / 5}")
+    layer.clearState()
   }
 
   "A LogSoftMax Module " should "generate correct output" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/EvaluatorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/EvaluatorSpec.scala
@@ -70,7 +70,7 @@ class EvaluatorSpec extends FlatSpec with Matchers with BeforeAndAfter{
 
     result(0)._1 should be (new AccuracyResult(0, 100))
     result(1)._1 should be (new AccuracyResult(100, 100))
-    result(2)._1 should be (new LossResult(57.669075f, 25))
+    result(2)._1 should be (new LossResult(57.66907f, 25))
     result(0)._1.result()._1 should be (0f)
     result(1)._1.result()._1 should be (1f)
     result(2)._1.result()._1 should be (2.306763f+-0.000001f)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Optimize LogSoftmax using MKL.

## How was this patch tested?
Unit Tests

For input = Tensor(20, 10000) and gradOutput = Tensor(20, 10000)

running on local desktop:
average elapsed time:

before = 0.029517 seconds
after = 8.99 * 1e-4 seconds

Boosting *32.8 times.
 

Test rnn model using spark-local with 4 cores
batchSize = 128
throughput is:
before:
174.9 records/s
after:
512.4 records/s



Tests on Broadwell with 44 cores.
one LSTM layer, throughput

outputSize before after
1000 	377.679 408.977
5000	346.314	331.818
10000	316.691	340.478
15000	306.378 338.387
20000	252.381 276.823