### PR TITLE
Support keras squared_hinge and sparse_categorial_crossentropy

### DIFF
--- a/docs/docs/APIGuide/Losses.md
+++ b/docs/docs/APIGuide/Losses.md
@@ -263,11 +263,11 @@ Gives the gradInput,
 
 **Scala:**
 ```scala
-val criterion = ClassNLLCriterion(weights = null, sizeAverage = true, acceptProb=false)
+val criterion = ClassNLLCriterion(weights = null, sizeAverage = true, logProbAsInput=true)
 ```
 **Python:**
 ```python
-criterion = ClassNLLCriterion(weights=None, size_average=True, acceptProb=False)
+criterion = ClassNLLCriterion(weights=None, size_average=True, logProbAsInput=true)
 ```
 
 The negative log likelihood criterion. It is useful to train a classification problem with n
@@ -275,12 +275,13 @@ classes. If provided, the optional argument weights should be a 1D Tensor assign
 each of the classes. This is particularly useful when you have an unbalanced training set.
 
 The input given through a `forward()` is expected to contain log-probabilities/probabilities of each class:
-input has to be a 1D Tensor of size `n`. Obtaining log-probabilities in a neural network is easily
-achieved by adding a `LogSoftMax` layer in the last layer of your neural network. You may use
+input has to be a 1D Tensor of size `n`. Obtaining log-probabilities/probabilities in a neural network is easily
+achieved by adding a `LogSoftMax`/`SoftMax` layer in the last layer of your neural network. You may use
 `CrossEntropyCriterion` instead, if you prefer not to add an extra layer to your network. This
 criterion expects a class index (1 to the number of class) as target when calling
 `forward(input, target)` and `backward(input, target)`.
 
+ In the log-probabilities case,
  The loss can be described as:
      `loss(x, class) = -x[class]`
  or in the case of the weights argument it is specified as follows:
@@ -300,8 +301,8 @@ Parameters:
 * `weights` weights of each element of the input
 * `sizeAverage` A boolean indicating whether normalizing by the number of elements in the input.
                   Default: true
-* `acceptProb` indicating whether to accept log-probabilities or probabilities as input. True means accepting
-               probabilities as input.
+* `logProbAsInput` indicating whether to accept log-probabilities or probabilities as input. True means accepting
+               log-probabilities as input.
 
 **Scala example:**
 ```scala

--- a/docs/docs/APIGuide/Losses.md
+++ b/docs/docs/APIGuide/Losses.md
@@ -263,18 +263,18 @@ Gives the gradInput,
 
 **Scala:**
 ```scala
-val criterion = ClassNLLCriterion(weights = null, sizeAverage = true)
+val criterion = ClassNLLCriterion(weights = null, sizeAverage = true, acceptProb=false)
 ```
 **Python:**
 ```python
-criterion = ClassNLLCriterion(weights=None, size_average=True)
+criterion = ClassNLLCriterion(weights=None, size_average=True, acceptProb=False)
 ```
 
 The negative log likelihood criterion. It is useful to train a classification problem with n
 classes. If provided, the optional argument weights should be a 1D Tensor assigning weight to
 each of the classes. This is particularly useful when you have an unbalanced training set.
 
-The input given through a `forward()` is expected to contain log-probabilities of each class:
+The input given through a `forward()` is expected to contain log-probabilities/probabilities of each class:
 input has to be a 1D Tensor of size `n`. Obtaining log-probabilities in a neural network is easily
 achieved by adding a `LogSoftMax` layer in the last layer of your neural network. You may use
 `CrossEntropyCriterion` instead, if you prefer not to add an extra layer to your network. This
@@ -300,6 +300,8 @@ Parameters:
 * `weights` weights of each element of the input
 * `sizeAverage` A boolean indicating whether normalizing by the number of elements in the input.
                   Default: true
+* `acceptProb` indicating whether to accept log-probabilities or probabilities as input. True means accepting
+               probabilities as input.
 
 **Scala example:**
 ```scala
