### PR TITLE
Use newInstance method to obtain FileSystem.

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/File.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/File.scala
@@ -17,6 +17,7 @@
 package com.intel.analytics.bigdl.utils
 
 import java.io._
+import java.net.URI
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataInputStream, FSDataOutputStream, FileSystem, Path}
@@ -199,7 +200,7 @@ object File {
     var fs: FileSystem = null
     var in: FSDataInputStream = null
     try {
-      fs = src.getFileSystem(new Configuration())
+      fs = FileSystem.newInstance(new URI(fileName), new Configuration())
       in = fs.open(src)
       val byteArrayOut = new ByteArrayOutputStream()
       IOUtils.copyBytes(in, byteArrayOut, 1024, true)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use FileSystem#newInstance method to prevent an unexpected error which occur when you use Spark's feature to store event log to HDFS.

The previous implementation which used getFileSystem method caused an unexpected IOException like the following.
```
2017-10-22 00:40:23 ERROR LiveListenerBus:91 - Listener EventLoggingListener threw an exception
java.io.IOException: Filesystem closed
        at org.apache.hadoop.hdfs.DFSClient.checkOpen(DFSClient.java:808)

(snip)
```

## How was this patch tested?
I executed manual tests according to the tutorial.
https://bigdl-project.github.io/master/#ScalaUserGuide/run/

