### PR TITLE
add getTimes in recurrent and TimeDistributed layer

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cell.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cell.scala
@@ -176,7 +176,6 @@ abstract class Cell[T : ClassTag](
     if (subModules != null) {
       var i = 0
       while (i < subModules.length) {
-        subModules(i) = null
         forwardTimes(i) = 0L
         backwardTimes(i) = 0L
         i += 1

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cell.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cell.scala
@@ -128,7 +128,7 @@ abstract class Cell[T : ClassTag](
   }
 
   override def updateOutput(input: Table): Table = {
-    output = cell.updateOutput(input).toTable
+    output = cell.forward(input).toTable
     output
   }
 
@@ -141,8 +141,22 @@ abstract class Cell[T : ClassTag](
     cell.accGradParameters(input, gradOutput)
   }
 
+  override def backward(input: Table, gradOutput: Table): Table = {
+    gradInput = cell.backward(input, gradOutput).toTable
+    gradInput
+  }
+
   override def updateParameters(learningRate: T): Unit = {
     cell.updateParameters(learningRate)
+  }
+
+  override def getTimes():
+  Array[(AbstractModule[_ <: Activity, _ <: Activity, T], Long, Long)] = {
+    cell.getTimes
+  }
+
+  override def resetTimes(): Unit = {
+    cell.resetTimes
   }
 
   override def zeroGradParameters(): Unit = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ConcatTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ConcatTable.scala
@@ -39,7 +39,7 @@ class ConcatTable[T : ClassTag]
     }
     var i = 0
     while (i < modules.length) {
-      val currentOutput = modules(i).updateOutput(input)
+      val currentOutput = modules(i).forward(input)
       output.toTable(i + 1) = currentOutput
       i += 1
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
@@ -117,7 +117,7 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
     } else {
       seqToTable(inputs.map(_.element.gradInput))
     }
-    backwardTime += System.nanoTime() - before
+    backwardTime = System.nanoTime() - before
     gradInput
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
@@ -72,7 +72,7 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
       } else {
         seqToTable(node.prevNodes.map(_.element.output))
       }
-      node.element.updateOutput(inputsBP(i))
+      node.element.forward(inputsBP(i))
       i += 1
     }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -379,6 +379,7 @@ class Recurrent[T : ClassTag]()
     val head = if (!cells.isEmpty) {
       cells.head
     } else null
