### PR TITLE
MapTable: Add module back in clearstate

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MapTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MapTable.scala
@@ -132,6 +132,9 @@ class MapTable[T: ClassTag](
 
   override def clearState(): this.type = {
     modules.clear()
+    if ( module != null) {
+      this.add(module)
+    }
     this
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/MapTableSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/MapTableSpec.scala
@@ -75,4 +75,12 @@ class MapTableSpec  extends FlatSpec with Matchers {
 
     mapGradInput should equal (expectedGradInput)
   }
+
+  "A MapTable clearstate" should "add not change modules" in {
+    val linear1 = new Linear[Float](10, 3)
+    val map = new MapTable[Float](linear1)
+
+    map.clearState()
+    map.modules.length should be (1)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

MapTable: Add module back in clearstate

## How was this patch tested?
unit test

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/1765

