### PR TITLE
Expose more API for graph

### DIFF
--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -51,6 +51,10 @@ class Node(JavaValue):
     def element(self):
         return Layer.of(self.value.element())
 
+    def pre_nodes(self):
+        jnodes = callBigDlFunc(self.bigdl_type, "getPreNodes", self.value)
+        return [Node.of(jnode.value()) for jnode in jnodes]
+
 
 class Layer(JavaValue):
     """
@@ -257,6 +261,14 @@ class Layer(JavaValue):
 
         return dict((layer_name, to_ndarray(params)) for layer_name, params in
                 name_to_params.items())
+
+    def forwardNodes(self):
+        """
+        Get nodes in the forwarding path
+        """
+        jnodes = callBigDlFunc(self.bigdl_type,
+                                       "getForwardNodesFromGraph", self.value)
+        return [Node.of(jnode.value()) for jnode in jnodes]
 
     def evaluate(self, *args):
         """
@@ -595,11 +607,17 @@ class Container(Layer):
 
     @property
     def layers(self):
+        """
+        Get layers or sub-containers at the first level of the current Container
+        """
         jlayers = callBigDlFunc(self.bigdl_type, "getContainerModules" , self)
         layers = [Layer.of(jlayer) for jlayer in jlayers]
         return layers
 
     def flattened_layers(self, include_container=False):
+        """
+        Get layers or sub-containers recursively
+        """
         jlayers = callBigDlFunc(self.bigdl_type, "getFlattenModules", self, include_container)
         layers = [Layer.of(jlayer) for jlayer in jlayers]
         return layers

--- a/pyspark/test/bigdl/keras/test_layer.py
+++ b/pyspark/test/bigdl/keras/test_layer.py
@@ -279,6 +279,55 @@ class TestLayer(BigDLTestCase):
                        dump_weights=True,
                        is_training=False)
 
+    def test_merge_method_lstm(self):
+        input_data1 = np.random.random_sample([2, 4, 5])
+        input_data2 = np.random.random_sample([2, 4, 5])
+
+        input1 = Input((4, 5))
+        input2 = Input((4, 5))
+        # out1 = LSTM(5, input_shape=(4, 5))(input1)
+        out2 = LSTM(6, input_shape=(4, 5))(input2)
+
+        kmodel = Model(input=input2, output=out2)
+        self.modelTest(input_data2,
+                       kmodel,
+                       random_weights=False,
+                       dump_weights=True,
+                       is_training=False)
+
+    def test_merge_method_sequential(self):
+        input_data1 = np.random.random_sample([2, 4, 5])
+        input_data2 = np.random.random_sample([2, 4, 5])
+
+        input1 = Input((4, 5))
+        input2 = Input((4, 5))
+
+        input_data1 = np.random.random_sample([2, 20])
+        input_data2 = np.random.random_sample([2, 20])
+        input1 = Input((20, ))
+        input2 = Input((20, ))
+        branch1 = Sequential()
+        branch1.add(Dense(4, input_shape=(20, )))
+        branch1.add(Dense(4, input_shape=(4, )))
+        branch1.add(Dense(4, input_shape=(4, )))
+
+        branch2 = Sequential()
+        branch2.add(Dense(4, input_shape=(20, )))
+        branch2.add(Dense(4, input_shape=(4, )))
+        branch2.add(Dense(4, input_shape=(4, )))
+
+        out1 = branch1(input1)
+        out2 = branch2(input2)
+
+        from keras.engine import merge
+        m = merge([out1, out2], mode="concat")
+        kmodel = Model(input=[input1, input2], output=m)
+        self.modelTest([input_data1, input_data2],
+                       kmodel,
+                       random_weights=False,
+                       dump_weights=True,
+                       is_training=False)
+
     def test_merge_method_cos(self):
         input_data1 = np.random.random_sample([2, 4])
         input_data2 = np.random.random_sample([2, 4])

--- a/pyspark/test/bigdl/test_utils.py
+++ b/pyspark/test/bigdl/test_utils.py
@@ -19,7 +19,7 @@ from keras.models import Sequential, Model
 np.random.seed(1337)  # for reproducibility
 from keras.layers.core import *
 from keras.layers.convolutional import *
-from keras.layers import Dense, Dropout, Input
+from keras.layers import *
 from keras.optimizers import RMSprop
 from bigdl.util.common import create_tmp_path
 from bigdl.keras.converter import *

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -35,7 +35,7 @@ import java.lang.{Integer, Boolean => JBoolean}
 import java.nio.ByteOrder
 import java.util
 
-import com.intel.analytics.bigdl.nn.Graph._
+import com.intel.analytics.bigdl.nn.Graph.{ModuleNode, _}
 import com.intel.analytics.bigdl.nn.tf.{Const, Fill, Shape, SplitAndSelect}
 import com.intel.analytics.bigdl.transform.vision.image._
 import com.intel.analytics.bigdl.transform.vision.image.augmentation._
@@ -80,6 +80,8 @@ case class JActivity(value: Activity)
  */
 
 case class EvaluatedResult(val result: Float, totalNum: Int, method: String)
+
+class JNode(val value: ModuleNode[Float])
 
 object PythonBigDL {
 
@@ -2291,6 +2293,16 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
 
   def findGraphNode(model: Graph[T], name: String): ModuleNode[T] = {
     model.node(name)
+  }
+
+  def getPreNodes(node: ModuleNode[T]): JList[JNode] = {
+    return node.prevNodes.map(n => new JNode(n.asInstanceOf[ModuleNode[Float]])).toList.asJava
+  }
+
+  def getForwardNodesFromGraph(model: Graph[T]):
+  JList[JNode] = {
+    return model.getForwardExecutions.map{n =>
+      new JNode(n.asInstanceOf[ModuleNode[Float]])}.toList.asJava
   }
 
   def getContainerModules(module: Container[Activity, Activity, T])


### PR DESCRIPTION
## What changes were proposed in this pull request?
The idea is user can use `forward_nodes` and `pre_nodes` to take a look at the Graph.
![image](https://user-images.githubusercontent.com/2662017/33758057-ad75a134-dc37-11e7-8b11-64e5ad2dff94.png)

## How was this patch tested?
manual test and unittest

