### PR TITLE
support multi output in graph follow up

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
@@ -323,6 +323,13 @@ private[bigdl] class Edge private (val fromIndex: Option[Int]) extends Serializa
   override def toString: String = {
     s"Edge(fromIndex: $fromIndex)"
   }
+
+  def newInstance(): Edge = {
+    fromIndex match {
+      case Some(index) => Edge(index)
+      case None => Edge()
+    }
+  }
 }
 
 object Edge {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
@@ -324,6 +324,10 @@ private[bigdl] class Edge private (val fromIndex: Option[Int]) extends Serializa
     s"Edge(fromIndex: $fromIndex)"
   }
 
+  /**
+   * Create a new Instance of this Edge
+   * @return a new Instance of this Edge
+   */
   def newInstance(): Edge = {
     fromIndex match {
       case Some(index) => Edge(index)

--- a/spark/dl/src/test/resources/tf/models/decoder.py
+++ b/spark/dl/src/test/resources/tf/models/decoder.py
@@ -21,6 +21,7 @@ from util import run_model
 
 def main():
 
+    tf.set_random_seed(1)
     n_steps = 2
     n_input = 10
     n_hidden = 10
@@ -41,6 +42,7 @@ def main():
         outputs.append(output)
 
     final = tf.identity(outputs, name="output")
+
     net_outputs = map(lambda x: tf.get_default_graph().get_tensor_by_name(x), argv[2].split(','))
     run_model(net_outputs, argv[1], 'rnn', argv[3] == 'True')
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoaderSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoaderSpec.scala
@@ -114,7 +114,7 @@ class TensorflowLoaderSpec extends TensorflowSpecHelper{
     val resource = getClass().getClassLoader().getResource("tf")
     val path = processPath(resource.getPath()) + JFile.separator + "test.pb"
     val results = TensorflowLoader.parse(path)
-    val (tfGraph, _) = TensorflowLoader.buildTFGraph(results, Seq("output"))
+    val (tfGraph, _, _) = TensorflowLoader.buildTFGraph(results, Seq("output"))
     tfGraph.size should be(15)  // there's a dummy output
     val topSort = tfGraph.topologySort// It can do topology sort
     topSort.length should be(15)
@@ -139,7 +139,7 @@ class TensorflowLoaderSpec extends TensorflowSpecHelper{
     val resource = getClass().getClassLoader().getResource("tf")
     val path = processPath(resource.getPath()) + JFile.separator + "test.pb"
     val results = TensorflowLoader.parse(path)
-    val (tfGraph, _) = TensorflowLoader.buildTFGraph(results, Seq("output"),
+    val (tfGraph, _, _) = TensorflowLoader.buildTFGraph(results, Seq("output"),
       (node: NodeDef) => node.getName == "Tanh")
     tfGraph.size should be(9)  // there's a dummy output
     val topSort = tfGraph.topologySort// It can do topology sort
@@ -522,7 +522,7 @@ class TensorflowLoaderSpec extends TensorflowSpecHelper{
     val tfNodes = TensorflowLoader.parse(modelFile)
 
     // filter node for gradient computing
-    val (tfGraph, inputs) =
+    val (tfGraph, inputs, _) =
       TensorflowLoader.buildTFGraph(tfNodes, endPoints.map(_.split(":")(0)),
         (node: NodeDef) => node.getName == "input_node")
     val context =


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Use new multi output node graph api in tensorflow loader
2. Support the scenario where some output tensor are not connected to any following nodes.
3. Fix match graph bug:
    We cannot connect bigdl module node when we traversing and matching the tf graph, for that way we 
    cannot enforce the same input order. We should connect bigdl module node when all the tf graph 
    nodes are converted. 
 

## How was this patch tested?

existing tests


