### PR TITLE
 fix OOMError caused by broadcastModel.cloneModule in DistributeOptimizer 

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/udfpredictor/Utils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/udfpredictor/Utils.scala
@@ -91,7 +91,7 @@ object Utils {
              word2Vec: Word2Vec)
             (implicit ev: TensorNumeric[Float]): (String) => Int = {
 
-    val broadcastModel = ModelBroadcast[Float].broadcast(sc, model)
+    val broadcastModel = ModelBroadcast[Float]().broadcast(sc, model)
     val word2IndexBC = sc.broadcast(word2Index)
     val word2VecBC = sc.broadcast(word2Vec)
 
@@ -129,7 +129,7 @@ object Utils {
       val featureTensor: Tensor[Float] = Tensor[Float]()
       var featureData: Array[Float] = null
       val sampleSize = sampleShape.product
-      val localModel = broadcastModel.value
+      val localModel = broadcastModel.value()
 
       // create tensor from input column
       if (featureData == null) {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
@@ -108,11 +108,10 @@ class ModelBroadcast[T: ClassTag](
     var i = 0
     while (i < localWeightBias.length) {
       if (localWeightBias(i) != null) {
+        localWeightBias(i).set(broadcastWeightBias(i))
         if (!inference) {
-          localWeightBias(i).resizeAs(broadcastWeightBias(i)).copy(broadcastWeightBias(i))
+          // init gradWeight & gradBias
           localGradWeightBias(i).resizeAs(broadcastWeightBias(i))
-        } else {
-          localWeightBias(i).set(broadcastWeightBias(i))
         }
       }
       i += 1

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
@@ -47,7 +47,7 @@ class ModelBroadcast[T: ClassTag](
   def broadcast(sc: SparkContext, model: Module[T]): this.type = {
     if (!inference) model.getParameters() // ensure training model's parameter is compacted.
     val weightsBias = getAndClearWeightBias(model.parameters())
-    broadcastModel = sc.broadcast(model)
+    broadcastModel = sc.broadcast(model.cloneModule())
     broadcastParameters = sc.broadcast(weightsBias)
     putWeightBias(weightsBias, model)
     initGradWeightBias(weightsBias, model)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -253,9 +253,9 @@ object DistriOptimizer {
               val offset = tid * taskSize + math.min(tid, extraTask)
               val length = taskSize + (if (tid < extraTask) 1 else 0)
               var i = 1
-              while (i < cached.modelGradients.length) {
+              while (i < finishedGradients.length) {
                   finishedGradients(0).narrow(1, offset + 1, length)
-                    .add(cached.modelGradients(i).narrow(1, offset + 1, length))
+                    .add(finishedGradients(i).narrow(1, offset + 1, length))
                 i += 1
               }
             }))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -52,7 +52,6 @@ object DistriOptimizer {
    * @param modelGradients gradients of the cached models
    * @param localCriterions cached criterion
    * @param localStates cached state
-   * @param gradient tensor buffer
    * @tparam T Tensor element type
    */
   case class Cache[T](
@@ -61,7 +60,6 @@ object DistriOptimizer {
     modelGradients: Array[Tensor[T]],
     localCriterions: Array[Criterion[T]],
     localStates: Array[Table],
-    gradient: Tensor[T],
     var moduleTimeList: Array[Long] = null,
     localMethods: Array[Option[Array[ValidationMethod[T]]]],
     optimMethod: OptimMethod[T]
@@ -252,20 +250,15 @@ object DistriOptimizer {
               cached.modelGradients(i).zero()
             )
 
-            // copy multi-model gradient to the buffer
+            // Aggregate multi-model's gradient to the first model's gradient
             val parallelNum = if (taskSize == 0) extraTask else _subModelNumber
             Engine.default.invokeAndWait((0 until parallelNum).map(tid => () => {
               val offset = tid * taskSize + math.min(tid, extraTask)
               val length = taskSize + (if (tid < extraTask) 1 else 0)
-              var i = 0
+              var i = 1
               while (i < cached.modelGradients.length) {
-                if (i == 0) {
-                  cached.gradient.narrow(1, offset + 1, length)
-                    .copy(cached.modelGradients(i).narrow(1, offset + 1, length))
-                } else {
-                  cached.gradient.narrow(1, offset + 1, length)
+                  cached.modelGradients(0).narrow(1, offset + 1, length)
                     .add(cached.modelGradients(i).narrow(1, offset + 1, length))
-                }
                 i += 1
               }
             }))
@@ -273,7 +266,8 @@ object DistriOptimizer {
           }
 
           val putG = System.nanoTime()
-          parameters.putGradients(cached.gradient)
+          // Put first model's gradient who aggregated all model's gradient to AllReduceParameter
+          parameters.putGradients(cached.modelGradients(0))
           driverMetrics.add("put gradient", System.nanoTime() - putG)
           tasks ++= Engine.default.invoke {
             (0 until _subModelNumber).map { i =>
@@ -584,7 +578,6 @@ object DistriOptimizer {
         cached.map(_._3), // gradients
         cached.map(_._4), // criterions
         cached.map(_._5), // states
-        cached.head._2.clone(), // a tensor buffer
         new Array[Long](_subModelNumber * computeThresholdbatchSize),
         cached.map(_._6),
         broadcastOptim.clone()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Evaluator.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Evaluator.scala
@@ -49,7 +49,7 @@ class Evaluator[T: ClassTag] private[optim](model: Module[T])(implicit ev: Tenso
    vMethods: Array[ValidationMethod[T]],
    batchSize: Option[Int] = None): Array[(ValidationResult, ValidationMethod[T])] = {
 
-    val modelBroad = ModelBroadcast[T].broadcast(dataset.sparkContext, model.evaluate())
+    val modelBroad = ModelBroadcast[T]().broadcast(dataset.sparkContext, model.evaluate())
     val partitionNum = dataset.partitions.length
 
     val totalBatch = batchSize.getOrElse(batchPerPartition * partitionNum)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Predictor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Predictor.scala
@@ -51,7 +51,7 @@ class Predictor[T: ClassTag] private[optim](
 
   def predict(dataSet: RDD[Sample[T]], batchSize: Int = -1,
               shareBuffer: Boolean = false): RDD[Activity] = {
-    val modelBroad = ModelBroadcast[T].broadcast(dataSet.sparkContext, model.evaluate())
+    val modelBroad = ModelBroadcast[T]().broadcast(dataSet.sparkContext, model.evaluate())
     val partitionNum = dataSet.partitions.length
     val totalBatch = if (batchSize > 0) {
       require(batchSize % partitionNum == 0, s"Predictor.predict: total batch size $batchSize " +

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/Session.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/Session.scala
@@ -483,7 +483,7 @@ class BigDLSessionImpl[T: ClassTag](
       }
     }
 
-    val modelBroadCast = ModelBroadcast[T].broadcast(sc, transformer)
+    val modelBroadCast = ModelBroadcast[T]().broadcast(sc, transformer)
     inputRdd.map { tensors =>
       val trans = modelBroadCast.value()
       val output = trans.forward(tensors.flatten())

--- a/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
+++ b/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
@@ -214,7 +214,7 @@ class DLModel[@specialized(Float, Double) T: ClassTag](
       featureData: RDD[Seq[AnyVal]], dataset: DataFrame): DataFrame = {
 
     model.evaluate()
-    val modelBroadCast = ModelBroadcast[T].broadcast(featureData.sparkContext, model)
+    val modelBroadCast = ModelBroadcast[T]().broadcast(featureData.sparkContext, model)
     val predictRdd = featureData.map { f =>
       // convert feature data type to the same type with model
       f.head match {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcastSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcastSpec.scala
@@ -33,7 +33,7 @@ class ModelBroadcastSpec extends FlatSpec with Matchers with BeforeAndAfter {
   "model broadcast" should "work properly" in {
     val model = LeNet5(10)
 
-    val modelBroadCast = ModelBroadcast[Float].broadcast(sc, model)
+    val modelBroadCast = ModelBroadcast[Float]().broadcast(sc, model)
     modelBroadCast.value().toString should be(model.toString)
     modelBroadCast.value().parameters()._1 should be(model.parameters()._1)
   }
@@ -42,7 +42,7 @@ class ModelBroadcastSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val model = LeNet5(10)
     model.getParameters()
 
-    val modelBroadCast = ModelBroadcast[Float].broadcast(sc, model)
+    val modelBroadCast = ModelBroadcast[Float]().broadcast(sc, model)
     modelBroadCast.value().toString should be(model.toString)
     modelBroadCast.value().parameters()._1 should be(model.parameters()._1)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support broadcast training model in ModelBroadcast.
Use ModelBroadcast to broadcast model in DistriOptimizer.
Reduce runtime memory consumption while caching models in DistriOptimizer.

## How was this patch tested?

unit tests, manual tests

## Related links or issues (optional)
fixed #1632 

