### PR TITLE
Support HDFS and S3 for Keras model loading

### DIFF
--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -589,6 +589,25 @@ def create_tmp_path():
     return tmp_file.name
 
 
+def text_from_path(path):
+    sc = get_spark_context()
+    return sc.textFile(path).collect()[0]
+
+
+def get_local_file(a_path):
+    if not is_distributed(a_path):
+        return a_path
+    path, data = get_spark_context().binaryFiles(a_path).collect()[0]
+    local_file_path = create_tmp_path()
+    with open(local_file_path, 'w') as local_file:
+        local_file.write(data)
+    return local_file_path
+
+
+def is_distributed(path):
+    return "://" in path
+
+
 def get_activation_by_name(activation_name, activation_id=None):
     """ Convert to a bigdl activation layer
         given the name of the activation as a string  """

--- a/pyspark/test/bigdl/keras/test_load_model.py
+++ b/pyspark/test/bigdl/keras/test_load_model.py
@@ -64,5 +64,21 @@ class TestLoadModel(BigDLTestCase):
         kmodel, input_data, output_data = TestModels.kmodel_seq_lenet_mnist()
         self.__kmodel_load_def_weight_test(kmodel, input_data)
 
+    def test_load_definition(self):
+        kmodel, input_data, output_data = TestModels.kmodel_seq_lenet_mnist()
+        keras_model_json_path, keras_model_hdf5_path = self._dump_keras(kmodel, dump_weights=True)
+        bmodel = DefinitionLoader.from_json_path(keras_model_json_path)
+        WeightLoader.load_weights_from_kmodel(bmodel, kmodel)
+        self.assert_allclose(bmodel.forward(input_data), kmodel.predict(input_data))
+
+    def test_load_weights(self):
+        kmodel, input_data, output_data = TestModels.kmodel_graph_1_layer()
+        keras_model_json_path, keras_model_hdf5_path = self._dump_keras(kmodel, dump_weights=True)
+        bmodel = DefinitionLoader.from_json_path(keras_model_json_path)
+        kmodel.set_weights([kmodel.get_weights()[0] + 100, kmodel.get_weights()[1]])
+        WeightLoader.load_weights_from_hdf5(bmodel, kmodel, filepath=keras_model_hdf5_path)
+        self.assert_allclose(bmodel.forward(input_data), kmodel.predict(input_data))
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## What changes were proposed in this pull request?

By leverage `sc.textfile` and `sc.binaryfile` we can easily support all Spark compatible file path.

## How was this patch tested?
unitest and manual test

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/1912

