### PR TITLE
[WIP] Use MKL method to implement a 'lazy' gradient zero

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Bilinear.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Bilinear.scala
@@ -179,12 +179,24 @@ class Bilinear[T: ClassTag](
       while (k < (weight.size(1) + 1)) {
         buff1.zero()
         buff1.cmul(res1, gradOutput.narrow(2, k, 1).expandAs(res1))
-        gradWeight.select(1, k).addmm(ev.fromType[Double](scaleW), buff1.t(), input(2))
+        if (zeroGradFlag) {
+          gradWeight.select(1, k).addmm(ev.fromType[Double](0.0),
+            ev.fromType[Double](scaleW), buff1.t(), input(2))
+        } else {
+          gradWeight.select(1, k).addmm(ev.fromType[Double](scaleW), buff1.t(), input(2))
+        }
         k += 1
       }
     }
 
-    if(null != bias && scaleB != 0) gradBias.add(ev.fromType[Double](scaleB), gradOutput.sum(1))
+    if(null != bias && scaleB != 0) {
+      if (zeroGradFlag) {
+        gradBias.map(gradOutput.sum(1),
+          (_, y) => (ev.times(ev.fromType[Double](scaleB), y)))
+      } else {
+        gradBias.add(ev.fromType[Double](scaleB), gradOutput.sum(1))
+      }
+    }
 
     if (wRegularizer != null && scaleW != 0) {
       wRegularizer.accRegularization(weight, gradWeight, scaleW)
@@ -192,12 +204,9 @@ class Bilinear[T: ClassTag](
     if (bRegularizer != null && scaleB != 0) {
       bRegularizer.accRegularization(bias, gradBias, scaleB)
     }
+    zeroGradFlag = false
   }
 
-  override def zeroGradParameters(): Unit = {
-    gradWeight.zero()
-    gradBias.zero()
-  }
 
   override def clearState(): this.type = {
     super.clearState()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Bilinear.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Bilinear.scala
@@ -191,8 +191,7 @@ class Bilinear[T: ClassTag](
 
     if(null != bias && scaleB != 0) {
       if (zeroGradFlag) {
-        gradBias.map(gradOutput.sum(1),
-          (_, y) => (ev.times(ev.fromType[Double](scaleB), y)))
+        gradBias.mul(gradOutput.sum(1), ev.fromType[Double](scaleB))
       } else {
         gradBias.add(ev.fromType[Double](scaleB), gradOutput.sum(1))
       }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CMul.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CMul.scala
@@ -146,8 +146,7 @@ class CMul[T: ClassTag](
           i += 1
         }
         if (zeroGradFlag) {
-          gradWeight.map(sumFrom,
-            (_, y) => (ev.times(ev.fromType[Double](scaleW), y)))
+          gradWeight.mul(sumFrom, ev.fromType[Double](scaleW))
         } else {
           gradWeight.add(ev.fromType[Double](scaleW), sumFrom)
         }
@@ -155,8 +154,7 @@ class CMul[T: ClassTag](
         _repeat.resizeAs(input).cmul(input, gradOutput)
         _sum.sum(_repeat, 1)
         if (zeroGradFlag) {
-          gradWeight.map(_sum,
-            (_, y) => (ev.times(ev.fromType[Double](scaleW), y)))
+          gradWeight.mul(_sum, ev.fromType[Double](scaleW))
         } else {
           gradWeight.add(ev.fromType[Double](scaleW), _sum)
         }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Linear.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Linear.scala
@@ -141,20 +141,38 @@ class Linear[T: ClassTag](
 
     if (input.dim() == 1) {
       if (scaleW != 0) {
-        gradWeight.addr(ev.fromType[Double](scaleW), gradOutput, input)
+        if (zeroGradFlag) {
+          gradWeight.addr(ev.fromType[Double](0.0), gradOutput, ev.fromType[Double](scaleW), input)
+        } else {
+          gradWeight.addr(ev.fromType[Double](scaleW), gradOutput, input)
+        }
       }
 
       if (withBias && scaleB != 0) {
-        gradBias.add(ev.fromType[Double](scaleB), gradOutput)
+        if (zeroGradFlag) {
+          gradBias.mul(gradOutput, ev.fromType[Double](scaleB))
+        } else {
+          gradBias.add(ev.fromType[Double](scaleB), gradOutput)
+        }
       }
     }
     else if (input.dim() == 2) {
       if (scaleW != 0) {
-        gradWeight.addmm(ev.fromType[Double](scaleW), gradOutput.t, input)
+        if (zeroGradFlag) {
+          gradWeight.addmm(ev.fromType[Double](0.0),
+            ev.fromType[Double](scaleW), gradOutput.t, input)
+        } else {
+          gradWeight.addmm(ev.fromType[Double](scaleW), gradOutput.t, input)
+        }
       }
 
       if (withBias && scaleB != 0) {
-        gradBias.addmv(ev.fromType[Double](scaleB), gradOutput.t, addBuffer)
+        if (zeroGradFlag) {
+          gradBias.addmv(ev.fromType[Double](0.0),
+            ev.fromType[Double](scaleB), gradOutput.t, addBuffer)
+        } else {
+          gradBias.addmv(ev.fromType[Double](scaleB), gradOutput.t, addBuffer)
+        }
       }
     }
 
@@ -164,6 +182,7 @@ class Linear[T: ClassTag](
     if (null != bRegularizer && scaleB != 0) {
       bRegularizer.accRegularization(bias, gradBias, scaleB)
     }
+    zeroGradFlag = false
   }
 
   override def updateParameters(learningRate: T): Unit = {
@@ -173,11 +192,10 @@ class Linear[T: ClassTag](
 
   override def zeroGradParameters(): Unit = {
     gradWeight.resize(outputSize, inputSize)
-    gradWeight.zero()
     if (withBias) {
       gradBias.resize(outputSize)
-      gradBias.zero()
     }
+    zeroGradFlag = true
   }
 
   override def clearState() : this.type = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -69,6 +69,13 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag,
   var gradInput: A = Activity[A, T]()
 
   /**
+   * The flag of zero gradient.
+   * The accumulated gradients should be reset to zero if it is true.
+   * It should be reset to false after updating the gradients.
+   */
+  private var zeroGradFlag: Boolean = false
+
+  /**
    * The scale of gradient weight and gradient bias
    * before gradParameters being accumulated.
    */
@@ -290,10 +297,9 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag,
   def accGradParameters(input: A, gradOutput: B): Unit = {}
 
   /**
-   * If the module has parameters, this will zero the accumulation of the gradients with respect
-   * to these parameters. Otherwise, it does nothing.
+   * It will only set the flag without actually reset a gradients to zero
    */
-  def zeroGradParameters(): Unit = {}
+  def zeroGradParameters(): Unit = { zeroGradFlag = true }
 
   def updateParameters(learningRate: T): Unit = {}
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -73,7 +73,7 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag,
    * The accumulated gradients should be reset to zero if it is true.
    * It should be reset to false after updating the gradients.
    */
-  private var zeroGradFlag: Boolean = false
+  protected var zeroGradFlag: Boolean = false
 
   /**
    * The scale of gradient weight and gradient bias

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/TensorMath.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/TensorMath.scala
@@ -454,7 +454,7 @@ trait TensorMath[T] {
    */
   def addr(t1: Tensor[T], t2: Tensor[T]): Tensor[T]
 
-  def addr(v1: T, t1: Tensor[T], t2: Tensor[T]): Tensor[T]
+  def addr(v2: T, t1: Tensor[T], t2: Tensor[T]): Tensor[T]
 
   def addr(v1: T, t1: Tensor[T], v2: T, t2: Tensor[T]): Tensor[T]
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/AddSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/AddSpec.scala
@@ -54,5 +54,11 @@ class AddSpec extends FlatSpec with Matchers {
     gradInput1 should be (gradInput2)
 
     layer2.gradBias should be (layer1.gradBias.mul(2))
+
+    // test zeroGradParameters here
+    layer2.zeroGradParameters()
+    layer2.backward(input, gradOutput)
+    layer2.gradBias should be (layer1.gradBias)
+
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/BatchNormalizationSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/BatchNormalizationSpec.scala
@@ -159,6 +159,56 @@ class BatchNormalizationSpec extends FlatSpec with Matchers {
     bn.gradBias(Array(3)) should be(1.8 +- 0.0001)
   }
 
+  "A BatchNormalization zero gradients" should "clean gradient" in {
+    val bn = new BatchNormalization[Double](3)
+    bn.weight(1) = 0.1
+    bn.weight(2) = 0.2
+    bn.weight(3) = 0.3
+
+    bn.bias(1) = 0.1
+    bn.bias(2) = 0.2
+    bn.bias(3) = 0.3
+    val input = Tensor[Double](3, 3)
+    var i = 0
+    input.apply1(_ => {
+      i += 1; i
+    })
+    bn.forward(input)
+
+    val gradOutput = Tensor[Double](3, 3)
+    var j = 0.0
+    gradOutput.apply1(_ => {
+      j += 0.1; j
+    })
+    bn.backward(input, gradOutput)
+
+    bn.gradWeight.nDimension() should be(1)
+    bn.gradWeight.size(1) should be(3)
+    bn.gradWeight(Array(1)) should be(0.7348 +- 0.0001)
+    bn.gradWeight(Array(2)) should be(0.7348 +- 0.0001)
+    bn.gradWeight(Array(3)) should be(0.7348 +- 0.0001)
+
+    bn.gradBias.nDimension() should be(1)
+    bn.gradBias.size(1) should be(3)
+    bn.gradBias(Array(1)) should be(1.2 +- 0.0001)
+    bn.gradBias(Array(2)) should be(1.5 +- 0.0001)
+    bn.gradBias(Array(3)) should be(1.8 +- 0.0001)
+
+    bn.zeroGradParameters()
+    bn.backward(input, gradOutput)
+    bn.gradWeight.nDimension() should be(1)
+    bn.gradWeight.size(1) should be(3)
+    bn.gradWeight(Array(1)) should be(0.7348 +- 0.0001)
+    bn.gradWeight(Array(2)) should be(0.7348 +- 0.0001)
+    bn.gradWeight(Array(3)) should be(0.7348 +- 0.0001)
+
+    bn.gradBias.nDimension() should be(1)
+    bn.gradBias.size(1) should be(3)
+    bn.gradBias(Array(1)) should be(1.2 +- 0.0001)
+    bn.gradBias(Array(2)) should be(1.5 +- 0.0001)
+    bn.gradBias(Array(3)) should be(1.8 +- 0.0001)
+  }
+
   "A BatchNormalization evaluating" should "generate correct output" in {
     val bn = new BatchNormalization[Double](3)
     bn.weight(1) = 0.1

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/BilinearSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/BilinearSpec.scala
@@ -50,5 +50,10 @@ class BilinearSpec extends FlatSpec with Matchers {
     gradInput1 should be (gradInput2)
 
     layer2.gradBias should be (layer1.gradBias.mul(2))
+
+    layer2.zeroGradParameters()
+    layer2.backward(input, gradOutput)
+    layer2.gradBias should be (layer1.gradBias)
+    layer2.gradWeight should be (layer1.gradWeight)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/CMulSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/CMulSpec.scala
@@ -49,5 +49,9 @@ class CMulSpec extends FlatSpec with Matchers {
     gradInput1 should be (gradInput2)
 
     layer2.gradWeight should be (layer1.gradWeight.mul(0.5))
+
+    layer2.zeroGradParameters()
+    layer2.backward(input, gradOutput)
+    layer2.gradWeight should be (layer1.gradWeight)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/CosineSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/CosineSpec.scala
@@ -49,5 +49,9 @@ class CosineSpec extends FlatSpec with Matchers {
     gradInput1 should be (gradInput2)
 
     layer2.gradWeight should be (layer1.gradWeight.mul(2))
+
+    layer2.zeroGradParameters()
+    layer2.backward(input, gradOutput)
+    layer2.gradWeight should be (layer1.gradWeight)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
@@ -386,6 +386,52 @@ class LinearSpec extends FlatSpec with Matchers {
 
     linear2.gradWeight should be(linear.gradWeight.mul(0.5))
     linear2.gradBias should be(linear.gradBias.mul(2))
+
+  }
+
+  "Linear zero gradient " should "be correct" in {
+    val weight = Tensor[Double](T(
+      T(1.0, 2.0, 3.0),
+      T(4.0, 5.0, 6.0)
+    ))
+    val bias = Tensor[Double](T(7.0, 8.0))
+    val linear = new Linear[Double](inputSize = 3, outputSize = 2,
+      initWeight = weight, initBias = bias)
+    val linear2 = linear.cloneModule().asInstanceOf[Linear[Double]].setScaleB(2.0).setScaleW(0.5)
+
+    val input = Tensor[Double](T(0.1, 0.2, 0.3))
+
+    val output1 = linear.forward(input)
+    linear2.forward(input)
+
+    val gradOutput = Tensor(output1)
+    linear.backward(input, gradOutput)
+    linear2.backward(input, gradOutput)
+    linear2.gradWeight should be(linear.gradWeight.mul(0.5))
+    linear2.gradBias should be(linear.gradBias.mul(2))
+
+    linear.zeroGradParameters()
+    linear2.zeroGradParameters()
+    linear.backward(input, gradOutput)
+    linear2.backward(input, gradOutput)
+    linear2.gradWeight should be(linear.gradWeight.mul(0.5))
+    linear2.gradBias should be(linear.gradBias.mul(2))
+
+
+    val input2 = Tensor[Double](T(
+      T(0.1, 0.2, 0.3),
+      T(1.0, 2.0, 3.0)
+    ))
+    // val input2 = Tensor[Double](2, 3).rand()
+    val output2 = linear.forward(input2)
+    linear2.forward(input2)
+    val gradOutput2 = Tensor(output2)
+    linear.zeroGradParameters()
+    linear2.zeroGradParameters()
+    linear.backward(input2, gradOutput2)
+    linear2.backward(input2, gradOutput2)
+    linear2.gradWeight should be(linear.gradWeight.mul(0.5))
+    linear2.gradBias should be(linear.gradBias.mul(2))
   }
 
   "Xavier" should "init right in SpatialConvolution" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialConvolutionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialConvolutionSpec.scala
@@ -2025,6 +2025,15 @@ class SpatialConvolutionSpec extends FlatSpec with Matchers {
     layer.gradWeight(Array(1, 1, 1, 2, 2)) should be(77)
 
     layer.gradBias(Array(1)) should be(10)
+
+    layer.zeroGradParameters()
+    layer.backward(input, gradOutput)
+    layer.gradWeight(Array(1, 1, 1, 1, 1)) should be(37)
+    layer.gradWeight(Array(1, 1, 1, 1, 2)) should be(47)
+    layer.gradWeight(Array(1, 1, 1, 2, 1)) should be(67)
+    layer.gradWeight(Array(1, 1, 1, 2, 2)) should be(77)
+
+    layer.gradBias(Array(1)) should be(10)
   }
 
   it should "generate correct gradWeight when group != 1" in {
@@ -2118,6 +2127,15 @@ class SpatialConvolutionSpec extends FlatSpec with Matchers {
     layer.updateGradInput(input, gradOutput)
     layer.accGradParameters(input, gradOutput)
 
+    layer.gradWeight(Array(1, 1, 1, 1, 1)) should be(37 * 3)
+    layer.gradWeight(Array(1, 1, 1, 1, 2)) should be(47 * 3)
+    layer.gradWeight(Array(1, 1, 1, 2, 1)) should be(67 * 3)
+    layer.gradWeight(Array(1, 1, 1, 2, 2)) should be(77 * 3)
+
+    layer.gradBias(Array(1)) should be(10 * 3)
+
+    layer.zeroGradParameters()
+    layer.backward(input, gradOutput)
     layer.gradWeight(Array(1, 1, 1, 1, 1)) should be(37 * 3)
     layer.gradWeight(Array(1, 1, 1, 1, 2)) should be(47 * 3)
     layer.gradWeight(Array(1, 1, 1, 2, 1)) should be(67 * 3)
@@ -2286,6 +2304,29 @@ class SpatialConvolutionSpec extends FlatSpec with Matchers {
     layer.gradWeight(Array(1, 2, 2, 1, 2)) should be(47)
     layer.gradWeight(Array(1, 2, 2, 2, 1)) should be(67)
     layer.gradWeight(Array(1, 2, 2, 2, 2)) should be(77)
+    layer.gradBias(Array(1)) should be (10)
+    layer.gradBias(Array(2)) should be (10)
+
+    layer.zeroGradParameters()
+    layer.backward(input, gradOutput)
+    layer.gradWeight(Array(1, 1, 1, 1, 1)) should be(37)
+    layer.gradWeight(Array(1, 1, 1, 1, 2)) should be(47)
+    layer.gradWeight(Array(1, 1, 1, 2, 1)) should be(67)
+    layer.gradWeight(Array(1, 1, 1, 2, 2)) should be(77)
+    layer.gradWeight(Array(1, 1, 2, 1, 1)) should be(37)
+    layer.gradWeight(Array(1, 1, 2, 1, 2)) should be(47)
+    layer.gradWeight(Array(1, 1, 2, 2, 1)) should be(67)
+    layer.gradWeight(Array(1, 1, 2, 2, 2)) should be(77)
+    layer.gradWeight(Array(1, 2, 1, 1, 1)) should be(37)
+    layer.gradWeight(Array(1, 2, 1, 1, 2)) should be(47)
+    layer.gradWeight(Array(1, 2, 1, 2, 1)) should be(67)
+    layer.gradWeight(Array(1, 2, 1, 2, 2)) should be(77)
+    layer.gradWeight(Array(1, 2, 2, 1, 1)) should be(37)
+    layer.gradWeight(Array(1, 2, 2, 1, 2)) should be(47)
+    layer.gradWeight(Array(1, 2, 2, 2, 1)) should be(67)
+    layer.gradWeight(Array(1, 2, 2, 2, 2)) should be(77)
+    layer.gradBias(Array(1)) should be (10)
+    layer.gradBias(Array(2)) should be (10)
   }
 
   "A SpatialConvolution with different input/output plane" should "get correct gradWeight" in {
@@ -2378,6 +2419,38 @@ class SpatialConvolutionSpec extends FlatSpec with Matchers {
     layer.gradWeight(Array(1, 3, 2, 1, 2)) should be(47)
     layer.gradWeight(Array(1, 3, 2, 2, 1)) should be(67)
     layer.gradWeight(Array(1, 3, 2, 2, 2)) should be(77)
+    layer.gradBias(Array(1)) should be(10)
+    layer.gradBias(Array(2)) should be(10)
+    layer.gradBias(Array(3)) should be(10)
+
+    layer.zeroGradParameters()
+    layer.gradWeight(Array(1, 1, 1, 1, 1)) should be(37)
+    layer.gradWeight(Array(1, 1, 1, 1, 2)) should be(47)
+    layer.gradWeight(Array(1, 1, 1, 2, 1)) should be(67)
+    layer.gradWeight(Array(1, 1, 1, 2, 2)) should be(77)
+    layer.gradWeight(Array(1, 1, 2, 1, 1)) should be(37)
+    layer.gradWeight(Array(1, 1, 2, 1, 2)) should be(47)
+    layer.gradWeight(Array(1, 1, 2, 2, 1)) should be(67)
+    layer.gradWeight(Array(1, 1, 2, 2, 2)) should be(77)
+    layer.gradWeight(Array(1, 2, 1, 1, 1)) should be(37)
+    layer.gradWeight(Array(1, 2, 1, 1, 2)) should be(47)
+    layer.gradWeight(Array(1, 2, 1, 2, 1)) should be(67)
+    layer.gradWeight(Array(1, 2, 1, 2, 2)) should be(77)
+    layer.gradWeight(Array(1, 2, 2, 1, 1)) should be(37)
+    layer.gradWeight(Array(1, 2, 2, 1, 2)) should be(47)
+    layer.gradWeight(Array(1, 2, 2, 2, 1)) should be(67)
+    layer.gradWeight(Array(1, 2, 2, 2, 2)) should be(77)
+    layer.gradWeight(Array(1, 3, 1, 1, 1)) should be(37)
+    layer.gradWeight(Array(1, 3, 1, 1, 2)) should be(47)
+    layer.gradWeight(Array(1, 3, 1, 2, 1)) should be(67)
+    layer.gradWeight(Array(1, 3, 1, 2, 2)) should be(77)
+    layer.gradWeight(Array(1, 3, 2, 1, 1)) should be(37)
+    layer.gradWeight(Array(1, 3, 2, 1, 2)) should be(47)
+    layer.gradWeight(Array(1, 3, 2, 2, 1)) should be(67)
+    layer.gradWeight(Array(1, 3, 2, 2, 2)) should be(77)
+    layer.gradBias(Array(1)) should be(10)
+    layer.gradBias(Array(2)) should be(10)
+    layer.gradBias(Array(3)) should be(10)
   }
 
   "A SpatialConvolution" should "generate correct gradWeight gradBias output gradInput" in {
@@ -2518,6 +2591,17 @@ class SpatialConvolutionSpec extends FlatSpec with Matchers {
       0.44375239087041, 0.2308612946304, 0.278725442139
     )
     val gradWeight = Tensor[Double](Storage(gradWeightData), 1, Array(3, 2, 2, 3))
+    module.gradBias.map(gradBias, (v1, v2) => {
+      assert(abs(v1 - v2) < 1e-6);
+      v1
+    })
+    module.gradWeight.map(gradWeight, (v1, v2) => {
+      assert(abs(v1 - v2) < 1e-6);
+      v1
+    })
+
+    module.zeroGradParameters()
+    module.backward(input, gradOutput)
     module.gradBias.map(gradBias, (v1, v2) => {
       assert(abs(v1 - v2) < 1e-6);
       v1
@@ -2928,6 +3012,12 @@ class SpatialConvolutionSpec extends FlatSpec with Matchers {
 
     layer2.gradWeight should be (layer1.gradWeight.mul(2))
     layer2.gradBias should be (layer1.gradBias.mul(0.5))
+
+    layer2.zeroGradParameters()
+    layer2.backward(input, gradOutput)
+    layer2.gradWeight should be (layer1.gradWeight)
+    layer2.gradBias should be (layer1.gradBias)
+
   }
 
   "A SpatialConvolution layer without bias" should "generate correct output" in {


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Remove `tensor.fill(0)` when the `zeroGradParameters` is called. Instead, only a flag named  `zeroGradFlag` is set to be `true` and then this method return instantly.
2. The clearance of gradient parameter is finished in `accGradParameters`. The different MKL math functions are called with different parameters according to `zeroGradFlag`.
3. `zeroGradFlag` is set to `false` after each `accGradParameters`.
3. Add corresponding unit tests or test cases.

## How was this patch tested?

unit tests


