### PR TITLE
Refactor the serde logic of JTensor and Sample

### DIFF
--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -190,7 +190,7 @@ class Sample(object):
     @classmethod
     def from_ndarray(cls, features, label, bigdl_type="float"):
         """
-        Convert a ndarray to Tensor which would be used in Java side.
+        Convert a ndarray of features and label to Sample, which would be used in Java side.
 
         >>> import numpy as np
         >>> from bigdl.util.common import callBigDlFunc

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -113,11 +113,13 @@ class EvaluatedResult():
         return "Evaluated result: %s, total_num: %s, method: %s" % (
             self.result, self.total_num, self.method)
 
+def get_dtype(bigdl_type):
+    # Always return float32 for now
+    return "float32"
 
 class JTensor(object):
     """
     A wrapper to easy our work when need to pass or return Tensor to/from Scala.
-
 
     >>> import numpy as np
     >>> from bigdl.util.common import JTensor
@@ -125,8 +127,12 @@ class JTensor(object):
     >>>
     """
     def __init__(self, storage, shape, bigdl_type="float"):
-        self.storage = storage
-        self.shape = shape
+        if isinstance(storage, bytes) and isinstance(shape, bytes):
+            self.storage = np.frombuffer(storage, dtype=get_dtype(bigdl_type))
+            self.shape = np.frombuffer(shape, dtype=np.int32)
+        else:
+            self.storage = np.array(storage, dtype=get_dtype(bigdl_type))
+            self.shape = np.array(shape, dtype=np.int32)
         self.bigdl_type = bigdl_type
 
     @classmethod
@@ -148,75 +154,69 @@ class JTensor(object):
         >>> (array_from_tensor == data).all()
         True
         """
-        return cls(*JTensor.flatten_ndarray(a_ndarray),
-                   bigdl_type= bigdl_type) if a_ndarray is not None else None  # noqa
+        if a_ndarray is None:
+            return None
+        assert isinstance(a_ndarray, np.ndarray), \
+            "input should be a np.ndarray, not %s" % type(a_ndarray)
+        return cls(a_ndarray,
+                   a_ndarray.shape if a_ndarray.shape else (a_ndarray.size),
+                   bigdl_type= bigdl_type)
 
     def to_ndarray(self):
-        def get_dtype():
-            if "float" == self.bigdl_type:
-                return "float32"
-            else:
-                return "float64"
-        return np.array(self.storage, dtype=get_dtype()).reshape(self.shape)  # noqa
-
-    @classmethod
-    def flatten_ndarray(cls, a_ndarray):
-        """
-        Utility method to flatten a ndarray
-
-        :return: (storage, shape)
-
-        >>> from bigdl.util.common import JTensor
-        >>> np.random.seed(123)
-        >>> data = np.random.uniform(0, 1, (2, 3))
-        >>> (storage, shape) = JTensor.flatten_ndarray(data)
-        >>> shape
-        [2, 3]
-        >>> (storage, shape) = JTensor.flatten_ndarray(np.array(2))
-        >>> shape
-        [1]
-        """
-        storage = [float(i) for i in a_ndarray.ravel()]
-        shape = list(a_ndarray.shape) if a_ndarray.shape else [a_ndarray.size]
-        return storage, shape
+        return np.array(self.storage, dtype=get_dtype(self.bigdl_type)).reshape(self.shape)  # noqa
 
     def __reduce__(self):
-        return (JTensor, (self.storage, self.shape, self.bigdl_type))
+        return JTensor, (self.storage.tostring(), self.shape.tostring(), self.bigdl_type)
 
     def __str__(self):
-        return "storage: %s, shape: %s," % (self.storage, self.storage)
+        return "JTensor: storage: %s, shape: %s" % (self.storage, self.shape)
+
+    def __repr__(self):
+        return "JTensor: storage: %s, shape: %s" % (self.storage, self.shape)
 
 
 class Sample(object):
