### PR TITLE
fix: QuantizeTensor supports for ModelBroadcast

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
@@ -71,9 +71,9 @@ class ModelBroadcast[T: ClassTag](implicit ev: TensorNumeric[T]) extends Seriali
       if (parameters._1(i) != null) {
         val wb = parameters._1(i)
         wb match {
-          case value1: QuantizedTensor[T] =>
-            weightsBias(i) = QuantizedTensor[T](value1.getStorage, value1.maxOfRow,
-              value1.minOfRow, value1.sumOfRow, value1.size(), value1.params)
+          case quantTensor: QuantizedTensor[T] =>
+            weightsBias(i) = QuantizedTensor[T](quantTensor.getStorage, quantTensor.maxOfRow,
+              quantTensor.minOfRow, quantTensor.sumOfRow, quantTensor.size(), quantTensor.params)
           case _ =>
             weightsBias(i) = Tensor[T](Storage(wb.storage().array()),
               wb.storageOffset(), wb.size(), wb.stride())
@@ -89,7 +89,7 @@ class ModelBroadcast[T: ClassTag](implicit ev: TensorNumeric[T]) extends Seriali
       i += 1
     }
 
-    // because in quantized mode, the parameters are not the same length.
+    // because in quantized mode, the weight number may be different with gradWeight number
     i = 0
     while (i < parameters._2.length) {
       if (parameters._2(i) != null) {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
@@ -17,7 +17,7 @@
 package com.intel.analytics.bigdl.models.utils
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
+import com.intel.analytics.bigdl.tensor.{QuantizedTensor, Storage, Tensor}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import org.apache.spark.SparkContext
 import org.apache.spark.broadcast.Broadcast
@@ -70,8 +70,14 @@ class ModelBroadcast[T: ClassTag](implicit ev: TensorNumeric[T]) extends Seriali
     while (i < parameters._1.length) {
       if (parameters._1(i) != null) {
         val wb = parameters._1(i)
-        weightsBias(i) = Tensor[T](Storage(wb.storage().array()),
-          wb.storageOffset(), wb.size(), wb.stride())
+        wb match {
+          case value1: QuantizedTensor[T] =>
+            weightsBias(i) = QuantizedTensor[T](value1.getStorage, value1.maxOfRow,
+              value1.minOfRow, value1.sumOfRow, value1.size(), value1.params)
+          case _ =>
+            weightsBias(i) = Tensor[T](Storage(wb.storage().array()),
+              wb.storageOffset(), wb.size(), wb.stride())
+        }
       }
       i += 1
     }
@@ -80,11 +86,18 @@ class ModelBroadcast[T: ClassTag](implicit ev: TensorNumeric[T]) extends Seriali
       if (parameters._1(i) != null) {
         parameters._1(i).set()
       }
+      i += 1
+    }
+
+    // because in quantized mode, the parameters are not the same length.
+    i = 0
+    while (i < parameters._2.length) {
       if (parameters._2(i) != null) {
         parameters._2(i).set()
       }
       i += 1
     }
+
     weightsBias
   }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcastSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcastSpec.scala
@@ -47,6 +47,14 @@ class ModelBroadcastSpec extends FlatSpec with Matchers with BeforeAndAfter {
     modelBroadCast.value().parameters()._1 should be(model.parameters()._1)
   }
 
+  "quantized model broadcast" should "work properly" in {
+    val model = LeNet5(10).quantize()
+
+    val modelBroadCast = ModelBroadcast[Float].broadcast(sc, model)
+    modelBroadCast.value().toString should be(model.toString)
+    modelBroadCast.value().parameters()._1 should be(model.parameters()._1)
+  }
+
   after {
     if (sc != null) {
       sc.stop()


### PR DESCRIPTION
## What changes were proposed in this pull request?

`QuantizeTensor` does not support storage method, so it needs specific judgement.

## How was this patch tested?
Jenkins.

