### PR TITLE
Do not check spark-bigdl.conf if sc exists

### DIFF
--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -406,7 +406,7 @@ def get_bigdl_conf():
                     if sys.version_info >= (3,):
                         content = str(content, 'latin-1')
                     return load_conf(content)
-    raise Exception("Cannot find spark-bigdl.conf.Pls add it to PYTHONPATH.")
+    return {}
 
 
 def to_list(a):
@@ -437,13 +437,21 @@ def get_spark_context(conf = None):
     :return: SparkContext
     """
     if hasattr(SparkContext, "getOrCreate"):
-        return SparkContext.getOrCreate(conf=conf or create_spark_conf())
+        with SparkContext._lock:
+            if SparkContext._active_spark_context is None:
+                spark_conf = create_spark_conf() if conf is None else conf
+                return SparkContext.getOrCreate(spark_conf)
+            else:
+                return SparkContext.getOrCreate()
+
     else:
         # Might have threading issue but we cann't add _lock here
         # as it's not RLock in spark1.5;
         if SparkContext._active_spark_context is None:
-            SparkContext(conf=conf or create_spark_conf())
-        return SparkContext._active_spark_context
+            spark_conf = create_spark_conf() if conf is None else conf
+            return SparkContext(spark_conf)
+        else:
+            return SparkContext._active_spark_context
 
 
 def get_spark_sql_context(sc):

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -449,7 +449,7 @@ def get_spark_context(conf = None):
         # as it's not RLock in spark1.5;
         if SparkContext._active_spark_context is None:
             spark_conf = create_spark_conf() if conf is None else conf
-            return SparkContext(spark_conf)
+            return SparkContext(conf=spark_conf)
         else:
             return SparkContext._active_spark_context
 

--- a/pyspark/test/bigdl/test_simple_integration.py
+++ b/pyspark/test/bigdl/test_simple_integration.py
@@ -45,6 +45,20 @@ class TestSimple():
         """
         self.sc.stop()
 
+    def test_ignore_check_conf(self):
+        path_backup = sys.path
+        sys.path = [path for path in sys.path if "python-api.zip" not in path and "spark-bigdl.conf" not in path]  # noqa
+        conf = get_bigdl_conf()
+        assert len(conf) == 0, "bigdl conf should be empty as it has been removed"
+        sc = get_spark_context()  # getting existing sc without checking spark-bigdl.conf
+        sc.stop()
+        ssc = get_spark_context()
+        assert ssc is not None
+        with pytest.raises(Exception) as excinfo:
+            init_engine()
+        assert "Engine.init: Can not find" in str(excinfo.value)
+        sys.path = path_backup
+
     def test_training(self):
         cadd = CAdd([5, 1])
         y = np.ones([5, 4])

--- a/pyspark/test/bigdl/test_simple_integration.py
+++ b/pyspark/test/bigdl/test_simple_integration.py
@@ -45,20 +45,6 @@ class TestSimple():
         """
         self.sc.stop()
 
-    def test_ignore_check_conf(self):
-        path_backup = sys.path
-        sys.path = [path for path in sys.path if "python-api.zip" not in path and "spark-bigdl.conf" not in path]  # noqa
-        conf = get_bigdl_conf()
-        assert len(conf) == 0, "bigdl conf should be empty as it has been removed"
-        sc = get_spark_context()  # getting existing sc without checking spark-bigdl.conf
-        sc.stop()
-        ssc = get_spark_context()
-        assert ssc is not None
-        with pytest.raises(Exception) as excinfo:
-            init_engine()
-        assert "Engine.init: Can not find" in str(excinfo.value)
-        sys.path = path_backup
-
     def test_training(self):
         cadd = CAdd([5, 1])
         y = np.ones([5, 4])

--- a/pyspark/test/dev/run-tests
+++ b/pyspark/test/dev/run-tests
@@ -34,7 +34,7 @@ do
     --ignore=../../../pyspark/bigdl/keras \
     --ignore=../../../pyspark/test/bigdl/keras/test_application.py \
     --ignore=../../../pyspark/bigdl/models/ && \
-    $p -m pytest -v -n 4 ../../../pyspark/test/ \
+    $p -m pytest -v ../../../pyspark/test/ \
     --ignore=../../../pyspark/test/bigdl/caffe/ \
     --ignore=../../../pyspark/test/bigdl/keras/ \
     --ignore=../../../pyspark/test/bigdl/test_utils.py


### PR DESCRIPTION
## What changes were proposed in this pull request?
Sometimes user create SparkContext with the require config settings, in that case we should not check and create "spark-bigdl.conf". 

## How was this patch tested?
unitest