### PR TITLE
fix: make the length of weight and gradWeight in quantized conv same length

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
@@ -105,7 +105,6 @@ class ModelBroadcast[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends Seria
       }
       // clear parameters
       clearTensor(parameters._1)
-      // because in quantized mode, the weight number may be different with gradWeight number
       clearTensor(parameters._2)
 
       weightsBias

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/SpatialConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/SpatialConvolution.scala
@@ -198,7 +198,7 @@ private[bigdl] class SpatialConvolution[T: ClassTag](
   }
 
   override def parameters(): (Array[Tensor[T]], Array[Tensor[T]]) = {
-    (weight :+ bias, Array.fill[Tensor[T]](nGroup)(empty) :+ empty)
+    (weight :+ bias, Array.fill[Tensor[T]](nGroup + 1)(empty)) // nGroup's weight + bias
   }
 
   override def getParametersTable(): Table = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/SpatialConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/SpatialConvolution.scala
@@ -198,7 +198,7 @@ private[bigdl] class SpatialConvolution[T: ClassTag](
   }
 
   override def parameters(): (Array[Tensor[T]], Array[Tensor[T]]) = {
-    (weight :+ bias, Array(empty, empty))
+    (weight :+ bias, Array.fill[Tensor[T]](nGroup)(empty) :+ empty)
   }
 
   override def getParametersTable(): Table = {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcastSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcastSpec.scala
@@ -16,6 +16,8 @@
 package com.intel.analytics.bigdl.models.utils
 
 import com.intel.analytics.bigdl.models.lenet.LeNet5
+import com.intel.analytics.bigdl.nn.Sequential
+import com.intel.analytics.bigdl.nn.SpatialConvolution
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
@@ -49,6 +51,16 @@ class ModelBroadcastSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
   "quantized model broadcast" should "work properly" in {
     val model = LeNet5(10).quantize()
+
+    val modelBroadCast = ModelBroadcast[Float].broadcast(sc, model)
+    modelBroadCast.value().toString should be(model.toString)
+    modelBroadCast.value().parameters()._1 should be(model.parameters()._1)
+  }
+
+  "quantized multi groups model" should "work properly" in {
+    val model = Sequential[Float]()
+      .add(SpatialConvolution[Float](2, 4, 4, 4, 1, 1, 0, 0, 2))
+      .quantize()
 
     val modelBroadCast = ModelBroadcast[Float].broadcast(sc, model)
     modelBroadCast.value().toString should be(model.toString)


### PR DESCRIPTION
fix: the different length of weight and gradWeight in quantized conv is
very confused. So make them same length.

## What changes were proposed in this pull request?

Jenkins

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If it is possible, please attach a screenshot; otherwise, remove this)

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

