### PR TITLE
support nhwc format in SpatialConvolution

### DIFF
--- a/docs/docs/APIGuide/Layers/Convolution-Layers.md
+++ b/docs/docs/APIGuide/Layers/Convolution-Layers.md
@@ -2,11 +2,11 @@
 
 **Scala:**
 ```scala
-val m = SpatialConvolution(nInputPlane,nOutputPlane,kernelW,kernelH,strideW=1,strideH=1,padW=0,padH=0,nGroup=1,propagateBack=true,wRegularizer=null,bRegularizer=null,initWeight=null, initBias=null, initGradWeight=null, initGradBias=null)
+val m = SpatialConvolution(nInputPlane,nOutputPlane,kernelW,kernelH,strideW=1,strideH=1,padW=0,padH=0,nGroup=1,propagateBack=true,wRegularizer=null,bRegularizer=null,initWeight=null, initBias=null, initGradWeight=null, initGradBias=null, withBias=true, dataFormat=DataFormat.NCHW)
 ```
 **Python:**
 ```python
-m = SpatialConvolution(n_input_plane,n_output_plane,kernel_w,kernel_h,stride_w=1,stride_h=1,pad_w=0,pad_h=0,n_group=1,propagate_back=True,wRegularizer=None,bRegularizer=None,init_weight=None,init_bias=None,init_grad_weight=None,init_grad_bias=None)
+m = SpatialConvolution(n_input_plane,n_output_plane,kernel_w,kernel_h,stride_w=1,stride_h=1,pad_w=0,pad_h=0,n_group=1,propagate_back=True,wRegularizer=None,bRegularizer=None,init_weight=None,init_bias=None,init_grad_weight=None,init_grad_bias=None, with_bias=True, data_format="NCHW")
 ```
 
 SpatialConvolution is a module that applies a 2D convolution over an input image.
@@ -32,6 +32,10 @@ Detailed paramter explaination for the constructor.
  * `initBias`  bias initializer
  * `initGradWeight` weight gradient initializer
  * `initGradBias` bias gradient initializer
