### PR TITLE
Fix install doc and model example issue

### DIFF
--- a/docs/docs/APIGuide/Module.md
+++ b/docs/docs/APIGuide/Module.md
@@ -79,7 +79,7 @@ val testSet = sc.parallelize(Seq(testSample))
 
 //train a new model or load an existing model
 //val model=...
-val evaluateResult = model.evaluate(testSet, Array(new Top1Accuracy))
+val evaluateResult = model.evaluate(testSet, Array(new Top1Accuracy), None)
 ```
 
 **Python example**
@@ -128,7 +128,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 //create some dummy dataset for prediction as example
 val feature = Tensor(10).rand()
 val label = Tensor(1).randn()
-val predictSample = Sample(feature, label)
+val predictSample = Sample(feature)
 val predictSet = sc.parallelize(Seq(predictSample))
 
 //train a new model or load an existing model

--- a/docs/docs/APIGuide/Module.md
+++ b/docs/docs/APIGuide/Module.md
@@ -127,7 +127,6 @@ import com.intel.analytics.bigdl.tensor.Tensor
 
 //create some dummy dataset for prediction as example
 val feature = Tensor(10).rand()
-val label = Tensor(1).randn()
 val predictSample = Sample(feature)
 val predictSet = sc.parallelize(Seq(predictSample))
 

--- a/docs/docs/ScalaUserGuide/install-pre-built.md
+++ b/docs/docs/ScalaUserGuide/install-pre-built.md
@@ -9,48 +9,17 @@ Currently, BigDL releases are hosted on maven central; here's an example to add 
 ```xml
 <dependency>
     <groupId>com.intel.analytics.bigdl</groupId>
-    <artifactId>bigdl</artifactId>
+    <artifactId>bigdl-[SPARK_1.5|SPARK_1.6|SPARK_2.1|SPARK_2.2]</artifactId>
     <version>${BIGDL_VERSION}</version>
 </dependency>
 ```
+Please choose the suffix according to your Spark platform.
+
 SBT developers can use
 ```sbt
-libraryDependencies += "com.intel.analytics.bigdl" % "bigdl" % "${BIGDL_VERSION}"
+libraryDependencies += "com.intel.analytics.bigdl" % "bigdl-[SPARK_1.5|SPARK_1.6|SPARK_2.1|SPARK_2.2]" % "${BIGDL_VERSION}"
 ```
 You can find the optional `${BIGDL_VERSION}` from the [Release Page](../release-download.md).
-
-*Note*: the BigDL lib default supports Spark 1.5.x and 1.6.x; if your project runs on Spark 2.0 and 2.1, use this
-```xml
-<dependency>
-    <groupId>com.intel.analytics.bigdl</groupId>
-    <artifactId>bigdl-SPARK_2.0</artifactId>
-    <version>${BIGDL_VERSION}</version>
-</dependency>
-```
-
-SBT developers can use
-```sbt
-libraryDependencies += "com.intel.analytics.bigdl" % "bigdl-SPARK_2.0" % "${BIGDL_VERSION}"
-```
-
-If your project runs on MacOS, you should add the dependency below,
-```xml
-<dependency>
-    <groupId>com.intel.analytics.bigdl.native</groupId>
-    <artifactId>mkl-java-mac</artifactId>
-    <version>${BIGDL_VERSION}</version>
-    <exclusions>
-        <exclusion>
-            <groupId>com.intel.analytics.bigdl.native</groupId>
-            <artifactId>bigdl-native</artifactId>
-        </exclusion>
-    </exclusions>
-</dependency>
-```
-SBT developers can use
-```sbt
-libraryDependencies += "com.intel.analytics.bigdl.native" % "mkl-java-mac" % "${BIGDL_VERSION}" from "http://repo1.maven.org/maven2/com/intel/analytics/bigdl/native/mkl-java-mac/${BIGDL_VERSION}/mkl-java-mac-${BIGDL_VERSION}.jar"
-```
 
 --- 
 ## **Link with a development version**


### PR DESCRIPTION
## What changes were proposed in this pull request?
The maven/sbt example in the install doc page is out of data. The PR fixes it.

Some scala example code in model.predict and model.evaluate is not correct. Also is fixed in this PR.

## How was this patch tested?
only document change

https://github.com/intel-analytics/BigDL/issues/1837 and https://github.com/intel-analytics/BigDL/issues/1836

