### PR TITLE
Cache zeroGrad future instead of use a driver local object

### DIFF
--- a/docs/docs/PythonUserGuide/install-from-pip.md
+++ b/docs/docs/PythonUserGuide/install-from-pip.md
@@ -5,7 +5,7 @@
 - We've tested this package with __Python 2.7__ and __Python 3.5__. Only these two Python versions are supported for now.
 
 
-## **Install BigDL-0.2.0.dev2**
+## **Install BigDL-0.3.0.dev0**
 
 Install BigDL release via pip (we tested this on pip 9.0.1)
 
@@ -16,6 +16,6 @@ Install BigDL release via pip (we tested this on pip 9.0.1)
 - `pyspark` will be automatically installed first before installing BigDL if it hasn't been detected locally.
 ```bash
 pip install --upgrade pip
-pip install BigDL==0.2.0.dev2     # for Python 2.7
-pip3 install BigDL==0.2.0.dev2    # for Python 3.5
+pip install BigDL==0.3.0.dev0     # for Python 2.7
+pip3 install BigDL==0.3.0.dev0    # for Python 3.5
 ```

--- a/pyspark/bigdl/version.py
+++ b/pyspark/bigdl/version.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.2.0.dev2"
+__version__ = "0.3.0.dev0"

--- a/spark/dl/src/main/resources/bigdl-version-info.properties
+++ b/spark/dl/src/main/resources/bigdl-version-info.properties
@@ -16,4 +16,4 @@
 
 #BigDL version info config
 
-version=0.3.0
+version=0.3.0-SNAPSHOT


### PR DESCRIPTION
## What changes were proposed in this pull request?
Cache zeroGrad future instead of use a driver local object

## How was this patch tested?
add assert in training process. Existing unit test