-    def __init__(self, features, label, features_shape, label_shape,
-                 bigdl_type="float"):
-        def get_dtype():
-            if "float" == bigdl_type:
-                return "float32"
-            else:
-                return "float64"
-        self.features = np.array(features, dtype=get_dtype()).reshape(features_shape)  # noqa
-        self.label = np.array(label, dtype=get_dtype()).reshape(label_shape)
+    def __init__(self, features, label, bigdl_type="float"):
+        """
+        User should always use Sample.from_ndarray to construct Sample.
+        :param features: a JTensor
+        :param label: a JTensor
+        :param bigdl_type: "double" or "float"
+        """
+        self.features = features
+        self.label = label
         self.bigdl_type = bigdl_type
 
     @classmethod
     def from_ndarray(cls, features, label, bigdl_type="float"):
+        """
+        Convert a ndarray to Tensor which would be used in Java side.
+
+        >>> import numpy as np
+        >>> from bigdl.util.common import callBigDlFunc
+        >>> from numpy.testing import assert_allclose
+        >>> sample = Sample.from_ndarray(np.random.random((2,3)), np.random.random((2,3)))
+        >>> sample_back = callBigDlFunc("float", "testSample", sample)
+        >>> assert_allclose(sample.features.to_ndarray(), sample_back.features.to_ndarray())
+        >>> assert_allclose(sample.label.to_ndarray(), sample_back.label.to_ndarray())
+        """
+        assert isinstance(features, np.ndarray), \
+            "features should be a np.ndarray, not %s" % type(features)
+        if not isinstance(label, np.ndarray): # in case label is a scalar.
+            label = np.array(label)
         return cls(
-            features=[float(i) for i in features.ravel()],
-            label=[float(i) for i in label.ravel()],
-            features_shape=list(features.shape),
-            label_shape=list(label.shape) if label.shape else [label.size],
+            features=JTensor.from_ndarray(features),
+            label=JTensor.from_ndarray(label),
             bigdl_type=bigdl_type)
 
     def __reduce__(self):
-        (features_storage, features_shape) = JTensor.flatten_ndarray(self.features)
-        (label_storage, label_shape) = JTensor.flatten_ndarray(self.label)
-        return (Sample, (
-            features_storage, label_storage, features_shape, label_shape,
-            self.bigdl_type))
+        return Sample, (self.features, self.label, self.bigdl_type)
 
     def __str__(self):
