### PR TITLE
Change default learning rate for DLEstimator

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/MLPipeline/DLEstimatorMultiLabelLR.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/MLPipeline/DLEstimatorMultiLabelLR.scala
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.intel.analytics.bigdl.example.MLPipeline
-
 import com.intel.analytics.bigdl.nn._
-import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric.NumericFloat
+import com.intel.analytics.bigdl.optim.LBFGS
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric.NumericDouble
 import com.intel.analytics.bigdl.utils.Engine
 import org.apache.spark.SparkContext
 import org.apache.spark.ml.DLEstimator
@@ -38,6 +37,8 @@ object DLEstimatorMultiLabelLR {
     val model = Sequential().add(Linear(2, 2))
     val criterion = MSECriterion()
     val estimator = new DLEstimator(model, criterion, Array(2), Array(2))
+      .setOptimMethod(new LBFGS[Double]())
+      .setLearningRate(1.0)
       .setBatchSize(4)
       .setMaxEpoch(10)
     val data = sc.parallelize(Seq(

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/MLPipeline/DLEstimatorMultiLabelLR.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/MLPipeline/DLEstimatorMultiLabelLR.scala
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.intel.analytics.bigdl.example.MLPipeline
+
 import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.optim.LBFGS
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric.NumericDouble

--- a/spark/dl/src/main/scala/org/apache/spark/ml/DLClassifier.scala
+++ b/spark/dl/src/main/scala/org/apache/spark/ml/DLClassifier.scala
@@ -18,7 +18,8 @@ package org.apache.spark.ml
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.{Criterion, Module}
-import org.apache.spark.ml.util.SchemaUtils
+import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.ml.util.{Identifiable, SchemaUtils}
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types._
 
@@ -37,7 +38,7 @@ class DLClassifier[@specialized(Float, Double) T: ClassTag](
     override val model: Module[T],
     override val criterion : Criterion[T],
     override val featureSize : Array[Int],
-    override val uid: String = "DLClassifier"
+    override val uid: String = Identifiable.randomUID("dlClassifier")
   )(implicit ev: TensorNumeric[T])
   extends DLEstimator[T](model, criterion, featureSize, Array(1)) {
 
@@ -50,6 +51,10 @@ class DLClassifier[@specialized(Float, Double) T: ClassTag](
   override def transformSchema(schema : StructType): StructType = {
     validateSchema(schema)
     SchemaUtils.appendColumn(schema, $(predictionCol), DoubleType)
+  }
+
+  override def copy(extra: ParamMap): DLClassifier[T] = {
+    copyValues(new DLClassifier(model, criterion, featureSize), extra)
   }
 }
 

--- a/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
+++ b/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
@@ -94,7 +94,7 @@ class DLEstimator[@specialized(Float, Double) T: ClassTag](
    * Default: 1.0
    */
   val learningRate = new DoubleParam(this, "learningRate", "learningRate", ParamValidators.gt(0))
-  setDefault(learningRate -> 1.0)
+  setDefault(learningRate -> 1e-3)
 
   def getLearningRate: Double = $(learningRate)
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLClassifierSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLClassifierSpec.scala
@@ -64,7 +64,7 @@ class DLClassifierSpec extends FlatSpec with Matchers with BeforeAndAfter {
     assert(estimator.getLabelCol == "label")
     assert(estimator.getMaxEpoch == 100)
     assert(estimator.getBatchSize == 1)
-    assert(estimator.getLearningRate == 1.0)
+    assert(estimator.getLearningRate == 1e-3)
     assert(estimator.getLearningRateDecay == 0)
   }
 
@@ -72,6 +72,8 @@ class DLClassifierSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val model = new Sequential().add(Linear[Float](6, 2)).add(LogSoftMax[Float])
     val criterion = ClassNLLCriterion[Float]()
     val classifier = new DLClassifier[Float](model, criterion, Array(6))
+      .setOptimMethod(new LBFGS[Float]())
+      .setLearningRate(0.1)
       .setBatchSize(nRecords)
       .setMaxEpoch(maxEpoch)
     val data = sc.parallelize(smallData)
@@ -138,7 +140,8 @@ class DLClassifierSpec extends FlatSpec with Matchers with BeforeAndAfter {
       val criterion = ClassNLLCriterion[Float]()
       val estimator = new DLClassifier[Float](model, criterion, Array(6))
         .setBatchSize(nRecords)
-        // intentionally set low since this only validates data format compatibitliy
+        .setOptimMethod(new LBFGS[Float]())
+        .setLearningRate(0.1)
         .setMaxEpoch(maxEpoch)
         .setFeaturesCol("scaled")
       val pipeline = new Pipeline().setStages(Array(scaler, estimator))

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLEstimatorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLEstimatorSpec.scala
@@ -63,7 +63,7 @@ class DLEstimatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     assert(estimator.getLabelCol == "label")
     assert(estimator.getMaxEpoch == 100)
     assert(estimator.getBatchSize == 1)
-    assert(estimator.getLearningRate == 1.0)
+    assert(estimator.getLearningRate == 1e-3)
     assert(estimator.getLearningRateDecay == 0)
 
   }
@@ -73,6 +73,8 @@ class DLEstimatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val criterion = ClassNLLCriterion[Float]()
     val estimator = new DLEstimator[Float](model, criterion, Array(6), Array(1))
       .setBatchSize(nRecords)
+      .setOptimMethod(new LBFGS[Float]())
+      .setLearningRate(0.1)
       .setMaxEpoch(maxEpoch)
     val data = sc.parallelize(smallData)
     val df = sqlContext.createDataFrame(data).toDF("features", "label")
@@ -222,6 +224,8 @@ class DLEstimatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
       val model = new Sequential().add(Linear[Float](6, 2)).add(LogSoftMax[Float])
       val criterion = ClassNLLCriterion[Float]()
       val estimator = new DLEstimator[Float](model, criterion, Array(6), Array(1))
+        .setOptimMethod(new LBFGS[Float]())
+        .setLearningRate(0.1)
         .setBatchSize(nRecords)
         .setMaxEpoch(maxEpoch)
         .setFeaturesCol("scaled")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since we have changed the default optimizer to SGD, we should set default learning rate to 1e-3.

update the unit test accordingly. Also use LBFGS in some unit tests to speed it up. (SGD takes much longer).

Add copy method to DLClassifier to support Grid Search.

## How was this patch tested?

existing unit tests



