### PR TITLE
add GaussianDropout, GaussianNoise and unit tests, python wrapper

### DIFF
--- a/docs/docs/APIGuide/Layers/Dropout-Layers.md
+++ b/docs/docs/APIGuide/Layers/Dropout-Layers.md
@@ -70,3 +70,99 @@ Output is
        [ 0.,  0.,  0.,  0.]], dtype=float32)]
 ```
 
+
+## GaussianDropout
+
+**Scala:**
+```scala
+val module = GaussianDropout(rate)
+```
+**Python:**
+```python
+module = GaussianDropout(rate)
+```
+
+Apply multiplicative 1-centered Gaussian noise.
+As it is a regularization layer, it is only active at training time.
+
+* `rate` is drop probability (as with `Dropout`).
+
+Reference: [Dropout: A Simple Way to Prevent Neural Networks from Overfitting Srivastava, Hinton, et al. 2014](http://www.cs.toronto.edu/~rsalakhu/papers/srivastava14a.pdf)
+
+**Scala example:**
+```scala
+scala> layer.training()
+res0: layer.type = GaussianDropout[fa8b4a5](0.5)
+
+scala> val input = Tensor(T(T(1.0,1.0,1.0),T(1.0,1.0,1.0)))
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+1.0     1.0     1.0
+1.0     1.0     1.0
+[com.intel.analytics.bigdl.tensor.DenseTensor$mcF$sp of size 2x3]
+
+scala> val output = layer.forward(input)
+output: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+-0.6049535      1.6871624       0.3253751
+1.2154467       1.4057124       2.019263
+[com.intel.analytics.bigdl.tensor.DenseTensor$mcF$sp of size 2x3]
+
+scala> val gradout = Tensor(T(T(1.0,1.0,1.0),T(1.0,1.0,1.0)))
+gradout: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+1.0     1.0     1.0
+1.0     1.0     1.0
+[com.intel.analytics.bigdl.tensor.DenseTensor$mcF$sp of size 2x3]
+
+scala> val gradin = layer.backward(input,gradout)
+gradin: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+-0.6049535      1.6871624       0.3253751
+1.2154467       1.4057124       2.019263
+[com.intel.analytics.bigdl.tensor.DenseTensor$mcF$sp of size 2x3]
+
+scala> layer.evaluate()
+res1: layer.type = GaussianDropout[fa8b4a5](0.5)
+
+scala> val output = layer.forward(input)
+output: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+1.0     1.0     1.0
+1.0     1.0     1.0
+[com.intel.analytics.bigdl.tensor.DenseTensor$mcF$sp of size 2x3]
+```
+
+**Python example:**
+```python
+```
+Output is
+```
+```
+
+## GaussianNoise
+
+**Scala:**
+```scala
+val module = GaussianNoise(stddev)
+```
+**Python:**
+```python
+module = GaussianNoise(stddev)
+```
+
+Apply additive zero-centered Gaussian noise. This is useful to mitigate overfitting (you could see it as a form of random data augmentation).
+Gaussian Noise (GS) is a natural choice as corruption process for real valued inputs.
+
+As it is a regularization layer, it is only active at training time.
+
+* `stddev` is the standard deviation of the noise distribution.
+
+**Scala example:**
+```scala
+```
+Output is
+```
+```
+
+**Python example:**
+```python
+```
+Output is
+```
+```

--- a/docs/docs/APIGuide/Layers/Dropout-Layers.md
+++ b/docs/docs/APIGuide/Layers/Dropout-Layers.md
@@ -91,8 +91,15 @@ Reference: [Dropout: A Simple Way to Prevent Neural Networks from Overfitting Sr
 
 **Scala example:**
 ```scala
+scala> import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric.NumericFloat
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric.NumericFloat
+
+scala> val layer = GaussianDropout(0.5)
+2017-11-27 14:03:48 INFO  ThreadPool$:79 - Set mkl threads to 1 on thread 1
+layer: com.intel.analytics.bigdl.nn.GaussianDropout[Float] = GaussianDropout[668c68cd](0.5)
+
 scala> layer.training()
