### PR TITLE
enable setting path for data in python examples on master

### DIFF
--- a/docs/docs/PythonUserGuide/install-from-pip.md
+++ b/docs/docs/PythonUserGuide/install-from-pip.md
@@ -1,7 +1,7 @@
 ## **NOTES**
 
 - Pip install supports __Mac__ and __Linux__ platforms.
-- This package is built with JDK7 by default, so you need to install Java __>= JDK7__ before runing BigDL.  
+- This package is built with JDK7 by default, so you need to install Java >= JDK7 before runing BigDL.
 - Pip install only supports __local__ mode. Might support cluster mode in the future. For those who want to use BigDL in cluster mode, try to [install without pip](./install-without-pip.md).
 - We've tested this package with __Python 2.7__ and __Python 3.5__. Only these two Python versions are supported for now.
 

--- a/docs/docs/PythonUserGuide/install-from-pip.md
+++ b/docs/docs/PythonUserGuide/install-from-pip.md
@@ -1,7 +1,7 @@
 ## **NOTES**
 
 - Pip install supports __Mac__ and __Linux__ platforms.
-- This package is built with JDK7 by default, so you need to install Java >= JDK7 before runing BigDL.
+- This package is built with JDK7 by default, so you need to install Java __>= JDK7__ before runing BigDL.
 - Pip install only supports __local__ mode. Might support cluster mode in the future. For those who want to use BigDL in cluster mode, try to [install without pip](./install-without-pip.md).
 - We've tested this package with __Python 2.7__ and __Python 3.5__. Only these two Python versions are supported for now.
 

--- a/pyspark/bigdl/models/lenet/README.md
+++ b/pyspark/bigdl/models/lenet/README.md
@@ -26,7 +26,6 @@ We would train a LeNet model in spark local mode with the following commands and
 
 ```
     BigDL_HOME=...
-
     SPARK_HOME=...
     MASTER=local[*]
     PYTHON_API_ZIP_PATH=${BigDL_HOME}/dist/lib/bigdl-VERSION-python-api.zip
@@ -45,11 +44,14 @@ We would train a LeNet model in spark local mode with the following commands and
         --conf spark.driver.extraClassPath=${BigDL_JAR_PATH} \
         --conf spark.executor.extraClassPath=bigdl-VERSION-jar-with-dependencies.jar \
         ${BigDL_HOME}/pyspark/bigdl/models/lenet/lenet5.py \
-        --action train
+        --action train \
+        --dataPath /tmp/mnist
  ```
 
 
 * ```--action``` it can be train or test.
+
+* ```--dataPath``` option can be used to set the path for downloading mnist data, the default value is /tmp/mnist. Make sure that you have write permission to the specified path.
 
 * ```--batchSize``` option can be used to set batch size, the default value is 128.
 
@@ -68,10 +70,9 @@ INFO  DistriOptimizer$:247 - [Epoch 1 0/60000][Iteration 1][Wall Clock 0.0s] Tra
 
 INFO  DistriOptimizer$:522 - Top1Accuracy is Accuracy(correct: 9572, count: 10000, accuracy: 0.9572)
 
-
 ```
 
 Or you can train a LeNet model directly in shell after installing BigDL from pip:
 ```
