### PR TITLE
update integration test for tensorflow model load/save on hdfs/s3

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/BigDLToTensorflow.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/BigDLToTensorflow.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.nn._
-import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.T
 import Tensorflow._
@@ -110,17 +110,24 @@ object SpatialConvolutionToTF extends BigDLToTensorflow {
     // squeeze will modify the weight tensor
     // GOIHW -> HWIO
     require(spatialConv.weight.size(1) == 1, "convolution group is not supported")
-    val filterTensor = spatialConv.weight.select(1, 1)
-      .transpose(2, 3).transpose(3, 4).transpose(1, 2).transpose(2, 3).transpose(3, 4).contiguous()
+    val (dataFormat, filterTensor) = if (spatialConv.format == DataFormat.NCHW) {
+      (TensorflowDataFormat.NCHW,
+        spatialConv.weight.select(1, 1)
+          .transpose(2, 3).transpose(3, 4)
+          .transpose(1, 2).transpose(2, 3)
+          .transpose(3, 4).contiguous())
+    } else {
+      (TensorflowDataFormat.NHWC, spatialConv.weight.select(1, 1))
+    }
 
     val filter = const(filterTensor, spatialConv.getName() + "/filter", byteOrder)
     val filterReader = identity(filter, spatialConv.getName() + "/filterReader")
     val conv = conv2D(inputs(0), filterReader, spatialConv.strideW, spatialConv.strideH,
       spatialConv.kernelW, spatialConv.kernelH, spatialConv.padW, spatialConv.padH,
-      getDataFormat(), spatialConv.getName() + "/conv2D")
+      dataFormat, spatialConv.getName() + "/conv2D")
     val bias = const(spatialConv.bias, spatialConv.getName() + "/bias", byteOrder)
     val biasReader = identity(bias, spatialConv.getName() + "/biasReader")
-    val add = biasAdd(conv, biasReader, getDataFormat(),
+    val add = biasAdd(conv, biasReader, dataFormat,
       spatialConv.getName() + "/biasAdd")
     Seq(add, biasReader, bias, conv, filterReader, filter)
   }
@@ -220,8 +227,13 @@ object MaxpoolToTF extends BigDLToTensorflow {
                        byteOrder: ByteOrder): Seq[NodeDef] = {
     require(inputs.length == 1, "Maxpool only accept one input")
     val layer = module.asInstanceOf[SpatialMaxPooling[_]]
+    val dataFormat = if (layer.format == DataFormat.NHWC) {
+      TensorflowDataFormat.NHWC
+    } else {
+      TensorflowDataFormat.NCHW
+    }
     Seq(maxPool(inputs(0), layer.kW, layer.kH, layer.padW, layer.padH,
-      layer.dW, layer.dH, getDataFormat(), layer.getName()))
+      layer.dW, layer.dH, dataFormat, layer.getName()))
   }
 }
 
@@ -251,8 +263,13 @@ object AvgpoolToTF extends BigDLToTensorflow {
                        byteOrder: ByteOrder): Seq[NodeDef] = {
     require(inputs.length == 1, "Avgpool only accept one input")
     val layer = module.asInstanceOf[SpatialAveragePooling[_]]
+    val dataFormat = if (layer.format == DataFormat.NHWC) {
+      TensorflowDataFormat.NHWC
+    } else {
+      TensorflowDataFormat.NCHW
+    }
     Seq(avgPool(inputs(0), layer.kW, layer.kH, layer.padW, layer.padH,
-      layer.dW, layer.dH, getDataFormat(), layer.getName()))
+      layer.dW, layer.dH, dataFormat, layer.getName()))
   }
 }
 
