### PR TITLE
optimize MSECriterion Adam

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MSECriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MSECriterion.scala
@@ -34,24 +34,19 @@ class MSECriterion[@specialized(Float, Double) T: ClassTag]
   var sizeAverage = true
 
   override def updateOutput(input: Tensor[T], target: Tensor[T]): T = {
-    output = ev.fromType[Int](0)
-
-    input.map(target, (a, b) => {
-      output = ev.plus(output, ev.times(ev.minus(a, b), ev.minus(a, b)));
-      a
-    })
-    if (sizeAverage) output = ev.divide(output, ev.fromType[Int](input.nElement()))
+    gradInput.resizeAs(input).copy(input)
+    gradInput.sub(target)
+    output = gradInput.dot(gradInput)
+    if (sizeAverage) output = ev.divide(output, ev.fromType[Int](input.nElement))
     output
   }
 
   override def updateGradInput(input: Tensor[T], target: Tensor[T]): Tensor[T] = {
-    gradInput.resizeAs(input)
     var norm = ev.fromType[Int](2)
     if (sizeAverage) {
-      norm = ev.fromType[Double](2.0 / input.nElement())
+      norm = ev.fromType[Double](2.0 / input.nElement)
     }
-    gradInput.copy(input)
-    gradInput.map(target, (a, b) => ev.times(norm, ev.minus(a, b)))
+    gradInput.mul(norm)
     gradInput
   }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/MSECriterionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/MSECriterionSpec.scala
@@ -23,6 +23,30 @@ import scala.math._
 
 @com.intel.analytics.bigdl.tags.Parallel
 class MSECriterionSpec extends FlatSpec {
+  "A MSE Criterion" should " be fast" in {
+    val mse = MSECriterion[Double]
+    val input = Tensor[Double](3, 50, 50)
+    val target = Tensor[Double](3, 50, 50)
+
+    val warmUp = 50
+    for (i <- 1 to warmUp) {
+      mse.forward(input, target)
+      mse.backward(input, target)
+    }
+
+    val iteration = 50
+    var sum = 0.0
+    for (i <- 1 to warmUp) {
+      val st = System.nanoTime
+      mse.forward(input, target)
+      mse.backward(input, target)
+      val eta = (System.nanoTime() - st) / 1e9
+      sum += eta
+      println(s"eta = ${eta}")
+    }
+
+    println(s"average eta = ${sum / iteration}")
+  }
   "A MSE Criterion " should "generate correct output and grad" in {
     val mse = new MSECriterion[Double]
     val input = Tensor[Double](2, 2, 2)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/AdamSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/AdamSpec.scala
@@ -16,11 +16,13 @@
 
 package com.intel.analytics.bigdl.optim
 
+import com.intel.analytics.bigdl.nn.{CrossEntropyCriterion, Linear, Sequential}
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.bigdl.utils.{T, TestUtils}
+import com.intel.analytics.bigdl.utils.{RandomGenerator, T, TestUtils}
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.collection.mutable.ArrayBuffer
+import scala.util.Random
 
 @com.intel.analytics.bigdl.tags.Parallel
 class AdamSpec extends FlatSpec with Matchers {
@@ -49,6 +51,60 @@ class AdamSpec extends FlatSpec with Matchers {
     (fx.last < 1e-9) should be(true)
     x(Array(1)) should be(1.0 +- 0.01)
     x(Array(2)) should be(1.0 +- 0.01)
+  }
+  "adam" should " work fast with MKL" in {
+    RandomGenerator.RNG.setSeed(100)
+    val inputSize = 500
+    val hiddenSize = 500
+    val outputSize = 10
+    val batchSize = 10
+    val model = Sequential[Float]()
+      .add(Linear[Float](inputSize, hiddenSize))
+    for (i <- 1 to 3) {
+      model.add(Linear[Float](hiddenSize, hiddenSize))
+    }
+    model.add(Linear[Float](hiddenSize, outputSize))
+    val criterion = CrossEntropyCriterion[Float]()
+
+    val input = Tensor[Float](batchSize, inputSize).rand
+    val label = Tensor[Float](batchSize).zero
+    for (i <- 1 to batchSize) {
+      val nextLabel = Random.nextInt(outputSize) + 1
+      label.setValue(i, nextLabel)
+    }
+
+    val (weights, grad) = model.getParameters()
+
+    val state = T("learningRate" -> 1e-1, "momentum" -> 0.9, "weightDecay" -> 5e-4,
+      "dampening" -> 0.0)
+
+    val adam = new Adam[Float]
+
+    def feval(x: Tensor[Float]): (Float, Tensor[Float]) = {
+      model.forward(input)
+      criterion.forward(model.output.asInstanceOf[Tensor[Float]], label)
+      model.zeroGradParameters()
+      val gradOutputTest = criterion.backward(model.output.asInstanceOf[Tensor[Float]], label)
+      model.backward(input, gradOutputTest)
+      (criterion.output, grad)
+    }
+
+    val warmUp = 30
+    val iter = 50
+    for (i <- 1 to warmUp) {
+      adam.optimize(feval, weights, state)
+    }
+    var startTime = System.nanoTime
+    var duration = (System.nanoTime() - startTime) / 1e9
+    var sum = 0.0
+    for (i <- 1 to iter) {
+      startTime = System.nanoTime
+      adam.optimize(feval, weights, state)
+      duration = (System.nanoTime() - startTime) / 1e9
+      sum += duration
+      println(s"iter-${i}, eta = ${duration} seconds")
+    }
+    println(s"average eta = ${sum / iter} seconds")
   }
 }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
@@ -68,6 +68,7 @@ class PythonSpec extends FlatSpec with Matchers with BeforeAndAfter {
     require(pythonBigDL.toTensor(joutput) == expectedOutput, "forward output should be the same")
 
     // test backward for linear
+    val loss = mse.forward(pythonBigDL.toTensor(joutput), target)
     val mseGradOutput = mse.backward(pythonBigDL.toTensor(joutput), target).toTensor[Float]
     val expectedLinearGradOutput = linear.backward(input, mseGradOutput)
     val jLinearGradOutput = pythonBigDL.modelBackward(linear,


### PR DESCRIPTION
## What changes were proposed in this pull request?

optimize MSECriterion Adam

Replace element-wise operations with MKL vector operations.
Add buffer for sharing memory

## How was this patch tested?
Unit Tests
single-threading

Test the average eta time in the Adam:
previous:
7.944 ms / iteration
after:
6.881 ms / iteration

inputsize: 3 * 50 * 50
before:
average eta = 4.0083114E-4
after:
average eta = 1.1305320000000002E-4

