### PR TITLE
optimize Adam and Adamax optimizer

### DIFF
--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/AdamSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/AdamSpec.scala
@@ -16,11 +16,13 @@
 
 package com.intel.analytics.bigdl.optim
 
+import com.intel.analytics.bigdl.nn.{CrossEntropyCriterion, Linear, Sequential}
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.bigdl.utils.{T, TestUtils}
+import com.intel.analytics.bigdl.utils.{RandomGenerator, T, TestUtils}
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.collection.mutable.ArrayBuffer
+import scala.util.Random
 
 @com.intel.analytics.bigdl.tags.Parallel
 class AdamSpec extends FlatSpec with Matchers {
@@ -49,6 +51,60 @@ class AdamSpec extends FlatSpec with Matchers {
     (fx.last < 1e-9) should be(true)
     x(Array(1)) should be(1.0 +- 0.01)
     x(Array(2)) should be(1.0 +- 0.01)
+  }
+  "adam" should " work fast with MKL" in {
+    RandomGenerator.RNG.setSeed(100)
+    val inputSize = 500
+    val hiddenSize = 500
+    val outputSize = 10
+    val batchSize = 10
+    val model = Sequential[Float]()
+      .add(Linear[Float](inputSize, hiddenSize))
+    for (i <- 1 to 3) {
+      model.add(Linear[Float](hiddenSize, hiddenSize))
+    }
+    model.add(Linear[Float](hiddenSize, outputSize))
+    val criterion = CrossEntropyCriterion[Float]()
+
+    val input = Tensor[Float](batchSize, inputSize).rand
+    val label = Tensor[Float](batchSize).zero
+    for (i <- 1 to batchSize) {
+      val nextLabel = Random.nextInt(outputSize) + 1
+      label.setValue(i, nextLabel)
+    }
+
+    val (weights, grad) = model.getParameters()
+
+    val state = T("learningRate" -> 1e-1, "momentum" -> 0.9, "weightDecay" -> 5e-4,
+      "dampening" -> 0.0)
+
+    val adam = new Adam[Float]
+
+    def feval(x: Tensor[Float]): (Float, Tensor[Float]) = {
+      model.forward(input)
+      criterion.forward(model.output.asInstanceOf[Tensor[Float]], label)
+      model.zeroGradParameters()
+      val gradOutputTest = criterion.backward(model.output.asInstanceOf[Tensor[Float]], label)
+      model.backward(input, gradOutputTest)
+      (criterion.output, grad)
+    }
+
+    val warmUp = 30
+    val iter = 50
+    for (i <- 1 to warmUp) {
+      adam.optimize(feval, weights, state)
+    }
+    var startTime = System.nanoTime
+    var duration = (System.nanoTime() - startTime) / 1e9
+    var sum = 0.0
+    for (i <- 1 to iter) {
+      startTime = System.nanoTime
+      adam.optimize(feval, weights, state)
+      duration = (System.nanoTime() - startTime) / 1e9
+      sum += duration
+      println(s"iter-${i}, eta = ${duration} seconds")
+    }
+    println(s"average eta = ${sum / iter} seconds")
   }
 }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/AdamaxSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/AdamaxSpec.scala
@@ -16,11 +16,13 @@
 
 package com.intel.analytics.bigdl.optim
 
+import com.intel.analytics.bigdl.nn.{CrossEntropyCriterion, Linear, Sequential}
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.bigdl.utils.{T, TestUtils}
+import com.intel.analytics.bigdl.utils.{RandomGenerator, T, TestUtils}
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.collection.mutable.ArrayBuffer
+import scala.util.Random
 
 @com.intel.analytics.bigdl.tags.Parallel
 class AdamaxSpec extends FlatSpec with Matchers {
@@ -49,6 +51,61 @@ class AdamaxSpec extends FlatSpec with Matchers {
     (fx.last < 1e-9) should be(true)
     x(Array(1)) should be(1.0 +- 0.01)
     x(Array(2)) should be(1.0 +- 0.01)
+  }
+  "adamax" should " work fast with MKL" in {
+    RandomGenerator.RNG.setSeed(100)
+    val inputSize = 500
+    val hiddenSize = 500
+    val outputSize = 10
+    val batchSize = 10
+    val model = Sequential[Float]()
+      .add(Linear[Float](inputSize, hiddenSize))
+    for (i <- 1 to 3) {
+      model.add(Linear[Float](hiddenSize, hiddenSize))
+    }
+    model.add(Linear[Float](hiddenSize, outputSize))
+    val criterion = CrossEntropyCriterion[Float]()
+
+    val input = Tensor[Float](batchSize, inputSize).rand
+    val label = Tensor[Float](batchSize).zero
+    for (i <- 1 to batchSize) {
+      val nextLabel = Random.nextInt(outputSize) + 1
+      label.setValue(i, nextLabel)
+    }
+
+    val (weights, grad) = model.getParameters()
+
+    val state = T("learningRate" -> 1e-1, "momentum" -> 0.9, "weightDecay" -> 5e-4,
+      "dampening" -> 0.0)
+
+    val adam = new Adamax[Float]
+
+    def feval(x: Tensor[Float]): (Float, Tensor[Float]) = {
+      model.forward(input)
+      criterion.forward(model.output.asInstanceOf[Tensor[Float]], label)
+      model.zeroGradParameters()
+      val gradOutputTest = criterion.backward(model.output.asInstanceOf[Tensor[Float]], label)
+      model.backward(input, gradOutputTest)
+      (criterion.output, grad)
+    }
+
+    val warmUp = 30
+    val iter = 50
+    for (i <- 1 to warmUp) {
+      adam.optimize(feval, weights, state)
+    }
+    var startTime = System.nanoTime
+    var duration = (System.nanoTime() - startTime) / 1e9
+    var sum = 0.0
+    println()
+    for (i <- 1 to iter) {
+      startTime = System.nanoTime
+      adam.optimize(feval, weights, state)
+      duration = (System.nanoTime() - startTime) / 1e9
+      sum += duration
+      println(s"iter-${i}, eta = ${duration} seconds")
+    }
+    println(s"average eta = ${sum / iter} seconds")
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Replace element-wise operations with MKL vector operations.
Add buffer for sharing memory

## How was this patch tested?
Unit Tests
JVM, single-threading

Adam:
Build a model with 5 linear layers. (500 * 500)
Total parameters(1million)

Test the average eta time in the Adam:

previous:
7.702 ms / iteration
after:
5.918 ms / iteration

Adamax:
Build a model with 5 linear layers. (500 * 500)
Total parameters(1million)

previous:
17.353 ms / iteration
after:
16.6666 ms / iteration

There is a max operation in Adamax which takes 1/4 of the elapsed time.
Currently, using (x + |x|) / 2 will give a worse performance w.r.t if-else branching method.