### PR TITLE
Add profile to minimize the size of jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,8 @@
         <spark-scope>provided</spark-scope>
 
         <mkl-java-os-version>mkl-java</mkl-java-os-version>
+        <bigquant-java-os-version>bigquant-java</bigquant-java-os-version>
+
     </properties>
 
     <modules>
@@ -579,6 +581,7 @@
             <id>mac</id>
             <properties>
                 <mkl-java-os-version>mkl-java-mac</mkl-java-os-version>
+                <bigquant-java-os-version>bigquant-java-mac</bigquant-java-os-version>
                 <os-flag>mac</os-flag>
             </properties>
         </profile>
@@ -592,6 +595,7 @@
             <id>win64</id>
             <properties>
                 <mkl-java-os-version>mkl-java-win64</mkl-java-os-version>
+                <bigquant-java-os-version>bigquant-java-win64</bigquant-java-os-version>
                 <os-flag>win64</os-flag>
             </properties>
         </profile>

--- a/pyspark/setup.py
+++ b/pyspark/setup.py
@@ -70,7 +70,7 @@ def init_env():
 
 def setup_package():
     metadata = dict(
-        name='BigDL',
+        name='BigDLttt',
         version=VERSION,
         description='Distributed Deep Learning Library for Apache Spark',
         author='BigDL Authors',

--- a/pyspark/setup.py
+++ b/pyspark/setup.py
@@ -70,7 +70,7 @@ def init_env():
 
 def setup_package():
     metadata = dict(
-        name='BigDLttt',
+        name='BigDL',
         version=VERSION,
         description='Distributed Deep Learning Library for Apache Spark',
         author='BigDL Authors',

--- a/spark/dl/pom.xml
+++ b/spark/dl/pom.xml
@@ -300,6 +300,19 @@
                         </exclusion>
                     </exclusions>
                 </dependency>
+
+                <dependency>
+                    <groupId>com.intel.analytics.bigdl.bigquant</groupId>
+                    <artifactId>${bigquant-java-os-version}</artifactId>
+                    <version>0.3.0-SNAPSHOT</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.intel.analytics.bigdl.bigquant</groupId>
+                            <artifactId>bigquant-native</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+
                 <dependency>
                     <groupId>com.intel.analytics.bigdl</groupId>
                     <artifactId>bigdl-core</artifactId>

--- a/spark/dl/pom.xml
+++ b/spark/dl/pom.xml
@@ -284,6 +284,33 @@
 
     <profiles>
         <profile>
+            <id>per_platform</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.intel.analytics.bigdl.native</groupId>
+                    <artifactId>${mkl-java-os-version}</artifactId>
+                    <version>0.3.0-SNAPSHOT</version>
+                    <exclusions>
+                        <!-- We already copy the dynamic lib files of this project to mkl-java, so we
+                        need not the dependency, which will break assembly step.
+                         -->
+                        <exclusion>
+                            <groupId>com.intel.analytics.bigdl.native</groupId>
+                            <artifactId>bigdl-native</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.intel.analytics.bigdl</groupId>
+                    <artifactId>bigdl-core</artifactId>
+                    <version>0.3.0-SNAPSHOT</version>
+                    <scope>provided</scope>
+                    <type>pom</type>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
             <id>parallel-tests</id>
             <properties>
                 <runSpecsInParallel>true</runSpecsInParallel>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently we would throw native libs into jar for all platform which would increase the size of the assembly package. This pr provide us another option which would only pack platform specify native libs into the final assembly package.

./make-dist.sh -Pspark_2.x -Pper_platform

## How was this patch tested?
manual test

