### PR TITLE
fix: change mkl threads to user defined.

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
@@ -140,7 +140,7 @@ object Engine {
   @volatile private var _default: ThreadPool = null
 
   // Thread pool for layer use
-  @volatile private var _model: ThreadPool = new ThreadPool(1).setMKLThread(MKL.getNumThreads)
+  @volatile private var _model: ThreadPool = new ThreadPool(1).setMKLThread(MKL.getMklNumThreads)
 
   /**
    * If user undefine the property bigdl.coreNumber, it will return physical core number
@@ -253,7 +253,7 @@ object Engine {
 
     if(_model == null || _model.getPoolSize != modelPoolSize) {
       _model = new ThreadPool(modelPoolSize)
-      _model.setMKLThread(MKL.getNumThreads)
+      _model.setMKLThread(MKL.getMklNumThreads)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`getNumThreads` will return the threads number omp set. `getMklNumThreads` will return the threads number user wants. Here we should use `getMklNumThreads`.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If it is possible, please attach a screenshot; otherwise, remove this)

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

