### PR TITLE
remove label check in BytesToGreyImg

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/BytesToGreyImg.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/BytesToGreyImg.scala
@@ -37,7 +37,6 @@ class BytesToGreyImg(row: Int, col: Int)
   override def apply(prev: Iterator[ByteRecord]): Iterator[LabeledGreyImage] = {
     prev.map(rawData => {
       require(row * col == rawData.data.length)
-      require(rawData.label >= 1)
       buffer.setLabel(rawData.label).copy(rawData.data, 255.0f)
     })
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

remove label check in BytesToGreyImg, since user may give some special labels

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/971

