### PR TITLE
Support Tensorflow Preprocessing

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/ColorJitter.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/ColorJitter.scala
@@ -95,7 +95,7 @@ class ColorJitter extends Transformer[LabeledBGRImage, LabeledBGRImage] {
     val order = Tensor.randperm[Float](3)
     var i = 1
     while (i <= order.size(1)) {
-      val idx = order(i).valueAt(1).toInt
+      val idx = order(i).value().toInt
       ts(idx)(input)
       i += 1
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
@@ -297,8 +297,7 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
   /**
    * Execution plan
    */
-  private val forwardNodes = backGraph.DFS
-    .filterNot(_.element.isInstanceOf[ControlDependency[T]]).toArray
+  private val forwardNodes = backGraph.DFS.toArray
   private val forwardScheduler = new Scheduler(
     forwardNodes.filter(_.prevNodes.length == 0),
     Seq(dummyOutput)
@@ -347,7 +346,8 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
     require(forwardNodes.map(_.element.getName()).distinct.length == forwardNodes.length,
       "the name of node in the graph should be unique")
     val roots = forwardNodes.filter(_.prevNodes.size == 0)
-      .filter(node => !node.element.isInstanceOf[WithoutInput])
+      .filter(node => !node.element.isInstanceOf[WithoutInput]
+        && !node.element.isInstanceOf[ControlDependency[_]])
     require(roots.size == inputs.length,
       s"There're ${inputs.length} inputs, but graph has ${roots.size} roots")
     inputs.foreach(n =>

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ops/Rank.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ops/Rank.scala
@@ -25,8 +25,11 @@ class Rank[T: ClassTag]()
   (implicit ev: TensorNumeric[T]) extends Operation[Tensor[_], Tensor[Int], T] {
 
   override def updateOutput(input: Tensor[_]): Tensor[Int] = {
-    output.resizeAs(input(1))
-    output.setValue(1, input.nDimension())
+    if (output.getType() != IntType) {
+      output = Tensor[Int]()
+    }
+    output.resize(Array[Int]())
+    output.setValue(input.nDimension())
 
     output
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -1716,12 +1716,13 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
                samples: JavaRDD[Sample],
                optMethod: OptimMethod[T],
                criterion: Criterion[T],
-               batchSize: Int, endWhen: Trigger): AbstractModule[Activity, Activity, T] = {
+               batchSize: Int,
+               endWhen: Trigger): AbstractModule[Activity, Activity, T] = {
     val nodeList = parse(modelPath)
 
     val context =
       new mutable.HashMap[String, (Tensor[T], Tensor[T], Option[Seq[(Int, Int)]])]()
-    val session = new BigDLSessionImpl[T](nodeList.asScala, context)
+    val session = new BigDLSessionImpl[T](nodeList.asScala, samples.sparkContext, context)
     val dataset = batching(samples, batchSize)
 
     val model = session.train(Seq(output), dataset,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
@@ -370,7 +370,7 @@ private[tensor] class DenseTensor[@specialized(Float, Double) T: ClassTag](
     val _dimension = dim - 1
     val _sliceIndex = index - 1
 
-    require(this.nDimension > 0, "empty or scalar tensor")
+    require(this.nDimension > 0, "empty or scalar tensor cannot be selected")
     val result = DenseTensor.newWithTensor(this)
     DenseTensor.select(result, null, _dimension, _sliceIndex)
     result

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
@@ -1006,6 +1006,11 @@ object Tensor {
     apply(Storage(matrix.toArray), 1, Array(matrix.numRows, matrix.numCols), strides)
   }
 
+  def scalar[T: ClassTag](value: T)(
+    implicit ev: TensorNumeric[T]): Tensor[T] = {
+    Tensor[T](Array(value), Array[Int]())
+  }
+
   /**
    * This is equivalent to DenseTensor.randperm[T](size)
    *

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
@@ -1006,6 +1006,10 @@ object Tensor {
     apply(Storage(matrix.toArray), 1, Array(matrix.numRows, matrix.numCols), strides)
   }
 
+  /**
+   * Create a scalar tensor of this value
+   * @return the created scalar tensor
+   */
   def scalar[T: ClassTag](value: T)(
     implicit ev: TensorNumeric[T]): Tensor[T] = {
     Tensor[T](Array(value), Array[Int]())

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
@@ -325,6 +325,18 @@ object T {
   }
 
   /**
+   * Construct a table from an array
+   *
+   * The index + 1 will be used as the key
+   *
+   * @param data
+   * @return
+   */
+  def seq(data: Seq[Any]): Table = {
+    new Table(data.toArray)
+  }
+
+  /**
    * Construct a table from a sequence of pair.
    */
   def apply(tuple: Tuple2[Any, Any], tuples: Tuple2[Any, Any]*): Table = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
@@ -289,6 +289,25 @@ class Table private[bigdl](
     new Table(newState)
   }
 
+  /**
+   * Return the elements of this table as a Seq.
+   * This method assumes the key of this table are all
+   * the integers between 1 to this.length(),
+   * the values are all Tensor[T]
+   */
+  def toSeq[T]: Seq[Tensor[T]] = {
+    for (i <- 0 until this.length()) yield {
+      try {
+        this(i + 1).asInstanceOf[Tensor[T]]
+      } catch {
+        case e: NoSuchElementException =>
+          throw new UnsupportedOperationException("toSeq requires the key of this table are" +
+            " all the integers between 1 to this.length()", e)
+      }
+
+    }
+  }
+
   override def toTensor[D]
   (implicit ev: TensorNumeric[D]): Tensor[D] =
     throw new IllegalArgumentException("Table cannot be cast to Tensor")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/Session.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/Session.scala
@@ -69,14 +69,6 @@ class BigDLSessionImpl[T: ClassTag](
     }
   }
 
-  private def seqToTable(tensors: Seq[Tensor[T]]): Table = {
-    val table = new Table()
-    for (tensor <- tensors) {
-      table.insert(tensor)
-    }
-    table
-  }
-
   private def handleReaderNode(node: Node[NodeDef], cache: DataCache): RDD[Table] = {
     require(node.prevNodes.length == 2, "require ReaderReadV2 only has two inputs")
     val readerNode = node.prevNodes.head
@@ -302,7 +294,7 @@ class BigDLSessionImpl[T: ClassTag](
         result.narrow(dimension, index + 1, 1).copy(tensor)
       }
     }
-    seqToTable(results)
+    T.seq(results)
   }
 
   type DataCache = mutable.HashMap[String, Array[Seq[Table]]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/Session.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/Session.scala
@@ -47,11 +47,10 @@ abstract class Session[T: ClassTag] {
 
 class BigDLSessionImpl[T: ClassTag](
        graph: Seq[NodeDef],
+       sc: SparkContext,
        context: mutable.HashMap[String, (Tensor[T], Tensor[T], Option[Seq[(Int, Int)]])])
                          (implicit ev: TensorNumeric[T]) extends Session[T] {
   import scala.collection.JavaConverters._
-
-  val sc = SparkContext.getOrCreate()
 
   private val inputOp = Set("ReaderReadV2", "QueueDequeueV2", "QueueDequeueManyV2", "Placeholder")
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/Session.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/Session.scala
@@ -29,6 +29,9 @@ import org.apache.spark.SparkContext
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.rdd.RDD
 import org.tensorflow.framework.{GraphDef, NodeDef}
+import com.google.protobuf.ByteString
+import com.intel.analytics.bigdl.models.utils.ModelBroadcast
+import TFTensorNumeric.NumericByteString
 
 import scala.collection.mutable
 import scala.reflect.ClassTag
@@ -52,10 +55,361 @@ class BigDLSessionImpl[T: ClassTag](
 
   private val inputOp = Set("ReaderReadV2", "QueueDequeueV2", "QueueDequeueManyV2", "Placeholder")
 
+  private val dequeueOp = Set("QueueDequeueV2", "QueueDequeueManyV2", "ReaderReadV2")
+
+  private val enqueueOp = Set("QueueEnqueueV2", "QueueEnqueueManyV2")
+
+  private val readerOps = Set("TFRecordReaderV2")
+
   private val (wholeTFGraph, _, _) = TensorflowLoader.buildTFGraph(graph.asJava, null)
 
   private val name2Node = wholeTFGraph.
-    DFS.filter(n => n.element != null).map(node => (node.element.getName, node)).toMap
+    DFS.filter(_.element != null).map(node => (node.element.getName, node)).toMap
+
+  private def tableToSeq(table: Table): Seq[Tensor[T]] = {
+    for (i <- 0 until table.length()) yield {
+      table(i).asInstanceOf[Tensor[T]]
+    }
+  }
+
+  private def seqToTable(tensors: Seq[Tensor[T]]): Table = {
+    val table = new Table()
+    for (tensor <- tensors) {
+      table.insert(tensor)
+    }
+    table
+  }
+
+  private def handleReaderNode(node: Node[NodeDef], cache: DataCache): RDD[Table] = {
+    require(node.prevNodes.length == 2, "require ReaderReadV2 only has two inputs")
+    val readerNode = node.prevNodes.head
+    val queueNode = node.prevNodes(1)
+    val dequeNodeNames = mutable.LinkedHashSet[String]()
+
+    queueNode.nextNodes
+      .filter(n => n.element != null && dequeueOp(n.element.getOp))
+      .map(n => n.element.getName.split(":")(0)).foreach(dequeNodeNames.add)
+
+    val nameToIndex = dequeNodeNames.zipWithIndex.toMap
+    val index = nameToIndex(node.element.getName)
+    val nSlices = dequeNodeNames.size
+
+    val enqueueNodes = queueNode.nextNodes
+      .filter(n => n.element != null && enqueueOp(n.element.getOp))
+    val filesSeq = if (cache.contains(queueNode.element.getName)) {
+      val resultArray = cache(queueNode.element.getName)
+      val result = resultArray(index)
+      resultArray(index) = null
+      result
+    } else {
+      val allResult = enqueueNodes.map { enqueueNode =>
+        val inputs = Seq(enqueueNode.element.getName)
+        val result = constructLocalData(inputs, new DataCache())
+        if (enqueueNode.element.getOp == "QueueEnqueueManyV2") {
+          result.flatMap { table =>
+            val nElem = table.length()
+            require(nElem >= 1, "EnqueueManyV2 encounter a empty table")
+            val first = table[Tensor[ByteString]](1)
+            require(first.nDimension() >= 1)
+            val depth = first.size(1)
+            val result = new Array[Table](depth)
+            var i = 0
+            while(i < depth) {
+              var j = 0
+              val newTable = new Table()
+              while (j < nElem) {
+                val elem = table[Tensor[ByteString]](j + 1)
+                newTable.insert(elem(i + 1))
+                j = j + 1
+              }
+              result(i) = newTable
+              i = i + 1
+            }
+            result
+          }
+        } else {
+          result
+        }
+      }.reduce { (outerSeq1, outerSeq2) =>
+        outerSeq1.zip(outerSeq2).map { case (seq1, seq2) =>
+          seq1.add(seq2)
+        }
+      }
+      val resultArray = split(allResult, nSlices)
+      cache.put(queueNode.element.getName, resultArray)
+      resultArray(index)
+    }
+
+    readerNode.element.getOp match {
+      case "TFRecordReaderV2" => readTFRecord(filesSeq)
+    }
+  }
+
+  private def split[A](xs: Seq[A], n: Int): Array[Seq[A]] = {
+    val result = new Array[Seq[A]](n)
+    var i = 0
+    while (i < n) {
+      result(i) = Vector[A]()
+      i = i + 1
+    }
+
+    var j = 0
+    while (j < xs.length) {
+      result(j % n) = result(j % n) :+ xs(j)
+      j = j + 1
+    }
+
+    result
+  }
+
+  private def readTFRecord(filesTable: Seq[Table]): RDD[Table] = {
+    val result = filesTable.map { t =>
+        require(t.length() == 1 && t(1).isInstanceOf[Tensor[ByteString]],
+          "Reader can only read one file at a time")
+        val fileTensor = t[Tensor[ByteString]](1)
+        require(fileTensor.isScalar)
+        val file = fileTensor.value()
+        file
+    }.flatMap { file =>
+      val iter = new TFRecordIterator(new java.io.File(file.toStringUtf8))
+      iter
+    }.map { record =>
+      val table = T()
+      val key = Tensor[ByteString](Array(ByteString.copyFromUtf8("somekey")), Array[Int]())
+      val value = Tensor[ByteString](Array(ByteString.copyFrom(record)), Array[Int]())
+      table.insert(key)
+      table.insert(value)
+      table
+    }
+    val resultRdd = sc.parallelize(result, numSlices = Engine.coreNumber())
+    resultRdd
+  }
+
+  private def handleLocalDequeue(node: Node[NodeDef], cache: DataCache): Seq[Table] = {
+    require(node.prevNodes.length == 1, "require QueueDequeueV2 only has one input")
+    val queueNode = node.prevNodes.head
+    val enqueueNodes = queueNode.nextNodes.filter(n => enqueueOp(n.element.getOp))
+    val dequeNodeNames = mutable.LinkedHashSet[String]()
+
+    queueNode.nextNodes
+      .filter(n => n.element != null && dequeueOp(n.element.getOp))
+      .map(n => n.element.getName.split(":")(0)).foreach(dequeNodeNames.add)
+
+    val nameToIndex = dequeNodeNames.zipWithIndex.toMap
+    val index = nameToIndex(node.element.getName)
+    val nSlices = dequeNodeNames.size
+
+    val dataSeq = if (cache.contains(queueNode.element.getName)) {
+      val resultArray = cache(queueNode.element.getName)
+      val result = resultArray(index)
+      resultArray(index) = null
+      result
+    } else {
+      val allResult = enqueueNodes.map { enqueueNode =>
+        val inputs = Seq(enqueueNode.element.getName)
+        constructLocalData(inputs, new DataCache())
+      }.reduce { (outerSeq1, outerSeq2) =>
+        outerSeq1.zip(outerSeq2).map { case (seq1, seq2) =>
+          seq1.add(seq2)
+        }
+      }
+      val resultArray = split(allResult, nSlices)
+      cache.put(queueNode.element.getName, resultArray)
+      resultArray(index)
+    }
+    dataSeq
+  }
+
+  private def handleDistriDequeue(node: Node[NodeDef], cache: DataCache): RDD[Table] = {
+    require(node.prevNodes.length == 1, "require QueueDequeueV2 only has one input")
+    val queueNode = node.prevNodes.head
+    val dequeueNodes = queueNode.nextNodes
+      .filter(n => n.element != null && dequeueOp(n.element.getOp))
+      .map(n => n.element.getName.split(":")(0)).toSet
+    require(dequeueNodes.size == 1, "only support one dequeue node after reader")
+    val enqueueNodes = queueNode.nextNodes
+      .filter(n => n.element != null && enqueueOp(n.element.getOp))
+    val rdd = enqueueNodes.map { enqueueNode =>
+      val inputs = Seq(enqueueNode.element.getName)
+      constructDistributeData(inputs, cache)
+    }.reduce { (rdd1, rdd2) =>
+      rdd1.union(rdd2)
+    }
+    rdd
+  }
+
+  private def handleDistriDequeueManyNode(node: Node[NodeDef], cache: DataCache): RDD[Table] = {
+    require(node.prevNodes.length == 2, "require QueueDequeueManyV2 only has two input")
+    val queueNode = node.prevNodes.head
+    val enqueueNodes = queueNode.nextNodes.filter(n => enqueueOp(n.element.getOp))
+    // get previous rdd
+    val rdd = enqueueNodes.map { enqueueNode =>
+      val inputs = Seq(enqueueNode.element.getName)
+      constructDistributeData(inputs, cache)
+    }.reduce { (rdd1, rdd2) =>
+      rdd1.zip(rdd2).map { case (seq1, seq2) =>
+        seq1.add(seq2)
+      }
+    }
+
+    // get batch size
+    val batchSizeNode = node.prevNodes(1)
+    require(batchSizeNode.element.getOp == "Const", "batchsize must be a const")
+
+    val batchSize = batchSizeNode.element.getAttrMap.get("value").getI.toInt
+
+    val batchRdd = rdd.mapPartitions { iter =>
+
+      new Iterator[Table] {
+        override def hasNext: Boolean = iter.hasNext
+
+        override def next(): Table = {
+          require(iter.hasNext, "Call next() on a empty iterator")
+          val batch = for (_ <- 0 until batchSize if iter.hasNext) yield {
+            iter.next()
+          }
+          pack(batch)
+        }
+      }
+
+    }
+    batchRdd
+  }
+
+  private def pack(tables: Seq[Table], dimension: Int = 1): Table = {
+    val batch = tables.map(tableToSeq)
+    val firstSeq = batch.head
+    val sizes = firstSeq.map { tensor =>
+      val nDim = tensor.nDimension()
+      val size: Array[Int] = new Array[Int](nDim + 1)
+      var i = 1
+      while(i <= nDim + 1) {
+        if (i < dimension) {
+          size(i-1) = tensor.size(i)
+        } else if (i == dimension) {
+          size(i-1) = batch.length
+        } else {
+          size(i-1) = tensor.size(i - 1)
+        }
+        i = i + 1
+      }
+      size
+    }
+
+    val results = sizes.map { size =>
+      Tensor[T](size)
+    }
+
+    for ((seq, index) <- batch.zipWithIndex) {
+      results.zip(seq).foreach { case (result, tensor) =>
+        result.narrow(dimension, index + 1, 1).copy(tensor)
+      }
+    }
+    seqToTable(results)
+  }
+
+  type DataCache = mutable.HashMap[String, Array[Seq[Table]]]
+
+  private def adjustInputNames(inputs: Seq[String]): Seq[String] = {
+    val stripedNames = inputs.map(_.split(":")(0))
+    val set = mutable.LinkedHashSet[String]()
+    for (name <- stripedNames) {
+      set.add(name)
+    }
+    set.toSeq
+  }
+
+  def constructLocalData(endPoints: Seq[String], cache: DataCache): Seq[Table] = {
+    val isInputOp = (n: NodeDef) => inputOp(n.getOp)
+    val (tfGraph, inputs, originInputs) = TensorflowLoader.
+      buildTFGraph(graph.asJava, endPoints, isInputOp)
+
+    val adjustedInputs = adjustInputNames(originInputs)
+    val transformer = TensorflowLoader.buildBigDLModel(
+      tfGraph,
+      inputs,
+      endPoints,
+      ByteOrder.LITTLE_ENDIAN,
+      "",
+      Some(context)
+    ).asInstanceOf[Graph[T]]
+
+
+    if (adjustedInputs.nonEmpty) {
+      val inputNodes = originInputs.map(name2Node)
+      val inputDataSeq = inputNodes.map { node => // this is the input op
+        node.element.getOp match {
+          // only support Dequeue before reader
+          case "QueueDequeueV2" => handleLocalDequeue(node, cache)
+        }
+      }
+
+      val reducedInputSeq = inputDataSeq.reduce { (outerSeq1, outerSeq2) =>
+        outerSeq1.zip(outerSeq2).map { case (seq1, seq2) =>
+          seq1.add(seq2)
+        }
+      }
+
+      reducedInputSeq.map { tensors =>
+        val output = transformer.forward(tensors.flatten())
+        toTable(output)
+      }
+    } else {
+      Seq(toTable(transformer.forward(T())))
+    }
+  }
+
+  private def toTable(activity: Activity): Table = {
+    activity match {
+      case t: Tensor[_] => T(t)
+      case t: Table => t
+    }
+  }
+
+  def constructDistributeData(endPoints: Seq[String], cache: DataCache): RDD[Table] = {
+    val isInputOp = (n: NodeDef) => inputOp(n.getOp)
+    val (tfGraph, inputs, originInputs) =
+      TensorflowLoader.buildTFGraph(graph.asJava, endPoints, isInputOp)
+
+    val adjustedInputs = adjustInputNames(originInputs)
+
+    val inputNodes = adjustedInputs.map(name2Node)
+
+    val transformer = TensorflowLoader.buildBigDLModel(
+      tfGraph,
+      inputs,
+      endPoints,
+      ByteOrder.LITTLE_ENDIAN,
+      "",
+      Some(context)
+    ).asInstanceOf[Graph[T]]
+
+    val inputRdds = inputNodes.map { node => // this is the input op
+      node.element.getOp match {
+        case "ReaderReadV2" => handleReaderNode(node, cache)
+        case "QueueDequeueV2" => handleDistriDequeue(node, cache)
+        case "QueueDequeueManyV2" => handleDistriDequeueManyNode(node, cache)
+      }
+    }
+    val inputRdd = inputRdds.reduce { (rdd1, rdd2) =>
+      rdd1.zip(rdd2).map { case (seq1, seq2) =>
+        seq1.add(seq2)
+      }
+    }
+
+    if (!inputRdd.isEmpty()) {
+      val first = inputRdd.first()
+      println(first)
+    }
+    val modelBroadCast = ModelBroadcast[T].broadcast(sc, transformer)
+    inputRdd.map { tensors =>
+      val trans = modelBroadCast.value()
+      val output = trans.forward(tensors.flatten())
+      output.asInstanceOf[Table]
+      tensors
+    }
+  }
+
 
   private def constructModel(endPoints: Seq[String]): (Graph[T], Node[NodeDef]) = {
     val isInputOp = (n: NodeDef) => inputOp(n.getOp)
@@ -97,5 +451,29 @@ class BigDLSessionImpl[T: ClassTag](
       .optimize()
     model
   }
+
+
+  def train(modelOutputs: Seq[String],
+                     labels: Seq[String],
+                     optMethod: OptimMethod[T],
+                     criterion: Criterion[T],
+                     endWhen: Trigger): Graph[T] = {
+    val (model, modelInput) = constructModel(modelOutputs)
+
+    val (transformerForLabel, labelInput) = constructModel(labels)
+
+    require(modelInput == labelInput, "data and label should come from the same queue")
+
+    val cache = new DataCache()
+
+    val data = constructDistributeData(modelOutputs ++ labels, cache)
+
+    throw new NotImplementedError()
+  }
+
+  def run(endPoints: Array[String], batchSize: Int): RDD[Array[Tensor[T]]] = {
+    throw new NotImplementedError()
+  }
+
 
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoader.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoader.scala
@@ -347,6 +347,10 @@ object TensorflowLoader{
       Seq[Node[NodeDef]]
     )] = {
 
+    if (graph.source.element.getOp == "ConcatV2") {
+      println()
+    }
+
     var i = 0
     while(i < patterns.length) {
       val (result, inputs) = matchGraph(graph, patterns(i).topology)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoader.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoader.scala
@@ -347,10 +347,6 @@ object TensorflowLoader{
       Seq[Node[NodeDef]]
     )] = {
 
-    if (graph.source.element.getOp == "ConcatV2") {
-      println()
-    }
-
     var i = 0
     while(i < patterns.length) {
       val (result, inputs) = matchGraph(graph, patterns(i).topology)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/TensorflowToBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/TensorflowToBigDL.scala
@@ -1742,6 +1742,7 @@ object ReaderReadTF extends TensorflowToBigDL {
 
   private val graph = {
     val node = Node("ReaderReadV2")
+    Node("*") -> node
     (Node("*") -> node).graph(reverse = true)
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/TensorflowToBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/TensorflowToBigDL.scala
@@ -252,7 +252,8 @@ object TensorflowToBigDL {
       Flatten, Conv1D, FlattenV2, BatchNormV2NHWCTF, BatchNormV2NCHWTF, AddNTF,
       ControlDependencyTF, RandomShuffleTF, AssertTF, GreaterTF, ReaderReadTF, QueueDequeTF,
       QueueDequeManyTF, EqualTF, RankTF, EnqueueManyTF, EnqueueTF, QueueTF, RandomShuffleQueueTF,
-      FullConnectionWithoutBiasTF, DeConv2D, ResizeBilinearTF, Conv2D2, Conv2DWithoutBias, ParseExampleTF
+      FullConnectionWithoutBiasTF, DeConv2D, ResizeBilinearTF, Conv2D2, Conv2DWithoutBias,
+      ParseExampleTF
     )
     res
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/TensorflowToBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/TensorflowToBigDL.scala
@@ -251,7 +251,7 @@ object TensorflowToBigDL {
       SplitTF, PaddingTF, MeanTF, UnpackTF, StrideSliceTF, ShapeTF, FillTF, PackTF, ConstTF,
       Flatten, Conv1D, FlattenV2, BatchNormV2NHWCTF, BatchNormV2NCHWTF, AddNTF,
       ControlDependencyTF, RandomShuffleTF, AssertTF, GreaterTF, ReaderReadTF, QueueDequeTF,
-      QueueDequeManyTF, EqualTF, RankTF, EnqueueManyTF, EnqueueTF, QueueTF, RandomShuffleQueueTF,
+      QueueDequeManyTF, EqualTF, RankTF, EnqueueManyTF, EnqueueTF,
       FullConnectionWithoutBiasTF, DeConv2D, ResizeBilinearTF, Conv2D2, Conv2DWithoutBias,
       ParseExampleTF
     )
@@ -1869,42 +1869,6 @@ object EnqueueManyTF extends TensorflowToBigDL {
      implicit ev: TensorNumeric[T]): AbstractModule[Activity, Activity, T] = {
 
     new Identity().asInstanceOf[AbstractModule[Activity, Activity, T]]
-  }
-}
-
-object QueueTF extends TensorflowToBigDL {
-
-  private val graph = {
-    val node = Node("FIFOQueueV2")
-    node.graph(reverse = true)
-  }
-
-  override def topology: DirectedGraph[String] = graph
-
-  override def layer[T: ClassTag](tfGraph: DirectedGraph[NodeDef],
-                                  context: Context[T],
-                                  byteOrder: ByteOrder)(
-      implicit ev: TensorNumeric[T]): AbstractModule[Activity, Activity, T] = {
-
-    new ControlDependency().asInstanceOf[AbstractModule[Activity, Activity, T]]
-  }
-}
-
-object RandomShuffleQueueTF extends TensorflowToBigDL {
-
-  private val graph = {
-    val node = Node("RandomShuffleQueueV2")
-    node.graph(reverse = true)
-  }
-
-  override def topology: DirectedGraph[String] = graph
-
-  override def layer[T: ClassTag](tfGraph: DirectedGraph[NodeDef],
-                                  context: Context[T],
-                                  byteOrder: ByteOrder)(
-     implicit ev: TensorNumeric[T]): AbstractModule[Activity, Activity, T] = {
-
-    new ControlDependency().asInstanceOf[AbstractModule[Activity, Activity, T]]
   }
 }
 

--- a/spark/dl/src/test/resources/tf/lenet.pbtxt
+++ b/spark/dl/src/test/resources/tf/lenet.pbtxt
@@ -1,0 +1,17028 @@
+node {
+  name: "global_step/Initializer/zeros"
+  op: "Const"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@global_step"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT64
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT64
+        tensor_shape {
+        }
+        int64_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "global_step"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@global_step"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT64
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "global_step/Assign"
+  op: "Assign"
+  input: "global_step"
+  input: "global_step/Initializer/zeros"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT64
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@global_step"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "global_step/read"
+  op: "Identity"
+  input: "global_step"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT64
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@global_step"
+      }
+    }
+  }
+}
+node {
+  name: "zeros"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT64
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT64
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int64_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "parallel_read/filenames/Const"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        string_val: "/home/yang/sources/models/slim/data/mnist_train.tfrecord"
+      }
+    }
+  }
+}
+node {
+  name: "parallel_read/filenames/Size"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "parallel_read/filenames/Greater/y"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "parallel_read/filenames/Greater"
+  op: "Greater"
+  input: "parallel_read/filenames/Size"
+  input: "parallel_read/filenames/Greater/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "parallel_read/filenames/Assert/Const"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "string_input_producer requires a non-null input tensor"
+      }
+    }
+  }
+}
+node {
+  name: "parallel_read/filenames/Assert/Assert/data_0"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "string_input_producer requires a non-null input tensor"
+      }
+    }
+  }
+}
+node {
+  name: "parallel_read/filenames/Assert/Assert"
+  op: "Assert"
+  input: "parallel_read/filenames/Greater"
+  input: "parallel_read/filenames/Assert/Assert/data_0"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      list {
+        type: DT_STRING
+      }
+    }
+  }
+  attr {
+    key: "summarize"
+    value {
+      i: 3
+    }
+  }
+}
+node {
+  name: "parallel_read/filenames/Identity"
+  op: "Identity"
+  input: "parallel_read/filenames/Const"
+  input: "^parallel_read/filenames/Assert/Assert"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+}
+node {
+  name: "parallel_read/filenames/RandomShuffle"
+  op: "RandomShuffle"
+  input: "parallel_read/filenames/Identity"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "seed"
+    value {
+      i: 0
+    }
+  }
+  attr {
+    key: "seed2"
+    value {
+      i: 0
+    }
+  }
+}
+node {
+  name: "parallel_read/filenames"
+  op: "FIFOQueueV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "capacity"
+    value {
+      i: 32
+    }
+  }
+  attr {
+    key: "component_types"
+    value {
+      list {
+        type: DT_STRING
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "shapes"
+    value {
+      list {
+        shape {
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "parallel_read/filenames/filenames_EnqueueMany"
+  op: "QueueEnqueueManyV2"
+  input: "parallel_read/filenames"
+  input: "parallel_read/filenames/RandomShuffle"
+  device: "/device:CPU:0"
+  attr {
+    key: "Tcomponents"
+    value {
+      list {
+        type: DT_STRING
+      }
+    }
+  }
+  attr {
+    key: "timeout_ms"
+    value {
+      i: -1
+    }
+  }
+}
+node {
+  name: "parallel_read/filenames/filenames_Close"
+  op: "QueueCloseV2"
+  input: "parallel_read/filenames"
+  device: "/device:CPU:0"
+  attr {
+    key: "cancel_pending_enqueues"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "parallel_read/filenames/filenames_Close_1"
+  op: "QueueCloseV2"
+  input: "parallel_read/filenames"
+  device: "/device:CPU:0"
+  attr {
+    key: "cancel_pending_enqueues"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "parallel_read/filenames/filenames_Size"
+  op: "QueueSizeV2"
+  input: "parallel_read/filenames"
+  device: "/device:CPU:0"
+}
+node {
+  name: "parallel_read/filenames/Cast"
+  op: "Cast"
+  input: "parallel_read/filenames/filenames_Size"
+  device: "/device:CPU:0"
+  attr {
+    key: "DstT"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "SrcT"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "parallel_read/filenames/mul/y"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.03125
+      }
+    }
+  }
+}
+node {
+  name: "parallel_read/filenames/mul"
+  op: "Mul"
+  input: "parallel_read/filenames/Cast"
+  input: "parallel_read/filenames/mul/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "parallel_read/filenames/fraction_of_32_full/tags"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "parallel_read/filenames/fraction_of_32_full"
+      }
+    }
+  }
+}
+node {
+  name: "parallel_read/filenames/fraction_of_32_full"
+  op: "ScalarSummary"
+  input: "parallel_read/filenames/fraction_of_32_full/tags"
+  input: "parallel_read/filenames/mul"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "parallel_read/common_queue"
+  op: "RandomShuffleQueueV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "capacity"
+    value {
+      i: 640
+    }
+  }
+  attr {
+    key: "component_types"
+    value {
+      list {
+        type: DT_STRING
+        type: DT_STRING
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "min_after_dequeue"
+    value {
+      i: 320
+    }
+  }
+  attr {
+    key: "seed"
+    value {
+      i: 0
+    }
+  }
+  attr {
+    key: "seed2"
+    value {
+      i: 0
+    }
+  }
+  attr {
+    key: "shapes"
+    value {
+      list {
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "parallel_read/common_queue_Size"
+  op: "QueueSizeV2"
+  input: "parallel_read/common_queue"
+  device: "/device:CPU:0"
+}
+node {
+  name: "parallel_read/ToFloat"
+  op: "Cast"
+  input: "parallel_read/common_queue_Size"
+  device: "/device:CPU:0"
+  attr {
+    key: "DstT"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "SrcT"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "parallel_read/mul/y"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.00156250002328
+      }
+    }
+  }
+}
+node {
+  name: "parallel_read/mul"
+  op: "Mul"
+  input: "parallel_read/ToFloat"
+  input: "parallel_read/mul/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "parallel_read/fraction_of_640_full/tags"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "parallel_read/fraction_of_640_full"
+      }
+    }
+  }
+}
+node {
+  name: "parallel_read/fraction_of_640_full"
+  op: "ScalarSummary"
+  input: "parallel_read/fraction_of_640_full/tags"
+  input: "parallel_read/mul"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "parallel_read/TFRecordReaderV2"
+  op: "TFRecordReaderV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "compression_type"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "parallel_read/TFRecordReaderV2_1"
+  op: "TFRecordReaderV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "compression_type"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "parallel_read/TFRecordReaderV2_2"
+  op: "TFRecordReaderV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "compression_type"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "parallel_read/TFRecordReaderV2_3"
+  op: "TFRecordReaderV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "compression_type"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "parallel_read/ReaderReadV2"
+  op: "ReaderReadV2"
+  input: "parallel_read/TFRecordReaderV2"
+  input: "parallel_read/filenames"
+  device: "/device:CPU:0"
+}
+node {
+  name: "parallel_read/common_queue_enqueue"
+  op: "QueueEnqueueV2"
+  input: "parallel_read/common_queue"
+  input: "parallel_read/ReaderReadV2"
+  input: "parallel_read/ReaderReadV2:1"
+  device: "/device:CPU:0"
+  attr {
+    key: "Tcomponents"
+    value {
+      list {
+        type: DT_STRING
+        type: DT_STRING
+      }
+    }
+  }
+  attr {
+    key: "timeout_ms"
+    value {
+      i: -1
+    }
+  }
+}
+node {
+  name: "parallel_read/ReaderReadV2_1"
+  op: "ReaderReadV2"
+  input: "parallel_read/TFRecordReaderV2_1"
+  input: "parallel_read/filenames"
+  device: "/device:CPU:0"
+}
+node {
+  name: "parallel_read/common_queue_enqueue_1"
+  op: "QueueEnqueueV2"
+  input: "parallel_read/common_queue"
+  input: "parallel_read/ReaderReadV2_1"
+  input: "parallel_read/ReaderReadV2_1:1"
+  device: "/device:CPU:0"
+  attr {
+    key: "Tcomponents"
+    value {
+      list {
+        type: DT_STRING
+        type: DT_STRING
+      }
+    }
+  }
+  attr {
+    key: "timeout_ms"
+    value {
+      i: -1
+    }
+  }
+}
+node {
+  name: "parallel_read/ReaderReadV2_2"
+  op: "ReaderReadV2"
+  input: "parallel_read/TFRecordReaderV2_2"
+  input: "parallel_read/filenames"
+  device: "/device:CPU:0"
+}
+node {
+  name: "parallel_read/common_queue_enqueue_2"
+  op: "QueueEnqueueV2"
+  input: "parallel_read/common_queue"
+  input: "parallel_read/ReaderReadV2_2"
+  input: "parallel_read/ReaderReadV2_2:1"
+  device: "/device:CPU:0"
+  attr {
+    key: "Tcomponents"
+    value {
+      list {
+        type: DT_STRING
+        type: DT_STRING
+      }
+    }
+  }
+  attr {
+    key: "timeout_ms"
+    value {
+      i: -1
+    }
+  }
+}
+node {
+  name: "parallel_read/ReaderReadV2_3"
+  op: "ReaderReadV2"
+  input: "parallel_read/TFRecordReaderV2_3"
+  input: "parallel_read/filenames"
+  device: "/device:CPU:0"
+}
+node {
+  name: "parallel_read/common_queue_enqueue_3"
+  op: "QueueEnqueueV2"
+  input: "parallel_read/common_queue"
+  input: "parallel_read/ReaderReadV2_3"
+  input: "parallel_read/ReaderReadV2_3:1"
+  device: "/device:CPU:0"
+  attr {
+    key: "Tcomponents"
+    value {
+      list {
+        type: DT_STRING
+        type: DT_STRING
+      }
+    }
+  }
+  attr {
+    key: "timeout_ms"
+    value {
+      i: -1
+    }
+  }
+}
+node {
+  name: "parallel_read/common_queue_Close"
+  op: "QueueCloseV2"
+  input: "parallel_read/common_queue"
+  device: "/device:CPU:0"
+  attr {
+    key: "cancel_pending_enqueues"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "parallel_read/common_queue_Close_1"
+  op: "QueueCloseV2"
+  input: "parallel_read/common_queue"
+  device: "/device:CPU:0"
+  attr {
+    key: "cancel_pending_enqueues"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "parallel_read/common_queue_Dequeue"
+  op: "QueueDequeueV2"
+  input: "parallel_read/common_queue"
+  device: "/device:CPU:0"
+  attr {
+    key: "component_types"
+    value {
+      list {
+        type: DT_STRING
+        type: DT_STRING
+      }
+    }
+  }
+  attr {
+    key: "timeout_ms"
+    value {
+      i: -1
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/Rank"
+  op: "Rank"
+  input: "parallel_read/common_queue_Dequeue:1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/Equal/y"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/Equal"
+  op: "Equal"
+  input: "ParseSingleExample/Rank"
+  input: "ParseSingleExample/Equal/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/SerializedIsScalar/Const"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "Input serialized must be a scalar"
+      }
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/SerializedIsScalar/Assert/data_0"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "Input serialized must be a scalar"
+      }
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/SerializedIsScalar/Assert"
+  op: "Assert"
+  input: "ParseSingleExample/Equal"
+  input: "ParseSingleExample/SerializedIsScalar/Assert/data_0"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      list {
+        type: DT_STRING
+      }
+    }
+  }
+  attr {
+    key: "summarize"
+    value {
+      i: 3
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/SerializedDependencies"
+  op: "Identity"
+  input: "parallel_read/common_queue_Dequeue:1"
+  input: "^ParseSingleExample/SerializedIsScalar/Assert"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@parallel_read/common_queue_Dequeue"
+      }
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/ExpandDims/dim"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/ExpandDims"
+  op: "ExpandDims"
+  input: "ParseSingleExample/SerializedDependencies"
+  input: "ParseSingleExample/ExpandDims/dim"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "Tdim"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/ParseExample/key_image/encoded"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: ""
+      }
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/ParseExample/Reshape/shape"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/ParseExample/Reshape"
+  op: "Reshape"
+  input: "ParseSingleExample/ParseExample/key_image/encoded"
+  input: "ParseSingleExample/ParseExample/Reshape/shape"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/ParseExample/key_image/format"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "raw"
+      }
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/ParseExample/Reshape_1/shape"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/ParseExample/Reshape_1"
+  op: "Reshape"
+  input: "ParseSingleExample/ParseExample/key_image/format"
+  input: "ParseSingleExample/ParseExample/Reshape_1/shape"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/ParseExample/ParseExample/names"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/ParseExample/ParseExample/dense_keys_0"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "image/class/label"
+      }
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/ParseExample/ParseExample/dense_keys_1"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "image/encoded"
+      }
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/ParseExample/ParseExample/dense_keys_2"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "image/format"
+      }
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/ParseExample/ParseExample"
+  op: "ParseExample"
+  input: "ParseSingleExample/ExpandDims"
+  input: "ParseSingleExample/ParseExample/ParseExample/names"
+  input: "ParseSingleExample/ParseExample/ParseExample/dense_keys_0"
+  input: "ParseSingleExample/ParseExample/ParseExample/dense_keys_1"
+  input: "ParseSingleExample/ParseExample/ParseExample/dense_keys_2"
+  input: "zeros"
+  input: "ParseSingleExample/ParseExample/Reshape"
+  input: "ParseSingleExample/ParseExample/Reshape_1"
+  device: "/device:CPU:0"
+  attr {
+    key: "Ndense"
+    value {
+      i: 3
+    }
+  }
+  attr {
+    key: "Nsparse"
+    value {
+      i: 0
+    }
+  }
+  attr {
+    key: "Tdense"
+    value {
+      list {
+        type: DT_INT64
+        type: DT_STRING
+        type: DT_STRING
+      }
+    }
+  }
+  attr {
+    key: "dense_shapes"
+    value {
+      list {
+        shape {
+          dim {
+            size: 1
+          }
+        }
+        shape {
+        }
+        shape {
+        }
+      }
+    }
+  }
+  attr {
+    key: "sparse_types"
+    value {
+      list {
+      }
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/Squeeze_image/class/label"
+  op: "Squeeze"
+  input: "ParseSingleExample/ParseExample/ParseExample"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT64
+    }
+  }
+  attr {
+    key: "squeeze_dims"
+    value {
+      list {
+        i: 0
+      }
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/Squeeze_image/encoded"
+  op: "Squeeze"
+  input: "ParseSingleExample/ParseExample/ParseExample:1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "squeeze_dims"
+    value {
+      list {
+        i: 0
+      }
+    }
+  }
+}
+node {
+  name: "ParseSingleExample/Squeeze_image/format"
+  op: "Squeeze"
+  input: "ParseSingleExample/ParseExample/ParseExample:2"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "squeeze_dims"
+    value {
+      list {
+        i: 0
+      }
+    }
+  }
+}
+node {
+  name: "Reshape/shape"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "Reshape"
+  op: "Reshape"
+  input: "ParseSingleExample/Squeeze_image/class/label"
+  input: "Reshape/shape"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT64
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "Reshape_1/shape"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "Reshape_1"
+  op: "Reshape"
+  input: "ParseSingleExample/Squeeze_image/format"
+  input: "Reshape_1/shape"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "Reshape_2/shape"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "Reshape_2"
+  op: "Reshape"
+  input: "ParseSingleExample/Squeeze_image/encoded"
+  input: "Reshape_2/shape"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "Equal/y"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "raw"
+      }
+    }
+  }
+}
+node {
+  name: "Equal"
+  op: "Equal"
+  input: "Reshape_1"
+  input: "Equal/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+}
+node {
+  name: "Equal_1/y"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "RAW"
+      }
+    }
+  }
+}
+node {
+  name: "Equal_1"
+  op: "Equal"
+  input: "Reshape_1"
+  input: "Equal_1/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+}
+node {
+  name: "LogicalOr"
+  op: "LogicalOr"
+  input: "Equal"
+  input: "Equal_1"
+  device: "/device:CPU:0"
+}
+node {
+  name: "case/not_0/LogicalNot"
+  op: "LogicalNot"
+  input: "LogicalOr"
+  device: "/device:CPU:0"
+}
+node {
+  name: "case/always_true"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_BOOL
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_BOOL
+        tensor_shape {
+        }
+        bool_val: true
+      }
+    }
+  }
+}
+node {
+  name: "case/and_not_0/LogicalAnd"
+  op: "LogicalAnd"
+  input: "case/always_true"
+  input: "case/not_0/LogicalNot"
+  device: "/device:CPU:0"
+}
+node {
+  name: "case/case_0/LogicalAnd"
+  op: "LogicalAnd"
+  input: "LogicalOr"
+  input: "case/always_true"
+  device: "/device:CPU:0"
+}
+node {
+  name: "case/preds_c"
+  op: "Pack"
+  input: "LogicalOr"
+  device: "/device:CPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 1
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+  attr {
+    key: "axis"
+    value {
+      i: 0
+    }
+  }
+}
+node {
+  name: "case/Cast"
+  op: "Cast"
+  input: "case/preds_c"
+  device: "/device:CPU:0"
+  attr {
+    key: "DstT"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "SrcT"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/Const"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "case/num_true_conds"
+  op: "Sum"
+  input: "case/Cast"
+  input: "case/Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "case/two_true_conds"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 2
+      }
+    }
+  }
+}
+node {
+  name: "case/Less"
+  op: "Less"
+  input: "case/num_true_conds"
+  input: "case/two_true_conds"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "case/Assert/Const"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "More than one condition evaluated as True but exclusive=True.  Conditions: (LogicalOr:0), Values:"
+      }
+    }
+  }
+}
+node {
+  name: "case/Assert/AssertGuard/Switch"
+  op: "Switch"
+  input: "case/Less"
+  input: "case/Less"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/Assert/AssertGuard/switch_t"
+  op: "Identity"
+  input: "case/Assert/AssertGuard/Switch:1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/Assert/AssertGuard/switch_f"
+  op: "Identity"
+  input: "case/Assert/AssertGuard/Switch"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/Assert/AssertGuard/pred_id"
+  op: "Identity"
+  input: "case/Less"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/Assert/AssertGuard/NoOp"
+  op: "NoOp"
+  input: "^case/Assert/AssertGuard/switch_t"
+  device: "/device:CPU:0"
+}
+node {
+  name: "case/Assert/AssertGuard/control_dependency"
+  op: "Identity"
+  input: "case/Assert/AssertGuard/switch_t"
+  input: "^case/Assert/AssertGuard/NoOp"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@case/Assert/AssertGuard/switch_t"
+      }
+    }
+  }
+}
+node {
+  name: "case/Assert/AssertGuard/Assert/data_0"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "More than one condition evaluated as True but exclusive=True.  Conditions: (LogicalOr:0), Values:"
+      }
+    }
+  }
+}
+node {
+  name: "case/Assert/AssertGuard/Assert/Switch"
+  op: "Switch"
+  input: "case/Less"
+  input: "case/Assert/AssertGuard/pred_id"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@case/Less"
+      }
+    }
+  }
+}
+node {
+  name: "case/Assert/AssertGuard/Assert/Switch_1"
+  op: "Switch"
+  input: "case/preds_c"
+  input: "case/Assert/AssertGuard/pred_id"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@case/preds_c"
+      }
+    }
+  }
+}
+node {
+  name: "case/Assert/AssertGuard/Assert"
+  op: "Assert"
+  input: "case/Assert/AssertGuard/Assert/Switch"
+  input: "case/Assert/AssertGuard/Assert/data_0"
+  input: "case/Assert/AssertGuard/Assert/Switch_1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      list {
+        type: DT_STRING
+        type: DT_BOOL
+      }
+    }
+  }
+  attr {
+    key: "summarize"
+    value {
+      i: 1
+    }
+  }
+}
+node {
+  name: "case/Assert/AssertGuard/control_dependency_1"
+  op: "Identity"
+  input: "case/Assert/AssertGuard/switch_f"
+  input: "^case/Assert/AssertGuard/Assert"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@case/Assert/AssertGuard/switch_f"
+      }
+    }
+  }
+}
+node {
+  name: "case/Assert/AssertGuard/Merge"
+  op: "Merge"
+  input: "case/Assert/AssertGuard/control_dependency_1"
+  input: "case/Assert/AssertGuard/control_dependency"
+  device: "/device:CPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 2
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/Switch"
+  op: "Switch"
+  input: "case/and_not_0/LogicalAnd"
+  input: "case/and_not_0/LogicalAnd"
+  input: "^case/Assert/AssertGuard/Merge"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/switch_t"
+  op: "Identity"
+  input: "case/If_0/Switch:1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/switch_f"
+  op: "Identity"
+  input: "case/If_0/Switch"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/pred_id"
+  op: "Identity"
+  input: "case/and_not_0/LogicalAnd"
+  input: "^case/Assert/AssertGuard/Merge"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/Substr/pos"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/switch_t"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/Substr/len"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/switch_t"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 3
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/Substr/Switch"
+  op: "Switch"
+  input: "Reshape_2"
+  input: "case/If_0/pred_id"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@Reshape_2"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/Substr"
+  op: "Substr"
+  input: "case/If_0/decode_image/Substr/Switch:1"
+  input: "case/If_0/decode_image/Substr/pos"
+  input: "case/If_0/decode_image/Substr/len"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/is_jpeg/y"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/switch_t"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "\377\330\377"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/is_jpeg"
+  op: "Equal"
+  input: "case/If_0/decode_image/Substr"
+  input: "case/If_0/decode_image/is_jpeg/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/Switch"
+  op: "Switch"
+  input: "case/If_0/decode_image/is_jpeg"
+  input: "case/If_0/decode_image/is_jpeg"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/switch_t"
+  op: "Identity"
+  input: "case/If_0/decode_image/cond_jpeg/Switch:1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/switch_f"
+  op: "Identity"
+  input: "case/If_0/decode_image/cond_jpeg/Switch"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/pred_id"
+  op: "Identity"
+  input: "case/If_0/decode_image/is_jpeg"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/check_jpeg_channels/x"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image/cond_jpeg/switch_t"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/check_jpeg_channels/y"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image/cond_jpeg/switch_t"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 4
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/check_jpeg_channels"
+  op: "NotEqual"
+  input: "case/If_0/decode_image/cond_jpeg/check_jpeg_channels/x"
+  input: "case/If_0/decode_image/cond_jpeg/check_jpeg_channels/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/Assert/Const"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image/cond_jpeg/switch_t"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "Channels must be in (None, 0, 1, 3) when decoding JPEG images"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/Assert/Assert/data_0"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image/cond_jpeg/switch_t"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "Channels must be in (None, 0, 1, 3) when decoding JPEG images"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/Assert/Assert"
+  op: "Assert"
+  input: "case/If_0/decode_image/cond_jpeg/check_jpeg_channels"
+  input: "case/If_0/decode_image/cond_jpeg/Assert/Assert/data_0"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      list {
+        type: DT_STRING
+      }
+    }
+  }
+  attr {
+    key: "summarize"
+    value {
+      i: 3
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/DecodeJpeg/Switch"
+  op: "Switch"
+  input: "case/If_0/decode_image/Substr/Switch:1"
+  input: "case/If_0/decode_image/cond_jpeg/pred_id"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@Reshape_2"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/DecodeJpeg"
+  op: "DecodeJpeg"
+  input: "case/If_0/decode_image/cond_jpeg/DecodeJpeg/Switch:1"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image/cond_jpeg/Assert/Assert"
+  device: "/device:CPU:0"
+  attr {
+    key: "acceptable_fraction"
+    value {
+      f: 1.0
+    }
+  }
+  attr {
+    key: "channels"
+    value {
+      i: 1
+    }
+  }
+  attr {
+    key: "dct_method"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "fancy_upscaling"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "ratio"
+    value {
+      i: 1
+    }
+  }
+  attr {
+    key: "try_recover_truncated"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/is_png/y"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image/cond_jpeg/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "\211PN"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/is_png/Switch"
+  op: "Switch"
+  input: "case/If_0/decode_image/Substr"
+  input: "case/If_0/decode_image/cond_jpeg/pred_id"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@case/If_0/decode_image/Substr"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/is_png"
+  op: "Equal"
+  input: "case/If_0/decode_image/cond_jpeg/is_png/Switch"
+  input: "case/If_0/decode_image/cond_jpeg/is_png/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/Switch"
+  op: "Switch"
+  input: "case/If_0/decode_image/cond_jpeg/is_png"
+  input: "case/If_0/decode_image/cond_jpeg/is_png"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/switch_t"
+  op: "Identity"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/Switch:1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/switch_f"
+  op: "Identity"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/Switch"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/pred_id"
+  op: "Identity"
+  input: "case/If_0/decode_image/cond_jpeg/is_png"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/DecodePng/Switch"
+  op: "Switch"
+  input: "case/If_0/decode_image/Substr/Switch:1"
+  input: "case/If_0/decode_image/cond_jpeg/pred_id"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@Reshape_2"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/DecodePng/Switch_1"
+  op: "Switch"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/DecodePng/Switch"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/pred_id"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@Reshape_2"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/DecodePng"
+  op: "DecodePng"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/DecodePng/Switch_1:1"
+  input: "^case/Assert/AssertGuard/Merge"
+  device: "/device:CPU:0"
+  attr {
+    key: "channels"
+    value {
+      i: 1
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_UINT8
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/is_gif/y"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image/cond_jpeg/cond_png/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "GIF"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/is_gif/Switch"
+  op: "Switch"
+  input: "case/If_0/decode_image/cond_jpeg/is_png/Switch"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/pred_id"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@case/If_0/decode_image/Substr"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/is_gif"
+  op: "Equal"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/is_gif/Switch"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/is_gif/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/Assert/Const"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image/cond_jpeg/cond_png/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "Unable to decode bytes as JPEG, PNG, or GIF"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/Assert/Assert/data_0"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image/cond_jpeg/cond_png/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "Unable to decode bytes as JPEG, PNG, or GIF"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/Assert/Assert"
+  op: "Assert"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/is_gif"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/Assert/Assert/data_0"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      list {
+        type: DT_STRING
+      }
+    }
+  }
+  attr {
+    key: "summarize"
+    value {
+      i: 3
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/check_gif_channels/x"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image/cond_jpeg/cond_png/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/check_gif_channels/y"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image/cond_jpeg/cond_png/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/check_gif_channels"
+  op: "NotEqual"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/check_gif_channels/x"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/check_gif_channels/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/check_gif_channels_1/x"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image/cond_jpeg/cond_png/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/check_gif_channels_1/y"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image/cond_jpeg/cond_png/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 4
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/check_gif_channels_1"
+  op: "NotEqual"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/check_gif_channels_1/x"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/check_gif_channels_1/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/LogicalAnd"
+  op: "LogicalAnd"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/check_gif_channels"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/check_gif_channels_1"
+  device: "/device:CPU:0"
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/Assert_1/Const"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image/cond_jpeg/cond_png/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "Channels must be in (None, 0, 3) when decoding GIF images"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/Assert_1/Assert/data_0"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image/cond_jpeg/cond_png/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "Channels must be in (None, 0, 3) when decoding GIF images"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/Assert_1/Assert"
+  op: "Assert"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/LogicalAnd"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/Assert_1/Assert/data_0"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      list {
+        type: DT_STRING
+      }
+    }
+  }
+  attr {
+    key: "summarize"
+    value {
+      i: 3
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/DecodeGif/Switch"
+  op: "Switch"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/DecodePng/Switch"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/pred_id"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@Reshape_2"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/DecodeGif"
+  op: "DecodeGif"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/DecodeGif/Switch"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image/cond_jpeg/cond_png/Assert/Assert"
+  input: "^case/If_0/decode_image/cond_jpeg/cond_png/Assert_1/Assert"
+  device: "/device:CPU:0"
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/cond_png/Merge"
+  op: "Merge"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/DecodeGif"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/DecodePng"
+  device: "/device:CPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 2
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_UINT8
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image/cond_jpeg/Merge"
+  op: "Merge"
+  input: "case/If_0/decode_image/cond_jpeg/cond_png/Merge"
+  input: "case/If_0/decode_image/cond_jpeg/DecodeJpeg"
+  device: "/device:CPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 2
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_UINT8
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/Substr/pos"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/Substr/len"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 3
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/Substr/Switch"
+  op: "Switch"
+  input: "Reshape_2"
+  input: "case/If_0/pred_id"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@Reshape_2"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/Substr"
+  op: "Substr"
+  input: "case/If_0/decode_image_1/Substr/Switch"
+  input: "case/If_0/decode_image_1/Substr/pos"
+  input: "case/If_0/decode_image_1/Substr/len"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/is_jpeg/y"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "\377\330\377"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/is_jpeg"
+  op: "Equal"
+  input: "case/If_0/decode_image_1/Substr"
+  input: "case/If_0/decode_image_1/is_jpeg/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/Switch"
+  op: "Switch"
+  input: "case/If_0/decode_image_1/is_jpeg"
+  input: "case/If_0/decode_image_1/is_jpeg"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/switch_t"
+  op: "Identity"
+  input: "case/If_0/decode_image_1/cond_jpeg/Switch:1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/switch_f"
+  op: "Identity"
+  input: "case/If_0/decode_image_1/cond_jpeg/Switch"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/pred_id"
+  op: "Identity"
+  input: "case/If_0/decode_image_1/is_jpeg"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/check_jpeg_channels/x"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image_1/cond_jpeg/switch_t"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/check_jpeg_channels/y"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image_1/cond_jpeg/switch_t"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 4
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/check_jpeg_channels"
+  op: "NotEqual"
+  input: "case/If_0/decode_image_1/cond_jpeg/check_jpeg_channels/x"
+  input: "case/If_0/decode_image_1/cond_jpeg/check_jpeg_channels/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/Assert/Const"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image_1/cond_jpeg/switch_t"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "Channels must be in (None, 0, 1, 3) when decoding JPEG images"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/Assert/Assert/data_0"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image_1/cond_jpeg/switch_t"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "Channels must be in (None, 0, 1, 3) when decoding JPEG images"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/Assert/Assert"
+  op: "Assert"
+  input: "case/If_0/decode_image_1/cond_jpeg/check_jpeg_channels"
+  input: "case/If_0/decode_image_1/cond_jpeg/Assert/Assert/data_0"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      list {
+        type: DT_STRING
+      }
+    }
+  }
+  attr {
+    key: "summarize"
+    value {
+      i: 3
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/DecodeJpeg/Switch"
+  op: "Switch"
+  input: "case/If_0/decode_image_1/Substr/Switch"
+  input: "case/If_0/decode_image_1/cond_jpeg/pred_id"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@Reshape_2"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/DecodeJpeg"
+  op: "DecodeJpeg"
+  input: "case/If_0/decode_image_1/cond_jpeg/DecodeJpeg/Switch:1"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image_1/cond_jpeg/Assert/Assert"
+  device: "/device:CPU:0"
+  attr {
+    key: "acceptable_fraction"
+    value {
+      f: 1.0
+    }
+  }
+  attr {
+    key: "channels"
+    value {
+      i: 1
+    }
+  }
+  attr {
+    key: "dct_method"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "fancy_upscaling"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "ratio"
+    value {
+      i: 1
+    }
+  }
+  attr {
+    key: "try_recover_truncated"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/is_png/y"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image_1/cond_jpeg/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "\211PN"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/is_png/Switch"
+  op: "Switch"
+  input: "case/If_0/decode_image_1/Substr"
+  input: "case/If_0/decode_image_1/cond_jpeg/pred_id"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@case/If_0/decode_image_1/Substr"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/is_png"
+  op: "Equal"
+  input: "case/If_0/decode_image_1/cond_jpeg/is_png/Switch"
+  input: "case/If_0/decode_image_1/cond_jpeg/is_png/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/Switch"
+  op: "Switch"
+  input: "case/If_0/decode_image_1/cond_jpeg/is_png"
+  input: "case/If_0/decode_image_1/cond_jpeg/is_png"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/switch_t"
+  op: "Identity"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/Switch:1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/switch_f"
+  op: "Identity"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/Switch"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/pred_id"
+  op: "Identity"
+  input: "case/If_0/decode_image_1/cond_jpeg/is_png"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/DecodePng/Switch"
+  op: "Switch"
+  input: "case/If_0/decode_image_1/Substr/Switch"
+  input: "case/If_0/decode_image_1/cond_jpeg/pred_id"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@Reshape_2"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/DecodePng/Switch_1"
+  op: "Switch"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/DecodePng/Switch"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/pred_id"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@Reshape_2"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/DecodePng"
+  op: "DecodePng"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/DecodePng/Switch_1:1"
+  input: "^case/Assert/AssertGuard/Merge"
+  device: "/device:CPU:0"
+  attr {
+    key: "channels"
+    value {
+      i: 1
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_UINT8
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/is_gif/y"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image_1/cond_jpeg/cond_png/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "GIF"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/is_gif/Switch"
+  op: "Switch"
+  input: "case/If_0/decode_image_1/cond_jpeg/is_png/Switch"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/pred_id"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@case/If_0/decode_image_1/Substr"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/is_gif"
+  op: "Equal"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/is_gif/Switch"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/is_gif/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/Assert/Const"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image_1/cond_jpeg/cond_png/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "Unable to decode bytes as JPEG, PNG, or GIF"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/Assert/Assert/data_0"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image_1/cond_jpeg/cond_png/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "Unable to decode bytes as JPEG, PNG, or GIF"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/Assert/Assert"
+  op: "Assert"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/is_gif"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/Assert/Assert/data_0"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      list {
+        type: DT_STRING
+      }
+    }
+  }
+  attr {
+    key: "summarize"
+    value {
+      i: 3
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/check_gif_channels/x"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image_1/cond_jpeg/cond_png/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/check_gif_channels/y"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image_1/cond_jpeg/cond_png/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/check_gif_channels"
+  op: "NotEqual"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/check_gif_channels/x"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/check_gif_channels/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/check_gif_channels_1/x"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image_1/cond_jpeg/cond_png/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/check_gif_channels_1/y"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image_1/cond_jpeg/cond_png/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 4
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/check_gif_channels_1"
+  op: "NotEqual"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/check_gif_channels_1/x"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/check_gif_channels_1/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/LogicalAnd"
+  op: "LogicalAnd"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/check_gif_channels"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/check_gif_channels_1"
+  device: "/device:CPU:0"
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/Assert_1/Const"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image_1/cond_jpeg/cond_png/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "Channels must be in (None, 0, 3) when decoding GIF images"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/Assert_1/Assert/data_0"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image_1/cond_jpeg/cond_png/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "Channels must be in (None, 0, 3) when decoding GIF images"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/Assert_1/Assert"
+  op: "Assert"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/LogicalAnd"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/Assert_1/Assert/data_0"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      list {
+        type: DT_STRING
+      }
+    }
+  }
+  attr {
+    key: "summarize"
+    value {
+      i: 3
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/DecodeGif/Switch"
+  op: "Switch"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/DecodePng/Switch"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/pred_id"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@Reshape_2"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/DecodeGif"
+  op: "DecodeGif"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/DecodeGif/Switch"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/decode_image_1/cond_jpeg/cond_png/Assert/Assert"
+  input: "^case/If_0/decode_image_1/cond_jpeg/cond_png/Assert_1/Assert"
+  device: "/device:CPU:0"
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/cond_png/Merge"
+  op: "Merge"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/DecodeGif"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/DecodePng"
+  device: "/device:CPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 2
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_UINT8
+    }
+  }
+}
+node {
+  name: "case/If_0/decode_image_1/cond_jpeg/Merge"
+  op: "Merge"
+  input: "case/If_0/decode_image_1/cond_jpeg/cond_png/Merge"
+  input: "case/If_0/decode_image_1/cond_jpeg/DecodeJpeg"
+  device: "/device:CPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 2
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_UINT8
+    }
+  }
+}
+node {
+  name: "case/If_0/Const"
+  op: "Const"
+  input: "^case/Assert/AssertGuard/Merge"
+  input: "^case/If_0/switch_f"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_UINT8
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_UINT8
+        tensor_shape {
+        }
+        int_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "case/If_0/Merge"
+  op: "Merge"
+  input: "case/If_0/Const"
+  input: "case/If_0/decode_image/cond_jpeg/Merge"
+  device: "/device:CPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 2
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_UINT8
+    }
+  }
+}
+node {
+  name: "case/If_1/Switch"
+  op: "Switch"
+  input: "case/case_0/LogicalAnd"
+  input: "case/case_0/LogicalAnd"
+  input: "^case/Assert/AssertGuard/Merge"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_1/switch_t"
+  op: "Identity"
+  input: "case/If_1/Switch:1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_1/switch_f"
+  op: "Identity"
+  input: "case/If_1/Switch"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_1/pred_id"
+  op: "Identity"
+  input: "case/case_0/LogicalAnd"
+  input: "^case/Assert/AssertGuard/Merge"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "case/If_1/DecodeRaw/Switch"
+  op: "Switch"
+  input: "Reshape_2"
+  input: "case/If_1/pred_id"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@Reshape_2"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_1/DecodeRaw"
+  op: "DecodeRaw"
+  input: "case/If_1/DecodeRaw/Switch:1"
+  input: "^case/Assert/AssertGuard/Merge"
+  device: "/device:CPU:0"
+  attr {
+    key: "little_endian"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "out_type"
+    value {
+      type: DT_UINT8
+    }
+  }
+}
+node {
+  name: "case/If_1/Switch_1"
+  op: "Switch"
+  input: "case/If_0/Merge"
+  input: "case/If_1/pred_id"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_UINT8
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@case/If_0/Merge"
+      }
+    }
+  }
+}
+node {
+  name: "case/If_1/Merge"
+  op: "Merge"
+  input: "case/If_1/Switch_1"
+  input: "case/If_1/DecodeRaw"
+  device: "/device:CPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 2
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_UINT8
+    }
+  }
+}
+node {
+  name: "Reshape_3/shape"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 3
+          }
+        }
+        tensor_content: "\034\000\000\000\034\000\000\000\001\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "Reshape_3"
+  op: "Reshape"
+  input: "case/If_1/Merge"
+  input: "Reshape_3/shape"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_UINT8
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "Reshape_4/shape"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "Reshape_4"
+  op: "Reshape"
+  input: "Reshape"
+  input: "Reshape_4/shape"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT64
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "sub/y"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT64
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT64
+        tensor_shape {
+        }
+        int64_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "sub"
+  op: "Sub"
+  input: "Reshape_4"
+  input: "sub/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT64
+    }
+  }
+}
+node {
+  name: "ToFloat"
+  op: "Cast"
+  input: "Reshape_3"
+  device: "/device:CPU:0"
+  attr {
+    key: "DstT"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "SrcT"
+    value {
+      type: DT_UINT8
+    }
+  }
+}
+node {
+  name: "ExpandDims/dim"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "ExpandDims"
+  op: "ExpandDims"
+  input: "ToFloat"
+  input: "ExpandDims/dim"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tdim"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "control_dependency"
+  op: "Identity"
+  input: "ExpandDims"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@ExpandDims"
+      }
+    }
+  }
+}
+node {
+  name: "control_dependency_1"
+  op: "Identity"
+  input: "control_dependency"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@ExpandDims"
+      }
+    }
+  }
+}
+node {
+  name: "stack"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 4
+          }
+        }
+        tensor_content: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "stack_1"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 4
+          }
+        }
+        tensor_content: "\377\377\377\377\034\000\000\000\034\000\000\000\377\377\377\377"
+      }
+    }
+  }
+}
+node {
+  name: "Slice"
+  op: "Slice"
+  input: "control_dependency_1"
+  input: "stack"
+  input: "stack_1"
+  device: "/device:CPU:0"
+  attr {
+    key: "Index"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "control_dependency_2"
+  op: "Identity"
+  input: "Slice"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@Slice"
+      }
+    }
+  }
+}
+node {
+  name: "stack_2"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 8
+          }
+        }
+        tensor_content: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "Reshape_5/shape"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
+        tensor_content: "\004\000\000\000\002\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "Reshape_5"
+  op: "Reshape"
+  input: "stack_2"
+  input: "Reshape_5/shape"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "Pad"
+  op: "Pad"
+  input: "control_dependency_2"
+  input: "Reshape_5"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tpaddings"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "control_dependency_3"
+  op: "Identity"
+  input: "Pad"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@Pad"
+      }
+    }
+  }
+}
+node {
+  name: "Squeeze"
+  op: "Squeeze"
+  input: "control_dependency_3"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "squeeze_dims"
+    value {
+      list {
+        i: 0
+      }
+    }
+  }
+}
+node {
+  name: "Sub/y"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 128.0
+      }
+    }
+  }
+}
+node {
+  name: "Sub"
+  op: "Sub"
+  input: "Squeeze"
+  input: "Sub/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "div/y"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 128.0
+      }
+    }
+  }
+}
+node {
+  name: "div"
+  op: "RealDiv"
+  input: "Sub"
+  input: "div/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "batch/Const"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_BOOL
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_BOOL
+        tensor_shape {
+        }
+        bool_val: true
+      }
+    }
+  }
+}
+node {
+  name: "batch/fifo_queue"
+  op: "FIFOQueueV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "capacity"
+    value {
+      i: 160
+    }
+  }
+  attr {
+    key: "component_types"
+    value {
+      list {
+        type: DT_FLOAT
+        type: DT_INT64
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "shapes"
+    value {
+      list {
+        shape {
+          dim {
+            size: 28
+          }
+          dim {
+            size: 28
+          }
+          dim {
+            size: 1
+          }
+        }
+        shape {
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "batch/fifo_queue_enqueue"
+  op: "QueueEnqueueV2"
+  input: "batch/fifo_queue"
+  input: "div"
+  input: "sub"
+  device: "/device:CPU:0"
+  attr {
+    key: "Tcomponents"
+    value {
+      list {
+        type: DT_FLOAT
+        type: DT_INT64
+      }
+    }
+  }
+  attr {
+    key: "timeout_ms"
+    value {
+      i: -1
+    }
+  }
+}
+node {
+  name: "batch/fifo_queue_Close"
+  op: "QueueCloseV2"
+  input: "batch/fifo_queue"
+  device: "/device:CPU:0"
+  attr {
+    key: "cancel_pending_enqueues"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "batch/fifo_queue_Close_1"
+  op: "QueueCloseV2"
+  input: "batch/fifo_queue"
+  device: "/device:CPU:0"
+  attr {
+    key: "cancel_pending_enqueues"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "batch/fifo_queue_Size"
+  op: "QueueSizeV2"
+  input: "batch/fifo_queue"
+  device: "/device:CPU:0"
+}
+node {
+  name: "batch/Cast"
+  op: "Cast"
+  input: "batch/fifo_queue_Size"
+  device: "/device:CPU:0"
+  attr {
+    key: "DstT"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "SrcT"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "batch/mul/y"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.00625000009313
+      }
+    }
+  }
+}
+node {
+  name: "batch/mul"
+  op: "Mul"
+  input: "batch/Cast"
+  input: "batch/mul/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "batch/fraction_of_160_full/tags"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "batch/fraction_of_160_full"
+      }
+    }
+  }
+}
+node {
+  name: "batch/fraction_of_160_full"
+  op: "ScalarSummary"
+  input: "batch/fraction_of_160_full/tags"
+  input: "batch/mul"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "batch/n"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 32
+      }
+    }
+  }
+}
+node {
+  name: "batch"
+  op: "QueueDequeueManyV2"
+  input: "batch/fifo_queue"
+  input: "batch/n"
+  device: "/device:CPU:0"
+  attr {
+    key: "component_types"
+    value {
+      list {
+        type: DT_FLOAT
+        type: DT_INT64
+      }
+    }
+  }
+  attr {
+    key: "timeout_ms"
+    value {
+      i: -1
+    }
+  }
+}
+node {
+  name: "OneHotEncoding/one_hot/Const"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 1.0
+      }
+    }
+  }
+}
+node {
+  name: "OneHotEncoding/one_hot/Const_1"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "OneHotEncoding/one_hot/depth"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 10
+      }
+    }
+  }
+}
+node {
+  name: "OneHotEncoding/one_hot/on_value"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 1.0
+      }
+    }
+  }
+}
+node {
+  name: "OneHotEncoding/one_hot/off_value"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "OneHotEncoding/one_hot"
+  op: "OneHot"
+  input: "batch:1"
+  input: "OneHotEncoding/one_hot/depth"
+  input: "OneHotEncoding/one_hot/on_value"
+  input: "OneHotEncoding/one_hot/off_value"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "TI"
+    value {
+      type: DT_INT64
+    }
+  }
+  attr {
+    key: "axis"
+    value {
+      i: -1
+    }
+  }
+}
+node {
+  name: "prefetch_queue/fifo_queue"
+  op: "FIFOQueueV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "capacity"
+    value {
+      i: 2
+    }
+  }
+  attr {
+    key: "component_types"
+    value {
+      list {
+        type: DT_FLOAT
+        type: DT_FLOAT
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "shapes"
+    value {
+      list {
+        shape {
+          dim {
+            size: 32
+          }
+          dim {
+            size: 28
+          }
+          dim {
+            size: 28
+          }
+          dim {
+            size: 1
+          }
+        }
+        shape {
+          dim {
+            size: 32
+          }
+          dim {
+            size: 10
+          }
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "prefetch_queue/fifo_queue_enqueue"
+  op: "QueueEnqueueV2"
+  input: "prefetch_queue/fifo_queue"
+  input: "batch"
+  input: "OneHotEncoding/one_hot"
+  device: "/device:CPU:0"
+  attr {
+    key: "Tcomponents"
+    value {
+      list {
+        type: DT_FLOAT
+        type: DT_FLOAT
+      }
+    }
+  }
+  attr {
+    key: "timeout_ms"
+    value {
+      i: -1
+    }
+  }
+}
+node {
+  name: "prefetch_queue/fifo_queue_Close"
+  op: "QueueCloseV2"
+  input: "prefetch_queue/fifo_queue"
+  device: "/device:CPU:0"
+  attr {
+    key: "cancel_pending_enqueues"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "prefetch_queue/fifo_queue_Close_1"
+  op: "QueueCloseV2"
+  input: "prefetch_queue/fifo_queue"
+  device: "/device:CPU:0"
+  attr {
+    key: "cancel_pending_enqueues"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "prefetch_queue/fifo_queue_Size"
+  op: "QueueSizeV2"
+  input: "prefetch_queue/fifo_queue"
+  device: "/device:CPU:0"
+}
+node {
+  name: "prefetch_queue/ToFloat"
+  op: "Cast"
+  input: "prefetch_queue/fifo_queue_Size"
+  device: "/device:CPU:0"
+  attr {
+    key: "DstT"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "SrcT"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "prefetch_queue/mul/y"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.5
+      }
+    }
+  }
+}
+node {
+  name: "prefetch_queue/mul"
+  op: "Mul"
+  input: "prefetch_queue/ToFloat"
+  input: "prefetch_queue/mul/y"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "prefetch_queue/fraction_of_2_full/tags"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "prefetch_queue/fraction_of_2_full"
+      }
+    }
+  }
+}
+node {
+  name: "prefetch_queue/fraction_of_2_full"
+  op: "ScalarSummary"
+  input: "prefetch_queue/fraction_of_2_full/tags"
+  input: "prefetch_queue/mul"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "fifo_queue_Dequeue"
+  op: "QueueDequeueV2"
+  input: "prefetch_queue/fifo_queue"
+  device: "/device:CPU:0"
+  attr {
+    key: "component_types"
+    value {
+      list {
+        type: DT_FLOAT
+        type: DT_FLOAT
+      }
+    }
+  }
+  attr {
+    key: "timeout_ms"
+    value {
+      i: -1
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/weights/Initializer/truncated_normal/shape"
+  op: "Const"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 4
+          }
+        }
+        tensor_content: "\005\000\000\000\005\000\000\000\001\000\000\000 \000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/weights/Initializer/truncated_normal/mean"
+  op: "Const"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/weights/Initializer/truncated_normal/stddev"
+  op: "Const"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.10000000149
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/weights/Initializer/truncated_normal/TruncatedNormal"
+  op: "TruncatedNormal"
+  input: "LeNet/conv1/weights/Initializer/truncated_normal/shape"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "seed"
+    value {
+      i: 0
+    }
+  }
+  attr {
+    key: "seed2"
+    value {
+      i: 0
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/weights/Initializer/truncated_normal/mul"
+  op: "Mul"
+  input: "LeNet/conv1/weights/Initializer/truncated_normal/TruncatedNormal"
+  input: "LeNet/conv1/weights/Initializer/truncated_normal/stddev"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/weights/Initializer/truncated_normal"
+  op: "Add"
+  input: "LeNet/conv1/weights/Initializer/truncated_normal/mul"
+  input: "LeNet/conv1/weights/Initializer/truncated_normal/mean"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/weights"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 5
+        }
+        dim {
+          size: 5
+        }
+        dim {
+          size: 1
+        }
+        dim {
+          size: 32
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/weights/Assign"
+  op: "Assign"
+  input: "LeNet/conv1/weights"
+  input: "LeNet/conv1/weights/Initializer/truncated_normal"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/weights/read"
+  op: "Identity"
+  input: "LeNet/conv1/weights"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/kernel/Regularizer/l2_regularizer/scale"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 3.99999989895e-05
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/kernel/Regularizer/l2_regularizer/L2Loss"
+  op: "L2Loss"
+  input: "LeNet/conv1/weights/read"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/kernel/Regularizer/l2_regularizer"
+  op: "Mul"
+  input: "LeNet/conv1/kernel/Regularizer/l2_regularizer/scale"
+  input: "LeNet/conv1/kernel/Regularizer/l2_regularizer/L2Loss"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/biases/Initializer/zeros"
+  op: "Const"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/biases"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 32
+          }
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/biases"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/biases"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 32
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/biases/Assign"
+  op: "Assign"
+  input: "LeNet/conv1/biases"
+  input: "LeNet/conv1/biases/Initializer/zeros"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/biases"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/biases/read"
+  op: "Identity"
+  input: "LeNet/conv1/biases"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/biases"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/convolution/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 4
+          }
+        }
+        tensor_content: "\005\000\000\000\005\000\000\000\001\000\000\000 \000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/convolution/dilation_rate"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
+        tensor_content: "\001\000\000\000\001\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/convolution"
+  op: "Conv2D"
+  input: "fifo_queue_Dequeue"
+  input: "LeNet/conv1/weights/read"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+  attr {
+    key: "padding"
+    value {
+      s: "SAME"
+    }
+  }
+  attr {
+    key: "strides"
+    value {
+      list {
+        i: 1
+        i: 1
+        i: 1
+        i: 1
+      }
+    }
+  }
+  attr {
+    key: "use_cudnn_on_gpu"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/BiasAdd"
+  op: "BiasAdd"
+  input: "LeNet/conv1/convolution"
+  input: "LeNet/conv1/biases/read"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/Relu"
+  op: "Relu"
+  input: "LeNet/conv1/BiasAdd"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "LeNet/pool1/MaxPool"
+  op: "MaxPool"
+  input: "LeNet/conv1/Relu"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+  attr {
+    key: "ksize"
+    value {
+      list {
+        i: 1
+        i: 2
+        i: 2
+        i: 1
+      }
+    }
+  }
+  attr {
+    key: "padding"
+    value {
+      s: "VALID"
+    }
+  }
+  attr {
+    key: "strides"
+    value {
+      list {
+        i: 1
+        i: 2
+        i: 2
+        i: 1
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/weights/Initializer/truncated_normal/shape"
+  op: "Const"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 4
+          }
+        }
+        tensor_content: "\005\000\000\000\005\000\000\000 \000\000\000@\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/weights/Initializer/truncated_normal/mean"
+  op: "Const"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/weights/Initializer/truncated_normal/stddev"
+  op: "Const"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.10000000149
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/weights/Initializer/truncated_normal/TruncatedNormal"
+  op: "TruncatedNormal"
+  input: "LeNet/conv2/weights/Initializer/truncated_normal/shape"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "seed"
+    value {
+      i: 0
+    }
+  }
+  attr {
+    key: "seed2"
+    value {
+      i: 0
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/weights/Initializer/truncated_normal/mul"
+  op: "Mul"
+  input: "LeNet/conv2/weights/Initializer/truncated_normal/TruncatedNormal"
+  input: "LeNet/conv2/weights/Initializer/truncated_normal/stddev"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/weights/Initializer/truncated_normal"
+  op: "Add"
+  input: "LeNet/conv2/weights/Initializer/truncated_normal/mul"
+  input: "LeNet/conv2/weights/Initializer/truncated_normal/mean"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/weights"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 5
+        }
+        dim {
+          size: 5
+        }
+        dim {
+          size: 32
+        }
+        dim {
+          size: 64
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/weights/Assign"
+  op: "Assign"
+  input: "LeNet/conv2/weights"
+  input: "LeNet/conv2/weights/Initializer/truncated_normal"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/weights/read"
+  op: "Identity"
+  input: "LeNet/conv2/weights"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/kernel/Regularizer/l2_regularizer/scale"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 3.99999989895e-05
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/kernel/Regularizer/l2_regularizer/L2Loss"
+  op: "L2Loss"
+  input: "LeNet/conv2/weights/read"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/kernel/Regularizer/l2_regularizer"
+  op: "Mul"
+  input: "LeNet/conv2/kernel/Regularizer/l2_regularizer/scale"
+  input: "LeNet/conv2/kernel/Regularizer/l2_regularizer/L2Loss"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/biases/Initializer/zeros"
+  op: "Const"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/biases"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 64
+          }
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/biases"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/biases"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 64
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/biases/Assign"
+  op: "Assign"
+  input: "LeNet/conv2/biases"
+  input: "LeNet/conv2/biases/Initializer/zeros"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/biases"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/biases/read"
+  op: "Identity"
+  input: "LeNet/conv2/biases"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/biases"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/convolution/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 4
+          }
+        }
+        tensor_content: "\005\000\000\000\005\000\000\000 \000\000\000@\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/convolution/dilation_rate"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
+        tensor_content: "\001\000\000\000\001\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/convolution"
+  op: "Conv2D"
+  input: "LeNet/pool1/MaxPool"
+  input: "LeNet/conv2/weights/read"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+  attr {
+    key: "padding"
+    value {
+      s: "SAME"
+    }
+  }
+  attr {
+    key: "strides"
+    value {
+      list {
+        i: 1
+        i: 1
+        i: 1
+        i: 1
+      }
+    }
+  }
+  attr {
+    key: "use_cudnn_on_gpu"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/BiasAdd"
+  op: "BiasAdd"
+  input: "LeNet/conv2/convolution"
+  input: "LeNet/conv2/biases/read"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/Relu"
+  op: "Relu"
+  input: "LeNet/conv2/BiasAdd"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "LeNet/pool2/MaxPool"
+  op: "MaxPool"
+  input: "LeNet/conv2/Relu"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+  attr {
+    key: "ksize"
+    value {
+      list {
+        i: 1
+        i: 2
+        i: 2
+        i: 1
+      }
+    }
+  }
+  attr {
+    key: "padding"
+    value {
+      s: "VALID"
+    }
+  }
+  attr {
+    key: "strides"
+    value {
+      list {
+        i: 1
+        i: 2
+        i: 2
+        i: 1
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/Flatten/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 4
+          }
+        }
+        tensor_content: " \000\000\000\007\000\000\000\007\000\000\000@\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/Flatten/Slice/begin"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/Flatten/Slice/size"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/Flatten/Slice"
+  op: "Slice"
+  input: "LeNet/Flatten/Shape"
+  input: "LeNet/Flatten/Slice/begin"
+  input: "LeNet/Flatten/Slice/size"
+  device: "/device:GPU:0"
+  attr {
+    key: "Index"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "LeNet/Flatten/Slice_1/begin"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/Flatten/Slice_1/size"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: 3
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/Flatten/Slice_1"
+  op: "Slice"
+  input: "LeNet/Flatten/Shape"
+  input: "LeNet/Flatten/Slice_1/begin"
+  input: "LeNet/Flatten/Slice_1/size"
+  device: "/device:GPU:0"
+  attr {
+    key: "Index"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "LeNet/Flatten/Const"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/Flatten/Prod"
+  op: "Prod"
+  input: "LeNet/Flatten/Slice_1"
+  input: "LeNet/Flatten/Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "LeNet/Flatten/ExpandDims/dim"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/Flatten/ExpandDims"
+  op: "ExpandDims"
+  input: "LeNet/Flatten/Prod"
+  input: "LeNet/Flatten/ExpandDims/dim"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "Tdim"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "LeNet/Flatten/concat/axis"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/Flatten/concat"
+  op: "ConcatV2"
+  input: "LeNet/Flatten/Slice"
+  input: "LeNet/Flatten/ExpandDims"
+  input: "LeNet/Flatten/concat/axis"
+  device: "/device:GPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 2
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "LeNet/Flatten/Reshape"
+  op: "Reshape"
+  input: "LeNet/pool2/MaxPool"
+  input: "LeNet/Flatten/concat"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/weights/Initializer/truncated_normal/shape"
+  op: "Const"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
+        tensor_content: "@\014\000\000\000\004\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/weights/Initializer/truncated_normal/mean"
+  op: "Const"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/weights/Initializer/truncated_normal/stddev"
+  op: "Const"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.10000000149
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/weights/Initializer/truncated_normal/TruncatedNormal"
+  op: "TruncatedNormal"
+  input: "LeNet/fc3/weights/Initializer/truncated_normal/shape"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "seed"
+    value {
+      i: 0
+    }
+  }
+  attr {
+    key: "seed2"
+    value {
+      i: 0
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/weights/Initializer/truncated_normal/mul"
+  op: "Mul"
+  input: "LeNet/fc3/weights/Initializer/truncated_normal/TruncatedNormal"
+  input: "LeNet/fc3/weights/Initializer/truncated_normal/stddev"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/weights/Initializer/truncated_normal"
+  op: "Add"
+  input: "LeNet/fc3/weights/Initializer/truncated_normal/mul"
+  input: "LeNet/fc3/weights/Initializer/truncated_normal/mean"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/weights"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 3136
+        }
+        dim {
+          size: 1024
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/weights/Assign"
+  op: "Assign"
+  input: "LeNet/fc3/weights"
+  input: "LeNet/fc3/weights/Initializer/truncated_normal"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/weights/read"
+  op: "Identity"
+  input: "LeNet/fc3/weights"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/kernel/Regularizer/l2_regularizer/scale"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 3.99999989895e-05
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/kernel/Regularizer/l2_regularizer/L2Loss"
+  op: "L2Loss"
+  input: "LeNet/fc3/weights/read"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/kernel/Regularizer/l2_regularizer"
+  op: "Mul"
+  input: "LeNet/fc3/kernel/Regularizer/l2_regularizer/scale"
+  input: "LeNet/fc3/kernel/Regularizer/l2_regularizer/L2Loss"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/biases/Initializer/zeros"
+  op: "Const"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/biases"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 1024
+          }
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/biases"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/biases"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 1024
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/biases/Assign"
+  op: "Assign"
+  input: "LeNet/fc3/biases"
+  input: "LeNet/fc3/biases/Initializer/zeros"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/biases"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/biases/read"
+  op: "Identity"
+  input: "LeNet/fc3/biases"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/biases"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/MatMul"
+  op: "MatMul"
+  input: "LeNet/Flatten/Reshape"
+  input: "LeNet/fc3/weights/read"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "transpose_a"
+    value {
+      b: false
+    }
+  }
+  attr {
+    key: "transpose_b"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/BiasAdd"
+  op: "BiasAdd"
+  input: "LeNet/fc3/MatMul"
+  input: "LeNet/fc3/biases/read"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/Relu"
+  op: "Relu"
+  input: "LeNet/fc3/BiasAdd"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "LeNet/dropout3/dropout/keep_prob"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.5
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/dropout3/dropout/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
+        tensor_content: " \000\000\000\000\004\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/dropout3/dropout/random_uniform/min"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/dropout3/dropout/random_uniform/max"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 1.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/dropout3/dropout/random_uniform/RandomUniform"
+  op: "RandomUniform"
+  input: "LeNet/dropout3/dropout/Shape"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "seed"
+    value {
+      i: 0
+    }
+  }
+  attr {
+    key: "seed2"
+    value {
+      i: 0
+    }
+  }
+}
+node {
+  name: "LeNet/dropout3/dropout/random_uniform/sub"
+  op: "Sub"
+  input: "LeNet/dropout3/dropout/random_uniform/max"
+  input: "LeNet/dropout3/dropout/random_uniform/min"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "LeNet/dropout3/dropout/random_uniform/mul"
+  op: "Mul"
+  input: "LeNet/dropout3/dropout/random_uniform/RandomUniform"
+  input: "LeNet/dropout3/dropout/random_uniform/sub"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "LeNet/dropout3/dropout/random_uniform"
+  op: "Add"
+  input: "LeNet/dropout3/dropout/random_uniform/mul"
+  input: "LeNet/dropout3/dropout/random_uniform/min"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "LeNet/dropout3/dropout/add"
+  op: "Add"
+  input: "LeNet/dropout3/dropout/keep_prob"
+  input: "LeNet/dropout3/dropout/random_uniform"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "LeNet/dropout3/dropout/Floor"
+  op: "Floor"
+  input: "LeNet/dropout3/dropout/add"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "LeNet/dropout3/dropout/div"
+  op: "RealDiv"
+  input: "LeNet/fc3/Relu"
+  input: "LeNet/dropout3/dropout/keep_prob"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "LeNet/dropout3/dropout/mul"
+  op: "Mul"
+  input: "LeNet/dropout3/dropout/div"
+  input: "LeNet/dropout3/dropout/Floor"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/weights/Initializer/truncated_normal/shape"
+  op: "Const"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
+        tensor_content: "\000\004\000\000\n\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/weights/Initializer/truncated_normal/mean"
+  op: "Const"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/weights/Initializer/truncated_normal/stddev"
+  op: "Const"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.10000000149
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/weights/Initializer/truncated_normal/TruncatedNormal"
+  op: "TruncatedNormal"
+  input: "LeNet/fc4/weights/Initializer/truncated_normal/shape"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "seed"
+    value {
+      i: 0
+    }
+  }
+  attr {
+    key: "seed2"
+    value {
+      i: 0
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/weights/Initializer/truncated_normal/mul"
+  op: "Mul"
+  input: "LeNet/fc4/weights/Initializer/truncated_normal/TruncatedNormal"
+  input: "LeNet/fc4/weights/Initializer/truncated_normal/stddev"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/weights/Initializer/truncated_normal"
+  op: "Add"
+  input: "LeNet/fc4/weights/Initializer/truncated_normal/mul"
+  input: "LeNet/fc4/weights/Initializer/truncated_normal/mean"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/weights"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 1024
+        }
+        dim {
+          size: 10
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/weights/Assign"
+  op: "Assign"
+  input: "LeNet/fc4/weights"
+  input: "LeNet/fc4/weights/Initializer/truncated_normal"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/weights/read"
+  op: "Identity"
+  input: "LeNet/fc4/weights"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/kernel/Regularizer/l2_regularizer/scale"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 3.99999989895e-05
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/kernel/Regularizer/l2_regularizer/L2Loss"
+  op: "L2Loss"
+  input: "LeNet/fc4/weights/read"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/kernel/Regularizer/l2_regularizer"
+  op: "Mul"
+  input: "LeNet/fc4/kernel/Regularizer/l2_regularizer/scale"
+  input: "LeNet/fc4/kernel/Regularizer/l2_regularizer/L2Loss"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/biases/Initializer/zeros"
+  op: "Const"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/biases"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 10
+          }
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/biases"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/biases"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 10
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/biases/Assign"
+  op: "Assign"
+  input: "LeNet/fc4/biases"
+  input: "LeNet/fc4/biases/Initializer/zeros"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/biases"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/biases/read"
+  op: "Identity"
+  input: "LeNet/fc4/biases"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/biases"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/MatMul"
+  op: "MatMul"
+  input: "LeNet/dropout3/dropout/mul"
+  input: "LeNet/fc4/weights/read"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "transpose_a"
+    value {
+      b: false
+    }
+  }
+  attr {
+    key: "transpose_b"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/BiasAdd"
+  op: "BiasAdd"
+  input: "LeNet/fc4/MatMul"
+  input: "LeNet/fc4/biases/read"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+}
+node {
+  name: "Predictions/Reshape/shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
+        tensor_content: "\377\377\377\377\n\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "Predictions/Reshape"
+  op: "Reshape"
+  input: "LeNet/fc4/BiasAdd"
+  input: "Predictions/Reshape/shape"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "Predictions/Softmax"
+  op: "Softmax"
+  input: "Predictions/Reshape"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "Predictions/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
+        tensor_content: " \000\000\000\n\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "Predictions/Reshape_1"
+  op: "Reshape"
+  input: "Predictions/Softmax"
+  input: "Predictions/Shape"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Rank"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 2
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
+        tensor_content: " \000\000\000\n\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Rank_1"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 2
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Shape_1"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
+        tensor_content: " \000\000\000\n\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Sub/y"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Sub"
+  op: "Sub"
+  input: "softmax_cross_entropy_loss/Rank_1"
+  input: "softmax_cross_entropy_loss/Sub/y"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Slice/begin"
+  op: "Pack"
+  input: "softmax_cross_entropy_loss/Sub"
+  device: "/device:GPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 1
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "axis"
+    value {
+      i: 0
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Slice/size"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Slice"
+  op: "Slice"
+  input: "softmax_cross_entropy_loss/Shape_1"
+  input: "softmax_cross_entropy_loss/Slice/begin"
+  input: "softmax_cross_entropy_loss/Slice/size"
+  device: "/device:GPU:0"
+  attr {
+    key: "Index"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/concat/values_0"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: -1
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/concat/axis"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/concat"
+  op: "ConcatV2"
+  input: "softmax_cross_entropy_loss/concat/values_0"
+  input: "softmax_cross_entropy_loss/Slice"
+  input: "softmax_cross_entropy_loss/concat/axis"
+  device: "/device:GPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 2
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Reshape"
+  op: "Reshape"
+  input: "LeNet/fc4/BiasAdd"
+  input: "softmax_cross_entropy_loss/concat"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Rank_2"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 2
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Shape_2"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
+        tensor_content: " \000\000\000\n\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Sub_1/y"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Sub_1"
+  op: "Sub"
+  input: "softmax_cross_entropy_loss/Rank_2"
+  input: "softmax_cross_entropy_loss/Sub_1/y"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Slice_1/begin"
+  op: "Pack"
+  input: "softmax_cross_entropy_loss/Sub_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 1
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "axis"
+    value {
+      i: 0
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Slice_1/size"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Slice_1"
+  op: "Slice"
+  input: "softmax_cross_entropy_loss/Shape_2"
+  input: "softmax_cross_entropy_loss/Slice_1/begin"
+  input: "softmax_cross_entropy_loss/Slice_1/size"
+  device: "/device:GPU:0"
+  attr {
+    key: "Index"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/concat_1/values_0"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: -1
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/concat_1/axis"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/concat_1"
+  op: "ConcatV2"
+  input: "softmax_cross_entropy_loss/concat_1/values_0"
+  input: "softmax_cross_entropy_loss/Slice_1"
+  input: "softmax_cross_entropy_loss/concat_1/axis"
+  device: "/device:GPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 2
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Reshape_1"
+  op: "Reshape"
+  input: "fifo_queue_Dequeue:1"
+  input: "softmax_cross_entropy_loss/concat_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/xentropy"
+  op: "SoftmaxCrossEntropyWithLogits"
+  input: "softmax_cross_entropy_loss/Reshape"
+  input: "softmax_cross_entropy_loss/Reshape_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Sub_2/y"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Sub_2"
+  op: "Sub"
+  input: "softmax_cross_entropy_loss/Rank"
+  input: "softmax_cross_entropy_loss/Sub_2/y"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Slice_2/begin"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Slice_2/size"
+  op: "Pack"
+  input: "softmax_cross_entropy_loss/Sub_2"
+  device: "/device:GPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 1
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "axis"
+    value {
+      i: 0
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Slice_2"
+  op: "Slice"
+  input: "softmax_cross_entropy_loss/Shape"
+  input: "softmax_cross_entropy_loss/Slice_2/begin"
+  input: "softmax_cross_entropy_loss/Slice_2/size"
+  device: "/device:GPU:0"
+  attr {
+    key: "Index"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Reshape_2"
+  op: "Reshape"
+  input: "softmax_cross_entropy_loss/xentropy"
+  input: "softmax_cross_entropy_loss/Slice_2"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/assert_broadcastable/weights"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 1.0
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/assert_broadcastable/weights/shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/assert_broadcastable/weights/rank"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/assert_broadcastable/values/shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: 32
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/assert_broadcastable/values/rank"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  op: "NoOp"
+  device: "/device:GPU:0"
+}
+node {
+  name: "softmax_cross_entropy_loss/ToFloat_1/x"
+  op: "Const"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 1.0
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Mul"
+  op: "Mul"
+  input: "softmax_cross_entropy_loss/Reshape_2"
+  input: "softmax_cross_entropy_loss/ToFloat_1/x"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Const"
+  op: "Const"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Sum"
+  op: "Sum"
+  input: "softmax_cross_entropy_loss/Mul"
+  input: "softmax_cross_entropy_loss/Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/num_present/Equal/y"
+  op: "Const"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/num_present/Equal"
+  op: "Equal"
+  input: "softmax_cross_entropy_loss/ToFloat_1/x"
+  input: "softmax_cross_entropy_loss/num_present/Equal/y"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/num_present/zeros_like"
+  op: "Const"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/num_present/ones_like/Shape"
+  op: "Const"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/num_present/ones_like/Const"
+  op: "Const"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 1.0
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/num_present/ones_like"
+  op: "Fill"
+  input: "softmax_cross_entropy_loss/num_present/ones_like/Shape"
+  input: "softmax_cross_entropy_loss/num_present/ones_like/Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/num_present/Select"
+  op: "Select"
+  input: "softmax_cross_entropy_loss/num_present/Equal"
+  input: "softmax_cross_entropy_loss/num_present/zeros_like"
+  input: "softmax_cross_entropy_loss/num_present/ones_like"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/num_present/broadcast_weights/assert_broadcastable/weights/shape"
+  op: "Const"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/num_present/broadcast_weights/assert_broadcastable/weights/rank"
+  op: "Const"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/num_present/broadcast_weights/assert_broadcastable/values/shape"
+  op: "Const"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: 32
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/num_present/broadcast_weights/assert_broadcastable/values/rank"
+  op: "Const"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/num_present/broadcast_weights/assert_broadcastable/static_scalar_check_success"
+  op: "NoOp"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+}
+node {
+  name: "softmax_cross_entropy_loss/num_present/broadcast_weights/ones_like/Shape"
+  op: "Const"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  input: "^softmax_cross_entropy_loss/num_present/broadcast_weights/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: 32
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/num_present/broadcast_weights/ones_like/Const"
+  op: "Const"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  input: "^softmax_cross_entropy_loss/num_present/broadcast_weights/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 1.0
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/num_present/broadcast_weights/ones_like"
+  op: "Fill"
+  input: "softmax_cross_entropy_loss/num_present/broadcast_weights/ones_like/Shape"
+  input: "softmax_cross_entropy_loss/num_present/broadcast_weights/ones_like/Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/num_present/broadcast_weights"
+  op: "Mul"
+  input: "softmax_cross_entropy_loss/num_present/Select"
+  input: "softmax_cross_entropy_loss/num_present/broadcast_weights/ones_like"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/num_present/Const"
+  op: "Const"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: 0
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/num_present"
+  op: "Sum"
+  input: "softmax_cross_entropy_loss/num_present/broadcast_weights"
+  input: "softmax_cross_entropy_loss/num_present/Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Const_1"
+  op: "Const"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Sum_1"
+  op: "Sum"
+  input: "softmax_cross_entropy_loss/Sum"
+  input: "softmax_cross_entropy_loss/Const_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Greater/y"
+  op: "Const"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Greater"
+  op: "Greater"
+  input: "softmax_cross_entropy_loss/num_present"
+  input: "softmax_cross_entropy_loss/Greater/y"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Equal/y"
+  op: "Const"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Equal"
+  op: "Equal"
+  input: "softmax_cross_entropy_loss/num_present"
+  input: "softmax_cross_entropy_loss/Equal/y"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/ones_like/Shape"
+  op: "Const"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/ones_like/Const"
+  op: "Const"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 1.0
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/ones_like"
+  op: "Fill"
+  input: "softmax_cross_entropy_loss/ones_like/Shape"
+  input: "softmax_cross_entropy_loss/ones_like/Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/Select"
+  op: "Select"
+  input: "softmax_cross_entropy_loss/Equal"
+  input: "softmax_cross_entropy_loss/ones_like"
+  input: "softmax_cross_entropy_loss/num_present"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/div"
+  op: "RealDiv"
+  input: "softmax_cross_entropy_loss/Sum_1"
+  input: "softmax_cross_entropy_loss/Select"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/zeros_like"
+  op: "Const"
+  input: "^softmax_cross_entropy_loss/assert_broadcastable/static_scalar_check_success"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "softmax_cross_entropy_loss/value"
+  op: "Select"
+  input: "softmax_cross_entropy_loss/Greater"
+  input: "softmax_cross_entropy_loss/div"
+  input: "softmax_cross_entropy_loss/zeros_like"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "activations/Logits/tag"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "activations/Logits"
+      }
+    }
+  }
+}
+node {
+  name: "activations/Logits"
+  op: "HistogramSummary"
+  input: "activations/Logits/tag"
+  input: "LeNet/fc4/BiasAdd"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "zero_fraction/zero"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "zero_fraction/Equal"
+  op: "Equal"
+  input: "LeNet/fc4/BiasAdd"
+  input: "zero_fraction/zero"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "zero_fraction/Cast"
+  op: "Cast"
+  input: "zero_fraction/Equal"
+  attr {
+    key: "DstT"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "SrcT"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "zero_fraction/Const"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
+        tensor_content: "\000\000\000\000\001\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "zero_fraction/Mean"
+  op: "Mean"
+  input: "zero_fraction/Cast"
+  input: "zero_fraction/Const"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "sparsity/Logits/tags"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "sparsity/Logits"
+      }
+    }
+  }
+}
+node {
+  name: "sparsity/Logits"
+  op: "ScalarSummary"
+  input: "sparsity/Logits/tags"
+  input: "zero_fraction/Mean"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "activations/Flatten/tag"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "activations/Flatten"
+      }
+    }
+  }
+}
+node {
+  name: "activations/Flatten"
+  op: "HistogramSummary"
+  input: "activations/Flatten/tag"
+  input: "LeNet/Flatten/Reshape"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "zero_fraction_1/zero"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "zero_fraction_1/Equal"
+  op: "Equal"
+  input: "LeNet/Flatten/Reshape"
+  input: "zero_fraction_1/zero"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "zero_fraction_1/Cast"
+  op: "Cast"
+  input: "zero_fraction_1/Equal"
+  attr {
+    key: "DstT"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "SrcT"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "zero_fraction_1/Const"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
+        tensor_content: "\000\000\000\000\001\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "zero_fraction_1/Mean"
+  op: "Mean"
+  input: "zero_fraction_1/Cast"
+  input: "zero_fraction_1/Const"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "sparsity/Flatten/tags"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "sparsity/Flatten"
+      }
+    }
+  }
+}
+node {
+  name: "sparsity/Flatten"
+  op: "ScalarSummary"
+  input: "sparsity/Flatten/tags"
+  input: "zero_fraction_1/Mean"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "activations/Predictions/tag"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "activations/Predictions"
+      }
+    }
+  }
+}
+node {
+  name: "activations/Predictions"
+  op: "HistogramSummary"
+  input: "activations/Predictions/tag"
+  input: "Predictions/Reshape_1"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "zero_fraction_2/zero"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "zero_fraction_2/Equal"
+  op: "Equal"
+  input: "Predictions/Reshape_1"
+  input: "zero_fraction_2/zero"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "zero_fraction_2/Cast"
+  op: "Cast"
+  input: "zero_fraction_2/Equal"
+  attr {
+    key: "DstT"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "SrcT"
+    value {
+      type: DT_BOOL
+    }
+  }
+}
+node {
+  name: "zero_fraction_2/Const"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
+        tensor_content: "\000\000\000\000\001\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "zero_fraction_2/Mean"
+  op: "Mean"
+  input: "zero_fraction_2/Cast"
+  input: "zero_fraction_2/Const"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "sparsity/Predictions/tags"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "sparsity/Predictions"
+      }
+    }
+  }
+}
+node {
+  name: "sparsity/Predictions"
+  op: "ScalarSummary"
+  input: "sparsity/Predictions/tags"
+  input: "zero_fraction_2/Mean"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "losses/softmax_cross_entropy_loss/value/tags"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "losses/softmax_cross_entropy_loss/value"
+      }
+    }
+  }
+}
+node {
+  name: "losses/softmax_cross_entropy_loss/value"
+  op: "ScalarSummary"
+  input: "losses/softmax_cross_entropy_loss/value/tags"
+  input: "softmax_cross_entropy_loss/value"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/weights_1/tag"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "LeNet/conv1/weights_1"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/weights_1"
+  op: "HistogramSummary"
+  input: "LeNet/conv1/weights_1/tag"
+  input: "LeNet/conv1/weights/read"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/biases_1/tag"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "LeNet/conv1/biases_1"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/biases_1"
+  op: "HistogramSummary"
+  input: "LeNet/conv1/biases_1/tag"
+  input: "LeNet/conv1/biases/read"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/weights_1/tag"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "LeNet/conv2/weights_1"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/weights_1"
+  op: "HistogramSummary"
+  input: "LeNet/conv2/weights_1/tag"
+  input: "LeNet/conv2/weights/read"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/biases_1/tag"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "LeNet/conv2/biases_1"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/biases_1"
+  op: "HistogramSummary"
+  input: "LeNet/conv2/biases_1/tag"
+  input: "LeNet/conv2/biases/read"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/weights_1/tag"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "LeNet/fc3/weights_1"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/weights_1"
+  op: "HistogramSummary"
+  input: "LeNet/fc3/weights_1/tag"
+  input: "LeNet/fc3/weights/read"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/biases_1/tag"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "LeNet/fc3/biases_1"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/biases_1"
+  op: "HistogramSummary"
+  input: "LeNet/fc3/biases_1/tag"
+  input: "LeNet/fc3/biases/read"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/weights_1/tag"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "LeNet/fc4/weights_1"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/weights_1"
+  op: "HistogramSummary"
+  input: "LeNet/fc4/weights_1/tag"
+  input: "LeNet/fc4/weights/read"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/biases_1/tag"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "LeNet/fc4/biases_1"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/biases_1"
+  op: "HistogramSummary"
+  input: "LeNet/fc4/biases_1/tag"
+  input: "LeNet/fc4/biases/read"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "exponential_decay_learning_rate/learning_rate"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.00999999977648
+      }
+    }
+  }
+}
+node {
+  name: "exponential_decay_learning_rate/Cast"
+  op: "Cast"
+  input: "global_step/read"
+  device: "/device:CPU:0"
+  attr {
+    key: "DstT"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "SrcT"
+    value {
+      type: DT_INT64
+    }
+  }
+}
+node {
+  name: "exponential_decay_learning_rate/Cast_1/x"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: 3750
+      }
+    }
+  }
+}
+node {
+  name: "exponential_decay_learning_rate/Cast_1"
+  op: "Cast"
+  input: "exponential_decay_learning_rate/Cast_1/x"
+  device: "/device:CPU:0"
+  attr {
+    key: "DstT"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "SrcT"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "exponential_decay_learning_rate/Cast_2/x"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.939999997616
+      }
+    }
+  }
+}
+node {
+  name: "exponential_decay_learning_rate/truediv"
+  op: "RealDiv"
+  input: "exponential_decay_learning_rate/Cast"
+  input: "exponential_decay_learning_rate/Cast_1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "exponential_decay_learning_rate/Floor"
+  op: "Floor"
+  input: "exponential_decay_learning_rate/truediv"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "exponential_decay_learning_rate/Pow"
+  op: "Pow"
+  input: "exponential_decay_learning_rate/Cast_2/x"
+  input: "exponential_decay_learning_rate/Floor"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "exponential_decay_learning_rate"
+  op: "Mul"
+  input: "exponential_decay_learning_rate/learning_rate"
+  input: "exponential_decay_learning_rate/Pow"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "learning_rate/tags"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "learning_rate"
+      }
+    }
+  }
+}
+node {
+  name: "learning_rate"
+  op: "ScalarSummary"
+  input: "learning_rate/tags"
+  input: "exponential_decay_learning_rate"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "clone_loss"
+  op: "Identity"
+  input: "softmax_cross_entropy_loss/value"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "regularization_loss"
+  op: "AddN"
+  input: "LeNet/conv1/kernel/Regularizer/l2_regularizer"
+  input: "LeNet/conv2/kernel/Regularizer/l2_regularizer"
+  input: "LeNet/fc3/kernel/Regularizer/l2_regularizer"
+  input: "LeNet/fc4/kernel/Regularizer/l2_regularizer"
+  device: "/device:GPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 4
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "AddN"
+  op: "AddN"
+  input: "clone_loss"
+  input: "regularization_loss"
+  device: "/device:GPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 2
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "clone_loss_1/tags"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "clone_loss_1"
+      }
+    }
+  }
+}
+node {
+  name: "clone_loss_1"
+  op: "ScalarSummary"
+  input: "clone_loss_1/tags"
+  input: "clone_loss"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "regularization_loss_1/tags"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "regularization_loss_1"
+      }
+    }
+  }
+}
+node {
+  name: "regularization_loss_1"
+  op: "ScalarSummary"
+  input: "regularization_loss_1/tags"
+  input: "regularization_loss"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "gradients/Const"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 1.0
+      }
+    }
+  }
+}
+node {
+  name: "gradients/Fill"
+  op: "Fill"
+  input: "gradients/Shape"
+  input: "gradients/Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/AddN_grad/tuple/group_deps"
+  op: "NoOp"
+  input: "^gradients/Fill"
+  device: "/device:GPU:0"
+}
+node {
+  name: "gradients/AddN_grad/tuple/control_dependency"
+  op: "Identity"
+  input: "gradients/Fill"
+  input: "^gradients/AddN_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/Fill"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/AddN_grad/tuple/control_dependency_1"
+  op: "Identity"
+  input: "gradients/Fill"
+  input: "^gradients/AddN_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/Fill"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/regularization_loss_grad/tuple/group_deps"
+  op: "NoOp"
+  input: "^gradients/AddN_grad/tuple/control_dependency_1"
+  device: "/device:GPU:0"
+}
+node {
+  name: "gradients/regularization_loss_grad/tuple/control_dependency"
+  op: "Identity"
+  input: "gradients/AddN_grad/tuple/control_dependency_1"
+  input: "^gradients/regularization_loss_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/Fill"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/regularization_loss_grad/tuple/control_dependency_1"
+  op: "Identity"
+  input: "gradients/AddN_grad/tuple/control_dependency_1"
+  input: "^gradients/regularization_loss_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/Fill"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/regularization_loss_grad/tuple/control_dependency_2"
+  op: "Identity"
+  input: "gradients/AddN_grad/tuple/control_dependency_1"
+  input: "^gradients/regularization_loss_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/Fill"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/regularization_loss_grad/tuple/control_dependency_3"
+  op: "Identity"
+  input: "gradients/AddN_grad/tuple/control_dependency_1"
+  input: "^gradients/regularization_loss_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/Fill"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/value_grad/zeros_like"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/value_grad/Select"
+  op: "Select"
+  input: "softmax_cross_entropy_loss/Greater"
+  input: "gradients/AddN_grad/tuple/control_dependency"
+  input: "gradients/softmax_cross_entropy_loss/value_grad/zeros_like"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/value_grad/Select_1"
+  op: "Select"
+  input: "softmax_cross_entropy_loss/Greater"
+  input: "gradients/softmax_cross_entropy_loss/value_grad/zeros_like"
+  input: "gradients/AddN_grad/tuple/control_dependency"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/value_grad/tuple/group_deps"
+  op: "NoOp"
+  input: "^gradients/softmax_cross_entropy_loss/value_grad/Select"
+  input: "^gradients/softmax_cross_entropy_loss/value_grad/Select_1"
+  device: "/device:GPU:0"
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/value_grad/tuple/control_dependency"
+  op: "Identity"
+  input: "gradients/softmax_cross_entropy_loss/value_grad/Select"
+  input: "^gradients/softmax_cross_entropy_loss/value_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/softmax_cross_entropy_loss/value_grad/Select"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/value_grad/tuple/control_dependency_1"
+  op: "Identity"
+  input: "gradients/softmax_cross_entropy_loss/value_grad/Select_1"
+  input: "^gradients/softmax_cross_entropy_loss/value_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/softmax_cross_entropy_loss/value_grad/Select_1"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/Shape_1"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/BroadcastGradientArgs"
+  op: "BroadcastGradientArgs"
+  input: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/Shape"
+  input: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/Shape_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/mul"
+  op: "Mul"
+  input: "gradients/regularization_loss_grad/tuple/control_dependency"
+  input: "LeNet/conv1/kernel/Regularizer/l2_regularizer/L2Loss"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/Sum"
+  op: "Sum"
+  input: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/mul"
+  input: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/BroadcastGradientArgs"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/Reshape"
+  op: "Reshape"
+  input: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/Sum"
+  input: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/Shape"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/mul_1"
+  op: "Mul"
+  input: "LeNet/conv1/kernel/Regularizer/l2_regularizer/scale"
+  input: "gradients/regularization_loss_grad/tuple/control_dependency"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/Sum_1"
+  op: "Sum"
+  input: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/mul_1"
+  input: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/BroadcastGradientArgs:1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/Reshape_1"
+  op: "Reshape"
+  input: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/Sum_1"
+  input: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/Shape_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/tuple/group_deps"
+  op: "NoOp"
+  input: "^gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/Reshape"
+  input: "^gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/Reshape_1"
+  device: "/device:GPU:0"
+}
+node {
+  name: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/tuple/control_dependency"
+  op: "Identity"
+  input: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/Reshape"
+  input: "^gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/Reshape"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/tuple/control_dependency_1"
+  op: "Identity"
+  input: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/Reshape_1"
+  input: "^gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/Reshape_1"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/Shape_1"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/BroadcastGradientArgs"
+  op: "BroadcastGradientArgs"
+  input: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/Shape"
+  input: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/Shape_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/mul"
+  op: "Mul"
+  input: "gradients/regularization_loss_grad/tuple/control_dependency_1"
+  input: "LeNet/conv2/kernel/Regularizer/l2_regularizer/L2Loss"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/Sum"
+  op: "Sum"
+  input: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/mul"
+  input: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/BroadcastGradientArgs"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/Reshape"
+  op: "Reshape"
+  input: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/Sum"
+  input: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/Shape"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/mul_1"
+  op: "Mul"
+  input: "LeNet/conv2/kernel/Regularizer/l2_regularizer/scale"
+  input: "gradients/regularization_loss_grad/tuple/control_dependency_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/Sum_1"
+  op: "Sum"
+  input: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/mul_1"
+  input: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/BroadcastGradientArgs:1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/Reshape_1"
+  op: "Reshape"
+  input: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/Sum_1"
+  input: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/Shape_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/tuple/group_deps"
+  op: "NoOp"
+  input: "^gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/Reshape"
+  input: "^gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/Reshape_1"
+  device: "/device:GPU:0"
+}
+node {
+  name: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/tuple/control_dependency"
+  op: "Identity"
+  input: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/Reshape"
+  input: "^gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/Reshape"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/tuple/control_dependency_1"
+  op: "Identity"
+  input: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/Reshape_1"
+  input: "^gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/Reshape_1"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/Shape_1"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/BroadcastGradientArgs"
+  op: "BroadcastGradientArgs"
+  input: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/Shape"
+  input: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/Shape_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/mul"
+  op: "Mul"
+  input: "gradients/regularization_loss_grad/tuple/control_dependency_2"
+  input: "LeNet/fc3/kernel/Regularizer/l2_regularizer/L2Loss"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/Sum"
+  op: "Sum"
+  input: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/mul"
+  input: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/BroadcastGradientArgs"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/Reshape"
+  op: "Reshape"
+  input: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/Sum"
+  input: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/Shape"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/mul_1"
+  op: "Mul"
+  input: "LeNet/fc3/kernel/Regularizer/l2_regularizer/scale"
+  input: "gradients/regularization_loss_grad/tuple/control_dependency_2"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/Sum_1"
+  op: "Sum"
+  input: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/mul_1"
+  input: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/BroadcastGradientArgs:1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/Reshape_1"
+  op: "Reshape"
+  input: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/Sum_1"
+  input: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/Shape_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/tuple/group_deps"
+  op: "NoOp"
+  input: "^gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/Reshape"
+  input: "^gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/Reshape_1"
+  device: "/device:GPU:0"
+}
+node {
+  name: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/tuple/control_dependency"
+  op: "Identity"
+  input: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/Reshape"
+  input: "^gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/Reshape"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/tuple/control_dependency_1"
+  op: "Identity"
+  input: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/Reshape_1"
+  input: "^gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/Reshape_1"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/Shape_1"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/BroadcastGradientArgs"
+  op: "BroadcastGradientArgs"
+  input: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/Shape"
+  input: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/Shape_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/mul"
+  op: "Mul"
+  input: "gradients/regularization_loss_grad/tuple/control_dependency_3"
+  input: "LeNet/fc4/kernel/Regularizer/l2_regularizer/L2Loss"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/Sum"
+  op: "Sum"
+  input: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/mul"
+  input: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/BroadcastGradientArgs"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/Reshape"
+  op: "Reshape"
+  input: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/Sum"
+  input: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/Shape"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/mul_1"
+  op: "Mul"
+  input: "LeNet/fc4/kernel/Regularizer/l2_regularizer/scale"
+  input: "gradients/regularization_loss_grad/tuple/control_dependency_3"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/Sum_1"
+  op: "Sum"
+  input: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/mul_1"
+  input: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/BroadcastGradientArgs:1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/Reshape_1"
+  op: "Reshape"
+  input: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/Sum_1"
+  input: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/Shape_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/tuple/group_deps"
+  op: "NoOp"
+  input: "^gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/Reshape"
+  input: "^gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/Reshape_1"
+  device: "/device:GPU:0"
+}
+node {
+  name: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/tuple/control_dependency"
+  op: "Identity"
+  input: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/Reshape"
+  input: "^gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/Reshape"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/tuple/control_dependency_1"
+  op: "Identity"
+  input: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/Reshape_1"
+  input: "^gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/Reshape_1"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/div_grad/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/div_grad/Shape_1"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/div_grad/BroadcastGradientArgs"
+  op: "BroadcastGradientArgs"
+  input: "gradients/softmax_cross_entropy_loss/div_grad/Shape"
+  input: "gradients/softmax_cross_entropy_loss/div_grad/Shape_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/div_grad/RealDiv"
+  op: "RealDiv"
+  input: "gradients/softmax_cross_entropy_loss/value_grad/tuple/control_dependency"
+  input: "softmax_cross_entropy_loss/Select"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/div_grad/Sum"
+  op: "Sum"
+  input: "gradients/softmax_cross_entropy_loss/div_grad/RealDiv"
+  input: "gradients/softmax_cross_entropy_loss/div_grad/BroadcastGradientArgs"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/div_grad/Reshape"
+  op: "Reshape"
+  input: "gradients/softmax_cross_entropy_loss/div_grad/Sum"
+  input: "gradients/softmax_cross_entropy_loss/div_grad/Shape"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/div_grad/Neg"
+  op: "Neg"
+  input: "softmax_cross_entropy_loss/Sum_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/div_grad/RealDiv_1"
+  op: "RealDiv"
+  input: "gradients/softmax_cross_entropy_loss/div_grad/Neg"
+  input: "softmax_cross_entropy_loss/Select"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/div_grad/RealDiv_2"
+  op: "RealDiv"
+  input: "gradients/softmax_cross_entropy_loss/div_grad/RealDiv_1"
+  input: "softmax_cross_entropy_loss/Select"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/div_grad/mul"
+  op: "Mul"
+  input: "gradients/softmax_cross_entropy_loss/value_grad/tuple/control_dependency"
+  input: "gradients/softmax_cross_entropy_loss/div_grad/RealDiv_2"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/div_grad/Sum_1"
+  op: "Sum"
+  input: "gradients/softmax_cross_entropy_loss/div_grad/mul"
+  input: "gradients/softmax_cross_entropy_loss/div_grad/BroadcastGradientArgs:1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/div_grad/Reshape_1"
+  op: "Reshape"
+  input: "gradients/softmax_cross_entropy_loss/div_grad/Sum_1"
+  input: "gradients/softmax_cross_entropy_loss/div_grad/Shape_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/div_grad/tuple/group_deps"
+  op: "NoOp"
+  input: "^gradients/softmax_cross_entropy_loss/div_grad/Reshape"
+  input: "^gradients/softmax_cross_entropy_loss/div_grad/Reshape_1"
+  device: "/device:GPU:0"
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/div_grad/tuple/control_dependency"
+  op: "Identity"
+  input: "gradients/softmax_cross_entropy_loss/div_grad/Reshape"
+  input: "^gradients/softmax_cross_entropy_loss/div_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/softmax_cross_entropy_loss/div_grad/Reshape"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/div_grad/tuple/control_dependency_1"
+  op: "Identity"
+  input: "gradients/softmax_cross_entropy_loss/div_grad/Reshape_1"
+  input: "^gradients/softmax_cross_entropy_loss/div_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/softmax_cross_entropy_loss/div_grad/Reshape_1"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer/L2Loss_grad/mul"
+  op: "Mul"
+  input: "LeNet/conv1/weights/read"
+  input: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer_grad/tuple/control_dependency_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer/L2Loss_grad/mul"
+  op: "Mul"
+  input: "LeNet/conv2/weights/read"
+  input: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer_grad/tuple/control_dependency_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer/L2Loss_grad/mul"
+  op: "Mul"
+  input: "LeNet/fc3/weights/read"
+  input: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer_grad/tuple/control_dependency_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer/L2Loss_grad/mul"
+  op: "Mul"
+  input: "LeNet/fc4/weights/read"
+  input: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer_grad/tuple/control_dependency_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Sum_1_grad/Reshape/shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Sum_1_grad/Reshape"
+  op: "Reshape"
+  input: "gradients/softmax_cross_entropy_loss/div_grad/tuple/control_dependency"
+  input: "gradients/softmax_cross_entropy_loss/Sum_1_grad/Reshape/shape"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Sum_1_grad/Tile/multiples"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Sum_1_grad/Tile"
+  op: "Tile"
+  input: "gradients/softmax_cross_entropy_loss/Sum_1_grad/Reshape"
+  input: "gradients/softmax_cross_entropy_loss/Sum_1_grad/Tile/multiples"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tmultiples"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Sum_grad/Reshape/shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Sum_grad/Reshape"
+  op: "Reshape"
+  input: "gradients/softmax_cross_entropy_loss/Sum_1_grad/Tile"
+  input: "gradients/softmax_cross_entropy_loss/Sum_grad/Reshape/shape"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Sum_grad/Tile/multiples"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: 32
+      }
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Sum_grad/Tile"
+  op: "Tile"
+  input: "gradients/softmax_cross_entropy_loss/Sum_grad/Reshape"
+  input: "gradients/softmax_cross_entropy_loss/Sum_grad/Tile/multiples"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tmultiples"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Mul_grad/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: 32
+      }
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Mul_grad/Shape_1"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Mul_grad/BroadcastGradientArgs"
+  op: "BroadcastGradientArgs"
+  input: "gradients/softmax_cross_entropy_loss/Mul_grad/Shape"
+  input: "gradients/softmax_cross_entropy_loss/Mul_grad/Shape_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Mul_grad/mul"
+  op: "Mul"
+  input: "gradients/softmax_cross_entropy_loss/Sum_grad/Tile"
+  input: "softmax_cross_entropy_loss/ToFloat_1/x"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Mul_grad/Sum"
+  op: "Sum"
+  input: "gradients/softmax_cross_entropy_loss/Mul_grad/mul"
+  input: "gradients/softmax_cross_entropy_loss/Mul_grad/BroadcastGradientArgs"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Mul_grad/Reshape"
+  op: "Reshape"
+  input: "gradients/softmax_cross_entropy_loss/Mul_grad/Sum"
+  input: "gradients/softmax_cross_entropy_loss/Mul_grad/Shape"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Mul_grad/mul_1"
+  op: "Mul"
+  input: "softmax_cross_entropy_loss/Reshape_2"
+  input: "gradients/softmax_cross_entropy_loss/Sum_grad/Tile"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Mul_grad/Sum_1"
+  op: "Sum"
+  input: "gradients/softmax_cross_entropy_loss/Mul_grad/mul_1"
+  input: "gradients/softmax_cross_entropy_loss/Mul_grad/BroadcastGradientArgs:1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Mul_grad/Reshape_1"
+  op: "Reshape"
+  input: "gradients/softmax_cross_entropy_loss/Mul_grad/Sum_1"
+  input: "gradients/softmax_cross_entropy_loss/Mul_grad/Shape_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Mul_grad/tuple/group_deps"
+  op: "NoOp"
+  input: "^gradients/softmax_cross_entropy_loss/Mul_grad/Reshape"
+  input: "^gradients/softmax_cross_entropy_loss/Mul_grad/Reshape_1"
+  device: "/device:GPU:0"
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Mul_grad/tuple/control_dependency"
+  op: "Identity"
+  input: "gradients/softmax_cross_entropy_loss/Mul_grad/Reshape"
+  input: "^gradients/softmax_cross_entropy_loss/Mul_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/softmax_cross_entropy_loss/Mul_grad/Reshape"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Mul_grad/tuple/control_dependency_1"
+  op: "Identity"
+  input: "gradients/softmax_cross_entropy_loss/Mul_grad/Reshape_1"
+  input: "^gradients/softmax_cross_entropy_loss/Mul_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/softmax_cross_entropy_loss/Mul_grad/Reshape_1"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Reshape_2_grad/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 1
+          }
+        }
+        int_val: 32
+      }
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Reshape_2_grad/Reshape"
+  op: "Reshape"
+  input: "gradients/softmax_cross_entropy_loss/Mul_grad/tuple/control_dependency"
+  input: "gradients/softmax_cross_entropy_loss/Reshape_2_grad/Shape"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/zeros_like"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 32
+          }
+          dim {
+            size: 10
+          }
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/xentropy_grad/ExpandDims/dim"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+        }
+        int_val: -1
+      }
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/xentropy_grad/ExpandDims"
+  op: "ExpandDims"
+  input: "gradients/softmax_cross_entropy_loss/Reshape_2_grad/Reshape"
+  input: "gradients/softmax_cross_entropy_loss/xentropy_grad/ExpandDims/dim"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tdim"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/xentropy_grad/mul"
+  op: "Mul"
+  input: "gradients/softmax_cross_entropy_loss/xentropy_grad/ExpandDims"
+  input: "softmax_cross_entropy_loss/xentropy:1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Reshape_grad/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
+        tensor_content: " \000\000\000\n\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/softmax_cross_entropy_loss/Reshape_grad/Reshape"
+  op: "Reshape"
+  input: "gradients/softmax_cross_entropy_loss/xentropy_grad/mul"
+  input: "gradients/softmax_cross_entropy_loss/Reshape_grad/Shape"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc4/BiasAdd_grad/BiasAddGrad"
+  op: "BiasAddGrad"
+  input: "gradients/softmax_cross_entropy_loss/Reshape_grad/Reshape"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc4/BiasAdd_grad/tuple/group_deps"
+  op: "NoOp"
+  input: "^gradients/softmax_cross_entropy_loss/Reshape_grad/Reshape"
+  input: "^gradients/LeNet/fc4/BiasAdd_grad/BiasAddGrad"
+  device: "/device:GPU:0"
+}
+node {
+  name: "gradients/LeNet/fc4/BiasAdd_grad/tuple/control_dependency"
+  op: "Identity"
+  input: "gradients/softmax_cross_entropy_loss/Reshape_grad/Reshape"
+  input: "^gradients/LeNet/fc4/BiasAdd_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/softmax_cross_entropy_loss/Reshape_grad/Reshape"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc4/BiasAdd_grad/tuple/control_dependency_1"
+  op: "Identity"
+  input: "gradients/LeNet/fc4/BiasAdd_grad/BiasAddGrad"
+  input: "^gradients/LeNet/fc4/BiasAdd_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/fc4/BiasAdd_grad/BiasAddGrad"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc4/MatMul_grad/MatMul"
+  op: "MatMul"
+  input: "gradients/LeNet/fc4/BiasAdd_grad/tuple/control_dependency"
+  input: "LeNet/fc4/weights/read"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "transpose_a"
+    value {
+      b: false
+    }
+  }
+  attr {
+    key: "transpose_b"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc4/MatMul_grad/MatMul_1"
+  op: "MatMul"
+  input: "LeNet/dropout3/dropout/mul"
+  input: "gradients/LeNet/fc4/BiasAdd_grad/tuple/control_dependency"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "transpose_a"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "transpose_b"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc4/MatMul_grad/tuple/group_deps"
+  op: "NoOp"
+  input: "^gradients/LeNet/fc4/MatMul_grad/MatMul"
+  input: "^gradients/LeNet/fc4/MatMul_grad/MatMul_1"
+  device: "/device:GPU:0"
+}
+node {
+  name: "gradients/LeNet/fc4/MatMul_grad/tuple/control_dependency"
+  op: "Identity"
+  input: "gradients/LeNet/fc4/MatMul_grad/MatMul"
+  input: "^gradients/LeNet/fc4/MatMul_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/fc4/MatMul_grad/MatMul"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc4/MatMul_grad/tuple/control_dependency_1"
+  op: "Identity"
+  input: "gradients/LeNet/fc4/MatMul_grad/MatMul_1"
+  input: "^gradients/LeNet/fc4/MatMul_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/fc4/MatMul_grad/MatMul_1"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/mul_grad/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
+        tensor_content: " \000\000\000\000\004\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/mul_grad/Shape_1"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
+        tensor_content: " \000\000\000\000\004\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/mul_grad/BroadcastGradientArgs"
+  op: "BroadcastGradientArgs"
+  input: "gradients/LeNet/dropout3/dropout/mul_grad/Shape"
+  input: "gradients/LeNet/dropout3/dropout/mul_grad/Shape_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/mul_grad/mul"
+  op: "Mul"
+  input: "gradients/LeNet/fc4/MatMul_grad/tuple/control_dependency"
+  input: "LeNet/dropout3/dropout/Floor"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/mul_grad/Sum"
+  op: "Sum"
+  input: "gradients/LeNet/dropout3/dropout/mul_grad/mul"
+  input: "gradients/LeNet/dropout3/dropout/mul_grad/BroadcastGradientArgs"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/mul_grad/Reshape"
+  op: "Reshape"
+  input: "gradients/LeNet/dropout3/dropout/mul_grad/Sum"
+  input: "gradients/LeNet/dropout3/dropout/mul_grad/Shape"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/mul_grad/mul_1"
+  op: "Mul"
+  input: "LeNet/dropout3/dropout/div"
+  input: "gradients/LeNet/fc4/MatMul_grad/tuple/control_dependency"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/mul_grad/Sum_1"
+  op: "Sum"
+  input: "gradients/LeNet/dropout3/dropout/mul_grad/mul_1"
+  input: "gradients/LeNet/dropout3/dropout/mul_grad/BroadcastGradientArgs:1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/mul_grad/Reshape_1"
+  op: "Reshape"
+  input: "gradients/LeNet/dropout3/dropout/mul_grad/Sum_1"
+  input: "gradients/LeNet/dropout3/dropout/mul_grad/Shape_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/mul_grad/tuple/group_deps"
+  op: "NoOp"
+  input: "^gradients/LeNet/dropout3/dropout/mul_grad/Reshape"
+  input: "^gradients/LeNet/dropout3/dropout/mul_grad/Reshape_1"
+  device: "/device:GPU:0"
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/mul_grad/tuple/control_dependency"
+  op: "Identity"
+  input: "gradients/LeNet/dropout3/dropout/mul_grad/Reshape"
+  input: "^gradients/LeNet/dropout3/dropout/mul_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/dropout3/dropout/mul_grad/Reshape"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/mul_grad/tuple/control_dependency_1"
+  op: "Identity"
+  input: "gradients/LeNet/dropout3/dropout/mul_grad/Reshape_1"
+  input: "^gradients/LeNet/dropout3/dropout/mul_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/dropout3/dropout/mul_grad/Reshape_1"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/AddN"
+  op: "AddN"
+  input: "gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer/L2Loss_grad/mul"
+  input: "gradients/LeNet/fc4/MatMul_grad/tuple/control_dependency_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 2
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/fc4/kernel/Regularizer/l2_regularizer/L2Loss_grad/mul"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/div_grad/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 2
+          }
+        }
+        tensor_content: " \000\000\000\000\004\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/div_grad/Shape_1"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/div_grad/BroadcastGradientArgs"
+  op: "BroadcastGradientArgs"
+  input: "gradients/LeNet/dropout3/dropout/div_grad/Shape"
+  input: "gradients/LeNet/dropout3/dropout/div_grad/Shape_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/div_grad/RealDiv"
+  op: "RealDiv"
+  input: "gradients/LeNet/dropout3/dropout/mul_grad/tuple/control_dependency"
+  input: "LeNet/dropout3/dropout/keep_prob"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/div_grad/Sum"
+  op: "Sum"
+  input: "gradients/LeNet/dropout3/dropout/div_grad/RealDiv"
+  input: "gradients/LeNet/dropout3/dropout/div_grad/BroadcastGradientArgs"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/div_grad/Reshape"
+  op: "Reshape"
+  input: "gradients/LeNet/dropout3/dropout/div_grad/Sum"
+  input: "gradients/LeNet/dropout3/dropout/div_grad/Shape"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/div_grad/Neg"
+  op: "Neg"
+  input: "LeNet/fc3/Relu"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/div_grad/RealDiv_1"
+  op: "RealDiv"
+  input: "gradients/LeNet/dropout3/dropout/div_grad/Neg"
+  input: "LeNet/dropout3/dropout/keep_prob"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/div_grad/RealDiv_2"
+  op: "RealDiv"
+  input: "gradients/LeNet/dropout3/dropout/div_grad/RealDiv_1"
+  input: "LeNet/dropout3/dropout/keep_prob"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/div_grad/mul"
+  op: "Mul"
+  input: "gradients/LeNet/dropout3/dropout/mul_grad/tuple/control_dependency"
+  input: "gradients/LeNet/dropout3/dropout/div_grad/RealDiv_2"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/div_grad/Sum_1"
+  op: "Sum"
+  input: "gradients/LeNet/dropout3/dropout/div_grad/mul"
+  input: "gradients/LeNet/dropout3/dropout/div_grad/BroadcastGradientArgs:1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tidx"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "keep_dims"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/div_grad/Reshape_1"
+  op: "Reshape"
+  input: "gradients/LeNet/dropout3/dropout/div_grad/Sum_1"
+  input: "gradients/LeNet/dropout3/dropout/div_grad/Shape_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/div_grad/tuple/group_deps"
+  op: "NoOp"
+  input: "^gradients/LeNet/dropout3/dropout/div_grad/Reshape"
+  input: "^gradients/LeNet/dropout3/dropout/div_grad/Reshape_1"
+  device: "/device:GPU:0"
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/div_grad/tuple/control_dependency"
+  op: "Identity"
+  input: "gradients/LeNet/dropout3/dropout/div_grad/Reshape"
+  input: "^gradients/LeNet/dropout3/dropout/div_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/dropout3/dropout/div_grad/Reshape"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/dropout3/dropout/div_grad/tuple/control_dependency_1"
+  op: "Identity"
+  input: "gradients/LeNet/dropout3/dropout/div_grad/Reshape_1"
+  input: "^gradients/LeNet/dropout3/dropout/div_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/dropout3/dropout/div_grad/Reshape_1"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/Relu_grad/ReluGrad"
+  op: "ReluGrad"
+  input: "gradients/LeNet/dropout3/dropout/div_grad/tuple/control_dependency"
+  input: "LeNet/fc3/Relu"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/BiasAdd_grad/BiasAddGrad"
+  op: "BiasAddGrad"
+  input: "gradients/LeNet/fc3/Relu_grad/ReluGrad"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/BiasAdd_grad/tuple/group_deps"
+  op: "NoOp"
+  input: "^gradients/LeNet/fc3/Relu_grad/ReluGrad"
+  input: "^gradients/LeNet/fc3/BiasAdd_grad/BiasAddGrad"
+  device: "/device:GPU:0"
+}
+node {
+  name: "gradients/LeNet/fc3/BiasAdd_grad/tuple/control_dependency"
+  op: "Identity"
+  input: "gradients/LeNet/fc3/Relu_grad/ReluGrad"
+  input: "^gradients/LeNet/fc3/BiasAdd_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/fc3/Relu_grad/ReluGrad"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/BiasAdd_grad/tuple/control_dependency_1"
+  op: "Identity"
+  input: "gradients/LeNet/fc3/BiasAdd_grad/BiasAddGrad"
+  input: "^gradients/LeNet/fc3/BiasAdd_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/fc3/BiasAdd_grad/BiasAddGrad"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/MatMul_grad/MatMul"
+  op: "MatMul"
+  input: "gradients/LeNet/fc3/BiasAdd_grad/tuple/control_dependency"
+  input: "LeNet/fc3/weights/read"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "transpose_a"
+    value {
+      b: false
+    }
+  }
+  attr {
+    key: "transpose_b"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/MatMul_grad/MatMul_1"
+  op: "MatMul"
+  input: "LeNet/Flatten/Reshape"
+  input: "gradients/LeNet/fc3/BiasAdd_grad/tuple/control_dependency"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "transpose_a"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "transpose_b"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/MatMul_grad/tuple/group_deps"
+  op: "NoOp"
+  input: "^gradients/LeNet/fc3/MatMul_grad/MatMul"
+  input: "^gradients/LeNet/fc3/MatMul_grad/MatMul_1"
+  device: "/device:GPU:0"
+}
+node {
+  name: "gradients/LeNet/fc3/MatMul_grad/tuple/control_dependency"
+  op: "Identity"
+  input: "gradients/LeNet/fc3/MatMul_grad/MatMul"
+  input: "^gradients/LeNet/fc3/MatMul_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/fc3/MatMul_grad/MatMul"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/fc3/MatMul_grad/tuple/control_dependency_1"
+  op: "Identity"
+  input: "gradients/LeNet/fc3/MatMul_grad/MatMul_1"
+  input: "^gradients/LeNet/fc3/MatMul_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/fc3/MatMul_grad/MatMul_1"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/Flatten/Reshape_grad/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 4
+          }
+        }
+        tensor_content: " \000\000\000\007\000\000\000\007\000\000\000@\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/Flatten/Reshape_grad/Reshape"
+  op: "Reshape"
+  input: "gradients/LeNet/fc3/MatMul_grad/tuple/control_dependency"
+  input: "gradients/LeNet/Flatten/Reshape_grad/Shape"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "Tshape"
+    value {
+      type: DT_INT32
+    }
+  }
+}
+node {
+  name: "gradients/AddN_1"
+  op: "AddN"
+  input: "gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer/L2Loss_grad/mul"
+  input: "gradients/LeNet/fc3/MatMul_grad/tuple/control_dependency_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 2
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/fc3/kernel/Regularizer/l2_regularizer/L2Loss_grad/mul"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/pool2/MaxPool_grad/MaxPoolGrad"
+  op: "MaxPoolGrad"
+  input: "LeNet/conv2/Relu"
+  input: "LeNet/pool2/MaxPool"
+  input: "gradients/LeNet/Flatten/Reshape_grad/Reshape"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+  attr {
+    key: "ksize"
+    value {
+      list {
+        i: 1
+        i: 2
+        i: 2
+        i: 1
+      }
+    }
+  }
+  attr {
+    key: "padding"
+    value {
+      s: "VALID"
+    }
+  }
+  attr {
+    key: "strides"
+    value {
+      list {
+        i: 1
+        i: 2
+        i: 2
+        i: 1
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/Relu_grad/ReluGrad"
+  op: "ReluGrad"
+  input: "gradients/LeNet/pool2/MaxPool_grad/MaxPoolGrad"
+  input: "LeNet/conv2/Relu"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/BiasAdd_grad/BiasAddGrad"
+  op: "BiasAddGrad"
+  input: "gradients/LeNet/conv2/Relu_grad/ReluGrad"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/BiasAdd_grad/tuple/group_deps"
+  op: "NoOp"
+  input: "^gradients/LeNet/conv2/Relu_grad/ReluGrad"
+  input: "^gradients/LeNet/conv2/BiasAdd_grad/BiasAddGrad"
+  device: "/device:GPU:0"
+}
+node {
+  name: "gradients/LeNet/conv2/BiasAdd_grad/tuple/control_dependency"
+  op: "Identity"
+  input: "gradients/LeNet/conv2/Relu_grad/ReluGrad"
+  input: "^gradients/LeNet/conv2/BiasAdd_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/conv2/Relu_grad/ReluGrad"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/BiasAdd_grad/tuple/control_dependency_1"
+  op: "Identity"
+  input: "gradients/LeNet/conv2/BiasAdd_grad/BiasAddGrad"
+  input: "^gradients/LeNet/conv2/BiasAdd_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/conv2/BiasAdd_grad/BiasAddGrad"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/convolution_grad/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 4
+          }
+        }
+        tensor_content: " \000\000\000\016\000\000\000\016\000\000\000 \000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/convolution_grad/Conv2DBackpropInput"
+  op: "Conv2DBackpropInput"
+  input: "gradients/LeNet/conv2/convolution_grad/Shape"
+  input: "LeNet/conv2/weights/read"
+  input: "gradients/LeNet/conv2/BiasAdd_grad/tuple/control_dependency"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+  attr {
+    key: "padding"
+    value {
+      s: "SAME"
+    }
+  }
+  attr {
+    key: "strides"
+    value {
+      list {
+        i: 1
+        i: 1
+        i: 1
+        i: 1
+      }
+    }
+  }
+  attr {
+    key: "use_cudnn_on_gpu"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/convolution_grad/Shape_1"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 4
+          }
+        }
+        tensor_content: "\005\000\000\000\005\000\000\000 \000\000\000@\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/convolution_grad/Conv2DBackpropFilter"
+  op: "Conv2DBackpropFilter"
+  input: "LeNet/pool1/MaxPool"
+  input: "gradients/LeNet/conv2/convolution_grad/Shape_1"
+  input: "gradients/LeNet/conv2/BiasAdd_grad/tuple/control_dependency"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+  attr {
+    key: "padding"
+    value {
+      s: "SAME"
+    }
+  }
+  attr {
+    key: "strides"
+    value {
+      list {
+        i: 1
+        i: 1
+        i: 1
+        i: 1
+      }
+    }
+  }
+  attr {
+    key: "use_cudnn_on_gpu"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/convolution_grad/tuple/group_deps"
+  op: "NoOp"
+  input: "^gradients/LeNet/conv2/convolution_grad/Conv2DBackpropInput"
+  input: "^gradients/LeNet/conv2/convolution_grad/Conv2DBackpropFilter"
+  device: "/device:GPU:0"
+}
+node {
+  name: "gradients/LeNet/conv2/convolution_grad/tuple/control_dependency"
+  op: "Identity"
+  input: "gradients/LeNet/conv2/convolution_grad/Conv2DBackpropInput"
+  input: "^gradients/LeNet/conv2/convolution_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/conv2/convolution_grad/Conv2DBackpropInput"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv2/convolution_grad/tuple/control_dependency_1"
+  op: "Identity"
+  input: "gradients/LeNet/conv2/convolution_grad/Conv2DBackpropFilter"
+  input: "^gradients/LeNet/conv2/convolution_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/conv2/convolution_grad/Conv2DBackpropFilter"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/pool1/MaxPool_grad/MaxPoolGrad"
+  op: "MaxPoolGrad"
+  input: "LeNet/conv1/Relu"
+  input: "LeNet/pool1/MaxPool"
+  input: "gradients/LeNet/conv2/convolution_grad/tuple/control_dependency"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+  attr {
+    key: "ksize"
+    value {
+      list {
+        i: 1
+        i: 2
+        i: 2
+        i: 1
+      }
+    }
+  }
+  attr {
+    key: "padding"
+    value {
+      s: "VALID"
+    }
+  }
+  attr {
+    key: "strides"
+    value {
+      list {
+        i: 1
+        i: 2
+        i: 2
+        i: 1
+      }
+    }
+  }
+}
+node {
+  name: "gradients/AddN_2"
+  op: "AddN"
+  input: "gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer/L2Loss_grad/mul"
+  input: "gradients/LeNet/conv2/convolution_grad/tuple/control_dependency_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 2
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/conv2/kernel/Regularizer/l2_regularizer/L2Loss_grad/mul"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/Relu_grad/ReluGrad"
+  op: "ReluGrad"
+  input: "gradients/LeNet/pool1/MaxPool_grad/MaxPoolGrad"
+  input: "LeNet/conv1/Relu"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/BiasAdd_grad/BiasAddGrad"
+  op: "BiasAddGrad"
+  input: "gradients/LeNet/conv1/Relu_grad/ReluGrad"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/BiasAdd_grad/tuple/group_deps"
+  op: "NoOp"
+  input: "^gradients/LeNet/conv1/Relu_grad/ReluGrad"
+  input: "^gradients/LeNet/conv1/BiasAdd_grad/BiasAddGrad"
+  device: "/device:GPU:0"
+}
+node {
+  name: "gradients/LeNet/conv1/BiasAdd_grad/tuple/control_dependency"
+  op: "Identity"
+  input: "gradients/LeNet/conv1/Relu_grad/ReluGrad"
+  input: "^gradients/LeNet/conv1/BiasAdd_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/conv1/Relu_grad/ReluGrad"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/BiasAdd_grad/tuple/control_dependency_1"
+  op: "Identity"
+  input: "gradients/LeNet/conv1/BiasAdd_grad/BiasAddGrad"
+  input: "^gradients/LeNet/conv1/BiasAdd_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/conv1/BiasAdd_grad/BiasAddGrad"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/convolution_grad/Shape"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 4
+          }
+        }
+        tensor_content: " \000\000\000\034\000\000\000\034\000\000\000\001\000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/convolution_grad/Conv2DBackpropInput"
+  op: "Conv2DBackpropInput"
+  input: "gradients/LeNet/conv1/convolution_grad/Shape"
+  input: "LeNet/conv1/weights/read"
+  input: "gradients/LeNet/conv1/BiasAdd_grad/tuple/control_dependency"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+  attr {
+    key: "padding"
+    value {
+      s: "SAME"
+    }
+  }
+  attr {
+    key: "strides"
+    value {
+      list {
+        i: 1
+        i: 1
+        i: 1
+        i: 1
+      }
+    }
+  }
+  attr {
+    key: "use_cudnn_on_gpu"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/convolution_grad/Shape_1"
+  op: "Const"
+  device: "/device:GPU:0"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT32
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT32
+        tensor_shape {
+          dim {
+            size: 4
+          }
+        }
+        tensor_content: "\005\000\000\000\005\000\000\000\001\000\000\000 \000\000\000"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/convolution_grad/Conv2DBackpropFilter"
+  op: "Conv2DBackpropFilter"
+  input: "fifo_queue_Dequeue"
+  input: "gradients/LeNet/conv1/convolution_grad/Shape_1"
+  input: "gradients/LeNet/conv1/BiasAdd_grad/tuple/control_dependency"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "data_format"
+    value {
+      s: "NHWC"
+    }
+  }
+  attr {
+    key: "padding"
+    value {
+      s: "SAME"
+    }
+  }
+  attr {
+    key: "strides"
+    value {
+      list {
+        i: 1
+        i: 1
+        i: 1
+        i: 1
+      }
+    }
+  }
+  attr {
+    key: "use_cudnn_on_gpu"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/convolution_grad/tuple/group_deps"
+  op: "NoOp"
+  input: "^gradients/LeNet/conv1/convolution_grad/Conv2DBackpropInput"
+  input: "^gradients/LeNet/conv1/convolution_grad/Conv2DBackpropFilter"
+  device: "/device:GPU:0"
+}
+node {
+  name: "gradients/LeNet/conv1/convolution_grad/tuple/control_dependency"
+  op: "Identity"
+  input: "gradients/LeNet/conv1/convolution_grad/Conv2DBackpropInput"
+  input: "^gradients/LeNet/conv1/convolution_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/conv1/convolution_grad/Conv2DBackpropInput"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/LeNet/conv1/convolution_grad/tuple/control_dependency_1"
+  op: "Identity"
+  input: "gradients/LeNet/conv1/convolution_grad/Conv2DBackpropFilter"
+  input: "^gradients/LeNet/conv1/convolution_grad/tuple/group_deps"
+  device: "/device:GPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/conv1/convolution_grad/Conv2DBackpropFilter"
+      }
+    }
+  }
+}
+node {
+  name: "gradients/AddN_3"
+  op: "AddN"
+  input: "gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer/L2Loss_grad/mul"
+  input: "gradients/LeNet/conv1/convolution_grad/tuple/control_dependency_1"
+  device: "/device:GPU:0"
+  attr {
+    key: "N"
+    value {
+      i: 2
+    }
+  }
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@gradients/LeNet/conv1/kernel/Regularizer/l2_regularizer/L2Loss_grad/mul"
+      }
+    }
+  }
+}
+node {
+  name: "total_loss"
+  op: "Identity"
+  input: "AddN"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "total_loss_1/tags"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_STRING
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_STRING
+        tensor_shape {
+        }
+        string_val: "total_loss_1"
+      }
+    }
+  }
+}
+node {
+  name: "total_loss_1"
+  op: "ScalarSummary"
+  input: "total_loss_1/tags"
+  input: "total_loss"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/weights/RMSProp/Initializer/ones"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 5
+          }
+          dim {
+            size: 5
+          }
+          dim {
+            size: 1
+          }
+          dim {
+            size: 32
+          }
+        }
+        float_val: 1.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/weights/RMSProp"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 5
+        }
+        dim {
+          size: 5
+        }
+        dim {
+          size: 1
+        }
+        dim {
+          size: 32
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/weights/RMSProp/Assign"
+  op: "Assign"
+  input: "LeNet/conv1/weights/RMSProp"
+  input: "LeNet/conv1/weights/RMSProp/Initializer/ones"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/weights/RMSProp/read"
+  op: "Identity"
+  input: "LeNet/conv1/weights/RMSProp"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/weights/RMSProp_1/Initializer/zeros"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 5
+          }
+          dim {
+            size: 5
+          }
+          dim {
+            size: 1
+          }
+          dim {
+            size: 32
+          }
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/weights/RMSProp_1"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 5
+        }
+        dim {
+          size: 5
+        }
+        dim {
+          size: 1
+        }
+        dim {
+          size: 32
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/weights/RMSProp_1/Assign"
+  op: "Assign"
+  input: "LeNet/conv1/weights/RMSProp_1"
+  input: "LeNet/conv1/weights/RMSProp_1/Initializer/zeros"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/weights/RMSProp_1/read"
+  op: "Identity"
+  input: "LeNet/conv1/weights/RMSProp_1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/biases/RMSProp/Initializer/ones"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/biases"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 32
+          }
+        }
+        float_val: 1.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/biases/RMSProp"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/biases"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 32
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/biases/RMSProp/Assign"
+  op: "Assign"
+  input: "LeNet/conv1/biases/RMSProp"
+  input: "LeNet/conv1/biases/RMSProp/Initializer/ones"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/biases"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/biases/RMSProp/read"
+  op: "Identity"
+  input: "LeNet/conv1/biases/RMSProp"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/biases"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/biases/RMSProp_1/Initializer/zeros"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/biases"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 32
+          }
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/biases/RMSProp_1"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/biases"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 32
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/biases/RMSProp_1/Assign"
+  op: "Assign"
+  input: "LeNet/conv1/biases/RMSProp_1"
+  input: "LeNet/conv1/biases/RMSProp_1/Initializer/zeros"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/biases"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/conv1/biases/RMSProp_1/read"
+  op: "Identity"
+  input: "LeNet/conv1/biases/RMSProp_1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/biases"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/weights/RMSProp/Initializer/ones"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 5
+          }
+          dim {
+            size: 5
+          }
+          dim {
+            size: 32
+          }
+          dim {
+            size: 64
+          }
+        }
+        float_val: 1.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/weights/RMSProp"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 5
+        }
+        dim {
+          size: 5
+        }
+        dim {
+          size: 32
+        }
+        dim {
+          size: 64
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/weights/RMSProp/Assign"
+  op: "Assign"
+  input: "LeNet/conv2/weights/RMSProp"
+  input: "LeNet/conv2/weights/RMSProp/Initializer/ones"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/weights/RMSProp/read"
+  op: "Identity"
+  input: "LeNet/conv2/weights/RMSProp"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/weights/RMSProp_1/Initializer/zeros"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 5
+          }
+          dim {
+            size: 5
+          }
+          dim {
+            size: 32
+          }
+          dim {
+            size: 64
+          }
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/weights/RMSProp_1"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 5
+        }
+        dim {
+          size: 5
+        }
+        dim {
+          size: 32
+        }
+        dim {
+          size: 64
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/weights/RMSProp_1/Assign"
+  op: "Assign"
+  input: "LeNet/conv2/weights/RMSProp_1"
+  input: "LeNet/conv2/weights/RMSProp_1/Initializer/zeros"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/weights/RMSProp_1/read"
+  op: "Identity"
+  input: "LeNet/conv2/weights/RMSProp_1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/biases/RMSProp/Initializer/ones"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/biases"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 64
+          }
+        }
+        float_val: 1.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/biases/RMSProp"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/biases"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 64
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/biases/RMSProp/Assign"
+  op: "Assign"
+  input: "LeNet/conv2/biases/RMSProp"
+  input: "LeNet/conv2/biases/RMSProp/Initializer/ones"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/biases"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/biases/RMSProp/read"
+  op: "Identity"
+  input: "LeNet/conv2/biases/RMSProp"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/biases"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/biases/RMSProp_1/Initializer/zeros"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/biases"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 64
+          }
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/biases/RMSProp_1"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/biases"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 64
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/biases/RMSProp_1/Assign"
+  op: "Assign"
+  input: "LeNet/conv2/biases/RMSProp_1"
+  input: "LeNet/conv2/biases/RMSProp_1/Initializer/zeros"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/biases"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/conv2/biases/RMSProp_1/read"
+  op: "Identity"
+  input: "LeNet/conv2/biases/RMSProp_1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/biases"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/weights/RMSProp/Initializer/ones"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 3136
+          }
+          dim {
+            size: 1024
+          }
+        }
+        float_val: 1.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/weights/RMSProp"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 3136
+        }
+        dim {
+          size: 1024
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/weights/RMSProp/Assign"
+  op: "Assign"
+  input: "LeNet/fc3/weights/RMSProp"
+  input: "LeNet/fc3/weights/RMSProp/Initializer/ones"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/weights/RMSProp/read"
+  op: "Identity"
+  input: "LeNet/fc3/weights/RMSProp"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/weights/RMSProp_1/Initializer/zeros"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 3136
+          }
+          dim {
+            size: 1024
+          }
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/weights/RMSProp_1"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 3136
+        }
+        dim {
+          size: 1024
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/weights/RMSProp_1/Assign"
+  op: "Assign"
+  input: "LeNet/fc3/weights/RMSProp_1"
+  input: "LeNet/fc3/weights/RMSProp_1/Initializer/zeros"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/weights/RMSProp_1/read"
+  op: "Identity"
+  input: "LeNet/fc3/weights/RMSProp_1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/biases/RMSProp/Initializer/ones"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/biases"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 1024
+          }
+        }
+        float_val: 1.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/biases/RMSProp"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/biases"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 1024
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/biases/RMSProp/Assign"
+  op: "Assign"
+  input: "LeNet/fc3/biases/RMSProp"
+  input: "LeNet/fc3/biases/RMSProp/Initializer/ones"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/biases"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/biases/RMSProp/read"
+  op: "Identity"
+  input: "LeNet/fc3/biases/RMSProp"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/biases"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/biases/RMSProp_1/Initializer/zeros"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/biases"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 1024
+          }
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/biases/RMSProp_1"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/biases"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 1024
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/biases/RMSProp_1/Assign"
+  op: "Assign"
+  input: "LeNet/fc3/biases/RMSProp_1"
+  input: "LeNet/fc3/biases/RMSProp_1/Initializer/zeros"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/biases"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/fc3/biases/RMSProp_1/read"
+  op: "Identity"
+  input: "LeNet/fc3/biases/RMSProp_1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/biases"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/weights/RMSProp/Initializer/ones"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 1024
+          }
+          dim {
+            size: 10
+          }
+        }
+        float_val: 1.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/weights/RMSProp"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 1024
+        }
+        dim {
+          size: 10
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/weights/RMSProp/Assign"
+  op: "Assign"
+  input: "LeNet/fc4/weights/RMSProp"
+  input: "LeNet/fc4/weights/RMSProp/Initializer/ones"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/weights/RMSProp/read"
+  op: "Identity"
+  input: "LeNet/fc4/weights/RMSProp"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/weights/RMSProp_1/Initializer/zeros"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 1024
+          }
+          dim {
+            size: 10
+          }
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/weights/RMSProp_1"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 1024
+        }
+        dim {
+          size: 10
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/weights/RMSProp_1/Assign"
+  op: "Assign"
+  input: "LeNet/fc4/weights/RMSProp_1"
+  input: "LeNet/fc4/weights/RMSProp_1/Initializer/zeros"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/weights/RMSProp_1/read"
+  op: "Identity"
+  input: "LeNet/fc4/weights/RMSProp_1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/biases/RMSProp/Initializer/ones"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/biases"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 10
+          }
+        }
+        float_val: 1.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/biases/RMSProp"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/biases"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 10
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/biases/RMSProp/Assign"
+  op: "Assign"
+  input: "LeNet/fc4/biases/RMSProp"
+  input: "LeNet/fc4/biases/RMSProp/Initializer/ones"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/biases"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/biases/RMSProp/read"
+  op: "Identity"
+  input: "LeNet/fc4/biases/RMSProp"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/biases"
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/biases/RMSProp_1/Initializer/zeros"
+  op: "Const"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/biases"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+          dim {
+            size: 10
+          }
+        }
+        float_val: 0.0
+      }
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/biases/RMSProp_1"
+  op: "VariableV2"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/biases"
+      }
+    }
+  }
+  attr {
+    key: "container"
+    value {
+      s: ""
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "shape"
+    value {
+      shape {
+        dim {
+          size: 10
+        }
+      }
+    }
+  }
+  attr {
+    key: "shared_name"
+    value {
+      s: ""
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/biases/RMSProp_1/Assign"
+  op: "Assign"
+  input: "LeNet/fc4/biases/RMSProp_1"
+  input: "LeNet/fc4/biases/RMSProp_1/Initializer/zeros"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/biases"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: true
+    }
+  }
+  attr {
+    key: "validate_shape"
+    value {
+      b: true
+    }
+  }
+}
+node {
+  name: "LeNet/fc4/biases/RMSProp_1/read"
+  op: "Identity"
+  input: "LeNet/fc4/biases/RMSProp_1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/biases"
+      }
+    }
+  }
+}
+node {
+  name: "RMSProp/decay"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.899999976158
+      }
+    }
+  }
+}
+node {
+  name: "RMSProp/momentum"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 0.899999976158
+      }
+    }
+  }
+}
+node {
+  name: "RMSProp/epsilon"
+  op: "Const"
+  attr {
+    key: "dtype"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_FLOAT
+        tensor_shape {
+        }
+        float_val: 1.0
+      }
+    }
+  }
+}
+node {
+  name: "RMSProp/update_LeNet/conv1/weights/ApplyRMSProp"
+  op: "ApplyRMSProp"
+  input: "LeNet/conv1/weights"
+  input: "LeNet/conv1/weights/RMSProp"
+  input: "LeNet/conv1/weights/RMSProp_1"
+  input: "exponential_decay_learning_rate"
+  input: "RMSProp/decay"
+  input: "RMSProp/momentum"
+  input: "RMSProp/epsilon"
+  input: "gradients/AddN_3"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/weights"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "RMSProp/update_LeNet/conv1/biases/ApplyRMSProp"
+  op: "ApplyRMSProp"
+  input: "LeNet/conv1/biases"
+  input: "LeNet/conv1/biases/RMSProp"
+  input: "LeNet/conv1/biases/RMSProp_1"
+  input: "exponential_decay_learning_rate"
+  input: "RMSProp/decay"
+  input: "RMSProp/momentum"
+  input: "RMSProp/epsilon"
+  input: "gradients/LeNet/conv1/BiasAdd_grad/tuple/control_dependency_1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv1/biases"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "RMSProp/update_LeNet/conv2/weights/ApplyRMSProp"
+  op: "ApplyRMSProp"
+  input: "LeNet/conv2/weights"
+  input: "LeNet/conv2/weights/RMSProp"
+  input: "LeNet/conv2/weights/RMSProp_1"
+  input: "exponential_decay_learning_rate"
+  input: "RMSProp/decay"
+  input: "RMSProp/momentum"
+  input: "RMSProp/epsilon"
+  input: "gradients/AddN_2"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/weights"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "RMSProp/update_LeNet/conv2/biases/ApplyRMSProp"
+  op: "ApplyRMSProp"
+  input: "LeNet/conv2/biases"
+  input: "LeNet/conv2/biases/RMSProp"
+  input: "LeNet/conv2/biases/RMSProp_1"
+  input: "exponential_decay_learning_rate"
+  input: "RMSProp/decay"
+  input: "RMSProp/momentum"
+  input: "RMSProp/epsilon"
+  input: "gradients/LeNet/conv2/BiasAdd_grad/tuple/control_dependency_1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/conv2/biases"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "RMSProp/update_LeNet/fc3/weights/ApplyRMSProp"
+  op: "ApplyRMSProp"
+  input: "LeNet/fc3/weights"
+  input: "LeNet/fc3/weights/RMSProp"
+  input: "LeNet/fc3/weights/RMSProp_1"
+  input: "exponential_decay_learning_rate"
+  input: "RMSProp/decay"
+  input: "RMSProp/momentum"
+  input: "RMSProp/epsilon"
+  input: "gradients/AddN_1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/weights"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "RMSProp/update_LeNet/fc3/biases/ApplyRMSProp"
+  op: "ApplyRMSProp"
+  input: "LeNet/fc3/biases"
+  input: "LeNet/fc3/biases/RMSProp"
+  input: "LeNet/fc3/biases/RMSProp_1"
+  input: "exponential_decay_learning_rate"
+  input: "RMSProp/decay"
+  input: "RMSProp/momentum"
+  input: "RMSProp/epsilon"
+  input: "gradients/LeNet/fc3/BiasAdd_grad/tuple/control_dependency_1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc3/biases"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "RMSProp/update_LeNet/fc4/weights/ApplyRMSProp"
+  op: "ApplyRMSProp"
+  input: "LeNet/fc4/weights"
+  input: "LeNet/fc4/weights/RMSProp"
+  input: "LeNet/fc4/weights/RMSProp_1"
+  input: "exponential_decay_learning_rate"
+  input: "RMSProp/decay"
+  input: "RMSProp/momentum"
+  input: "RMSProp/epsilon"
+  input: "gradients/AddN"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/weights"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "RMSProp/update_LeNet/fc4/biases/ApplyRMSProp"
+  op: "ApplyRMSProp"
+  input: "LeNet/fc4/biases"
+  input: "LeNet/fc4/biases/RMSProp"
+  input: "LeNet/fc4/biases/RMSProp_1"
+  input: "exponential_decay_learning_rate"
+  input: "RMSProp/decay"
+  input: "RMSProp/momentum"
+  input: "RMSProp/epsilon"
+  input: "gradients/LeNet/fc4/BiasAdd_grad/tuple/control_dependency_1"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@LeNet/fc4/biases"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "RMSProp/update"
+  op: "NoOp"
+  input: "^RMSProp/update_LeNet/conv1/weights/ApplyRMSProp"
+  input: "^RMSProp/update_LeNet/conv1/biases/ApplyRMSProp"
+  input: "^RMSProp/update_LeNet/conv2/weights/ApplyRMSProp"
+  input: "^RMSProp/update_LeNet/conv2/biases/ApplyRMSProp"
+  input: "^RMSProp/update_LeNet/fc3/weights/ApplyRMSProp"
+  input: "^RMSProp/update_LeNet/fc3/biases/ApplyRMSProp"
+  input: "^RMSProp/update_LeNet/fc4/weights/ApplyRMSProp"
+  input: "^RMSProp/update_LeNet/fc4/biases/ApplyRMSProp"
+  device: "/device:CPU:0"
+}
+node {
+  name: "RMSProp/value"
+  op: "Const"
+  input: "^RMSProp/update"
+  device: "/device:CPU:0"
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@global_step"
+      }
+    }
+  }
+  attr {
+    key: "dtype"
+    value {
+      type: DT_INT64
+    }
+  }
+  attr {
+    key: "value"
+    value {
+      tensor {
+        dtype: DT_INT64
+        tensor_shape {
+        }
+        int64_val: 1
+      }
+    }
+  }
+}
+node {
+  name: "RMSProp"
+  op: "AssignAdd"
+  input: "global_step"
+  input: "RMSProp/value"
+  device: "/device:CPU:0"
+  attr {
+    key: "T"
+    value {
+      type: DT_INT64
+    }
+  }
+  attr {
+    key: "_class"
+    value {
+      list {
+        s: "loc:@global_step"
+      }
+    }
+  }
+  attr {
+    key: "use_locking"
+    value {
+      b: false
+    }
+  }
+}
+node {
+  name: "group_deps"
+  op: "NoOp"
+  input: "^RMSProp"
+  device: "/device:CPU:0"
+}
+node {
+  name: "train_op"
+  op: "Identity"
+  input: "total_loss"
+  input: "^group_deps"
+  attr {
+    key: "T"
+    value {
+      type: DT_FLOAT
+    }
+  }
+}
+node {
+  name: "summary_op/summary_op"
+  op: "MergeSummary"
+  input: "LeNet/fc4/weights_1"
+  input: "LeNet/conv2/biases_1"
+  input: "regularization_loss_1"
+  input: "LeNet/fc4/biases_1"
+  input: "total_loss_1"
+  input: "activations/Flatten"
+  input: "parallel_read/filenames/fraction_of_32_full"
+  input: "losses/softmax_cross_entropy_loss/value"
+  input: "LeNet/conv1/weights_1"
+  input: "LeNet/conv1/biases_1"
+  input: "parallel_read/fraction_of_640_full"
+  input: "LeNet/conv2/weights_1"
+  input: "sparsity/Predictions"
+  input: "learning_rate"
+  input: "prefetch_queue/fraction_of_2_full"
+  input: "sparsity/Flatten"
+  input: "sparsity/Logits"
+  input: "activations/Predictions"
+  input: "activations/Logits"
+  input: "LeNet/fc3/weights_1"
+  input: "batch/fraction_of_160_full"
+  input: "LeNet/fc3/biases_1"
+  input: "clone_loss_1"
+  attr {
+    key: "N"
+    value {
+      i: 23
+    }
+  }
+}
+versions {
+  producer: 22
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ops/RankSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ops/RankSpec.scala
@@ -24,7 +24,7 @@ class RankSpec extends FlatSpec with Matchers {
     val input =
         Tensor[Float](T(1f, 2f, 2f))
 
-    val expectOutput = Tensor[Int](T(1))
+    val expectOutput = Tensor[Int](Array(1), Array[Int]())
 
     val output = Rank[Int]().forward(input)
     output should be(expectOutput)
@@ -34,7 +34,7 @@ class RankSpec extends FlatSpec with Matchers {
     val input =
         Tensor[Boolean](T(true, true, false))
 
-    val expectOutput = Tensor[Int](T(1))
+    val expectOutput = Tensor[Int](Array(1), Array[Int]())
 
     val output = Rank[Int]().forward(input)
     output should be(expectOutput)
@@ -44,7 +44,7 @@ class RankSpec extends FlatSpec with Matchers {
     val input =
         Tensor[Double](T(2.0, 3.0, 2.0))
 
-    val expectOutput = Tensor[Int](T(1))
+    val expectOutput = Tensor[Int](Array(1), Array[Int]())
 
     val output = Rank[Int]().forward(input)
     output should be(expectOutput)
@@ -54,7 +54,7 @@ class RankSpec extends FlatSpec with Matchers {
     val input =
         Tensor[Char](T('b', 'c', 'a'))
 
-    val expectOutput = Tensor[Int](T(1))
+    val expectOutput = Tensor[Int](Array(1), Array[Int]())
 
     val output = Rank[Int]().forward(input)
     output should be(expectOutput)
@@ -64,7 +64,7 @@ class RankSpec extends FlatSpec with Matchers {
     val input =
         Tensor[Long](T(2L, 3L, 2L))
 
-    val expectOutput = Tensor[Int](T(1))
+    val expectOutput = Tensor[Int](Array(1), Array[Int]())
 
     val output = Rank[Int]().forward(input)
     output should be(expectOutput)
@@ -74,7 +74,7 @@ class RankSpec extends FlatSpec with Matchers {
     val input =
         Tensor[String](T("aaa", "ccc", "aaa"))
 
-    val expectOutput = Tensor[Int](T(1))
+    val expectOutput = Tensor[Int](Array(1), Array[Int]())
 
     val output = Rank[Int]().forward(input)
     output should be(expectOutput)
@@ -84,7 +84,7 @@ class RankSpec extends FlatSpec with Matchers {
     val input =
         Tensor[Short](T(2: Short, 3: Short, 2: Short))
 
-    val expectOutput = Tensor[Int](T(1))
+    val expectOutput = Tensor[Int](Array(1), Array[Int]())
 
     val output = Rank[Int]().forward(input)
     output should be(expectOutput)
@@ -94,7 +94,7 @@ class RankSpec extends FlatSpec with Matchers {
     val input =
         Tensor[Int](T(2, 3, 2))
 
-    val expectOutput = Tensor[Int](T(1))
+    val expectOutput = Tensor[Int](Array(1), Array[Int]())
 
     val output = Rank[Int]().forward(input)
     output should be(expectOutput)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ops/RankSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ops/RankSpec.scala
@@ -24,7 +24,7 @@ class RankSpec extends FlatSpec with Matchers {
     val input =
         Tensor[Float](T(1f, 2f, 2f))
 
-    val expectOutput = Tensor[Int](Array(1), Array[Int]())
+    val expectOutput = Tensor.scalar(1)
 
     val output = Rank[Int]().forward(input)
     output should be(expectOutput)
@@ -34,7 +34,7 @@ class RankSpec extends FlatSpec with Matchers {
     val input =
         Tensor[Boolean](T(true, true, false))
 
-    val expectOutput = Tensor[Int](Array(1), Array[Int]())
+    val expectOutput = Tensor.scalar(1)
 
     val output = Rank[Int]().forward(input)
     output should be(expectOutput)
@@ -44,7 +44,7 @@ class RankSpec extends FlatSpec with Matchers {
     val input =
         Tensor[Double](T(2.0, 3.0, 2.0))
 
-    val expectOutput = Tensor[Int](Array(1), Array[Int]())
+    val expectOutput = Tensor.scalar(1)
 
     val output = Rank[Int]().forward(input)
     output should be(expectOutput)
@@ -54,7 +54,7 @@ class RankSpec extends FlatSpec with Matchers {
     val input =
         Tensor[Char](T('b', 'c', 'a'))
 
-    val expectOutput = Tensor[Int](Array(1), Array[Int]())
+    val expectOutput = Tensor.scalar(1)
 
     val output = Rank[Int]().forward(input)
     output should be(expectOutput)
@@ -64,7 +64,7 @@ class RankSpec extends FlatSpec with Matchers {
     val input =
         Tensor[Long](T(2L, 3L, 2L))
 
-    val expectOutput = Tensor[Int](Array(1), Array[Int]())
+    val expectOutput = Tensor.scalar(1)
 
     val output = Rank[Int]().forward(input)
     output should be(expectOutput)
@@ -74,7 +74,7 @@ class RankSpec extends FlatSpec with Matchers {
     val input =
         Tensor[String](T("aaa", "ccc", "aaa"))
 
-    val expectOutput = Tensor[Int](Array(1), Array[Int]())
+    val expectOutput = Tensor.scalar(1)
 
     val output = Rank[Int]().forward(input)
     output should be(expectOutput)
@@ -84,7 +84,7 @@ class RankSpec extends FlatSpec with Matchers {
     val input =
         Tensor[Short](T(2: Short, 3: Short, 2: Short))
 
-    val expectOutput = Tensor[Int](Array(1), Array[Int]())
+    val expectOutput = Tensor.scalar(1)
 
     val output = Rank[Int]().forward(input)
     output should be(expectOutput)
@@ -94,7 +94,7 @@ class RankSpec extends FlatSpec with Matchers {
     val input =
         Tensor[Int](T(2, 3, 2))
 
-    val expectOutput = Tensor[Int](Array(1), Array[Int]())
+    val expectOutput = Tensor.scalar(1)
 
     val output = Rank[Int]().forward(input)
     output should be(expectOutput)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
@@ -281,4 +281,11 @@ class TableSpec extends FlatSpec with Matchers {
 
     output.toTable should be(output)
   }
+
+  "toSeq" should "work correclty" in {
+
+    val t = T(Tensor[Double](T(1.0)), Tensor[Double](T(2.0)))
+
+    t.toSeq[Double] should be (Seq(Tensor[Double](T(1.0)), Tensor[Double](T(2.0))))
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/ValidationSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/ValidationSpec.scala
@@ -30,7 +30,7 @@ class ValidationSpec extends FlatSpec with Matchers {
         T(0.0, 1.0, 0.0, 0.0)))
 
     val target = Tensor[Double](
-      T(3.0))
+      T(T(3.0)))
 
     val validation = new TreeNNAccuracy[Double]()
     val result = validation(output, target)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DenseTensorMathSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DenseTensorMathSpec.scala
@@ -949,7 +949,7 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
 
   "addmv on 1 element vector" should "return right result 1" in {
     val mat = Tensor[Float](84, 1).fill(2.0f)
-    val vec = Tensor[Float](2).apply(2).fill(3.0f)
+    val vec = Tensor[Float](2).narrow(1, 2, 1).fill(3.0f)
 
     val r = Tensor[Float](84).fill(9.0f)
 
@@ -960,7 +960,7 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
 
   "addmv on 1 element vector" should "return right result 2" in {
     val mat = Tensor[Float](84, 2).narrow(2, 1, 1).fill(2.0f)
-    val vec = Tensor[Float](2).apply(1).fill(3.0f)
+    val vec = Tensor[Float](2).narrow(1, 1, 1).fill(3.0f)
 
     val r = Tensor[Float](84).fill(9.0f)
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DenseTensorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DenseTensorSpec.scala
@@ -109,7 +109,8 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     val t: Tensor[Double] = new DenseTensor[Double](3, 3)
     var i = 0
     t.apply1(v => {
-      i = i + 1; i
+      i = i + 1;
+      i
     })
     t(Array(1, 1)) should be(1)
     t(Array(1, 2)) should be(2)
@@ -159,7 +160,8 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     val t: Tensor[Double] = new DenseTensor[Double](3, 2, 2)
     var i = 0
     t.apply1(v => {
-      i = i + 1; i
+      i = i + 1;
+      i
     })
 
     t(T(2, 2, 1)) should be(new DenseTensor[Double](1).fill(7))
@@ -216,7 +218,8 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     val t: Tensor[Double] = new DenseTensor[Double](3, 2)
     var i = 0
     t.apply1(v => {
-      i = i + 1; i
+      i = i + 1;
+      i
     })
     t(T(2, 2)) = 0
     t(Array(1, 1)) should be(1)
@@ -250,7 +253,8 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     val t: Tensor[Double] = new DenseTensor[Double](3, 2)
     var i = 0
     t.apply1(v => {
-      i = i + 1; i
+      i = i + 1;
+      i
     })
     val criteria: Double => Boolean = v => v >= 4
     t(criteria) = 0
@@ -323,7 +327,8 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     val t: Tensor[Double] = new DenseTensor[Double](3, 2)
     var i = 0
     t.apply1(v => {
-      i = i + 1; i
+      i = i + 1;
+      i
     })
     val t1 = t.select(1, 2)
     t1.nDimension() should be(1)
@@ -336,7 +341,8 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     val t: Tensor[Double] = new DenseTensor[Double](3, 2)
     var i = 0
     t.apply1(v => {
-      i = i + 1; i
+      i = i + 1;
+      i
     })
     val s = t.storage().asInstanceOf[Storage[Double]]
     var j = 0
@@ -357,7 +363,8 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     val t: Tensor[Double] = new DenseTensor[Double](3, 3)
     var i = 0
     t.apply1(v => {
-      i = i + 1; i
+      i = i + 1;
+      i
     })
     val t1 = t.narrow(1, 2, 2)
     t1.nDimension() should be(2)
@@ -398,7 +405,8 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     val t: Tensor[Double] = new DenseTensor[Double](2, 2)
     var i = 0
     t.apply1(v => {
-      i = i + 1; i
+      i = i + 1;
+      i
     })
     t(Array(1, 1)) should be(1)
     t(Array(1, 2)) should be(2)
@@ -410,12 +418,14 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     val t: Tensor[Double] = new DenseTensor[Double](2, 2)
     var i = 0
     t.apply1(v => {
-      i = i + 1; i
+      i = i + 1;
+      i
     })
     val t1: Tensor[Double] = new DenseTensor[Double](2, 2)
     i = 0
     t1.apply1(v => {
-      i = i + 1; i
+      i = i + 1;
+      i
     })
 
     t.map(t1, (a, b) => a * b)
@@ -463,14 +473,16 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     t = new DenseTensor[Double](3, 4)
     var i = 0
     t.apply1(v => {
-      i = i + 1; i
+      i = i + 1;
+      i
     })
     t.toString should be(MATRIX_STRING)
 
     t = new DenseTensor(2, 5, 3, 4)
     i = 0
     t.apply1(v => {
-      i = i + 1; i
+      i = i + 1;
+      i
     })
     println(t)
   }
@@ -532,7 +544,8 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     val x = Tensor[Double](3, 1)
     var i = 0
     x.apply1(e => {
-      i += 1; i
+      i += 1;
+      i
     })
 
     val result = x.expand(Array(3, 2))
@@ -736,42 +749,42 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     val input = Tensor[Float](4, 10).fill(1.0f)
     val output = input.narrow(1, 2, 1).squeezeNewTensor()
 
-    output.size() should be (Array(10))
-    input should be (Tensor[Float](4, 10).fill(1.0f))
+    output.size() should be(Array(10))
+    input should be(Tensor[Float](4, 10).fill(1.0f))
   }
 
   "tensor apply on 1D tensor" should "work correctly" in {
     val a = Tensor[Float](4)
     a.rand()
     val b = a(2)
-    b.storageOffset() should be (2)
-    b.size() should be (Array(1))
-    b.stride() should be (Array(1))
-    b.nElement() should be (1)
+    b.storageOffset() should be(2)
+    b.size() should be(Array(1))
+    b.stride() should be(Array(1))
+    b.nElement() should be(1)
 
     b.setValue(1, 0.01f)
-    b.valueAt(1) should be (0.01f)
-    a.valueAt(2) should be (0.01f)
+    b.valueAt(1) should be(0.01f)
+    a.valueAt(2) should be(0.01f)
   }
 
   "tensor apply on 2D tensor" should "work correctly" in {
     val a = Tensor[Float](3, 4)
     a.rand()
     val b = a(2)
-    b.storageOffset() should be (5)
-    b.size() should be (Array(4))
-    b.stride() should be (Array(1))
-    b.nElement() should be (4)
+    b.storageOffset() should be(5)
+    b.size() should be(Array(4))
+    b.stride() should be(Array(1))
+    b.nElement() should be(4)
 
     b.setValue(3, 0.01f)
-    b.valueAt(3) should be (0.01f)
-    a.valueAt(2, 3) should be (0.01f)
+    b.valueAt(3) should be(0.01f)
+    a.valueAt(2, 3) should be(0.01f)
   }
 
   "Scalar tensor" should "be able to construct" in {
     val t: Tensor[Double] = DenseTensor[Double](1.0)
     t.nDimension should be(0)
-    t.size().isEmpty should be (true)
+    t.size().isEmpty should be(true)
   }
 
   "Scalar tensor" should "not have size" in {
@@ -779,52 +792,52 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     val thrown = intercept[Exception] {
       t.size(1)
     }
-    thrown.isInstanceOf[IllegalArgumentException] should be (true)
+    thrown.isInstanceOf[IllegalArgumentException] should be(true)
   }
 
   "Scalar tensor" should "be able to add" in {
     val t: Tensor[Double] = DenseTensor[Double](1.0)
     val y: Tensor[Double] = DenseTensor[Double](1.0)
     t.add(1.0, y)
-    t should be (DenseTensor[Double](2.0))
+    t should be(DenseTensor[Double](2.0))
   }
 
   "Scalar tensor" should "be able to set value" in {
     val t: Tensor[Double] = DenseTensor[Double](1.0)
     t.setValue(2.0)
-    t should be (DenseTensor[Double](2.0))
+    t should be(DenseTensor[Double](2.0))
   }
 
   "Scalar tensor" should "be able to calc max" in {
     val t: Tensor[Double] = DenseTensor[Double](1.0)
-    t.max() should be (1.0)
+    t.max() should be(1.0)
   }
 
   "Scalar tensor" should "be able to calc min" in {
     val t: Tensor[Double] = DenseTensor[Double](1.0)
-    t.max() should be (1.0)
+    t.max() should be(1.0)
   }
 
   "Scalar tensor" should "be able to calc nElement" in {
     val t: Tensor[Double] = DenseTensor[Double](1.0)
-    t.nElement() should be (1)
+    t.nElement() should be(1)
   }
 
   "Scalar tensor" should "be able to get element" in {
     val t: Tensor[Double] = DenseTensor[Double](1.0)
-    t.apply(Array[Int]()) should be (1.0)
+    t.apply(Array[Int]()) should be(1.0)
   }
 
   "Scalar tensor" should "be able to update" in {
     val t: Tensor[Double] = DenseTensor[Double](1.0)
     t.update(Array[Int](), 2.0)
-    t should be (DenseTensor[Double](2.0))
+    t should be(DenseTensor[Double](2.0))
   }
 
   "Tensor add" should "support broadcasting" in {
     val t1 = Tensor[Double](T(1, 2, 3))
     val t2 = Tensor[Double](T(T(2, 5, 3), T(3, 6, 4)))
-    t2.add(t1) should be (Tensor[Double](T(T(3, 7, 6), T(4, 8, 7))))
+    t2.add(t1) should be(Tensor[Double](T(T(3, 7, 6), T(4, 8, 7))))
   }
 
   "Tensor add" should "support broadcasting 2" in {
@@ -851,7 +864,7 @@ class DenseTensorSpec extends FlatSpec with Matchers {
 
     val cloneT1 = t1.clone()
     val oldStorage = t1.storage()
-    t1.add(t2) should be (Tensor[Double](T(
+    t1.add(t2) should be(Tensor[Double](T(
       T(
         T(3, 4, 5),
         T(7, 8, 9)
@@ -867,7 +880,7 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     )))
     oldStorage.eq(t1.storage()) should be(true)
 
-    t2.add(cloneT1) should be (Tensor[Double](T(
+    t2.add(cloneT1) should be(Tensor[Double](T(
       T(
         T(3, 4, 5),
         T(7, 8, 9)
@@ -886,14 +899,14 @@ class DenseTensorSpec extends FlatSpec with Matchers {
   "Tensor add" should "support broadcasting with singleton dimension" in {
     val t1 = Tensor[Double](T(T(1, 2, 3)))
     val t2 = Tensor[Double](T(T(2, 5, 3), T(3, 6, 4)))
-    t2.add(t1) should be (Tensor[Double](T(T(3, 7, 6), T(4, 8, 7))))
+    t2.add(t1) should be(Tensor[Double](T(T(3, 7, 6), T(4, 8, 7))))
   }
 
   "Tensor add" should "catch exception when broadcasting size not match" in {
     val t1 = Tensor[Double](T(1, 2))
     val t2 = Tensor[Double](T(T(2, 5, 3), T(3, 6, 4)))
     intercept[IllegalArgumentException] {
-      t2.add(t1) should be (Tensor[Double](T(T(3, 7, 6), T(4, 8, 7))))
+      t2.add(t1) should be(Tensor[Double](T(T(3, 7, 6), T(4, 8, 7))))
     }
   }
 
@@ -901,7 +914,13 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     val t1 = Tensor[Double](T(T(1, 2, 3), T(1, 2, 3), T(1, 2, 3)))
     val t2 = Tensor[Double](T(T(2, 5, 3), T(3, 6, 4)))
     intercept[IllegalArgumentException] {
-      t2.add(t1) should be (Tensor[Double](T(T(3, 7, 6), T(4, 8, 7))))
+      t2.add(t1) should be(Tensor[Double](T(T(3, 7, 6), T(4, 8, 7))))
     }
+  }
+
+  "Select on a Vector " should "be a scalar" in {
+    val t: Tensor[Double] = new DenseTensor[Double](2)
+    val result = t.select(1, 1)
+    result.isScalar should be(true)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DenseTensorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DenseTensorSpec.scala
@@ -758,12 +758,12 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     a.rand()
     val b = a(2)
     b.storageOffset() should be(2)
-    b.size() should be(Array(1))
-    b.stride() should be(Array(1))
+    b.size() should be(Array())
+    b.stride() should be(Array())
     b.nElement() should be(1)
 
-    b.setValue(1, 0.01f)
-    b.valueAt(1) should be(0.01f)
+    b.setValue(0.01f)
+    b.value() should be(0.01f)
     a.valueAt(2) should be(0.01f)
   }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/SessionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/SessionSpec.scala
@@ -64,7 +64,7 @@ class SessionSpec extends FlatSpec with Matchers with BeforeAndAfter {
     import scala.collection.JavaConverters._
     val context =
       new mutable.HashMap[String, (Tensor[Float], Tensor[Float], Option[Seq[(Int, Int)]])]()
-    val session = new BigDLSessionImpl[Float](nodes.asScala, context)
+    val session = new BigDLSessionImpl[Float](nodes.asScala, sc, context)
 
     val data = new Array[Tensor[Float]](100)
     val label = new Array[Tensor[Float]](100)
@@ -115,7 +115,7 @@ class SessionSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     val context =
       new mutable.HashMap[String, (Tensor[Float], Tensor[Float], Option[Seq[(Int, Int)]])]()
-    val session = new BigDLSessionImpl[Float](newModel, context)
+    val session = new BigDLSessionImpl[Float](newModel, sc, context)
 
     val endpoints = Seq(
       "ParseSingleExample/SerializedDependencies"

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/SessionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/SessionSpec.scala
@@ -19,7 +19,7 @@ import com.intel.analytics.bigdl.dataset._
 import com.intel.analytics.bigdl.nn.{CrossEntropyCriterion, MSECriterion}
 import com.intel.analytics.bigdl.optim.{SGD, Trigger}
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.bigdl.utils.Engine
+import com.intel.analytics.bigdl.utils.{Engine, Table}
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.SparkContext
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
@@ -74,7 +74,7 @@ class SessionSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     val optim = new SGD[Float](0.001)
     val criterion = MSECriterion[Float]()
-    val endWhen = Trigger.maxEpoch(5)
+    val endWhen = Trigger.maxEpoch(2)
 
     val samples = data.zip(label).map { case (dataTensor, labelTensor) =>
       Sample(dataTensor, labelTensor)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/SessionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/SessionSpec.scala
@@ -90,4 +90,24 @@ class SessionSpec extends FlatSpec with Matchers with BeforeAndAfter {
      module.forward(Tensor[Float](Array(1)))
   }
 
+  "Session" should "work" in {
+
+    val path = "/tmp/lenet/lenet.pbtxt"
+    val nodes = TensorflowLoader.parseTxt(path)
+    import scala.collection.JavaConverters._
+    val context =
+      new mutable.HashMap[String, (Tensor[Float], Tensor[Float], Option[Seq[(Int, Int)]])]()
+    val session = new BigDLSessionImpl[Float](nodes.asScala, context)
+
+    val cache = new mutable.HashMap[String, Array[Seq[Table]]]()
+    val endpoints = Seq(
+      "ParseSingleExample/Squeeze_image/class/label",
+      "ParseSingleExample/Squeeze_image/encoded",
+      "ParseSingleExample/Squeeze_image/format"
+    )
+    val rdd = session.constructDistributeData(endpoints, cache)
+    val result = rdd.first()
+    println(result)
+  }
+
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoaderSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoaderSpec.scala
@@ -104,19 +104,6 @@ class TensorflowLoaderSpec extends TensorflowSpecHelper{
     System.setProperty("bigdl.enableNHWC", "false")
   }
 
-  "TensorFlow loader" should "convert tensor protobuf to bigdl tensor" in {
-
-    val tftensorBuilder = TensorProto.newBuilder()
-      .setDtype(DataType.DT_INT32)
-      .setTensorShape(TensorShapeProto
-        .newBuilder().build())
-
-    tftensorBuilder.addIntVal(3)
-
-    val tensor = TFUtils.parseTensor(tftensorBuilder.build(), ByteOrder.LITTLE_ENDIAN)
-    println(tensor)
-  }
-
   "TensorFlow loader" should "read a list of nodes from pb file" in {
     val resource = getClass().getClassLoader().getResource("tf")
     val path = processPath(resource.getPath()) + JFile.separator + "test.pb"

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoaderSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoaderSpec.scala
@@ -19,6 +19,7 @@ import java.io.{File => JFile}
 import java.nio.ByteOrder
 import java.util.UUID
 
+import com.google.protobuf.ByteString
 import com.intel.analytics.bigdl.dataset.{DistributedDataSet, MiniBatch}
 import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.optim.{DistriOptimizer, Trigger}
@@ -28,7 +29,7 @@ import org.apache.log4j.{Level, Logger}
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import com.intel.analytics.bigdl.numeric.NumericFloat
-import org.tensorflow.framework.NodeDef
+import org.tensorflow.framework.{DataType, NodeDef, TensorProto, TensorShapeProto}
 
 import scala.collection.mutable
 import scala.sys.process._
@@ -101,6 +102,19 @@ class TensorflowLoaderSpec extends TensorflowSpecHelper{
       sc.stop()
     }
     System.setProperty("bigdl.enableNHWC", "false")
+  }
+
+  "TensorFlow loader" should "convert tensor protobuf to bigdl tensor" in {
+
+    val tftensorBuilder = TensorProto.newBuilder()
+      .setDtype(DataType.DT_INT32)
+      .setTensorShape(TensorShapeProto
+        .newBuilder().build())
+
+    tftensorBuilder.addIntVal(3)
+
+    val tensor = TFUtils.parseTensor(tftensorBuilder.build(), ByteOrder.LITTLE_ENDIAN)
+    println(tensor)
   }
 
   "TensorFlow loader" should "read a list of nodes from pb file" in {


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Support Tensorflow Preprocessing
2. Change the behavior of selecting on 1-d tensor, return a scalar tensor instead of a 1-d tensor.
Normally selecting on a n-d tensor would return a (n-1)-d tensor.
Originally in BigDL, however, selecting on a 1-d tensor would also return a 1-d tensor, as we change the select operation to a narrow operation.
Since we support scalar now, selecting on a 1-d tensor should return a scalar.

## How was this patch tested?

unit tests