-python .../models/lenet/lenet5.py
+python ${BigDL_HOME}/pyspark/bigdl/models/lenet/lenet5.py
 ```

--- a/pyspark/bigdl/models/lenet/lenet5.py
+++ b/pyspark/bigdl/models/lenet/lenet5.py
@@ -65,6 +65,7 @@ if __name__ == "__main__":
     parser.add_option("-c", "--checkpointPath", dest="checkpointPath", default="/tmp/lenet5")
     parser.add_option("-t", "--endTriggerType", dest="endTriggerType", default="epoch")
     parser.add_option("-n", "--endTriggerNum", type=int, dest="endTriggerNum", default="20")
+    parser.add_option("-d", "--dataPath", dest="dataPath", default="/tmp/mnist")
 
     (options, args) = parser.parse_args(sys.argv)
 
@@ -80,11 +81,11 @@ if __name__ == "__main__":
             else:
                 return MaxIteration(options.endTriggerNum)
 
-        train_data = get_mnist(sc, "train")\
+        train_data = get_mnist(sc, "train", options.dataPath)\
             .map(lambda rec_tuple: (normalizer(rec_tuple[0], mnist.TRAIN_MEAN, mnist.TRAIN_STD),
                                rec_tuple[1]))\
             .map(lambda t: Sample.from_ndarray(t[0], t[1]))
-        test_data = get_mnist(sc, "test")\
+        test_data = get_mnist(sc, "test", options.dataPath)\
             .map(lambda rec_tuple: (normalizer(rec_tuple[0], mnist.TEST_MEAN, mnist.TEST_STD),
                                rec_tuple[1]))\
             .map(lambda t: Sample.from_ndarray(t[0], t[1]))

--- a/pyspark/bigdl/models/textclassifier/README.md
+++ b/pyspark/bigdl/models/textclassifier/README.md
@@ -57,14 +57,16 @@ python ${BigDL_HOME}/pyspark/bigdl/models/textclassifier/textclassifier.py --max
             --conf spark.executor.extraClassPath=bigdl-VERSION-jar-with-dependencies.jar \
             --conf spark.executorEnv.PYTHONHASHSEED=${PYTHONHASHSEED} \
             ${BigDL_HOME}/pyspark/bigdl/models/textclassifier/textclassifier.py \
-             --max_epoch 3
-             --model cnn
+            --data_path /tmp/news20/
+            --max_epoch 3
+            --model cnn
 ```
+* `--data_path` option can be used to set the path for downloading news20 data, the default value is /tmp/news20. Make sure that you have write permission to the specified path.
 
-* `--max_epoch` option can be used to set how many epochs the model to be trained
+* `--max_epoch` option can be used to set how many epochs the model to be trained.
 
 * `--model` option can be used to choose a model to be trained, three models are supported in this example,
-which are `cnn`, `lstm` and `gru`, default is `cnn`
+which are `cnn`, `lstm` and `gru`, default is `cnn`.
 
 * `--batchSize` option can be used to set batch size, the default value is 128.
 

--- a/pyspark/bigdl/models/textclassifier/README.md
+++ b/pyspark/bigdl/models/textclassifier/README.md
@@ -57,8 +57,8 @@ python ${BigDL_HOME}/pyspark/bigdl/models/textclassifier/textclassifier.py --max
             --conf spark.executor.extraClassPath=bigdl-VERSION-jar-with-dependencies.jar \
             --conf spark.executorEnv.PYTHONHASHSEED=${PYTHONHASHSEED} \
             ${BigDL_HOME}/pyspark/bigdl/models/textclassifier/textclassifier.py \
-            --data_path /tmp/news20/
-            --max_epoch 3
+            --data_path /tmp/news20/ \
+            --max_epoch 3 \
             --model cnn
 ```
 * `--data_path` option can be used to set the path for downloading news20 data, the default value is /tmp/news20. Make sure that you have write permission to the specified path.

--- a/pyspark/bigdl/models/textclassifier/textclassifier.py
+++ b/pyspark/bigdl/models/textclassifier/textclassifier.py
@@ -99,11 +99,11 @@ def build_model(class_num):
     return model
 
 
-def train(sc,
+def train(sc, data_path,
           batch_size,
           sequence_len, max_words, embedding_dim, training_split):
     print('Processing text dataset')
-    texts = news20.get_news20()
+    texts = news20.get_news20(source_dir=data_path)
     data_rdd = sc.parallelize(texts, 2)
 
     word_to_ic = analyze_texts(data_rdd)
@@ -155,6 +155,7 @@ if __name__ == "__main__":
     parser.add_option("-m", "--max_epoch", dest="max_epoch", default="15")
     parser.add_option("--model", dest="model_type", default="cnn")
     parser.add_option("-p", "--p", dest="p", default="0.0")
+    parser.add_option("-d", "--data_path", dest="data_path", default="/tmp/news20/")
 
     (options, args) = parser.parse_args(sys.argv)
     if options.action == "train":
@@ -168,10 +169,11 @@ if __name__ == "__main__":
         training_split = 0.8
         sc = SparkContext(appName="text_classifier",
                           conf=create_spark_conf())
+        data_path = options.data_path
         redire_spark_logs()
         show_bigdl_info_logs()
         init_engine()
-        train(sc,
+        train(sc, data_path,
               batch_size,
               sequence_len, max_words, embedding_dim, training_split)
         sc.stop()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix #1764 on master branch.
Enable users to pass argument --dataPath to set path for downloading dataset in lenet, textclassifier examples python.
Update README accordingly.

## How was this patch tested?

Locally test file download path and jenkins.
