### PR TITLE
update download link in doc pages

### DIFF
--- a/docs/docs/release-download.md
+++ b/docs/docs/release-download.md
@@ -10,10 +10,10 @@ Here are the folders for nightly build packages. The packages are built from lat
 
 |               | Download Link |
 | ------------- | --------- |
-| Spark 1.5.2   | [download](https://oss.sonatype.org/content/groups/public/com/intel/analytics/bigdl/dist-spark-1.5.2-scala-2.10.5-linux64/0.3.0-SNAPSHOT/) |
-| Spark 1.6.2   | [download](https://oss.sonatype.org/content/groups/public/com/intel/analytics/bigdl/dist-spark-1.6.2-scala-2.10.5-linux64/0.3.0-SNAPSHOT/) |
-| Spark 2.0.2   | [download](https://oss.sonatype.org/content/groups/public/com/intel/analytics/bigdl/dist-spark-2.0.2-scala-2.11.8-linux64/0.3.0-SNAPSHOT/) |
-| Spark 2.1.1   | [download](https://oss.sonatype.org/content/groups/public/com/intel/analytics/bigdl/dist-spark-2.1.1-scala-2.11.8-linux64/0.3.0-SNAPSHOT/) |
+| Spark 1.5.2   | [download](https://oss.sonatype.org/content/groups/public/com/intel/analytics/bigdl/dist-spark-1.5.2-scala-2.10.5-linux64/0.4.0-SNAPSHOT/) |
+| Spark 1.6.2   | [download](https://oss.sonatype.org/content/groups/public/com/intel/analytics/bigdl/dist-spark-1.6.2-scala-2.10.5-linux64/0.4.0-SNAPSHOT/) |
+| Spark 2.1.1   | [download](https://oss.sonatype.org/content/groups/public/com/intel/analytics/bigdl/dist-spark-2.1.1-scala-2.11.8-linux64/0.4.0-SNAPSHOT/) |
+| Spark 2.2.0   | [download](https://oss.sonatype.org/content/groups/public/com/intel/analytics/bigdl/dist-spark-2.2.0-scala-2.11.8-linux64/0.4.0-SNAPSHOT/) |
 
 
 --- 
@@ -21,10 +21,10 @@ Here are the folders for nightly build packages. The packages are built from lat
 ## **Release 0.3.0**
 |               | Download Link (for Linux x64, Mac and Win64) |
 | ------------- | --------- |
-| Spark 1.5.2   | [download](https://repo1.maven.org/maven2/com/intel/analytics/bigdl/dist-spark-1.5.2-scala-2.10.5-linux64/0.3.0/dist-spark-1.5.2-scala-2.10.5-linux64-0.3.0-dist.zip) |
-| Spark 1.6.2   | [download](https://repo1.maven.org/maven2/com/intel/analytics/bigdl/dist-spark-1.6.2-scala-2.10.5-linux64/0.3.0/dist-spark-1.6.2-scala-2.10.5-linux64-0.3.0-dist.zip) |
-| Spark 2.1.1   | [download](https://repo1.maven.org/maven2/com/intel/analytics/bigdl/dist-spark-2.1.1-scala-2.11.8-linux64/0.3.0/dist-spark-2.1.1-scala-2.11.8-linux64-0.3.0-dist.zip) |
-| Spark 2.2.0   | [download](https://repo1.maven.org/maven2/com/intel/analytics/bigdl/dist-spark-2.2.0-scala-2.11.8-linux64/0.3.0/dist-spark-2.2.0-scala-2.11.8-linux64-0.3.0-dist.zip) |
+| Spark 1.5.2   | [download](https://s3-ap-southeast-1.amazonaws.com/bigdl-download/dist-spark-1.5.2-scala-2.10.5-0.3.0-dist.zip) |
+| Spark 1.6.2   | [download](https://s3-ap-southeast-1.amazonaws.com/bigdl-download/dist-spark-1.6.2-scala-2.10.5-0.3.0-dist.zip) |
+| Spark 2.1.1   | [download](https://s3-ap-southeast-1.amazonaws.com/bigdl-download/dist-spark-2.1.1-scala-2.11.8-0.3.0-dist.zip) |
+| Spark 2.2.0   | [download](https://s3-ap-southeast-1.amazonaws.com/bigdl-download/dist-spark-2.2.0-scala-2.11.8-0.3.0-dist.zip) |
 
 
 --- 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Update the nightly download links and move the release download of 0.3.0 to s3 files

## How was this patch tested?
only doc change, manual test

