### PR TITLE
add isSplitInput in BiRecurrent

### DIFF
--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/BiRecurrentSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/BiRecurrentSpec.scala
@@ -63,7 +63,7 @@ class BiRecurrentSpec  extends TorchSpec {
     val gradOutput1 = gradOutput.narrow(3, 1, outputSize).contiguous()
     val gradOutput2 = gradOutput.narrow(3, 1 + outputSize, outputSize).contiguous()
 
-    val birnn = BiRecurrent[Double](JoinTable[Double](3, 0), isCloneInput = false)
+    val birnn = BiRecurrent[Double](JoinTable[Double](3, 0), isSplitInput = true)
       .add(RnnCell[Double](half, outputSize, ReLU[Double]()))
 
     val recurrent1 = Recurrent[Double]()

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/BiRecurrentSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/BiRecurrentSpec.scala
@@ -46,7 +46,7 @@ class BiRecurrentSpec  extends TorchSpec {
     }
   }
 
-  "A BiRecurrent" should "uses isCloneInput correctly" in {
+  "A BiRecurrent" should "uses isSplitInput correctly" in {
     val inputSize = 4
     val outputSize = 5
     val seqLength = 7

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/ModuleSerializerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/ModuleSerializerSpec.scala
@@ -152,12 +152,12 @@ class ModuleSerializerSpec extends FlatSpec with Matchers {
     res1 should be (res2)
   }
 
-  "BiRecurrent serializer" should "work properly with isCloneInput" in {
+  "BiRecurrent serializer" should "work properly with isSplitInput" in {
     val input1 = Tensor(1, 5, 6).apply1(e => Random.nextFloat()).transpose(1, 2)
     val input2 = Tensor()
     input2.resizeAs(input1).copy(input1)
     RNG.setSeed(100)
-    val biRecurrent = BiRecurrent(isCloneInput = true).add(RnnCell(6, 4, Sigmoid()))
+    val biRecurrent = BiRecurrent(isSplitInput = false).add(RnnCell(6, 4, Sigmoid()))
     val res1 = biRecurrent.forward(input1)
     ModulePersister.saveToFile("/tmp/biRecurrent.bigdl", biRecurrent, true)
     RNG.setSeed(100)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/ModuleSerializerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/ModuleSerializerSpec.scala
@@ -152,6 +152,20 @@ class ModuleSerializerSpec extends FlatSpec with Matchers {
     res1 should be (res2)
   }
 
+  "BiRecurrent serializer" should "work properly with isCloneInput" in {
+    val input1 = Tensor(1, 5, 6).apply1(e => Random.nextFloat()).transpose(1, 2)
+    val input2 = Tensor()
+    input2.resizeAs(input1).copy(input1)
+    RNG.setSeed(100)
+    val biRecurrent = BiRecurrent(isCloneInput = true).add(RnnCell(6, 4, Sigmoid()))
+    val res1 = biRecurrent.forward(input1)
+    ModulePersister.saveToFile("/tmp/biRecurrent.bigdl", biRecurrent, true)
+    RNG.setSeed(100)
+    val loadedRecurent = ModuleLoader.loadFromFile("/tmp/biRecurrent.bigdl")
+    val res2 = loadedRecurent.forward(input2)
+    res1 should be (res2)
+  }
+
   "Bottle serializer" should "work properly" in {
     val input1 = Tensor(10).apply1(e => Random.nextFloat())
     val input2 = Tensor()


### PR DESCRIPTION
## What changes were proposed in this pull request?
add a different behavior inside BiRecurrent layer:

isCloneInput = true  => ConcatTable
isCloneInput = false => BifurcateSplitTable

## How was this patch tested?
Unit Tests