-res0: layer.type = GaussianDropout[fa8b4a5](0.5)
+res0: layer.type = GaussianDropout[668c68cd](0.5)
 
 scala> val input = Tensor(T(T(1.0,1.0,1.0),T(1.0,1.0,1.0)))
 input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
@@ -102,8 +109,8 @@ input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
 
 scala> val output = layer.forward(input)
 output: com.intel.analytics.bigdl.tensor.Tensor[Float] =
--0.6049535      1.6871624       0.3253751
-1.2154467       1.4057124       2.019263
+1.1833225       1.1171452       0.27325004
+0.436912        0.9357152       0.47588816
 [com.intel.analytics.bigdl.tensor.DenseTensor$mcF$sp of size 2x3]
 
 scala> val gradout = Tensor(T(T(1.0,1.0,1.0),T(1.0,1.0,1.0)))
@@ -114,12 +121,12 @@ gradout: com.intel.analytics.bigdl.tensor.Tensor[Float] =
 
 scala> val gradin = layer.backward(input,gradout)
 gradin: com.intel.analytics.bigdl.tensor.Tensor[Float] =
--0.6049535      1.6871624       0.3253751
-1.2154467       1.4057124       2.019263
+1.4862849       1.0372512       0.91885364
+-0.18087652     2.3662233       0.9388555
 [com.intel.analytics.bigdl.tensor.DenseTensor$mcF$sp of size 2x3]
 
 scala> layer.evaluate()
-res1: layer.type = GaussianDropout[fa8b4a5](0.5)
+res1: layer.type = GaussianDropout[668c68cd](0.5)
 
 scala> val output = layer.forward(input)
 output: com.intel.analytics.bigdl.tensor.Tensor[Float] =
@@ -130,9 +137,33 @@ output: com.intel.analytics.bigdl.tensor.Tensor[Float] =
 
 **Python example:**
 ```python
+layer = GaussianDropout(0.5) # Try to create a Linear layer
+
+#training mode
+layer.training()
+inp=np.ones([2,1])
+outp = layer.forward(inp)
+
+gradoutp = np.ones([2,1])
+gradinp = layer.backward(inp,gradoutp)
+print "training:forward=",outp
+print "trainig:backward=",gradinp
+
+#evaluation mode
+layer.evaluate()
+print "evaluate:forward=",layer.forward(inp)
+
 ```
 Output is
 ```
+creating: createGaussianDropout
+training:forward= [[ 0.80695641]
+ [ 1.82794702]]
+trainig:backward= [[ 0.1289842 ]
+ [ 1.22549391]]
+evaluate:forward= [[ 1.]
+ [ 1.]]
+
 ```
 
 ## GaussianNoise
@@ -155,14 +186,72 @@ As it is a regularization layer, it is only active at training time.
 
 **Scala example:**
 ```scala
-```
-Output is
-```
+scala> val layer = GaussianNoise(0.2)
+layer: com.intel.analytics.bigdl.nn.GaussianNoise[Float] = GaussianNoise[77daa92e](0.2)
+
+scala> layer.training()
+res3: layer.type = GaussianNoise[77daa92e](0.2)
+
+scala> val input = Tensor(T(T(1.0,1.0,1.0),T(1.0,1.0,1.0)))
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+1.0     1.0     1.0
+1.0     1.0     1.0
+[com.intel.analytics.bigdl.tensor.DenseTensor$mcF$sp of size 2x3]
+
+scala> val output = layer.forward(input)
+output: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+1.263781        0.91440135      0.928574
+0.88923925      1.1450694       0.97276205
+[com.intel.analytics.bigdl.tensor.DenseTensor$mcF$sp of size 2x3]
+
+scala> val gradout = Tensor(T(T(1.0,1.0,1.0),T(1.0,1.0,1.0)))
+gradout: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+1.0     1.0     1.0
+1.0     1.0     1.0
+[com.intel.analytics.bigdl.tensor.DenseTensor$mcF$sp of size 2x3]
+
+scala> val gradin = layer.backward(input,gradout)
+gradin: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+1.0     1.0     1.0
+1.0     1.0     1.0
+[com.intel.analytics.bigdl.tensor.DenseTensor$mcF$sp of size 2x3]
+
+scala> layer.evaluate()
+res2: layer.type = GaussianNoise[77daa92e](0.2)
+
+scala> val output = layer.forward(input)
+output: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+1.0     1.0     1.0
+1.0     1.0     1.0
+[com.intel.analytics.bigdl.tensor.DenseTensor$mcF$sp of size 2x3]
 ```
 
 **Python example:**
 ```python
+layer = GaussianNoise(0.5) 
+
+#training mode
+layer.training()
+inp=np.ones([2,1])
+outp = layer.forward(inp)
+
+gradoutp = np.ones([2,1])
+gradinp = layer.backward(inp,gradoutp)
+print "training:forward=",outp
+print "trainig:backward=",gradinp
+
+#evaluation mode
+layer.evaluate()
+print "evaluate:forward=",layer.forward(inp)
+
 ```
 Output is
 ```
+creating: createGaussianNoise
+training:forward= [[ 0.99984151]
+ [ 1.11269045]]
+trainig:backward= [[ 1.]
+ [ 1.]]
+evaluate:forward= [[ 1.]
+ [ 1.]]
 ```

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -1689,6 +1689,49 @@ class Dropout(Layer):
                                       scale)
 
 
