### PR TITLE
add google cloud dataproc initialization script

### DIFF
--- a/docs/docs/ProgrammingGuide/run-on-dataproc.md
+++ b/docs/docs/ProgrammingGuide/run-on-dataproc.md
@@ -1,0 +1,49 @@
+---
+
+## **The Google Cloud Dataproc Initialization Script**
+
+To make it easier to try out BigDL examples on Spark using Google Cloud Dataproc, a public initialization script is provided (the source script is also avaliable in this repo path `scripts/launch-dataproc.sh`). The script will automatically retrieve BigDL package (version 0.2.0), run it on Dataproc's Spark Yarn cluster, then configure and setup the Jupyter Notebook and Tensorboard for the interactive usage. Two examples, including LeNet and Text Classifier, will be provided in the Notebook.
+
+---
+## **Before You Start**
+
+Before using BigDL on Dataproc, you need a valid Google Cloud account and setup your Google Cloud SDK (you may refer to [https://cloud.google.com/sdk/docs/how-to](https://cloud.google.com/sdk/docs/how-to) for more instructions).
+
+---
+## **Create Spark Cluster with BigDL**
+
+Run the following command to create your cluster
+```bash
+gcloud dataproc clusters create bigdl \
+    --initialization-actions gs://dataproc-initial/bigdl.sh \
+    --worker-machine-type n1-highmem-4 \
+    --master-machine-type n1-highmem-2 \
+    --num-workers 2 \
+    --zone us-central1-b \
+    --image-version 1.1
+```
+You can change `bigdl` into any other name as the cluster name, and you are also free to upload `scripts/launch-dataproc.sh` into your own Google Cloud Storage bucket and use it instead of `gs://dataproc-initial/bigdl.sh` in the initialization-actions field.
+
+When creating a larger cluster with more workers, it is suggested to pass the number of executor into the script via the metadata field as, 
+```bash
+gcloud dataproc clusters create bigdl \
+    --initialization-actions gs://dataproc-initial/bigdl.sh \
+    --metadata "NUM_EXECUTORS=8" \
+    --worker-machine-type n1-highmem-4 \
+    --master-machine-type n1-highmem-2 \
+    --num-workers 4 \
+    --num-preemptible-workers 4 \
+    --zone us-central1-b \
+    --image-version 1.1
+```
+
+Please note that it is highly recommended to run BigDL in the region where the compute instances come with Xeon E5 v3 or v4 processors (you may find the [Google Cloud Regions and Zones](https://cloud.google.com/compute/docs/regions-zones/regions-zones) for more details).
+
+---
+## **Play Around with BigDL**
+Once your dataproc cluster is ready, directly go to the following URL (change `bigdl` into your own cluster name if you are using a different one) to play around BigDL in Jupyter Notebook. Note that you need to [create an SSH tunel and SOCKS proxy](https://cloud.google.com/dataproc/docs/concepts/cluster-web-interfaces) to visit them. 
+* Jupyter Notebook: http://bigdl-m:8888/
+* Tensorboard: http://bigdl-m:6006/
+* YARN ResourceManager: http://bigdl-m:8088/
+
+Inside your Jupyter Notebook, you may find two examples are already there. Start your BigDL journey with them.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -40,7 +40,8 @@ pages:
   - Optimization: ProgrammingGuide/optimization.md
   - Use Spark ML: ProgrammingGuide/MLPipeline.md
   - Visualization: ProgrammingGuide/visualization.md
-  - Run on Amazon EC2: ProgrammingGuide/run-on-ec2.md 
+  - Run on Amazon EC2: ProgrammingGuide/run-on-ec2.md
+  - Run on Google Cloud Dataproc: ProgrammingGuide/run-on-dataproc.md
   - Tensorflow Support: ProgrammingGuide/tensorflow-support.md
   - Caffe Support: ProgrammingGuide/caffe-support.md
 - API Guide:

--- a/scripts/launch-dataproc.sh
+++ b/scripts/launch-dataproc.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
 
+#
+# Licensed to Intel Corporation under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# Intel Corporation licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 set -e
 
 apt-get update && apt-get install -y python-dev build-essential libfreetype6-dev unzip

--- a/scripts/launch-dataproc.sh
+++ b/scripts/launch-dataproc.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -e
+
+apt-get update && apt-get install -y python-dev build-essential libfreetype6-dev unzip
+curl https://bootstrap.pypa.io/get-pip.py | python
+
+PIP_PACKAGES=$(curl -f -s -H Metadata-Flavor:Google http://metadata/computeMetadata/v1/instance/attributes/PIP_PACKAGES || true)
+NUM_EXECUTORS=$(curl -f -s -H Metadata-Flavor:Google http://metadata/computeMetadata/v1/instance/attributes/NUM_EXECUTORS || true)
+NOTEBOOK_DIR="/root/notebooks"
+TENSORBOARD_LOGDIR="/tmp/bigdl_summaries"
+
+ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+if [[ "${ROLE}" == 'Master' ]]; then
+    pip install IPython==5.0 jupyter tensorboard virtualenv numpy scipy pandas scikit-learn matplotlib seaborn wordcloud opencv-python nltk
+    wget https://repo1.maven.org/maven2/com/intel/analytics/bigdl/dist-spark-2.0.2-scala-2.11.8-linux64/0.2.0/dist-spark-2.0.2-scala-2.11.8-linux64-0.2.0-dist.zip -P /root/ 
+    unzip /root/dist-spark-2.0.2-scala-2.11.8-linux64-0.2.0-dist.zip -d /root/
+    rm /root/dist-spark-2.0.2-scala-2.11.8-linux64-0.2.0-dist.zip   
+    [[ ! -d "~/.jupyter" ]] && mkdir -p ~/.jupyter
+    [[ ! -d ${NOTEBOOK_DIR} ]] && mkdir -p $NOTEBOOK_DIR
+    
+    # uncomment the following two lines if you want the bigdl tutorials are in the notebook by default
+    #git clone https://github.com/intel-analytics/BigDL-Tutorials.git /root/bigdl-tutorials
+    #cp /root/bigdl-tutorials/notebooks/*/*.ipynb $NOTEBOOK_DIR/
+    gsutil cp gs://dataproc-initial/examples/*.ipynb $NOTEBOOK_DIR/
+
+    # package the virtual environment
+    VENV="/root/venv"
+    virtualenv $VENV
+    virtualenv --relocatable $VENV
+    . $VENV/bin/activate
+    zip -q -r $VENV.zip $VENV
+ 
+    echo "c.NotebookApp.token = u''" >> ~/.jupyter/jupyter_notebook_config.py
+    if [ -z "${NUM_EXECUTORS}" ]; then
+        NUM_EXECUTORS=$(yarn node -list | sed -n 's/Total Nodes:\(.*\)/\1/p')
+    fi
+    cat << EOF > "/usr/local/share/jupyter/kernels/python2/kernel.json"
+{
+  "argv": [
+    "python",
+    "-m",
+    "ipykernel_launcher",
+    "-f",
+    "{connection_file}"
+  ],
+  "display_name": "PySpark",
+  "language": "python",
+  "env": {
+    "SPARK_HOME": "/usr/lib/spark",
+    "PYTHONPATH": "/root/lib/bigdl-0.2.0-python-api.zip",
+    "PYSPARK_SUBMIT_ARGS": "--master yarn --deploy-mode client --conf spark.yarn.appMasterEnv.PYSPARK_PYTHON=./venv.zip/venv/bin/python --driver-memory 13g --executor-memory 13g --driver-cores 4 --executor-cores 4 --num-executors ${NUM_EXECUTORS} --properties-file /root/conf/spark-bigdl.conf --jars /root/lib/bigdl-SPARK_2.0-0.2.0-jar-with-dependencies.jar --archives /root/venv.zip --py-files /root/lib/bigdl-0.2.0-python-api.zip --conf spark.driver.extraClassPath=/root/lib/bigdl-SPARK_2.0-0.2.0-jar-with-dependencies.jar --conf spark.executor.extraClassPath=bigdl-SPARK_2.0-0.2.0-jar-with-dependencies.jar pyspark-shell"
+  }
+}
+EOF
+    # Lanuch tensorboard and Jupyter
+    cat << EOF > "/usr/lib/systemd/system/tensorboard.service"
+[Unit]
+Description=Tensorboard Server
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/tensorboard --logdir=${TENSORBOARD_LOGDIR}
+[Install]
+WantedBy=multi-user.target
+EOF
+    cat << EOF > "/usr/lib/systemd/system/jupyter.service"
+[Unit]
+Description=Jupyter Server
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/jupyter notebook --notebook-dir=${NOTEBOOK_DIR} --ip=* --no-browser --allow-root
+[Install]
+WantedBy=multi-user.target
+EOF
+    chmod a+rw /usr/lib/systemd/system/tensorboard.service
+    chmod a+rw /usr/lib/systemd/system/jupyter.service 
+    systemctl daemon-reload
+    systemctl enable tensorboard
+    systemctl enable jupyter
+    systemctl restart tensorboard
+    systemctl restart jupyter
+fi
+
+# Install customized packages
+if [ -n "${PIP_PACKAGES}" ]; then
+    echo "Installing custom pip packages '$(echo ${PIP_PACKAGES} | tr ':' ' ')'"
+    pip install $(echo ${PIP_PACKAGES} | tr ':' ' ')
+fi

--- a/spark/dist/assembly/dist.xml
+++ b/spark/dist/assembly/dist.xml
@@ -23,6 +23,7 @@
           <include>flickr.urls</include>
           <include>run.example.sh</include>
           <include>dump_tf_graph.py</include>
+          <include>launch-dataproc.sh</include>
       </includes>
     </fileSet>
     <fileSet>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add an initialization action script and readme file to launch BigDL in Spark cluster with Google Cloud Dataproc.

## How was this patch tested?

Follow the instructions in `docs/docs/ProgrammingGuide/run-on-dataproc.md`. The expected results would be a ready-to-use Jupyter notebook and Tensorboard page as shown below. 
<img width="628" alt="untitled" src="https://user-images.githubusercontent.com/8477259/29304925-80bfb9d2-81c8-11e7-87a3-4bbbaf147bcf.png">
<img width="632" alt="untitled1" src="https://user-images.githubusercontent.com/8477259/29304933-8ad336b0-81c8-11e7-8f50-f07ee5ec12ee.png">

## Related links or issues (optional)