### PR TITLE
Clone graph keep their original prevs nodes and next nodes sequence

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
@@ -509,14 +509,17 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
         activity.toTensor[T].add(other.toTensor[T])
       } else {
         val actTable = activity.toTable
-        val actLen = actTable.length()
         val otherTable = other.toTable
-        val otherLen = otherTable.length()
-        require(actLen == otherLen, "table length is not equal")
+        val maxActIndex = actTable.keySet.map(_.asInstanceOf[Int]).max
+        val maxOtherIndex = otherTable.keySet.map(_.asInstanceOf[Int]).max
+        val maxIndex = Math.max(maxActIndex, maxOtherIndex)
         var i = 1
-        while(i <= actLen) {
-          require(actTable[Activity](i) != null, "Invalid table element")
-          accActivity(actTable[Activity](i), otherTable[Activity](i))
+        while(i <= maxIndex) {
+          if (actTable.contains(i) && otherTable.contains(i)) {
+            accActivity(actTable[Activity](i), otherTable[Activity](i))
+          } else if (otherTable.contains(i)) {
+            actTable.insert(i, otherTable(i))
+          }
           i += 1
         }
         actTable

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
@@ -509,25 +509,18 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
         activity.toTensor[T].add(other.toTensor[T])
       } else {
         // if 'activity' and 'other' are both table, we need to merge 'other' to 'activity'
-        // first find the maxIndex from two tables (their index may not be contiguous)
-        // then iterate index over [1, maxIndex],
         // if 'other' and 'activity' both contains the index, update 'activity' by sum
         // if 'other' contains the index while 'activity' does not,
-        // just insert the corresponding tensor to 'activity'
+        // just insert the corresponding tensor of 'other' to 'activity'
         val actTable = activity.toTable
         val otherTable = other.toTable
-        val maxActIndex = actTable.keySet.map(_.asInstanceOf[Int]).max
-        val maxOtherIndex = otherTable.keySet.map(_.asInstanceOf[Int]).max
-        val maxIndex = Math.max(maxActIndex, maxOtherIndex)
-        var i = 1
-        while(i <= maxIndex) {
-          if (actTable.contains(i) && otherTable.contains(i)) {
-            accActivity(actTable[Activity](i), otherTable[Activity](i))
-          } else if (otherTable.contains(i)) {
-            actTable.insert(i, otherTable(i))
+        otherTable.keySet.foreach(index => {
+          if (actTable.contains(index)) {
+            accActivity(actTable[Activity](index), otherTable[Activity](index))
+          } else {
+            actTable.insert(index.asInstanceOf[Int], otherTable(index))
           }
-          i += 1
-        }
+        })
         actTable
       }
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
@@ -508,6 +508,12 @@ class Graph[T: ClassTag](val inputs : Seq[ModuleNode[T]],
         require(activity.isTensor, "Cannot add a table to a tensor")
         activity.toTensor[T].add(other.toTensor[T])
       } else {
+        // if 'activity' and 'other' are both table, we need to merge 'other' to 'activity'
+        // first find the maxIndex from two tables (their index may not be contiguous)
+        // then iterate index over [1, maxIndex],
+        // if 'other' and 'activity' both contains the index, update 'activity' by sum
+        // if 'other' contains the index while 'activity' does not,
+        // just insert the corresponding tensor to 'activity'
         val actTable = activity.toTable
         val otherTable = other.toTable
         val maxActIndex = actTable.keySet.map(_.asInstanceOf[Int]).max

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
@@ -152,7 +152,7 @@ class DirectedGraph[T](val source : Node[T], val reverse : Boolean = false) exte
     bfs.foreach(node => {
       if (reverseEdge) {
         node.nextNodesAndEdges.foreach(nextNodeAndEdge => {
-          // some node may be ignored
+          // Some next nodes may be not included in the graph
           if (oldToNew.containsKey(nextNodeAndEdge._1)) {
             oldToNew.get(nextNodeAndEdge._1).add(oldToNew.get(node), nextNodeAndEdge._2)
           }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
@@ -146,6 +146,9 @@ class DirectedGraph[T](val source : Node[T], val reverse : Boolean = false) exte
     bfs.foreach(node => {
       oldToNew.put(node, new Node[T](node.element))
     })
+    // Keep the order in the nextNodes array and prevNodes array of the current node.
+    // As we go through all node in bfs from source, the prevNodes order can be preserved.
+    // For each node, we iterate and add their nextNodes, the nextNodes order can also be preserved.
     bfs.foreach(node => {
       if (reverseEdge) {
         node.nextNodesAndEdges.foreach(nextNodeAndEdge => {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
@@ -148,12 +148,17 @@ class DirectedGraph[T](val source : Node[T], val reverse : Boolean = false) exte
     })
     bfs.foreach(node => {
       if (reverseEdge) {
-        node.prevNodesAndEdges.foreach(prevNodeAndEdge => {
-          oldToNew.get(node).add(oldToNew.get(prevNodeAndEdge._1), prevNodeAndEdge._2)
+        node.nextNodesAndEdges.foreach(nextNodeAndEdge => {
+          // some node may be ignored
+          if (oldToNew.containsKey(nextNodeAndEdge._1)) {
+            oldToNew.get(nextNodeAndEdge._1).add(oldToNew.get(node), nextNodeAndEdge._2)
+          }
         })
       } else {
-        node.prevNodesAndEdges.foreach(prevNodeAndEdge => {
-          oldToNew.get(prevNodeAndEdge._1).add(oldToNew.get(node), prevNodeAndEdge._2)
+        node.nextNodesAndEdges.foreach(nextNodeAndEdge => {
+          if (oldToNew.containsKey(nextNodeAndEdge._1)) {
+            oldToNew.get(node).add(oldToNew.get(nextNodeAndEdge._1), nextNodeAndEdge._2)
+          }
         })
       }
     })

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/DirectedGraphSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/DirectedGraphSpec.scala
@@ -315,7 +315,13 @@ class DirectedGraphSpec extends FlatSpec with Matchers {
 
     val graph = nodeA.graph()
     val cloneGraph = graph.cloneGraph()
-    graph.topologySort.map(_.element) should be(cloneGraph.topologySort.map(_.element))
+    val sort1 = graph.topologySort
+    val sort2 = cloneGraph.topologySort
+    sort1.map(_.element) should be(sort2.map(_.element))
+    sort1.zip(sort2).foreach(x => {
+      x._1.prevNodes.map(_.element) should be (x._2.prevNodes.map(_.element))
+      x._1.nextNodes.map(_.element) should be (x._2.nextNodes.map(_.element))
+    })
   }
 
   "Clone graph" should "should reuse the edge" in {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Clone graph keep their original prevs nodes and next nodes order.
Current cloneGraph may change the next nodes order, thus will influence the update of tree-lstm (it has many shared component)

In the meantime, fix a bug in graph backward that caused by the following ut

"Graph backward" should "be correct when contains nested output"

## How was this patch tested?

unit test
test over tree lstm training

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/1743

