### PR TITLE
Support passing JActivity from python to java

### DIFF
--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -122,7 +122,34 @@ def get_dtype(bigdl_type):
 class JActivity(object):
 
     def __init__(self, value):
-        self.value = value
+        self.value = self.__to_np(value)  # self.value is a ndarray or nested list of ndarray
+
+    @staticmethod
+    def __to_np(v):
+        """
+        This method would convert the JTensor to ndarray
+        :return: ndarray or nested list of ndarray
+        """
+        if isinstance(v, JTensor):
+            return v.to_ndarray()
+        elif isinstance(v, list):
+            return [JActivity.__to_np(i) for i in v]
+        elif isinstance(v, np.ndarray):
+            return v
+        else:
+            raise Exception("Unsupported type: %s", type(v))
+
+    @staticmethod
+    def __do_convertion(v):
+        if isinstance(v, np.ndarray):
+            return JTensor.from_ndarray(v)
+        elif isinstance(v, list):
+            return [JActivity.__do_convertion(i) for i in v]
+        else:
+            raise Exception("Unsupported type: %s", type(v))
+
+    def __reduce__(self):
+        return JActivity, (JActivity.__do_convertion(self.value),)
 
 
 class JTensor(object):

--- a/pyspark/test/bigdl/test_pickler.py
+++ b/pyspark/test/bigdl/test_pickler.py
@@ -48,20 +48,44 @@ class TestPickler():
 
     def test_activity_with_jtensor(self):
         back = callBigDlFunc("float", "testActivityWithTensor")
-        assert isinstance(back.value, JTensor)
+        assert isinstance(back.value, np.ndarray)
 
     def test_activity_with_table_of_tensor(self):
         back = callBigDlFunc("float", "testActivityWithTableOfTensor")
         assert isinstance(back.value, list)
-        assert isinstance(back.value[0], JTensor)
-        assert back.value[0].to_ndarray()[0] < back.value[1].to_ndarray()[0]
-        assert back.value[1].to_ndarray()[0] < back.value[2].to_ndarray()[0]
+        assert isinstance(back.value[0], np.ndarray)
+        assert back.value[0][0] < back.value[1][0]
+        assert back.value[1][0] < back.value[2][0]
 
     def test_activity_with_table_of_table(self):
         back = callBigDlFunc("float", "testActivityWithTableOfTable")
         assert isinstance(back.value, list)
         assert isinstance(back.value[0], list)
-        assert isinstance(back.value[0][0], JTensor)
+        assert isinstance(back.value[0][0], np.ndarray)
+
+        back_again = callBigDlFunc("float", "testPyToJavaActivity", back)
+        assert isinstance(back_again.value, list)
+        assert isinstance(back_again.value[0], list)
+        assert isinstance(back_again.value[0][0], np.ndarray)
+
+    def test_activity_py_to_java(self):
+        back = callBigDlFunc("float", "testPyToJavaActivity",
+                             JActivity(np.random.random_sample([2, 3])))
+        assert back.value.shape == (2, 3)
+
+    def test_nested_activity_py_to_java(self):
+        value = np.random.random_sample([2, 3])
+        list_value = [value, value]
+        nested1 = JActivity(list_value)
+        nested2 = JActivity([list_value, list_value])
+        back = callBigDlFunc("float", "testPyToJavaActivity",
+                             nested1)
+        assert back.value[0].shape == (2, 3)
+        back = callBigDlFunc("float", "testPyToJavaActivity",
+                             nested2)
+        assert back.value[0][0].shape == (2, 3)
+
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLValidator.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLValidator.scala
@@ -78,4 +78,8 @@ class PythonBigDLValidator[T: ClassTag](implicit ev: TensorNumeric[T]) extends P
     nestedTable.insert(table)
     return JActivity(nestedTable)
   }
+
+  def testPyToJavaActivity(jactivity: JActivity): JActivity = {
+    jactivity
+  }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Table.scala
@@ -31,7 +31,7 @@ import scala.collection.immutable.{Map => ImmutableMap}
  * @param state
  * @param topIndex
  */
-class Table private[bigdl](
+class Table (
   private val state: Map[Any, Any] = new mutable.HashMap[Any, Any](),
   // index of last element in the contiguous numeric number indexed elements start from 1
   private var topIndex: Int = 0


### PR DESCRIPTION
## What changes were proposed in this pull request?

i.e:
```
        value = np.random.random_sample([2, 3])
        nested = JActivity([ [value, value],  [value, value]])
        back = callBigDlFunc("float", "testPyToJavaActivity",
                             nested)
```
## How was this patch tested?
unittest

