### PR TITLE
fix: update rh5 and get back of other profiles because Python needs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -578,9 +578,26 @@
             </modules>
         </profile>
         <profile>
+            <id>mac</id>
+            <properties>
+                <mkl-java-os-version>mkl-java-mac</mkl-java-os-version>
+                <bigquant-java-os-version>bigquant-java-mac</bigquant-java-os-version>
+                <os-flag>mac</os-flag>
+            </properties>
+        </profile>
+        <profile>
             <id>rh5</id>
             <properties>
                 <mkl-java-os-version>mkl-java-rh5</mkl-java-os-version>
+                <bigquant-java-os-version>bigquant-java-rh5</bigquant-java-os-version>
+            </properties>
+        </profile>
+        <profile>
+            <id>win64</id>
+            <properties>
+                <mkl-java-os-version>mkl-java-win64</mkl-java-os-version>
+                <bigquant-java-os-version>bigquant-java-win64</bigquant-java-os-version>
+                <os-flag>win64</os-flag>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
## What changes were proposed in this pull request?
For rh5, we should combine two profiles, `per_platform` and `rh5`.
So the commands is: `./make-dist.sh -P per_platform -P rh5`.

## How was this patch tested?
Manually test.

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

