### PR TITLE
Support feature with one or more tensors for Sample in python 

### DIFF
--- a/docs/docs/APIGuide/Data.md
+++ b/docs/docs/APIGuide/Data.md
@@ -125,7 +125,7 @@ import numpy as np
 
 image = np.random.rand(3, 32, 32)
 label = np.array(1)
-Sample.from_ndarray(image, label)
+sample = Sample.from_ndarray(image, label)
 ```
 
 ---

--- a/docs/docs/ProgrammingGuide/Model/Sequential.md
+++ b/docs/docs/ProgrammingGuide/Model/Sequential.md
@@ -137,7 +137,7 @@ val branches = ParallelTable()
 val branch1 = Sequential().add(Linear(...)).add(ReLU())
 val branch2 = Sequential().add(Linear(...)).add(ReLU())
 branches.add(branch1).add(branch2)
-model.add(branches).add(CAddTable)
+model.add(branches).add(CAddTable())
 ```
 
 **Python**
@@ -147,7 +147,7 @@ branches = ParallelTable()
 branch1 = Sequential().add(Linear(...)).add(ReLU())
 branch2 = Sequential().add(Linear(...)).add(ReLU())
 branches.add(branch1).add(branch2)
-model.add(branches).add(CAddTable)
+model.add(branches).add(CAddTable())
 ```
 
 In the above code, we use ParallelTable to handle the multiple inputs. ParallelTable also

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -179,7 +179,7 @@ class Sample(object):
     def __init__(self, features, label, bigdl_type="float"):
         """
         User should always use Sample.from_ndarray to construct Sample.
-        :param features: a JTensor or a list of JTensors
+        :param features: a list of JTensors
         :param label: a JTensor
         :param bigdl_type: "double" or "float"
         """
@@ -191,7 +191,9 @@ class Sample(object):
     def from_ndarray(cls, features, label, bigdl_type="float"):
         """
         Convert a ndarray of features and label to Sample, which would be used in Java side.
-
+        :param features: an ndarray or a list of ndarrays
+        :param label: an ndarray or a scalar
+        :param bigdl_type: "double" or "float"
         >>> import numpy as np
         >>> from bigdl.util.common import callBigDlFunc
         >>> from numpy.testing import assert_allclose

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -209,7 +209,7 @@ class Sample(object):
             label = np.array(label)
         return cls(
             features=[JTensor.from_ndarray(f) for f in features],
-            label=label,
+            label=JTensor.from_ndarray(label),
             bigdl_type=bigdl_type)
 
     def __reduce__(self):

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -194,6 +194,7 @@ class Sample(object):
         :param features: an ndarray or a list of ndarrays
         :param label: an ndarray or a scalar
         :param bigdl_type: "double" or "float"
+
         >>> import numpy as np
         >>> from bigdl.util.common import callBigDlFunc
         >>> from numpy.testing import assert_allclose

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -179,7 +179,7 @@ class Sample(object):
     def __init__(self, features, label, bigdl_type="float"):
         """
         User should always use Sample.from_ndarray to construct Sample.
-        :param features: a JTensor
+        :param features: a JTensor or a list of JTensors
         :param label: a JTensor
         :param bigdl_type: "double" or "float"
         """
@@ -200,13 +200,16 @@ class Sample(object):
         >>> assert_allclose(sample.features.to_ndarray(), sample_back.features.to_ndarray())
         >>> assert_allclose(sample.label.to_ndarray(), sample_back.label.to_ndarray())
         """
-        assert isinstance(features, np.ndarray), \
-            "features should be a np.ndarray, not %s" % type(features)
+        if isinstance(features, np.ndarray):
+            features = [features]
+        else:
+            assert all(isinstance(feature, np.ndarray) for feature in features), \
+                "features should be a list of np.ndarray, not %s" % type(features)
         if not isinstance(label, np.ndarray): # in case label is a scalar.
             label = np.array(label)
         return cls(
-            features=JTensor.from_ndarray(features),
-            label=JTensor.from_ndarray(label),
+            features=[JTensor.from_ndarray(f) for f in features],
+            label=label,
             bigdl_type=bigdl_type)
 
     def __reduce__(self):

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -200,7 +200,7 @@ class Sample(object):
         >>> from numpy.testing import assert_allclose
         >>> sample = Sample.from_ndarray(np.random.random((2,3)), np.random.random((2,3)))
         >>> sample_back = callBigDlFunc("float", "testSample", sample)
-        >>> assert_allclose(sample.features.to_ndarray(), sample_back.features.to_ndarray())
+        >>> assert_allclose(sample.features[0].to_ndarray(), sample_back.features[0].to_ndarray())
         >>> assert_allclose(sample.label.to_ndarray(), sample_back.label.to_ndarray())
         """
         if isinstance(features, np.ndarray):

--- a/pyspark/test/bigdl/test_simple_integration.py
+++ b/pyspark/test/bigdl/test_simple_integration.py
@@ -267,6 +267,50 @@ class TestSimple():
         for test_result in test_results:
             print(test_result)
 
+    def test_multiple_input(self):
+        """
+        Test training data of samples with several tensors as feature using a sequential model with multiple inputs
+        """
+        FEATURES_DIM = 2
+        data_len = 100
+        batch_size = 32
+        epoch_num = 5
+
+        def gen_rand_sample():
+            features1 = np.random.uniform(0, 1, (FEATURES_DIM))
+            features2 = np.random.uniform(0, 1, (FEATURES_DIM))
+            label = np.array((2 * (features1+features2)).sum() + 0.4)
+            return Sample.from_ndarray([features1,features2], label)
+
+        trainingData = self.sc.parallelize(range(0, data_len)).map(
+            lambda i: gen_rand_sample())
+
+        model_test = Sequential()
+        branches = ParallelTable()
+        branch1 = Sequential().add(Linear(FEATURES_DIM, 1)).add(ReLU())
+        branch2 = Sequential().add(Linear(FEATURES_DIM, 1)).add(ReLU())
+        branches.add(branch1).add(branch2)
+        model_test.add(branches).add(CAddTable())
+
+        optim_method = SGD(learningrate=0.01, learningrate_decay=0.0002, weightdecay=0.0,
+                           momentum=0.0, dampening=0.0, nesterov=False,
+                           leaningrate_schedule=Poly(0.5, int((data_len / batch_size) * epoch_num)))
+        optimizer = Optimizer(
+            model=model_test,
+            training_rdd=trainingData,
+            criterion=MSECriterion(),
+            optim_method=optim_method,
+            end_trigger=MaxEpoch(epoch_num),
+            batch_size=batch_size)
+        optimizer.set_validation(
+            batch_size=batch_size,
+            val_rdd=trainingData,
+            trigger=EveryEpoch(),
+            val_method=[Top1Accuracy()]
+        )
+
+        optimizer.optimize()
+
     def test_forward_backward(self):
         from bigdl.nn.layer import Linear
         rng = RNG()

--- a/pyspark/test/bigdl/test_simple_integration.py
+++ b/pyspark/test/bigdl/test_simple_integration.py
@@ -269,7 +269,8 @@ class TestSimple():
 
     def test_multiple_input(self):
         """
-        Test training data of samples with several tensors as feature using a sequential model with multiple inputs
+        Test training data of samples with several tensors as feature
+        using a sequential model with multiple inputs.
         """
         FEATURES_DIM = 2
         data_len = 100
@@ -279,8 +280,8 @@ class TestSimple():
         def gen_rand_sample():
             features1 = np.random.uniform(0, 1, (FEATURES_DIM))
             features2 = np.random.uniform(0, 1, (FEATURES_DIM))
-            label = np.array((2 * (features1+features2)).sum() + 0.4)
-            return Sample.from_ndarray([features1,features2], label)
+            label = np.array((2 * (features1 + features2)).sum() + 0.4)
+            return Sample.from_ndarray([features1, features2], label)
 
         trainingData = self.sc.parallelize(range(0, data_len)).map(
             lambda i: gen_rand_sample())

--- a/pyspark/test/dev/run-tests
+++ b/pyspark/test/dev/run-tests
@@ -30,6 +30,7 @@ do
     export PYSPARK_DRIVER_PYTHON=$p
     $p -m pytest -v --doctest-modules ../../../pyspark/bigdl \
     --ignore=../../../pyspark/bigdl/dataset/ \
+    --ignore=../../../pyspark/bigdl/util/ \
     --ignore=../../../pyspark/bigdl/models/ && \
     $p -m pytest -v -n 4 ../../../pyspark/test/
     exit_status=$?

--- a/pyspark/test/dev/run-tests
+++ b/pyspark/test/dev/run-tests
@@ -30,7 +30,6 @@ do
     export PYSPARK_DRIVER_PYTHON=$p
     $p -m pytest -v --doctest-modules ../../../pyspark/bigdl \
     --ignore=../../../pyspark/bigdl/dataset/ \
-    --ignore=../../../pyspark/bigdl/util/ \
     --ignore=../../../pyspark/bigdl/models/ && \
     $p -m pytest -v -n 4 ../../../pyspark/test/
     exit_status=$?

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
@@ -217,7 +217,7 @@ object BigDLSerDe extends BigDLSerDeBase with Serializable {
       if (args.length != 3) {
         throw new PickleException("should be 3, not : " + args.length)
       }
-      new Sample(args(0).asInstanceOf[JTensor],
+      new Sample(args(0).asInstanceOf[JList[JTensor]],
         args(1).asInstanceOf[JTensor],
         args(2).asInstanceOf[String])
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -54,7 +54,7 @@ import scala.reflect.ClassTag
  * @param label labels
  * @param bigdlType bigdl numeric type
  */
-case class Sample(features: JTensor,
+case class Sample(features: JList[JTensor],
                   label: JTensor,
                   bigdlType: String)
 
@@ -112,7 +112,9 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
 
   def toPySample(sample: JSample[T]): Sample = {
     val cls = implicitly[ClassTag[T]].runtimeClass
-    Sample(toJTensor(sample.feature()), toJTensor(sample.label()), cls.getSimpleName)
+    val features = new JArrayList[JTensor]()
+    features.add(toJTensor(sample.feature()))
+    Sample(features, toJTensor(sample.label()), cls.getSimpleName)
   }
 
   def toTensor(jTensor: JTensor): Tensor[T] = {
@@ -155,7 +157,7 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   def toSample(record: Sample): JSample[T] = {
     require(record.bigdlType == this.typeName,
       s"record.bigdlType: ${record.bigdlType} == this.typeName: ${this.typeName}")
-    JSample[T](toTensor(record.features), toTensor(record.label))
+    JSample[T](record.features.asScala.toArray.map(toTensor(_)), toTensor(record.label))
   }
 
   private def batching(rdd: RDD[Sample], batchSize: Int)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
@@ -17,7 +17,7 @@
 package com.intel.analytics.bigdl.python.api
 
 import java.util
-import java.util.{List => JList, Map => JMap}
+import java.util.{ArrayList => JArrayList, List => JList, Map => JMap}
 
 import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.nn._
@@ -162,7 +162,9 @@ class PythonSpec extends FlatSpec with Matchers with BeforeAndAfter {
       val label = JTensor(Array(i % 2 + 1.0f), Array(1), "double")
       val feature = JTensor(Range(0, 100).map(_ => Random.nextFloat()).toArray,
         Array(100), "double")
-      Sample(feature, label, "double")
+      val features = new JArrayList[JTensor]()
+      features.add(feature)
+      Sample(features, label, "double")
     }
 
     BigDLSerDe.javaToPython(data.toJavaRDD().asInstanceOf[JavaRDD[Any]])


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Support one or more `Tensor` (list of tensors) for feature in `Sample` on Python side.
2. Add test for the change. Model having multiple tensor as inputs.
3. Correct minor typo in docs.

## How was this patch tested?

Jenkins.
