### PR TITLE
feat: quantized tensor support

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/Desc.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/Desc.scala
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.quantized
+
+import com.intel.analytics.bigdl.bigquant.BigQuant
+import com.intel.analytics.bigdl.tensor.{FloatType, QuantizedTensor}
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import scala.reflect.ClassTag
+
+sealed trait DescType extends Serializable
+object ConvData extends DescType
+object ConvWeight extends DescType
+object LinearData extends DescType
+object LinearWeight extends DescType
+
+trait DescParams extends Serializable with Product {
+  def copy(): DescParams
+  def array: Array[Any] = this.productIterator.toArray
+  def getType: DescType
+}
+
+case class ConvDataParams(nInputPlane: Int, kernelH: Int, kernelW: Int,
+  strideH: Int, strideW: Int, padH: Int, padW: Int, dilationHeight: Int, dilationWidth: Int,
+  batchSize: Int, inputHeight: Int, inputWidth: Int) extends DescParams {
+  override def copy(): DescParams = {
+    val p = this
+    new ConvDataParams(p.nInputPlane, p.kernelH, p.kernelW, p.strideH, p.strideW,
+      p.padH, p.padW, p.dilationHeight, p.dilationWidth, p.batchSize, p.inputHeight,
+      p.inputWidth)
+  }
+
+  override def getType: DescType = ConvData
+}
+
+object ConvDataParams {
+  def apply(params: Array[Int]): ConvDataParams = new ConvDataParams(
+    params(0), // nInputPlane
+    params(1), // kernelH
+    params(2), // kernelW
+    params(3), // strideH
+    params(4), // strideW
+    params(5), // padH
+    params(6), // padW
+    params(7), // dilationHeight
+    params(8), // dilationWidth
+    params(9), // batchSize
+    params(10), // inputHeigh
+    params(11)) // inputWidth
+}
+
+case class ConvWeightParams(nOutputPlane: Int, nInputPlane: Int, kernelH: Int,
+  kernelW: Int, dataFormat: Int) extends DescParams {
+
+  override def copy(): DescParams = {
+    val p = this
+    new ConvWeightParams(p.nOutputPlane, p.nInputPlane, p.kernelH, p.kernelW, dataFormat)
+  }
+
+  override def getType: DescType = ConvWeight
+}
+
+object ConvWeightParams {
+  def apply(params: Array[Int]): ConvWeightParams = ConvWeightParams(
+    params(0), // nOutputPlane
+    params(1), // nInputPlane
+    params(2), // kernelH
+    params(3), // kernelW
+    params(4)) // data format
+}
+
+case class LinearDataParams(batchSize: Int, inputSize: Int) extends DescParams {
+
+  override def copy(): DescParams = {
+    val p = this
+    new LinearDataParams(p.batchSize, p.inputSize)
+  }
+
+  override def getType: DescType = LinearData
+}
+
+object LinearDataParams {
+  def apply(params: Array[Int]): LinearDataParams = LinearDataParams(
+    params(0), // batchSize
+    params(1)) // inputSize
+
+}
+
+case class LinearWeightParams(outputSize: Int, inputSize: Int) extends DescParams {
+
+  override def copy(): DescParams = {
+    val p = this
+    new LinearWeightParams(p.outputSize, p.inputSize)
+  }
+
+  override def getType: DescType = LinearWeight
+}
+
+object LinearWeightParams {
+  def apply(params: Array[Int]): LinearWeightParams = LinearWeightParams(
+    params(0), // outputSize
+    params(1)) // inputSize
+
+}
+
+object Desc {
+  def get[T: ClassTag](params: DescParams, bytes: Array[Byte], offset: Int,
+    max: Array[T], min: Array[T]): Long = {
+    val desc = params.getType match {
+      case ConvData =>
+        val p = params.asInstanceOf[ConvDataParams]
+        BigQuant.ConvDataDescInit(p.nInputPlane,
+          p.kernelH, p.kernelW, p.strideH, p.strideW, p.padH, p.padW,
+          p.dilationHeight, p.dilationWidth, p.batchSize, p.inputHeight, p.inputWidth)
+
+      case ConvWeight =>
+        val p = params.asInstanceOf[ConvWeightParams]
+        val desc = BigQuant.ConvKernelDescInit(p.nOutputPlane, p.nInputPlane, p.kernelH, p.kernelW)
+        if (bytes != null) {
+          convWeigth(p, desc, bytes, offset, max, min)
+        }
+        desc
+
+      case LinearData =>
+        val p = params.asInstanceOf[LinearDataParams]
+        BigQuant.FCDataDescInit(p.batchSize, p.inputSize)
+
+      case LinearWeight =>
+        val p = params.asInstanceOf[LinearWeightParams]
+        val desc = BigQuant.FCKernelDescInit(p.outputSize, p.inputSize)
+        if (bytes != null) {
+          linearWeight(p, desc, bytes, offset, max, min)
+        }
+        desc
+    }
+
+    desc
+  }
+
+  private def linearWeight[T: ClassTag](p: LinearWeightParams, desc: Long, bytes: Array[Byte],
+    offset: Int, max: Array[T], min: Array[T]): Long = {
+    val minArray = min.asInstanceOf[Array[Float]]
+    val maxArray = max.asInstanceOf[Array[Float]]
+
+    BigQuant.FCKernelLoadFromModel(desc, bytes, minArray, maxArray,
+      p.outputSize, p.inputSize, QuantParams.WEIGHT_THRESHOLD, BigQuant.NCHW)
+    desc
+  }
+
+  private def convWeigth[T: ClassTag](p: ConvWeightParams, desc: Long, bytes: Array[Byte],
+    offset: Int, max: Array[T], min: Array[T]): Long = {
+    val minArray = min.asInstanceOf[Array[Float]]
+    val maxArray = max.asInstanceOf[Array[Float]]
+    BigQuant.ConvKernelLoadFromModel(desc,
+      bytes, offset,
+      minArray, maxArray, p.nOutputPlane, p.nInputPlane,
+      p.kernelH, p.kernelW, QuantParams.WEIGHT_THRESHOLD, p.dataFormat)
+    desc
+  }
+}
+
+object QuantParams {
+  val FAULT_TOLERANCE = 0.5f
+  val WEIGHT_THRESHOLD = 64.0f
+  val THRESHOLD = 127.0f
+}
+

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
@@ -1989,6 +1989,9 @@ private[tensor] class DenseTensor[@specialized T: ClassTag](
   }
 
   override def getTensorNumeric(): TensorNumeric[T] = ev
