### PR TITLE
use shade to package jar-with-dependencies

### DIFF
--- a/spark/dl/pom.xml
+++ b/spark/dl/pom.xml
@@ -167,11 +167,6 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.0.0</version>
                 <configuration>
-                    <artifactSet>
-                        <includes>
-                            <include>com.google.protobuf</include>
-                        </includes>
-                    </artifactSet>
                     <filters>
                         <filter>
                             <artifact>com.google.protobuf</artifact>
@@ -189,30 +184,36 @@
                 </configuration>
                 <executions>
                     <execution>
+			            <id>shade</id>
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.google.protobuf</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                    <execution>
+			            <id>without-spark</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+			                <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
-                    <execution>
-                        <id>without-spark</id>
-                        <configuration>
-                            <descriptorRefs>
-                                <descriptorRef>jar-with-dependencies</descriptorRef>
-                            </descriptorRefs>
-                        </configuration>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
                     <execution>
                         <id>with-spark</id>
                         <configuration>

--- a/spark/dl/pom.xml
+++ b/spark/dl/pom.xml
@@ -184,7 +184,7 @@
                 </configuration>
                 <executions>
                     <execution>
-			            <id>shade</id>
+                        <id>shade</id>
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
@@ -198,13 +198,13 @@
                         </configuration>
                     </execution>
                     <execution>
-			            <id>without-spark</id>
+                        <id>without-spark</id>
                         <phase>package</phase>
                         <goals>
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-			                <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## What changes were proposed in this pull request?

use shade to package jar-with-dependencies to exclude protobuf.

## How was this patch tested?

unit tests

## Related links or issues (optional)
fixed #1833 

