### PR TITLE
code refactor to reduce code duplicate and avoid manual toBatch operation.

### DIFF
--- a/spark/dl/src/main/scala/org/apache/spark/ml/DLClassifier.scala
+++ b/spark/dl/src/main/scala/org/apache/spark/ml/DLClassifier.scala
@@ -35,7 +35,7 @@ import scala.reflect.ClassTag
  * @param featureSize The size (Tensor dimensions) of the feature data.
  */
 class DLClassifier[@specialized(Float, Double) T: ClassTag](
-    override val model: Module[T],
+    @transient override val model: Module[T],
     override val criterion : Criterion[T],
     override val featureSize : Array[Int],
     override val uid: String = Identifiable.randomUID("dlClassifier")
@@ -49,7 +49,7 @@ class DLClassifier[@specialized(Float, Double) T: ClassTag](
   }
 
   override def transformSchema(schema : StructType): StructType = {
-    validateSchema(schema, $(featuresCol))
+    validateDataType(schema, $(featuresCol))
     SchemaUtils.appendColumn(schema, $(predictionCol), DoubleType)
   }
 
@@ -66,23 +66,17 @@ class DLClassifier[@specialized(Float, Double) T: ClassTag](
  * @param featureSize The size (Tensor dimensions) of the feature data.
  */
 class DLClassifierModel[@specialized(Float, Double) T: ClassTag](
-    override val model: Module[T],
+    @transient override val model: Module[T],
     featureSize : Array[Int],
     override val uid: String = "DLClassifierModel"
   )(implicit ev: TensorNumeric[T]) extends DLModel[T](model, featureSize) {
 
-  override protected def batchOutputToPrediction(output: Tensor[T]): Iterable[_] = {
-    output.split(1)
-    val result = if (output.dim == 2) {
-      output.split(1).map(t => t.max(1)._2.storage().head)
-    } else {
-      throw new IllegalArgumentException
-    }
-    result.map(ev.toType[Double])
+  protected override def outputToPrediction(output: Tensor[T]): Any = {
+    ev.toType[Double](output.max(1)._2.valueAt(1))
   }
 
   override def transformSchema(schema : StructType): StructType = {
-    validateSchema(schema, $(featuresCol))
+    validateDataType(schema, $(featuresCol))
     SchemaUtils.appendColumn(schema, $(predictionCol), DoubleType)
   }
 }

--- a/spark/dl/src/main/scala/org/apache/spark/ml/DLClassifier.scala
+++ b/spark/dl/src/main/scala/org/apache/spark/ml/DLClassifier.scala
@@ -49,7 +49,7 @@ class DLClassifier[@specialized(Float, Double) T: ClassTag](
   }
 
   override def transformSchema(schema : StructType): StructType = {
-    validateSchema(schema)
+    validateSchema(schema, $(featuresCol))
     SchemaUtils.appendColumn(schema, $(predictionCol), DoubleType)
   }
 
@@ -82,7 +82,7 @@ class DLClassifierModel[@specialized(Float, Double) T: ClassTag](
   }
 
   override def transformSchema(schema : StructType): StructType = {
-    validateSchema(schema)
+    validateSchema(schema, $(featuresCol))
     SchemaUtils.appendColumn(schema, $(predictionCol), DoubleType)
   }
 }

--- a/spark/dl/src/main/scala/org/apache/spark/ml/DLClassifier.scala
+++ b/spark/dl/src/main/scala/org/apache/spark/ml/DLClassifier.scala
@@ -50,6 +50,7 @@ class DLClassifier[@specialized(Float, Double) T: ClassTag](
 
   override def transformSchema(schema : StructType): StructType = {
     validateDataType(schema, $(featuresCol))
+    validateDataType(schema, $(labelCol))
     SchemaUtils.appendColumn(schema, $(predictionCol), DoubleType)
   }
 

--- a/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
+++ b/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
@@ -114,7 +114,8 @@ class DLEstimator[@specialized(Float, Double) T: ClassTag](
   def setLearningRateDecay(value: Double): this.type = set(learningRateDecay, value)
 
   override def transformSchema(schema : StructType): StructType = {
-    validateSchema(schema)
+    super.validateSchema(schema, $(featuresCol))
+    super.validateSchema(schema, $(labelCol))
     SchemaUtils.appendColumn(schema, $(predictionCol), ArrayType(DoubleType, false))
   }
 
@@ -254,7 +255,7 @@ class DLModel[@specialized(Float, Double) T: ClassTag](
   }
 
   override def transformSchema(schema : StructType): StructType = {
-    validateSchema(schema)
+    validateSchema(schema, $(featuresCol))
     SchemaUtils.appendColumn(schema, $(predictionCol), ArrayType(DoubleType, false))
   }
 

--- a/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
+++ b/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
@@ -65,7 +65,8 @@ private[ml] trait DLParams[@specialized(Float, Double) T] extends HasFeaturesCol
    * learning rate for the optimizer in the DLEstimator.
    * Default: 0.001
    */
-  final val learningRate = new DoubleParam(this, "learningRate", "learningRate", ParamValidators.gt(0))
+  final val learningRate = new DoubleParam(
+    this, "learningRate", "learningRate", ParamValidators.gt(0))
 
   def getLearningRate: Double = $(learningRate)
 

--- a/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
+++ b/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
@@ -78,6 +78,10 @@ private[ml] trait DLParams[@specialized(Float, Double) T] extends HasFeaturesCol
 
   setDefault(batchSize -> 1)
 
+  /**
+   * Validate if feature and label columns are of supported data types.
+   * Default: 0
+   */
   protected def validateDataType(schema: StructType, colName: String): Unit = {
     val dataTypes = Seq(
       new ArrayType(DoubleType, false),
@@ -95,6 +99,10 @@ private[ml] trait DLParams[@specialized(Float, Double) T] extends HasFeaturesCol
         s"${dataTypes.mkString("[", ", ", "]")} but was actually of type $actualDataType.")
   }
 
+  /**
+   * Get conversion function to extract data from original DataFrame
+   * Default: 0
+   */
   protected def getConvertFunc(colType: DataType): (Row, Int) => Seq[AnyVal] = {
     colType match {
       case ArrayType(DoubleType, false) =>
@@ -203,8 +211,7 @@ class DLEstimator[@specialized(Float, Double) T: ClassTag](
       }
       (feature, label)
     }.map { case (feature, label) =>
-      val fArr = feature.toArray
-      Sample(Tensor(fArr, featureSize), Tensor(label.toArray, labelSize))
+      Sample(Tensor(feature.toArray, featureSize), Tensor(label.toArray, labelSize))
     }
 
     if(!isDefined(optimMethod)) {
@@ -269,8 +276,6 @@ class DLModel[@specialized(Float, Double) T: ClassTag](
 
   /**
    * Perform a prediction on featureCol, and write result to the predictionCol.
-   * @param dataFrame featureData in the format of Seq
-   * @return output DataFrame
    */
   protected override def internalTransform(dataFrame: DataFrame): DataFrame = {
     val featureType = dataFrame.schema($(featuresCol)).dataType

--- a/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
+++ b/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
@@ -170,7 +170,7 @@ class DLEstimator[@specialized(Float, Double) T: ClassTag](
   def setOptimMethod(value: OptimMethod[T]): this.type = set(optimMethod, value)
 
   def setMaxEpoch(value: Int): this.type = set(maxEpoch, value)
-  setDefault(maxEpoch -> 100)
+  setDefault(maxEpoch -> 50)
 
   def setLearningRate(value: Double): this.type = set(learningRate, value)
   setDefault(learningRate -> 1e-3)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLClassifierSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLClassifierSpec.scala
@@ -62,7 +62,7 @@ class DLClassifierSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val estimator = new DLClassifier[Float](model, criterion, Array(10))
     assert(estimator.getFeaturesCol == "features")
     assert(estimator.getLabelCol == "label")
-    assert(estimator.getMaxEpoch == 100)
+    assert(estimator.getMaxEpoch == 50)
     assert(estimator.getBatchSize == 1)
     assert(estimator.getLearningRate == 1e-3)
     assert(estimator.getLearningRateDecay == 0)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLEstimatorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLEstimatorSpec.scala
@@ -61,7 +61,7 @@ class DLEstimatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val estimator = new DLEstimator[Float](model, criterion, Array(10), Array(1))
     assert(estimator.getFeaturesCol == "features")
     assert(estimator.getLabelCol == "label")
-    assert(estimator.getMaxEpoch == 100)
+    assert(estimator.getMaxEpoch == 50)
     assert(estimator.getBatchSize == 1)
     assert(estimator.getLearningRate == 1e-3)
     assert(estimator.getLearningRateDecay == 0)

--- a/spark/spark-version/1.5-plus/src/main/scala/org/apache/spark/ml/DLEstimatorBase.scala
+++ b/spark/spark-version/1.5-plus/src/main/scala/org/apache/spark/ml/DLEstimatorBase.scala
@@ -22,41 +22,23 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row}
 
+/**
+ * Handle different Vector types in Spark 1.5/1.6 and Spark 2.0+.
+ * Only support MLlib Vector for Spark 1.5/1.6.
+ */
+trait VectorCompatibility {
 
-private[ml] trait DLParams extends HasFeaturesCol with HasPredictionCol {
+  val validVectorTypes = Seq(new VectorUDT)
 
-  /**
-   * only validate feature columns here
-   */
-  protected def validateSchema(schema: StructType): Unit = {
-    val dataTypes = Seq(
-      new ArrayType(DoubleType, false),
-      new ArrayType(FloatType, false),
-      new VectorUDT)
-
-    // TODO use SchemaUtils.checkColumnTypes after convert to 2.0
-    val actualDataType = schema($(featuresCol)).dataType
-    require(dataTypes.exists(actualDataType.equals),
-      s"Column ${$(featuresCol)} must be of type equal to one of the following types: " +
-        s"${dataTypes.mkString("[", ", ", "]")} but was actually of type $actualDataType.")
-  }
-
-  def supportedTypesToSeq(row: Row, colType: DataType, index: Int): Seq[AnyVal] = {
-    val featureArr = if (colType == new VectorUDT) {
-      row.getAs[Vector](index).toArray.toSeq
-    } else if (colType == ArrayType(DoubleType, false)) {
-      row.getSeq[Double](index)
-    } else if (colType == ArrayType(FloatType, false)) {
-      row.getSeq[Float](index)
-    } else if (colType == DoubleType) {
-      Seq[Double](row.getDouble(index))
+  def getVectorSeq(row: Row, colType: DataType, index: Int): Seq[AnyVal] = {
+    if (colType == new org.apache.spark.mllib.linalg.VectorUDT) {
+      row.getAs[org.apache.spark.mllib.linalg.Vector](index).toArray.toSeq
+    } else {
+      throw new IllegalArgumentException(
+        s"$colType is not a supported vector type for Spark 1.5/1.6")
     }
-    featureArr.asInstanceOf[Seq[AnyVal]]
   }
-
-  protected def getFeatureArrayCol: String = $(featuresCol) + "_Array"
 }
-
 
 /**
  *A wrapper from org.apache.spark.ml.Estimator
@@ -65,52 +47,13 @@ private[ml] trait DLParams extends HasFeaturesCol with HasPredictionCol {
  */
 private[ml] abstract class DLEstimatorBase[Learner <: DLEstimatorBase[Learner, M],
     M <: DLTransformerBase[M]]
-  extends Estimator[M] with DLParams with HasLabelCol {
+  extends Estimator[M] with HasLabelCol {
 
-  protected def getLabelArrayCol: String = $(labelCol) + "_Array"
+  protected def internalFit(dataFrame: DataFrame): M
 
-  protected def internalFit(featureAndLabel: RDD[(Seq[AnyVal], Seq[AnyVal])]): M
-
-  override def fit(dataset: DataFrame): M = {
-    transformSchema(dataset.schema, logging = true)
-    internalFit(toArrayType(dataset))
-  }
-
-  /**
-   * convert feature and label columns to array data
-   */
-  protected def toArrayType(dataset: DataFrame): RDD[(Seq[AnyVal], Seq[AnyVal])] = {
-    val featureType = dataset.schema($(featuresCol)).dataType
-    val featureColIndex = dataset.schema.fieldIndex($(featuresCol))
-    val labelType = dataset.schema($(labelCol)).dataType
-    val labelColIndex = dataset.schema.fieldIndex($(labelCol))
-
-    dataset.rdd.map { row =>
-      val features = supportedTypesToSeq(row, featureType, featureColIndex)
-      val labels = supportedTypesToSeq(row, labelType, labelColIndex)
-      (features, labels)
-    }
-  }
-
-  /**
-   * validate both feature and label columns
-   */
-  protected override def validateSchema(schema: StructType): Unit = {
-    // validate feature column
-    super.validateSchema(schema)
-
-    // validate label column
-    val dataTypes = Seq(
-      new ArrayType(DoubleType, false),
-      new ArrayType(FloatType, false),
-      new VectorUDT,
-      DoubleType)
-
-    // TODO use SchemaUtils.checkColumnTypes after convert to 2.0
-    val actualDataType = schema($(labelCol)).dataType
-    require(dataTypes.exists(actualDataType.equals),
-      s"Column ${$(labelCol)} must be of type equal to one of the following types: " +
-        s"${dataTypes.mkString("[", ", ", "]")} but was actually of type $actualDataType.")
+  override def fit(dataFrame: DataFrame): M = {
+    transformSchema(dataFrame.schema, logging = true)
+    internalFit(dataFrame)
   }
 
   override def copy(extra: ParamMap): Learner = defaultCopy(extra)

--- a/spark/spark-version/1.5-plus/src/main/scala/org/apache/spark/ml/DLTransformerBase.scala
+++ b/spark/spark-version/1.5-plus/src/main/scala/org/apache/spark/ml/DLTransformerBase.scala
@@ -16,7 +16,6 @@
 package org.apache.spark.ml
 
 import org.apache.spark.ml.param.ParamMap
-import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.DataFrame
 
 /**
@@ -25,30 +24,13 @@ import org.apache.spark.sql.DataFrame
  * both spark 1.5 and spark 2.0.
  */
 private[ml] abstract class DLTransformerBase[M <: DLTransformerBase[M]]
-  extends Model[M] with DLParams {
+  extends Model[M] {
 
-  /**
-   * convert feature columns(MLlib Vectors or Array) to Seq format
-   */
-  protected def internalTransform(featureData: RDD[Seq[AnyVal]], dataset: DataFrame): DataFrame
+  protected def internalTransform(dataFrame: DataFrame): DataFrame
 
-  override def transform(dataset: DataFrame): DataFrame = {
-    transformSchema(dataset.schema, logging = true)
-    internalTransform(toArrayType(dataset), dataset)
-  }
-
-  /**
-   * convert feature columns to Seq format
-   */
-  protected def toArrayType(dataset: DataFrame): RDD[Seq[AnyVal]] = {
-
-    val featureType = dataset.schema($(featuresCol)).dataType
-    val featureColIndex = dataset.schema.fieldIndex($(featuresCol))
-
-    dataset.rdd.map { row =>
-      val features = supportedTypesToSeq(row, featureType, featureColIndex)
-      features
-    }
+  override def transform(dataFrame: DataFrame): DataFrame = {
+    transformSchema(dataFrame.schema, logging = true)
+    internalTransform(dataFrame)
   }
 
   override def copy(extra: ParamMap): M = defaultCopy(extra)

--- a/spark/spark-version/2.0/src/main/scala/org/apache/spark/ml/DLTransformerBase.scala
+++ b/spark/spark-version/2.0/src/main/scala/org/apache/spark/ml/DLTransformerBase.scala
@@ -25,29 +25,16 @@ import org.apache.spark.sql.{DataFrame, Dataset}
  * both spark 1.5 and spark 2.0.
  */
 private[ml] abstract class DLTransformerBase[M <: DLTransformerBase[M]]
-  extends Model[M] with DLParams {
+  extends Model[M] {
 
   /**
    * convert feature columns(MLlib Vectors or Array) to Seq format
    */
-  protected def internalTransform(featureData: RDD[Seq[AnyVal]], dataset: DataFrame): DataFrame
+  protected def internalTransform(dataFrame: DataFrame): DataFrame
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
-    val df = dataset.toDF()
-    internalTransform(toArrayType(df), df)
-  }
-
-  /**
-   * convert feature columns to Seq format
-   */
-  protected def toArrayType(dataset: DataFrame): RDD[Seq[AnyVal]] = {
-    val featureType = dataset.schema($(featuresCol)).dataType
-    val featureColIndex = dataset.schema.fieldIndex($(featuresCol))
-    dataset.rdd.map { row =>
-      val features = supportedTypesToSeq(row, featureType, featureColIndex)
-      features
-    }
+    internalTransform(dataset.toDF())
   }
 
   override def copy(extra: ParamMap): M = defaultCopy(extra)

--- a/spark/spark-version/2.0/src/main/scala/org/apache/spark/ml/DLTransformerBase.scala
+++ b/spark/spark-version/2.0/src/main/scala/org/apache/spark/ml/DLTransformerBase.scala
@@ -34,17 +34,16 @@ private[ml] abstract class DLTransformerBase[M <: DLTransformerBase[M]]
 
   override def transform(dataset: Dataset[_]): DataFrame = {
     transformSchema(dataset.schema, logging = true)
-    internalTransform(toArrayType(dataset.toDF()), dataset.toDF())
+    val df = dataset.toDF()
+    internalTransform(toArrayType(df), df)
   }
 
   /**
    * convert feature columns to Seq format
    */
   protected def toArrayType(dataset: DataFrame): RDD[Seq[AnyVal]] = {
-
     val featureType = dataset.schema($(featuresCol)).dataType
     val featureColIndex = dataset.schema.fieldIndex($(featuresCol))
-
     dataset.rdd.map { row =>
       val features = supportedTypesToSeq(row, featureType, featureColIndex)
       features


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Support more data types for features and label columns.
2. Move DLParam from SparkVersion to dl folder, to avoid code duplicate between Spark 1.6 and 2.0+
3. add transient to model parameter in DLEstimator and DLClassifier, to avoid unnecessary serialization.
4. use Optimizer and Predictor for batch training and avoid manual toBatch operation.

Other new functions will be added in follow-up PRs.

## How was this patch tested?

existing unit tests

