### PR TITLE
Handle jar path different spark versions; Redirect Spark Logs in Python

### DIFF
--- a/pyspark/bigdl/models/lenet/lenet5.py
+++ b/pyspark/bigdl/models/lenet/lenet5.py
@@ -69,9 +69,9 @@ if __name__ == "__main__":
     (options, args) = parser.parse_args(sys.argv)
 
     sc = SparkContext(appName="lenet5", conf=create_spark_conf())
+    redire_spark_logs()
+    show_bigdl_info_logs()
     init_engine()
-    print("Redirecting spark logs to "+os.getcwd()+"/bigdl.log")
-    redireSparkInfoLogs()
 
     if options.action == "train":
         def get_end_trigger():

--- a/pyspark/bigdl/models/lenet/lenet5.py
+++ b/pyspark/bigdl/models/lenet/lenet5.py
@@ -70,6 +70,7 @@ if __name__ == "__main__":
 
     sc = SparkContext(appName="lenet5", conf=create_spark_conf())
     init_engine()
+    redireSparkInfoLogs()
 
     if options.action == "train":
         def get_end_trigger():

--- a/pyspark/bigdl/models/lenet/lenet5.py
+++ b/pyspark/bigdl/models/lenet/lenet5.py
@@ -86,7 +86,6 @@ if __name__ == "__main__":
             .map(lambda rec_tuple: (normalizer(rec_tuple[0], mnist.TEST_MEAN, mnist.TEST_STD),
                                rec_tuple[1]))\
             .map(lambda t: Sample.from_ndarray(t[0], t[1]))