+ * `with_bias` the optional initial value for if need bias
+ * `data_format` a string value (or DataFormat Object in Scala) of "NHWC" or "NCHW" to specify the input data format of this layer. In "NHWC" format
+                        data is stored in the order of \[batch_size, height, width, channels\], in "NCHW" format data is stored
+                        in the order of \[batch_size, channels, height, width\].
  
 **Scala example:**
 ```scala

--- a/docs/docs/APIGuide/Layers/Convolution-Layers.md
+++ b/docs/docs/APIGuide/Layers/Convolution-Layers.md
@@ -14,6 +14,18 @@ SpatialConvolution is a module that applies a 2D convolution over an input image
 The input tensor in `forward(input)` is expected to be
 either a 4D tensor (`batch x nInputPlane x height x width`) or a 3D tensor (` nInputPlane x height x width`). The convolution is performed on the last two dimensions.
 
+As for padding, when padW and padH are both -1, we use a padding algorithm similar to the "SAME" padding of tensorflow. That is
+```scala
+ outHeight = Math.ceil(inHeight.toFloat/strideH.toFloat)
+ outWidth = Math.ceil(inWidth.toFloat/strideW.toFloat)
+
+ padAlongHeight = (outHeight - 1) * strideH + kernelH - inHeight
+ padAlongWidth = (outWidth - 1) * strideW + kernelW - inWidth
+
+ padTop = padAlongHeight / 2
+ padLeft = padAlongWidth / 2
+```
+
 Detailed paramter explaination for the constructor.
  
  * `nInputPlane` The number of expected input planes in the image given into forward()

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -736,6 +736,9 @@ class SpatialConvolution(Layer):
     :param init_grad_weight: the optional initial value for the grad_weight
     :param init_grad_bias: the optional initial value for the grad_bias
     :param with_bias: the optional initial value for if need bias
+    :param data_format: a string value of "NHWC" or "NCHW" to specify the input data format of this layer. In "NHWC" format
+                       data is stored in the order of [batch_size, height, width, channels], in "NCHW" format data is stored
+                       in the order of [batch_size, channels, height, width].
 
     >>> spatialConvolution = SpatialConvolution(6, 12, 5, 5)
     creating: createSpatialConvolution
@@ -748,7 +751,7 @@ class SpatialConvolution(Layer):
     >>> init_bias = np.random.randn(12)
     >>> init_grad_weight = np.zeros([1, 12, 6, 5, 5])
     >>> init_grad_bias = np.zeros([12])
-    >>> spatialConvolution = SpatialConvolution(6, 12, 5, 5, 1, 1, 0, 0, 1, True, L1Regularizer(0.5), L1Regularizer(0.5), init_weight, init_bias, init_grad_weight, init_grad_bias)
+    >>> spatialConvolution = SpatialConvolution(6, 12, 5, 5, 1, 1, 0, 0, 1, True, L1Regularizer(0.5), L1Regularizer(0.5), init_weight, init_bias, init_grad_weight, init_grad_bias, True, "NCHW")
     creating: createL1Regularizer
     creating: createL1Regularizer
     creating: createSpatialConvolution
@@ -772,6 +775,7 @@ class SpatialConvolution(Layer):
                  init_grad_weight=None,
                  init_grad_bias=None,
                  with_bias=True,
+                 data_format="NCHW",
                  bigdl_type="float"):
         super(SpatialConvolution, self).__init__(None, bigdl_type,
                                                  n_input_plane,
@@ -790,7 +794,8 @@ class SpatialConvolution(Layer):
                                                  JTensor.from_ndarray(init_bias),
                                                  JTensor.from_ndarray(init_grad_weight),
                                                  JTensor.from_ndarray(init_grad_bias),
-                                                 with_bias)
+                                                 with_bias,
+                                                 data_format)
     def set_init_method(self, weight_init_method = None, bias_init_method = None):
         callBigDlFunc(self.bigdl_type, "setInitMethod", self.value,
                   weight_init_method, bias_init_method)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/InitializationMethod.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/InitializationMethod.scala
@@ -129,6 +129,18 @@ object VariableFormat {
     }
   }
 
+  case object GP_KH_KW_IN_OUT extends VariableFormat {
+    override def getFanIn(shape: Array[Int]): Int = {
+      val receptiveFieldSize = shape(0) * shape(1) * shape(2)
+      shape(2) * receptiveFieldSize
+    }
+
+    override def getFanOut(shape: Array[Int]): Int = {
+      val receptiveFieldSize = shape(0) * shape(1) * shape(2)
+      shape(3) * receptiveFieldSize
+    }
+  }
+
 }
 
 /**

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/InitializationMethod.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/InitializationMethod.scala
@@ -22,6 +22,8 @@ import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 
 /**
  * VariableFormat describe the meaning of each dimension of the variable
+ * (the trainable parameters of a model like weight and bias) and can be used to
+ * return the fan in and fan out size of the variable when provided the variable shape.
  */
 trait VariableFormat {
   def getFanIn(shape: Array[Int]): Int = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/NNPrimitive.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/NNPrimitive.scala
@@ -25,18 +25,12 @@ private[nn] object NNPrimitive {
     fInput: Tensor[Double], input: Tensor[Double],
     kW: Int, kH: Int,
     dW: Int, dH: Int,
-    padLeft: Int, padTop: Int,
+    padLeft: Int, padTop: Int, padRight: Int, padBottom: Int,
     outputWidth: Int, outputHeight: Int): Unit = {
 
     val nInputPlane = input.size(1)
     val inputHeight = input.size(2)
     val inputWidth = input.size(3)
-
-    val padAlongWidth = (outputWidth -1) * dW + kW - inputWidth
-    val padAlongHeight = (outputHeight - 1) * dH + kH - inputHeight
-
-    val padRight = padAlongWidth - padLeft
-    val padBottom = padAlongHeight - padTop
 
     val inputData = input.storage().array()
     val fInputData = fInput.storage().array()
@@ -49,7 +43,7 @@ private[nn] object NNPrimitive {
       val kw = rest % kW
       val dstOffset = k * outputHeight * outputWidth + fInput.storageOffset() - 1
       val srcOffset = nip * inputWidth * inputHeight + input.storageOffset() - 1
-      if (padAlongWidth > 0 || padAlongHeight > 0) {
+      if (padLeft + padRight > 0  || padTop + padBottom > 0) {
         var y = 0
         while (y < outputHeight) {
           val iy = y * dH - padTop + kh
@@ -115,18 +109,12 @@ private[nn] object NNPrimitive {
     fInput: Tensor[Float], input: Tensor[Float],
     kW: Int, kH: Int,
     dW: Int, dH: Int,
-    padLeft: Int, padTop: Int,
+    padLeft: Int, padTop: Int, padRight: Int, padBottom: Int,
     outputWidth: Int, outputHeight: Int): Unit = {
 
     val nInputPlane = input.size(1)
     val inputHeight = input.size(2)
     val inputWidth = input.size(3)
-
-    val padAlongWidth = (outputWidth -1) * dW + kW - inputWidth
-    val padAlongHeight = (outputHeight - 1) * dH + kH - inputHeight
-
-    val padRight = padAlongWidth - padLeft
-    val padBottom = padAlongHeight - padTop
 
     val inputData = input.storage().array()
     val fInputData = fInput.storage().array()
@@ -139,7 +127,7 @@ private[nn] object NNPrimitive {
       val kw = rest % kW
       val dstOffset = k * outputHeight * outputWidth + fInput.storageOffset() - 1
       val srcOffset = nip * inputWidth * inputHeight + input.storageOffset() - 1
-      if (padAlongWidth > 0  || padAlongHeight > 0) {
+      if (padLeft + padRight > 0  || padTop + padBottom > 0) {
         var y = 0
         while (y < outputHeight) {
           val iy = y * dH - padTop + kh
@@ -205,7 +193,7 @@ private[nn] object NNPrimitive {
     fInput: Tensor[Double], input: Tensor[Double],
     kW: Int, kH: Int,
     dW: Int, dH: Int,
-    padW: Int, padH: Int,
+    padLeft: Int, padTop: Int, padRight: Int, padBottom: Int,
     outputWidth: Int, outputHeight: Int
   ): Unit = {
 
@@ -225,15 +213,15 @@ private[nn] object NNPrimitive {
             kh * (kW * outputHeight * outputWidth) +
             kw * (outputHeight * outputWidth) + fInput.storageOffset() - 1
           val dstOffset = nPlane * (inputHeight * inputWidth) + input.storageOffset() - 1
-          if (padW > 0 || padH > 0) {
+          if (padLeft + padRight > 0 || padTop + padBottom > 0) {
             var y = 0
             while (y < outputHeight) {
-              val iy = y * dH - padH + kh
+              val iy = y * dH - padTop + kh
               if (iy >= 0 && iy < inputHeight) {
                 if (dW == 1) {
-                  val ix = 0 - padW + kw
-                  val lPad = Math.max(0, padW - kw)
-                  val rPad = Math.max(0, padW - (kW - kw - 1))
+                  val ix = 0 - padLeft + kw
+                  val lPad = Math.max(0, padLeft - kw)
+                  val rPad = Math.max(0, padRight - (kW - kw - 1))
                   val inputDataOffset = dstOffset + iy * inputWidth + ix + lPad
                   val fInputDataOffset = srcOffset + y * outputWidth + lPad
                   val n = outputWidth - lPad - rPad
@@ -245,7 +233,7 @@ private[nn] object NNPrimitive {
                 } else {
                   var x = 0
                   while (x < outputWidth) {
-                    val ix = x * dW - padW + kw
+                    val ix = x * dW - padLeft + kw
                     if (ix >= 0 && ix < inputWidth) {
                       inputData(dstOffset + iy * inputWidth + ix) +=
                         fInputData(srcOffset + y * outputWidth + x)
@@ -292,7 +280,7 @@ private[nn] object NNPrimitive {
     fInput: Tensor[Float], input: Tensor[Float],
     kW: Int, kH: Int,
     dW: Int, dH: Int,
-    padW: Int, padH: Int,
+    padLeft: Int, padTop: Int, padRight: Int, padBottom: Int,
     outputWidth: Int, outputHeight: Int
   ): Unit = {
 
@@ -312,15 +300,15 @@ private[nn] object NNPrimitive {
             (kW * outputHeight * outputWidth) +
             kw * (outputHeight * outputWidth) + fInput.storageOffset() - 1
           val dstOffset = nPlane * (inputHeight * inputWidth) + input.storageOffset() - 1
-          if (padW > 0 || padH > 0) {
+          if (padLeft + padRight > 0 || padTop + padBottom > 0) {
             var y = 0
             while (y < outputHeight) {
-              val iy = y * dH - padH + kh
+              val iy = y * dH - padTop + kh
               if (iy >= 0 && iy < inputHeight) {
                 if (dW == 1) {
-                  val ix = 0 - padW + kw
-                  val lPad = Math.max(0, padW - kw)
-                  val rPad = Math.max(0, padW - (kW - kw - 1))
+                  val ix = 0 - padLeft + kw
+                  val lPad = Math.max(0, padLeft - kw)
+                  val rPad = Math.max(0, padRight - (kW - kw - 1))
                   val inputDataOffset = dstOffset + iy * inputWidth + ix + lPad
                   val fInputDataOffset = srcOffset + y * outputWidth + lPad
                   val n = outputWidth - lPad - rPad
@@ -332,7 +320,7 @@ private[nn] object NNPrimitive {
                 } else {
                   var x = 0
                   while (x < outputWidth) {
-                    val ix = x * dW - padW + kw
+                    val ix = x * dW - padLeft + kw
                     if (ix >= 0 && ix < inputWidth) {
                       inputData(dstOffset + iy * inputWidth + ix) +=
                         fInputData(srcOffset + y * outputWidth + x)
@@ -379,7 +367,7 @@ private[nn] object NNPrimitive {
     fInput: Tensor[Double], input: Tensor[Double],
     kW: Int, kH: Int,
     dW: Int, dH: Int,
-    padLeft: Int, padTop: Int,
+    padLeft: Int, padTop: Int, padRight: Int, padBottom: Int,
     outputWidth: Int, outputHeight: Int): Unit = {
 
     val nInputPlane = input.size(3)
@@ -438,7 +426,7 @@ private[nn] object NNPrimitive {
     fInput: Tensor[Float], input: Tensor[Float],
     kW: Int, kH: Int,
     dW: Int, dH: Int,
-    padLeft: Int, padTop: Int,
+    padLeft: Int, padTop: Int, padRight: Int, padBottom: Int,
     outputWidth: Int, outputHeight: Int): Unit = {
 
     val nInputPlane = input.size(3)
@@ -497,7 +485,7 @@ private[nn] object NNPrimitive {
     fInput: Tensor[Double], input: Tensor[Double],
     kW: Int, kH: Int,
     dW: Int, dH: Int,
-    padLeft: Int, padTop: Int,
+    padLeft: Int, padTop: Int, padRight: Int, padBottom: Int,
     outputWidth: Int, outputHeight: Int): Unit = {
 
     val nInputPlane = input.size(3)
@@ -546,7 +534,7 @@ private[nn] object NNPrimitive {
     fInput: Tensor[Float], input: Tensor[Float],
     kW: Int, kH: Int,
     dW: Int, dH: Int,
-    padLeft: Int, padTop: Int,
+    padLeft: Int, padTop: Int, padRight: Int, padBottom: Int,
     outputWidth: Int, outputHeight: Int): Unit = {
 
     val nInputPlane = input.size(3)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/NNPrimitive.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/NNPrimitive.scala
@@ -43,7 +43,7 @@ private[nn] object NNPrimitive {
       val kw = rest % kW
       val dstOffset = k * outputHeight * outputWidth + fInput.storageOffset() - 1
       val srcOffset = nip * inputWidth * inputHeight + input.storageOffset() - 1
-      if (padLeft + padRight > 0  || padTop + padBottom > 0) {
+      if (padLeft > 0 || padRight > 0 || padTop > 0 || padBottom > 0) {
         var y = 0
         while (y < outputHeight) {
           val iy = y * dH - padTop + kh
@@ -127,7 +127,7 @@ private[nn] object NNPrimitive {
       val kw = rest % kW
       val dstOffset = k * outputHeight * outputWidth + fInput.storageOffset() - 1
       val srcOffset = nip * inputWidth * inputHeight + input.storageOffset() - 1
-      if (padLeft + padRight > 0  || padTop + padBottom > 0) {
+      if (padLeft > 0 || padRight > 0 || padTop > 0 || padBottom > 0) {
         var y = 0
         while (y < outputHeight) {
           val iy = y * dH - padTop + kh
@@ -213,7 +213,7 @@ private[nn] object NNPrimitive {
             kh * (kW * outputHeight * outputWidth) +
             kw * (outputHeight * outputWidth) + fInput.storageOffset() - 1
           val dstOffset = nPlane * (inputHeight * inputWidth) + input.storageOffset() - 1
-          if (padLeft + padRight > 0 || padTop + padBottom > 0) {
+          if (padLeft > 0 || padRight > 0 || padTop > 0 || padBottom > 0) {
             var y = 0
             while (y < outputHeight) {
               val iy = y * dH - padTop + kh
@@ -300,7 +300,7 @@ private[nn] object NNPrimitive {
             (kW * outputHeight * outputWidth) +
             kw * (outputHeight * outputWidth) + fInput.storageOffset() - 1
           val dstOffset = nPlane * (inputHeight * inputWidth) + input.storageOffset() - 1
-          if (padLeft + padRight > 0 || padTop + padBottom > 0) {
+          if (padLeft > 0 || padRight > 0 || padTop > 0 || padBottom > 0) {
             var y = 0
             while (y < outputHeight) {
               val iy = y * dH - padTop + kh
@@ -370,6 +370,9 @@ private[nn] object NNPrimitive {
     padLeft: Int, padTop: Int, padRight: Int, padBottom: Int,
     outputWidth: Int, outputHeight: Int): Unit = {
 
+    // padRight and padBottom are used in the NCHW version but not here,
+    // add it to keep api consistent
+
     val nInputPlane = input.size(3)
     val inputHeight = input.size(1)
     val inputWidth = input.size(2)
@@ -428,6 +431,9 @@ private[nn] object NNPrimitive {
     dW: Int, dH: Int,
     padLeft: Int, padTop: Int, padRight: Int, padBottom: Int,
     outputWidth: Int, outputHeight: Int): Unit = {
+
+    // padRight and padBottom are used in the NCHW version but not here,
+    // add it to keep api consistent
 
     val nInputPlane = input.size(3)
     val inputHeight = input.size(1)
@@ -488,6 +494,9 @@ private[nn] object NNPrimitive {
     padLeft: Int, padTop: Int, padRight: Int, padBottom: Int,
     outputWidth: Int, outputHeight: Int): Unit = {
 
+    // padRight and padBottom are used in the NCHW version but not here,
+    // add it to keep api consistent
+
     val nInputPlane = input.size(3)
     val inputHeight = input.size(1)
     val inputWidth = input.size(2)
@@ -536,6 +545,9 @@ private[nn] object NNPrimitive {
     dW: Int, dH: Int,
     padLeft: Int, padTop: Int, padRight: Int, padBottom: Int,
     outputWidth: Int, outputHeight: Int): Unit = {
+
+    // padRight and padBottom are used in the NCHW version but not here,
+    // add it to keep api consistent
 
     val nInputPlane = input.size(3)
     val inputHeight = input.size(1)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/NNPrimitive.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/NNPrimitive.scala
@@ -25,12 +25,18 @@ private[nn] object NNPrimitive {
     fInput: Tensor[Double], input: Tensor[Double],
     kW: Int, kH: Int,
     dW: Int, dH: Int,
-    padW: Int, padH: Int,
+    padLeft: Int, padTop: Int,
     outputWidth: Int, outputHeight: Int): Unit = {
 
     val nInputPlane = input.size(1)
     val inputHeight = input.size(2)
     val inputWidth = input.size(3)
+
+    val padAlongWidth = (outputWidth -1) * dW + kW - inputWidth
+    val padAlongHeight = (outputHeight - 1) * dH + kH - inputHeight
+
+    val padRight = padAlongWidth - padLeft
+    val padBottom = padAlongHeight - padTop
 
     val inputData = input.storage().array()
     val fInputData = fInput.storage().array()
@@ -43,18 +49,18 @@ private[nn] object NNPrimitive {
       val kw = rest % kW
       val dstOffset = k * outputHeight * outputWidth + fInput.storageOffset() - 1
       val srcOffset = nip * inputWidth * inputHeight + input.storageOffset() - 1
-      if (padW > 0 || padH > 0) {
+      if (padAlongWidth > 0 || padAlongHeight > 0) {
         var y = 0
         while (y < outputHeight) {
-          val iy = y * dH - padH + kh
+          val iy = y * dH - padTop + kh
           if (iy < 0 || iy >= inputHeight) {
             util.Arrays.fill(fInputData, dstOffset + y * outputWidth,
               dstOffset + (y + 1) * outputWidth, 0)
           } else {
             if (dW == 1) {
-              val ix = 0 - padW + kw
-              val lpad = Math.max(0, padW - kw)
-              val rpad = Math.max(0, padW - (kW - kw - 1))
+              val ix = 0 - padLeft + kw
+              val lpad = Math.max(0, padLeft - kw)
+              val rpad = Math.max(0, padRight - (kW - kw - 1))
               if (outputWidth - rpad - lpad <= 0) {
                 util.Arrays.fill(fInputData, dstOffset + y * outputWidth,
                   dstOffset + (y + 1) * outputWidth, 0)
@@ -69,7 +75,7 @@ private[nn] object NNPrimitive {
             } else {
               var x = 0
               while (x < outputWidth) {
-                val ix = x * dW - padW + kw
+                val ix = x * dW - padLeft + kw
                 if (ix < 0 || ix >= inputWidth) {
                   fInputData(dstOffset + y * outputWidth + x) = 0
                 } else {
@@ -109,12 +115,18 @@ private[nn] object NNPrimitive {
     fInput: Tensor[Float], input: Tensor[Float],
     kW: Int, kH: Int,
     dW: Int, dH: Int,
-    padW: Int, padH: Int,
+    padLeft: Int, padTop: Int,
     outputWidth: Int, outputHeight: Int): Unit = {
 
     val nInputPlane = input.size(1)
     val inputHeight = input.size(2)
     val inputWidth = input.size(3)
+
+    val padAlongWidth = (outputWidth -1) * dW + kW - inputWidth
+    val padAlongHeight = (outputHeight - 1) * dH + kH - inputHeight
+
+    val padRight = padAlongWidth - padLeft
+    val padBottom = padAlongHeight - padTop
 
     val inputData = input.storage().array()
     val fInputData = fInput.storage().array()
@@ -127,18 +139,18 @@ private[nn] object NNPrimitive {
       val kw = rest % kW
       val dstOffset = k * outputHeight * outputWidth + fInput.storageOffset() - 1
       val srcOffset = nip * inputWidth * inputHeight + input.storageOffset() - 1
-      if (padW > 0 || padH > 0) {
+      if (padAlongWidth > 0  || padAlongHeight > 0) {
         var y = 0
         while (y < outputHeight) {
-          val iy = y * dH - padH + kh
+          val iy = y * dH - padTop + kh
           if (iy < 0 || iy >= inputHeight) {
             util.Arrays.fill(fInputData, dstOffset + y * outputWidth,
               dstOffset + (y + 1) * outputWidth, 0)
           } else {
             if (dW == 1) {
-              val ix = 0 - padW + kw
-              val lpad = Math.max(0, padW - kw)
-              val rpad = Math.max(0, padW - (kW - kw - 1))
+              val ix = 0 - padTop + kw
+              val lpad = Math.max(0, padLeft - kw)
+              val rpad = Math.max(0, padRight - (kW - kw - 1))
               if (outputWidth - rpad - lpad <= 0) {
                 util.Arrays.fill(fInputData, dstOffset + y * outputWidth,
                   dstOffset + (y + 1) * outputWidth, 0)
@@ -153,7 +165,7 @@ private[nn] object NNPrimitive {
             } else {
               var x = 0
               while (x < outputWidth) {
-                val ix = x * dW - padW + kw
+                val ix = x * dW - padLeft + kw
                 if (ix < 0 || ix >= inputWidth) {
                   fInputData(dstOffset + y * outputWidth + x) = 0
                 } else {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialConvolution.scala
@@ -16,21 +16,31 @@
 
 package com.intel.analytics.bigdl.nn
 
-import com.intel.analytics.bigdl.nn.abstractnn.{Initializable, TensorModule}
+import com.intel.analytics.bigdl.nn.abstractnn.{Initializable, DataFormat, TensorModule}
 import com.intel.analytics.bigdl.optim.Regularizer
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.tensor._
 import com.intel.analytics.bigdl.utils._
-import com.intel.analytics.bigdl.utils.RandomGenerator._
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, Future}
+import scala.concurrent.Future
 import scala.reflect.ClassTag
 
 /**
  * Applies a 2D convolution over an input image composed of several input planes.
  * The input tensor in forward(input) is expected to be
  * a 3D tensor (nInputPlane x height x width).
+ *
+ * When padW and padH are both -1, we use a padding algorithm similar to the "SAME"
+ * padding of tensorflow. That is
+ *
+ * outHeight = Math.ceil(inHeight.toFloat/strideH.toFloat)
+ * outWidth = Math.ceil(inWidth.toFloat/strideW.toFloat)
+ *
+ * padAlongHeight = (outHeight - 1) * strideH + kernelH - inHeight
+ * padAlongWidth = (outWidth - 1) * strideW + kernelW - inWidth
+ *
+ * padTop = padAlongHeight / 2
+ * padLeft = padAlongWidth / 2
  *
  * @param wRegularizer: instance of [[Regularizer]]
  *                    (eg. L1 or L2 regularization), applied to the input weights matrices.
@@ -56,16 +66,41 @@ class SpatialConvolution[T: ClassTag](
   val initBias: Tensor[T] = null,
   val initGradWeight: Tensor[T] = null,
   val initGradBias: Tensor[T] = null,
-  val withBias: Boolean = true
+  val withBias: Boolean = true,
+  val format: DataFormat = DataFormat.NCHW
 )(implicit ev: TensorNumeric[T]) extends TensorModule[T] with Initializable {
 
   require(nInputPlane % nGroup == 0, "Number of input channels should be multiples of group.")
   require(nOutputPlane % nGroup == 0, "Number of output channels should be multiples of group.")
+  if (nGroup != 1) {
+    require(format == DataFormat.NCHW, "group convolution is not supported in NHWC format " )
+  }
+
+  private val weightShape = format match {
+    case DataFormat.NCHW =>
+      Array(nGroup, nOutputPlane / nGroup, nInputPlane / nGroup, kernelH, kernelW)
+    case DataFormat.NHWC =>
+      Array(1, kernelH, kernelW, nInputPlane, nOutputPlane)
+  }
+
+  private val weightFormat = format match {
+    case DataFormat.NCHW =>
+      VariableFormat.GP_OUT_IN_KW_KH
+    case DataFormat.NHWC =>
+      VariableFormat.GP_KH_KW_IN_OUT
+  }
+
+  private val weightMMShape = format match {
+    case DataFormat.NCHW =>
+      Array(nGroup, nOutputPlane / nGroup, nInputPlane * kernelH * kernelW / nGroup)
+    case DataFormat.NHWC =>
+      Array(1, nInputPlane * kernelH * kernelW, nOutputPlane)
+  }
 
   val weight: Tensor[T] = if (initWeight != null) {
     initWeight
   } else {
-    Tensor[T](nGroup, nOutputPlane / nGroup, nInputPlane / nGroup, kernelH, kernelW)
+    Tensor[T](weightShape)
   }
 
   val bias: Tensor[T] = if (!withBias) null
@@ -74,7 +109,7 @@ class SpatialConvolution[T: ClassTag](
   val gradWeight: Tensor[T] = if (initGradWeight != null) {
     initGradWeight
   } else {
-    Tensor[T](nGroup, nOutputPlane / nGroup, nInputPlane / nGroup, kernelH, kernelW)
+    Tensor[T](weightShape)
   }
 
   val gradBias: Tensor[T] = if (!withBias) null
@@ -117,12 +152,63 @@ class SpatialConvolution[T: ClassTag](
 
   override def reset(): Unit = {
     if (initWeight == null) {
-      weightInitMethod.init(weight, VariableFormat.GP_OUT_IN_KW_KH)
+      weightInitMethod.init(weight, weightFormat)
     }
     if (withBias && initBias == null) {
       biasInitMethod.init(bias, VariableFormat.ONE_D)
     }
     zeroGradParameters()
+  }
+
+  private def getOutputShape(oh: Int, ow: Int, batchSize: Int = -1): Array[Int] = {
+    format match {
+      case DataFormat.NCHW =>
+        if (batchSize == -1) {
+          Array(nOutputPlane, oh, ow)
+        } else {
+          Array(batchSize, nOutputPlane, oh, ow)
+        }
+      case DataFormat.NHWC =>
+        if (batchSize == -1) {
+          Array(oh, ow, nOutputPlane)
+        } else {
+          Array(batchSize, oh, ow, nOutputPlane)
+        }
+
+    }
+  }
+
+  private def getFInputShape(oh: Int, ow: Int, batchSize: Int = -1): Array[Int] = {
+    format match {
+      case DataFormat.NCHW =>
+        if (batchSize == -1) {
+          Array(nGroup, kernelW * kernelH * nInputPlane / nGroup, oh * ow)
+        } else {
+          Array(batchSize, nGroup, kernelW * kernelH * nInputPlane / nGroup, oh * ow)
+        }
+      case DataFormat.NHWC =>
+        if (batchSize == -1) {
+          Array(1, oh * ow, kernelW * kernelH * nInputPlane)
+        } else {
+          Array(batchSize, 1, oh * ow, kernelW * kernelH * nInputPlane)
+        }
+
+    }
+  }
+
+  // return (padTop, padDown, padLeft, padRight)
+  private def getPadding(inputHeight: Int, inputWidth: Int): (Int, Int, Int, Int) = {
+    if (padW == -1 && padH == -1) {
+      // deal with SAME padding
+      val oW = Math.ceil(inputWidth.toFloat / strideW.toFloat).toInt
+      val oH = Math.ceil(inputHeight.toFloat / strideH.toFloat).toInt
+      val padAlongWidth = (oW -1) * strideW + kernelW - inputWidth
+      val padAlongHeight = (oH - 1) * strideH + kernelH - inputHeight
+      (padAlongHeight/2, padAlongHeight - padAlongHeight/2,
+        padAlongWidth/2, padAlongWidth - padAlongWidth/2)
+    } else {
+      (padH, padH, padW, padW)
+    }
   }
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
@@ -131,17 +217,21 @@ class SpatialConvolution[T: ClassTag](
     require(input.isContiguous())
 
     if (weightMM == null || weightMM.storage().isEmpty) {
-      weightMM = weight.view(nGroup, nOutputPlane / nGroup,
-        nInputPlane * kernelH * kernelW / nGroup)
+      weightMM = weight.view(weightMMShape)
     }
-    val dimWidth = if (input.dim() == 3) 3 else 4
-    val dimHeight = if (input.dim() == 3) 2 else 3
+
+    val (dimHeight, dimWidth, channelDim) = format.getHWCDims(input.dim())
+    require(input.size(channelDim) == nInputPlane, s"input channel size " +
+      s"${input.size(channelDim)} is not the same as nInputPlane $nInputPlane")
 
     val inputWidth = input.size(dimWidth)
     val inputHeight = input.size(dimHeight)
 
-    val outputWidth = (inputWidth + 2 * padW - kernelW) / strideW + 1
-    val outputHeight = (inputHeight + 2 * padH - kernelH) / strideH + 1
+    // deal with SAME padding
+    val (padTop, padDown, padLeft, padRight) = getPadding(inputHeight, inputWidth)
+
+    val outputWidth = (inputWidth + padLeft + padRight - kernelW) / strideW + 1
+    val outputHeight = (inputHeight + padTop + padDown - kernelH) / strideH + 1
 
     require(outputWidth >= 1 && outputHeight >= 1,
       s"output size is too small. outputWidth: $outputWidth, outputHeight: $outputHeight")
@@ -151,16 +241,13 @@ class SpatialConvolution[T: ClassTag](
     }
 
     if (input.dim() == 3) {
-      require(input.size(1) == nInputPlane)
       require(input.isContiguous())
-      output.resize(Array(nOutputPlane, outputHeight, outputWidth))
+      output.resize(getOutputShape(outputHeight, outputWidth))
       if (_1x1) {
         fInput.set(input)
-        fInput.resize(Array(nGroup, kernelW * kernelH * nInputPlane / nGroup,
-          outputHeight * outputWidth))
+        fInput.resize(getFInputShape(outputHeight, outputWidth))
       } else {
-        fInput.resize(Array(nGroup, kernelW * kernelH * nInputPlane / nGroup,
-          outputHeight * outputWidth))
+        fInput.resize(getFInputShape(outputHeight, outputWidth))
       }
       var g = 0
       while (g < nGroup) {
@@ -168,28 +255,25 @@ class SpatialConvolution[T: ClassTag](
           bias.narrow(1, g * nOutputPlane / nGroup + 1, nOutputPlane / nGroup)
         } else null
         updateOutputFrame(
-          input.narrow(1, g * nInputPlane / nGroup + 1, nInputPlane / nGroup),
-          output.narrow(1, g * nOutputPlane / nGroup + 1, nOutputPlane / nGroup),
+          input.narrow(channelDim, g * nInputPlane / nGroup + 1, nInputPlane / nGroup),
+          output.narrow(channelDim, g * nOutputPlane / nGroup + 1, nOutputPlane / nGroup),
           weightMM.select(1, g + 1),
           biasUse,
           fInput.select(1, g + 1),
           kernelW, kernelH, strideW, strideH,
-          padW, padH,
+          padLeft, padTop,
           nInputPlane / nGroup, inputWidth, inputHeight,
           nOutputPlane / nGroup, outputWidth, outputHeight)
         g += 1
       }
     } else {
-      require(input.size(2) == nInputPlane)
       val batchSize = input.size(1)
-      output.resize(Array(batchSize, nOutputPlane, outputHeight, outputWidth))
+      output.resize(getOutputShape(outputHeight, outputWidth, batchSize))
       if (_1x1) {
         fInput.set(input)
-        fInput.resize(Array(batchSize, nGroup, kernelW * kernelH * nInputPlane / nGroup,
-          outputHeight * outputWidth))
+        fInput.resize(getFInputShape(outputHeight, outputWidth, batchSize))
       } else {
-        fInput.resize(Array(batchSize, nGroup, kernelW * kernelH * nInputPlane / nGroup,
-          outputHeight * outputWidth))
+        fInput.resize(getFInputShape(outputHeight, outputWidth, batchSize))
       }
 
       if (results == null || results.length != batchSize) {
@@ -210,13 +294,13 @@ class SpatialConvolution[T: ClassTag](
               bias.narrow(1, g * nOutputPlane / nGroup + 1, nOutputPlane / nGroup)
             } else null
             updateOutputFrame(
-              inputT.narrow(1, g * nInputPlane / nGroup + 1, nInputPlane / nGroup),
-              outputT.narrow(1, g * nOutputPlane / nGroup + 1, nOutputPlane / nGroup),
+              inputT.narrow(channelDim - 1, g * nInputPlane / nGroup + 1, nInputPlane / nGroup),
+              outputT.narrow(channelDim - 1, g * nOutputPlane / nGroup + 1, nOutputPlane / nGroup),
               weightMM.select(1, g + 1),
               biasUse,
               fInputT.select(1, g + 1),
               kernelW, kernelH, strideW, strideH,
-              padW, padH,
+              padLeft, padTop,
               nInputPlane / nGroup, inputWidth, inputHeight,
               nOutputPlane / nGroup, outputWidth, outputHeight)
             g += 1
@@ -234,6 +318,15 @@ class SpatialConvolution[T: ClassTag](
       return gradInput
     }
 
+    val (ohDim, owDim, cDim) = format.getHWCDims(input.dim())
+    val oh = gradOutput.size(ohDim)
+    val ow = gradOutput.size(owDim)
+
+    val inputWidth = input.size(owDim)
+    val inputHeight = input.size(ohDim)
+
+    val (padTop, padDown, padLeft, padRight) = getPadding(inputHeight, inputWidth)
+
     require(input.nDimension() == 3 || input.nDimension() == 4, "Only support 3D or 4D input")
     gradInput.resizeAs(input)
     if (_1x1) {
@@ -248,11 +341,11 @@ class SpatialConvolution[T: ClassTag](
       var g = 0
       while (g < nGroup) {
         updateGradInputFrame(
-          gradInput.narrow(1, g * nInputPlane / nGroup + 1, nInputPlane / nGroup),
-          gradOutput.narrow(1, g * nOutputPlane / nGroup + 1, nOutputPlane / nGroup),
+          gradInput.narrow(cDim, g * nInputPlane / nGroup + 1, nInputPlane / nGroup),
+          gradOutput.narrow(cDim, g * nOutputPlane / nGroup + 1, nOutputPlane / nGroup),
           weightMM.select(1, g + 1).transpose(1, 2),
           fGradInput.select(1, g + 1),
-          kernelW, kernelH, strideW, strideH, padW, padH)
+          kernelW, kernelH, strideW, strideH, padLeft, padTop)
         g += 1
       }
     } else {
@@ -268,11 +361,11 @@ class SpatialConvolution[T: ClassTag](
           var g = 0
           while (g < nGroup) {
             updateGradInputFrame(
-              gradInputT.narrow(1, g * nInputPlane / nGroup + 1, nInputPlane / nGroup),
-              gradOutputT.narrow(1, g * nOutputPlane / nGroup + 1, nOutputPlane / nGroup),
+              gradInputT.narrow(cDim - 1, g * nInputPlane / nGroup + 1, nInputPlane / nGroup),
+              gradOutputT.narrow(cDim - 1, g * nOutputPlane / nGroup + 1, nOutputPlane / nGroup),
               weightMM.select(1, g + 1).transpose(1, 2),
               fgradInputT.select(1, g + 1),
-              kernelW, kernelH, strideW, strideH, padW, padH)
+              kernelW, kernelH, strideW, strideH, padLeft, padTop)
             g += 1
           }
         })
@@ -281,17 +374,27 @@ class SpatialConvolution[T: ClassTag](
       Engine.model.sync(results)
     }
 
-    return gradInput
+    gradInput
+  }
+
+  private def getGradWeightMMInBatchShape(batchSize: Int) = format match {
+    case DataFormat.NCHW =>
+      Array(batchSize, nGroup, nOutputPlane / nGroup, nInputPlane * kernelH * kernelW / nGroup)
+    case DataFormat.NHWC =>
+      Array(batchSize, 1, nInputPlane * kernelH * kernelW, nOutputPlane)
   }
 
   override def accGradParameters(input: Tensor[T], gradOutput: Tensor[T]): Unit = {
     require(input.nDimension() == 3 || input.nDimension() == 4, "Only support 3D or 4D input")
     require(gradOutput.isContiguous())
 
+    val (ohDim, owDim, cDim) = format.getHWCDims(input.dim())
+    val oh = gradOutput.size(ohDim)
+    val ow = gradOutput.size(owDim)
+
     if (input.nDimension() == 3) {
       if (gradWeightMM == null) {
-        gradWeightMM = gradWeight.view(nGroup, nOutputPlane / nGroup,
-          nInputPlane * kernelH * kernelW / nGroup)
+        gradWeightMM = gradWeight.view(weightMMShape)
       }
       var g = 0
       while (g < nGroup) {
@@ -300,7 +403,7 @@ class SpatialConvolution[T: ClassTag](
         } else null
 
         accGradParametersFrame(
-          gradOutput.narrow(1, g * nOutputPlane / nGroup + 1, nOutputPlane / nGroup),
+          gradOutput.narrow(cDim, g * nOutputPlane / nGroup + 1, nOutputPlane / nGroup),
           gradWeightMM.select(1, g + 1),
           gradBiasUse,
           fInput.select(1, g + 1),
@@ -311,14 +414,13 @@ class SpatialConvolution[T: ClassTag](
     } else {
       val batchSize = input.size(1)
       if (gradWeightMMInBatch == null) {
-        gradWeightMMInBatch = Tensor[T]().resize(Array(batchSize, nGroup, nOutputPlane / nGroup,
-          nInputPlane * kernelH * kernelW / nGroup))
+        gradWeightMMInBatch = Tensor[T]().resize(getGradWeightMMInBatchShape(batchSize))
       }
       if(withBias && gradientBiasMT.nElement() == 0) {
         gradientBiasMT.resize(Array(batchSize, nOutputPlane))
       }
-      if (ones.dim() != 1 || ones.size(1) != gradOutput.size(3) * gradOutput.size(4)) {
-        ones.resize(Array(gradOutput.size(3) * gradOutput.size(4))).fill(ev.fromType(1.0))
+      if (ones.dim() != 1 || ones.size(1) != oh * ow) {
+        ones.resize(Array(oh * ow)).fill(ev.fromType(1.0))
       }
 
       if (onesBatch.dim() != 1 || onesBatch.size(1) != batchSize) {
@@ -337,7 +439,7 @@ class SpatialConvolution[T: ClassTag](
                 nOutputPlane / nGroup)
             } else null
             calcGradParametersFrame(
-              gradOutputT.narrow(1, g * nOutputPlane / nGroup + 1, nOutputPlane / nGroup),
+              gradOutputT.narrow(cDim - 1, g * nOutputPlane / nGroup + 1, nOutputPlane / nGroup),
               gradWeightMMInBatch.select(1, _i).select(1, g + 1),
               gradientBiasMTUse,
               fInputT.select(1, g + 1),
@@ -467,66 +569,134 @@ class SpatialConvolution[T: ClassTag](
       s" $kernelH, $strideW, $strideH, $padW, $padH)"
   }
 
-  protected def updateOutputFrame(input: Tensor[T], output: Tensor[T], weight: Tensor[T],
-    bias: Tensor[T], fInput: Tensor[T],
-    kW: Int, kH: Int, dW: Int, dH: Int, padW: Int, padH: Int,
-    nInputPlane: Int, inputWidth: Int, inputHeight: Int,
-    nOutputPlane: Int, outputWidth: Int, outputHeight: Int)(
+  protected def updateOutputFrame(
+     input: Tensor[T], output: Tensor[T], weight: Tensor[T],
+     bias: Tensor[T], fInput: Tensor[T],
+     kW: Int, kH: Int, dW: Int, dH: Int, padLeft: Int, padTop: Int,
+     nInputPlane: Int, inputWidth: Int, inputHeight: Int,
+     nOutputPlane: Int, outputWidth: Int, outputHeight: Int)(
     implicit ev: TensorNumeric[T]): Unit = {
 
-    val output2d = output.view(nOutputPlane, outputHeight * outputWidth)
-    if (!_1x1) {
-      ev.getType() match {
-        case DoubleType =>
-          val before = System.nanoTime()
-          NNPrimitive.im2colDouble(fInput.asInstanceOf[Tensor[Double]],
-            input.asInstanceOf[Tensor[Double]], kW, kH, dW, dH, padW, padH,
-            outputWidth, outputHeight)
-          im2colTime += System.nanoTime() - before
-        case FloatType =>
-          val before = System.nanoTime()
-          NNPrimitive.im2colFloat(fInput.asInstanceOf[Tensor[Float]],
-            input.asInstanceOf[Tensor[Float]], kW, kH, dW, dH, padW, padH,
-            outputWidth, outputHeight)
-          im2colTime += System.nanoTime() - before
-        case _ => throw new UnsupportedOperationException(s"Only Float/Double supported")
-      }
+    format match {
+      case DataFormat.NCHW =>
+        val output2d = output.view(nOutputPlane, outputHeight * outputWidth)
+        if (!_1x1) {
+          ev.getType() match {
+            case DoubleType =>
+              val before = System.nanoTime()
+              NNPrimitive.im2colDouble(fInput.asInstanceOf[Tensor[Double]],
+                input.asInstanceOf[Tensor[Double]], kW, kH, dW, dH, padLeft, padTop,
+                outputWidth, outputHeight)
+              im2colTime += System.nanoTime() - before
+            case FloatType =>
+              val before = System.nanoTime()
+              NNPrimitive.im2colFloat(fInput.asInstanceOf[Tensor[Float]],
+                input.asInstanceOf[Tensor[Float]], kW, kH, dW, dH, padLeft, padTop,
+                outputWidth, outputHeight)
+              im2colTime += System.nanoTime() - before
+            case _ => throw new UnsupportedOperationException(s"Only Float/Double supported")
+          }
+        }
+        output2d.addmm(ev.fromType[Int](0), output2d, ev.fromType[Int](1), weight, fInput)
+        if (withBias) output2d.addr(ev.fromType(1), bias, onesBias)
+      case DataFormat.NHWC =>
+        val output2d = output.view(outputHeight * outputWidth, nOutputPlane)
+        if (!_1x1) {
+          ev.getType() match {
+            case DoubleType =>
+              val before = System.nanoTime()
+              NNPrimitive.im2colDoubleNHWC(fInput.asInstanceOf[Tensor[Double]],
+                input.asInstanceOf[Tensor[Double]], kW, kH, dW, dH, padLeft, padTop,
+                outputWidth, outputHeight)
+              im2colTime += System.nanoTime() - before
+            case FloatType =>
+              val before = System.nanoTime()
+              NNPrimitive.im2colFloatNHWC(fInput.asInstanceOf[Tensor[Float]],
+                input.asInstanceOf[Tensor[Float]], kW, kH, dW, dH, padLeft, padTop,
+                outputWidth, outputHeight)
+              im2colTime += System.nanoTime() - before
+            case _ => throw new UnsupportedOperationException(s"Only Float/Double supported")
+          }
+        }
+        output2d.addmm(ev.fromType[Int](0), output2d, ev.fromType[Int](1), fInput, weight)
+        if (withBias) output2d.addr(ev.fromType(1), onesBias, bias)
     }
-    output2d.addmm(ev.fromType[Int](0), output2d, ev.fromType[Int](1), weight, fInput)
-    if (withBias) output2d.addr(ev.fromType(1), bias, onesBias)
   }
 
-  protected def updateGradInputFrame(gradInput: Tensor[T], gradOutput: Tensor[T],
-    weight: Tensor[T], fgradInput: Tensor[T], kW: Int, kH: Int, dW: Int, dH: Int,
-    padW: Int, padH: Int)(implicit ev: TensorNumeric[T]): Unit = {
+  protected def updateGradInputFrame(
+     gradInput: Tensor[T], gradOutput: Tensor[T],
+     weight: Tensor[T], fgradInput: Tensor[T], kW: Int, kH: Int, dW: Int, dH: Int,
+     padLeft: Int, padTop: Int)(implicit ev: TensorNumeric[T]): Unit = {
     ev.getType() match {
       case DoubleType =>
-        val gradOutput2d = Tensor(gradOutput.storage().asInstanceOf[Storage[Double]],
-          gradOutput.storageOffset(), Array(gradOutput.size(1),
-            gradOutput.size(2) * gradOutput.size(3)))
-        fgradInput.asInstanceOf[Tensor[Double]].addmm(0.0, fgradInput.asInstanceOf[Tensor[Double]],
-          1.0, weight.asInstanceOf[Tensor[Double]], gradOutput2d)
-        if (!_1x1) {
-          gradInput.asInstanceOf[Tensor[Double]].zero()
-          val before = System.nanoTime()
-          NNPrimitive.col2imDouble(fgradInput.asInstanceOf[Tensor[Double]],
-            gradInput.asInstanceOf[Tensor[Double]], kW, kH, dW, dH, padW, padH,
-            gradOutput.size(3), gradOutput.size(2))
-          col2imTime += System.nanoTime() - before
+        val gradOutDouble = gradOutput.asInstanceOf[Tensor[Double]]
+        val fGradInDouble = fgradInput.asInstanceOf[Tensor[Double]]
+        val weightDouble = weight.asInstanceOf[Tensor[Double]]
+        val gradInputDouble = gradInput.asInstanceOf[Tensor[Double]]
+        format match {
+          case DataFormat.NCHW =>
+            val channel = gradOutDouble.size(1)
+            val oh = gradOutDouble.size(2)
+            val ow = gradOutDouble.size(3)
+            val gradOutput2d = gradOutDouble.view(Array(channel, oh * ow))
+            fGradInDouble.addmm(0.0, fGradInDouble, 1.0, weightDouble, gradOutput2d)
+            if (!_1x1) {
+              gradInputDouble.zero()
+              val before = System.nanoTime()
+              NNPrimitive.col2imDouble(fGradInDouble,
+                gradInputDouble, kW, kH, dW, dH, padLeft, padTop,
+                gradOutput.size(3), gradOutput.size(2))
+              col2imTime += System.nanoTime() - before
+            }
+          case DataFormat.NHWC =>
+            val channel = gradOutDouble.size(3)
+            val oh = gradOutDouble.size(1)
+            val ow = gradOutDouble.size(2)
+            val gradOutput2d = gradOutDouble.view(Array(oh * ow, channel))
+            fGradInDouble.addmm(0.0, fGradInDouble, 1.0, gradOutput2d, weightDouble)
+            if (!_1x1) {
+              gradInputDouble.zero()
+              val before = System.nanoTime()
+              NNPrimitive.col2imDoubleNHWC(fGradInDouble,
+                gradInputDouble, kW, kH, dW, dH, padLeft, padTop,
+                gradOutput.size(2), gradOutput.size(1))
+              col2imTime += System.nanoTime() - before
+            }
         }
       case FloatType =>
-        val gradOutput2d = Tensor(gradOutput.storage().asInstanceOf[Storage[Float]],
-          gradOutput.storageOffset(),
-          Array(gradOutput.size(1), gradOutput.size(2) * gradOutput.size(3)))
-        fgradInput.asInstanceOf[Tensor[Float]].addmm(0.0f, fgradInput.asInstanceOf[Tensor[Float]],
-          1.0f, weight.asInstanceOf[Tensor[Float]], gradOutput2d)
-        if (!_1x1) {
-          gradInput.asInstanceOf[Tensor[Float]].zero()
-          val before = System.nanoTime()
-          NNPrimitive.col2imFloat(fgradInput.asInstanceOf[Tensor[Float]],
-            gradInput.asInstanceOf[Tensor[Float]], kW, kH, dW, dH, padW, padH,
-            gradOutput.size(3), gradOutput.size(2))
-          col2imTime += System.nanoTime() - before
+        val gradOutFloat = gradOutput.asInstanceOf[Tensor[Float]]
+        val fGradInFloat = fgradInput.asInstanceOf[Tensor[Float]]
+        val weightFloat = weight.asInstanceOf[Tensor[Float]]
+        val gradInputFloat = gradInput.asInstanceOf[Tensor[Float]]
+        format match {
+          case DataFormat.NCHW =>
+            val channel = gradOutFloat.size(1)
+            val oh = gradOutFloat.size(2)
+            val ow = gradOutFloat.size(3)
+            val gradOutput2d = gradOutFloat.view(Array(channel, oh * ow))
+            fGradInFloat.addmm(0.0f, fGradInFloat, 1.0f, weightFloat, gradOutput2d)
+            if (!_1x1) {
+              gradInputFloat.zero()
+              val before = System.nanoTime()
+              NNPrimitive.col2imFloat(fGradInFloat,
+                gradInputFloat, kW, kH, dW, dH, padLeft, padTop,
+                gradOutput.size(3), gradOutput.size(2))
+              col2imTime += System.nanoTime() - before
+            }
+          case DataFormat.NHWC =>
+            val channel = gradOutFloat.size(3)
+            val oh = gradOutFloat.size(1)
+            val ow = gradOutFloat.size(2)
+            val gradOutput2d = gradOutFloat.view(Array(oh * ow, channel))
+            fGradInFloat.addmm(0.0f, fGradInFloat, 1.0f, gradOutput2d, weightFloat)
+            if (!_1x1) {
+              gradInputFloat.zero()
+              val before = System.nanoTime()
+              NNPrimitive.col2imFloatNHWC(fGradInFloat,
+                gradInputFloat, kW, kH, dW, dH, padLeft, padTop,
+                gradOutput.size(2), gradOutput.size(1))
+              col2imTime += System.nanoTime() - before
+            }
         }
       case _ => throw new UnsupportedOperationException(s"Only Float/Double supported")
     }
@@ -538,61 +708,118 @@ class SpatialConvolution[T: ClassTag](
 
     ev.getType() match {
       case DoubleType =>
-        val gradOutput2d = Tensor[Double](gradOutput.storage().asInstanceOf[Storage[Double]],
-          gradOutput.storageOffset(),
-          Array(gradOutput.size(1), gradOutput.size(2) * gradOutput.size(3)))
-        if (scaleW !=0 ) {
-          gradWeight.asInstanceOf[Tensor[Double]].addmm(1.0,
-            gradWeight.asInstanceOf[Tensor[Double]],
-            ev.toType[Double](scaleW), gradOutput2d,
-            fInput.t.asInstanceOf[Tensor[Double]])
-        }
-
-        if (withBias && scaleB != 0) {
-          var i = 0
-          while (i < gradBias.size(1)) {
-            var sum = 0.0
-            val data = gradOutput2d.storage().array()
-            val offset = gradOutput2d.storageOffset() - 1 + i * gradOutput2d.stride(1)
-            var k = 0
-            while (k < gradOutput2d.size(2)) {
-              sum += data(k + offset)
-              k += 1
+        val gradODouble = gradOutput.asInstanceOf[Tensor[Double]]
+        val gradWDouble = gradWeight.asInstanceOf[Tensor[Double]]
+        val fIDouble = fInput.asInstanceOf[Tensor[Double]]
+        val sWDouble = ev.toType[Double](scaleW)
+        val sBDouble = ev.toType[Double](scaleB)
+        val gradBDouble = gradBias.asInstanceOf[Tensor[Double]]
+        format match {
+          case DataFormat.NCHW =>
+            val outChannel = gradOutput.size(1)
+            val outSize = gradOutput.size(2) * gradOutput.size(3)
+            val gradOutput2d = gradODouble.view(Array(outChannel, outSize))
+            if (sWDouble != 0) {
+              gradWDouble.addmm(1.0, gradWDouble, sWDouble, gradOutput2d, fIDouble.t)
             }
-            gradBias.asInstanceOf[Tensor[Double]].setValue(
-              i + 1, gradBias.asInstanceOf[Tensor[Double]].valueAt(i + 1) +
-                (ev.toType[Double](scaleB) * sum))
-            i += 1
-          }
+            if ( withBias && sBDouble != 0) {
+              var i = 0
+              while (i < gradBias.size(1)) {
+                var sum = 0.0
+                val data = gradOutput2d.storage().array()
+                val offset = gradOutput2d.storageOffset() - 1 + i * gradOutput2d.stride(1)
+                var k = 0
+                while (k < gradOutput2d.size(2)) {
+                  sum += data(k + offset)
+                  k += 1
+                }
+                gradBDouble.setValue(i + 1, gradBDouble.valueAt(i + 1) + (sBDouble * sum))
+                i += 1
+              }
+            }
+          case DataFormat.NHWC =>
+            val outChannel = gradOutput.size(3)
+            val outSize = gradOutput.size(1) * gradOutput.size(2)
+            val gradOutput2d = gradODouble.view(Array(outSize, outChannel))
+
+            if (sWDouble != 0) {
+              gradWDouble.addmm(1.0, gradWDouble, sWDouble, fIDouble.t, gradOutput2d)
+            }
+
+            if (sBDouble != 0) {
+              var i = 0
+              val gradData = gradOutput2d.storage().array()
+              val biasData = gradBDouble.storage().array()
+              val biasOffset = gradBDouble.storageOffset() - 1
+
+              while (i < gradODouble.size(1)) {
+                val gradOffset = gradOutput2d.storageOffset() - 1 + i * gradOutput2d.stride(1)
+                var j = 0
+                while (j < gradOutput2d.size(2)) {
+                  biasData(biasOffset + j) += gradData(gradOffset + j)
+                  j = j + 1
+                }
+                i = i + 1
+              }
+            }
         }
 
       case FloatType =>
-        val gradOutput2d = Tensor[Float](gradOutput.storage().asInstanceOf[Storage[Float]],
-          gradOutput.storageOffset(),
-          Array(gradOutput.size(1), gradOutput.size(2) * gradOutput.size(3)))
-        if (scaleW != 0) {
-          gradWeight.asInstanceOf[Tensor[Float]].addmm(1.0f,
-            gradWeight.asInstanceOf[Tensor[Float]],
-            ev.toType[Float](scaleW), gradOutput2d,
-            fInput.t.asInstanceOf[Tensor[Float]])
-        }
-
-        if (withBias && scaleB != 0) {
-          var i = 0
-          while (i < gradBias.size(1)) {
-            var sum = 0.0f
-            val data = gradOutput2d.storage().array()
-            val offset = gradOutput2d.storageOffset() - 1 + i * gradOutput2d.stride(1)
-            var k = 0
-            while (k < gradOutput2d.size(2)) {
-              sum += data(k + offset)
-              k += 1
+        val gradOFloat = gradOutput.asInstanceOf[Tensor[Float]]
+        val gradWFloat = gradWeight.asInstanceOf[Tensor[Float]]
+        val fIFloat = fInput.asInstanceOf[Tensor[Float]]
+        val sWFloat = ev.toType[Float](scaleW)
+        val sBFloat = ev.toType[Float](scaleB)
+        val gradBFloat = gradBias.asInstanceOf[Tensor[Float]]
+        format match {
+          case DataFormat.NCHW =>
+            val outChannel = gradOutput.size(1)
+            val outSize = gradOutput.size(2) * gradOutput.size(3)
+            val gradOutput2d = gradOFloat.view(Array(outChannel, outSize))
+            if (sWFloat != 0) {
+              gradWFloat.addmm(1.0f, gradWFloat, sWFloat, gradOutput2d, fIFloat.t)
             }
-            gradBias.asInstanceOf[Tensor[Float]].setValue(
-              i + 1, gradBias.asInstanceOf[Tensor[Float]].valueAt(i + 1) +
-                (ev.toType[Float](scaleB) * sum))
-            i += 1
-          }
+
+            if (withBias && sBFloat != 0) {
+              var i = 0
+              while (i < gradBias.size(1)) {
+                var sum = 0.0f
+                val data = gradOutput2d.storage().array()
+                val offset = gradOutput2d.storageOffset() - 1 + i * gradOutput2d.stride(1)
+                var k = 0
+                while (k < gradOutput2d.size(2)) {
+                  sum += data(k + offset)
+                  k += 1
+                }
+                gradBFloat.setValue(i + 1, gradBFloat.valueAt(i + 1) + (sBFloat * sum))
+                i += 1
+              }
+            }
+          case DataFormat.NHWC =>
+            val outChannel = gradOutput.size(3)
+            val outSize = gradOutput.size(1) * gradOutput.size(2)
+            val gradOutput2d = gradOFloat.view(Array(outSize, outChannel))
+
+            if (sWFloat != 0) {
+              gradWFloat.addmm(1.0f, gradWFloat, sWFloat, fIFloat.t, gradOutput2d)
+            }
+
+            if (sBFloat != 0) {
+              var i = 0
+              val gradData = gradOutput2d.storage().array()
+              val biasData = gradBFloat.storage().array()
+              val biasOffset = gradBFloat.storageOffset() - 1
+
+              while (i < gradOFloat.size(1)) {
+                val gradOffset = gradOutput2d.storageOffset() - 1 + i * gradOutput2d.stride(1)
+                var j = 0
+                while (j < gradOutput2d.size(2)) {
+                  biasData(biasOffset + j) += gradData(gradOffset + j)
+                  j = j + 1
+                }
+                i = i + 1
+              }
+            }
         }
 
       case _ => throw new UnsupportedOperationException(s"Only Float/Double supported")
@@ -605,36 +832,80 @@ class SpatialConvolution[T: ClassTag](
 
     ev.getType() match {
       case DoubleType =>
-        val gradOutput2d = Tensor[Double](gradOutput.storage().asInstanceOf[Storage[Double]],
-          gradOutput.storageOffset(),
-          Array(gradOutput.size(1), gradOutput.size(2) * gradOutput.size(3)))
+        val gradODouble = gradOutput.asInstanceOf[Tensor[Double]]
+        val gradWDouble = gradWeight.asInstanceOf[Tensor[Double]]
+        val sWDouble = ev.toType[Double](scaleW)
+        val sBDouble = ev.toType[Double](scaleB)
+        val fIDouble = fInput.asInstanceOf[Tensor[Double]]
+        val gradBDouble = gradBias.asInstanceOf[Tensor[Double]]
+        val onesDouble = ones.asInstanceOf[Tensor[Double]]
 
-        if (scaleW != 0) {
-          gradWeight.asInstanceOf[Tensor[Double]].addmm(0.0,
-            gradWeight.asInstanceOf[Tensor[Double]],
-            ev.toType[Double](scaleW), gradOutput2d,
-            fInput.t.asInstanceOf[Tensor[Double]])
-        }
+        format match {
+          case DataFormat.NCHW =>
+            val channel = gradODouble.size(1)
+            val oh = gradODouble.size(2)
+            val ow = gradODouble.size(3)
+            val gradOutput2d = gradODouble.view(Array(channel, oh * ow))
 
-        if (withBias && scaleB != 0) {
-          gradBias.asInstanceOf[Tensor[Double]].addmv(0.0, ev.toType[Double](scaleB), gradOutput2d,
-            ones.asInstanceOf[Tensor[Double]])
+            if (scaleW != 0) {
+              gradWDouble.addmm(0.0, gradWDouble, sWDouble, gradOutput2d, fIDouble.t)
+            }
+
+            if (withBias && scaleB != 0) {
+              gradBDouble.addmv(0.0, sBDouble, gradOutput2d, onesDouble)
+            }
+          case DataFormat.NHWC =>
+            val channel = gradODouble.size(3)
+            val oh = gradODouble.size(1)
+            val ow = gradODouble.size(2)
+            val gradOutput2d = gradODouble.view(Array(oh * ow, channel))
+
+            if (scaleW != 0) {
+              gradWDouble.addmm(0.0, gradWDouble, sWDouble, fIDouble.t, gradOutput2d)
+            }
+
+            if (withBias && scaleB != 0) {
+              gradBDouble.addmv(0.0, sBDouble, gradOutput2d.t, onesDouble)
+            }
         }
 
       case FloatType =>
-        val gradOutput2d = Tensor[Float](gradOutput.storage().asInstanceOf[Storage[Float]],
-          gradOutput.storageOffset(),
-          Array(gradOutput.size(1), gradOutput.size(2) * gradOutput.size(3)))
-        if (scaleW != 0) {
-            gradWeight.asInstanceOf[Tensor[Float]].addmm(0.0f,
-              gradWeight.asInstanceOf[Tensor[Float]],
-              ev.toType[Float](scaleW), gradOutput2d,
-              fInput.t.asInstanceOf[Tensor[Float]])
-        }
+        val gradOFloat = gradOutput.asInstanceOf[Tensor[Float]]
+        val gradWFloat = gradWeight.asInstanceOf[Tensor[Float]]
+        val sWFloat = ev.toType[Float](scaleW)
+        val sBFloat = ev.toType[Float](scaleB)
+        val fIFloat = fInput.asInstanceOf[Tensor[Float]]
+        val gradBFloat = gradBias.asInstanceOf[Tensor[Float]]
+        val onesFloat = ones.asInstanceOf[Tensor[Float]]
 
-        if (withBias && scaleB != 0) {
-          gradBias.asInstanceOf[Tensor[Float]].addmv(0.0f, ev.toType[Float](scaleB), gradOutput2d,
-            ones.asInstanceOf[Tensor[Float]])
+        format match {
+          case DataFormat.NCHW =>
+            val channel = gradOFloat.size(1)
+            val oh = gradOFloat.size(2)
+            val ow = gradOFloat.size(3)
+            val gradOutput2d = gradOFloat.view(Array(channel, oh * ow))
+
+            if (scaleW != 0) {
+              gradWFloat.addmm(0.0f, gradWFloat, sWFloat, gradOutput2d, fIFloat.t)
+            }
+
+            if (withBias && scaleB != 0) {
+              gradBFloat.addmv(0.0f, sBFloat, gradOutput2d, onesFloat)
+            }
+
+          case DataFormat.NHWC =>
+            val channel = gradOFloat.size(3)
+            val oh = gradOFloat.size(1)
+            val ow = gradOFloat.size(2)
+            val gradOutput2d = gradOFloat.view(Array(oh * ow, channel))
+
+            if (scaleW != 0) {
+              gradWFloat.addmm(0.0f, gradWFloat, sWFloat, fIFloat.t, gradOutput2d)
+            }
+
+            if (withBias && scaleB != 0) {
+              gradBFloat.addmv(0.0f, sBFloat, gradOutput2d.t, onesFloat)
+            }
         }
 
       case _ => throw new UnsupportedOperationException(s"Only Float/Double supported")
@@ -660,10 +931,11 @@ object SpatialConvolution {
       initBias: Tensor[T] = null,
       initGradWeight: Tensor[T] = null,
       initGradBias: Tensor[T] = null,
-      withBias: Boolean = true
+      withBias: Boolean = true,
+      format: DataFormat = DataFormat.NCHW
   )(implicit ev: TensorNumeric[T]): SpatialConvolution[T] = {
     new SpatialConvolution[T](nInputPlane, nOutputPlane, kernelW, kernelH,
-      strideW, strideH, padW, padH, nGroup, propagateBack,
-      wRegularizer, bRegularizer, initWeight, initBias, initGradWeight, initGradBias, withBias)
+      strideW, strideH, padW, padH, nGroup, propagateBack, wRegularizer,
+      bRegularizer, initWeight, initBias, initGradWeight, initGradBias, withBias, format)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialConvolution.scala
@@ -204,8 +204,8 @@ class SpatialConvolution[T: ClassTag](
       // deal with SAME padding
       val oW = Math.ceil(inputWidth.toFloat / strideW.toFloat).toInt
       val oH = Math.ceil(inputHeight.toFloat / strideH.toFloat).toInt
-      val padAlongWidth = (oW -1) * strideW + kernelW - inputWidth
-      val padAlongHeight = (oH - 1) * strideH + kernelH - inputHeight
+      val padAlongWidth = Math.max(0, (oW -1) * strideW + kernelW - inputWidth)
+      val padAlongHeight = Math.max(0, (oH - 1) * strideH + kernelH - inputHeight)
       (padAlongHeight/2, padAlongHeight - padAlongHeight/2,
         padAlongWidth/2, padAlongWidth - padAlongWidth/2)
     } else {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/DataFormat.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/DataFormat.scala
@@ -27,7 +27,7 @@ sealed trait DataFormat {
 }
 
 object DataFormat {
-  def getFormat(formatString: String): DataFormat = {
+  def apply(formatString: String): DataFormat = {
     formatString.toUpperCase match {
       case "NHWC" => NHWC
       case "NCHW" => NCHW

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/DataFormat.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/DataFormat.scala
@@ -16,6 +16,10 @@
 
 package com.intel.analytics.bigdl.nn.abstractnn
 
+/**
+ * DataFormat are used to specify the data format of the input and output data when data is
+ * 2-D images.
+ */
 sealed trait DataFormat {
   def getHWCDims(inputDims: Int): (Int, Int, Int)
 
@@ -29,6 +33,11 @@ object DataFormat {
       case "NCHW" => NCHW
     }
   }
+
+  /**
+   * Specify the input/output data format when data is stored in the order of
+   * [batch, channels, height, width]
+   */
   case object NCHW extends DataFormat {
     def getHWCDims(inputDims: Int): (Int, Int, Int) = {
       if (inputDims == 3) (2, 3, 1) else (3, 4, 2)
@@ -36,6 +45,11 @@ object DataFormat {
 
     val value = "NCHW"
   }
+
+  /**
+   * Specify the input/output data format when data is stored in the order of
+   * [batch, height, width, channels]
+   */
   case object NHWC extends DataFormat {
     def getHWCDims(inputDims: Int): (Int, Int, Int) = {
       if (inputDims == 3) (1, 2, 3) else (2, 3, 4)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/DataFormat.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/DataFormat.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.abstractnn
+
+sealed trait DataFormat {
+  def getHWCDims(inputDims: Int): (Int, Int, Int)
+
+  val value: String
+}
+
+object DataFormat {
+  def getFormat(formatString: String): DataFormat = {
+    formatString.toUpperCase match {
+      case "NHWC" => NHWC
+      case "NCHW" => NCHW
+    }
+  }
+  case object NCHW extends DataFormat {
+    def getHWCDims(inputDims: Int): (Int, Int, Int) = {
+      if (inputDims == 3) (2, 3, 1) else (3, 4, 2)
+    }
+
+    val value = "NCHW"
+  }
+  case object NHWC extends DataFormat {
+    def getHWCDims(inputDims: Int): (Int, Int, Int) = {
+      if (inputDims == 3) (1, 2, 3) else (2, 3, 4)
+    }
+
+    val value = "NHWC"
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -350,7 +350,7 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
       toTensor(initGradWeight),
       toTensor(initGradBias),
       withBias,
-      DataFormat.getFormat(dataFormat)
+      DataFormat(dataFormat)
     )
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -329,7 +329,8 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
                                initBias: JTensor = null,
                                initGradWeight: JTensor = null,
                                initGradBias: JTensor = null,
-                               withBias: Boolean = true
+                               withBias: Boolean = true,
+                               dataFormat: String = "NCHW"
                               )
   : SpatialConvolution[T] = {
     SpatialConvolution[T](nInputPlane,
@@ -348,7 +349,8 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
       toTensor(initBias),
       toTensor(initGradWeight),
       toTensor(initGradBias),
-      withBias
+      withBias,
+      DataFormat.getFormat(dataFormat)
     )
   }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialConvolutionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialConvolutionSpec.scala
@@ -21,11 +21,12 @@ import org.scalatest.{FlatSpec, Matchers}
 
 import scala.math._
 import com.intel.analytics.bigdl._
+import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
 import com.intel.analytics.bigdl.optim.{L2Regularizer, SGD}
-import com.intel.analytics.bigdl.utils.T
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 
 import scala.util.Random
+import com.intel.analytics.bigdl.utils.T
 
 @com.intel.analytics.bigdl.tags.Parallel
 class SpatialConvolutionSpec extends FlatSpec with Matchers {
@@ -232,6 +233,73 @@ class SpatialConvolutionSpec extends FlatSpec with Matchers {
     output(Array(1, 1, 2)) should be(63)
     output(Array(1, 2, 1)) should be(91)
     output(Array(1, 2, 2)) should be(105)
+  }
+
+  "A SpatialConvolution layer" should "generate same output with NCHW and NHWC" in {
+    import tensor.TensorNumericMath.TensorNumeric.NumericDouble
+    case class Conv(nIn: Int, nOut: Int, kW: Int,
+                    kH: Int, dW: Int, dH: Int, pW: Int, pH: Int)
+    val params = List(
+      Conv(1, 1, 3, 3, 1, 1, 0, 0),
+      Conv(1, 1, 1, 1, 1, 1, 0, 0),
+      Conv(1, 1, 5, 5, 1, 1, 0, 0),
+      Conv(4, 4, 3, 3, 1, 1, 0, 0),
+      Conv(4, 4, 1, 1, 1, 1, 0, 0),
+      Conv(4, 4, 5, 5, 1, 1, 0, 0),
+      Conv(4, 4, 3, 3, 2, 2, 0, 0),
+      Conv(4, 4, 1, 1, 2, 2, 0, 0),
+      Conv(4, 4, 5, 5, 2, 2, 0, 0),
+      Conv(4, 4, 3, 3, 2, 2, 1, 1),
+      Conv(4, 4, 1, 1, 2, 2, 1, 1),
+      Conv(4, 4, 5, 5, 2, 2, 1, 1)
+    )
+
+    for (param <- params) {
+      println(param)
+      val layer = new SpatialConvolution(param.nIn, param.nOut,
+        param.kW, param.kH, param.dW, param.dH, param.pW, param.pH)
+      val layerNHWC = new SpatialConvolution(param.nIn, param.nOut,
+        param.kW, param.kH, param.dW, param.dH, param.pW, param.pH, format = DataFormat.NHWC)
+
+      val input = Tensor(Array(4, param.nIn, 7, 7)).randn()
+
+      val inputNHWC = Tensor(input.size())
+        .copy(input).transpose(2, 4).transpose(2, 3).contiguous()
+
+      val kernel = Tensor(Array(param.nOut, param.nIn, param.kH, param.kW)).randn()
+      val bias = Tensor(Array(param.nOut)).randn()
+
+      val kernelNHWC = Tensor(Array(1, param.nOut, param.nIn, param.kH, param.kW))
+        .copy(kernel).transpose(2, 5).transpose(3, 4).transpose(2, 3).contiguous()
+      val biasNHWC = Tensor(Array(param.nOut)).copy(bias)
+
+      layer.weight.copy(kernel)
+      layerNHWC.weight.copy(kernelNHWC)
+      layer.bias.copy(bias)
+      layerNHWC.bias.copy(biasNHWC)
+
+      val output = layer.forward(input)
+      val outputNHWC = layerNHWC.forward(inputNHWC)
+      val gradOutput = Tensor(output.size()).fill(1.0)
+      val gradOutputNHWC = Tensor(outputNHWC.size()).fill(1.0)
+
+      val gradInput = layer.backward(input, gradOutput)
+      val gradInputNHWC = layerNHWC.backward(inputNHWC, gradOutputNHWC)
+
+
+      outputNHWC.transpose(2, 4).transpose(3, 4)
+        .sub(output).pow(2).sum() should be < 1e-7
+
+      gradInputNHWC.transpose(2, 4).transpose(3, 4)
+        .sub(gradInput).pow(2).sum() should be < 1e-7
+
+      layer.updateParameters(0.01)
+      layerNHWC.updateParameters(0.01)
+
+      val transWeight = layerNHWC.weight.transpose(2, 5).transpose(3, 4).transpose(4, 5)
+      transWeight.sub(layer.weight).pow(2).sum() should be < 1e-7
+
+    }
   }
 
   "A SpatialConvolution layer" should "generate correct output with given weight" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialConvolutionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialConvolutionSpec.scala
@@ -272,21 +272,21 @@ class SpatialConvolutionSpec extends FlatSpec with Matchers {
     import tensor.TensorNumericMath.TensorNumeric.NumericFloat
     val nInputPlane = 1
     val nOutputPlane = 1
-    val kW = 2
-    val kH = 2
-    val dW = 1
-    val dH = 1
+    val kW = 1
+    val kH = 1
+    val dW = 2
+    val dH = 2
     val padW = -1
     val padH = -1
     val layer = new SpatialConvolution(nInputPlane, nOutputPlane,
       kW, kH, dW, dH, padW, padH)
 
     val inputData = Array(
-      1.0f, 2, 3, 4
+      0.0f, 1.0f, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
     )
 
     val kernelData = Array(
-      1.0f, 2, 3, 4
+      1.0f
     )
 
     val biasData = Array(0.0f)
@@ -294,11 +294,13 @@ class SpatialConvolutionSpec extends FlatSpec with Matchers {
     layer.weight.copy(Tensor(Storage(kernelData), 1, Array(nOutputPlane,
       nInputPlane, kH, kW)))
     layer.bias.copy(Tensor(Storage(biasData), 1, Array(nOutputPlane)))
-    val input = Tensor(Storage(inputData), 1, Array(1, 2, 2))
+    val input = Tensor(Storage(inputData), 1, Array(1, 4, 4))
     val output = layer.updateOutput(input)
     val gradInput = layer.backward(input, output)
-    output.storage().array() should be (Array(30.0f, 14, 11, 4))
-    gradInput.storage().array() should be (Array(30.0f, 74, 101, 188))
+    output.storage().array() should be (Array(0.0f, 2, 8, 10))
+    gradInput.storage().array() should be (Array(
+      0.0f, 0, 2, 0, 0, 0, 0, 0, 8, 0, 10, 0, 0, 0, 0, 0
+    ))
   }
 
   "A SpatialConvolution layer" should "generate same output with NCHW and NHWC" in {
@@ -306,6 +308,7 @@ class SpatialConvolutionSpec extends FlatSpec with Matchers {
     case class Conv(nIn: Int, nOut: Int, kW: Int,
                     kH: Int, dW: Int, dH: Int, pW: Int, pH: Int)
     val params = List(
+      Conv(1, 1, 1, 1, 2, 2, -1, -1),
       Conv(1, 1, 3, 3, 1, 1, 0, 0),
       Conv(1, 1, 1, 1, 1, 1, 0, 0),
       Conv(1, 1, 5, 5, 1, 1, 0, 0),

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialConvolutionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialConvolutionSpec.scala
@@ -235,6 +235,71 @@ class SpatialConvolutionSpec extends FlatSpec with Matchers {
     output(Array(1, 2, 2)) should be(105)
   }
 
+  "A SpatialConvolution layer" should "work with SAME padding using NHWC format" in {
+    import tensor.TensorNumericMath.TensorNumeric.NumericFloat
+    val nInputPlane = 1
+    val nOutputPlane = 1
+    val kW = 2
+    val kH = 2
+    val dW = 1
+    val dH = 1
+    val padW = -1
+    val padH = -1
+    val layer = new SpatialConvolution(nInputPlane, nOutputPlane,
+      kW, kH, dW, dH, padW, padH, format = DataFormat.NHWC)
+
+    val inputData = Array(
+      1.0f, 2, 3, 4
+    )
+
+    val kernelData = Array(
+      1.0f, 2, 3, 4
+    )
+
+    val biasData = Array(0.0f)
+
+    layer.weight.copy(Tensor(Storage(kernelData), 1, Array(kH, kW, nOutputPlane,
+      nInputPlane)))
+    layer.bias.copy(Tensor(Storage(biasData), 1, Array(nOutputPlane)))
+    val input = Tensor(Storage(inputData), 1, Array(2, 2, 1))
+    val output = layer.updateOutput(input)
+    output.storage().array() should be (Array(30.0f, 14, 11, 4))
+  }
+
+  "A SpatialConvolution layer" should "work with SAME padding using NCHW format" in {
+    import tensor.TensorNumericMath.TensorNumeric.NumericFloat
+    val nInputPlane = 1
+    val nOutputPlane = 1
+    val kW = 2
+    val kH = 2
+    val dW = 1
+    val dH = 1
+    val padW = -1
+    val padH = -1
+    val layer = new SpatialConvolution(nInputPlane, nOutputPlane,
+      kW, kH, dW, dH, padW, padH)
+
+    val inputData = Array(
+      1.0f, 2, 3, 4
+    )
+
+    val kernelData = Array(
+      1.0f, 2, 3, 4
+    )
+
+    val biasData = Array(0.0f)
+
+    layer.weight.copy(Tensor(Storage(kernelData), 1, Array(nOutputPlane,
+      nInputPlane, kH, kW)))
+    layer.bias.copy(Tensor(Storage(biasData), 1, Array(nOutputPlane)))
+    val input = Tensor(Storage(inputData), 1, Array(1, 2, 2))
+    val output = layer.updateOutput(input)
+    output(Array(1, 1, 1)) should be(30)
+    output(Array(1, 1, 2)) should be(14)
+    output(Array(1, 2, 1)) should be(11)
+    output(Array(1, 2, 2)) should be(4)
+  }
+
   "A SpatialConvolution layer" should "generate same output with NCHW and NHWC" in {
     import tensor.TensorNumericMath.TensorNumeric.NumericDouble
     case class Conv(nIn: Int, nOut: Int, kW: Int,
@@ -251,7 +316,9 @@ class SpatialConvolutionSpec extends FlatSpec with Matchers {
       Conv(4, 4, 5, 5, 2, 2, 0, 0),
       Conv(4, 4, 3, 3, 2, 2, 1, 1),
       Conv(4, 4, 1, 1, 2, 2, 1, 1),
-      Conv(4, 4, 5, 5, 2, 2, 1, 1)
+      Conv(4, 4, 5, 5, 2, 2, 1, 1),
+      Conv(4, 4, 1, 1, 2, 2, 1, -1),
+      Conv(4, 4, 5, 5, 2, 2, 1, -1)
     )
 
     for (param <- params) {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialConvolutionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialConvolutionSpec.scala
@@ -263,7 +263,9 @@ class SpatialConvolutionSpec extends FlatSpec with Matchers {
     layer.bias.copy(Tensor(Storage(biasData), 1, Array(nOutputPlane)))
     val input = Tensor(Storage(inputData), 1, Array(2, 2, 1))
     val output = layer.updateOutput(input)
+    val gradInput = layer.backward(input, output)
     output.storage().array() should be (Array(30.0f, 14, 11, 4))
+    gradInput.storage().array() should be (Array(30.0f, 74, 101, 188))
   }
 
   "A SpatialConvolution layer" should "work with SAME padding using NCHW format" in {
@@ -294,10 +296,9 @@ class SpatialConvolutionSpec extends FlatSpec with Matchers {
     layer.bias.copy(Tensor(Storage(biasData), 1, Array(nOutputPlane)))
     val input = Tensor(Storage(inputData), 1, Array(1, 2, 2))
     val output = layer.updateOutput(input)
-    output(Array(1, 1, 1)) should be(30)
-    output(Array(1, 1, 2)) should be(14)
-    output(Array(1, 2, 1)) should be(11)
-    output(Array(1, 2, 2)) should be(4)
+    val gradInput = layer.backward(input, output)
+    output.storage().array() should be (Array(30.0f, 14, 11, 4))
+    gradInput.storage().array() should be (Array(30.0f, 74, 101, 188))
   }
 
   "A SpatialConvolution layer" should "generate same output with NCHW and NHWC" in {
@@ -317,8 +318,9 @@ class SpatialConvolutionSpec extends FlatSpec with Matchers {
       Conv(4, 4, 3, 3, 2, 2, 1, 1),
       Conv(4, 4, 1, 1, 2, 2, 1, 1),
       Conv(4, 4, 5, 5, 2, 2, 1, 1),
-      Conv(4, 4, 1, 1, 2, 2, 1, -1),
-      Conv(4, 4, 5, 5, 2, 2, 1, -1)
+      Conv(4, 4, 1, 1, 2, 2, -1, -1),
+      Conv(4, 4, 5, 5, 2, 2, -1, -1),
+      Conv(1, 1, 2, 2, 1, 1, -1, -1)
     )
 
     for (param <- params) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

support nhwc format in SpatialConvolution

Regression Performance Tests

Model       |phase    | this_pr | 8-13 | 8-12 | 8-11 | 8-10 |
--------       | --------   |-----------| -------|--------|-------|--------|
alexnet     | train      | 124.87 | 108.75|112.85|104.53|105.29|
alexnet     | perdict  | 168.54 |186.16|186.57|172.88|188.15|
incept-v1   | train     | 76.45   |65.27|64.6|66.95|66.83|
incept-v1  | predict  | 174.29 |145.09|145.83|150.53|154.04|
incept-v2   | train     | 54.8     |48.32|48.84|48.56|48.15|
incept-v2  | predict  | 152.98 |120.32|120.01|121.47|123.1|
vgg16       | train      | 8.57    |7.7|7.58|7.81|7.3|
vgg16       | predict  | 14.79  |17.48|17.3|17.53|15.81|
vgg19       | train      | 6.03    |5.75|5.48|5.67|5.59|
vgg19       | predict  | 13.13  |15.66|13.81|13.43|15.17|
resnet50   | train      | 25.26  |21.86|21.87|22.11|21.82|
resnet50   | predict  | 74.18  |60.25|61.09|64.26|60.08|

## How was this patch tested?

add unit tests

