### PR TITLE
add a page to share BigDL video links

### DIFF
--- a/docs/docs/other-resource.md
+++ b/docs/docs/other-resource.md
@@ -1,0 +1,20 @@
+
+---
+
+** Videos:** 
+
+* [BigDL Overview](https://software.intel.com/en-us/videos/bigdl-overview)
+
+* [Introduction to BigDL on Apache Spark* Part1](https://software.intel.com/en-us/videos/introduction-to-bigdl-on-apache-spark-part1) 
+
+* [Introduction to BigDL on Apache Spark* Part2 ](https://software.intel.com/en-us/videos/introduction-to-bigdl-on-apache-spark-part2)
+
+* [Introduction to BigDL on Apache Spark* Part3 ](https://software.intel.com/en-us/videos/introduction-to-bigdl-on-apache-spark-part3)
+
+* [Spark Summit East 2017: Building Deep Learning Powered Big Data](https://spark-summit.org/east-2017/events/building-deep-learning-powered-big-data/)
+
+* [Spark Summit East 2017: BigDL: A Distributed Deep Learning Library on Spark](https://spark-summit.org/east-2017/events/bigdl-a-distributed-deep-learning-library-on-spark/)
+
+* [Spark Summit 2017: BigDL: Bringing Ease of Use of Deep Learning for Apache Spark](https://spark-summit.org/2017/events/bigdl-bringing-ease-of-use-of-deep-learning-for-apache-spark/)
+
+* [Spark Summit 2017: Deep Learning to Big Data Analytics on Apache Spark Using BigDL](https://spark-summit.org/2017/events/deep-learning-to-big-data-analytics-on-apache-spark-using-bigdl/)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -77,3 +77,4 @@ pages:
     - Python API Docs: APIGuide/python-api-doc.md
 - Powered by: powered-by.md
 - Known Issues: known-issues.md
+- Other Resource: other-resource.md


### PR DESCRIPTION
## What changes were proposed in this pull request?

per suggest, add a new page "other resource" to store published video and talks

