### PR TITLE
fix Logsoftmax infinity error

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSoftMax.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSoftMax.scala
@@ -81,6 +81,7 @@ class LogSoftMax[T: ClassTag](
     if (buffer.nElement() != out.nElement) {
       buffer.resizeAs(out)
     }
+    // use exp(in - maxInput) to avoid Infinity error
     val maxInput = in.max()
 
     buffer.fill(ev.negative(maxInput))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSoftMax.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSoftMax.scala
@@ -78,9 +78,6 @@ class LogSoftMax[T: ClassTag](
     if (ones.nElement() < in.nElement) {
       ones.resizeAs(in).fill(ev.one)
     }
-    if (buffer.nElement() != in.nElement) {
-      buffer.resizeAs(in)
-    }
     val maxInput = in.max()
 
     var logSum = ev.zero
@@ -121,10 +118,12 @@ class LogSoftMax[T: ClassTag](
   }
 
   private def updateGradInputFrame(out: Tensor[T], gradOut: Tensor[T]): Unit = {
+    if (buffer.nElement() != out.nElement) {
+      buffer.resizeAs(out)
+    }
     buffer.exp(out)
-    val dot = gradOut.dot(ones)
-    val sum = ev.negative(dot)
-    gradOut.add(sum, buffer)
+    val outSum = gradOut.dot(ones)
+    gradOut.add(ev.negative(outSum), buffer)
   }
 
   override def clearState() : this.type = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSoftMax.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSoftMax.scala
@@ -82,6 +82,7 @@ class LogSoftMax[T: ClassTag](
 
     var logSum = ev.zero
     in.apply1(v => {
+      // Use exp(v - maxInput) to avoid Infinity.
       logSum = ev.plus(logSum, ev.exp(ev.minus(v, maxInput))); v
     })
     logSum = ev.plus(maxInput, ev.log(logSum))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSoftMax.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSoftMax.scala
@@ -42,10 +42,8 @@ class LogSoftMax[T: ClassTag](
   implicit ev: TensorNumeric[T]) extends TensorModule[T] {
   @transient
   private var results: Array[Future[Unit]] = null
-  @transient
-  private var ones: Array[T] = null
-  @transient
-  private var buffer: Array[T] = null
+  private var ones: Tensor[T] = Tensor()
+  private var buffer: Tensor[T] = Tensor()
 
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
@@ -77,37 +75,21 @@ class LogSoftMax[T: ClassTag](
   }
 
   private def updateOutputFrame(in: Tensor[T], out: Tensor[T]): Unit = {
-    if (ones == null || ones.length < in.nElement) {
-      ones = Array.fill(in.nElement)(ev.fromType[Int](1))
+    if (ones.nElement() < in.nElement) {
+      ones.resizeAs(in).fill(ev.one)
     }
-    if (buffer == null || buffer.length < in.nElement) {
-      buffer = new Array[T](in.nElement)
+    if (buffer.nElement() != in.nElement) {
+      buffer.resizeAs(in)
     }
+    val maxInput = in.max()
 
-    ev.vExp(in.nElement,
-      in.storage.array,
-      in.storageOffset - 1,
-      buffer,
-      0)
+    var logsum = ev.zero
+    in.apply1(v => {
+      logsum = ev.plus(logsum, ev.exp(ev.minus(v, maxInput))); v
+    })
+    logsum = ev.plus(maxInput, ev.log(logsum))
 
-    val dot = ev.dot(in.nElement,
-      buffer,
-      0,
-      1,
-      ones,
-      0,
-      1)
-
-    val sum = ev.negative(ev.log(dot))
-
-    ev.axpy(in.nElement,
-      sum,
-      ones,
-      0,
-      1,
-      out.storage.array,
-      out.storageOffset - 1,
-      1)
+    out.add(ev.negative(logsum))
   }
 
   override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
@@ -139,36 +121,19 @@ class LogSoftMax[T: ClassTag](
   }
 
   private def updateGradInputFrame(out: Tensor[T], gradOut: Tensor[T]): Unit = {
-    ev.vExp(out.nElement,
-      out.storage.array,
-      out.storageOffset - 1,
-      buffer,
-      0)
+    buffer.exp(out)
 
-    val dot = ev.dot(gradOut.nElement,
-      gradOut.storage.array,
-      gradOut.storageOffset - 1,
-      1,
-      ones,
-      0,
-      1)
+    val dot = gradOut.dot(ones)
 
     val sum = ev.negative(dot)
 
-    ev.axpy(gradOut.nElement,
-      sum,
-      buffer,
-      0,
-      1,
-      gradOut.storage.array,
-      gradOut.storageOffset - 1,
-      1)
+    gradOut.add(sum, buffer)
   }
 
   override def clearState() : this.type = {
     super.clearState()
-    ones = null
-    buffer = null
+    ones.set()
+    buffer.set()
     results = null
     this
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSoftMax.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSoftMax.scala
@@ -42,8 +42,8 @@ class LogSoftMax[T: ClassTag](
   implicit ev: TensorNumeric[T]) extends TensorModule[T] {
   @transient
   private var results: Array[Future[Unit]] = null
-  private var ones: Tensor[T] = Tensor()
-  private var buffer: Tensor[T] = Tensor()
+  private val ones: Tensor[T] = Tensor()
+  private val buffer: Tensor[T] = Tensor()
 
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
@@ -83,13 +83,13 @@ class LogSoftMax[T: ClassTag](
     }
     val maxInput = in.max()
 
-    var logsum = ev.zero
+    var logSum = ev.zero
     in.apply1(v => {
-      logsum = ev.plus(logsum, ev.exp(ev.minus(v, maxInput))); v
+      logSum = ev.plus(logSum, ev.exp(ev.minus(v, maxInput))); v
     })
-    logsum = ev.plus(maxInput, ev.log(logsum))
+    logSum = ev.plus(maxInput, ev.log(logSum))
 
-    out.add(ev.negative(logsum))
+    out.add(ev.negative(logSum))
   }
 
   override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
@@ -122,11 +122,8 @@ class LogSoftMax[T: ClassTag](
 
   private def updateGradInputFrame(out: Tensor[T], gradOut: Tensor[T]): Unit = {
     buffer.exp(out)
-
     val dot = gradOut.dot(ones)
-
     val sum = ev.negative(dot)
-
     gradOut.add(sum, buffer)
   }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/InceptionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/InceptionSpec.scala
@@ -774,7 +774,7 @@ class InceptionSpec extends TorchSpec {
     val loss = criterion.forward(output, labels)
 
     // since we already set the seed, the loss should match exactly
-    loss should be (6.9011583f)
+    loss should be (6.901158f)
   }
 
   "Inception_Layer_V1 graph" should "be correct" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/InceptionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/InceptionSpec.scala
@@ -754,7 +754,7 @@ class InceptionSpec extends TorchSpec {
     val loss = criterion.forward(output, labels)
 
     // since we already set the seed, the loss should match exactly
-    loss should be (6.8930426f)
+    loss should be (6.893043f)
   }
 
   "InceptionV1 " should "init right" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/ModelGraientCheckSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/ModelGraientCheckSpec.scala
@@ -67,7 +67,7 @@ class ModelGraientCheckSpec extends FlatSpec with BeforeAndAfter with Matchers {
     val output = model.forward(input)
     val loss = criterion.forward(output, labels)
 
-    loss should be (6.9059443926654875)
+    loss should be (6.905944392665487)
   }
 
   "GoogleNet_v2 model in batch mode" should "be good in gradient check for input" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/ModelGraientCheckSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/ModelGraientCheckSpec.scala
@@ -67,7 +67,7 @@ class ModelGraientCheckSpec extends FlatSpec with BeforeAndAfter with Matchers {
     val output = model.forward(input)
     val loss = criterion.forward(output, labels)
 
-    loss should be (6.905944392665487)
+    loss should be (6.9059443926654875)
   }
 
   "GoogleNet_v2 model in batch mode" should "be good in gradient check for input" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LogSoftMaxSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LogSoftMaxSpec.scala
@@ -21,6 +21,8 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.torch.TH
 import com.intel.analytics.bigdl.utils.Engine
 
+import scala.util.Random
+
 @com.intel.analytics.bigdl.tags.Parallel
 class LogSoftMaxSpec extends FlatSpec with Matchers with BeforeAndAfter {
   before {
@@ -115,5 +117,13 @@ class LogSoftMaxSpec extends FlatSpec with Matchers with BeforeAndAfter {
     gradInput should be(expectedGrad)
     input should be(inputOrg)
     gradOutput should be(gradOutputOrg)
+  }
+
+  "LogSoftMax float module" should "won't return Infinity when input is bigger than 89" in {
+    val module = new LogSoftMax[Float]()
+    Random.setSeed(100)
+    val input = Tensor[Float](2, 5).apply1(e => Random.nextFloat() + 90)
+    val output = module.forward(input).toTensor[Float]
+    output.apply1(v => {v.isInfinity should be (false); v})
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/EvaluatorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/EvaluatorSpec.scala
@@ -70,7 +70,7 @@ class EvaluatorSpec extends FlatSpec with Matchers with BeforeAndAfter{
 
     result(0)._1 should be (new AccuracyResult(0, 100))
     result(1)._1 should be (new AccuracyResult(100, 100))
-    result(2)._1 should be (new LossResult(57.66907f, 25))
+    result(2)._1 should be (new LossResult(57.669075f, 25))
     result(0)._1.result()._1 should be (0f)
     result(1)._1.result()._1 should be (1f)
     result(2)._1.result()._1 should be (2.306763f+-0.000001f)


### PR DESCRIPTION
## What changes were proposed in this pull request?

#1424 's optimization may cause an Infinity output when one of the input's bigger than 88.72283905206835.
Because `log(Float.MaxValue) == 88.72283905206835`.

This pr can fix this issue.

## How was this patch tested?

unit tests

## Related links or issues (optional)
fixed #1486 

