### PR TITLE
update deploy script

### DIFF
--- a/docs/docs/ScalaUserGuide/install-build-src.md
+++ b/docs/docs/ScalaUserGuide/install-build-src.md
@@ -37,24 +37,7 @@ After that, you can find a `dist` folder, which contains all the needed files to
 * **dist/lib/bigdl-VERSION-python-api.zip**: This zip package contains all Python files of BigDL.
 * **dist/conf/spark-bigdl.conf**: This file contains necessary property configurations. ```Engine.createSparkConf``` will populate these properties, so try to use that method in your code. Or you need to pass the file to Spark with the "--properties-file" option. 
 
-
-## **Build for MacOS**
-
-The instructions above will only build for Linux. To build BigDL for macOS, pass `-P mac` to the `make-dist.sh` script as follows:
-```bash
-$ bash make-dist.sh -P mac
-```
-
-## **Build for Windows**
-
-To build BigDL for Windows, pass `-P win64` to the build command:
-```bash
-> mvn clean package -DskipTests -P win64
-```
-
-Please note that we only test it on Windows 10
-
-* **Build for Spark 2.0 and above**
+## **Build for Spark 2.0 and above**
 
 The instructions above will build BigDL with Spark 1.5.x or 1.6.x (using Scala 2.10); to build for Spark 2.0 and above (which uses Scala 2.11 by default), pass `-P spark_2.x` to the `make-dist.sh` script:
 ```bash

--- a/docs/docs/ScalaUserGuide/install-build-src.md
+++ b/docs/docs/ScalaUserGuide/install-build-src.md
@@ -98,8 +98,6 @@ After that, you can find that the three jar packages in `PATH_To_BigDL`/target/,
 
 Note that the instructions above will build BigDL with Spark 1.5.x or 1.6.x (using Scala 2.10) for Linux, and skip the build of native library code. Similarly, you may customize the default behaviors by passing the following parameters to maven:
 
- - `-P mac`: build for maxOS
- - `-P win64`: build for windows
  - `-P spark_2.x`: build for Spark 2.0 and above (using Scala 2.11). (Again, it is highly recommended to use _**Java 8**_ when running with Spark 2.0; otherwise you may observe very poor performance.)
  * `-P full-build`: full build
  * `-P scala_2.10` (or `-P scala_2.11`): build using Scala 2.10 (or Scala 2.11) 

--- a/pom.xml
+++ b/pom.xml
@@ -578,25 +578,9 @@
             </modules>
         </profile>
         <profile>
-            <id>mac</id>
-            <properties>
-                <mkl-java-os-version>mkl-java-mac</mkl-java-os-version>
-                <bigquant-java-os-version>bigquant-java-mac</bigquant-java-os-version>
-                <os-flag>mac</os-flag>
-            </properties>
-        </profile>
-        <profile>
             <id>rh5</id>
             <properties>
                 <mkl-java-os-version>mkl-java-rh5</mkl-java-os-version>
-            </properties>
-        </profile>
-        <profile>
-            <id>win64</id>
-            <properties>
-                <mkl-java-os-version>mkl-java-win64</mkl-java-os-version>
-                <bigquant-java-os-version>bigquant-java-win64</bigquant-java-os-version>
-                <os-flag>win64</os-flag>
             </properties>
         </profile>
         <profile>

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -64,16 +64,12 @@ function deploy {
     cd spark-version && mvn deploy -DskipTests -P sign -Dspark.version=$1 -DSPARK_PLATFORM=$2 $3 && cd ..
     cd dl && mvn deploy -DskipTests -P sign -Dspark.version=$1 -DSPARK_PLATFORM=$2 $3 && cd ..
     cd dist && mvn deploy -DskipTests -P sign -Dspark.version=$1 -DSPARK_PLATFORM=$2 $3 && cd ..
-    mvn clean install -DskipTests -P sign -Dspark.version=$1 -DSPARK_PLATFORM=$2 -P mac $3
-    cd dist && mvn deploy -DskipTests -P sign -Dspark.version=$1 -DSPARK_PLATFORM=$2 -P mac $3 && cd ..
-    mvn clean install -DskipTests -P sign -Dspark.version=$1 -DSPARK_PLATFORM=$2 -P win64 $3
-    cd dist && mvn deploy -DskipTests -P sign -Dspark.version=$1 -DSPARK_PLATFORM=$2 -P win64 $3 && cd ..
 }
 
 deploy 1.5.2 SPARK_1.5 ''
 deploy 1.6.2 SPARK_1.6 ''
-deploy 2.0.2 SPARK_2.0 '-P spark_2.x'
 deploy 2.1.1 SPARK_2.1 '-P spark_2.x'
+deploy 2.2.0 SPARK_2.2 '-P spark_2.x'
 
 mv dl/pom.xml.origin dl/pom.xml
 mv spark-version/1.5-plus/pom.xml.origin spark-version/1.5-plus/pom.xml


### PR DESCRIPTION
## What changes were proposed in this pull request?
update deploy script. Remove win64/mac release as we package them together now. And replace spark 2.0.0 release with 2.2.0.