@@ -799,16 +801,17 @@ creating: createHingeEmbeddingCriterion
 
 **Scala:**
 ```scala
-criterion = MarginCriterion(margin=1.0, sizeAverage=true)
+criterion = MarginCriterion(margin=1.0, sizeAverage=true, squared=false)
 ```
 **Python:**
 ```python
-criterion = MarginCriterion(margin=1.0, sizeAverage=true, bigdl_type="float")
+criterion = MarginCriterion(margin=1.0, sizeAverage=True, squared=False, bigdl_type="float")
 ```
 
-Creates a criterion that optimizes a two-class classification hinge loss (margin-based loss) between input x (a Tensor of dimension 1) and output y.
+Creates a criterion that optimizes a two-class classification (squared) hinge loss (margin-based loss) between input x (a Tensor of dimension 1) and output y.
  * `margin` if unspecified, is by default 1.
  * `sizeAverage` whether to average the loss, is by default true
+ * `squared` whether to calculate the squared hinge loss
 
 **Scala example:**
 ```scala

--- a/pyspark/bigdl/nn/criterion.py
+++ b/pyspark/bigdl/nn/criterion.py
@@ -359,10 +359,12 @@ class MarginCriterion(Criterion):
     def __init__(self,
                  margin=1.0,
                  size_average=True,
+                 squared=False,
                  bigdl_type="float"):
         super(MarginCriterion, self).__init__(None, bigdl_type,
                                               margin,
-                                              size_average)
+                                              size_average,
+                                              squared)
 
 
 class MarginRankingCriterion(Criterion):

--- a/pyspark/bigdl/nn/criterion.py
+++ b/pyspark/bigdl/nn/criterion.py
@@ -350,6 +350,7 @@ class MarginCriterion(Criterion):
 
     :param margin: if unspecified, is by default 1.
     :param size_average: size average in a mini-batch
+    :param squared: whether to calculate the squared hinge loss
 
 
     >>> marginCriterion = MarginCriterion(1e-5, True, False)

--- a/pyspark/bigdl/nn/criterion.py
+++ b/pyspark/bigdl/nn/criterion.py
@@ -103,13 +103,14 @@ class ClassNLLCriterion(Criterion):
     classes. If provided, the optional argument weights should be a 1D Tensor assigning weight to
     each of the classes. This is particularly useful when you have an unbalanced training set.
 
-    The input given through a forward() is expected to contain log-probabilities of each class:
-    input has to be a 1D Tensor of size n. Obtaining log-probabilities in a neural network is easily
-    achieved by adding a LogSoftMax layer in the last layer of your neural network. You may use
-    CrossEntropyCriterion instead, if you prefer not to add an extra layer to your network. This
-    criterion expects a class index (1 to the number of class) as target when calling
-    forward(input, target) and backward(input, target).
+    The input given through a forward() is expected to contain log-probabilities/probabilities of
+    each class: input has to be a 1D Tensor of size n. Obtaining log-probabilities/probabilities
+    in a neural network is easily achieved by adding a LogSoftMax/SoftMax layer in the last layer
+    of your neural network. You may use CrossEntropyCriterion instead, if you prefer not to add an
+    extra layer to your network. This criterion expects a class index (1 to the number of class) as
+    target when calling forward(input, target) and backward(input, target).
 
+    In the log-probabilities case,
     The loss can be described as:
         loss(x, class) = -x[class]
     or in the case of the weights argument it is specified as follows:
@@ -127,11 +128,12 @@ class ClassNLLCriterion(Criterion):
 
     :param weights: weights of each class
     :param size_average: whether to average or not
+    :param logProbAsInput: indicating whether to accept log-probabilities or probabilities as input.
 
 
     >>> np.random.seed(123)
     >>> weights = np.random.uniform(0, 1, (2,)).astype("float32")
-    >>> classNLLCriterion = ClassNLLCriterion(weights,True, False)
+    >>> classNLLCriterion = ClassNLLCriterion(weights, True, True)
     creating: createClassNLLCriterion
     >>> classNLLCriterion = ClassNLLCriterion()
     creating: createClassNLLCriterion
@@ -140,10 +142,11 @@ class ClassNLLCriterion(Criterion):
     def __init__(self,
                  weights=None,
                  size_average=True,
+                 logProbAsInput=True,
                  bigdl_type="float"):
         super(ClassNLLCriterion, self).__init__(None, bigdl_type,
                                                 JTensor.from_ndarray(weights),
-                                                size_average)
+                                                size_average, logProbAsInput)
 
 
 class MSECriterion(Criterion):

--- a/pyspark/bigdl/nn/criterion.py
+++ b/pyspark/bigdl/nn/criterion.py
@@ -131,7 +131,7 @@ class ClassNLLCriterion(Criterion):
 
     >>> np.random.seed(123)
     >>> weights = np.random.uniform(0, 1, (2,)).astype("float32")
-    >>> classNLLCriterion = ClassNLLCriterion(weights,True)
+    >>> classNLLCriterion = ClassNLLCriterion(weights,True, False)
     creating: createClassNLLCriterion
     >>> classNLLCriterion = ClassNLLCriterion()
     creating: createClassNLLCriterion
@@ -349,7 +349,7 @@ class MarginCriterion(Criterion):
     :param size_average: size average in a mini-batch
 
 
-    >>> marginCriterion = MarginCriterion(1e-5, True)
+    >>> marginCriterion = MarginCriterion(1e-5, True, False)
     creating: createMarginCriterion
     '''
 

--- a/pyspark/bigdl/nn/criterion.py
+++ b/pyspark/bigdl/nn/criterion.py
@@ -125,6 +125,9 @@ class ClassNLLCriterion(Criterion):
     By default, the losses are averaged over observations for each minibatch. However, if the field
     sizeAverage is set to false, the losses are instead summed for each minibatch.
 
+    In particular, when weights=None, size_average=True and logProbAsInput=False, this is same as
+    `sparse_categorical_crossentropy` loss in keras.
+
 
     :param weights: weights of each class
     :param size_average: whether to average or not
@@ -347,6 +350,8 @@ class MarginCriterion(Criterion):
     Creates a criterion that optimizes a two-class classification hinge loss (margin-based loss)
     between input x (a Tensor of dimension 1) and output y.
 
+    When margin = 1, size_average = True and squared = False, this is the same as hinge loss in keras;
+    When margin = 1, size_average = False and squared = True, this is the same as squared_hinge loss in keras.
 
     :param margin: if unspecified, is by default 1.
     :param size_average: size average in a mini-batch

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterion.scala
@@ -53,6 +53,9 @@ import com.intel.analytics.bigdl.utils.Engine
  * By default, the losses are averaged over observations for each minibatch. However, if the field
  * sizeAverage is set to false, the losses are instead summed for each minibatch.
  *
+ * In particular, when weights=None, size_average=True and logProbAsInput=False, this is same as
+ * `sparse_categorical_crossentropy` loss in keras.
+ *
  * @param weights weights of each element of the input
  * @param sizeAverage size average of batch
  * @param logProbAsInput indicating whether to accept log-probabilities or probabilities as input.

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MarginCriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MarginCriterion.scala
@@ -25,6 +25,10 @@ import scala.reflect.ClassTag
  * Creates a criterion that optimizes a two-class classification (squared)
  * hinge loss (margin-based loss) between input x (a Tensor of dimension 1) and output y.
  *
+ * When margin = 1, sizeAverage = True and squared = False, this is the same as hinge loss in keras;
+ * When margin = 1, sizeAverage = False and squared = True, this is the same as squared_hinge loss
+ * in keras.
+ *
  * @param margin if unspecified, is by default 1.
  * @param sizeAverage whether to average the loss
  * @param squared whether to calculate the squared hinge loss

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -1419,10 +1419,10 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   }
 
   def createClassNLLCriterion(weights: JTensor = null,
-    sizeAverage: Boolean = true)
+    sizeAverage: Boolean = true, acceptProb: Boolean = false)
   : ClassNLLCriterion[T] = {
     ClassNLLCriterion[T](if (weights == null) null else toTensor(weights),
-      sizeAverage)
+      sizeAverage, acceptProb)
   }
 
   def createMSECriterion: MSECriterion[T] = {
@@ -1470,10 +1470,10 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   }
 
   def createMarginCriterion(margin: Double = 1.0,
-    sizeAverage: Boolean = true)
+    sizeAverage: Boolean = true, squared: Boolean = false)
   : MarginCriterion[T] = {
     MarginCriterion[T](margin,
-      sizeAverage)
+      sizeAverage, squared)
   }
 
   def createMarginRankingCriterion(margin: Double = 1.0,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -1419,10 +1419,10 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   }
 
   def createClassNLLCriterion(weights: JTensor = null,
-    sizeAverage: Boolean = true, acceptProb: Boolean = false)
+    sizeAverage: Boolean = true, logProbAsInput: Boolean = true)
   : ClassNLLCriterion[T] = {
     ClassNLLCriterion[T](if (weights == null) null else toTensor(weights),
-      sizeAverage, acceptProb)
+      sizeAverage, logProbAsInput)
   }
 
   def createMSECriterion: MSECriterion[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/TensorNumeric.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/TensorNumeric.scala
@@ -190,6 +190,8 @@ object TensorNumericMath {
     def truncate(a: T): T
 
     def floorDiv(a: T, b: T): T
+
+    def clip(a: T, lower: T, upper: T): T
   }
 
   /**
@@ -450,6 +452,10 @@ object TensorNumericMath {
     override def floorDiv(a: T, b: T): T =
       throw new UnsupportedOperationException(typeName +
         " in tensor does not support floorDiv operation")
+
+    def clip(a: T, lower: T, upper: T): T =
+      throw new UnsupportedOperationException(typeName +
+        " in tensor does not support clip operation")
   }
 
   /**
@@ -759,6 +765,12 @@ object TensorNumericMath {
       override def floorDiv(a: Float, b: Float): Float = {
         Math.floor(a / b).toFloat
       }
+
+      override def clip(a: Float, lower: Float, upper: Float): Float = {
+        require(lower <= upper, "lower bound must be less or equal than upper bound")
+        math.min(math.max(a, lower), upper)
+      }
+
     }
 
     implicit object NumericDouble extends UndefinedTensorNumeric[Double]("Double") {
@@ -1057,6 +1069,11 @@ object TensorNumericMath {
 
       override def floorDiv(a: Double, b: Double): Double = {
         Math.floor(a / b)
+      }
+
+      override def clip(a: Double, lower: Double, upper: Double): Double = {
+        require(lower <= upper, "lower bound must be less or equal than upper bound")
+        math.min(math.max(a, lower), upper)
       }
     }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterionSpec.scala
@@ -234,4 +234,52 @@ class ClassNLLCriterionSpec extends FlatSpec with Matchers {
       v1
     })
   }
+
+  "A ClassNLL Criterion with probabilities input" should "generate correct output and grad" in {
+
+    val input = Tensor[Float](Array(4, 4)).rand()
+    val target = Tensor[Float](Array[Float](1, 2, 3, 4), Array(4))
+
+    val logSoftMax = LogSoftMax[Float]()
+    val softMax = SoftMax[Float]()
+
+    val logProb = logSoftMax.forward(input)
+    val prob = softMax.forward(input)
+
+    val referenceLayer = ClassNLLCriterion[Float]()
+    val testedLayer = ClassNLLCriterion[Float](acceptProb = true)
+
+    val expectedLoss = referenceLayer.forward(logProb, target)
+    val loss = testedLayer.forward(prob, target)
+
+    val expectedGradInput = logSoftMax.backward(input, referenceLayer.backward(logProb, target))
+    val gradInput = softMax.backward(input, testedLayer.backward(prob, target))
+
+    math.abs(expectedLoss - loss) < 1e-5 should be (true)
+    expectedGradInput.almostEqual(gradInput, 1e-5) should be (true)
+  }
+
+  "A ClassNLL Criterion with probabilities input 1d" should "generate correct output and grad" in {
+
+    val input = Tensor[Float](Array(4)).rand()
+    val target = Tensor[Float](Array[Float](4), Array(1))
+
+    val logSoftMax = LogSoftMax[Float]()
+    val softMax = SoftMax[Float]()
+
+    val logProb = logSoftMax.forward(input)
+    val prob = softMax.forward(input)
+
+    val referenceLayer = ClassNLLCriterion[Float]()
+    val testedLayer = ClassNLLCriterion[Float](acceptProb = true)
+
+    val expectedLoss = referenceLayer.forward(logProb, target)
+    val loss = testedLayer.forward(prob, target)
+
+    val expectedGradInput = logSoftMax.backward(input, referenceLayer.backward(logProb, target))
+    val gradInput = softMax.backward(input, testedLayer.backward(prob, target))
+
+    math.abs(expectedLoss - loss) < 1e-5 should be (true)
+    expectedGradInput.almostEqual(gradInput, 1e-5) should be (true)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterionSpec.scala
@@ -247,7 +247,7 @@ class ClassNLLCriterionSpec extends FlatSpec with Matchers {
     val prob = softMax.forward(input)
 
     val referenceLayer = ClassNLLCriterion[Float]()
-    val testedLayer = ClassNLLCriterion[Float](acceptProb = true)
+    val testedLayer = ClassNLLCriterion[Float](logProbAsInput = false)
 
     val expectedLoss = referenceLayer.forward(logProb, target)
     val loss = testedLayer.forward(prob, target)
@@ -271,7 +271,7 @@ class ClassNLLCriterionSpec extends FlatSpec with Matchers {
     val prob = softMax.forward(input)
 
     val referenceLayer = ClassNLLCriterion[Float]()
-    val testedLayer = ClassNLLCriterion[Float](acceptProb = true)
+    val testedLayer = ClassNLLCriterion[Float](logProbAsInput = false)
 
     val expectedLoss = referenceLayer.forward(logProb, target)
     val loss = testedLayer.forward(prob, target)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/MarginCriterionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/MarginCriterionSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn
+
+import com.intel.analytics.bigdl.tensor.Tensor
+import org.scalatest.{FlatSpec, Matchers}
+
+
+class MarginCriterionSpec extends FlatSpec with Matchers {
+
+  "MarginCriterion " should "calculate correct squared hinge loss" in {
+    val input = Tensor[Float](Array[Float](0.1f, 0.2f, 0.3f, 0.4f), Array(4))
+    val target = Tensor[Float](Array[Float](0.4f, 0.3f, 0.2f, 0.1f), Array(4))
+
+    val criterion = MarginCriterion[Float](squared = true)
+
+    val loss = criterion.forward(input, target)
+
+    val gradInput = criterion.backward(input, target)
+    val expectedGradInput =
+      Tensor[Float](Array[Float](-0.192f, -0.141f, -0.094f, -0.048f), Array(4))
+
+    math.abs(loss - 0.9026) < 1e-5 should be (true)
+
+    gradInput.almostEqual(expectedGradInput, 1e-5) should be (true)
+
+  }
+
+  "MarginCriterion " should "calculate correct squared hinge loss 2" in {
+    val input = Tensor[Float](Array[Float](1f, 0.2f, 3f, 0.4f), Array(4))
+    val target = Tensor[Float](Array[Float](4f, 0.3f, 2f, 0.1f), Array(4))
+
+    val criterion = MarginCriterion[Float](squared = true)
+
+    val loss = criterion.forward(input, target)
+
+    val gradInput = criterion.backward(input, target)
+    val expectedGradInput =
+      Tensor[Float](Array[Float](-0.0f, -0.141f, -0.0f, -0.048f), Array(4))
+
+    math.abs(loss - 0.4513) < 1e-5 should be (true)
+
+    gradInput.almostEqual(expectedGradInput, 1e-5) should be (true)
+
+  }
+
+  "MarginCriterion " should "calculate correct hinge loss" in {
+    val input = Tensor[Float](Array[Float](0.1f, 0.2f, 0.3f, 0.4f), Array(4))
+    val target = Tensor[Float](Array[Float](0.4f, 0.3f, 0.2f, 0.1f), Array(4))
+
+    val criterion = MarginCriterion[Float](sizeAverage = false)
+
+    val loss = criterion.forward(input, target)
+
+    val gradInput = criterion.backward(input, target)
+    val expectedGradInput =
+      Tensor[Float](Array[Float](-0.4f, -0.3f, -0.2f, -0.1f), Array(4))
+
+    math.abs(loss - 3.8) < 1e-5 should be (true)
+
+    gradInput.almostEqual(expectedGradInput, 1e-5) should be (true)
+
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support keras squared_hinge and sparse_categorial_cross_entropy

squared_hinge -> MarginCriterion(1.0, True, True)
sparse_categorial_crossentropy -> ClassNLLCriterion(null, True, False)

## How was this patch tested?

added unit tests