+class GaussianDropout(Layer):
+
+    '''
+    Apply multiplicative 1-centered Gaussian noise.
+    The multiplicative noise will have standard deviation `sqrt(rate / (1 - rate)).
+
+    As it is a regularization layer, it is only active at training time.
+
+    :param rate: drop probability (as with `Dropout`).
+
+
+    >>> GaussianDropout = GaussianDropout(0.5)
+    creating: createGaussianDropout
+    '''
+
+    def __init__(self,
+                 rate,
+                 bigdl_type="float"):
+        super(GaussianDropout, self).__init__(None, bigdl_type,
+                                              rate)
+
+
+class GaussianNoise(Layer):
+
+    '''
+    Apply additive zero-centered Gaussian noise.
+    This is useful to mitigate overfitting
+    (you could see it as a form of random data augmentation).
+    Gaussian Noise (GS) is a natural choice as corruption process for real valued inputs.
+
+    As it is a regularization layer, it is only active at training time.
+
+    :param stdev: standard deviation of the noise distribution
+
+    >>> GaussianNoise = GaussianNoise(0.5)
+    creating: createGaussianNoise
+    '''
+    def __init__(self,
+                 stddev,
+                 bigdl_type="float"):
+        super(GaussianNoise, self).__init__(None, bigdl_type,
+                                            stddev)
+
 class View(Layer):
 
     '''

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GaussianDropout.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GaussianDropout.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn
+
+import com.intel.analytics.bigdl.nn.abstractnn.TensorModule
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+
+import scala.reflect.ClassTag
+
+/**
+ * Apply multiplicative 1-centered Gaussian noise.
+ * The multiplicative noise will have standard deviation `sqrt(rate / (1 - rate)).
+ *
+ * As it is a regularization layer, it is only active at training time.
+ *
+ * Output shape is the same as input.
+ *
+ *
+ * @param rate double, drop probability (as with `Dropout`).
+ *
+ */
+
+@SerialVersionUID(- 1575781981601306833L)
+class GaussianDropout[T: ClassTag](
+   val rate: Double
+  )(implicit ev: TensorNumeric[T]) extends TensorModule[T]{
+
+  var noise = Tensor[T]()
+
+  val stddev:Double = Math.sqrt(rate / (1.0-rate))
+
+  override def updateOutput(input: Tensor[T]): Tensor[T] = {
+    //TODO may support inplace
+    this.output.resizeAs(input).copy(input)
+
+    if(train) {
+      noise.resizeAs(input)
+      noise.randn(1.0,stddev)
+      this.output.cmul(noise)
+    } else {
+      this.output
+    }
+  }
+
+  override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
+
+    if (train){
+      //TODO, support inplace update
+      this.gradInput.resizeAs(gradOutput).copy(gradOutput)
+      this.gradInput.cmul(noise)
+    } else {
+      throw new IllegalArgumentException("backprop only defined while training")
+    }
+    this.gradInput
+  }
+
+  override def toString(): String = {
+    s"${getPrintName}($rate)"
+  }
+
+
+  override def clearState(): this.type = {
+    super.clearState()
+    noise.set()
+    this
+  }
+}
+
+object GaussianDropout {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    rate: Double
+    )(implicit ev: TensorNumeric[T]) : GaussianDropout[T] = {
+    new GaussianDropout[T](rate)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GaussianDropout.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GaussianDropout.scala
@@ -41,15 +41,15 @@ class GaussianDropout[T: ClassTag](
 
   var noise = Tensor[T]()
 
-  val stddev:Double = Math.sqrt(rate / (1.0-rate))
+  val stddev: Double = Math.sqrt(rate / (1.0-rate))
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
-    //TODO may support inplace
+
     this.output.resizeAs(input).copy(input)
 
     if(train) {
       noise.resizeAs(input)
-      noise.randn(1.0,stddev)
+      noise.randn(1.0, stddev)
       this.output.cmul(noise)
     } else {
       this.output
@@ -58,8 +58,7 @@ class GaussianDropout[T: ClassTag](
 
   override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
 
-    if (train){
-      //TODO, support inplace update
+    if (train) {
       this.gradInput.resizeAs(gradOutput).copy(gradOutput)
       this.gradInput.cmul(noise)
     } else {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GaussianNoise.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GaussianNoise.scala
@@ -40,13 +40,13 @@ class GaussianNoise[T: ClassTag](
    val stddev: Double
   )(implicit ev: TensorNumeric[T]) extends TensorModule[T]{
 
-  var noise = Tensor[T]()
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
 
     this.output.resizeAs(input).copy(input)
 
     if(train) {
+      val noise = Tensor[T]()
       noise.resizeAs(input)
       noise.randn(0.0, stddev)
       this.output.add(noise)
@@ -70,11 +70,6 @@ class GaussianNoise[T: ClassTag](
   }
 
 
-  override def clearState(): this.type = {
-    super.clearState()
-    noise.set()
-    this
-  }
 }
 
 object GaussianNoise {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GaussianNoise.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GaussianNoise.scala
@@ -43,12 +43,12 @@ class GaussianNoise[T: ClassTag](
   var noise = Tensor[T]()
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
-    //TODO may support inplace
+
     this.output.resizeAs(input).copy(input)
 
     if(train) {
       noise.resizeAs(input)
-      noise.randn(0.0,stddev)
+      noise.randn(0.0, stddev)
       this.output.add(noise)
     } else {
       this.output
@@ -57,8 +57,7 @@ class GaussianNoise[T: ClassTag](
 
   override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
 
-    if (train){
-      //TODO, support inplace update
+    if (train) {
       this.gradInput.resizeAs(gradOutput).copy(gradOutput)
     } else {
       throw new IllegalArgumentException("backprop only defined while training")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GaussianNoise.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GaussianNoise.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn
+
+import com.intel.analytics.bigdl.nn.abstractnn.TensorModule
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+
+import scala.reflect.ClassTag
+
+/**
+ * Apply additive zero-centered Gaussian noise.
+ * This is useful to mitigate overfitting (you could see it as a form of random data
+ * augmentation).
+ * Gaussian Noise (GS) is a natural choice as corruption process for real valued inputs.
+ * As it is a regularization layer, it is only active at training time.
+ *
+ * Output shape is the same as input.
+ *
+ *
+ * @param stddev double, standard deviation of the noise distribution.
+ *
+ */
+
+@SerialVersionUID(- 2590701089601246637L)
+class GaussianNoise[T: ClassTag](
+   val stddev: Double
+  )(implicit ev: TensorNumeric[T]) extends TensorModule[T]{
+
+  var noise = Tensor[T]()
+
+  override def updateOutput(input: Tensor[T]): Tensor[T] = {
+    //TODO may support inplace
+    this.output.resizeAs(input).copy(input)
+
+    if(train) {
+      noise.resizeAs(input)
+      noise.randn(0.0,stddev)
+      this.output.add(noise)
+    } else {
+      this.output
+    }
+  }
+
+  override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
+
+    if (train){
+      //TODO, support inplace update
+      this.gradInput.resizeAs(gradOutput).copy(gradOutput)
+    } else {
+      throw new IllegalArgumentException("backprop only defined while training")
+    }
+    this.gradInput
+  }
+
+  override def toString(): String = {
+    s"${getPrintName}($stddev)"
+  }
+
+
+  override def clearState(): this.type = {
+    super.clearState()
+    noise.set()
+    this
+  }
+}
+
+object GaussianNoise {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    stddev: Double
+    )(implicit ev: TensorNumeric[T]) : GaussianNoise[T] = {
+    new GaussianNoise[T](stddev)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -527,6 +527,16 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
     Dropout[T](initP, inplace, scale)
   }
 
+  def createGaussianDropout(rate: Double)
+  : GaussianDropout[T] = {
+    GaussianDropout[T](rate)
+  }
+
+  def createGaussianNoise(stddev: Double)
+  : GaussianNoise[T] = {
+    GaussianNoise[T](stddev)
+  }
+
   def createView(sizes: JList[Int], num_input_dims: Int = 0): View[T] = {
     View[T](sizes.asScala.toArray).setNumInputDims(num_input_dims)
   }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GaussianDropoutSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GaussianDropoutSpec.scala
@@ -33,19 +33,19 @@ class GaussianDropoutSpec extends FlatSpec with Matchers {
     val gradOutput = Tensor[Double](batchN, outputN).rand()
 
     val module = new GaussianDropout[Double](0.5)
-    //training mode
+    // training mode
     module.training()
     val output = module.forward(input)
-    //check size, output should be same size as input
-    assertIntArrayEqual(output.size(),input.size())
+    // check size, output should be same size as input
+    assertIntArrayEqual(output.size(), input.size())
 
     val gradInput = module.backward(input, gradOutput)
-    assertIntArrayEqual(gradInput.size(),gradOutput.size())
+    assertIntArrayEqual(gradInput.size(), gradOutput.size())
 
-    //evaluation mode
+    // evaluation mode
     module.evaluate()
     val outputEval = module.forward(input)
-    //output should be the same as input
+    // output should be the same as input
     assert(input equals outputEval)
 
   }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GaussianDropoutSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GaussianDropoutSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn
+
+import com.intel.analytics.bigdl.tensor.Tensor
+import org.scalatest.{FlatSpec, Matchers}
+
+  /**
+  * Unit test for GussianDropout.
+  */
+@com.intel.analytics.bigdl.tags.Parallel
+class GaussianDropoutSpec extends FlatSpec with Matchers {
+  "GaussianDropout" should "run through without problem" in {
+    val batchN = 3
+    val inputN = 5
+    val outputN = inputN
+
+    val input = Tensor[Double](batchN, inputN).rand()
+    val gradOutput = Tensor[Double](batchN, outputN).rand()
+
+    val module = new GaussianDropout[Double](0.5)
+    //training mode
+    module.training()
+    val output = module.forward(input)
+    //check size, output should be same size as input
+    assertIntArrayEqual(output.size(),input.size())
+
+    val gradInput = module.backward(input, gradOutput)
+    assertIntArrayEqual(gradInput.size(),gradOutput.size())
+
+    //evaluation mode
+    module.evaluate()
+    val outputEval = module.forward(input)
+    //output should be the same as input
+    assert(input equals outputEval)
+
+  }
+
+  def assertIntArrayEqual(a1: Array[Int], a2: Array[Int]): Unit = {
+    (a1 zip a2).foreach(x => assert(x._1 == x._2))
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GaussianDropoutSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GaussianDropoutSpec.scala
@@ -20,17 +20,18 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import org.scalatest.{FlatSpec, Matchers}
 
   /**
-  * Unit test for GussianDropout.
+  * Unit test for GaussianDropout.
   */
 @com.intel.analytics.bigdl.tags.Parallel
 class GaussianDropoutSpec extends FlatSpec with Matchers {
-  "GaussianDropout" should "run through without problem" in {
+  "GaussianDropout" should "run through without problem in training mode" in {
     val batchN = 3
     val inputN = 5
     val outputN = inputN
 
     val input = Tensor[Double](batchN, inputN).rand()
     val gradOutput = Tensor[Double](batchN, outputN).rand()
+
 
     val module = new GaussianDropout[Double](0.5)
     // training mode
@@ -41,12 +42,35 @@ class GaussianDropoutSpec extends FlatSpec with Matchers {
 
     val gradInput = module.backward(input, gradOutput)
     assertIntArrayEqual(gradInput.size(), gradOutput.size())
+  }
 
-    // evaluation mode
+  "GaussianDropout" should "run correctly in evaluation mode" in {
+    val batchN = 3
+    val inputN = 5
+    val outputN = inputN
+
+    val input = Tensor[Double](batchN, inputN).rand()
+    val gradOutput = Tensor[Double](batchN, outputN).rand()
+
+    val module = new GaussianDropout[Double](0.5)
     module.evaluate()
     val outputEval = module.forward(input)
     // output should be the same as input
     assert(input equals outputEval)
+    // backward reports error in evaluation mode
+    intercept[IllegalArgumentException] {
+      module.backward(input, gradOutput)
+    }
+
+  }
+
+  "GaussianDropout" should "throw exception for illegal rate argument" in {
+    intercept[IllegalArgumentException] {
+      val module = new GaussianDropout[Double](-0.1)
+    }
+    intercept[IllegalArgumentException] {
+      val module = new GaussianDropout[Double](2)
+    }
 
   }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GaussianNoiseSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GaussianNoiseSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn
+
+import com.intel.analytics.bigdl.tensor.Tensor
+import org.scalatest.{FlatSpec, Matchers}
+
+  /**
+  * Unit test for GaussianNoise
+  */
+@com.intel.analytics.bigdl.tags.Parallel
+class GaussianNoiseSpec extends FlatSpec with Matchers {
+  "GaussianNoise" should "run through correctly" in {
+    val batchN = 3
+    val inputN = 5
+    val outputN = inputN
+
+    val input = Tensor[Double](batchN, inputN).rand()
+    val gradOutput = Tensor[Double](batchN, outputN).rand()
+
+    val module = new GaussianNoise[Double](0.2)
+
+    //training mode
+    module.training()
+    val output = module.forward(input)
+    assertIntArrayEqual(output.size(),input.size())
+
+    val gradInput = module.backward(input, gradOutput)
+    assertIntArrayEqual(gradInput.size(),gradOutput.size())
+
+    //evaluation mode
+    module.evaluate()
+    val outputEval = module.forward(input)
+    //output should be the same as input
+    assert(input equals outputEval)
+
+  }
+
+  def assertIntArrayEqual(a1: Array[Int], a2: Array[Int]): Unit = {
+    (a1 zip a2).foreach(x => assert(x._1 == x._2))
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GaussianNoiseSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GaussianNoiseSpec.scala
@@ -34,18 +34,18 @@ class GaussianNoiseSpec extends FlatSpec with Matchers {
 
     val module = new GaussianNoise[Double](0.2)
 
-    //training mode
+    // training mode
     module.training()
     val output = module.forward(input)
-    assertIntArrayEqual(output.size(),input.size())
+    assertIntArrayEqual(output.size(), input.size())
 
     val gradInput = module.backward(input, gradOutput)
-    assertIntArrayEqual(gradInput.size(),gradOutput.size())
+    assertIntArrayEqual(gradInput.size(), gradOutput.size())
 
-    //evaluation mode
+    // evaluation mode
     module.evaluate()
     val outputEval = module.forward(input)
-    //output should be the same as input
+    // output should be the same as input
     assert(input equals outputEval)
 
   }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GaussianNoiseSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/GaussianNoiseSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.{FlatSpec, Matchers}
   */
 @com.intel.analytics.bigdl.tags.Parallel
 class GaussianNoiseSpec extends FlatSpec with Matchers {
-  "GaussianNoise" should "run through correctly" in {
+  "GaussianNoise" should "run through in training mode" in {
     val batchN = 3
     val inputN = 5
     val outputN = inputN
@@ -42,12 +42,27 @@ class GaussianNoiseSpec extends FlatSpec with Matchers {
     val gradInput = module.backward(input, gradOutput)
     assertIntArrayEqual(gradInput.size(), gradOutput.size())
 
+  }
+
+  "GaussianNoise" should "run correctly in evaluation mode" in {
+    val batchN = 3
+    val inputN = 5
+    val outputN = inputN
+
+    val input = Tensor[Double](batchN, inputN).rand()
+    val gradOutput = Tensor[Double](batchN, outputN).rand()
+
+    val module = new GaussianNoise[Double](0.2)
+
     // evaluation mode
     module.evaluate()
     val outputEval = module.forward(input)
     // output should be the same as input
     assert(input equals outputEval)
 
+    intercept[IllegalArgumentException] {
+      module.backward(input, gradOutput)
+    }
   }
 
   def assertIntArrayEqual(a1: Array[Int], a2: Array[Int]): Unit = {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/ModuleSerializerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/ModuleSerializerSpec.scala
@@ -582,9 +582,9 @@ class ModuleSerializerSpec extends FlatSpec with Matchers {
     tensor2.resizeAs(tensor1).copy(tensor1)
     val res1 = gd.forward(tensor1)
 
-    ModulePersister.saveToFile("/tmp/dropout.bigdl", gd, true)
+    ModulePersister.saveToFile("/tmp/gaussianDropout.bigdl", gd, true)
     RNG.setSeed(100)
-    val loadedGd = ModuleLoader.loadFromFile("/tmp/dropout.bigdl")
+    val loadedGd = ModuleLoader.loadFromFile("/tmp/gaussianDropout.bigdl")
     val res2 = loadedGd.forward(tensor2)
     res1 should be (res2)
   }
@@ -598,9 +598,9 @@ class ModuleSerializerSpec extends FlatSpec with Matchers {
     tensor2.resizeAs(tensor1).copy(tensor1)
     val res1 = gn.forward(tensor1)
 
-    ModulePersister.saveToFile("/tmp/dropout.bigdl", gn, true)
+    ModulePersister.saveToFile("/tmp/gaussianNoise.bigdl", gn, true)
     RNG.setSeed(100)
-    val loadedGn = ModuleLoader.loadFromFile("/tmp/dropout.bigdl")
+    val loadedGn = ModuleLoader.loadFromFile("/tmp/gaussianNoise.bigdl")
     val res2 = loadedGn.forward(tensor2)
     res1 should be (res2)
   }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/ModuleSerializerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/ModuleSerializerSpec.scala
@@ -573,6 +573,38 @@ class ModuleSerializerSpec extends FlatSpec with Matchers {
     res1 should be (res2)
   }
 
+  "GaussianDropout serializer" should "work properly" in {
+    RNG.setSeed(100)
+    val gd = GaussianDropout(0.5)
+
+    val tensor1 = Tensor(10).apply1(_ => Random.nextFloat())
+    val tensor2 = Tensor()
+    tensor2.resizeAs(tensor1).copy(tensor1)
+    val res1 = gd.forward(tensor1)
+
+    ModulePersister.saveToFile("/tmp/dropout.bigdl", gd, true)
+    RNG.setSeed(100)
+    val loadedGd = ModuleLoader.loadFromFile("/tmp/dropout.bigdl")
+    val res2 = loadedGd.forward(tensor2)
+    res1 should be (res2)
+  }
+
+  "GaussianNoise serializer" should "work properly" in {
+    RNG.setSeed(100)
+    val gn = GaussianNoise(0.5)
+
+    val tensor1 = Tensor(10).apply1(_ => Random.nextFloat())
+    val tensor2 = Tensor()
+    tensor2.resizeAs(tensor1).copy(tensor1)
+    val res1 = gn.forward(tensor1)
+
+    ModulePersister.saveToFile("/tmp/dropout.bigdl", gn, true)
+    RNG.setSeed(100)
+    val loadedGn = ModuleLoader.loadFromFile("/tmp/dropout.bigdl")
+    val res2 = loadedGn.forward(tensor2)
+    res1 should be (res2)
+  }
+
   "GradientReversal serializer" should "work properly" in {
     val gradientReversal = GradientReversal()
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added 2 noise layers for Keras:  GaussianDropout, GaussianNoise, with unit tests, python wrapper, serializatoin test.. 

## How was this patch tested?

PR validation test passed. 

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

Do we need compare with Keras? How to deal with random numbers?