### PR TITLE
Expose local optimizer and predictor

### DIFF
--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -267,6 +267,19 @@ class Layer(JavaValue):
         else:
             raise Exception("Error when calling evaluate(): it takes no argument or exactly three arguments only")
 
+    def predict_local(self, X):
+        result = callBigDlFunc(self.bigdl_type,
+                             "predictLocal", self.value, JTensor.from_ndarray(X))
+        return [r.to_ndarray() for r in result]
+
+    def predict_local_class(self, X):
+        result = callBigDlFunc(self.bigdl_type,
+                             "predictLocal", self.value, JTensor.from_ndarray(X))
+        return [r.to_ndarray() for r in result]
+
+    def predict_class_local(self, X, batch=32):
+        pass
+
     def predict(self, data_rdd):
         """
         Model inference base on the given data.

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -277,9 +277,6 @@ class Layer(JavaValue):
                              "predictLocal", self.value, JTensor.from_ndarray(X))
         return [r.to_ndarray() for r in result]
 
-    def predict_class_local(self, X, batch=32):
-        pass
-
     def predict(self, data_rdd):
         """
         Model inference base on the given data.

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -268,14 +268,31 @@ class Layer(JavaValue):
             raise Exception("Error when calling evaluate(): it takes no argument or exactly three arguments only")
 
     def predict_local(self, X):
+        """
+        :param X: X can be a ndarray or list of ndarray if the model has multiple inputs.
+                  The first dimension of X should be batch.
+        :return: ndarray as the prediction result.
+        """
+
         result = callBigDlFunc(self.bigdl_type,
-                             "predictLocal", self.value, JTensor.from_ndarray(X))
-        return [r.to_ndarray() for r in result]
+                             "predictLocal",
+                               self.value,
+                               [JTensor.from_ndarray(i) for i in to_list(X)])
+
+        return np.stack(result)
 
     def predict_local_class(self, X):
+        """
+
+        :param X: X can be a ndarray or list of ndarray if the model has multiple inputs.
+                  The first dimension of X should be batch.
+        :return: a ndarray as the prediction result.
+        """
         result = callBigDlFunc(self.bigdl_type,
-                             "predictLocal", self.value, JTensor.from_ndarray(X))
-        return [r.to_ndarray() for r in result]
+                             "predictLocalClass",
+                               self.value,
+                               [JTensor.from_ndarray(i) for i in to_list(X)])
+        return np.stack(result)
 
     def predict(self, data_rdd):
         """

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -268,8 +268,6 @@ class Layer(JavaValue):
             raise Exception("Error when calling evaluate(): it takes no argument or exactly three arguments only")
 
     def _to_jtensors(self, x):
-        if not x:
-            raise Exception("Empty input")
         x = to_list(x)
         if isinstance(x[0], np.ndarray):
             return [JTensor.from_ndarray(i) for i in x]

--- a/pyspark/bigdl/optim/optimizer.py
+++ b/pyspark/bigdl/optim/optimizer.py
@@ -552,7 +552,7 @@ class LocalOptimizer(JavaValue):
 
 
     :param model: the neural net model
-    :param X: the training features which is an ndarray or list of ndarray
+    :param Xs: the training features which is an ndarray or list of ndarray
     :param Y: the training label which is an ndarray
     :param criterion: the loss function
     :param optim_method: the algorithm to use for optimization,
@@ -588,17 +588,19 @@ class LocalOptimizer(JavaValue):
         from bigdl.nn.layer import Layer
         return Layer.of(jmodel)
 
+
 class Optimizer(JavaValue):
     """
+    This is a distrubuted optimizer.
     An optimizer is in general to minimize any function with respect