-        return "features: %s, label: %s," % (self.features, self.label)
+        return "Sample: features: %s, label: %s," % (self.features, self.label)
+
+    def __repr__(self):
+        return "Sample: features: %s, label: %s" % (self.storage, self.shape)
 
 class RNG():
     """

--- a/pyspark/test/bigdl/test_simple_integration.py
+++ b/pyspark/test/bigdl/test_simple_integration.py
@@ -189,7 +189,7 @@ class TestSimple():
 
         def gen_rand_sample():
             features = np.random.uniform(0, 1, (FEATURES_DIM))
-            label = (2 * features).sum() + 0.4
+            label = np.array((2 * features).sum() + 0.4)
             return Sample.from_ndarray(features, label)
 
         trainingData = self.sc.parallelize(range(0, data_len)).map(

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
@@ -209,7 +209,8 @@ object BigDLSerDe extends BigDLSerDeBase with Serializable {
       saveObjects(out,
         pickler,
         record.features,
-        record.label)
+        record.label,
+        record.bigdlType)
     }
 
     def construct(args: Array[Object]): Object = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
@@ -19,9 +19,11 @@
 package org.apache.spark.bigdl.api.python
 
 import java.io.OutputStream
+import java.nio.charset.StandardCharsets
+import java.nio.{ByteBuffer, ByteOrder}
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, Map => JMap}
 
-import com.intel.analytics.bigdl.python.api.{JTensor, Sample, EvaluatedResult}
+import com.intel.analytics.bigdl.python.api.{EvaluatedResult, JTensor, Sample}
 import net.razorvine.pickle._
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.api.python.SerDeUtil
@@ -98,7 +100,6 @@ object BigDLSerDe extends BigDLSerDeBase with Serializable {
   val PYSPARK_PACKAGE = "bigdl.util.common"
   val LATIN1 = "ISO-8859-1"
 
-
   /**
    * Base class used for pickle
    */
@@ -145,12 +146,57 @@ object BigDLSerDe extends BigDLSerDeBase with Serializable {
       out.write(code)
     }
 
+    protected def saveBytes(out: OutputStream, pickler: Pickler, bytes: Array[Byte]): Unit = {
+      out.write(Opcodes.BINSTRING)
+      out.write(PickleUtils.integer_to_bytes(bytes.length))
+      out.write(bytes)
+    }
+
     protected def getBytes(obj: Object): Array[Byte] = {
       if (obj.getClass.isArray) {
         obj.asInstanceOf[Array[Byte]]
       } else {
-        obj.asInstanceOf[String].getBytes(LATIN1)
+        // This must be ISO 8859-1 / Latin 1, not UTF-8, to interoperate correctly
+        obj.asInstanceOf[String].getBytes(StandardCharsets.ISO_8859_1)
       }
+    }
+
+    protected def objToInt32Array(obj: Object): Array[Int] = {
+      val bytes = getBytes(obj)
+      val bb = ByteBuffer.wrap(bytes, 0, bytes.length)
+      bb.order(ByteOrder.nativeOrder())
+      val db = bb.asIntBuffer()
+      val ans = new Array[Int](bytes.length / 4)
+      db.get(ans)
+      ans
+    }
+
+    protected def objToFloatArray(obj: Object): Array[Float] = {
+      val bytes = getBytes(obj)
+      val bb = ByteBuffer.wrap(bytes, 0, bytes.length)
+      bb.order(ByteOrder.nativeOrder())
+      val db = bb.asFloatBuffer()
+      val ans = new Array[Float](bytes.length / 4)
+      db.get(ans)
+      ans
+    }
+
+    protected def floatArrayToBytes(arr: Array[Float]): Array[Byte] = {
+      val bytes = new Array[Byte](4 * arr.size)
+      val bb = ByteBuffer.wrap(bytes)
+      bb.order(ByteOrder.nativeOrder())
+      val db = bb.asFloatBuffer()
+      db.put(arr)
+      bytes
+    }
+
+    protected def int32ArrayToBytes(arr: Array[Int]): Array[Byte] = {
+      val bytes = new Array[Byte](4 * arr.size)
+      val bb = ByteBuffer.wrap(bytes)
+      bb.order(ByteOrder.nativeOrder())
+      val db = bb.asIntBuffer()
+      db.put(arr)
+      bytes
     }
 
     private[python] def saveState(obj: Object, out: OutputStream, pickler: Pickler)
@@ -163,18 +209,16 @@ object BigDLSerDe extends BigDLSerDeBase with Serializable {
       saveObjects(out,
         pickler,
         record.features,
-        record.label, record.featuresShape, record.labelShape)
+        record.label)
     }
 
     def construct(args: Array[Object]): Object = {
-      if (args.length != 5) {
-        throw new PickleException("should be 5, not : " + args.length)
+      if (args.length != 3) {
+        throw new PickleException("should be 3, not : " + args.length)
       }
-      new Sample(args(0).asInstanceOf[JArrayList[Any]],
-        args(1).asInstanceOf[JArrayList[Any]],
-        args(2).asInstanceOf[JArrayList[Int]],
-        args(3).asInstanceOf[JArrayList[Int]],
-        args(4).asInstanceOf[String])
+      new Sample(args(0).asInstanceOf[JTensor],
+        args(1).asInstanceOf[JTensor],
+        args(2).asInstanceOf[String])
     }
   }
 
@@ -201,30 +245,23 @@ object BigDLSerDe extends BigDLSerDeBase with Serializable {
   private[python] class JTensorPickler extends BigDLBasePickler[JTensor] {
 
     def saveState(obj: Object, out: OutputStream, pickler: Pickler): Unit = {
-      val testResult = obj.asInstanceOf[JTensor]
-      saveObjects(out,
-        pickler,
-        testResult.storage,
-        testResult.shape, testResult.bigdlType)
+      val jTensor = obj.asInstanceOf[JTensor]
+      saveBytes(out, pickler, floatArrayToBytes(jTensor.storage))
+      saveBytes(out, pickler, int32ArrayToBytes(jTensor.shape))
+      pickler.save(jTensor.bigdlType)
+      out.write(Opcodes.TUPLE3)
     }
+
 
     def construct(args: Array[Object]): Object = {
       if (args.length != 3) {
         throw new PickleException("should be 3, not : " + args.length)
       }
       val bigdl_type = args(2).asInstanceOf[String]
-      // Only allow float and double for now same as Tensor
-      val rawStorage = args(0).asInstanceOf[JArrayList[Double]].asScala
-      val storage = bigdl_type match {
-        case "float" =>
-          rawStorage.map(_.toFloat).toList.asJava
-        case "double" =>
-          rawStorage.toList.asJava
-        case _ => throw new IllegalArgumentException("Only support float and double for now")
-      }
-      new JTensor(storage.asInstanceOf[JList[Any]],
-        args(1).asInstanceOf[JArrayList[Int]],
-        bigdl_type)
+      val storage = objToFloatArray(args(0))
+      val shape = objToInt32Array(args(1))
+      val result = new JTensor(storage, shape, bigdl_type)
+      result
     }
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -125,16 +125,13 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   def toJTensor(tensor: Tensor[T]): JTensor = {
     // clone here in case the the size of storage larger then the size of tensor.
     require(tensor != null, "tensor cannot be null")
-    val cloneTensor = tensor.clone()
-    val result = JTensor(cloneTensor.storage().array().map(i => ev.toType[Float](i)),
-      cloneTensor.size(), typeName)
-    result
     if (tensor.nElement() == 0) {
-      JTensor(new JArrayList[Any](0), List(0).asJava, typeName)
+      JTensor(Array(0), Array(0), typeName)
     } else {
       val cloneTensor = tensor.clone()
-      JTensor(cloneTensor.storage().toList.map(_.asInstanceOf[Any]).asJava,
-        cloneTensor.size().toList.asJava, typeName)
+      val result = JTensor(cloneTensor.storage().array().map(i => ev.toType[Float](i)),
+        cloneTensor.size(), typeName)
+      result
     }
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -46,17 +46,13 @@ import scala.reflect.ClassTag
  * [[com.intel.analytics.bigdl.dataset.Sample]] for python.
  * @param features features
  * @param label labels
- * @param featuresShape feature size
- * @param labelShape label size
  * @param bigdlType bigdl numeric type
  */
-case class Sample(features: JList[Any],
-                  label: JList[Any],
-                  featuresShape: JList[Int],
-                  labelShape: JList[Int],
+case class Sample(features: JTensor,
+                  label: JTensor,
                   bigdlType: String)
 
-case class JTensor(storage: JList[Any], shape: JList[Int], bigdlType: String)
+case class JTensor(storage: Array[Float], shape: Array[Int], bigdlType: String)
 
 /**
  * [[ValidationResult]] for python
@@ -109,26 +105,30 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   }
 
   def toPySample(sample: JSample[T]): Sample = {
-    val featureList = sample.feature().contiguous().storage().toArray[T].toList.asJava
-    val labelList = sample.label().contiguous().storage().toArray[T].toList.asJava
     val cls = implicitly[ClassTag[T]].runtimeClass
-    Sample(featureList.asInstanceOf[JList[Any]],
-      labelList.asInstanceOf[JList[Any]],
-      sample.feature().size().toList.asJava,
-      sample.label().size().toList.asJava,
-      cls.getSimpleName)
+    Sample(toJTensor(sample.feature()), toJTensor(sample.label()), cls.getSimpleName)
   }
 
   def toTensor(jTensor: JTensor): Tensor[T] = {
-    if (jTensor == null) null else {
-      Tensor(jTensor.storage.asScala.map(_.asInstanceOf[T]).toArray,
-        jTensor.shape.asScala.toArray)
+    if (jTensor == null) return null
+
+    this.typeName match {
+      case "float" =>
+        Tensor(jTensor.storage.map(x => ev.fromType(x.toFloat)), jTensor.shape)
+      case "double" =>
+        Tensor(jTensor.storage.map(x => ev.fromType(x.toDouble)), jTensor.shape)
+      case t: String =>
+        throw new IllegalArgumentException(s"Not supported type: ${t}")
     }
   }
 
   def toJTensor(tensor: Tensor[T]): JTensor = {
     // clone here in case the the size of storage larger then the size of tensor.
     require(tensor != null, "tensor cannot be null")
+    val cloneTensor = tensor.clone()
+    val result = JTensor(cloneTensor.storage().array().map(i => ev.toType[Float](i)),
+      cloneTensor.size(), typeName)
+    result
     if (tensor.nElement() == 0) {
       JTensor(new JArrayList[Any](0), List(0).asJava, typeName)
     } else {
@@ -143,34 +143,16 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
     toJTensor(tensor)
   }
 
+
+  def testSample(sample: Sample): Sample = {
+    val jsample = toSample(sample)
+    toPySample(jsample)
+  }
+
   def toSample(record: Sample): JSample[T] = {
     require(record.bigdlType == this.typeName,
       s"record.bigdlType: ${record.bigdlType} == this.typeName: ${this.typeName}")
-    val sample = this.typeName match {
-      case "float" =>
-        val feature = Tensor[Float](Storage[Float](
-          record.features.asInstanceOf[JList[Double]].asScala.map(_.toFloat).toArray[Float]),
-          1,
-          record.featuresShape.asScala.toArray[Int])
-        val label = Tensor[Float](
-          Storage(record.label.asInstanceOf[JList[Double]].asScala.map(_.toFloat).toArray[Float]),
-          1,
-          record.labelShape.asScala.toArray[Int])
-        JSample[Float](feature, label)
-      case "double" =>
-        val feature = Tensor[Double](Storage[Double](
-          record.features.asInstanceOf[JList[Double]].asScala.toArray[Double]),
-          1,
-          record.featuresShape.asScala.toArray[Int])
-        val label = Tensor[Double](
-          Storage(record.label.asInstanceOf[JList[Double]].asScala.toArray[Double]),
-          1,
-          record.labelShape.asScala.toArray[Int])
-        JSample[Double](feature, label)
-      case t: String =>
-        throw new IllegalArgumentException(s"Not supported type: ${t}")
-    }
-    sample.asInstanceOf[JSample[T]]
+    JSample[T](toTensor(record.features), toTensor(record.label))
   }
 
   private def batching(rdd: RDD[Sample], batchSize: Int)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
@@ -159,13 +159,10 @@ class PythonSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val labelShape = util.Arrays.asList(1)
 
     val data = sc.parallelize(0 to 100).map {i =>
-      Sample(
-        Range(0, 100).toList.map(_ => Random.nextDouble()).asJava.asInstanceOf[JList[Any]],
-        util.Arrays.asList(i % 2 + 1.0d),
-        featuresShape,
-        labelShape,
-        "double"
-      )
+      val label = JTensor(Array(i % 2 + 1.0f), Array(1), "double")
+      val feature = JTensor(Range(0, 100).map(_ => Random.nextFloat()).toArray,
+        Array(100), "double")
+      Sample(feature, label, "double")
     }
 
     BigDLSerDe.javaToPython(data.toJavaRDD().asInstanceOf[JavaRDD[Any]])


### PR DESCRIPTION
## What changes were proposed in this pull request?

Previously we pass JTensor from python to java via ArrayList which would result in bad performance.
After this changes we would use Array[Byte] directly for those transforming.

## How was this patch tested?
unittest