@@ -341,16 +358,37 @@ object BatchNorm2DToTF extends BigDLToTensorflow {
     require(inputs.length == 1, "BatchNorm only accept one input")
     val layer = module.asInstanceOf[SpatialBatchNormalization[_]]
     require(!layer.isTraining(), "Only support evaluate mode batch norm")
+    // reshape to nchw
+    val size = Tensor[Float](layer.nDim)
+    for (i <- 0 until layer.nDim) {
+      size.setValue(i + 1, 1)
+    }
+    size(2) = layer.weight.size(1)
+    val shapeVar = const(size, layer.getName() + "/reshape_1/shape",
+      byteOrder, false, DataType.DT_INT32)
+    val shapeMean = const(size, layer.getName() + "/reshape_2/shape",
+      byteOrder, false, DataType.DT_INT32)
+    val shapeScale = const(size, layer.getName() + "/reshape_3/shape",
+      byteOrder, false, DataType.DT_INT32)
+    val shapeOffset = const(size, layer.getName() + "/reshape_4/shape",
+      byteOrder, false, DataType.DT_INT32)
     val varNode = const(layer.runningVar, layer.getName() + "/std", byteOrder)
     val mean = const(layer.runningMean, layer.getName() + "/mean", byteOrder)
     val scale = const(layer.weight, layer.getName() + "/scale", byteOrder)
     val offset = const(layer.bias, layer.getName() + "/offset", byteOrder)
-    val sqrtVar = rsqrt(varNode, layer.getName() + "/stdvar")
-    val mul0 = multiply(scale, sqrtVar, layer.getName() + "/mul0")
+    val reshapeVar = reshape(varNode, shapeVar, s"${layer.getName()}/reshape_1")
+    val reshapeMean = reshape(mean, shapeMean, s"${layer.getName()}/reshape_2")
+    val reshapeScale = reshape(scale, shapeScale, s"${layer.getName()}/reshape_3")
+    val reshapeOffset = reshape(offset, shapeOffset, s"${layer.getName()}/reshape_4")
+    // construct graph
+    val sqrtVar = rsqrt(reshapeVar, layer.getName() + "/stdvar")
+    val mul0 = multiply(reshapeScale, sqrtVar, layer.getName() + "/mul0")
     val mul1 = multiply(inputs(0), mul0, layer.getName() + "/mul1")
-    val mul2 = multiply(mean, mul0, layer.getName() + "/mul2")
-    val sub = subtract(offset, mul2, layer.getName() + "/sub")
+    val mul2 = multiply(reshapeMean, mul0, layer.getName() + "/mul2")
+    val sub = subtract(reshapeOffset, mul2, layer.getName() + "/sub")
     val output = add(mul1, sub, layer.getName() + "/output")
-    Seq(output, sub, mul2, mul1, mul0, offset, scale, mean, sqrtVar, varNode)
+    Seq(output, sub, mul2, mul1, mul0, reshapeOffset, reshapeMean, reshapeScale,
+      shapeOffset, shapeMean, shapeScale, offset, scale, mean,
+      sqrtVar, reshapeVar, shapeVar, varNode)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/integration/HdfsSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/integration/HdfsSpec.scala
@@ -148,8 +148,7 @@ class HdfsSpec extends FlatSpec with Matchers with BeforeAndAfter{
 
   }
 
-  "Save/load tensorflow lenet to/from HDFS" should "works properly" in {
-    System.setProperty("bigdl.enableNHWC", "true")
+  "Save/load tensorflow lenet NCHW to/from HDFS" should "works properly" in {
     val conv1 = SpatialConvolution[Float](1, 6, 5, 5).setName("conv1").inputs()
     val tanh1 = Tanh[Float]().setName("tanh1").inputs(conv1)
     val pool1 = SpatialMaxPooling[Float](2, 2, 2, 2).setName("pool1").inputs(tanh1)
@@ -169,10 +168,8 @@ class HdfsSpec extends FlatSpec with Matchers with BeforeAndAfter{
       Seq("input"),
       Seq("output"),
       ByteOrder.LITTLE_ENDIAN)
-    val loadedOutput = loadedModel.forward(inputData.
-      transpose(2, 3).transpose(3, 4).contiguous()).toTensor[Float]
+    val loadedOutput = loadedModel.forward(inputData).toTensor[Float]
     loadedOutput.almostEqual(outputData, 1e-7)
-    System.setProperty("bigdl.enableNHWC", "false")
   }
 
   "Persist and Load Caffe to/from HDFS" should "works properly" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/integration/S3Spec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/integration/S3Spec.scala
@@ -126,7 +126,7 @@ class S3Spec extends FlatSpec with Matchers with BeforeAndAfter{
 
   }
 
-  "Load tensorflow lenet to/from HDFS" should "works properly" in {
+  "Save/load tensorflow lenet to/from s3" should "works properly" in {
     System.setProperty("bigdl.enableNHWC", "true")
     val conv1 = SpatialConvolution[Float](1, 6, 5, 5).setName("conv1").inputs()
     val tanh1 = Tanh[Float]().setName("tanh1").inputs(conv1)
@@ -140,14 +140,16 @@ class S3Spec extends FlatSpec with Matchers with BeforeAndAfter{
     val outputData = funcModel.forward(inputData).toTensor[Float]
 
     val s3Dir = s3aPath + s"/${ com.google.common.io.Files.createTempDir().getPath() }"
-    TensorflowSaver.saveGraph[Float](funcModel, Seq(("input", Seq(4, 28, 28, 1))), s3Dir)
+    TensorflowSaver.saveGraph[Float](funcModel, Seq(("input", Seq(4, 28, 28, 1))),
+      s3Dir + "/test.tfmodel")
 
 
-    val loadedModel = TensorflowLoader.load[Float](s3Dir,
+    val loadedModel = TensorflowLoader.load[Float](s3Dir + "/test.tfmodel",
       Seq("input"),
       Seq("output"),
       ByteOrder.LITTLE_ENDIAN)
-    val loadedOutput = loadedModel.forward(inputData).toTensor[Float]
+    val loadedOutput = loadedModel.forward(inputData.
+      transpose(2, 3).transpose(3, 4).contiguous()).toTensor[Float]
     loadedOutput.almostEqual(outputData, 1e-7)
     System.setProperty("bigdl.enableNHWC", "false")
   }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/integration/S3Spec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/integration/S3Spec.scala
@@ -126,8 +126,7 @@ class S3Spec extends FlatSpec with Matchers with BeforeAndAfter{
 
   }
 
-  "Save/load tensorflow lenet to/from s3" should "works properly" in {
-    System.setProperty("bigdl.enableNHWC", "true")
+  "Save/load tensorflow lenet NCHW to/from s3" should "works properly" in {
     val conv1 = SpatialConvolution[Float](1, 6, 5, 5).setName("conv1").inputs()
     val tanh1 = Tanh[Float]().setName("tanh1").inputs(conv1)
     val pool1 = SpatialMaxPooling[Float](2, 2, 2, 2).setName("pool1").inputs(tanh1)
@@ -148,9 +147,7 @@ class S3Spec extends FlatSpec with Matchers with BeforeAndAfter{
       Seq("input"),
       Seq("output"),
       ByteOrder.LITTLE_ENDIAN)
-    val loadedOutput = loadedModel.forward(inputData.
-      transpose(2, 3).transpose(3, 4).contiguous()).toTensor[Float]
+    val loadedOutput = loadedModel.forward(inputData).toTensor[Float]
     loadedOutput.almostEqual(outputData, 1e-7)
-    System.setProperty("bigdl.enableNHWC", "false")
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowSaverSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowSaverSpec.scala
@@ -19,7 +19,7 @@ package com.intel.analytics.bigdl.utils.tf
 import java.nio.ByteOrder
 import java.util.UUID
 
-import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
 import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.tensor.Tensor
@@ -60,11 +60,11 @@ class TensorflowSaverSpec extends TensorflowSpecHelper {
       T(1.0f, 2.0f, 5.0f),
       T(-3.0f, -4.0f, -7.0f)
     ))
-    test(layer, input, false, "/biasAdd") should be(true)
+    test(layer, input, "/biasAdd") should be(true)
   }
 
-  "AvgPooling" should "be correctly saved" in {
-    val layer = SpatialAveragePooling(2, 2)
+  "AvgPooling NHWC" should "be correctly saved" in {
+    val layer = SpatialAveragePooling(2, 2, format = DataFormat.NHWC)
     val input = Tensor[Float](T(T(
       T(
         T(1.0f, 2.0f, 5.0f),
@@ -77,11 +77,11 @@ class TensorflowSaverSpec extends TensorflowSpecHelper {
         T(4.0f, 2.0f, 1.0f)
       )
     )))
-    test(layer, input, true) should be(true)
+    test(layer, input) should be(true)
   }
 
-  "MaxPooling" should "be correctly saved" in {
-    val layer = SpatialMaxPooling(2, 2)
+  "MaxPooling NHWC" should "be correctly saved" in {
+    val layer = SpatialMaxPooling(2, 2, format = DataFormat.NHWC)
     val input = Tensor[Float](T(T(
       T(
         T(1.0f, 2.0f, 5.0f),
@@ -94,7 +94,7 @@ class TensorflowSaverSpec extends TensorflowSpecHelper {
         T(4.0f, 2.0f, 1.0f)
       )
     )))
-    test(layer, input, true) should be(true)
+    test(layer, input) should be(true)
   }
 
   "Tanh" should "be correctly saved" in {
@@ -107,7 +107,7 @@ class TensorflowSaverSpec extends TensorflowSpecHelper {
     System.setProperty("bigdl.enableNHWC", "false")
     val layer = Squeeze(3)
     val input = Tensor[Float](4, 2, 1, 2).rand()
-    test(layer, input, false) should be(true)
+    test(layer, input) should be(true)
   }
 
   "CAddTableToTF" should "be correct" in {
@@ -134,43 +134,43 @@ class TensorflowSaverSpec extends TensorflowSpecHelper {
   "LogSoftMax" should "be correctly saved" in {
     val layer = LogSoftMax()
     val input = Tensor[Float](4, 5).rand()
-    test(layer, input, false) should be(true)
+    test(layer, input) should be(true)
   }
 
   "SoftMax" should "be correctly saved" in {
     val layer = SoftMax()
     val input = Tensor[Float](4, 5).rand()
-    test(layer, input, false) should be(true)
+    test(layer, input) should be(true)
   }
 
   "Sigmoid" should "be correctly saved" in {
     val layer = Sigmoid()
     val input = Tensor[Float](4, 5).rand()
-    test(layer, input, false) should be(true)
+    test(layer, input) should be(true)
   }
 
-  "SpatialConvolution" should "be correctly saved" in {
-    val layer = SpatialConvolution(3, 5, 2, 2)
-    val input = Tensor[Float](4, 3, 5, 5).rand()
-    test(layer, input, true, "/biasAdd") should be(true)
+  "SpatialConvolution NHWC" should "be correctly saved" in {
+    val layer = SpatialConvolution(3, 5, 2, 2, format = DataFormat.NHWC)
+    val input = Tensor[Float](4, 5, 5, 3).rand()
+    test(layer, input, "/biasAdd") should be(true)
   }
 
   "TemporalConvolution" should "be correctly saved" in {
     val layer = TemporalConvolution(3, 5, 2, 2)
     val input = Tensor[Float](4, 16, 3).rand()
-    test(layer, input, false, "/biasAdd") should be(true)
+    test(layer, input, "/biasAdd") should be(true)
   }
 
   "Mean" should "be correctly saved" in {
     val layer = Mean(1, -1, true)
     val input = Tensor[Float](4, 5).rand()
-    test(layer, input, false, "/output") should be(true)
+    test(layer, input, "/output") should be(true)
   }
 
   "Padding" should "be correctly saved" in {
     val layer = Padding(1, 2, 2)
     val input = Tensor[Float](4, 5).rand()
-    test(layer, input, false, "/output") should be(true)
+    test(layer, input, "/output") should be(true)
   }
 
   "Batch Norm2D" should "be correctly saved" in {
@@ -181,26 +181,26 @@ class TensorflowSaverSpec extends TensorflowSpecHelper {
     layer.runningVar.rand(0.9, 1.1)
     layer.runningMean.rand()
     val input = Tensor[Float](3, 2, 4, 5).rand()
-    test(layer, input, true, "/output") should be(true)
+    test(layer, input, "/output") should be(true)
   }
 
   "Dropout" should "be correctly saved" in {
     val layer = Dropout()
     layer.evaluate()
     val input = Tensor[Float](3, 2).rand()
-    test(layer, input, false) should be(true)
+    test(layer, input) should be(true)
   }
 
   "View" should "be correctly saved" in {
     val layer = View(2, 4)
     val input = Tensor[Float](2, 2, 2).rand()
-    test(layer, input, false) should be(true)
+    test(layer, input) should be(true)
   }
 
   "Reshape" should "be correctly saved" in {
     val layer = Reshape(Array(2, 4))
     val input = Tensor[Float](2, 2, 2).rand()
-    test(layer, input, false) should be(true)
+    test(layer, input) should be(true)
   }
 
   "lenet" should "be correctly saved" in {
@@ -232,7 +232,6 @@ class TensorflowSaverSpec extends TensorflowSpecHelper {
 
   private def test(layer: AbstractModule[Tensor[Float], Tensor[Float], Float],
                    inputTensor: Tensor[Float],
-                   convertNHWC: Boolean = false,
                    outputSuffix: String = "") : Boolean = {
     tfCheck()
     val layerNode = layer.setName("output").inputs()
@@ -241,22 +240,13 @@ class TensorflowSaverSpec extends TensorflowSpecHelper {
 
     val tmpFile = java.io.File.createTempFile("tensorflowSaverTest" + UUID.randomUUID(), "Layer")
     logger.info(s"Save model to ${tmpFile}")
-    val tfTensor = if (convertNHWC) {
-      inputTensor.transpose(2, 3).transpose(3, 4).contiguous()
-    } else {
-      inputTensor
-    }
-    val outputSave = if (convertNHWC) {
-      outputTensor.transpose(2, 3).transpose(3, 4).contiguous()
-    } else {
-      outputTensor
-    }
+
     TensorflowSaver.saveGraphWithNodeDef(
       graph,
-      Seq(Tensorflow.const(tfTensor, "input", ByteOrder.LITTLE_ENDIAN)),
+      Seq(Tensorflow.const(inputTensor, "input", ByteOrder.LITTLE_ENDIAN)),
       tmpFile.getPath,
       ByteOrder.LITTLE_ENDIAN,
-      Set(Tensorflow.const(outputSave, "target", ByteOrder.LITTLE_ENDIAN))
+      Set(Tensorflow.const(outputTensor, "target", ByteOrder.LITTLE_ENDIAN))
     )
     runPythonSaveTest(tmpFile.getPath, outputSuffix)
   }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowSaverSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowSaverSpec.scala
@@ -214,17 +214,15 @@ class TensorflowSaverSpec extends TensorflowSpecHelper {
 
     val funcModel = Graph(conv1, pool2)
     val inputData = Tensor(4, 1, 28, 28).rand()
-    val transInput = inputData.transpose(2, 3).transpose(3, 4).contiguous()
     val outputData = funcModel.forward(inputData).toTensor
 
     val tmpFile = java.io.File.createTempFile("tensorflowSaverTest" + UUID.randomUUID(), "lenet")
     TensorflowSaver.saveGraphWithNodeDef(
       funcModel,
-      Seq(Tensorflow.const(transInput, "input", ByteOrder.LITTLE_ENDIAN)),
+      Seq(Tensorflow.const(inputData, "input", ByteOrder.LITTLE_ENDIAN)),
       tmpFile.getPath,
       ByteOrder.LITTLE_ENDIAN,
-      Set(Tensorflow.const(outputData.transpose(2, 3).transpose(3, 4).contiguous(),
-        "target", ByteOrder.LITTLE_ENDIAN))
+      Set(Tensorflow.const(outputData, "target", ByteOrder.LITTLE_ENDIAN))
     )
 
     runPythonSaveTest(tmpFile.getPath, "") should be(true)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowSaverSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowSaverSpec.scala
@@ -173,7 +173,7 @@ class TensorflowSaverSpec extends TensorflowSpecHelper {
     test(layer, input, "/output") should be(true)
   }
 
-  "Batch Norm2D" should "be correctly saved" in {
+  "Batch Norm2D NCHW" should "be correctly saved" in {
     val layer = SpatialBatchNormalization(2)
     layer.evaluate()
     layer.weight.rand(10.0, 20.0)
@@ -203,17 +203,21 @@ class TensorflowSaverSpec extends TensorflowSpecHelper {
     test(layer, input) should be(true)
   }
 
-  "lenet" should "be correctly saved" in {
+  "lenet NHWC" should "be correctly saved" in {
     tfCheck()
-    val conv1 = SpatialConvolution(1, 6, 5, 5).setName("conv1").inputs()
+    val conv1 = SpatialConvolution(1, 6, 5, 5, format = DataFormat.NHWC)
+      .setName("conv1").inputs()
     val tanh1 = Tanh().setName("tanh1").inputs(conv1)
-    val pool1 = SpatialMaxPooling(2, 2, 2, 2).setName("pool1").inputs(tanh1)
+    val pool1 = SpatialMaxPooling(2, 2, 2, 2, format = DataFormat.NHWC)
+      .setName("pool1").inputs(tanh1)
     val tanh2 = Tanh().setName("tanh2").inputs(pool1)
-    val conv2 = SpatialConvolution(6, 12, 5, 5).setName("conv2").inputs(tanh2)
-    val pool2 = SpatialMaxPooling(2, 2, 2, 2).setName("output").inputs(conv2)
+    val conv2 = SpatialConvolution(6, 12, 5, 5, format = DataFormat.NHWC)
+      .setName("conv2").inputs(tanh2)
+    val pool2 = SpatialMaxPooling(2, 2, 2, 2, format = DataFormat.NHWC)
+      .setName("output").inputs(conv2)
 
     val funcModel = Graph(conv1, pool2)
-    val inputData = Tensor(4, 1, 28, 28).rand()
+    val inputData = Tensor(4, 28, 28, 1).rand()
     val outputData = funcModel.forward(inputData).toTensor
 
     val tmpFile = java.io.File.createTempFile("tensorflowSaverTest" + UUID.randomUUID(), "lenet")


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Fix data format mismatch in integration test of tensorflow model load/save on hdfs and s3 
2. Change data format in `TensorflowSaverSpec` to `NHWC` except `BatchNormalization` since BigDL has not support `NHWC` `BatchNormalization` yet.
3. Remove format transformation while saving BigDL model to Tensorflow model. The saved tf model will have same format as the original BigDL model.
4. Add Reshape node in `BatchNorm2DToTF` to support `NCHW` batch normalization. The dimension size 
 of ReShape is set to [1, C, 1, 1] since the `BatchNormalization` in BigDL is `NCHW`. The new topology of saved graph is same as `tf.layers.batch_normalization`.
![graph-run](https://user-images.githubusercontent.com/2098682/30361188-25de4ffc-9888-11e7-93eb-79c4f65df3f0.png)


## How was this patch tested?

unit tests, integration tests




