### PR TITLE
Save bigdl model to torch model error corrected

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/TorchFile.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/TorchFile.scala
@@ -162,6 +162,7 @@ object TorchFile {
       case "nn.SpatialConvolution" => readSpatialConvolutionWithType(elements)
       case "nn.SpatialConvolutionMap" => readSpatialConvolutionMapWithType(elements)
       case "nn.SpatialConvolutionMM" => readSpatialConvolutionWithType(elements)
+      case "nn.SpatialCrossMapLRN" => readSpatialCrossMapLRNWithType(elements)
       case "nn.SpatialZeroPadding" => readSpatialZeroPaddingWithType(elements)
       case "nn.Threshold" => readThresholdWithType(elements)
       case "nn.View" => readViewWithType(elements)
@@ -294,6 +295,9 @@ object TorchFile {
       case m: LogSoftMax[_] =>
         writeVersionAndClass("V 1", "nn.LogSoftMax", rawData, path)
         writeLogSoftMax(m, rawData, path)
+      case m: SpatialCrossMapLRN[_] =>
+        writeVersionAndClass("V 1", "nn.SpatialCrossMapLRN", rawData, path)
+        writeSpatialCrossMapLRN(m, rawData, path)
       case _ => throw new Error(s"Unimplemented module $module")
     }
 
@@ -498,6 +502,21 @@ object TorchFile {
     table("padH") = source.padH
     table("indices") = source.indices
     table("ceil_mode") = source.ceilMode
+    writeObject(table, rawData, path, TYPE_TABLE)
+    byteWrite(rawData, path)
+  }
+
+
+  private def writeSpatialCrossMapLRN(source: SpatialCrossMapLRN[_],
+                                      rawData: ByteBuffer, path: Path): Unit = {
+    val table: Table = T()
+    writeGeneralParameters(source, table)
+    table("prePad") = source.prePad
+    table("size") = source.size
+    table("alpha") = source.alpha
+    table("beta") = source.beta
+    table("k") = source.k
+
     writeObject(table, rawData, path, TYPE_TABLE)
     byteWrite(rawData, path)
   }
@@ -941,6 +960,19 @@ object TorchFile {
     )
     result.weight.copy(weight)
     result.bias.copy(bias)
+    result
+  }
+
+  private def readSpatialCrossMapLRNWithType[T: ClassTag](elements: Table)(
+    implicit ev: TensorNumeric[T]): SpatialCrossMapLRN[T] = {
+    val weight = elements.getOrElse("weight", null).asInstanceOf[Tensor[T]]
+    val bias = elements.getOrElse("bias", null).asInstanceOf[Tensor[T]]
+    val result = SpatialCrossMapLRN[T](
+      size = elements.getOrElse("size", 5.0).toInt,
+      alpha = elements.getOrElse("alpha", 1.0),
+      beta = elements.getOrElse("beta", 0.75),
+      k = elements.getOrElse("k", 1.0)
+    )
     result
   }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialCrossMapLRNSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/SpatialCrossMapLRNSpec.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.torch
 
-import com.intel.analytics.bigdl.nn.{GradientChecker, SpatialCrossMapLRN}
+import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 import com.intel.analytics.bigdl._
@@ -120,4 +120,33 @@ class SpatialCrossMapLRNSpec extends TorchSpec {
     val checker = new GradientChecker(1e-3)
     checker.checkLayer[Double](layer, input, 1e-3) should be(true)
   }
+
+  "SpatialCrossMapLRN module" should "be saved to or loaded from Torch model correctly" in {
+    torchCheck()
+    val seed = 100
+    RNG.setSeed(seed)
+
+    val layer = new SpatialCrossMapLRN[Double](5, 1.0, 0.75, 1.0)
+
+    val tmpFile = java.io.File.createTempFile("module", ".t7")
+    val absolutePath = tmpFile.getAbsolutePath
+    layer.saveTorch(absolutePath, true)
+
+    val model = Module.loadTorch[Double](absolutePath).asInstanceOf[SpatialCrossMapLRN[Double]]
+    model shouldEqual layer
+
+    val input = Tensor[Double](16, 3, 224, 224).rand()
+    val output = layer.updateOutput(input)
+
+    val code = "torch.manualSeed(" + seed + ")\n" +
+      "layer = torch.load(\'" + absolutePath + "\')\n" +
+      "output = layer:forward(input) "
+
+    val torchResult = TH.run(code, Map("input" -> input), Array("output"))._2
+    val luaOutput = torchResult("output").asInstanceOf[Tensor[Double]]
+
+    output shouldEqual luaOutput
+  }
+
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Made SpatialCrossMapLRN layer in BigDL compatible with Torch models (both read and write).

## How was this patch tested?
Used unit tests to do the test. First save a certain SpatialCrossMapLRN layer to a Torch model. Then load the Torch model and compare it with the former one. Also, used Lua code to run the produced Torch model and then compared the output with that of the former one.

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/1585

