### PR TITLE
remove scala doc and python doc generation in gen_site.py

### DIFF
--- a/docs/gen_site.py
+++ b/docs/gen_site.py
@@ -72,41 +72,52 @@ run_cmd(['mv', '/tmp/bigdl-doc/mkdocs_windmill', dir_name],
 run_cmd(['mv', '/tmp/bigdl-doc/extra.css', '{}/docs'.format(dir_name)],
     'mv theme foler error')
 
-run_cmd(['rm', '-rf', '/tmp/bigdl-doc'],
-    'rm theme folder error')
-
 # mkdocs build
 run_cmd(['mkdocs', 'build'],
     'mkdocs build error')
 
-if scaladocs:
-    print 'build scala doc'
-    bigdl_dir = os.path.dirname(dir_name)
-    os.chdir(bigdl_dir)
-    run_cmd(['mvn', 'scala:doc'], 'Build scala doc error')
-    scaladocs_dir = bigdl_dir + '/spark/dl/target/site/scaladocs/*'
-    target_dir = dir_name + '/site/APIdocs/scaladoc/'
-    run_cmd(['cp', '-r', scaladocs_dir, target_dir],
-        'mv scaladocs error', s=True)
+# replace resources folder in site
+run_cmd(['cp', '/tmp/bigdl-doc/css/*', '{}/site/css'.format(dir_name)],
+    'mv theme foler error', s=True)
+run_cmd(['cp', '/tmp/bigdl-doc/js/*', '{}/site/js'.format(dir_name)],
+    'mv theme foler error', s=True)
+run_cmd(['cp', '/tmp/bigdl-doc/fonts/*', '{}/site/fonts'.format(dir_name)],
+    'mv theme foler error', s=True)
+run_cmd(['cp', '/tmp/bigdl-doc/img/*', '{}/site/img'.format(dir_name)],
+    'mv theme foler error', s=True)
+run_cmd(['cp', '/tmp/bigdl-doc/version-list', '{}/site'.format(dir_name)],
+    'mv theme foler error', s=True)
 
-if pythondocs:
-    print 'build python'
-    pyspark_dir = os.path.dirname(dir_name) + '/pyspark/docs/'
-    target_dir = dir_name + '/site/APIdocs/python-api-doc/'
-    os.chdir(pyspark_dir)
-    run_cmd(['./doc-gen.sh'], 'Build python doc error')
-    pythondocs_dir = pyspark_dir + '_build/html/*'
-    run_cmd(['cp', '-r', pythondocs_dir, target_dir],
-        'mv scaladocs error', s=True)
+run_cmd(['rm', '-rf', '/tmp/bigdl-doc'],
+    'rm theme folder error')
+
+# if scaladocs:
+#     print 'build scala doc'
+#     bigdl_dir = os.path.dirname(dir_name)
+#     os.chdir(bigdl_dir)
+#     run_cmd(['mvn', 'scala:doc'], 'Build scala doc error')
+#     scaladocs_dir = bigdl_dir + '/spark/dl/target/site/scaladocs/*'
+#     target_dir = dir_name + '/site/APIGuide/scaladoc/'
+#     run_cmd(['cp', '-r', scaladocs_dir, target_dir],
+#         'mv scaladocs error', s=True)
+# 
+# if pythondocs:
+#     print 'build python'
+#     pyspark_dir = os.path.dirname(dir_name) + '/pyspark/docs/'
+#     target_dir = dir_name + '/site/APIGuide/python-api-doc/'
+#     os.chdir(pyspark_dir)
+#     run_cmd(['./doc-gen.sh'], 'Build python doc error')
+#     pythondocs_dir = pyspark_dir + '_build/html/*'
+#     run_cmd(['cp', '-r', pythondocs_dir, target_dir],
+#         'mv scaladocs error', s=True)
 
 os.chdir(dir_name)
-
 
 if args.debugport != None:
     print 'starting mkdoc server in debug mode'
     addr = '--dev-addr=*:'+str(args.debugport)
     run_cmd(['mkdocs', 'serve', addr],
-        'mkdocs start serve error')
+         'mkdocs start serve error')
 
 if args.port != None:
     os.chdir(dir_name + '/site')


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove Scala document and Python document generation due to the absence of corresponding directory in document site.

## How was this patch tested?

manual tests


## Related links or issues (optional)
https://github.com/intel-analytics/BigDL/issues/1368
https://github.com/intel-analytics/BigDL/issues/1363

These two issues can be closed if the corresponding directories of Scala doc and Python doc are removed from document site of branch-0.1.


