### PR TITLE
fix scalar api

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
@@ -539,6 +539,12 @@ private[tensor] class DenseTensor[@specialized(Float, Double) T: ClassTag](
     this._storage(offset)
   }
 
+  override def valueAt(): T = {
+    require(0 == this.nDimension, s"invalid size: 0 == ${this.nDimension}")
+    var offset = this._storageOffset
+    this._storage(offset)
+  }
+
   override def valueAt(d1: Int): T = {
     require(1 == this.nDimension, s"invalid size: 1 == ${this.nDimension}")
     var offset = this._storageOffset

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
@@ -539,7 +539,7 @@ private[tensor] class DenseTensor[@specialized(Float, Double) T: ClassTag](
     this._storage(offset)
   }
 
-  override def valueAt(): T = {
+  override def value(): T = {
     require(0 == this.nDimension, s"invalid size: 0 == ${this.nDimension}")
     var offset = this._storageOffset
     this._storage(offset)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
@@ -183,7 +183,10 @@ trait Tensor[T] extends Serializable with TensorMath[T] with Activity {
   def apply(indexes: Array[Int]): T
 
 
-  def valueAt(): T
+  /**
+   * @return the value of a scalar. Requires the tensor to be a scalar.
+   */
+  def value(): T
 
   /**
    * Query the value on a given position. The number of parameters

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
@@ -182,6 +182,9 @@ trait Tensor[T] extends Serializable with TensorMath[T] with Activity {
    */
   def apply(indexes: Array[Int]): T
 
+
+  def valueAt(): T
+
   /**
    * Query the value on a given position. The number of parameters
    * should be equal to the dimension number of the tensor.
@@ -190,7 +193,6 @@ trait Tensor[T] extends Serializable with TensorMath[T] with Activity {
    * @param d1,( d2, d3, d4, d5) the given position
    * @return the value on a given position
    */
-
   def valueAt(d1: Int): T
 
   def valueAt(d1: Int, d2: Int): T
@@ -909,12 +911,6 @@ object Tensor {
    */
   def apply[@specialized(Float, Double) T: ClassTag](other: Tensor[T])(
     implicit ev: TensorNumeric[T]): Tensor[T] = new DenseTensor(other)
-
-  def apply[@specialized(Float, Double) T: ClassTag](value: T)(
-    implicit ev: TensorNumeric[T]): Tensor[T] = {
-    new DenseTensor[T](new ArrayStorage[T](Array(value)), 0, Array[Int](),
-      Array[Int](), 0)
-  }
 
   /**
    * create a tensor with a given breeze vector. The tensor will have the same size

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/TensorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/TensorSpec.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.tensor
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class TensorSpec extends FlatSpec with Matchers {
+
+  "Tensor factory method" should "be able to construct scalar" in {
+    val tensor = Tensor[Int](Array(4), Array[Int]())
+    tensor.valueAt() should be (4)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/TensorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/TensorSpec.scala
@@ -21,7 +21,7 @@ class TensorSpec extends FlatSpec with Matchers {
 
   "Tensor factory method" should "be able to construct scalar" in {
     val tensor = Tensor[Int](Array(4), Array[Int]())
-    tensor.valueAt() should be (4)
+    tensor.value() should be (4)
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. remove the Tensor factory method that is ambiguous with original ones
2. add a convenient valueAt method to return a scalar value  

## How was this patch tested?

add unit tests


