### PR TITLE
fix copyStatus method in TimeDistributed layer

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributed.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributed.scala
@@ -37,7 +37,7 @@ import scala.reflect.ClassTag
  * @tparam T data type, which can be [[Double]] or [[Float]]
  */
 
-class TimeDistributed[T : ClassTag] (layer: TensorModule[T])
+class TimeDistributed[T : ClassTag] (val layer: TensorModule[T])
   (implicit ev: TensorNumeric[T]) extends TensorModule[T] {
 
   private var inputSize: Array[Int] = _
@@ -197,7 +197,8 @@ class TimeDistributed[T : ClassTag] (layer: TensorModule[T])
    * @return this
    */
   override def copyStatus(src: Module[T]): TimeDistributed.this.type = {
-    layer.copyStatus(src)
+    val other = src.asInstanceOf[TimeDistributed[T]]
+    layer.copyStatus(other.layer.asInstanceOf[Module[T]])
     this
   }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/TimeDistributedSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/TimeDistributedSpec.scala
@@ -16,11 +16,40 @@
 
 package com.intel.analytics.bigdl.nn
 
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 import org.scalatest.{FlatSpec, Matchers}
 
 class TimeDistributedSpec extends FlatSpec with Matchers {
+  "A TimeDistributed Module" should " copyStatus correctly" in {
+    RNG.setSeed(100)
+    val batchSize = 5
+    val times = 5
+    val inputDim = 3
+    val outputDim = 4
+    val timeDim = 1
+    val input1 = Tensor[Float](Array(batchSize, times, inputDim)).randn()
+    val gradOutput1 = Tensor[Float](Array(batchSize, times, outputDim)).randn()
+    val input2 = Tensor[Float](Array(batchSize, times, inputDim)).randn()
+    val gradOutput2 = Tensor[Float](Array(batchSize, times, outputDim)).randn()
+    val bnorm1 = BatchNormalization[Float](inputDim, outputDim)
+    val bnorm2 = BatchNormalization[Float](inputDim, outputDim)
+    val model1 = TimeDistributed[Float](bnorm1)
+    val model2 = TimeDistributed[Float](bnorm2)
+
+    model1.forward(input1)
+    model1.backward(input1, gradOutput1)
+
+    model2.forward(input2)
+    model2.backward(input2, gradOutput2)
+
+    model1.copyStatus(model2.asInstanceOf[AbstractModule[Activity, Activity, Float]])
+
+    bnorm1.runningMean should be (bnorm2.runningMean)
+    bnorm1.runningVar should be (bnorm2.runningVar)
+  }
+
   "A TimeDistributed Module" should " reset correctly" in {
     RNG.setSeed(100)
     val batchSize = 5


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix bug in copyStatus method in TimeDistributed layer

TimeDistributed is a recurrent layer and including one contained layer as its class variable.
Thus copyStatus should be applied to its contained layer instead of itself.

## How was this patch tested?
Unit Test


