### PR TITLE
An Activity wrapper for python to simplify the returning value

### DIFF
--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -118,6 +118,13 @@ def get_dtype(bigdl_type):
     # Always return float32 for now
     return "float32"
 
+
+class JActivity(object):
+
+    def __init__(self, value):
+        self.value = value
+
+
 class JTensor(object):
     """
     A wrapper to easy our work when need to pass or return Tensor to/from Scala.
@@ -362,7 +369,8 @@ _picklable_classes = [
     'LabeledPoint',
     'Sample',
     'EvaluatedResult',
-    'JTensor'
+    'JTensor',
+    'JActivity'
 ]
 
 

--- a/pyspark/test/bigdl/test_pickler.py
+++ b/pyspark/test/bigdl/test_pickler.py
@@ -54,15 +54,14 @@ class TestPickler():
         back = callBigDlFunc("float", "testActivityWithTableOfTensor")
         assert isinstance(back.value, list)
         assert isinstance(back.value[0], JTensor)
-        print(back)
+        assert back.value[0].to_ndarray()[0] < back.value[1].to_ndarray()[0]
+        assert back.value[1].to_ndarray()[0] < back.value[2].to_ndarray()[0]
 
     def test_activity_with_table_of_table(self):
         back = callBigDlFunc("float", "testActivityWithTableOfTable")
         assert isinstance(back.value, list)
         assert isinstance(back.value[0], list)
         assert isinstance(back.value[0][0], JTensor)
-        print(back)
-
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/pyspark/test/bigdl/test_pickler.py
+++ b/pyspark/test/bigdl/test_pickler.py
@@ -1,0 +1,68 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from bigdl.nn.layer import *
+from bigdl.nn.initialization_method import *
+from bigdl.nn.criterion import *
+from bigdl.optim.optimizer import *
+from bigdl.util.common import *
+from bigdl.util.common import _py2java
+from bigdl.nn.initialization_method import *
+from bigdl.dataset import movielens
+import numpy as np
+import tempfile
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+from bigdl.util.engine import compare_version
+np.random.seed(1337)  # for reproducibility
+
+
+class TestPickler():
+    def setup_method(self, method):
+        """ setup any state tied to the execution of the given method in a
+        class.  setup_method is invoked for every test method of a class.
+        """
+        JavaCreator.set_creator_class("com.intel.analytics.bigdl.python.api.PythonBigDLValidator")
+        sparkConf = create_spark_conf().setMaster("local[4]").setAppName("test model")
+        self.sc = get_spark_context(sparkConf)
+        init_engine()
+
+    def teardown_method(self, method):
+        """ teardown any state that was previously setup with a setup_method
+        call.
+        """
+        self.sc.stop()
+
+    def test_activity_with_jtensor(self):
+        back = callBigDlFunc("float", "testActivityWithTensor")
+        assert isinstance(back.value, JTensor)
+
+    def test_activity_with_table_of_tensor(self):
+        back = callBigDlFunc("float", "testActivityWithTableOfTensor")
+        assert isinstance(back.value, list)
+        assert isinstance(back.value[0], JTensor)
+        print(back)
+
+    def test_activity_with_table_of_table(self):
+        back = callBigDlFunc("float", "testActivityWithTableOfTable")
+        assert isinstance(back.value, list)
+        assert isinstance(back.value[0], list)
+        assert isinstance(back.value[0][0], JTensor)
+        print(back)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
@@ -23,7 +23,10 @@ import java.nio.charset.StandardCharsets
 import java.nio.{ByteBuffer, ByteOrder}
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, Map => JMap}
 
-import com.intel.analytics.bigdl.python.api.{EvaluatedResult, JTensor, Sample}
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.python.api._
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Table
 import net.razorvine.pickle._
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.api.python.SerDeUtil
@@ -223,6 +226,45 @@ object BigDLSerDe extends BigDLSerDeBase with Serializable {
     }
   }
 
+  private[python] class JActivityPickler extends BigDLBasePickler[JActivity] {
+    private def doConvertTable(table: Table): Any = {
+      val tMap = table.getState()
+      if (tMap.isEmpty) {
+        throw new RuntimeException("Found empty table")
+      }
+      if (tMap.values.iterator.next().isInstanceOf[Activity]) {
+        return tMap.values.map { value =>
+          doConvertActivity(value.asInstanceOf[Activity])
+        }.toList.asJava
+      } else {
+        throw new RuntimeException(s"""not supported type:
+          ${tMap.values.iterator.next().getClass.getSimpleName}""")
+      }
+    }
+    private def doConvertActivity(activity: Activity): Any = {
+      if (activity.isTable) {
+        return doConvertTable(activity.toTable)
+      } else if (activity.isTensor) {
+        return PythonBigDL.ofFloat().toJTensor(activity.toTensor)
+      } else {
+        throw new RuntimeException(s"""not supported type:
+          ${activity.getClass.getSimpleName}""")
+      }
+    }
+
+    def saveState(obj: Object, out: OutputStream, pickler: Pickler): Unit = {
+      val record = obj.asInstanceOf[JActivity]
+      saveObjects(out,
+        pickler,
+        doConvertActivity(record.value))
+    }
+
+    def construct(args: Array[Object]): Object = {
+      throw new RuntimeException("haven't be implemented")
+    }
+  }
+
+
   private[python] class TestResultPickler extends BigDLBasePickler[EvaluatedResult] {
 
     def saveState(obj: Object, out: OutputStream, pickler: Pickler): Unit = {
@@ -286,6 +328,7 @@ object BigDLSerDe extends BigDLSerDeBase with Serializable {
         new SamplePickler().register()
         new TestResultPickler().register()
         new JTensorPickler().register()
+        new JActivityPickler().register()
         initialized = true
       }
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
@@ -25,7 +25,6 @@ import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, M
 
 import com.intel.analytics.bigdl.nn.abstractnn.Activity
 import com.intel.analytics.bigdl.python.api._
-import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Table
 import net.razorvine.pickle._
 import org.apache.spark.api.java.JavaRDD
@@ -34,7 +33,6 @@ import org.apache.spark.mllib.api.python.SerDe
 import org.apache.spark.rdd.RDD
 
 import scala.collection.JavaConverters._
-import scala.collection.immutable.ListMap
 import scala.language.existentials
 import scala.reflect.ClassTag
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
@@ -227,7 +227,7 @@ object BigDLSerDe extends BigDLSerDeBase with Serializable {
 
   private[python] class JActivityPickler extends BigDLBasePickler[JActivity] {
     private def doConvertTable(table: Table): Any = {
-      val valuesOrderByKey = table.toSeqActivity
+      val valuesOrderByKey = table.toSeq[Activity]
       if (valuesOrderByKey.isEmpty) {
         throw new RuntimeException("Found empty table")
       }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
@@ -227,7 +227,7 @@ object BigDLSerDe extends BigDLSerDeBase with Serializable {
 
   private[python] class JActivityPickler extends BigDLBasePickler[JActivity] {
     private def doConvertTable(table: Table): Any = {
-      val valuesOrderByKey = table.toSeq[Float]
+      val valuesOrderByKey = table.toSeqActivity
       if (valuesOrderByKey.isEmpty) {
         throw new RuntimeException("Found empty table")
       }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/BigDLSerde.scala
@@ -227,19 +227,11 @@ object BigDLSerDe extends BigDLSerDeBase with Serializable {
 
   private[python] class JActivityPickler extends BigDLBasePickler[JActivity] {
     private def doConvertTable(table: Table): Any = {
-      val sortedList = table.getState().toList.sortWith(
-        _._1.asInstanceOf[Int] < _._1.asInstanceOf[Int])
-      if (sortedList.isEmpty) {
+      val valuesOrderByKey = table.toSeq[Float]
+      if (valuesOrderByKey.isEmpty) {
         throw new RuntimeException("Found empty table")
       }
-      if (sortedList.iterator.next()._2.isInstanceOf[Activity]) {
-        return sortedList.map { item =>
-          doConvertActivity(item._2.asInstanceOf[Activity])
-        }.asJava
-      } else {
-        throw new RuntimeException(s"""not supported type:
-          ${sortedList.iterator.next().getClass.getSimpleName}""")
-      }
+      return valuesOrderByKey.map { item => doConvertActivity(item) }.asJava
     }
     private def doConvertActivity(activity: Activity): Any = {
       if (activity.isTable) {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -49,6 +49,8 @@ import org.apache.log4j._
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable
+import scala.collection.mutable.{ArrayBuffer, Map}
 import scala.language.existentials
 import scala.reflect.ClassTag
 
@@ -65,6 +67,8 @@ case class Sample(features: JList[JTensor],
 
 case class JTensor(storage: Array[Float], shape: Array[Int],
                    bigdlType: String, indices: Array[Array[Int]] = null)
+
+case class JActivity(value: Activity)
 
 /**
  * [[ValidationResult]] for python

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLValidator.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLValidator.scala
@@ -59,10 +59,13 @@ class PythonBigDLValidator[T: ClassTag](implicit ev: TensorNumeric[T]) extends P
   }
 
   def testActivityWithTableOfTensor(): JActivity = {
-    val tensor = Tensor(Array(1.0f, 2.0f, 3.0f, 4.0f), Array(4, 1))
+    val tensor1 = Tensor(Array(1.0f, 1.0f), Array(2))
+    val tensor2 = Tensor(Array(2.0f, 2.0f), Array(2))
+    val tensor3 = Tensor(Array(3.0f, 3.0f), Array(2))
     val table = new Table()
-    table.insert(tensor)
-    table.insert(tensor)
+    table.insert(tensor1)
+    table.insert(tensor2)
+    table.insert(tensor3)
     return JActivity(table)
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLValidator.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLValidator.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.python.api
+
+import java.lang.{Boolean => JBoolean}
+import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, Map => JMap}
+
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Table
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.Map
+import scala.language.existentials
+import scala.reflect.ClassTag
+
+object PythonBigDLValidator {
+
+  def ofFloat(): PythonBigDLValidator[Float] = new PythonBigDLValidator[Float]()
+
+  def ofDouble(): PythonBigDLValidator[Double] = new PythonBigDLValidator[Double]()
+}
+
+class PythonBigDLValidator[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonBigDL[T]{
+
+  def testDict(): JMap[String, String] = {
+    return Map("jack" -> "40", "lucy" -> "50").asJava
+  }
+
+  def testDictJTensor(): JMap[String, JTensor] = {
+    return Map("jack" -> JTensor(Array(1.0f, 2.0f, 3.0f, 4.0f), Array(4, 1), "float")).asJava
+  }
+
+  def testDictJMapJTensor(): JMap[String, JMap[String, JTensor]] = {
+    val table = new Table()
+    val tensor = JTensor(Array(1.0f, 2.0f, 3.0f, 4.0f), Array(4, 1), "float")
+    val result = Map("jack" -> tensor).asJava
+    table.insert(tensor)
+    return Map("nested" -> result).asJava
+  }
+
+  def testActivityWithTensor(): JActivity = {
+    val tensor = Tensor(Array(1.0f, 2.0f, 3.0f, 4.0f), Array(4, 1))
+    return JActivity(tensor)
+  }
+
+  def testActivityWithTableOfTensor(): JActivity = {
+    val tensor = Tensor(Array(1.0f, 2.0f, 3.0f, 4.0f), Array(4, 1))
+    val table = new Table()
+    table.insert(tensor)
+    table.insert(tensor)
+    return JActivity(table)
+  }
+
+  def testActivityWithTableOfTable(): JActivity = {
+    val tensor = Tensor(Array(1.0f, 2.0f, 3.0f, 4.0f), Array(4, 1))
+    val table = new Table()
+    table.insert(tensor)
+    val nestedTable = new Table()
+    nestedTable.insert(table)
+    nestedTable.insert(table)
+    return JActivity(nestedTable)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
@@ -59,7 +59,7 @@ class Table private[bigdl](
    */
   override def isTable: Boolean = true
 
-  def getState(): ImmutableMap[Any, Any] = {
+  private[bigdl] def getState(): ImmutableMap[Any, Any] = {
     return state.toMap
   }
   /**
@@ -295,10 +295,10 @@ class Table private[bigdl](
    * the integers between 1 to this.length(),
    * the values are all Tensor[T]
    */
-  def toSeq[T]: Seq[Tensor[T]] = {
+  def toSeq[T]: Seq[Activity] = {
     for (i <- 0 until this.length()) yield {
       try {
-        this(i + 1).asInstanceOf[Tensor[T]]
+        this(i + 1).asInstanceOf[Activity]
       } catch {
         case e: NoSuchElementException =>
           throw new UnsupportedOperationException("toSeq requires the key of this table are" +

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
@@ -59,7 +59,7 @@ class Table private[bigdl](
    */
   override def isTable: Boolean = true
 
-  private[bigdl] def getState(): ImmutableMap[Any, Any] = {
+  def getState(): ImmutableMap[Any, Any] = {
     return state.toMap
   }
   /**

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
@@ -295,7 +295,26 @@ class Table private[bigdl](
    * the integers between 1 to this.length(),
    * the values are all Tensor[T]
    */
-  def toSeq[T]: Seq[Activity] = {
+  def toSeq[T]: Seq[Tensor[T]] = {
+    for (i <- 0 until this.length()) yield {
+      try {
+        this(i + 1).asInstanceOf[Tensor[T]]
+      } catch {
+        case e: NoSuchElementException =>
+          throw new UnsupportedOperationException("toSeq requires the key of this table are" +
+            " all the integers between 1 to this.length()", e)
+      }
+
+    }
+  }
+
+  /**
+   * Return the elements of this table as a Seq.
+   * This method assumes the key of this table are all
+   * the integers between 1 to this.length(),
+   * the values are all Activity
+   */
+  def toSeqActivity[T]: Seq[Activity] = {
     for (i <- 0 until this.length()) yield {
       try {
         this(i + 1).asInstanceOf[Activity]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
@@ -293,31 +293,12 @@ class Table private[bigdl](
    * Return the elements of this table as a Seq.
    * This method assumes the key of this table are all
    * the integers between 1 to this.length(),
-   * the values are all Tensor[T]
+   * the values are all D
    */
-  def toSeq[T]: Seq[Tensor[T]] = {
+  def toSeq[D]: Seq[D] = {
     for (i <- 0 until this.length()) yield {
       try {
-        this(i + 1).asInstanceOf[Tensor[T]]
-      } catch {
-        case e: NoSuchElementException =>
-          throw new UnsupportedOperationException("toSeq requires the key of this table are" +
-            " all the integers between 1 to this.length()", e)
-      }
-
-    }
-  }
-
-  /**
-   * Return the elements of this table as a Seq.
-   * This method assumes the key of this table are all
-   * the integers between 1 to this.length(),
-   * the values are all Activity
-   */
-  def toSeqActivity[T]: Seq[Activity] = {
-    for (i <- 0 until this.length()) yield {
-      try {
-        this(i + 1).asInstanceOf[Activity]
+        this(i + 1).asInstanceOf[D]
       } catch {
         case e: NoSuchElementException =>
           throw new UnsupportedOperationException("toSeq requires the key of this table are" +

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/Session.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/Session.scala
@@ -446,7 +446,7 @@ class BigDLSessionImpl[T: ClassTag](graph: Seq[NodeDef], context: Context[T],
               iter.next()
             }
 
-          val batch = tables.map(_.toSeq)
+          val batch = tables.map(_.toSeq[Tensor[T]])
           val firstSeq = batch.head
           val sizes = firstSeq.map { tensor =>
             val nDim = tensor.nDimension()
@@ -732,7 +732,7 @@ object BigDLSessionImpl {
   private def toSample[T: ClassTag](rdd: RDD[Table])
                            (implicit ev: TensorNumeric[T]): RDD[Sample[T]] = {
     rdd.map{ t =>
-      val arr = t.toSeq[T].toArray
+      val arr = t.toSeq[Tensor[T]].toArray
       Sample[T](arr)
     }
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/Session.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/Session.scala
@@ -446,7 +446,7 @@ class BigDLSessionImpl[T: ClassTag](graph: Seq[NodeDef], context: Context[T],
               iter.next()
             }
 
-          val batch = tables.map(_.toSeq.map(_.toTensor[T]))
+          val batch = tables.map(_.toSeq)
           val firstSeq = batch.head
           val sizes = firstSeq.map { tensor =>
             val nDim = tensor.nDimension()
@@ -732,7 +732,7 @@ object BigDLSessionImpl {
   private def toSample[T: ClassTag](rdd: RDD[Table])
                            (implicit ev: TensorNumeric[T]): RDD[Sample[T]] = {
     rdd.map{ t =>
-      val arr = t.toSeq[T].map(_.toTensor[T]).toArray
+      val arr = t.toSeq[T].toArray
       Sample[T](arr)
     }
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/Session.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/Session.scala
@@ -446,7 +446,7 @@ class BigDLSessionImpl[T: ClassTag](graph: Seq[NodeDef], context: Context[T],
               iter.next()
             }
 
-          val batch = tables.map(_.toSeq)
+          val batch = tables.map(_.toSeq.map(_.toTensor[T]))
           val firstSeq = batch.head
           val sizes = firstSeq.map { tensor =>
             val nDim = tensor.nDimension()
@@ -732,7 +732,7 @@ object BigDLSessionImpl {
   private def toSample[T: ClassTag](rdd: RDD[Table])
                            (implicit ev: TensorNumeric[T]): RDD[Sample[T]] = {
     rdd.map{ t =>
-      val arr = t.toSeq[T].toArray
+      val arr = t.toSeq[T].map(_.toTensor[T]).toArray
       Sample[T](arr)
     }
   }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
@@ -286,6 +286,6 @@ class TableSpec extends FlatSpec with Matchers {
 
     val t = T(Tensor[Double](T(1.0)), Tensor[Double](T(2.0)))
 
-    t.toSeq[Double] should be (Seq(Tensor[Double](T(1.0)), Tensor[Double](T(2.0))))
+    t.toSeq[Tensor[Double]] should be (Seq(Tensor[Double](T(1.0)), Tensor[Double](T(2.0))))
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
@@ -286,6 +286,6 @@ class TableSpec extends FlatSpec with Matchers {
 
     val t = T(Tensor[Double](T(1.0)), Tensor[Double](T(2.0)))
 
-    t.toSeq[Double] should be (Seq(Tensor[Double](T(1.0)), Tensor[Double](T(2.0))))
+    t.toSeq[Double].map(_.toTensor[Double]) should be (Seq(Tensor[Double](T(1.0)), Tensor[Double](T(2.0))))
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
@@ -286,6 +286,6 @@ class TableSpec extends FlatSpec with Matchers {
 
     val t = T(Tensor[Double](T(1.0)), Tensor[Double](T(2.0)))
 
-    t.toSeq[Double].map(_.toTensor[Double]) should be (Seq(Tensor[Double](T(1.0)), Tensor[Double](T(2.0))))
+    t.toSeq[Double] should be (Seq(Tensor[Double](T(1.0)), Tensor[Double](T(2.0))))
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
@@ -22,7 +22,7 @@ import java.util.{ArrayList => JArrayList, List => JList, Map => JMap}
 import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.optim.{Loss, SGD, Top1Accuracy, Trigger}
-import com.intel.analytics.bigdl.utils.{Engine, T, TestUtils}
+import com.intel.analytics.bigdl.utils.{Engine, T, Table, TestUtils}
 import com.intel.analytics.bigdl.visualization.{TrainSummary, ValidationSummary}
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.SparkContext
@@ -52,6 +52,15 @@ class PythonSpec extends FlatSpec with Matchers with BeforeAndAfter {
     if (sc != null) {
       sc.stop()
     }
+  }
+
+  "pickle activity" should "be test" in {
+    val tensor = Tensor(Array(1.0f, 2.0f, 3.0f, 4.0f), Array(4, 1))
+    val table = new Table()
+    table.insert(tensor)
+    table.insert(tensor)
+    val r = JActivity(table)
+    org.apache.spark.bigdl.api.python.BigDLSerDe.dumps(r)
   }
 
   "model forward and backward with sigle tensor input" should "be test" in {


### PR DESCRIPTION
## What changes were proposed in this pull request?

def getHiddenStates(rec: Recurrent[T]): JList[JList[JTensor]] = {
This is too complex; instead of doing this, maybe we can have automatic mapping of Table to python list?

## How was this patch tested?
unitest.

## Related links or issues (optional)
https://github.com/intel-analytics/BigDL/issues/1937

