### PR TITLE
Fix mnist example

### DIFF
--- a/pyspark/bigdl/dataset/transformer.py
+++ b/pyspark/bigdl/dataset/transformer.py
@@ -18,9 +18,9 @@
 from bigdl.util.common import Sample
 
 
-def normalizer(mean, std):
+def normalizer(data, mean, std):
     """
     Normalize features by standard deviation
+    data is a ndarray
     """
-    return lambda sample: Sample.from_ndarray((sample.features - mean) / std,
-                                              sample.label, sample.bigdl_type)
+    return (data - mean) / std


### PR DESCRIPTION
## What changes were proposed in this pull request?

This error is introduced by: https://github.com/intel-analytics/BigDL/pull/1510 due to the field changes within Sample.
```
TypeError: unsupported operand type(s) for -: 'JTensor' and 'float'

	at org.apache.spark.api.python.PythonRunner$$anon$1.read(PythonRDD.scala:193)
	at org.apache.spark.api.python.PythonRunner$$anon$1.<init>(PythonRDD.scala:234)
	at org.apache.spark.api.python.PythonRunner.compute(PythonRDD.scala:152)
	at org.apache.spark.api.python.PythonRDD.compute(PythonRDD.scala:63)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:319)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:283)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:38)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:319)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:283)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:38)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:319)
```

## How was this patch tested?
manual test