+
     var i = 1
     while (i < times) {
       head.addTimes(cells(i))
@@ -389,7 +390,6 @@ class Recurrent[T : ClassTag]()
     appendTimes(head)
 
     val (bufferForward, bufferBackward) = bufferTime()
-
     timeBuffer.append(
       (this,
         this.forwardTime - bufferForward,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -349,7 +349,8 @@ class Recurrent[T : ClassTag]()
     if (preTopology != null) {
       gradInput = preTopology.backward(input, gradInputCell).toTensor[T]
     }
-    backwardTime += System.nanoTime - st
+
+    this.backwardTime += System.nanoTime - st
     gradInput
   }
 
@@ -366,7 +367,7 @@ class Recurrent[T : ClassTag]()
     var backwardSum = 0L
     timeBuffer.foreach(x => {
       forwardSum += x._2
-      backwardSum += x._2
+      backwardSum += x._3
     })
     (forwardSum, backwardSum)
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -350,7 +350,7 @@ class Recurrent[T : ClassTag]()
       gradInput = preTopology.backward(input, gradInputCell).toTensor[T]
     }
 
-    this.backwardTime += System.nanoTime - st
+    this.backwardTime = System.nanoTime - st
     gradInput
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -375,7 +375,9 @@ class Recurrent[T : ClassTag]()
   Array[(AbstractModule[_ <: Activity, _ <: Activity, T], Long, Long)] = {
     timeBuffer.clear
 
-    val head = cells.head
+    val head = if (!cells.isEmpty) {
+      cells.head
+    } else null
     var i = 1
     while (i < times) {
       head.addTimes(cells(i))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -52,7 +52,6 @@ class Recurrent[T : ClassTag]()
     new ArrayBuffer[Array[Dropout[T]]]
   private val timeBuffer =
     new ArrayBuffer[(AbstractModule[_ <: Activity, _ <: Activity, T], Long, Long)]
-  private var cellTimes: CellTimes[T] = null
 
   /**
    *
@@ -367,22 +366,26 @@ class Recurrent[T : ClassTag]()
       })
     }
 
-    val numOfSubModules = cells.head.getTimes.length
-    if (cellTimes == null || cellTimes.numOfSubModules != numOfSubModules) {
-      cellTimes = CellTimes[T](numOfSubModules)
+    val head = cells.head
+    var i = 1
+    while (i < times) {
+      head.addTimes(cells(i))
+      i += 1
     }
-    cells.foreach(x => {
-      cellTimes.add(x)
-    })
 
-    cellTimes.getTimes.foreach(x => {
+    var cellForwardTimes = 0L
+    var cellBackwardTimes = 0L
+
+    head.getTimes.foreach(x => {
       timeBuffer.append(x)
+      cellForwardTimes += x._2
+      cellBackwardTimes += x._3
     })
 
     timeBuffer.append(
       (this,
-        this.forwardTime - modulesForwardTime - cellTimes.getForwardTimes,
-        this.backwardTime - modulesBackwardTime - cellTimes.getBackwardTimes))
+        this.forwardTime - modulesForwardTime - cellForwardTimes,
+        this.backwardTime - modulesBackwardTime - cellBackwardTimes))
     timeBuffer.toArray
   }
 
@@ -397,9 +400,6 @@ class Recurrent[T : ClassTag]()
     }
     this.forwardTime = 0
     this.backwardTime = 0
-    if (cellTimes != null) {
-      cellTimes.resetTimes
-    }
   }
 
   override def clearState() : this.type = {
@@ -416,7 +416,6 @@ class Recurrent[T : ClassTag]()
     cells.clear()
     timeBuffer.clear()
     initState = null
-    cellTimes = null
     this
   }
 
@@ -452,79 +451,5 @@ object Recurrent {
   def apply[@specialized(Float, Double) T: ClassTag]()
     (implicit ev: TensorNumeric[T]) : Recurrent[T] = {
     new Recurrent[T]()
-  }
-}
-
-/**
- * CellTimes class to add the total forward and backward elapsed time for each submodule
- * of Cell in the Array[Cell] in Recurrent layer.
- * All the cloned cells along the time step will be condensed to one by adding the corresponding
- * elapsed time in each submodule in cell.
- *
- * For example, if we call a SimpleRNN cell which contains the following submodules:
- *
- * Input[e00cc11c], 2108, 2687
- * CAddTable[84032019], 72358, 92797
- * Tanh[713c3e7e], 38840, 94434
- * Identity[99edb9d1], 1470, 2526
- * Identity[92f95cf1], 1711, 2501
- *
- * Then each of the cell in the Array[Cell] will add the corresponding forward and backward
- * elapsed time into one cell format.
- * @param numOfSubModules
- * @tparam T
- */
-case class CellTimes[T : ClassTag](numOfSubModules: Int) {
-  val subModules = new Array[AbstractModule[_ <: Activity, _ <: Activity, T]](numOfSubModules)
-  val forwardTimes = new Array[Long](numOfSubModules)
-  val backwardTimes = new Array[Long](numOfSubModules)
-  val times =
-    new Array[(AbstractModule[_ <: Activity, _ <: Activity, T], Long, Long)](numOfSubModules)
-
-  def add(other: Cell[T]): Unit = {
-    val cellTimes = other.getTimes
-    val length = cellTimes.length
-    require(numOfSubModules == length,
-      " Recurrent -> CellTimes: cell.getTimes.length does not comform to number of submodules." +
-      s" cell.getTimes.length = ${length}, number of submodules = ${numOfSubModules}")
-    var i = 0
-    while (i < length) {
-      if (subModules(i) != null) {
-        val subModule = cellTimes(i)._1.getClass.getName
-        require(subModules(i).getClass.getName == subModule,
-          s" Recurrent -> CellTimes: ${i}-th submodule in cell" +
-            s" does not comform to ${i}-th submodule in cell.getTimes." +
-            s" ${i}-th submodule is ${subModules(i)}," +
-            s" ${i}-th submodule in cell.getTimes is ${cellTimes(i)._1}")
-      } else {
-        subModules(i) = cellTimes(i)._1
-      }
-      forwardTimes(i) += cellTimes(i)._2
-      backwardTimes(i) += cellTimes(i)._3
-      i += 1
-    }
-  }
-
-  def getTimes(): Array[(AbstractModule[_ <: Activity, _ <: Activity, T], Long, Long)] = {
-    var i = 0
-    while (i < numOfSubModules) {
-      times(i) = (subModules(i), forwardTimes(i), backwardTimes(i))
-      i += 1
-    }
-    times
-  }
-
-  def getForwardTimes(): Long = forwardTimes.sum
-
-  def getBackwardTimes(): Long = backwardTimes.sum
-
-  def resetTimes(): Unit = {
-    var i = 0
-    while (i < numOfSubModules) {
-      subModules(i) = null
-      forwardTimes(i) = 0L
-      backwardTimes(i) = 0L
-      i += 1
-    }
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
@@ -86,20 +86,20 @@ class RecurrentSpec extends FlatSpec with Matchers {
   }
 
   "A Recurrent" should " call getTimes correctly" in {
-    val hiddenSize = 4
-    val inputSize = 5
-    val outputSize = 5
-    val time = 4
-    val batchSize1 = 5
+    val hiddenSize = 128
+    val inputSize = 1280
+    val outputSize = 128
+    val time = 30
+    val batchSize1 = 100
     val batchSize2 = 8
     val seed = 100
     RNG.setSeed(seed)
 
     val model = Sequential[Double]()
       .add(Recurrent[Double]()
-        .add(RnnCell[Double](inputSize, hiddenSize, Tanh[Double]())))
+        .add(LSTM[Double](inputSize, hiddenSize)))
       .add(Select(2, 1))
-      .add(Linear[Double](hiddenSize, outputSize))
+//      .add(Linear[Double](hiddenSize, outputSize))
 
     val input = Tensor[Double](Array(batchSize1, time, inputSize)).rand
     val gradOutput = Tensor[Double](batchSize1, outputSize).rand
@@ -109,7 +109,7 @@ class RecurrentSpec extends FlatSpec with Matchers {
     model.resetTimes
     model.getTimes
 
-    for (i <- 1 to 5) {
+    for (i <- 1 to 10) {
       model.resetTimes
       model.forward(input)
       model.backward(input, gradOutput)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
@@ -106,9 +106,14 @@ class RecurrentSpec extends FlatSpec with Matchers {
 
     model.clearState()
 
+    model.resetTimes
+    model.getTimes
+
     for (i <- 1 to 5) {
+      model.resetTimes
       model.forward(input)
       model.backward(input, gradOutput)
+      model.getTimes()
     }
     model.resetTimes()
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
@@ -28,7 +28,7 @@ import scala.math._
 @com.intel.analytics.bigdl.tags.Serial
 class RecurrentSpec extends FlatSpec with Matchers {
 
-  "A Recurrent class CellTimes" should " add correctly" in {
+  "A Cell class " should "call addTimes() correctly" in {
     val hiddenSize = 5
     val inputSize = 5
     val outputSize = 5
@@ -55,12 +55,6 @@ class RecurrentSpec extends FlatSpec with Matchers {
     rnnCell4.forward(T(input, hidden))
     rnnCell4.backward(T(input, hidden), T(gradOutput, gradHidden))
 
-    val cellTimes = CellTimes[Double](6)
-    cellTimes.add(rnnCell1)
-    cellTimes.add(rnnCell2)
-    cellTimes.add(rnnCell3)
-    cellTimes.add(rnnCell4)
-
     val forwardSum = new Array[Long](6)
     val backwardSum = new Array[Long](6)
 
@@ -81,9 +75,13 @@ class RecurrentSpec extends FlatSpec with Matchers {
       backwardSum(i) += rnnCell4.getTimes()(i)._3
     }
 
+    rnnCell1.addTimes(rnnCell2)
+    rnnCell1.addTimes(rnnCell3)
+    rnnCell1.addTimes(rnnCell4)
+
     for (i <- 0 until 6) {
-      forwardSum(i) should be (cellTimes.getTimes()(i)._2)
-      backwardSum(i) should be (cellTimes.getTimes()(i)._3)
+      forwardSum(i) should be (rnnCell1.getTimes()(i)._2)
+      backwardSum(i) should be (rnnCell1.getTimes()(i)._3)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
add getTimes for performance test

## How was this patch tested?
Unit Tests


forward eta = 733759
backward eta = 905272

Linear[f7061e76](5 -> 4), 29445, 30471
TimeDistributed[c4f80e13], 24301, 24342
Linear[d23da34](4 -> 4), 108246, 118053
Input[e00cc11c], 2108, 2687
CAddTable[84032019], 72358, 92797
Tanh[713c3e7e], 38840, 94434
Identity[99edb9d1], 1470, 2526
Identity[92f95cf1], 1711, 2501
Recurrent[5f625a57], 410161, 462520
nn.Select, 13894, 23026
Linear[42210f1c](4 -> 5), 24296, 43186

forwardSum = 726830
backwardSum = 896543