-    to a set of parameters and its a distrubuted optimizer.
+    to a set of parameters.
     In case of training a neural network,
     an optimizer tries to minimize the loss of the neural net with
     respect to its weights/biases, over the training set.
     """
     def __init__(self,
                  model,
-                 training_data,
+                 training_rdd,
                  criterion,
                  end_trigger,
                  batch_size,
@@ -617,7 +619,7 @@ class Optimizer(JavaValue):
         :param batch_size: training batch size
         """
         self.pvalue = DistriOptimizer(model,
-                                      training_data,
+                                      training_rdd,
                                       criterion,
                                       end_trigger,
                                       batch_size,

--- a/pyspark/bigdl/optim/optimizer.py
+++ b/pyspark/bigdl/optim/optimizer.py
@@ -552,12 +552,14 @@ class LocalOptimizer(JavaValue):
 
 
     :param model: the neural net model
-    :param training_data: the training dataset
+    :param X: the training features which is an ndarray or list of ndarray
+    :param Y: the training label which is an ndarray
     :param criterion: the loss function
     :param optim_method: the algorithm to use for optimization,
        e.g. SGD, Adagrad, etc. If optim_method is None, the default algorithm is SGD.
     :param end_trigger: when to end the optimization
     :param batch_size: training batch size
+    :param cores: by default is the total physical cores.
     """
     def __init__(self,
                  X,
@@ -569,18 +571,6 @@ class LocalOptimizer(JavaValue):
                  optim_method=None,
                  cores=None,
                  bigdl_type="float"):
-        """
-        Create an optimizer.
-
-
-        :param model: the neural net model
-        :param training_rdd: the training dataset
-        :param criterion: the loss function
-        :param optim_method: the algorithm to use for optimization,
-           e.g. SGD, Adagrad, etc. If optim_method is None, the default algorithm is SGD.
-        :param end_trigger: when to end the optimization
-        :param batch_size: training batch size
-        """
         if cores is None:
             cores = multiprocessing.cpu_count()
         JavaValue.__init__(self, None, bigdl_type,
@@ -601,7 +591,8 @@ class LocalOptimizer(JavaValue):
 class Optimizer(JavaValue):
     """
     An optimizer is in general to minimize any function with respect
-    to a set of parameters. In case of training a neural network,
+    to a set of parameters and its a distrubuted optimizer.
+    In case of training a neural network,
     an optimizer tries to minimize the loss of the neural net with
     respect to its weights/biases, over the training set.
     """

--- a/pyspark/bigdl/optim/optimizer.py
+++ b/pyspark/bigdl/optim/optimizer.py
@@ -523,7 +523,7 @@ class MultiStep(JavaValue):
 class DistriOptimizer(JavaValue):
     def __init__(self,
                  model,
-                 training_data,
+                 training_rdd,
                  criterion,
                  end_trigger,
                  batch_size,

--- a/pyspark/bigdl/optim/optimizer.py
+++ b/pyspark/bigdl/optim/optimizer.py
@@ -562,7 +562,7 @@ class LocalOptimizer(JavaValue):
     :param cores: by default is the total physical cores.
     """
     def __init__(self,
-                 X,
+                 Xs,
                  y,
                  model,
                  criterion,
@@ -574,7 +574,7 @@ class LocalOptimizer(JavaValue):
         if cores is None:
             cores = multiprocessing.cpu_count()
         JavaValue.__init__(self, None, bigdl_type,
-                           JTensor.from_ndarray(X),
+                           [JTensor.from_ndarray(X) for X in to_list(Xs)],
                            JTensor.from_ndarray(y),
                            model.value,
                            criterion,

--- a/pyspark/bigdl/optim/optimizer.py
+++ b/pyspark/bigdl/optim/optimizer.py
@@ -552,7 +552,7 @@ class LocalOptimizer(JavaValue):
 
 
     :param model: the neural net model
-    :param Xs: the training features which is an ndarray or list of ndarray
+    :param X: the training features which is an ndarray or list of ndarray
     :param Y: the training label which is an ndarray
     :param criterion: the loss function
     :param optim_method: the algorithm to use for optimization,
@@ -562,7 +562,7 @@ class LocalOptimizer(JavaValue):
     :param cores: by default is the total physical cores.
     """
     def __init__(self,
-                 Xs,
+                 X,
                  y,
                  model,
                  criterion,
@@ -574,7 +574,7 @@ class LocalOptimizer(JavaValue):
         if cores is None:
             cores = multiprocessing.cpu_count()
         JavaValue.__init__(self, None, bigdl_type,
-                           [JTensor.from_ndarray(X) for X in to_list(Xs)],
+                           [JTensor.from_ndarray(X) for X in to_list(X)],
                            JTensor.from_ndarray(y),
                            model.value,
                            criterion,

--- a/pyspark/test/bigdl/test_simple_integration.py
+++ b/pyspark/test/bigdl/test_simple_integration.py
@@ -25,7 +25,7 @@ from bigdl.dataset import movielens
 import numpy as np
 import tempfile
 import pytest
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 from bigdl.util.engine import compare_version
 np.random.seed(1337)  # for reproducibility
 
@@ -501,29 +501,15 @@ class TestSimple():
 
     def test_local_predict_class(self):
         feature_num = 2
-        data_len = 1000
-        batch_size = 32
-        epoch_num = 500
-
-        X_ = np.random.uniform(0, 1, (data_len, feature_num))
-        y_ = np.where((0.4 * X_).sum(1) + 0.1 > 0.5, 1, 0)
+        data_len = 3
+        X_ = np.random.uniform(-1, 1, (data_len, feature_num))
         model = Sequential()
         l1 = Linear(feature_num, 1)
         model.add(l1)
         model.add(Sigmoid())
-
-        localOptimizer = LocalOptimizer(
-            model=model,
-            X =X_,
-            y=y_,
-            criterion=BCECriterion(),
-            optim_method=SGD(learningrate=1e-2),
-            end_trigger=MaxEpoch(epoch_num),
-            batch_size=batch_size)
-        trained_model = localOptimizer.optimize()
-
-        predict_result2 = model.predict_local_class(X_)
-        print predict_result2
+        model.set_seed(1234).reset()
+        predict_result = model.predict_local_class(X_)
+        assert_array_equal(predict_result, np.ones([3]))
 
 
 if __name__ == "__main__":

--- a/pyspark/test/bigdl/test_simple_integration.py
+++ b/pyspark/test/bigdl/test_simple_integration.py
@@ -496,7 +496,7 @@ class TestSimple():
         assert_allclose(w[1], np.array([0.4]), rtol=1e-1)
 
         predict_result = trained_model.predict_local(X_)
-        assert_allclose(y_, predict_result, rtol=1e-1)
+        assert_allclose(y_, predict_result.reshape((data_len,)), rtol=1e-1)
 
     def test_local_predict_class(self):
         feature_num = 2

--- a/pyspark/test/bigdl/test_simple_integration.py
+++ b/pyspark/test/bigdl/test_simple_integration.py
@@ -30,7 +30,6 @@ from bigdl.util.engine import compare_version
 np.random.seed(1337)  # for reproducibility
 
 
-
 class TestSimple():
     def setup_method(self, method):
         """ setup any state tied to the execution of the given method in a
@@ -484,7 +483,7 @@ class TestSimple():
 
         localOptimizer = LocalOptimizer(
             model=model,
-            X =X_,
+            X=X_,
             y=y_,
             criterion=MSECriterion(),
             optim_method=SGD(learningrate=1e-2),
@@ -510,6 +509,23 @@ class TestSimple():
         model.set_seed(1234).reset()
         predict_result = model.predict_local_class(X_)
         assert_array_equal(predict_result, np.ones([3]))
+
+    def test_local_predict_multiple_input(self):
+        l1 = Linear(3, 2)()
+        l2 = Linear(3, 3)()
+        joinTable = JoinTable(dimension=1, n_input_dims=1)([l1, l2])
+        model = Model(inputs=[l1, l2], outputs=joinTable)
+        result = model.predict_local([np.ones([4, 3]), np.ones([4, 3])])
+        assert result.shape == (4, 5)
+        result2 = model.predict_local_class([np.ones([4, 3]), np.ones([4, 3])])
+        assert result2.shape == (4,)
+
+        result3 = model.predict_local([JTensor.from_ndarray(np.ones([4, 3])),
+                                      JTensor.from_ndarray(np.ones([4, 3]))])
+        assert result3.shape == (4, 5)
+        result4 = model.predict_local_class([JTensor.from_ndarray(np.ones([4, 3])),
+                                      JTensor.from_ndarray(np.ones([4, 3]))])
+        assert result4.shape == (4,)
 
 
 if __name__ == "__main__":

--- a/pyspark/test/bigdl/test_simple_integration.py
+++ b/pyspark/test/bigdl/test_simple_integration.py
@@ -521,10 +521,10 @@ class TestSimple():
         assert result2.shape == (4,)
 
         result3 = model.predict_local([JTensor.from_ndarray(np.ones([4, 3])),
-                                      JTensor.from_ndarray(np.ones([4, 3]))])
+                                       JTensor.from_ndarray(np.ones([4, 3]))])
         assert result3.shape == (4, 5)
         result4 = model.predict_local_class([JTensor.from_ndarray(np.ones([4, 3])),
-                                      JTensor.from_ndarray(np.ones([4, 3]))])
+                                             JTensor.from_ndarray(np.ones([4, 3]))])
         assert result4.shape == (4,)
 
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalOptimizer.scala
@@ -38,7 +38,7 @@ object LocalOptimizer {
  * @param dataset data set
  * @param criterion criterion to be used
  */
-class LocalOptimizer[T: ClassTag] private[optim](
+class LocalOptimizer[T: ClassTag] (
   model: Module[T],
   dataset: LocalDataSet[MiniBatch[T]],
   criterion: Criterion[T]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalPredictor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalPredictor.scala
@@ -127,42 +127,6 @@ class LocalPredictor[T: ClassTag] private[optim](model: Module[T], weightsBias: 
             val input = currentMiniBatch.getInput()
             val output = workingModels(b).forward(input).toTensor[T]
             output.clone()
-          }
-        )
-      )
-      val batchResult = result.flatMap(_.split(1)).map(_.asInstanceOf[Activity])
-      batchResult
-    }).toArray.flatten
-
-  }
-
-  def predictSeq(dataSet: Array[Sample[T]]): Array[Activity] = {
-    val iter = dataSet.iterator
-    val transformer = SampleToBatch[T](
-      batchSize = batchPerCore * subModelNumber, None, None, None,
-      partitionNum = Some(1))
-    val dataIter = transformer(iter)
-
-    val workingModels = (1 to subModelNumber).map(_ => {
-      val submodel = model.cloneModule().evaluate()
-      putWeightBias(weightsBias, submodel)
-      submodel
-    }).toArray
-
-    dataIter.map(batch => {
-      val stackSize = batch.size() / subModelNumber
-      val extraSize = batch.size() % subModelNumber
-      val parallelism = if (stackSize == 0) extraSize else subModelNumber
-      val start = System.nanoTime()
-      val result = Engine.default.invokeAndWaitSeq(
-        (0 until parallelism).map(b =>
-          () => {
-            val offset = b * stackSize + math.min(b, extraSize) + 1
-            val length = stackSize + (if (b < extraSize) 1 else 0)
-            val currentMiniBatch = batch.slice(offset, length)
-            val input = currentMiniBatch.getInput()
-            val output = workingModels(b).forward(input).toTensor[T]
-            output
 
           }
         )

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalPredictor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalPredictor.scala
@@ -17,12 +17,12 @@
 package com.intel.analytics.bigdl.optim
 
 import com.intel.analytics.bigdl._
-import com.intel.analytics.bigdl.dataset.{LocalDataSet, MiniBatch, Sample, SampleToBatch}
+import com.intel.analytics.bigdl.dataset._
 import com.intel.analytics.bigdl.nn.abstractnn.Activity
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.{Engine, MklBlas}
-
+import com.intel.analytics.bigdl.dataset.SampleToMiniBatch
 
 import scala.reflect.ClassTag
 
@@ -102,8 +102,8 @@ class LocalPredictor[T: ClassTag] private[optim](model: Module[T], weightsBias: 
 
   def predict(dataSet: Array[Sample[T]]): Array[Activity] = {
     val iter = dataSet.iterator
-    val transformer = SampleToBatch[T](
-      batchSize = batchPerCore * subModelNumber, None, None, None,
+    val transformer = SampleToMiniBatch[T](
+      batchSize = batchPerCore * subModelNumber, None, None,
       partitionNum = Some(1))
     val dataIter = transformer(iter)
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
@@ -23,7 +23,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.{ByteBuffer, ByteOrder}
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, Map => JMap}
 
-import com.intel.analytics.bigdl.python.api.{EvaluatedResult, JTensor, Sample}
+import com.intel.analytics.bigdl.python.api.{EvaluatedResult, JTensor, PSample}
 import net.razorvine.pickle._
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.api.python.SerDeUtil
@@ -202,10 +202,10 @@ object BigDLSerDe extends BigDLSerDeBase with Serializable {
     private[python] def saveState(obj: Object, out: OutputStream, pickler: Pickler)
   }
 
-  private[python] class SamplePickler extends BigDLBasePickler[Sample] {
+  private[python] class SamplePickler extends BigDLBasePickler[PSample] {
 
     def saveState(obj: Object, out: OutputStream, pickler: Pickler): Unit = {
-      val record = obj.asInstanceOf[Sample]
+      val record = obj.asInstanceOf[PSample]
       saveObjects(out,
         pickler,
         record.features,
@@ -217,7 +217,7 @@ object BigDLSerDe extends BigDLSerDeBase with Serializable {
       if (args.length != 3) {
         throw new PickleException("should be 3, not : " + args.length)
       }
-      Sample(args(0).asInstanceOf[JList[JTensor]],
+      new PSample(args(0).asInstanceOf[JList[JTensor]],
         args(1).asInstanceOf[JTensor],
         args(2).asInstanceOf[String])
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
@@ -23,7 +23,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.{ByteBuffer, ByteOrder}
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, Map => JMap}
 
-import com.intel.analytics.bigdl.python.api.{EvaluatedResult, JTensor, PSample}
+import com.intel.analytics.bigdl.python.api.{EvaluatedResult, JTensor, Sample}
 import net.razorvine.pickle._
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.api.python.SerDeUtil
@@ -202,10 +202,10 @@ object BigDLSerDe extends BigDLSerDeBase with Serializable {
     private[python] def saveState(obj: Object, out: OutputStream, pickler: Pickler)
   }
 
-  private[python] class SamplePickler extends BigDLBasePickler[PSample] {
+  private[python] class SamplePickler extends BigDLBasePickler[Sample] {
 
     def saveState(obj: Object, out: OutputStream, pickler: Pickler): Unit = {
-      val record = obj.asInstanceOf[PSample]
+      val record = obj.asInstanceOf[Sample]
       saveObjects(out,
         pickler,
         record.features,
@@ -217,7 +217,7 @@ object BigDLSerDe extends BigDLSerDeBase with Serializable {
       if (args.length != 3) {
         throw new PickleException("should be 3, not : " + args.length)
       }
-      new PSample(args(0).asInstanceOf[JList[JTensor]],
+      Sample(args(0).asInstanceOf[JList[JTensor]],
         args(1).asInstanceOf[JTensor],
         args(2).asInstanceOf[String])
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -188,7 +188,7 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
     toPySample(jsample)
   }
 
-  private def toJSample(record: Sample): JSample[T] = {
+  def toJSample(record: Sample): JSample[T] = {
     require(record.bigdlType == this.typeName,
       s"record.bigdlType: ${record.bigdlType} == this.typeName: ${this.typeName}")
     JSample[T](record.features.asScala.toArray.map(toTensor(_)), toTensor(record.label))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -19,7 +19,7 @@ package com.intel.analytics.bigdl.python.api
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, Map => JMap}
 
 import com.intel.analytics.bigdl._
-import com.intel.analytics.bigdl.dataset.{Identity => DIdentity, Sample => JSample, _}
+import com.intel.analytics.bigdl.dataset.{Identity => DIdentity, Sample, _}
 import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, _}
 import com.intel.analytics.bigdl.numeric._
@@ -60,9 +60,9 @@ import scala.reflect.ClassTag
  * @param label labels
  * @param bigdlType bigdl numeric type
  */
-case class Sample(features: JList[JTensor],
-                  label: JTensor,
-                  bigdlType: String)
+case class PSample(features: JList[JTensor],
+                   label: JTensor,
+                   bigdlType: String)
 
 case class JTensor(storage: Array[Float], shape: Array[Int],
                    bigdlType: String, indices: Array[Array[Int]] = null)
@@ -118,11 +118,11 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
     }
   }
 
-  def toPySample(sample: JSample[T]): Sample = {
+  def toPySample(sample: Sample[T]): PSample = {
     val cls = implicitly[ClassTag[T]].runtimeClass
     val features = new JArrayList[JTensor]()
     features.add(toJTensor(sample.feature()))
-    Sample(features, toJTensor(sample.label()), cls.getSimpleName)
+    PSample(features, toJTensor(sample.label()), cls.getSimpleName)
   }
 
   def toTensor(jTensor: JTensor): Tensor[T] = {
@@ -183,22 +183,62 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   }
 
 
-  def testSample(sample: Sample): Sample = {
+  def testSample(sample: PSample): PSample = {
     val jsample = toSample(sample)
     toPySample(jsample)
   }
 
-  def toSample(record: Sample): JSample[T] = {
+  def toSample(record: PSample): Sample[T] = {
     require(record.bigdlType == this.typeName,
       s"record.bigdlType: ${record.bigdlType} == this.typeName: ${this.typeName}")
-    JSample[T](record.features.asScala.toArray.map(toTensor(_)), toTensor(record.label))
+    Sample[T](record.features.asScala.toArray.map(toTensor(_)), toTensor(record.label))
   }
 
-  private def batching(rdd: RDD[Sample], batchSize: Int)
-  : DistributedDataSet[MiniBatch[T]] = {
-    val recordRDD = rdd.map(toSample(_))
-    (DataSet.rdd(recordRDD) -> SampleToMiniBatch[T](batchSize))
-      .asInstanceOf[DistributedDataSet[MiniBatch[T]]]
+  def toSample(psamples: RDD[PSample]): RDD[Sample[T]] = {
+    psamples.map(toSample(_))
+  }
+
+  // The first dimension is batch for both X and y
+  private def toSampleArray(X: Tensor[T], y: Tensor[T] = null): Array[Sample[T]] = {
+    val totalNum = X.size()(0)
+    var i = 1
+    val samples = new Array[Sample[T]](totalNum)
+
+    if (y != null) {
+      require(X.size()(0) == y.size()(0),
+        s"The batch dim should be equal, but we got: ${X.size()(0)} vs ${y.size()(0)}")
+      while (i <= totalNum) {
+        samples(i-1) = Sample(X.select(1, i), y.select(1, i))
+        i += 1
+      }
+    } else {
+      val dummyTensor = Tensor[T](1).fill(ev.fromType(1))
+      while (i <= totalNum) {
+        samples(i-1) = Sample(X.select(1, i), dummyTensor)
+        i += 1
+      }
+    }
+
+    samples
+  }
+
+
+  def batching(dataset: DataSet[Sample[T]], batchSize: Int)
+  : DataSet[MiniBatch[T]] = {
+    dataset -> SampleToMiniBatch[T](batchSize)
+  }
+
+  private def enrichOptimizer[T](optimizer: Optimizer[T, MiniBatch[T]],
+                                 endTrigger: Trigger,
+                                 optimMethod: OptimMethod[T]): Optimizer[T, MiniBatch[T]] = {
+    optimizer.setEndWhen(endTrigger)
+
+    optimizer.setOptimMethod(optimMethod)
+
+    // TODO: remove this
+    optimizer.disableCheckSingleton()
+
+    optimizer
   }
 
   def createSequential(): Sequential[T] = {
@@ -1510,9 +1550,9 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   }
 
   def modelEvaluate(model: AbstractModule[Activity, Activity, T],
-    valRDD: JavaRDD[Sample],
-    batchSize: Int,
-    valMethods: JList[ValidationMethod[T]])
+                    valRDD: JavaRDD[PSample],
+                    batchSize: Int,
+                    valMethods: JList[ValidationMethod[T]])
   : JList[EvaluatedResult] = {
     val resultArray = model.evaluate(valRDD.rdd.map(toSample(_)),
       valMethods.asScala.toArray, Some(batchSize))
@@ -1581,8 +1621,25 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
     model.saveTF(scalaInputs, path, order, format)
   }
 
+  def predictLocal(model: AbstractModule[Activity, Activity, T],
+                   X: JTensor): JList[JTensor] = {
+    val sampleArray = toSampleArray(toTensor(X))
+    val localModel = LocalModule(model)
+    val result = localModel.predict(sampleArray)
+    result.map{a => toJTensor(a.asInstanceOf[Tensor[T]])}.toList.asJava
+  }
+
+  def predictLocalClass(model: AbstractModule[Activity, Activity, T],
+                   X: JTensor): JList[JTensor] = {
+    val sampleArray = toSampleArray(toTensor(X))
+    val localModel = LocalModule(model)
+    val result = localModel.predictClass(sampleArray)
+    result.map{a => toJTensor(a.asInstanceOf[Tensor[T]])}.toList.asJava
+  }
+
+
   def modelPredictRDD(model: AbstractModule[Activity, Activity, T],
-    dataRdd: JavaRDD[Sample]): JavaRDD[JTensor] = {
+                      dataRdd: JavaRDD[PSample]): JavaRDD[JTensor] = {
     val tensorRDD = model.predict(dataRdd.rdd.map(toSample(_)))
     val listRDD = tensorRDD.map { res =>
       val tensor = res.asInstanceOf[Tensor[T]]
@@ -1599,8 +1656,9 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   }
 
   def modelPredictClass(model: AbstractModule[Activity, Activity, T],
-    dataRdd: JavaRDD[Sample]): JavaRDD[Int] = {
-    val tensorRDD = model.predictClass(dataRdd.rdd.map(toSample(_)))
+                      dataRdd: JavaRDD[PSample]): JavaRDD[Int] = {
+    val sampleRdd = toSample(dataRdd)
+    val tensorRDD = model.predictClass(sampleRdd)
     new JavaRDD[Int](tensorRDD)
   }
 
@@ -1800,45 +1858,58 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   }
 
   def trainTF(
-    modelPath: String,
-    output: String,
-    samples: JavaRDD[Sample],
-    optMethod: OptimMethod[T],
-    criterion: Criterion[T],
-    batchSize: Int,
-    endWhen: Trigger): AbstractModule[Activity, Activity, T] = {
+               modelPath: String,
+               output: String,
+               samples: JavaRDD[PSample],
+               optMethod: OptimMethod[T],
+               criterion: Criterion[T],
+               batchSize: Int,
+               endWhen: Trigger): AbstractModule[Activity, Activity, T] = {
     val nodeList = parse(modelPath)
 
     val context = new Context[T]()
     val session = new BigDLSessionImpl[T](nodeList.asScala, context, ByteOrder.LITTLE_ENDIAN)
-    val dataset = batching(samples, batchSize)
-
+    val dataset = batching(DataSet.rdd(toSample(samples)),
+      batchSize).asInstanceOf[DistributedDataSet[MiniBatch[T]]]
     val model = session.train(Seq(output), dataset,
       optMethod, criterion, endWhen)
     model
   }
 
-  def createOptimizer(model: AbstractModule[Activity, Activity, T],
-    trainingRdd: JavaRDD[Sample],
-    criterion: Criterion[T],
-    optimMethod: OptimMethod[T],
-    endTrigger: Trigger,
-    batchSize: Int): Optimizer[T, MiniBatch[T]] = {
+  def createLocalOptimizer(X: JTensor,
+                           y: JTensor,
+                           model: AbstractModule[Activity, Activity, T],
+                           criterion: Criterion[T],
+                           optimMethod: OptimMethod[T],
+                           endTrigger: Trigger,
+                           batchSize: Int,
+                           localCores: Int): Optimizer[T, MiniBatch[T]] = {
+    val sampleArray = toSampleArray(toTensor(X), toTensor(y))
+    val optimizer = new LocalOptimizer[T](
+      model,
+      batching(DataSet.array(sampleArray), batchSize)
+        .asInstanceOf[LocalDataSet[MiniBatch[T]]],
+      criterion
+    ).asInstanceOf[Optimizer[T, MiniBatch[T]]]
+    Engine.setNodeAndCore(1, localCores)
+    enrichOptimizer(optimizer, endTrigger, optimMethod)
+  }
+
+  def createDistriOptimizer(model: AbstractModule[Activity, Activity, T],
+                            trainingRdd: JavaRDD[PSample],
+                            criterion: Criterion[T],
+                            optimMethod: OptimMethod[T],
+                            endTrigger: Trigger,
+                            batchSize: Int): Optimizer[T, MiniBatch[T]] = {
+    val sampleRDD = toSample(trainingRdd)
+
     val optimizer = new DistriOptimizer(
       _model = model,
-      dataset = batching(trainingRdd, batchSize),
+      dataset = batching(DataSet.rdd(sampleRDD), batchSize)
+        .asInstanceOf[DistributedDataSet[MiniBatch[T]]],
       criterion = criterion
     ).asInstanceOf[Optimizer[T, MiniBatch[T]]]
-    // TODO: we should provide a more convenient way to create Table
-
-    optimizer.setEndWhen(endTrigger)
-
-    optimizer.setOptimMethod(optimMethod)
-
-    // TODO: remove this
-    optimizer.disableCheckSingleton()
-
-    optimizer
+    enrichOptimizer(optimizer, endTrigger, optimMethod)
   }
 
   def createL1L2Regularizer(l1: Double, l2: Double): L1L2Regularizer[T] = {
@@ -1854,11 +1925,13 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   }
 
   def setValidation(optimizer: Optimizer[T, MiniBatch[T]],
-    batchSize: Int,
-    trigger: Trigger,
-    valRdd: JavaRDD[Sample],
-    vMethods: JList[ValidationMethod[T]]): Unit = {
-    optimizer.setValidation(trigger, batching(valRdd, batchSize.toInt), vMethods.asScala.toArray)
+                    batchSize: Int,
+                    trigger: Trigger,
+                    valRdd: JavaRDD[PSample],
+                    vMethods: JList[ValidationMethod[T]]): Unit = {
+    val sampleRDD = toSample(valRdd)
+    optimizer.setValidation(trigger, batching(DataSet.rdd(sampleRDD), batchSize.toInt),
+      vMethods.asScala.toArray)
   }
 
   def setCheckPoint(optimizer: Optimizer[T, MiniBatch[T]],

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/LocalModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/LocalModule.scala
@@ -79,5 +79,9 @@ class LocalModule[T: ClassTag] private(model: Module[T], weightsBias: Array[Tens
   def predict(dataSet: Array[Sample[T]]): Array[Activity] = {
     predictor.predict(dataSet)
   }
+
+  def predictSeq(dataSet: Array[Sample[T]]): Array[Activity] = {
+    predictor.predict(dataSet)
+  }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/LocalModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/LocalModule.scala
@@ -53,7 +53,7 @@ object LocalModule {
 
   def apply[T: ClassTag](model: Module[T])
                         (implicit ev: TensorNumeric[T]): LocalModule[T] = {
-    val weightsBias = getAndClearWeightBias(model.parameters())
+    val weightsBias = getAndClearWeightBias(model.cloneModule().parameters())
     new LocalModule[T](model, weightsBias)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/LocalModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/LocalModule.scala
@@ -79,9 +79,5 @@ class LocalModule[T: ClassTag] private(model: Module[T], weightsBias: Array[Tens
   def predict(dataSet: Array[Sample[T]]): Array[Activity] = {
     predictor.predict(dataSet)
   }
-
-  def predictSeq(dataSet: Array[Sample[T]]): Array[Activity] = {
-    predictor.predict(dataSet)
-  }
 }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
@@ -219,16 +219,16 @@ class PythonSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     val localData = data.collect()
     pp.toTensor(preResult.get(0)) should be
-    (trainedModel.forward(pp.toSample(localData(0)).feature))
+    (trainedModel.forward(pp.toJSample(localData(0)).feature))
 
     pp.toTensor(preResult.get(25)) should be
-    (trainedModel.forward(pp.toSample(localData(25)).feature))
+    (trainedModel.forward(pp.toJSample(localData(25)).feature))
 
     pp.toTensor(preResult.get(55)) should be
-    (trainedModel.forward(pp.toSample(localData(55)).feature))
+    (trainedModel.forward(pp.toJSample(localData(55)).feature))
 
     pp.toTensor(preResult.get(75)) should be
-    (trainedModel.forward(pp.toSample(localData(75)).feature))
+    (trainedModel.forward(pp.toJSample(localData(75)).feature))
 
     // TODO: verify the parameters result
     val parameters = pp.modelGetParameters(trainedModel)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
@@ -165,7 +165,7 @@ class PythonSpec extends FlatSpec with Matchers with BeforeAndAfter {
         Array(100), "double")
       val features = new JArrayList[JTensor]()
       features.add(feature)
-      PSample(features, label, "double")
+      Sample(features, label, "double")
     }
 
     BigDLSerDe.javaToPython(data.toJavaRDD().asInstanceOf[JavaRDD[Any]])
@@ -263,7 +263,7 @@ class PythonSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val batchSize = 32
     val optimMethod = new SGD[Double]()
     val optimizer = pp.createLocalOptimizer(
-      X,
+      List(X).asJava,
       y,
       model,
       ClassNLLCriterion[Double](),
@@ -273,7 +273,7 @@ class PythonSpec extends FlatSpec with Matchers with BeforeAndAfter {
       2)
     val trainedModel = optimizer.optimize()
     val predictedResult = pp.predictLocal(
-      trainedModel, pp.toJTensor(Tensor[Double](Array(34, 100)).randn()))
+      trainedModel, List(pp.toJTensor(Tensor[Double](Array(34, 100)).randn())).asJava)
     println(predictedResult)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

User can train or predict the model locally without spark cluster or spark local mode.

``` python
        feature_num = 2
        data_len = 1000
        batch_size = 32
        epoch_num = 500

        X_ = np.random.uniform(0, 1, (data_len, feature_num))
        y_ = (2 * X_).sum(1) + 0.4
        model = Sequential()
        l1 = Linear(feature_num, 1)
        model.add(l1)

        localOptimizer = LocalOptimizer(
            model=model,
            X =X_,
            y=y_,
            criterion=MSECriterion(),
            optim_method=SGD(learningrate=1e-2),
            end_trigger=MaxEpoch(epoch_num),
            batch_size=batch_size)
        trained_model = localOptimizer.optimize()
        w = trained_model.get_weights()

       trained_model.predict_local(X_)
```

## How was this patch tested?
unittest