-
         optimizer = Optimizer(
             model=build_model(10),
             training_rdd=train_data,

--- a/pyspark/bigdl/models/lenet/lenet5.py
+++ b/pyspark/bigdl/models/lenet/lenet5.py
@@ -70,6 +70,7 @@ if __name__ == "__main__":
 
     sc = SparkContext(appName="lenet5", conf=create_spark_conf())
     init_engine()
+    print("Redirecting spark logs to "+os.getcwd()+"/bigdl.log")
     redireSparkInfoLogs()
 
     if options.action == "train":

--- a/pyspark/bigdl/models/rnn/rnnexample.py
+++ b/pyspark/bigdl/models/rnn/rnnexample.py
@@ -152,6 +152,8 @@ if __name__ == "__main__":
 
     sc = SparkContext(appName="simplernn_example",
                       conf=create_spark_conf())
+    redire_spark_logs()
+    show_bigdl_info_logs()
     init_engine()
 
     (train_rdd, val_rdd, vob_size) = prepare_data(sc, folder, vob_size, training_split)

--- a/pyspark/bigdl/models/textclassifier/textclassifier.py
+++ b/pyspark/bigdl/models/textclassifier/textclassifier.py
@@ -168,6 +168,8 @@ if __name__ == "__main__":
         training_split = 0.8
         sc = SparkContext(appName="text_classifier",
                           conf=create_spark_conf())
+        redire_spark_logs()
+        show_bigdl_info_logs()
         init_engine()
         train(sc,
               batch_size,

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -256,7 +256,7 @@ def init_engine(bigdl_type="float"):
 def redireSparkInfoLogs(disableRedirect="false", enableSparkLogRedirect="true",
                         logPath=os.getcwd()+"/bigdl.log", bigdl_type="float"):
     """
-    Redirect Spark INFO level logs to the specified path.
+    Redirect Spark logs to the specified path.
     :param disableRedirect: "true" to disable redirecting logs of Spark and BigDL; "false" to enable redirection
     :param enableSparkLogRedirect: "true" to enable redirecting logs of Spark to logFile; "false" otherwise
     :param logPath: file path for logs to be redirected

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -28,7 +28,7 @@ from pyspark.mllib.common import callJavaFunc
 from pyspark import SparkConf
 import numpy as np
 import threading
-from bigdl.util.engine import compare_version, get_bigdl_classpath
+from bigdl.util.engine import get_bigdl_classpath, is_spark_below_2_2_0
 
 INTMAX = 2147483647
 INTMIN = -2147483648
@@ -285,13 +285,8 @@ def create_spark_conf():
     bigdl_conf = get_bigdl_conf()
     sparkConf = SparkConf()
     sparkConf.setAll(bigdl_conf.items())
-    try:
-        import pyspark.version
-        spark_version = pyspark.version.__version__.split("+")[0]
-        if(compare_version(spark_version,"2.2.0")>=0):
-            add_driver_classpath(sparkConf, get_bigdl_classpath())
-    except ImportError:
-        pass
+    if not is_spark_below_2_2_0():
+        add_driver_classpath(sparkConf, get_bigdl_classpath())
     return sparkConf
 
 def get_spark_context(conf = None):

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -247,6 +247,9 @@ _picklable_classes = [
 
 def init_engine(bigdl_type="float"):
     callBigDlFunc(bigdl_type, "initEngine")
+    print('Setting current log level to "INFO"')
+    sc = get_spark_context()
+    sc.setLogLevel("INFO")
 
 
 def get_bigdl_conf():
@@ -276,10 +279,12 @@ def to_list(a):
         return a
     return [a]
 
+
 def extend_spark_driver_cp(sparkConf, path):
     original_driver_classpath = ":" + sparkConf.get("spark.driver.extraClassPath") \
         if sparkConf.contains("spark.driver.extraClassPath") else ""
     sparkConf.set("spark.driver.extraClassPath", path + original_driver_classpath)
+
 
 def create_spark_conf():
     bigdl_conf = get_bigdl_conf()
@@ -288,6 +293,7 @@ def create_spark_conf():
     if not is_spark_below_2_2_0():
         extend_spark_driver_cp(sparkConf, get_bigdl_classpath())
     return sparkConf
+
 
 def get_spark_context(conf = None):
     """

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -276,7 +276,7 @@ def to_list(a):
         return a
     return [a]
 
-def add_driver_classpath(sparkConf, path):
+def extend_spark_driver_cp(sparkConf, path):
     original_driver_classpath = ":" + sparkConf.get("spark.driver.extraClassPath") \
         if sparkConf.contains("spark.driver.extraClassPath") else ""
     sparkConf.set("spark.driver.extraClassPath", path + original_driver_classpath)
@@ -286,7 +286,7 @@ def create_spark_conf():
     sparkConf = SparkConf()
     sparkConf.setAll(bigdl_conf.items())
     if not is_spark_below_2_2_0():
-        add_driver_classpath(sparkConf, get_bigdl_classpath())
+        extend_spark_driver_cp(sparkConf, get_bigdl_classpath())
     return sparkConf
 
 def get_spark_context(conf = None):

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -253,6 +253,18 @@ def init_engine(bigdl_type="float"):
     sc.setLogLevel("INFO")
 
 
+def redireSparkInfoLogs(disableRedirect="false", enableSparkLogRedirect="true",
+                        logPath=os.getcwd()+"/bigdl.log", bigdl_type="float"):
+    """
+    Redirect Spark INFO level logs to the specified path.
+    :param disableRedirect: "true" to disable redirecting logs of Spark and BigDL; "false" to enable redirection
+    :param enableSparkLogRedirect: "true" to enable redirecting logs of Spark to logFile; "false" otherwise
+    :param logPath: file path for logs to be redirected
+    :param bigdl_type: "double" or "float"
+    """
+    callBigDlFunc(bigdl_type, "redirectSparkInfoLogs", disableRedirect, enableSparkLogRedirect, logPath)
+
+
 def get_bigdl_conf():
     bigdl_conf_file = "spark-bigdl.conf"
     bigdl_python_wrapper = "python-api.zip"

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -247,8 +247,8 @@ _picklable_classes = [
 
 def init_engine(bigdl_type="float"):
     callBigDlFunc(bigdl_type, "initEngine")
-    print('Setting current log level to "INFO"')
-    print("You can call setLogLevel on SparkContext to change log level if you wish.")
+    print('Setting current log level to "INFO".')
+    print("To adjust logging level use sc.setLogLevel(newLevel).")
     sc = get_spark_context()
     sc.setLogLevel("INFO")
 

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -28,7 +28,7 @@ from pyspark.mllib.common import callJavaFunc
 from pyspark import SparkConf
 import numpy as np
 import threading
-from bigdl.util.engine import get_bigdl_classpath, is_spark_below_2_2_0
+from bigdl.util.engine import get_bigdl_classpath, is_spark_below_2_2
 
 INTMAX = 2147483647
 INTMIN = -2147483648
@@ -247,23 +247,22 @@ _picklable_classes = [
 
 def init_engine(bigdl_type="float"):
     callBigDlFunc(bigdl_type, "initEngine")
-    print('Setting current log level to "INFO".')
-    print("To adjust logging level use sc.setLogLevel(newLevel).")
-    sc = get_spark_context()
-    sc.setLogLevel("INFO")
 
 
-def redireSparkInfoLogs(bigdl_type="float", disableRedirect="false",
-                        enableSparkLogRedirect="true",
-                        logPath=os.getcwd()+"/bigdl.log"):
+def redire_spark_logs(bigdl_type="float", logPath=os.getcwd()+"/bigdl.log"):
     """
     Redirect spark logs to the specified path.
     :param bigdl_type: "double" or "float"
-    :param disableRedirect: "false" by default to enable redirection; "true" to disable any redirection.
-    :param enableSparkLogRedirect: "false" will not output spark logs to file.
     :param logPath: the file path to be redirected to; the default file is under the current workspace named `bigdl.log`.
     """
-    callBigDlFunc(bigdl_type, "redirectSparkInfoLogs", disableRedirect, enableSparkLogRedirect, logPath)
+    callBigDlFunc(bigdl_type, "redirectSparkLogs", logPath)
+
+def show_bigdl_info_logs(bigdl_type="float"):
+    """
+    Set BigDL log level to INFO.
+    :param bigdl_type: "double" or "float"
+    """
+    callBigDlFunc(bigdl_type, "showBigDlInfoLogs")
 
 
 def get_bigdl_conf():
@@ -304,7 +303,7 @@ def create_spark_conf():
     bigdl_conf = get_bigdl_conf()
     sparkConf = SparkConf()
     sparkConf.setAll(bigdl_conf.items())
-    if not is_spark_below_2_2_0():
+    if not is_spark_below_2_2():
         extend_spark_driver_cp(sparkConf, get_bigdl_classpath())
     return sparkConf
 

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -276,11 +276,29 @@ def to_list(a):
         return a
     return [a]
 
+def add_cp(sparkConf,str):
+    original_driver_classpath = ":" + sparkConf.get("spark.driver.extraClassPath") \
+        if sparkConf.contains("spark.driver.extraClassPath") else ""
+    original_executor_classpath = ":" + sparkConf.get("spark.executor.extraClassPath") \
+        if sparkConf.contains("spark.executor.extraClassPath") else ""
+    sparkConf.set("spark.driver.extraClassPath", str + original_driver_classpath)
+    sparkConf.set("spark.executor.extraClassPath", str + original_executor_classpath)
+
+def add_cp_from_env(sparkConf):
+    if(os.getenv("BIGDL_CLASSPATH")):
+        add_cp(sparkConf, os.getenv("BIGDL_CLASSPATH"))
+
+def add_cp_from_pip(sparkConf):
+    jar_dir = os.path.abspath(__file__ + "/../../")
+    jar_paths = glob.glob(os.path.join(jar_dir, "share/lib/*.jar"))
+    if jar_paths:
+        add_cp(sparkConf,jar_paths[0])
 
 def create_spark_conf():
     bigdl_conf = get_bigdl_conf()
     sparkConf = SparkConf()
     sparkConf.setAll(bigdl_conf.items())
+    add_cp_from_env(sparkConf)
     return sparkConf
 
 def get_spark_context(conf = None):

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -248,6 +248,7 @@ _picklable_classes = [
 def init_engine(bigdl_type="float"):
     callBigDlFunc(bigdl_type, "initEngine")
     print('Setting current log level to "INFO"')
+    print("You can call setLogLevel on SparkContext to change log level if you wish.")
     sc = get_spark_context()
     sc.setLogLevel("INFO")
 

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -286,6 +286,7 @@ def add_cp(sparkConf,str):
 
 def add_cp_from_env(sparkConf):
     if(os.getenv("BIGDL_CLASSPATH")):
+        print(os.getenv("BIGDL_CLASSPATH"))
         add_cp(sparkConf, os.getenv("BIGDL_CLASSPATH"))
 
 def add_cp_from_pip(sparkConf):
@@ -298,7 +299,8 @@ def create_spark_conf():
     bigdl_conf = get_bigdl_conf()
     sparkConf = SparkConf()
     sparkConf.setAll(bigdl_conf.items())
-    add_cp_from_env(sparkConf)
+    add_cp_from_pip(sparkConf)
+    #add_cp_from_env(sparkConf)
     return sparkConf
 
 def get_spark_context(conf = None):

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -253,14 +253,15 @@ def init_engine(bigdl_type="float"):
     sc.setLogLevel("INFO")
 
 
-def redireSparkInfoLogs(disableRedirect="false", enableSparkLogRedirect="true",
-                        logPath=os.getcwd()+"/bigdl.log", bigdl_type="float"):
+def redireSparkInfoLogs(bigdl_type="float", disableRedirect="false",
+                        enableSparkLogRedirect="true",
+                        logPath=os.getcwd()+"/bigdl.log"):
     """
-    Redirect Spark logs to the specified path.
-    :param disableRedirect: "true" to disable redirecting logs of Spark and BigDL; "false" to enable redirection
-    :param enableSparkLogRedirect: "true" to enable redirecting logs of Spark to logFile; "false" otherwise
-    :param logPath: file path for logs to be redirected
+    Redirect spark logs to the specified path.
     :param bigdl_type: "double" or "float"
+    :param disableRedirect: "false" by default to enable redirection; "true" to disable any redirection.
+    :param enableSparkLogRedirect: "false" will not output spark logs to file.
+    :param logPath: the file path to be redirected to; the default file is under the current workspace named `bigdl.log`.
     """
     callBigDlFunc(bigdl_type, "redirectSparkInfoLogs", disableRedirect, enableSparkLogRedirect, logPath)
 

--- a/pyspark/bigdl/util/engine.py
+++ b/pyspark/bigdl/util/engine.py
@@ -46,13 +46,45 @@ def __prepare_bigdl_env():
         except KeyError:
             os.environ[env_var_name] = path
 
-    if conf_paths and conf_paths:
-        assert len(conf_paths) == 1, "Expecting one jar: %s" % len(jar_paths)
+    if jar_paths and conf_paths:
+        assert len(jar_paths) == 1, "Expecting one jar: %s" % len(jar_paths)
         assert len(conf_paths) == 1, "Expecting one conf: %s" % len(conf_paths)
-        #append_path("SPARK_CLASSPATH", jar_paths[0])
+        append_path("BIGDL_CLASSPATH", jar_paths[0])
         print("Prepending %s to sys.path" % conf_paths[0])
         sys.path.insert(0, conf_paths[0])
 
+    def set_spark_classpath(env_var_name):
+        try:
+            os.environ["SPARK_CLASSPATH"] = os.environ[env_var_name]
+        except KeyError:
+            pass
+
+    try:
+        import pyspark.version
+        spark_version = pyspark.version.__version__.split("+")[0]
+        if (compare_version(spark_version, "2.2.0") == -1):
+            set_spark_classpath("BIGDL_CLASSPATH")
+    except ImportError:
+        set_spark_classpath("BIGDL_CLASSPATH")
+
+def compare_version(version1, version2):
+    v1Arr = version1.split(".")
+    v2Arr = version2.split(".")
+    len1 = len(v1Arr)
+    len2 = len(v2Arr)
+    lenMax = max(len1, len2)
+    for x in range(lenMax):
+        v1Token = 0
+        if x < len1:
+            v1Token = int(v1Arr[x])
+        v2Token = 0
+        if x < len2:
+            v2Token = int(v2Arr[x])
+        if v1Token < v2Token:
+            return -1
+        if v1Token > v2Token:
+            return 1
+    return 0
 
 def prepare_env():
     __prepare_spark_env()

--- a/pyspark/bigdl/util/engine.py
+++ b/pyspark/bigdl/util/engine.py
@@ -50,26 +50,26 @@ def __prepare_bigdl_env():
         assert len(conf_paths) == 1, "Expecting one conf: %s" % len(conf_paths)
         print("Prepending %s to sys.path" % conf_paths[0])
         sys.path.insert(0, conf_paths[0])
-
-    try:
-        import pyspark.version
-        spark_version = pyspark.version.__version__.split("+")[0]
-        if (compare_version(spark_version, "2.2.0") == -1):
-            append_path("SPARK_CLASSPATH", BigDL_Classpath)
-    except ImportError:
+    if is_spark_below_2_2_0():
         append_path("SPARK_CLASSPATH", BigDL_Classpath)
 
 def get_bigdl_classpath():
-    try:
-        bigdl_classpath = os.environ["BIGDL_CLASSPATH"]
-    except KeyError:
-        bigdl_classpath = ""
+    if(os.getenv("BIGDL_CLASSPATH")):
+        return os.environ["BIGDL_CLASSPATH"]
     jar_dir = os.path.abspath(__file__ + "/../../")
     jar_paths = glob.glob(os.path.join(jar_dir, "share/lib/*.jar"))
     if jar_paths:
         assert len(jar_paths) == 1, "Expecting one jar: %s" % len(jar_paths)
-        bigdl_classpath = jar_paths[0] + ":" + bigdl_classpath
-    return bigdl_classpath
+        return jar_paths[0]
+    return ""
+
+def is_spark_below_2_2_0():
+    import pyspark
+    if(hasattr(pyspark,"version")):
+        spark_version = getattr(pyspark,"version").__version__.split("+")[0]
+        if(compare_version(spark_version, "2.2.0")>=0):
+            return False
+    return True
 
 def compare_version(version1, version2):
     v1Arr = version1.split(".")

--- a/pyspark/bigdl/util/engine.py
+++ b/pyspark/bigdl/util/engine.py
@@ -49,7 +49,7 @@ def __prepare_bigdl_env():
     if conf_paths and conf_paths:
         assert len(conf_paths) == 1, "Expecting one jar: %s" % len(jar_paths)
         assert len(conf_paths) == 1, "Expecting one conf: %s" % len(conf_paths)
-        append_path("SPARK_CLASSPATH", jar_paths[0])
+        #append_path("SPARK_CLASSPATH", jar_paths[0])
         print("Prepending %s to sys.path" % conf_paths[0])
         sys.path.insert(0, conf_paths[0])
 

--- a/pyspark/bigdl/util/engine.py
+++ b/pyspark/bigdl/util/engine.py
@@ -36,7 +36,7 @@ def __prepare_spark_env():
 def __prepare_bigdl_env():
     jar_dir = os.path.abspath(__file__ + "/../../")
     conf_paths = glob.glob(os.path.join(jar_dir, "share/conf/*.conf"))
-    BigDL_Classpath = get_bigdl_classpath()
+    bigdl_classpath = get_bigdl_classpath()
 
     def append_path(env_var_name, path):
         try:
@@ -51,7 +51,7 @@ def __prepare_bigdl_env():
         print("Prepending %s to sys.path" % conf_paths[0])
         sys.path.insert(0, conf_paths[0])
     if is_spark_below_2_2_0():
-        append_path("SPARK_CLASSPATH", BigDL_Classpath)
+        append_path("SPARK_CLASSPATH", bigdl_classpath)
 
 def get_bigdl_classpath():
     if(os.getenv("BIGDL_CLASSPATH")):
@@ -66,7 +66,7 @@ def get_bigdl_classpath():
 def is_spark_below_2_2_0():
     import pyspark
     if(hasattr(pyspark,"version")):
-        spark_version = getattr(pyspark,"version").__version__.split("+")[0]
+        spark_version = pyspark.__version__.split("+")[0]
         if(compare_version(spark_version, "2.2.0")>=0):
             return False
     return True

--- a/pyspark/bigdl/util/engine.py
+++ b/pyspark/bigdl/util/engine.py
@@ -51,11 +51,14 @@ def __prepare_bigdl_env():
         print("Prepending %s to sys.path" % conf_paths[0])
         sys.path.insert(0, conf_paths[0])
 
-    if is_spark_below_2_2_0():
+    if bigdl_classpath and is_spark_below_2_2():
         append_path("SPARK_CLASSPATH", bigdl_classpath)
 
 
 def get_bigdl_classpath():
+    """
+    Get and return the jar path for bigdl if exists.
+    """
     if(os.getenv("BIGDL_CLASSPATH")):
         return os.environ["BIGDL_CLASSPATH"]
     jar_dir = os.path.abspath(__file__ + "/../../")
@@ -66,16 +69,28 @@ def get_bigdl_classpath():
     return ""
 
 
-def is_spark_below_2_2_0():
+def is_spark_below_2_2():
+    """
+    Check if spark version is below 2.2
+    """
     import pyspark
     if(hasattr(pyspark,"version")):
-        spark_version = pyspark.version.__version__.split("+")[0]
-        if(compare_version(spark_version, "2.2.0")>=0):
+        full_version = pyspark.version.__version__
+        # We only need the general spark version (eg, 1.6, 2.2).
+        parts = full_version.split(".")
+        spark_version = parts[0] + "." + parts[1]
+        if(compare_version(spark_version, "2.2")>=0):
             return False
     return True
 
 
 def compare_version(version1, version2):
+    """
+    Compare version strings.
+    :param version1;
+    :param version2;
+    :return: 1 if version1 is after version2; -1 if version1 is before version2; 0 if two versions are the same.
+    """
     v1Arr = version1.split(".")
     v2Arr = version2.split(".")
     len1 = len(v1Arr)

--- a/pyspark/bigdl/util/engine.py
+++ b/pyspark/bigdl/util/engine.py
@@ -66,7 +66,7 @@ def get_bigdl_classpath():
 def is_spark_below_2_2_0():
     import pyspark
     if(hasattr(pyspark,"version")):
-        spark_version = pyspark.__version__.split("+")[0]
+        spark_version = pyspark.version.__version__.split("+")[0]
         if(compare_version(spark_version, "2.2.0")>=0):
             return False
     return True

--- a/pyspark/bigdl/util/engine.py
+++ b/pyspark/bigdl/util/engine.py
@@ -50,8 +50,10 @@ def __prepare_bigdl_env():
         assert len(conf_paths) == 1, "Expecting one conf: %s" % len(conf_paths)
         print("Prepending %s to sys.path" % conf_paths[0])
         sys.path.insert(0, conf_paths[0])
+
     if is_spark_below_2_2_0():
         append_path("SPARK_CLASSPATH", bigdl_classpath)
+
 
 def get_bigdl_classpath():
     if(os.getenv("BIGDL_CLASSPATH")):
@@ -63,6 +65,7 @@ def get_bigdl_classpath():
         return jar_paths[0]
     return ""
 
+
 def is_spark_below_2_2_0():
     import pyspark
     if(hasattr(pyspark,"version")):
@@ -70,6 +73,7 @@ def is_spark_below_2_2_0():
         if(compare_version(spark_version, "2.2.0")>=0):
             return False
     return True
+
 
 def compare_version(version1, version2):
     v1Arr = version1.split(".")
@@ -89,6 +93,7 @@ def compare_version(version1, version2):
         if v1Token > v2Token:
             return 1
     return 0
+
 
 def prepare_env():
     __prepare_spark_env()

--- a/pyspark/test/bigdl/test_simple_integration.py
+++ b/pyspark/test/bigdl/test_simple_integration.py
@@ -26,6 +26,7 @@ import numpy as np
 import tempfile
 import pytest
 from numpy.testing import assert_allclose
+from bigdl.util.engine import compare_version
 
 
 class TestSimple():
@@ -410,6 +411,14 @@ class TestSimple():
         tensors["tensor2"] = JTensor.from_ndarray(np.random.rand(3, 2))
         # in old impl, this will throw an exception
         _py2java(self.sc, tensors)
+
+    def test_compare_version(self):
+        assert compare_version("2.1.1", "2.2.0") == -1
+        assert compare_version("2.2.0", "1.6.2") == 1
+        assert compare_version("2.2.0", "2.2.0") == 0
+        assert compare_version("1.6.0", "2.1.0") == -1
+        assert compare_version("2.1.0", "2.1.1") == -1
+        assert compare_version("2.0.1", "1.5.2") == 1
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/pyspark/test/dev/prepare_env.sh
+++ b/pyspark/test/dev/prepare_env.sh
@@ -30,9 +30,8 @@ export PYSPARK_ZIP=`find $SPARK_HOME/python/lib  -type f -iname '*.zip' | tr "\n
 
 export PYTHONPATH=$PYSPARK_ZIP:$DL_PYTHON_HOME:$DL_PYTHON_HOME/:$DL_PYTHON_HOME/test/dev:$BIGDL_HOME/spark/dl/src/main/resources/spark-bigdl.conf
 
-export SPARK_CLASSPATH=$(find $BIGDL_HOME/spark/dl/target/ -name "*with-dependencies.jar" | head -n 1)
-echo "SPARK_CLASSPATH": $SPARK_CLASSPATH
-echo "PYTHONPATH" : $PYTHONPATH
+export BIGDL_CLASSPATH=$(find $BIGDL_HOME/spark/dl/target/ -name "*with-dependencies.jar" | head -n 1)
+echo "BIGDL_CLASSPATH": $BIGDL_CLASSPATH
 
 export PYTHON_EXECUTABLES=("python2.7" "python3.5")
 

--- a/pyspark/test/dev/prepare_env.sh
+++ b/pyspark/test/dev/prepare_env.sh
@@ -32,6 +32,7 @@ export PYTHONPATH=$PYSPARK_ZIP:$DL_PYTHON_HOME:$DL_PYTHON_HOME/:$DL_PYTHON_HOME/
 
 export SPARK_CLASSPATH=$(find $BIGDL_HOME/spark/dl/target/ -name "*with-dependencies.jar" | head -n 1)
 echo "SPARK_CLASSPATH": $SPARK_CLASSPATH
+echo "PYTHONPATH" : $PYTHONPATH
 
 export PYTHON_EXECUTABLES=("python2.7" "python3.5")
 

--- a/pyspark/test/dev/release/release.sh
+++ b/pyspark/test/dev/release/release.sh
@@ -25,7 +25,7 @@ BIGDL_PYTHON_DIR="$(cd ${RUN_SCRIPT_DIR}/../../../../pyspark; pwd)"
 echo $BIGDL_PYTHON_DIR
 
 if (( $# < 2)); then
-  echo "Bad parameters. Uasge: release.sh mac spark_2.x"
+  echo "Bad parameters. Usage: release.sh mac spark_2.x"
   exit -1
 fi
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -38,6 +38,7 @@ import com.intel.analytics.bigdl.nn.Graph._
 import com.intel.analytics.bigdl.nn.tf.{Const, Fill, Shape, SplitAndSelect}
 import com.intel.analytics.bigdl.utils.tf.TensorflowLoader.{buildBigDLModel, buildTFGraph, parse}
 import com.intel.analytics.bigdl.utils.tf.{BigDLSessionImpl, TensorflowDataFormat, TensorflowSaver}
+import org.apache.log4j._
 import org.apache.spark.SparkContext
 import org.tensorflow.framework.NodeDef
 
@@ -45,6 +46,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.language.existentials
 import scala.reflect.ClassTag
+
 
 /**
  * [[com.intel.analytics.bigdl.dataset.Sample]] for python.
@@ -1946,10 +1948,12 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
       alignCorner)
   }
 
-  def redirectSparkInfoLogs(disableRedirect: String,
-                            enableSparkLogRedirect: String,
-                            logPath: String): Unit = {
-    LoggerFilter.redirectSparkInfoLogs(disableRedirect, enableSparkLogRedirect, logPath)
+  def redirectSparkLogs(logPath: String): Unit = {
+    LoggerFilter.redirectSparkInfoLogs(logPath)
+  }
+
+  def showBigDlInfoLogs(): Unit = {
+    Logger.getLogger("com.intel.analytics.bigdl.optim").setLevel(Level.INFO)
   }
 
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -1945,4 +1945,11 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
       outputWidth,
       alignCorner)
   }
+
+  def redirectSparkInfoLogs(disableRedirect: String,
+                            enableSparkLogRedirect: String,
+                            logPath: String): Unit = {
+    LoggerFilter.redirectSparkInfoLogs(disableRedirect, enableSparkLogRedirect, logPath)
+  }
+
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/LoggerFilter.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/LoggerFilter.scala
@@ -80,19 +80,23 @@ object LoggerFilter {
     Logger.getLogger(className).addAppender(appender)
   }
 
+  private val defaultPath = Paths.get(System.getProperty("user.dir"), "bigdl.log").toString
+
   /**
    * 1. redirect all spark log to file, which can be set by `-Dbigdl.utils.LoggerFilter.logFile`
    *    the default file is under current workspace named `bigdl.log`.
    * 2. `-Dbigdl.utils.LoggerFilter.disable=true` will disable redirection.
    * 3. `-Dbigdl.utils.LoggerFilter.enableSparkLog=false` will not output spark log to file
    */
-  def redirectSparkInfoLogs(): Unit = {
-    val disable = System.getProperty("bigdl.utils.LoggerFilter.disable", "false")
-    val enableSparkLog = System.getProperty("bigdl.utils.LoggerFilter.enableSparkLog", "true")
+  def redirectSparkInfoLogs(disableRedirect: String = "false",
+                            enableSparkLogRedirect: String = "true",
+                            logPath: String = defaultPath): Unit = {
+    val disable = System.getProperty("bigdl.utils.LoggerFilter.disable", disableRedirect)
+    val enableSparkLog = System.getProperty("bigdl.utils.LoggerFilter.enableSparkLog",
+      enableSparkLogRedirect)
 
     def getLogFile: String = {
-      val default = Paths.get(System.getProperty("user.dir"), "bigdl.log").toString
-      val logFile = System.getProperty("bigdl.utils.LoggerFilter.logFile", default)
+      val logFile = System.getProperty("bigdl.utils.LoggerFilter.logFile", logPath)
 
       // If the file doesn't exist, create a new one. If it's a directory, throw an error.
       val logFilePath = Paths.get(logFile)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/LoggerFilter.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/LoggerFilter.scala
@@ -88,12 +88,9 @@ object LoggerFilter {
    * 2. `-Dbigdl.utils.LoggerFilter.disable=true` will disable redirection.
    * 3. `-Dbigdl.utils.LoggerFilter.enableSparkLog=false` will not output spark log to file
    */
-  def redirectSparkInfoLogs(disableRedirect: String = "false",
-                            enableSparkLogRedirect: String = "true",
-                            logPath: String = defaultPath): Unit = {
-    val disable = System.getProperty("bigdl.utils.LoggerFilter.disable", disableRedirect)
-    val enableSparkLog = System.getProperty("bigdl.utils.LoggerFilter.enableSparkLog",
-      enableSparkLogRedirect)
+  def redirectSparkInfoLogs(logPath: String = defaultPath): Unit = {
+    val disable = System.getProperty("bigdl.utils.LoggerFilter.disable", "false")
+    val enableSparkLog = System.getProperty("bigdl.utils.LoggerFilter.enableSparkLog", "true")
 
     def getLogFile: String = {
       val logFile = System.getProperty("bigdl.utils.LoggerFilter.logFile", logPath)


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Using SPARK_CLASSPATH or spark.driver.extraClassPath to input jar path for different spark versions.
2. Enable showing bigdl INFO logs and redirecting spark logs in Python. The behavior in Python and Scala are now the same.

## How was this patch tested?
Tested both locally (using spark 1.6.3, 2.0.0, 2.1.0, 2.2.0) and on Jenkins.
http://172.168.2.101:8080/view/PR-Validation/job/BigDL-PR-Validation/1915/