### PR TITLE
[backport 0.3] Clone graph keep their original prevs nodes and next nodes sequence (…

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
@@ -146,14 +146,22 @@ class DirectedGraph[T](val source : Node[T], val reverse : Boolean = false) exte
     bfs.foreach(node => {
       oldToNew.put(node, new Node[T](node.element))
     })
+    // Keep the order in the nextNodes array and prevNodes array of the current node.
+    // As we go through all node in bfs from source, the prevNodes order can be preserved.
+    // For each node, we iterate and add their nextNodes, the nextNodes order can also be preserved.
     bfs.foreach(node => {
       if (reverseEdge) {
-        node.prevNodesAndEdges.foreach(prevNodeAndEdge => {
-          oldToNew.get(node).add(oldToNew.get(prevNodeAndEdge._1), prevNodeAndEdge._2)
+        node.nextNodesAndEdges.foreach(nextNodeAndEdge => {
+          // Some next nodes may be not included in the graph
+          if (oldToNew.containsKey(nextNodeAndEdge._1)) {
+            oldToNew.get(nextNodeAndEdge._1).add(oldToNew.get(node), nextNodeAndEdge._2)
+          }
         })
       } else {
-        node.prevNodesAndEdges.foreach(prevNodeAndEdge => {
-          oldToNew.get(prevNodeAndEdge._1).add(oldToNew.get(node), prevNodeAndEdge._2)
+        node.nextNodesAndEdges.foreach(nextNodeAndEdge => {
+          if (oldToNew.containsKey(nextNodeAndEdge._1)) {
+            oldToNew.get(node).add(oldToNew.get(nextNodeAndEdge._1), nextNodeAndEdge._2)
+          }
         })
       }
     })

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/DirectedGraphSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/DirectedGraphSpec.scala
@@ -315,7 +315,13 @@ class DirectedGraphSpec extends FlatSpec with Matchers {
 
     val graph = nodeA.graph()
     val cloneGraph = graph.cloneGraph()
-    graph.topologySort.map(_.element) should be(cloneGraph.topologySort.map(_.element))
+    val sort1 = graph.topologySort
+    val sort2 = cloneGraph.topologySort
+    sort1.map(_.element) should be(sort2.map(_.element))
+    sort1.zip(sort2).foreach(x => {
+      x._1.prevNodes.map(_.element) should be (x._2.prevNodes.map(_.element))
+      x._1.nextNodes.map(_.element) should be (x._2.nextNodes.map(_.element))
+    })
   }
 
   "Clone graph" should "should reuse the edge" in {


### PR DESCRIPTION
…#1763)

* Clone graph keep their original prevs nodes and next nodes sequence

* add comments

* update

* simplify table merge

## What changes were proposed in this pull request?

(Please fill in changes proposed in this patch)

## How was this patch tested?

unit test

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/1743

