### PR TITLE
revert previous fix back for eltwise layer mapping

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/caffe/Converter.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/caffe/Converter.scala
@@ -225,11 +225,17 @@ abstract class Converter[T: ClassTag](implicit ev: TensorNumeric[T]) {
       case EltwiseOp.PROD => CMulTable[T]().setName(layerName).inputs()
       case EltwiseOp.MAX => CMaxTable[T]().setName(layerName).inputs()
       case EltwiseOp.SUM =>
+        val coeff1 = if (param.getCoeffCount == 0) 1 else param.getCoeff(0)
         val coeff2 = if (param.getCoeffCount == 0) 1 else param.getCoeff(1)
-        if (coeff2 > 0) {
+        if (coeff1 == 1 && coeff2 == 1) {
           CAddTable[T]().setName(layerName).inputs()
-        } else {
+        } else if (coeff1 == 1 && coeff2 == -1) {
           CSubTable[T]().setName(layerName).inputs()
+        } else {
+          val mul1 = MulConstant[T](coeff1.toFloat).inputs()
+          val mul2 = MulConstant[T](coeff2.toFloat).inputs()
+          val caddTable = CAddTable[T]().setName(layerName).inputs(mul1, mul2)
+          Graph[T](Array(mul1, mul2), Array(caddTable)).inputs()
         }
       case _ => null
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/caffe/Converter.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/caffe/Converter.scala
@@ -225,7 +225,7 @@ abstract class Converter[T: ClassTag](implicit ev: TensorNumeric[T]) {
       case EltwiseOp.PROD => CMulTable[T]().setName(layerName).inputs()
       case EltwiseOp.MAX => CMaxTable[T]().setName(layerName).inputs()
       case EltwiseOp.SUM =>
-        val coeff2 = param.getCoeff(1)
+        val coeff2 = if (param.getCoeffCount == 0) 1 else param.getCoeff(1)
         if (coeff2 > 0) {
           CAddTable[T]().setName(layerName).inputs()
         } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Revert the change in https://github.com/intel-analytics/BigDL/pull/1700 back for EltWise layer

we should still check the coeff size, 1 by default for empty list

## How was this patch tested?

Unit test and Resnet-50 

## Related links or issues (optional)


