### PR TITLE
Support dynamic control flow in BigDL graph

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
@@ -17,9 +17,12 @@ package com.intel.analytics.bigdl.nn
 
 import java.util
 
+import com.intel.analytics.bigdl.Module
+
 import scala.collection.JavaConverters._
 import com.intel.analytics.bigdl.nn.Graph.ModuleNode
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, TensorModule}
+import com.intel.analytics.bigdl.nn.ops.ControlOps
 import com.intel.analytics.bigdl.nn.tf.{ControlDependency, WithoutInput}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
@@ -66,17 +69,18 @@ import org.tensorflow.framework.GraphDef
  */
 @SerialVersionUID(- 2896121321564992779L)
 class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
-    private val outputs : Seq[ModuleNode[T]],
-    private val variables: Option[(Array[Tensor[T]], Array[Tensor[T]])] = None)
-    (implicit ev: TensorNumeric[T])
+  private val outputs : Seq[ModuleNode[T]],
+  private val variables: Option[(Array[Tensor[T]], Array[Tensor[T]])] = None,
+  generateBackward: Boolean = true
+)(implicit ev: TensorNumeric[T])
     extends Container[Activity, Activity, T]{
 
   type absModule = AbstractModule[_ <: Activity, _ <: Activity, T]
 
   override def updateOutput(input: Activity): Activity = {
-    var i = 0
-    while(i < forwardExecutions.length) {
-      val node = forwardExecutions(i)
+    forwardScheduler.reset()
+    while (!forwardScheduler.isFinished()) {
+      val node = forwardScheduler.fetch()
       val nodeInput = if (node.prevNodes.isEmpty && !node.element.isInstanceOf[WithoutInput]) {
         inputData(node, input)
       } else {
@@ -95,8 +99,8 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
         }
       }
       node.element.forward(nodeInput)
-      inputsBP.put(node.element.getName(), nodeInput)
-      i += 1
+      inputCache(node.element.getName()) = nodeInput
+      forwardScheduler.schedule(node)
     }
 
     output = dummyOutput.element.output
@@ -104,20 +108,20 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
   }
 
   override def backward(input: Activity, gradOutput: Activity): Activity = {
+    if (!generateBackward) return null
+
     val before = System.nanoTime()
-    dummyOutputGrad.element.gradInput = gradOutput
+    backwardScheduler.reset()
+    while (!backwardScheduler.isFinished()) {
+      val curNode = backwardScheduler.fetch()
+      var curGradOutput : Activity = if (curNode.eq(dummyOutputGrad)) gradOutput else null
 
-    var i = 0
-    while (i < backwardExecutions.length) {
-      val curNode = backwardExecutions(i)
-      var curGradOutput : Activity = null
-
-      curNode.nextNodesAndEdges.filterNot(n => n._1.element.isInstanceOf[ControlDependency[T]])
+      curNode.prevNodesAndEdges.filterNot(n => n._1.element.isInstanceOf[ControlDependency[T]])
         .foreach(n => {
-        val otherActivity = if (n._1.element.gradInput.isTensor || n._1.prevEdges.length == 1) {
+        val otherActivity = if (n._1.element.gradInput.isTensor || n._1.nextEdges.length == 1) {
           n._1.element.gradInput
         } else {
-          val index = n._1.prevEdges.indexOf(n._2) + 1
+          val index = n._1.nextEdges.indexOf(n._2) + 1
           n._1.element.gradInput.toTable.apply[Activity](index)
         }
 
@@ -133,13 +137,13 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
         }
       })
 
-      gradOutputBP(i) = curGradOutput
+      gradOutputCache(curNode.element.getName()) = curGradOutput
       if (!isStopGradient(curNode.element)) {
-        curNode.element.backward(inputsBP.get(curNode.element.getName()), curGradOutput)
+        curNode.element.backward(inputCache(curNode.element.getName()), curGradOutput)
       } else {
-        curNode.element.accGradParameters(inputsBP.get(curNode.element.getName()), curGradOutput)
+        curNode.element.accGradParameters(inputCache(curNode.element.getName()), curGradOutput)
       }
-      i += 1
+      backwardScheduler.schedule(curNode)
     }
 
     gradInput = if (inputs.length == 1) {
@@ -176,41 +180,39 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
   }
 
   override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
-    dummyOutputGrad.element.gradInput = gradOutput
+    if (!generateBackward) return null
 
-    var i = 0
-    while (i < backwardExecutions.length) {
-      val curNode = backwardExecutions(i)
-      var curGradOutput : Activity = null
-      if (curNode.element.output.isTable) {
-        curGradOutput = T()
-      }
+    backwardScheduler.reset()
+    while (!backwardScheduler.isFinished()) {
+      val curNode = backwardScheduler.fetch()
+      var curGradOutput : Activity = if (curNode.eq(dummyOutputGrad)) gradOutput else null
 
-      curNode.nextNodesAndEdges
-        .filterNot(n => n._1.element.isInstanceOf[ControlDependency[T]])
+      curNode.prevNodesAndEdges.filterNot(n => n._1.element.isInstanceOf[ControlDependency[T]])
         .foreach(n => {
-        val otherActivity = if (n._1.element.gradInput.isTensor || n._1.prevEdges.length == 1) {
-          n._1.element.gradInput
-        } else {
-          val index = n._1.prevEdges.indexOf(n._2) + 1
-          n._1.element.gradInput.toTable.apply[Activity](index)
-        }
+          val otherActivity = if (n._1.element.gradInput.isTensor || n._1.nextEdges.length == 1) {
+            n._1.element.gradInput
+          } else {
+            val index = n._1.nextEdges.indexOf(n._2) + 1
+            n._1.element.gradInput.toTable.apply[Activity](index)
+          }
 
-        n._2.fromIndex match {
-          case Some(i) =>
-            val curActivity = curGradOutput.toTable.getOrElse[Activity](i, null)
-            curGradOutput.toTable(i) = accActivity(curActivity, otherActivity)
-          case None =>
-            curGradOutput = accActivity(curGradOutput, otherActivity)
-        }
-      })
+          n._2.fromIndex match {
+            case Some(i) =>
+              if (curNode.element.output.isTable && curGradOutput == null) {
+                curGradOutput = T()
+              }
+              val curActivity = curGradOutput.toTable.getOrElse[Activity](i, null)
+              curGradOutput.toTable(i) = accActivity(curActivity, otherActivity)
+            case None =>
+              curGradOutput = accActivity(curGradOutput, otherActivity)
+          }
+        })
 
-      gradOutputBP(i) = curGradOutput
-
+      gradOutputCache(curNode.element.getName()) = curGradOutput
       if (!isStopGradient(curNode.element)) {
-        curNode.element.updateGradInput(inputsBP.get(curNode.element.getName()), curGradOutput)
+        curNode.element.updateGradInput(inputCache(curNode.element.getName()), curGradOutput)
       }
-      i += 1
+      backwardScheduler.schedule(curNode)
     }
 
     gradInput = if (inputs.length == 1) {
@@ -223,9 +225,10 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
 
   override def accGradParameters(input: Activity, gradOutput: Activity): Unit = {
     var i = 0
-    while (i < backwardExecutions.length) {
-      val curNode = backwardExecutions(i)
-      curNode.element.accGradParameters(inputsBP.get(curNode.element.getName()), gradOutputBP(i))
+    while (i < backwardNodes.length) {
+      val curNode = backwardNodes(i)
+      curNode.element.accGradParameters(inputCache(curNode.element.getName()),
+        gradOutputCache(curNode.element.getName()))
       i += 1
     }
   }
@@ -255,42 +258,59 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
    * Computing backgraph
    */
   private val backGraph = dummyOutput.graph(reverse = true)
-  private var gradGraph: DirectedGraph[AbstractModule[Activity, Activity, T]] = null
+  private var gradGraph: DirectedGraph[AbstractModule[Activity, Activity, T]] = _
 
   /**
    * Execution plan
    */
-  private val forwardExecutions = backGraph.topologySort
-    .filterNot(_.element.isInstanceOf[ControlDependency[T]]).reverse
-  private var backwardExecutions: Array[Node[AbstractModule[Activity, Activity, T]]] = null
+  private val forwardNodes = backGraph.DFS
+    .filterNot(_.element.isInstanceOf[ControlDependency[T]]).toArray
+  private val forwardScheduler = new Scheduler(
+    forwardNodes.filter(_.prevNodes.length == 0),
+    Seq(dummyOutput)
+  )
 
-  modules.appendAll(forwardExecutions.filter(n => !n.eq(dummyOutput)).map(_.element))
+  private var backwardScheduler : Scheduler[T] = _
+  private var backwardNodes: Array[Node[AbstractModule[Activity, Activity, T]]] = _
+
+
+  modules.appendAll(forwardNodes.filter(n => !n.eq(dummyOutput)).map(_.element))
 
   /**
-   * build is needed when the stopGrad is changed
+   * Generate backward graph and apply the stopGrad
    */
   private[bigdl] def build(): this.type = {
-    val gradGraph = backGraph.cloneGraph()
+    val gradGraph = backGraph.cloneGraph(true)
     dummyOutputGrad = gradGraph.source
-    val nodes = gradGraph.DFS
-    nodes.filter(x => isStopGradient(x.element)).foreach(_.removePrevEdges())
-    backwardExecutions = gradGraph.topologySort.filter(n => !n.eq(dummyOutputGrad))
-      .filterNot(_.element.isInstanceOf[ControlDependency[T]])
+    val originalNodes = gradGraph.DFS
+    originalNodes.filter(x => isStopGradient(x.element)).foreach(_.removePrevEdges())
+    backwardNodes = gradGraph.DFS.filter(n => !n.eq(dummyOutputGrad))
+      .filterNot(_.element.isInstanceOf[ControlDependency[_]]).toArray
+    backwardScheduler = new Scheduler[T](
+      Seq(dummyOutputGrad),
+      backwardNodes.filter(_.nextNodes.length == 0)
+    )
     clearState()
     this
   }
 
 
-  private val inputsBP = new util.HashMap[String, Activity]()
+  private val inputCache = new mutable.HashMap[String, Activity]()
 
   // Check all inputs of the graph should be passed in
   checkRoots
-  build
+  if (generateBackward) {
+    forwardNodes.foreach(n => require(!n.element.isInstanceOf[ControlOps[_]],
+      "Not suppot generate back graph with control ops node"))
+    build()
+  }
 
-  private val gradOutputBP = new Array[Activity](forwardExecutions.length - 1)
+  private val gradOutputCache = new mutable.HashMap[String, Activity]()
 
   private def checkRoots: Unit = {
-    val roots = forwardExecutions.filter(_.prevNodes.size == 0)
+    require(forwardNodes.map(_.element.getName()).distinct.length == forwardNodes.length,
+      "the name of node in the graph should be unique")
+    val roots = forwardNodes.filter(_.prevNodes.size == 0)
       .filter(node => !node.element.isInstanceOf[WithoutInput])
     require(roots.size == inputs.length,
       s"There're ${inputs.length} inputs, but graph has ${roots.size} roots")
@@ -407,7 +427,7 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
    * @return
    */
   def getForwardExecutions: Array[Node[AbstractModule[Activity, Activity, T]]] = {
-    forwardExecutions.filter(n => !n.eq(dummyOutput))
+    forwardNodes.filter(n => !n.eq(dummyOutput))
   }
 
   @inline
@@ -468,9 +488,9 @@ object Graph extends ContainerSerializable {
    * @return a graph container
    */
   def apply[T: ClassTag](input : Array[ModuleNode[T]], output : Array[ModuleNode[T]],
-      variables: Option[(Array[Tensor[T]], Array[Tensor[T]])] = None)
-      (implicit ev: TensorNumeric[T]) : Graph[T] = {
-    new Graph[T](input, output, variables)
+      variables: Option[(Array[Tensor[T]], Array[Tensor[T]])] = None,
+    generateBackward: Boolean = true)(implicit ev: TensorNumeric[T]) : Graph[T] = {
+    new Graph[T](input, output, variables, generateBackward)
   }
 
   /**

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Scheduler.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Scheduler.scala
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn
+
+import com.intel.analytics.bigdl.Module
+import com.intel.analytics.bigdl.nn.Graph.ModuleNode
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
+import com.intel.analytics.bigdl.nn.ops._
+import com.intel.analytics.bigdl.nn.tf.WithoutInput
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.{Edge, Node, T}
+
+import scala.collection.mutable
+import scala.reflect.ClassTag
+
+/**
+ * Scheduler of a graph execution. It supports a graph with cycle. Please note that the cycle must
+ * be created from ControlNodes.while.
+ *
+ * Scheduler also records execution status. So some const graph won't be executed multiple times.
+ *
+ * @param inputNodes start nodes
+ * @param outputNodes target nodes
+ * @tparam T
+ */
+private[bigdl] class Scheduler[T](
+    inputNodes: Seq[ModuleNode[T]], outputNodes: Seq[ModuleNode[T]]
+  ) {
+
+  import Scheduler._
+
+  private val readyQueue = new mutable.Queue[ModuleNode[T]]()
+  private val nodeStatus = new NodeStatusManager[T]()
+
+  /**
+   * User must reset the scheduler after first use it or finish a graph execution
+   */
+  def reset(): Unit = {
+    readyQueue.clear()
+    inputNodes.foreach(n => {
+      readyQueue.enqueue(n)
+    })
+    nodeStatus.removeUnConstStatus()
+  }
+
+
+  /**
+   * If every output nodes is executed. Please note if some of the output nodes has not been
+   * executed but the execution can't move forward, an exception will be thrown
+   * @return
+   */
+  def isFinished(): Boolean = {
+    val isEmpty = readyQueue.isEmpty
+    if (isEmpty) {
+      outputNodes.foreach(n => {
+        require(!nodeStatus.notExecuted(n), "Some output nodes have not been executed")
+      })
+    }
+    isEmpty
+  }
+
+
+  /**
+   * Fetch a node to execute. Don't call it when isFinished is true, or it will throw an exception
+   * @return
+   */
+  def fetch(): ModuleNode[T] = {
+    var node = readyQueue.dequeue()
+    while (nodeStatus.isConst(node)) {
+      schedule(node)
+      node = readyQueue.dequeue()
+    }
+    node
+  }
+
+  /**
+   * Schedule nodes depend on the given node
+   * @param node
+   */
+  def schedule(node: ModuleNode[T]): Unit = {
+    // Update status of current node
+    node.element match {
+      case e: Enter[_] =>
+        require(node.prevNodes.length == 1, "Enter only accept one node input")
+        nodeStatus(node) = nodeStatus.stackIteration(nodeStatus(node.prevNodes.head))
+      case x: Exit[_] =>
+        require(node.prevNodes.length == 1, "Exit only accept one node input")
+        nodeStatus(node) = nodeStatus.unstackIteration(nodeStatus.iteration(node.prevNodes.head))
+      case n: NextIteration[_] =>
+        require(node.prevNodes.length == 1, "NextIteration only accept one node input")
+        val lastIteration = nodeStatus.iteration(node.prevNodes.head)
+        lastIteration.outOfDate = true
+        nodeStatus(node) = Iteration(lastIteration.prev)
+      case _ =>
+        nodeStatus(node) = if (node.prevNodes.length == 0) {
+          if (node.element.isInstanceOf[com.intel.analytics.bigdl.nn.tf.Const[_]]) {
+            Const()
+          } else {
+            Ready()
+          }
+        } else {
+          val constNodes = node.prevNodes.filter(nodeStatus.isConst(_))
+          if (constNodes.length == node.prevNodes.length) {
+            Const()
+          } else {
+            val iterationNodes = node.prevNodes.filter(nodeStatus.isIteration(_))
+              .filter(!nodeStatus.iteration(_).outOfDate)
+              .filter(!_.element.isInstanceOf[LoopCondition[_]])
+            if (iterationNodes.length == 0) {
+              Ready()
+            } else {
+              nodeStatus.iteration(iterationNodes.head)
+            }
+          }
+        }
+    }
+
+    // Schedule next nodes
+    node.element match {
+      case s: SwitchOps[_] =>
+        val switchNode = node.asInstanceOf[SwitchControlNode[Module[T]]]
+        selectNexts(switchNode.availableNodes(), node)
+      case _ =>
+        selectNexts(node.nextNodes, node)
+    }
+  }
+
+  private def selectNexts(candidateNodes: Seq[ModuleNode[T]], curNode: ModuleNode[T]): Unit = {
+    candidateNodes.foreach(nextNode => {
+      if (nextNode.element.isInstanceOf[MergeOps[_]]) {
+        val merge = nextNode.element.asInstanceOf[MergeOps[_]]
+        require(nodeStatus.notExecuted(nextNode), s"Merge node(${nextNode.element.getName()}) " +
+          s"should not be executed twice out of loop or in a same iteration of a loop")
+        merge.setSwitch(nextNode.prevNodes.indexOf(curNode) + 1)
+        readyQueue.enqueue(nextNode)
+      } else {
+        if (isNodeReady(nextNode)) {
+          readyQueue.enqueue(nextNode)
+        }
+      }
+    })
+  }
+
+  private def isNodeReady(node: ModuleNode[T]): Boolean = {
+    if (node.prevNodes.filter(nodeStatus.notExecuted(_)).length != 0) {
+      return false
+    }
+    node.prevNodes.filter(_.isInstanceOf[SwitchControlNode[_]]).foreach(n => {
+      if (!n.asInstanceOf[SwitchControlNode[T]].availableNodes().contains(node)) {
+        return false
+      }
+    })
+
+    return true
+  }
+}
+
+object Scheduler {
+  // Default parent of iteration status
+  private val DEFAULT_ITERATION = Iteration(null)
+
+  class NodeStatusManager[T] {
+    private val nodeStatus = new mutable.HashMap[String, NodeStatus]()
+
+    /**
+     * Create an iteration status. Its parent status will be the given status if the given status
+     * is Iteration; Or the parent status will point to the DEFAULT_ITERATION
+     * @param status
+     * @return
+     */
+    def stackIteration(status: NodeStatus): Iteration = {
+      val parent = status match {
+        case i: Iteration => i
+        case _ => DEFAULT_ITERATION
+      }
+      Iteration(parent)
+    }
+
+    /**
+     * Create a node status from an iteration status. If the iteration status parent is
+     * DEFAULT_STATUS, return a new Ready status, or return parent iteration
+     * @param status
+     * @return
+     */
+    def unstackIteration(status: Iteration): NodeStatus = {
+      if (status.prev.eq(DEFAULT_ITERATION)) {
+        Ready()
+      } else {
+        status.prev
+      }
+    }
+
+    /**
+     * Update node status
+     * @param node
+     * @param status
+     */
+    def update(node: ModuleNode[T], status: NodeStatus): Unit = {
+      require(node != null && status != null, "Not accept null")
+      nodeStatus(node.element.getName()) = status
+    }
+
+    /**
+     * Get status of node. Throw exception if it doesn't exist.
+     * @param node
+     * @return
+     */
+    def apply(node: ModuleNode[T]): NodeStatus = {
+      nodeStatus(node.element.getName())
+    }
+
+    /**
+     * Check if a given node status is const
+     * @param node
+     * @return
+     */
+    def isConst(node: ModuleNode[T]): Boolean = {
+      nodeStatus.contains(node.element.getName()) &&
+        nodeStatus(node.element.getName()).isInstanceOf[Const]
+    }
+
+    /**
+     * Check if a given node status is iteration
+     * @param node
+     * @return
+     */
+    def isIteration(node: ModuleNode[T]): Boolean = {
+      nodeStatus.contains(node.element.getName()) &&
+        nodeStatus(node.element.getName()).isInstanceOf[Iteration]
+    }
+
+    /**
+     * If the given node has been executed or out of date
+     * @param node
+     * @return
+     */
+    def notExecuted(node: ModuleNode[T]): Boolean = {
+      if (!nodeStatus.contains(node.element.getName())) return true
+      if (nodeStatus(node.element.getName()).isInstanceOf[Iteration] &&
+        nodeStatus(node.element.getName()).asInstanceOf[Iteration].outOfDate) {
+        return true
+      }
+      return false
+    }
+
+    /**
+     * Get current node status. It must be Iteration or exception is thrown
+     * @param node
+     * @return
+     */
+    def iteration(node: ModuleNode[T]): Iteration = {
+      nodeStatus(node.element.getName()).asInstanceOf[Iteration]
+    }
+
+    /**
+     * Remove unconst node status
+     * @return
+     */
+    def removeUnConstStatus(): this.type = {
+      val iter = nodeStatus.iterator
+      while (iter.hasNext) {
+        val entry = iter.next()
+        if (!entry._2.isInstanceOf[Const]) {
+          nodeStatus.remove(entry._1)
+        }
+      }
+      this
+    }
+  }
+
+
+  /**
+   * Node status
+   */
+  private[nn] sealed trait NodeStatus
+
+  /**
+   * Current node is const or all of its dependencies are from const node
+   */
+  private[nn] case class Const() extends NodeStatus
+
+  /**
+   * Current nodes has been executed, while it's not const
+   */
+  private[nn] case class Ready() extends NodeStatus
+
+  /**
+   * Current node is in a loop
+   * @param outOfDate is out of date
+   * @param prev the stacked iteration for nested loop
+   */
+  private[nn] case class Iteration(val prev: Iteration, var outOfDate: Boolean = false)
+    extends NodeStatus
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ops/ControlOps.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ops/ControlOps.scala
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.ops
+
+import com.intel.analytics.bigdl._
+import com.intel.analytics.bigdl.nn.Graph._
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.{Edge, Node, T}
+
+import scala.reflect.ClassTag
+
+/**
+ *  Control flow related operations
+ * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
+ */
+sealed abstract class ControlOps[T: ClassTag]()(implicit ev: TensorNumeric[T])
+  extends Operation[Activity, Activity, T] {
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    throw new UnsupportedOperationException("Operation does not support updateGradInput() method")
+  }
+  override def accGradParameters(input: Activity, gradOutput: Activity): Unit = {
+    throw new UnsupportedOperationException("Operation does not support updateGradInput() method")
+  }
+  override def backward(input: Activity, gradOutput: Activity): Activity = {
+    throw new UnsupportedOperationException("Operation does not support backward() method")
+  }
+}
+
+/**
+ * Control flow related operations, and they just pass the input without modifying them
+ * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
+ */
+abstract class IdentityControl[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends ControlOps[T] {
+  override def updateOutput(input: Activity): Activity = {
+    output = input
+    output
+  }
+}
+
+/**
+ * Mark start of next iteration. User should use ControlNodes.whileLoop to use such operation.
+ * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
+ */
+class NextIteration[T: ClassTag] private[ops]()(implicit ev: TensorNumeric[T])
+  extends IdentityControl[T]
+
+/**
+ * Mark start of a loop. User should use ControlNodes.whileLoop to use such operation.
+ * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
+ */
+class Enter[T: ClassTag] private[ops]()(implicit ev: TensorNumeric[T]) extends IdentityControl[T]
+
+/**
+ * Mark this dataflow is condition flow. It will erase the iteration status.
+ * User should use ControlNodes.whileLoop to use such operation.
+ * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
+ */
+class LoopCondition[T: ClassTag] private[ops]()(implicit ev: TensorNumeric[T])
+  extends IdentityControl[T]
+
+/**
+ * Mark end of a loop. User should use ControlNodes.whileLoop to use such operation.
+ * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
+ */
+class Exit[T: ClassTag] private[ops]()(implicit ev: TensorNumeric[T]) extends IdentityControl[T]
+
+/**
+ * Switch the control flow. It will construct a table. It accepts a table input containing two
+ * elements. The first element is a boolean scalar. The second element is the data.
+ * It produces a table output containing two elements. If the boolean scalar is true, the first
+ * element of the output is data and the second one is null; if the boolean scala is false, the
+ * position is exchanged.
+ *
+ * When connect to some other node. You should never connect the whole output to other node. You
+ * should always use SwitchNodeOutput(1) and SwitchNodeOutput(2). Or there will be run time failure.
+ *
+ * User should use ControlNodes.whileLoop or ControlNodes.switch to use this operation
+ * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
+ */
+private[nn] class SwitchOps[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends ControlOps[T] {
+  override def updateOutput(input: Activity): Activity = {
+    val condition = input.toTable[Tensor[Boolean]](1)
+    val data = input.toTable[Activity](2)
+    if (condition.valueAt(1)) {
+      this.output = T(data, null)
+    } else {
+      this.output = T(null, data)
+    }
+    this.output
+  }
+}
+
+/**
+ * MergeOps will run as soon as one of the node dependency is ready. and pass the data from that
+ * node. If the MergeOps is not in a loop, it should only be executed once. If it's in a loop, it
+ * should be still executed once in a iteration.
+ *
+ * User should use ControlNodes.whileLoop or ControlNodes.merge to use this operation
+ * @param switch which dependency node is avaliable
+ * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
+ */
+private[nn] class MergeOps[T: ClassTag](private var switch : Int = 1)(
+  implicit ev: TensorNumeric[T]) extends ControlOps[T] {
+
+  def setSwitch(s: Int) : this.type = {
+    this.switch = s
+    this
+  }
+
+  override def updateOutput(input: Activity): Activity = {
+    this.output = input.toTable[Activity](switch)
+    this.output
+  }
+
+  override def toString(): String = getPrintName() + s"($switch)"
+}
+
+/**
+ * A wrapper of node for switch operation. Make code easy to read.
+ *
+ * @param element element
+ * @tparam T element type
+ */
+sealed class SwitchControlNode[T] private[ops] (element: T) extends Node[T](element) {
+
+  /**
+   * The output edge which will be run when condition scalar is true. You should not connect one
+   * node with both type edges.
+   * @return
+   */
+  def trueEdge() : ((Node[T], Int)) = (this, 1)
+
+  /**
+   * The output edge which will be run when condition scalar is false. You should not connect one
+   * node with both type edges.
+   * @return
+   */
+  def falseEdge() : ((Node[T], Int)) = (this, 2)
+
+  /**
+   * Return nodes triggered by current node
+   * @return
+   */
+  def availableNodes() : Seq[Node[T]] = {
+    val bothNodes = this.nextNodesAndEdges.filter(_._2.fromIndex.isEmpty).map(_._1).distinct
+    require(bothNodes.length == 0, "You should not connect to one node with both type of edges")
+
+    val trueNodes = this.nextNodesAndEdges.filter(_._2.fromIndex.get == 1).map(_._1).distinct
+    val falseNodes = this.nextNodesAndEdges.filter(_._2.fromIndex.get == 2).map(_._1).distinct
+    trueNodes.foreach( n =>
+      require(!falseNodes.contains(n),
+        "You should not connect to one node with both type of edges")
+    )
+
+    val swtich = element.asInstanceOf[SwitchOps[T]]
+    if (swtich.output.toTable(1) == null) {
+      falseNodes
+    } else {
+      trueNodes
+    }
+  }
+}
+
+/**
+ * A wrapper of node for merge operation.
+ *
+ * @param element element
+ * @tparam T element type
+ */
+sealed class MergeControlNode[T] private[ops] (element: T) extends Node[T](element) {
+
+  /**
+   * Add another dependency node
+   * @param dependency
+   * @return
+   */
+  def append(dependency: Node[T]): this.type = {
+    dependency -> this
+    this
+  }
+
+  /**
+   * Add another dependency node with edge
+   * @param dependencyIndex
+   * @return
+   */
+  def append(dependencyIndex: (Node[T], Int)): this.type = {
+    dependencyIndex._1.add(this, Edge(dependencyIndex._2))
+    this
+  }
+}
+
+/**
+ * Factory method of control flow related nodes
+ */
+object ControlNodes {
+
+  /**
+   * Create a switch node
+   * @param data data to pass down
+   * @param condition condition node, should pass in a boolean scalar
+   * @param ev
+   * @tparam T
+   * @return
+   */
+  def switch[T: ClassTag](data: ModuleNode[T], condition: ModuleNode[T]
+  )(implicit ev: TensorNumeric[T]): SwitchControlNode[Module[T]] = {
+    val curNode = new SwitchControlNode[Module[T]](new SwitchOps())
+    condition -> curNode
+    data -> curNode
+    curNode
+  }
+
+  /**
+   * Create a switch node
+   * @param data data to pass down, from an edge
+   * @param condition data to pass down, from an edge
+   * @param ev
+   * @tparam T
+   * @return
+   */
+  def switch[T: ClassTag](data: (ModuleNode[T], Int), condition: (ModuleNode[T], Int)
+  )(implicit ev: TensorNumeric[T]): SwitchControlNode[Module[T]] = {
+    val curNode = new SwitchControlNode[Module[T]](new SwitchOps())
+    data._1.add(curNode, Edge(data._2))
+    condition._1.add(curNode, Edge(data._2))
+    curNode
+  }
+
+  /**
+   * Create a merge node
+   * @param first dependency node, for method overload
+   * @param nodesWithIndex dependency nodes
+   * @param ev
+   * @tparam T
+   * @return
+   */
+  def merge[T: ClassTag](first: (ModuleNode[T], Int), nodesWithIndex : (ModuleNode[T], Int)*)(
+    implicit ev: TensorNumeric[T]): MergeControlNode[Module[T]] = {
+    val curNode = new MergeControlNode[Module[T]](new MergeOps())
+    first._1.add(curNode, Edge(first._2))
+    nodesWithIndex.foreach(nodeWithIndex => {
+      nodeWithIndex._1.add(curNode, Edge(nodeWithIndex._2))
+    })
+    curNode
+  }
+
+  /**
+   * Create a merge node
+   * @param nodes dependency nodes
+   * @param ev
+   * @tparam T
+   * @return
+   */
+  def merge[T: ClassTag](nodes : ModuleNode[T]*)(
+    implicit ev: TensorNumeric[T]): MergeControlNode[Module[T]] = {
+    val curNode = new MergeControlNode[Module[T]](new MergeOps())
+    nodes.foreach(node => {
+      node.add(curNode, Edge())
+    })
+    curNode
+  }
+
+  /**
+   * Constructor a while loop in the graph
+   * @param condition a sub graph produce a boolean scalar
+   * @param body while body, input/output tuple. body length is seq of nodes with same length of
+   *             loopVars
+   * @param loopVars loop vars
+   * @tparam T
+   * @return a seq of nodes with same length of loopVars
+   */
+  def whileLoop[T: ClassTag](
+    condition: (Seq[ModuleNode[T]], ModuleNode[T]),
+    body: Seq[(ModuleNode[T], ModuleNode[T])],
+    loopVars: (Seq[ModuleNode[T]]),
+    name: String = null
+  )(implicit ev: TensorNumeric[T]): Seq[ModuleNode[T]] = {
+    val lc = new LoopCondition[T]().inputs(condition._2)
+    if (name != null) lc.element.setName(s"$name/loopCondition")
+
+    loopVars.zip(condition._1).zip(body).zipWithIndex.map(tuple => {
+      val (((input, cond), update), indexBase0) = tuple
+      val index = indexBase0 + 1
+      val enter = new Enter[T]().inputs(input)
+      if (name != null) enter.element.setName(s"$name/enter$index")
+      val mergeNode = merge[T](enter)
+      if (name != null) mergeNode.element.setName(s"$name/merge$index")
+      mergeNode -> cond
+      val switchNode = switch[T](mergeNode, lc)
+      if (name != null) switchNode.element.setName(s"$name/switch$index")
+      val exitNode = new Exit[T]().inputs(switchNode.trueEdge())
+      if (name != null) exitNode.element.setName(s"$name/exit$index")
+      val identity = Identity[T]().inputs(switchNode.falseEdge())
+      if (name != null) identity.element.setName(s"$name/switchFalse$index")
+      identity -> update._1
+      val nextIteration = new NextIteration[T].inputs(update._2)
+      if (name != null) nextIteration.element.setName(s"$name/nextIteration$index")
+      mergeNode.append(nextIteration)
+      exitNode
+    })
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
@@ -125,26 +125,37 @@ class DirectedGraph[T](val source : Node[T], val reverse : Boolean = false) exte
       }
     }
   }
+  // scalastyle:on methodName
 
   /**
    * Clone the graph structure, will not clone the node element
-   * @return new graph
+   * @param reverseEdge if reverse the edge in the nodes
+   * @return
    */
-  def cloneGraph(): DirectedGraph[T] = {
+  def cloneGraph(reverseEdge: Boolean = false): DirectedGraph[T] = {
     val oldToNew = new util.HashMap[Node[T], Node[T]]()
     val bfs = BFS.toArray
     bfs.foreach(node => {
       oldToNew.put(node, new Node[T](node.element))
     })
     bfs.foreach(node => {
-      node.prevNodesAndEdges.foreach(prevNodeAndEdge => {
-        oldToNew.get(prevNodeAndEdge._1).add(oldToNew.get(node), prevNodeAndEdge._2)
-      })
+      if (reverseEdge) {
+        node.prevNodesAndEdges.foreach(prevNodeAndEdge => {
+          oldToNew.get(node).add(oldToNew.get(prevNodeAndEdge._1), prevNodeAndEdge._2)
+        })
+      } else {
+        node.prevNodesAndEdges.foreach(prevNodeAndEdge => {
+          oldToNew.get(prevNodeAndEdge._1).add(oldToNew.get(node), prevNodeAndEdge._2)
+        })
+      }
     })
-    new DirectedGraph[T](oldToNew.get(source), reverse)
-  }
 
-  // scalastyle:on methodName
+    if (reverseEdge) {
+      new DirectedGraph[T](oldToNew.get(source), !reverse)
+    } else {
+      new DirectedGraph[T](oldToNew.get(source), reverse)
+    }
+  }
 }
 
 /**
@@ -214,6 +225,12 @@ class Node[T](val element: T) extends Serializable {
     node
   }
 
+  def from(node: Node[T], e: Edge = Edge()): Node[T] = {
+    if (!node.nexts.contains((this, e))) node.nexts.append((this, e))
+    if (!this.prevs.contains((node, e))) this.prevs.append((node, e))
+    node
+  }
+
   /**
    * Remove linkage with another node
    *  @param node another node
@@ -279,7 +296,11 @@ object Node {
  * An edge in the graph
  * @param fromIndex A preserved position to store meta info.
  */
-private[bigdl] class Edge private (val fromIndex: Option[Int]) extends Serializable
+private[bigdl] class Edge private (val fromIndex: Option[Int]) extends Serializable {
+  override def toString: String = {
+    s"Edge(fromIndex: $fromIndex)"
+  }
+}
 
 object Edge {
   def apply(value : Int): Edge = new Edge(Some(value))

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/DirectedGraphSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/DirectedGraphSpec.scala
@@ -334,6 +334,25 @@ class DirectedGraphSpec extends FlatSpec with Matchers {
     })
   }
 
+  "Reverse graph" should "be correct" in {
+    val nodeA = new Node("A")
+    val nodeB = new Node("B")
+    val nodeC = new Node("C")
+    val nodeD = new Node("D")
+    nodeA -> nodeB -> nodeC
+    nodeB -> nodeD
+
+    val graph = nodeA.graph()
+    val reverseGraph = graph.cloneGraph(true)
+    val originSort = graph.topologySort
+    val sorted = reverseGraph.topologySort
+    originSort.map(_.element) should be(sorted.map(_.element))
+    originSort(1).nextNodes.length should be(2)
+    originSort(1).prevNodes.length should be(1)
+    sorted(1).nextNodes.length should be(1)
+    sorted(1).prevNodes.length should be(2)
+  }
+
   "delete edge" should "be correct when specify edge" in {
     val e1 = Edge(1)
     val e2 = Edge(2)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Instead of using top sort, this PR implement a scheduler which can support dynamic path execution in BigDL graph. Some control flow related ops are also included in this PR(switch, merge, enter loop, exit loop, next iteration, loop condition). Users should not create these nodes directly, but use them through provided API.

Another improvement in this PR is that for const nodes, or node can be inferred by const nodes, the scheduler won't execute them multiple times.

Because of the overhead of the scheduler, comparing to a static graph, the performance is a little decrease in testing, see below(single core, warm up 20, avg 20)

AlexNet 4x3x227x227 forward+backward before(334ms), after(380ms)
Inception 4x3x224x224 forward+backward before(745ms), after(770ms)
ResNet20 4x3x224x224 forward before(1045ms), after(1201ms)
Lenet 32x28x28 forward+backward before(13ms), after(16.79013465ms)

## How was this patch tested?
unit tests

