### PR TITLE
Add cos for merge

### DIFF
--- a/pyspark/bigdl/keras/converter.py
+++ b/pyspark/bigdl/keras/converter.py
@@ -540,7 +540,12 @@ class LayerConverter:
                 inplace=False,
                 bigdl_type="float")
         elif klayer.mode in ['cos']:
-            raise Exception("Merge mode `%s` not supported for now" % klayer.mode)
+            if len(input_shape[0]) >= 3:
+                raise Exception("For merge mode cos, 3D input or above is not supported for now.")
+            if klayer.dot_axes != [1, 1]:
+                raise Exception("For merge mode cos, only dot_axes=1 is supported for now.")
+            blayer = BLayer.Sequential()
+            blayer.add(BLayer.CosineDistance(bigdl_type="float")).add(BLayer.Reshape([1, 1], True))
         else:  # invalid mode or lambda functions
             raise Exception("Invalid merge mode: `%s`. Lambda/function as merge mode is not supported for now." % klayer.mode)
         if self.__is_from_sequential(klayer, kclayer):

--- a/pyspark/test/bigdl/keras/test_layer.py
+++ b/pyspark/test/bigdl/keras/test_layer.py
@@ -22,9 +22,9 @@ np.random.seed(1337)  # for reproducibility
 from keras.layers.core import *
 from keras.layers.convolutional import *
 from keras.layers import Dense, Input
+from keras.regularizers import l1, l2, l1l2
 from bigdl.keras.converter import *
 from test.bigdl.test_utils import BigDLTestCase
-from keras.regularizers import l1, l2, l1l2
 
 
 class TestLayer(BigDLTestCase):
@@ -274,6 +274,22 @@ class TestLayer(BigDLTestCase):
         kmodel = Model(input=[input1], output=branch2_tensor)
         kmodel.predict([input_data1])
         self.modelTest(input_data1,
+                       kmodel,
+                       random_weights=False,
+                       dump_weights=True,
+                       is_training=False)
+
+    def test_merge_method_cos(self):
+        input_data1 = np.random.random_sample([2, 4])
+        input_data2 = np.random.random_sample([2, 4])
+        input1 = Input((4,))
+        input2 = Input((4,))
+        out1 = Dense(4)(input1)
+        out2 = Dense(4)(input2)
+        from keras.engine import merge
+        m = merge([out1, out2], mode="cos", dot_axes=1)
+        kmodel = Model(input=[input1, input2], output=m)
+        self.modelTest([input_data1, input_data2],
                        kmodel,
                        random_weights=False,
                        dump_weights=True,

--- a/pyspark/test/bigdl/test_utils.py
+++ b/pyspark/test/bigdl/test_utils.py
@@ -16,7 +16,6 @@
 from __future__ import print_function
 import numpy as np
 from keras.models import Sequential, Model
-from bigdl.keras.converter import WeightLoader, WeightsConverter
 np.random.seed(1337)  # for reproducibility
 from keras.layers.core import *
 from keras.layers.convolutional import *
@@ -24,6 +23,7 @@ from keras.layers import Dense, Dropout, Input
 from keras.optimizers import RMSprop
 from bigdl.util.common import create_tmp_path
 from bigdl.keras.converter import *
+from bigdl.keras.converter import WeightLoader, WeightsConverter
 import numpy as np
 from unittest import TestCase
 import keras


### PR DESCRIPTION
## What changes were proposed in this pull request?
Usage:
```
        input1 = Input((4,))
        input2 = Input((4,))
        out1 = Dense(4)(input1)
        out2 = Dense(4)(input2)
        from keras.engine import merge
        m = merge([out1, out2], mode="cos", dot_axes=1)
        model = Model(input=[input1, input2], output=m)
```
## How was this patch tested?
unittest