+
+  override def getTensorType: TensorType = DenseType
+
 }
 
 object DenseTensor {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/QuantizedTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/QuantizedTensor.scala
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.tensor
+
+import com.intel.analytics.bigdl.bigquant.BigQuant
+import com.intel.analytics.bigdl.nn.quantized._
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import java.io.{IOException, ObjectInputStream}
+import scala.reflect.ClassTag
+
+@SerialVersionUID(- 1766499387282335147L)
+private[bigdl] class QuantizedTensor[@specialized(Float) T: ClassTag](
+  private var _size: Array[Int],
+  private var _stride: Array[Int],
+  var nDimension: Int)(implicit ev: TensorNumeric[T]) extends QuantizedTensorUnsupported[T] {
+  @transient private var desc = 0L
+  private var internalStorage: Array[Byte] = null
+
+  var maxOfRow: Array[T] = null
+  var minOfRow: Array[T] = null
+  var sumOfRow: Array[T] = null
+
+  var params: DescParams = _
+
+  def getStorage: Array[Byte] = {
+    internalStorage
+  }
+
+  def getNativeStorage: Long = {
+    desc
+  }
+
+  def release(): this.type = {
+    if (desc != 0) {
+      BigQuant.FreeMemory(desc)
+    }
+    desc = 0L
+    this
+  }
+
+  override def equals(obj: Any): Boolean = {
+    if (obj == null) {
+      return false
+    }
+
+    if (!obj.isInstanceOf[QuantizedTensor[T]]) {
+      return false
+    }
+
+    val other = obj.asInstanceOf[QuantizedTensor[T]]
+    if (this.eq(other)) {
+      return true
+    }
+
+    if (this.nDimension != other.nDimension) {
+      return false
+    }
+
+    var d = 1
+    while (d <= this.nDimension) {
+      if (this.size(d) != other.size(d)) {
+        return false
+      }
+      d += 1
+    }
+
+    var result = true
+    for (i <- internalStorage.indices) {
+      result = internalStorage(i) == other.getStorage(i)
+    }
+
+    result
+  }
+
+  override def hashCode(): Int = {
+    val seed = 37
+    var hash = 1
+
+    hash = hash * seed + this.nDimension
+    var d = 1
+    while (d <= this.nDimension) {
+      hash = hash * seed + this.size(d)
+      d += 1
+    }
+
+    if (internalStorage != null) {
+      var i = 0
+      while (i < internalStorage.length) {
+        hash = hash * seed + internalStorage(i).toFloat.hashCode()
+        i += 1
+      }
+    }
+
+    hash
+  }
+
+  def this(size: Array[Int], params: DescParams)(
+    implicit ev: TensorNumeric[T]) = {
+    this(size, DenseTensor.size2Stride(size), size.length)
+    this.params = params
+    this.desc = Desc.get(params, null, 0, null, null)
+  }
+
+  def this(src: Tensor[T], descParams: DescParams)(
+    implicit ev: TensorNumeric[T]) = {
+    this(src.size(), src.stride(), src.nDimension())
+    this.internalStorage = createInternalStorage(src)
+    this.params = descParams
+    this.desc = Desc.get(descParams, this.internalStorage, 0, this.maxOfRow, this.minOfRow)
+  }
+
+  def this(src: Array[Byte], size: Array[Int], max: Array[T], min: Array[T], sum: Array[T],
+    descParams: DescParams)(implicit ev: TensorNumeric[T]) = {
+    this(size, DenseTensor.size2Stride(size), size.length)
+    require(src.length == size.product, s"size mismatch, byte array size should equal to shape")
+
+    this.internalStorage = src
+    this.maxOfRow = max
+    this.minOfRow = min
+    this.sumOfRow = sum
+    this.params = descParams
+    this.desc = Desc.get(descParams, this.internalStorage, 0, this.maxOfRow, this.minOfRow)
+  }
+
+  private def createInternalStorage(tensor: Tensor[T]): Array[Byte] = {
+    val size = tensor.size(1)
+    maxOfRow = new Array[T](size)
+    minOfRow = new Array[T](size)
+    sumOfRow = new Array[T](size)
+
+    for (i <- 1 to size) {
+      val tmp = tensor.select(1, i)
+      minOfRow(i - 1) = tmp.min()
+      maxOfRow(i - 1) = tmp.max()
+      sumOfRow(i - 1) = tmp.sum()
+    }
+
+    val bytes = new Array[Byte](this.nElement())
+    val bytesOffset = 0
+    ev.getType() match {
+      case FloatType =>
+        Quantization.quantize(tensor.asInstanceOf[Tensor[Float]], bytes, bytesOffset)
+      case _ =>
+        throw new UnsupportedOperationException(s"Only support Float for quantized model")
+    }
+
+    bytes
+  }
+
+  override def getTensorType: TensorType = QuantizedType
+
+  override def dim(): Int = nDimension
+
+  override def size(): Array[Int] = _size
+
+  override def size(dim: Int): Int = {
+    require(dim > 0 && dim <= this.nDimension,
+      s"dimension ${dim} out of range of ${this.nDimension}D tensor")
+    _size(dim - 1)
+  }
+
+  override def stride(): Array[Int] = _stride.slice(0, this.nDimension)
+
+  override def stride(dim: Int): Int = {
+    require(dim > 0 && dim <= this.nDimension,
+      s"dimension ${dim} out of range of ${this.nDimension}D tensor")
+    _stride(dim - 1)
+  }
+
+  override def nElement(): Int = {
+    if (this.nDimension == 0) {
+      0
+    } else {
+      var n = 1
+      var d = 0
+      while (d < this.nDimension) {
+        n = n * this._size(d)
+        d += 1
+      }
+      n
+    }
+  }
+
+  override def set(): Tensor[T] = {
+    internalStorage = null
+    maxOfRow = null
+    minOfRow = null
+    sumOfRow = null
+    desc = 0L
+    this
+  }
+
+  /**
+   * set from other tensor, it will share the storage and desc with other
+   *
+   * @param other the given tensor
+   * @return current tensor
+   */
+  override def set(other: Tensor[T]): Tensor[T] = {
+    if (other.isInstanceOf[QuantizedTensor[T]]) {
+      val o = other.asInstanceOf[QuantizedTensor[T]]
+
+      this.internalStorage = o.getStorage
+      this.params = o.params
+      this.desc = o.getNativeStorage
+
+      this.maxOfRow = o.maxOfRow
+      this.minOfRow = o.minOfRow
+      this.sumOfRow = o.sumOfRow
+
+      this._size = o.size()
+      this._stride = o.stride()
+      this.nDimension = o.nDimension
+
+    } else {
+      throw new UnsupportedOperationException(s"can't set from other type of tensor.")
+    }
+    this
+  }
+
+  /**
+   * copy from another QuantizedTensor, it will a new storage and new desc
+   *
+   * @param other source tensor
+   * @return current tensor
+   */
+  override def copy(other: Tensor[T]): Tensor[T] = {
+    if (other.isInstanceOf[QuantizedTensor[T]] && other.size().deep == this.size().deep) {
+      val quantizedTensor = other.asInstanceOf[QuantizedTensor[T]]
+
+      if (internalStorage != null) {
+        internalStorage = new Array[Byte](other.nElement())
+      }
+
+      System.arraycopy(quantizedTensor.getStorage, 0, internalStorage, 0, this.nElement())
+
+      params = quantizedTensor.params.copy()
+
+      val length = quantizedTensor.maxOfRow.length
+      maxOfRow = new Array[T](length)
+      System.arraycopy(quantizedTensor.maxOfRow, 0, maxOfRow, 0, length)
+
+      minOfRow = new Array[T](length)
+      System.arraycopy(quantizedTensor.minOfRow, 0, minOfRow, 0, length)
+
+      sumOfRow = new Array[T](length)
+      System.arraycopy(quantizedTensor.sumOfRow, 0, sumOfRow, 0, length)
+
+      new QuantizedTensor[T](internalStorage, size(), maxOfRow, minOfRow, sumOfRow, params)
+    } else {
+      throw new UnsupportedOperationException(s"can't set from other type of tensor.")
+    }
+
+    this
+  }
+
+  @throws(classOf[IOException])
+  private def readObject(in: ObjectInputStream): Unit = {
+    in.defaultReadObject()
+
+    this.desc = Desc.get(params, internalStorage, 0, maxOfRow, minOfRow)
+  }
+}
+
+object QuantizedTensor {
+  def apply[@specialized(Float, Double) T: ClassTag](size: Array[Int], params: DescParams)(
+    implicit ev: TensorNumeric[T]): QuantizedTensor[T] =
+    new QuantizedTensor[T](size, params)
+
+  def apply[@specialized(Float, Double) T: ClassTag](src: Tensor[T], descParams: DescParams)(
+    implicit ev: TensorNumeric[T]): QuantizedTensor[T] = {
+    new QuantizedTensor[T](src, descParams)
+  }
+
+  def apply[@specialized(Float, Double) T: ClassTag](src: Array[Byte], max: Array[T], min: Array[T],
+    sum: Array[T], size: Array[Int], descParams: DescParams)(
+    implicit ev: TensorNumeric[T]): QuantizedTensor[T] = {
+    new QuantizedTensor[T](src, size, max, min, sum, descParams)
+  }
+}
+
+object QuantizedDummyTensor {
+  def apply[@specialized(Float, Double) T: ClassTag]()(
+    implicit ev: TensorNumeric[T]): QuantizedTensor[T] = {
+    QuantizedTensor[T](Tensor(1, 1), LinearWeightParams(1, 1))
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/QuantizedTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/QuantizedTensor.scala
@@ -23,7 +23,7 @@ import java.io.{IOException, ObjectInputStream}
 import scala.reflect.ClassTag
 
 @SerialVersionUID(- 1766499387282335147L)
-private[bigdl] class QuantizedTensor[@specialized(Float) T: ClassTag](
+private[bigdl] class QuantizedTensor[T: ClassTag](
   private var _size: Array[Int],
   private var _stride: Array[Int],
   var nDimension: Int)(implicit ev: TensorNumeric[T]) extends QuantizedTensorUnsupported[T] {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/QuantizedTensorUnsupported.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/QuantizedTensorUnsupported.scala
@@ -1,0 +1,1399 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.tensor
+
+import breeze.linalg.{DenseMatrix => BrzDenseMatrix, DenseVector => BrzDenseVector}
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Table
+import org.apache.spark.mllib.linalg.{DenseMatrix, DenseVector, Matrix, Vector}
+import scala.reflect.ClassTag
+
+abstract class QuantizedTensorUnsupported[T: ClassTag] extends Tensor[T] {
+  val errorString = s"QuantizeTensor doesn't support this operation now"
+
+  /**
+   * Fill with a given value. It will change the value of the current tensor and return itself
+   *
+   * @param v value to fill the tensor
+   * @return current tensor
+   */
+  override def fill(v: T): Tensor[T] = throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Fill with zero. It will change the value of the current tensor and return itself
+   *
+   * @return current tensor
+   */
+  override def zero(): Tensor[T] = throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Fill with random value(normal gaussian distribution).
+   * It will change the value of the current tensor and return itself
+   *
+   * @return current tensor
+   */
+  override def randn(): Tensor[T] = throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Fill with random value(normal gaussian distribution with the specified mean
+   * and stdv).
+   * It will change the value of the current tensor and return itself
+   *
+   * @return current tensor
+   */
+  override def randn(mean: Double, stdv: Double): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Fill with random value(uniform distribution).
+   * It will change the value of the current tensor and return itself
+   *
+   * @return current tensor
+   */
+  override def rand(): Tensor[T] = throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Fill with random value(uniform distribution between [lowerBound, upperBound])
+   * It will change the value of the current tensor and return itself
+   *
+   * @return current tensor
+   */
+  override def rand(lowerBound: Double, upperBound: Double): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Fill with random value(bernoulli distribution).
+   * It will change the value of the current tensor and return itself
+   *
+   * @return current tensor
+   */
+  override def bernoulli(p: Double): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /** *
+   * Create a new tensor which exchanges the given dimensions of the current tensor
+   *
+   * @param dim1 dimension to be exchanged, count from one
+   * @param dim2 dimension to be exchanged, count from one
+   * @return new tensor
+   */
+  override def transpose(dim1: Int, dim2: Int): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Shortcut of transpose(1, 2) for 2D tensor
+   *
+   * @see transpose()
+   */
+  override def t(): Tensor[T] = throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Query tensor on a given index. Tensor should not be empty
+   *
+   * @param index count from 1
+   * @return
+   */
+  override def apply(index: Int): Tensor[T] = throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Query the value on a given index. Tensor should not be empty
+   *
+   * @param indexes the indexes length should be same as the tensor dimension length and each
+   *                value count from 1
+   * @return the value on the given index
+   */
+  override def apply(indexes: Array[Int]): T = throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Query the value on a given position. The number of parameters
+   * should be equal to the dimension number of the tensor.
+   * Tensor should not be empty.
+   *
+   * @param d1 ,( d2, d3, d4, d5) the given position
+   * @return the value on a given position
+   */
+  override def valueAt(d1: Int): T = throw new UnsupportedOperationException(errorString)
+
+  override def valueAt(d1: Int, d2: Int): T = throw new UnsupportedOperationException(errorString)
+
+  override def valueAt(d1: Int, d2: Int, d3: Int): T =
+    throw new UnsupportedOperationException(errorString)
+
+  override def valueAt(d1: Int, d2: Int, d3: Int, d4: Int): T =
+    throw new UnsupportedOperationException(errorString)
+
+  override def valueAt(d1: Int, d2: Int, d3: Int, d4: Int, d5: Int): T =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Subset the tensor by apply the element of the given table to corresponding dimension of the
+   * tensor. The element of the given table can be an Int or another Table.
+   * An Int means select on current dimension; A table means narrow on current dimension,
+   * the table should has two elements, of which the first is start index and
+   * the second is the end index. An empty table is equals to Table(1, size_of_current_dimension)
+   * If the table length is less than the tensor dimension, the missing dimension is applied by
+   * an empty table
+   *
+   * @see select
+   * @see narrow
+   * @param t The table length should be less than or equal to the tensor dimensions
+   * @return
+   */
+  override def apply(t: Table): Tensor[T] = throw new UnsupportedOperationException(errorString)
+
+  /**
+   * For tensor(i) = value. If tensor(i) is another tensor, it will fill the selected subset by
+   * the given value
+   *
+   * @param index index
+   * @param value value to write
+   */
+  override def update(index: Int, value: T): Unit =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Copy the give tensor value to the select subset of the current tensor by the given index.
+   * The subset should
+   * has the same size of the given tensor
+   *
+   * @param index index
+   * @param src   tensor to write
+   */
+  override def update(index: Int, src: Tensor[T]): Unit =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Write the value to the value indexed by the given index array
+   *
+   * @param indexes index array. It should has same length with the tensor dimension
+   * @param value   value to write
+   */
+  override def update(indexes: Array[Int], value: T): Unit =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Write the value on a given position. The number of parameters
+   * should be equal to the dimension number of the tensor.
+   *
+   * @param d1    ,( d2, d3, d4, d5) the given position
+   * @param value the written value
+   * @return
+   */
+  override def setValue(d1: Int, value: T): this.type =
+    throw new UnsupportedOperationException(errorString)
+
+  override def setValue(d1: Int, d2: Int, value: T): this.type =
+    throw new UnsupportedOperationException(errorString)
+
+  override def setValue(d1: Int, d2: Int, d3: Int, value: T): this.type =
+    throw new UnsupportedOperationException(errorString)
+
+  override def setValue(d1: Int, d2: Int, d3: Int, d4: Int, value: T): this.type =
+    throw new UnsupportedOperationException(errorString)
+
+  override def setValue(d1: Int, d2: Int, d3: Int, d4: Int, d5: Int,
+    value: T): this.type = throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Fill the select subset of the current tensor with the given value.
+   * The element of the given table can be an Int or another Table. An Int means select on current
+   * dimension; A tablemeans narrow on current dimension, the table should has two elements,
+   * of which the first is start index and the second is the end index. An empty table is equals
+   * to Table(1, size_of_current_dimension) If the table length is less than the tensor dimension,
+   * the missing dimension is applied by an empty table
+   *
+   * @param t     subset table
+   * @param value value to write
+   */
+  override def update(t: Table, value: T): Unit =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Copy the given tensor value to the select subset of the current tensor
+   * The element of the given table can be an Int or another Table. An Int means select on current
+   * dimension; A table means narrow on current dimension, the table should has two elements,
+   * of which the first is start index and the second is the end index. An empty table is equals
+   * to Table(1, size_of_current_dimension) If the table length is less than the tensor dimension,
+   * the missing dimension is applied by an empty table
+   *
+   * @param t   subset table
+   * @param src tensor to copy
+   */
+  override def update(t: Table, src: Tensor[T]): Unit =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Update the value meeting the filter criteria with the give value
+   *
+   * @param filter filter
+   * @param value  value to update
+   */
+  override def update(filter: (T) => Boolean, value: T): Unit =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Check if the tensor is contiguous on the storage
+   *
+   * @return true if it's contiguous
+   */
+  override def isContiguous(): Boolean = throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Get a contiguous tensor from current tensor
+   *
+   * @return the current tensor if it's contiguous; or a new contiguous tensor with separated
+   *         storage
+   */
+  override def contiguous(): Tensor[T] = throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Check if the size is same with the give tensor
+   *
+   * @param other tensor to be compared
+   * @return true if they have same size
+   */
+  override def isSameSizeAs(other: Tensor[_]): Boolean =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Resize the current tensor to the same size of the given tensor. It will still use the same
+   * storage if the storage
+   * is sufficient for the new size
+   *
+   * @param src target tensor
+   * @return current tensor
+   */
+  override def resizeAs(src: Tensor[_]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Remove the dim-th dimension and return the subset part. For instance
+   * tensor =
+   * 1 2 3
+   * 4 5 6
+   * tensor.select(1, 1) is [1 2 3]
+   * tensor.select(1, 2) is [4 5 6]
+   * tensor.select(2, 3) is [3 6]
+   *
+   * @param dim
+   * @param index
+   * @return
+   */
+  override def select(dim: Int, index: Int): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Get the storage
+   *
+   * @return storage
+   */
+  override def storage(): Storage[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * tensor offset on the storage
+   *
+   * @return storage offset, count from 1
+   */
+  override def storageOffset(): Int =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * The Tensor is now going to "view" the given storage, starting at position storageOffset (>=1)
+   * with the given dimension sizes and the optional given strides. As the result, any
+   * modification in the elements of the Storage will have an impact on the elements of the Tensor,
+   * and vice-versa. This is an efficient method, as there is no memory copy!
+   *
+   * If only storage is provided, the whole storage will be viewed as a 1D Tensor.
+   *
+   * @param storage
+   * @param storageOffset
+   * @param sizes
+   * @param strides
+   * @return current tensor
+   */
+  override def set(storage: Storage[T], storageOffset: Int, sizes: Array[Int],
+    strides: Array[Int]): Tensor[T] = throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Get a subset of the tensor on dim-th dimension. The offset is given by index, and length is
+   * give by size. The important difference with select is that it will not reduce the dimension
+   * number. For Instance
+   * tensor =
+   * 1 2 3
+   * 4 5 6
+   * tensor.narrow(1, 1, 1) is [1 2 3]
+   * tensor.narrow(2, 2, 2) is
+   * 2 3
+   * 5 6
+   *
+   * @param dim
+   * @param index
+   * @param size
+   * @return
+   */
+  override def narrow(dim: Int, index: Int, size: Int): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Apply a function to each element of the tensor and modified it value if it return a double
+   *
+   * @param func applied function
+   * @return current tensor
+   */
+  override def apply1(func: (T) => T): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Map value of another tensor to corresponding value of current tensor and apply function on
+   * the two value and change the value of the current tensor
+   * The another tensor should has the same size of the current tensor
+   *
+   * @param other another tensor
+   * @param func  applied function
+   * @return current tensor
+   */
+  override def map(other: Tensor[T], func: (T, T) => T): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Removes all singleton dimensions of the tensor
+   *
+   * @return current tensor
+   */
+  override def squeeze(): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Removes given dimensions of the tensor if it's singleton
+   *
+   * @return current tensor
+   */
+  override def squeeze(dim: Int): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Create a new tensor that removes all singleton dimensions of the tensor
+   *
+   * @return create a new tensor
+   */
+  override def squeezeNewTensor(): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def view(sizes: Array[Int]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   *
+   * Returns a tensor which contains all slices of size @param size
+   * in the dimension @param dim. Step between two slices is given by @param step.
+   *
+   * @param dim
+   * @param size
+   * @param step Step between two slices
+   * @return new tensor
+   */
+  override def unfold(dim: Int, size: Int, step: Int): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Repeating a tensor allocates new memory, unless result is provided, in which case its memory
+   * is resized. sizes specify the number of times the tensor is repeated in each dimension.
+   *
+   * @param sizes
+   * @return
+   */
+  override def repeatTensor(sizes: Array[Int]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * This is equivalent to this.expand(template.size())
+   *
+   * @param template the given tensor
+   * @return
+   */
+  override def expandAs(template: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Expanding a tensor allocates new memory, tensor where singleton dimensions can be expanded
+   * to multiple ones by setting the stride to 0. Any dimension that has size 1 can be expanded
+   * to arbitrary value with new memory allocation. Attempting to expand along a dimension that
+   * does not have size 1 will result in an error.
+   *
+   * @param sizes the size that tensor will expend to
+   * @return
+   */
+  override def expand(sizes: Array[Int]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Splits current tensor along dimension dim into a result table of Tensors of size size
+   * (a number) or less (in the case of the last Tensor). The sizes of the non-dim dimensions
+   * remain unchanged. Internally, a series of narrows are performed along dimensions dim.
+   * Argument dim defaults to 1.
+   *
+   * @param size
+   * @param dim
+   * @return
+   */
+  override def split(size: Int, dim: Int): Array[Tensor[T]] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * spilt one tensor into multi tensor along the `dim` dimension
+   *
+   * @param dim the specific dimension
+   * @return
+   */
+  override def split(dim: Int): Array[Tensor[T]] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * convert the tensor to BreezeVector, the dimension of the tensor need to be 1.
+   *
+   * @return BrzDenseVector
+   */
+  override def toBreezeVector(): BrzDenseVector[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * convert the tensor to MLlibVector, the dimension of the
+   * tensor need to be 1, and tensor need to be continuous.
+   *
+   * @return Vector
+   */
+  override def toMLlibVector(): Vector =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * convert the tensor to BreezeMatrix, the dimension of the tensor need to be 2.
+   *
+   * @return BrzDenseMatrix
+   */
+  override def toBreezeMatrix(): BrzDenseMatrix[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * convert the tensor to MLlibMatrix, the dimension of the
+   * tensor need to be 2, and tensor need to be continuous.
+   *
+   * @return Matrix
+   */
+  override def toMLlibMatrix(): Matrix =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * return the tensor datatype( DoubleType or FloatType)
+   *
+   * @return
+   */
+  override def getType(): TensorDataType =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Compare and print differences between two tensors
+   *
+   * @param other
+   * @param count
+   * @return true if there's difference, vice versa
+   */
+  override def diff(other: Tensor[T], count: Int, reverse: Boolean): Boolean =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * view this.tensor and add a Singleton Dimension to `dim` dimension
+   *
+   * @param t   source tensor
+   * @param dim the specific dimension, default is 1
+   * @return this
+   */
+  override def addSingletonDimension(t: Tensor[T], dim: Int): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * create a new tensor without any change of the tensor
+   *
+   * @param sizes the size of the new Tensor
+   * @return
+   */
+  override def reshape(sizes: Array[Int]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Save the tensor to given path
+   *
+   * @param path
+   * @param overWrite
+   * @return
+   */
+  override def save(path: String, overWrite: Boolean): this.type =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Return tensor numeric
+   *
+   * @return
+   */
+  override def getTensorNumeric(): TensorNumeric[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  // scalastyle:off methodName
+  /**
+   * Add all elements of this with value not in place.
+   * It will allocate new memory.
+   *
+   * @param s
+   * @return
+   */
+  override def +(s: T): Tensor[T] = throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Add a Tensor to another one, return the result in new allocated memory.
+   * The number of elements in the Tensors must match, but the sizes do not matter.
+   * The size of the returned Tensor will be the size of the first Tensor
+   *
+   * @param t
+   * @return
+   */
+  override def +(t: Tensor[T]): Tensor[T] = throw new UnsupportedOperationException(errorString)
+
+  /**
+   * subtract all elements of this with the value not in place.
+   * It will allocate new memory.
+   *
+   * @param s
+   * @return
+   */
+  override def -(s: T): Tensor[T] = throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Subtract a Tensor from another one, return the result in new allocated memory.
+   * The number of elements in the Tensors must match, but the sizes do not matter.
+   * The size of the returned Tensor will be the size of the first Tensor
+   *
+   * @param t
+   * @return
+   */
+  override def -(t: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def unary_-(): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * divide all elements of this with value not in place.
+   * It will allocate new memory.
+   *
+   * @param s
+   * @return
+   */
+  override def /(s: T): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Divide a Tensor by another one, return the result in new allocated memory.
+   * The number of elements in the Tensors must match, but the sizes do not matter.
+   * The size of the returned Tensor will be the size of the first Tensor
+   *
+   * @param t
+   * @return
+   */
+  override def /(t: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * multiply all elements of this with value not in place.
+   * It will allocate new memory.
+   *
+   * @param s
+   * @return
+   */
+  override def *(s: T): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Multiply a Tensor by another one, return the result in new allocated memory.
+   * The number of elements in the Tensors must match, but the sizes do not matter.
+   * The size of the returned Tensor will be the size of the first Tensor
+   *
+   * @param t
+   * @return
+   */
+  override def *(t: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+  // scalastyle:on methodName
+
+  /**
+   * returns the sum of the elements of this
+   *
+   * @return
+   */
+  override def sum(): T =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * performs the sum operation over the dimension dim
+   *
+   * @param dim
+   * @return
+   */
+  override def sum(dim: Int): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def sum(x: Tensor[T], dim: Int): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  def prod(): T =
+    throw new UnsupportedOperationException(errorString)
+
+  def prod(x: Tensor[T], dim: Int): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * returns the mean of all elements of this.
+   *
+   * @return
+   */
+  override def mean(): T =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * performs the mean operation over the dimension dim.
+   *
+   * @param dim
+   * @return
+   */
+  override def mean(dim: Int): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * returns the single biggest element of x
+   *
+   * @return
+   */
+  override def max(): T =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * performs the max operation over the dimension n
+   *
+   * @param dim
+   * @return
+   */
+  override def max(dim: Int): (Tensor[T], Tensor[T]) =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * performs the max operation over the dimension n
+   *
+   * @param values
+   * @param indices
+   * @param dim
+   * @return
+   */
+  override def max(values: Tensor[T], indices: Tensor[T], dim: Int): (Tensor[T], Tensor[T]) =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * returns the single minimum element of x
+   *
+   * @return
+   */
+  override def min(): T =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * performs the min operation over the dimension n
+   *
+   * @param dim
+   * @return
+   */
+  override def min(dim: Int): (Tensor[T], Tensor[T]) =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * performs the min operation over the dimension n
+   *
+   * @param values
+   * @param indices
+   * @param dim
+   * @return
+   */
+  override def min(values: Tensor[T], indices: Tensor[T], dim: Int): (Tensor[T], Tensor[T]) =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Writes all values from tensor src into this tensor at the specified indices
+   *
+   * @param dim
+   * @param index
+   * @param src
+   * @return this
+   */
+  override def scatter(dim: Int, index: Tensor[T], src: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * change this tensor with values from the original tensor by gathering a number of values
+   * from each "row", where the rows are along the dimension dim.
+   *
+   * @param dim
+   * @param index
+   * @param src
+   * @return this
+   */
+  override def gather(dim: Int, index: Tensor[T], src: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * This function computes 2 dimensional convolution of a single image
+   * with a single kernel (2D output). the dimensions of input and kernel
+   * need to be 2, and Input image needs to be bigger than kernel. The
+   * last argument controls if the convolution is a full ('F') or valid
+   * ('V') convolution. The default is valid convolution.
+   *
+   * @param kernel
+   * @param vf full ('F') or valid ('V') convolution.
+   * @return
+   */
+  override def conv2(kernel: Tensor[T], vf: Char): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * This function operates with same options and input/output configurations as conv2,
+   * but performs cross-correlation of the input with the kernel k.
+   *
+   * @param kernel
+   * @param vf full ('F') or valid ('V') convolution.
+   * @return
+   */
+  override def xcorr2(kernel: Tensor[T], vf: Char): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * replaces all elements in-place with the square root of the elements of this.
+   *
+   * @return
+   */
+  override def sqrt(): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * replaces all elements in-place with the absolute values of the elements of this.
+   *
+   * @return
+   */
+  override def abs(): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * x.add(value,y) multiply-accumulates values of y into x.
+   *
+   * @param value scalar
+   * @param y     other tensor
+   * @return current tensor
+   */
+  override def add(value: T, y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * accumulates all elements of y into this
+   *
+   * @param y other tensor
+   * @return current tensor
+   */
+  override def add(y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * z.add(x, value, y) puts the result of x + value * y in z.
+   *
+   * @param x
+   * @param value
+   * @param y
+   * @return
+   */
+  override def add(x: Tensor[T], value: T, y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * x.add(value) : add value to all elements of x in place.
+   *
+   * @param value
+   * @return
+   */
+  override def add(value: T): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def add(x: Tensor[T], y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Performs the dot product. The number of elements must match: both Tensors are seen as a 1D
+   * vector.
+   *
+   * @param y
+   * @return
+   */
+  override def dot(y: Tensor[T]): T =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * For each elements of the tensor, performs the max operation compared with the given value
+   * vector.
+   *
+   * @param value
+   * @return
+   */
+  override def cmax(value: T): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Performs the p-norm distance calculation between two tensors
+   *
+   * @param y    the secode Tensor
+   * @param norm the norm of distance
+   * @return
+   */
+  override def dist(y: Tensor[T], norm: Int): T =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Performs the element-wise multiplication of tensor1 by tensor2, multiply the result by the
+   * scalar value (1 if not present) and add it to x. The number of elements must match, but sizes
+   * do not matter.
+   *
+   * @param value
+   * @param tensor1
+   * @param tensor2
+   */
+  override def addcmul(value: T, tensor1: Tensor[T], tensor2: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def addcmul(tensor1: Tensor[T], tensor2: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Performs the element-wise division of tensor1 by tensor2, multiply the result by the scalar
+   * value and add it to x.
+   * The number of elements must match, but sizes do not matter.
+   *
+   * @param value
+   * @param tensor1
+   * @param tensor2
+   * @return
+   */
+  override def addcdiv(value: T, tensor1: Tensor[T], tensor2: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def sub(value: T, y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def sub(x: Tensor[T], value: T, y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * subtracts all elements of y from this
+   *
+   * @param y other tensor
+   * @return current tensor
+   */
+  override def sub(y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def sub(x: Tensor[T], y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def sub(value: T): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Element-wise multiply
+   * x.cmul(y) multiplies all elements of x with corresponding elements of y.
+   * x = x * y
+   *
+   * @param y tensor
+   * @return current tensor
+   */
+  override def cmul(y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Element-wise multiply
+   * z.cmul(x, y) equals z = x * y
+   *
+   * @param x tensor
+   * @param y tensor
+   * @return current tensor
+   */
+  override def cmul(x: Tensor[T], y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Element-wise divide
+   * x.cdiv(y) all elements of x divide all elements of y.
+   * x = x / y
+   *
+   * @param y tensor
+   * @return current tensor
+   */
+  override def cdiv(y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Element-wise divide
+   * z.cdiv(x, y) means z = x / y
+   *
+   * @param x tensor
+   * @param y tensor
+   * @return current tensor
+   */
+  override def cdiv(x: Tensor[T], y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * multiply all elements of this with value in-place.
+   *
+   * @param value
+   * @return
+   */
+  override def mul(value: T): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * divide all elements of this with value in-place.
+   *
+   * @param value
+   * @return
+   */
+  override def div(value: T): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * put the result of x * value in current tensor
+   *
+   * @param value
+   * @return
+   */
+  override def mul(x: Tensor[T], value: T): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Performs a matrix-matrix multiplication between mat1 (2D tensor) and mat2 (2D tensor).
+   * Optional values v1 and v2 are scalars that multiply M and mat1 * mat2 respectively.
+   * Optional value beta is a scalar that scales the result tensor, before accumulating the result
+   * into the tensor. Defaults to 1.0.
+   * If mat1 is a n x m matrix, mat2 a m x p matrix, M must be a n x p matrix.
+   *
+   * res = (v1 * M) + (v2 * mat1*mat2)
+   *
+   * @param v1
+   * @param M
+   * @param v2
+   * @param mat1
+   * @param mat2
+   */
+  override def addmm(v1: T, M: Tensor[T], v2: T, mat1: Tensor[T], mat2: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /** res = M + (mat1*mat2) */
+  override def addmm(M: Tensor[T], mat1: Tensor[T], mat2: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /** res = res + mat1 * mat2 */
+  override def addmm(mat1: Tensor[T], mat2: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /** res = res + v2 * mat1 * mat2 */
+  override def addmm(v2: T, mat1: Tensor[T], mat2: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /** res = v1 * res + v2 * mat1*mat2 */
+  override def addmm(v1: T, v2: T, mat1: Tensor[T], mat2: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /** res = mat1*mat2 */
+  override def mm(mat1: Tensor[T], mat2: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Performs the outer-product between vec1 (1D tensor) and vec2 (1D tensor).
+   * Optional values v1 and v2 are scalars that multiply mat and vec1 [out] vec2 respectively.
+   * In other words,
+   * res_ij = (v1 * mat_ij) + (v2 * vec1_i * vec2_j)
+   *
+   * @param t1
+   * @param t2
+   * @return
+   */
+  override def addr(t1: Tensor[T], t2: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def addr(v1: T, t1: Tensor[T], t2: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def addr(v1: T, t1: Tensor[T], v2: T, t2: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Performs the outer-product between vec1 (1D Tensor) and vec2 (1D Tensor).
+   * Optional values v1 and v2 are scalars that multiply mat and vec1 [out] vec2 respectively.
+   * In other words,res_ij = (v1 * mat_ij) + (v2 * vec1_i * vec2_j)
+   *
+   * @param v1
+   * @param t1
+   * @param v2
+   * @param t2
+   * @param t3
+   * @return
+   */
+  override def addr(v1: T, t1: Tensor[T], v2: T, t2: Tensor[T], t3: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * return pseudo-random numbers, require 0<=args.length<=2
+   * if args.length = 0, return [0, 1)
+   * if args.length = 1, return [1, args(0)] or [args(0), 1]
+   * if args.length = 2, return [args(0), args(1)]
+   *
+   * @param args
+   */
+  override def uniform(args: T*): T =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Performs a matrix-vector multiplication between mat (2D Tensor) and vec2 (1D Tensor) and add
+   * it to vec1. Optional values v1 and v2 are scalars that multiply vec1 and vec2 respectively.
+   *
+   * In other words,
+   * res = (beta * vec1) + alpha * (mat * vec2)
+   *
+   * Sizes must respect the matrix-multiplication operation: if mat is a n × m matrix,
+   * vec2 must be vector of size m and vec1 must be a vector of size n.
+   */
+  override def addmv(beta: T, vec1: Tensor[T], alpha: T, mat: Tensor[T],
+    vec2: Tensor[T]): Tensor[T] = throw new UnsupportedOperationException(errorString)
+
+  /** res = beta * res + alpha * (mat * vec2) */
+  override def addmv(beta: T, alpha: T, mat: Tensor[T], vec2: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /** res = res + alpha * (mat * vec2) */
+  override def addmv(alpha: T, mat: Tensor[T], vec2: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /** res = res + (mat * vec2) */
+  override def mv(mat: Tensor[T], vec2: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Perform a batch matrix matrix multiplication of matrices and stored in batch1 and batch2
+   * with batch add. batch1 and batch2 must be 3D Tensors each containing the same number of
+   * matrices. If batch1 is a b × n × m Tensor, batch2 a b × m × p Tensor, res will be a
+   * b × n × p Tensor.
+   *
+   * In other words,
+   * res_i = (beta * M_i) + (alpha * batch1_i * batch2_i)
+   */
+  override def baddbmm(beta: T, M: Tensor[T], alpha: T, batch1: Tensor[T],
+    batch2: Tensor[T]): Tensor[T] = throw new UnsupportedOperationException(errorString)
+
+  /** res_i = (beta * res_i) + (alpha * batch1_i * batch2_i) */
+  override def baddbmm(beta: T, alpha: T, batch1: Tensor[T], batch2: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /** res_i = res_i + (alpha * batch1_i * batch2_i) */
+  override def baddbmm(alpha: T, batch1: Tensor[T], batch2: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /** res_i = res_i + batch1_i * batch2_i */
+  override def bmm(batch1: Tensor[T], batch2: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Replaces all elements in-place with the elements of x to the power of n
+   *
+   * @param y
+   * @param n
+   * @return current tensor reference
+   */
+  override def pow(y: Tensor[T], n: T): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def pow(n: T): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Get the top k smallest values and their indices.
+   *
+   * @param result   result buffer
+   * @param indices  indices buffer
+   * @param k
+   * @param dim      dimension, default is the last dimension
+   * @param increase sort order, set it to true if you want to get the smallest top k values
+   * @return
+   */
+  override def topk(k: Int, dim: Int, increase: Boolean, result: Tensor[T],
+    indices: Tensor[T]): (Tensor[T], Tensor[T]) =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Replaces all elements in-place with the elements of lnx
+   *
+   * @param y
+   * @return current tensor reference
+   */
+  override def log(y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def exp(y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def sqrt(y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def log1p(y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+  override def log(): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+  override def exp(): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def log1p(): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def abs(x: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * returns the p-norms of the Tensor x computed over the dimension dim.
+   *
+   * @param y result buffer
+   * @param value
+   * @param dim
+   * @return
+   */
+  override def norm(y: Tensor[T], value: Int, dim: Int): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Implements > operator comparing each element in x with y
+   *
+   * @param x
+   * @param y
+   * @return current tensor reference
+   */
+  override def gt(x: Tensor[T], y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Implements < operator comparing each element in x with y
+   *
+   * @param x
+   * @param y
+   * @return current tensor reference
+   */
+  override def lt(x: Tensor[T], y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Implements <= operator comparing each element in x with y
+   *
+   * @param x
+   * @param y
+   * @return current tensor reference
+   */
+  override def le(x: Tensor[T], y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Implements == operator comparing each element in x with y
+   *
+   * @param y
+   * @return current tensor reference
+   */
+  override def eq(x: Tensor[T], y: T): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Fills the masked elements of itself with value val
+   *
+   * @param mask
+   * @param e
+   * @return current tensor reference
+   */
+  override def maskedFill(mask: Tensor[T], e: T): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Copies the elements of tensor into mask locations of itself.
+   *
+   * @param mask
+   * @param y
+   * @return current tensor reference
+   */
+  override def maskedCopy(mask: Tensor[T], y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Returns a new Tensor which contains all elements aligned to a 1 in the corresponding mask.
+   *
+   * @param mask
+   * @param y
+   * @return current tensor reference
+   */
+  override def maskedSelect(mask: Tensor[T], y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * returns the sum of the n-norms on the Tensor x
+   *
+   * @param value the n-norms
+   * @return
+   */
+  override def norm(value: Int): T =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * returns a new Tensor with the sign (+/- 1 or 0) of the elements of x.
+   *
+   * @return
+   */
+  override def sign(): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Implements >= operator comparing each element in x with value
+   *
+   * @param x
+   * @param value
+   * @return
+   */
+  override def ge(x: Tensor[T], value: Double): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Accumulate the elements of tensor into the original tensor by adding to the indices
+   * in the order given in index. The shape of tensor must exactly match the elements indexed
+   * or an error will be thrown.
+   *
+   * @param dim
+   * @param index
+   * @param y
+   * @return
+   */
+  override def indexAdd(dim: Int, index: Tensor[T], y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * Accumulate the elements of tensor into the original tensor by adding to the indices
+   * in the order given in index. The shape of tensor must exactly match the elements indexed
+   * or an error will be thrown.
+   *
+   * @param dim
+   * @param index
+   * @param y
+   * @return
+   */
+  override def index(dim: Int, index: Tensor[T], y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * stores the element-wise maximum of x and y in x.
+   * x.cmax(y) = max(x, y)
+   *
+   * @param y tensor
+   * @return current tensor
+   */
+  override def cmax(y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * stores the element-wise maximum of x and y in z.
+   * z.cmax(x, y) means z = max(x, y)
+   *
+   * @param x tensor
+   * @param y tensor
+   */
+  override def cmax(x: Tensor[T], y: Tensor[T]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  /**
+   * resize this tensor size to floor((xmax - xmin) / step) + 1 and set values from
+   * xmin to xmax with step (default to 1).
+   *
+   * @param xmin
+   * @param xmax
+   * @param step
+   * @return this tensor
+   */
+  override def range(xmin: Double, xmax: Double, step: Int): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def toTensor[D](implicit ev: TensorNumeric[D]): Tensor[D] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def tanh(): Tensor[T] = throw new UnsupportedOperationException(errorString)
+
+  override def tanh(y: Tensor[T]): Tensor[T] = throw new UnsupportedOperationException(errorString)
+
+  override def resize(sizes: Array[Int], strides: Array[Int]): this.type =
+    throw new UnsupportedOperationException(errorString)
+
+  override def resize(size1: Int): this.type = throw new UnsupportedOperationException(errorString)
+
+  override def resize(size1: Int, size2: Int): this.type =
+    throw new UnsupportedOperationException(errorString)
+
+  override def resize(size1: Int, size2: Int, size3: Int): this.type =
+    throw new UnsupportedOperationException(errorString)
+
+  override def resize(size1: Int, size2: Int, size3: Int, size4: Int): this.type =
+    throw new UnsupportedOperationException(errorString)
+
+  override def resize(size1: Int, size2: Int, size3: Int, size4: Int, size5: Int): this.type =
+    throw new UnsupportedOperationException(errorString)
+
+  override def isEmpty: Boolean =
+    throw new UnsupportedOperationException(errorString)
+
+  override def isScalar: Boolean =
+    throw new UnsupportedOperationException(errorString)
+
+  override def value(): T =
+    throw new UnsupportedOperationException(errorString)
+
+  override def setValue(value: T): this.type =
+    throw new UnsupportedOperationException(errorString)
+
+  override def zipWith[A: ClassTag, B: ClassTag](t1: Tensor[A], t2: Tensor[B],
+    func: (A, B) => T): Tensor[T] = throw new UnsupportedOperationException(errorString)
+
+  override def forceFill(v: Any): Tensor[T] = throw new UnsupportedOperationException(errorString)
+
+  override def emptyInstance(): Tensor[T] = throw new UnsupportedOperationException(errorString)
+
+  override def forceCopy(other: Tensor[_]): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def applyFun[A: ClassTag](t: Tensor[A], func: (A) => T): Tensor[T] =
+    throw new UnsupportedOperationException(errorString)
+
+  override def cast[D: ClassTag](castTensor: Tensor[D])(implicit ev: TensorNumeric[D]): Tensor[D] =
+    throw new UnsupportedOperationException(errorString)
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
@@ -746,6 +746,12 @@ trait Tensor[T] extends Serializable with TensorMath[T] with Activity {
   def getTensorNumeric(): TensorNumeric[T]
 
   /**
+   * Return tensor type
+   * @return Dense / Quant
+   */
+  def getTensorType: TensorType
+
+  /**
    * Compare with other tensor. The shape of the other tensor must be same with this tensor.
    * If element wise difference is less than delta, return true.
    * @param other
@@ -785,6 +791,11 @@ object LongType extends TensorDataType
 object FloatType extends TensorDataType
 
 object DoubleType extends TensorDataType
+sealed trait TensorType
+
+object DenseType extends TensorType
+
+object QuantizedType extends TensorType
 
 object Tensor {
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/QuantizedTensorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/QuantizedTensorSpec.scala
@@ -27,33 +27,21 @@ class QuantizedTensorSpec extends FlatSpec with Matchers {
   "A QuantizeTensor set to empty" should "work correctly" in {
     val inputChannel = 4
     val outputChannel = 4
-    val batchSize = 3
 
-    val threshold = 64.0f
-
-    val fp32Tensor = Tensor(outputChannel, inputChannel).rand
-
+    val fp32Tensor = Tensor(outputChannel, inputChannel).rand()
     val tensor = QuantizedTensor[Float](fp32Tensor, LinearWeightParams(outputChannel, inputChannel))
-
-    val minArray = Array.fill[Float](outputChannel)(0)
-    val maxArray = Array.fill[Float](outputChannel)(0)
-
-    val desc = tensor.getNativeStorage
 
     tensor.set()
 
     tensor.getNativeStorage should be (0L)
     tensor.getStorage should be (null)
 
-    BigQuant.FreeMemory(desc)
+    tensor.release()
   }
 
   "A QuantizeTensor set to other tensor" should "work correctly" in {
     val inputChannel = 4
     val outputChannel = 4
-    val batchSize = 3
-
-    val threshold = 64.0f
 
     val fp32Tensor = Tensor(outputChannel, inputChannel).rand
 
@@ -62,23 +50,20 @@ class QuantizedTensorSpec extends FlatSpec with Matchers {
     val tensor2 = QuantizedTensor[Float](fp32Tensor,
       LinearWeightParams(outputChannel, inputChannel))
 
-    val desc = tensor2.getNativeStorage
-
+    tensor2.release()
     tensor2.set(tensor1)
 
     tensor2.getNativeStorage should be (tensor1.getNativeStorage)
     tensor2.getStorage should be (tensor1.getStorage)
 
     tensor1.release()
-    BigQuant.FreeMemory(desc)
   }
 
   "A QuantizeTensor set to itself" should "work correctly" in {
     val inputChannel = 4
     val outputChannel = 4
-    val batchSize = 3
 
-    val fp32Tensor = Tensor(outputChannel, inputChannel).rand
+    val fp32Tensor = Tensor(outputChannel, inputChannel).rand()
     val tensor = QuantizedTensor[Float](fp32Tensor, LinearWeightParams(outputChannel, inputChannel))
 
     tensor.set(tensor)
@@ -87,18 +72,14 @@ class QuantizedTensorSpec extends FlatSpec with Matchers {
     tensor.getStorage should not be null
 
     tensor.release()
-
     tensor.getNativeStorage should be (0L)
   }
 
   "A QuantizeTensor set" should "work correctly" in {
     val inputChannel = 4
     val outputChannel = 4
-    val batchSize = 3
 
-    val threshold = 64.0f
-
-    val fp32Tensor = Tensor(outputChannel, inputChannel).rand
+    val fp32Tensor = Tensor(outputChannel, inputChannel).rand()
 
     val tensor1 = QuantizedTensor[Float](fp32Tensor,
       LinearWeightParams(outputChannel, inputChannel))
@@ -124,13 +105,12 @@ class QuantizedTensorSpec extends FlatSpec with Matchers {
   "A QuantizeTensor serialzation" should "work correctly" in {
     val inputChannel = 4
     val outputChannel = 4
-    val batchSize = 3
 
-    val threshold = 64.0f
-
-    val fp32Tensor = Tensor(outputChannel, inputChannel).rand
+    val fp32Tensor = Tensor(outputChannel, inputChannel).rand()
 
     val tensor = QuantizedTensor[Float](fp32Tensor, LinearWeightParams(outputChannel, inputChannel))
+
+    val test = SerializationUtils.clone(fp32Tensor)
 
     val clone = SerializationUtils.clone(tensor).asInstanceOf[QuantizedTensor[Float]]
 
@@ -139,6 +119,6 @@ class QuantizedTensorSpec extends FlatSpec with Matchers {
     tensor.minOfRow should be (clone.minOfRow)
     tensor.sumOfRow should be (clone.sumOfRow)
 
-    tensor.getNativeStorage should not be (clone.getNativeStorage)
+    tensor.getNativeStorage should not be clone.getNativeStorage
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/QuantizedTensorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/QuantizedTensorSpec.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.tensor
+
+import com.intel.analytics.bigdl.bigquant.BigQuant
+import com.intel.analytics.bigdl.numeric.NumericFloat
+import com.intel.analytics.bigdl.nn.quantized.{LinearWeight, LinearWeightParams}
+import org.apache.commons.lang.SerializationUtils
+import org.scalatest.{FlatSpec, Matchers}
+
+@com.intel.analytics.bigdl.tags.Parallel
+class QuantizedTensorSpec extends FlatSpec with Matchers {
+  "A QuantizeTensor set to empty" should "work correctly" in {
+    val inputChannel = 4
+    val outputChannel = 4
+    val batchSize = 3
+
+    val threshold = 64.0f
+
+    val fp32Tensor = Tensor(outputChannel, inputChannel).rand
+
+    val tensor = QuantizedTensor[Float](fp32Tensor, LinearWeightParams(outputChannel, inputChannel))
+
+    val minArray = Array.fill[Float](outputChannel)(0)
+    val maxArray = Array.fill[Float](outputChannel)(0)
+
+    val desc = tensor.getNativeStorage
+
+    tensor.set()
+
+    tensor.getNativeStorage should be (0L)
+    tensor.getStorage should be (null)
+
+    BigQuant.FreeMemory(desc)
+  }
+
+  "A QuantizeTensor set to other tensor" should "work correctly" in {
+    val inputChannel = 4
+    val outputChannel = 4
+    val batchSize = 3
+
+    val threshold = 64.0f
+
+    val fp32Tensor = Tensor(outputChannel, inputChannel).rand
+
+    val tensor1 = QuantizedTensor[Float](fp32Tensor,
+      LinearWeightParams(outputChannel, inputChannel))
+    val tensor2 = QuantizedTensor[Float](fp32Tensor,
+      LinearWeightParams(outputChannel, inputChannel))
+
+    val desc = tensor2.getNativeStorage
+
+    tensor2.set(tensor1)
+
+    tensor2.getNativeStorage should be (tensor1.getNativeStorage)
+    tensor2.getStorage should be (tensor1.getStorage)
+
+    tensor1.release()
+    BigQuant.FreeMemory(desc)
+  }
+
+  "A QuantizeTensor set to itself" should "work correctly" in {
+    val inputChannel = 4
+    val outputChannel = 4
+    val batchSize = 3
+
+    val fp32Tensor = Tensor(outputChannel, inputChannel).rand
+    val tensor = QuantizedTensor[Float](fp32Tensor, LinearWeightParams(outputChannel, inputChannel))
+
+    tensor.set(tensor)
+
+    tensor.getNativeStorage should not be 0L
+    tensor.getStorage should not be null
+
+    tensor.release()
+
+    tensor.getNativeStorage should be (0L)
+  }
+
+  "A QuantizeTensor set" should "work correctly" in {
+    val inputChannel = 4
+    val outputChannel = 4
+    val batchSize = 3
+
+    val threshold = 64.0f
+
+    val fp32Tensor = Tensor(outputChannel, inputChannel).rand
+
+    val tensor1 = QuantizedTensor[Float](fp32Tensor,
+      LinearWeightParams(outputChannel, inputChannel))
+    val tensor2 = QuantizedTensor[Float](fp32Tensor,
+      LinearWeightParams(outputChannel, inputChannel))
+    val tensor3 = QuantizedTensor[Float](fp32Tensor,
+      LinearWeightParams(outputChannel, inputChannel))
+
+    tensor2.release()
+    tensor2.set(tensor1)
+
+    tensor2.getNativeStorage should be (tensor1.getNativeStorage)
+    tensor2.getStorage should be (tensor1.getStorage)
+
+    tensor2.release()
+    tensor2.set(tensor3)
+
+    tensor2.getNativeStorage should not be tensor1.getNativeStorage
+
+    tensor3.release()
+  }
+
+  "A QuantizeTensor serialzation" should "work correctly" in {
+    val inputChannel = 4
+    val outputChannel = 4
+    val batchSize = 3
+
+    val threshold = 64.0f
+
+    val fp32Tensor = Tensor(outputChannel, inputChannel).rand
+
+    val tensor = QuantizedTensor[Float](fp32Tensor, LinearWeightParams(outputChannel, inputChannel))
+
+    val clone = SerializationUtils.clone(tensor).asInstanceOf[QuantizedTensor[Float]]
+
+    tensor.getStorage should be (clone.getStorage)
+    tensor.maxOfRow should be (clone.maxOfRow)
+    tensor.minOfRow should be (clone.minOfRow)
+    tensor.sumOfRow should be (clone.sumOfRow)
+
+    tensor.getNativeStorage should not be (clone.getNativeStorage)
+  }
+}


### PR DESCRIPTION

## What changes were proposed in this pull request?

QuantizedTensor inherits from Tensor with supporting part of methods.
The memory is allocated from native code, so it only matains a
pointer `getNativeStorage`.

Note,

We don't support automatically `free` method. Anyone using this method
should think about the memory lacking, especially for memory
optimization.

test: quantized tensor tests

## How was this patch tested?
Jenkins


