### PR TITLE
get large model from executor

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BatchNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BatchNormalization.scala
@@ -141,14 +141,6 @@ class BatchNormalization[T: ClassTag](
     this
   }
 
-  override def copyStatus(src: Module[T]): this.type = {
-    require(canEqual(src), s"copyStatus: type mismatch, $src is different from $this")
-    val srcModule = src.asInstanceOf[BatchNormalization[T]]
-    runningMean.copy(srcModule.runningMean)
-    runningVar.copy(srcModule.runningVar)
-    this
-  }
-
   override def zeroGradParameters(): Unit = {
     if (affine) {
       gradWeight.zero()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BatchNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BatchNormalization.scala
@@ -141,6 +141,7 @@ class BatchNormalization[T: ClassTag](
     this
   }
 
+  @deprecated("Please use get/setExtraParameter API", "since 0.4.0")
   override def copyStatus(src: Module[T]): this.type = {
     require(canEqual(src), s"copyStatus: type mismatch, $src is different from $this")
     val srcModule = src.asInstanceOf[BatchNormalization[T]]
@@ -162,6 +163,10 @@ class BatchNormalization[T: ClassTag](
     } else {
       null
     }
+  }
+
+  override def getExtraParameter(): Array[Tensor[T]] = {
+    Array(runningMean, runningVar)
   }
 
   override def getParametersTable(): Table = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BatchNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BatchNormalization.scala
@@ -141,7 +141,6 @@ class BatchNormalization[T: ClassTag](
     this
   }
 
-  @deprecated("Please use get/setExtraParameter API", "since 0.4.0")
   override def copyStatus(src: Module[T]): this.type = {
     require(canEqual(src), s"copyStatus: type mismatch, $src is different from $this")
     val srcModule = src.asInstanceOf[BatchNormalization[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
@@ -108,14 +108,14 @@ abstract class Container[A <: Activity : ClassTag,
   }
 
   override def getExtraParameter(): Array[Tensor[T]] = {
-    val extraState = new ArrayBuffer[Tensor[T]]()
+    val extraParam = new ArrayBuffer[Tensor[T]]()
     modules.foreach(m => {
       val state = m.getExtraParameter()
       if (state != null) {
-        extraState ++= state
+        extraParam ++= state
       }
     })
-    extraState.toArray
+    extraParam.toArray
   }
 
   override def getParametersTable(): Table = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
@@ -148,20 +148,6 @@ abstract class Container[A <: Activity : ClassTag,
     nodes
   }
 
-  override def copyStatus(src: Module[T]): this.type = {
-    require(canEqual(src), s"copyStatus: type mismatch, $src is different from $this")
-    val srcContainer = src.asInstanceOf[Container[A, B, T]]
-    require(srcContainer.modules.length == modules.length,
-      s"copyStatus: container's length mismatch" +
-        s"excepted ${modules.length}, but get ${srcContainer.modules.length}")
-    var i = 0
-    while (i < modules.length) {
-      modules(i).copyStatus(srcContainer.modules(i))
-      i += 1
-    }
-    this
-  }
-
   override def clearState() : this.type = {
     super.clearState()
     modules.foreach(_.clearState())

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
@@ -107,10 +107,10 @@ abstract class Container[A <: Activity : ClassTag,
     (weights.toArray, gradWeights.toArray)
   }
 
-  override def getExtraState(): Array[Tensor[T]] = {
+  override def getExtraParameter(): Array[Tensor[T]] = {
     val extraState = new ArrayBuffer[Tensor[T]]()
     modules.foreach(m => {
-      val state = m.getExtraState()
+      val state = m.getExtraParameter()
       if (state != null) {
         extraState ++= state
       }
@@ -148,6 +148,7 @@ abstract class Container[A <: Activity : ClassTag,
     nodes
   }
 
+  @deprecated("Please use get/setExtraParameter API", "since 0.4.0")
   override def copyStatus(src: Module[T]): this.type = {
     require(canEqual(src), s"copyStatus: type mismatch, $src is different from $this")
     val srcContainer = src.asInstanceOf[Container[A, B, T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
@@ -107,6 +107,17 @@ abstract class Container[A <: Activity : ClassTag,
     (weights.toArray, gradWeights.toArray)
   }
 
+  override def getExtraState(): Array[Tensor[T]] = {
+    val extraState = new ArrayBuffer[Tensor[T]]()
+    modules.foreach(m => {
+      val state = m.getExtraState()
+      if (state != null) {
+        extraState ++= state
+      }
+    })
+    extraState.toArray
+  }
+
   override def getParametersTable(): Table = {
     val pt = T()
     modules.foreach(m => {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
@@ -148,7 +148,6 @@ abstract class Container[A <: Activity : ClassTag,
     nodes
   }
 
-  @deprecated("Please use get/setExtraParameter API", "since 0.4.0")
   override def copyStatus(src: Module[T]): this.type = {
     require(canEqual(src), s"copyStatus: type mismatch, $src is different from $this")
     val srcContainer = src.asInstanceOf[Container[A, B, T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Module.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Module.scala
@@ -162,19 +162,4 @@ object Module {
 
     return Tensor(storage)
   }
-
-  def setExtraState[@specialized(Float, Double) T: ClassTag](
-      module: Module[T],
-      state: Array[Tensor[T]])(
-    implicit ev: TensorNumeric[T]): Module[T] = {
-    val currentState = module.getExtraState()
-    require(state.length == currentState.length, "state's length doesn't match, excepted:" +
-      s"${currentState.length}, but got  ${state.length}")
-    var i = 0
-    while (i < state.length) {
-      currentState(i).copy(state(i))
-      i += 1
-    }
-    module
-  }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Module.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Module.scala
@@ -162,4 +162,19 @@ object Module {
 
     return Tensor(storage)
   }
+
+  def setExtraState[@specialized(Float, Double) T: ClassTag](
+      module: Module[T],
+      state: Array[Tensor[T]])(
+    implicit ev: TensorNumeric[T]): Module[T] = {
+    val currentState = module.getExtraState()
+    require(state.length == currentState.length, "state's length doesn't match, excepted:" +
+      s"${currentState.length}, but got  ${state.length}")
+    var i = 0
+    while (i < state.length) {
+      currentState(i).copy(state(i))
+      i += 1
+    }
+    module
+  }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributed.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributed.scala
@@ -237,7 +237,6 @@ class TimeDistributed[T : ClassTag] (val layer: TensorModule[T])
    * @param src source Module
    * @return this
    */
-  @deprecated("Please use get/setExtraParameter API", "since 0.4.0")
   override def copyStatus(src: Module[T]): TimeDistributed.this.type = {
     val other = src.asInstanceOf[TimeDistributed[T]]
     layer.copyStatus(other.layer.asInstanceOf[Module[T]])

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributed.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributed.scala
@@ -224,6 +224,10 @@ class TimeDistributed[T : ClassTag] (val layer: TensorModule[T])
    */
   override def getParametersTable(): Table = layer.getParametersTable()
 
+  override def getExtraState(): Array[Tensor[T]] = {
+    layer.getExtraState()
+  }
+
   /**
    * Copy the useful running status from src to this.
    *

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributed.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributed.scala
@@ -228,21 +228,6 @@ class TimeDistributed[T : ClassTag] (val layer: TensorModule[T])
     layer.getExtraParameter()
   }
 
-  /**
-   * Copy the useful running status from src to this.
-   *
-   * The subclass should override this method if it has some parameters besides weight and bias.
-   * Such as runningMean and runningVar of BatchNormalization.
-   *
-   * @param src source Module
-   * @return this
-   */
-  override def copyStatus(src: Module[T]): TimeDistributed.this.type = {
-    val other = src.asInstanceOf[TimeDistributed[T]]
-    layer.copyStatus(other.layer.asInstanceOf[Module[T]])
-    this
-  }
-
   override def clearState(): TimeDistributed.this.type = {
     super.clearState()
     layer.clearState()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributed.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributed.scala
@@ -224,8 +224,8 @@ class TimeDistributed[T : ClassTag] (val layer: TensorModule[T])
    */
   override def getParametersTable(): Table = layer.getParametersTable()
 
-  override def getExtraState(): Array[Tensor[T]] = {
-    layer.getExtraState()
+  override def getExtraParameter(): Array[Tensor[T]] = {
+    layer.getExtraParameter()
   }
 
   /**
@@ -237,6 +237,7 @@ class TimeDistributed[T : ClassTag] (val layer: TensorModule[T])
    * @param src source Module
    * @return this
    */
+  @deprecated("Please use get/setExtraParameter API", "since 0.4.0")
   override def copyStatus(src: Module[T]): TimeDistributed.this.type = {
     val other = src.asInstanceOf[TimeDistributed[T]]
     layer.copyStatus(other.layer.asInstanceOf[Module[T]])

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Utils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Utils.scala
@@ -235,7 +235,7 @@ object Utils {
       s"$src and $dst is not the same type.")
     dstParameters.copy(srcParameters)
     // copy running status
-    dst.copyStatus(src)
+    dst.setExtraParameter(src.getExtraParameter())
     dst
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -368,6 +368,15 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag, 
   def parameters(): (Array[Tensor[T]], Array[Tensor[T]]) = null
 
   /**
+   * Get some extra status in this module. Such as runningMean and runningVar of BatchNormalization.
+   *
+   * The subclass should override this method if it has some parameters besides weight and bias.
+   *
+   * @return
+   */
+  def getExtraState(): Array[Tensor[T]] = null
+
+  /**
    * This function returns a table contains ModuleName, the parameter names and parameter value
    * in this module.
    * The result table is a structure of Table(ModuleName -> Table(ParameterName -> ParameterValue)),

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -125,7 +125,6 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag, 
    * @param src source Module
    * @return this
    */
-  @deprecated("Please use get/setExtraParameter API", "since 0.4.0")
   def copyStatus(src: Module[T]) : this.type = {
     this
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -117,19 +117,6 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag, 
   }
 
   /**
-   * Copy the useful running status from src to this.
-   *
-   * The subclass should override this method if it has some parameters besides weight and bias.
-   * Such as runningMean and runningVar of BatchNormalization.
-   *
-   * @param src source Module
-   * @return this
-   */
-  def copyStatus(src: Module[T]) : this.type = {
-    this
-  }
-
-  /**
    * Clear cached activities to save storage space or network bandwidth. Note that we use
    * Tensor.set to keep some information like tensor share
    *

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -385,16 +385,24 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag, 
    *
    * @return this
    */
-  def setExtraParameter(state: Array[Tensor[T]]): this.type = {
-    val currentState = this.getExtraParameter()
-    require(state.length == currentState.length, "state's length doesn't match, excepted:" +
-      s"${currentState.length}, but got  ${state.length}")
-    var i = 0
-    while (i < state.length) {
-      currentState(i).copy(state(i))
-      i += 1
+  def setExtraParameter(extraParam: Array[Tensor[T]]): this.type = {
+    val currentExtraParam = this.getExtraParameter()
+    if (extraParam != null && currentExtraParam != null) {
+      require(extraParam.length == currentExtraParam.length,
+        "state's length doesn't match, excepted:" +
+        s"${currentExtraParam.length}, but got  ${extraParam.length}")
+      var i = 0
+      while (i < extraParam.length) {
+        currentExtraParam(i).copy(extraParam(i))
+        i += 1
+      }
+      this
+    } else if (extraParam == null && currentExtraParam == null) {
+      this
+    } else {
+      throw new IllegalArgumentException(s"module's extraParameter is $currentExtraParam" +
+        s", while setting param is ${extraParam}")
     }
-    this
   }
 
   /**

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -125,6 +125,7 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag, 
    * @param src source Module
    * @return this
    */
+  @deprecated("Please use get/setExtraParameter API", "since 0.4.0")
   def copyStatus(src: Module[T]) : this.type = {
     this
   }
@@ -368,13 +369,34 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag, 
   def parameters(): (Array[Tensor[T]], Array[Tensor[T]]) = null
 
   /**
-   * Get some extra status in this module. Such as runningMean and runningVar of BatchNormalization.
+   * Get extra parameter in this module.
+   * Extra parameter means the trainable parameters beside weight and bias. Such as runningMean
+   * and runningVar in BatchNormalization.
    *
    * The subclass should override this method if it has some parameters besides weight and bias.
    *
-   * @return
+   * @return an array of tensor
    */
-  def getExtraState(): Array[Tensor[T]] = null
+  def getExtraParameter(): Array[Tensor[T]] = null
+
+  /**
+   * Set extra parameter to this module.
+   * Extra parameter means the trainable parameters beside weight and bias. Such as runningMean
+   * and runningVar in BatchNormalization.
+   *
+   * @return this
+   */
+  def setExtraParameter(state: Array[Tensor[T]]): this.type = {
+    val currentState = this.getExtraParameter()
+    require(state.length == currentState.length, "state's length doesn't match, excepted:" +
+      s"${currentState.length}, but got  ${state.length}")
+    var i = 0
+    while (i < state.length) {
+      currentState(i).copy(state(i))
+      i += 1
+    }
+    this
+  }
 
   /**
    * This function returns a table contains ModuleName, the parameter names and parameter value

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -87,6 +87,7 @@ object DistriOptimizer {
    * @param isOverWrite  if overwrite the checkpoint
    */
   private[optim] def optimize[T: ClassTag](
+    trainingModel: Module[T],
     dataset: DistributedDataSet[MiniBatch[T]],
     coresPerNode: Int,
     state: Table,
@@ -396,7 +397,8 @@ object DistriOptimizer {
             summary,
             models,
             driverState,
-            parameters
+            parameters,
+            trainingModel
           )
         }
 
@@ -408,7 +410,8 @@ object DistriOptimizer {
           models,
           driverState,
           parameters,
-          optimMethod
+          optimMethod,
+          trainingModel
         )
 
       } else {
@@ -439,12 +442,13 @@ object DistriOptimizer {
       models: RDD[Cache[T]],
       state: Table,
       parameters: AllReduceParameter[T],
-      optimMethod: OptimMethod[T]): Unit = {
+      optimMethod: OptimMethod[T],
+      trainingModel: Module[T]): Unit = {
     cacheTrigger.foreach { trigger =>
       cachePath.foreach { path =>
         if (trigger(state)) {
           println(s"[Wall Clock ${wallClockTime / 1e9}s] Save model to $path")
-          saveModel(getModel(models, parameters), cachePath, isOverWrite,
+          saveModel(getModel(models, parameters, trainingModel), cachePath, isOverWrite,
             s".${state[Int]("neval")}")
           optimMethod.state.update("epoch", state[Int]("epoch"))
           optimMethod.state.update("neval", state[Int]("neval"))
@@ -466,11 +470,12 @@ object DistriOptimizer {
         trainSummary: TrainSummary,
         models: RDD[Cache[T]],
         driverState: Table,
-        parameters: AllReduceParameter[T])(implicit ev: TensorNumeric[T]): Unit = {
+        parameters: AllReduceParameter[T],
+        trainingModel: Module[T])(implicit ev: TensorNumeric[T]): Unit = {
     val currentIteration = driverState[Int]("neval") - 1
       val parametersTrigger = trainSummary.getSummaryTrigger("Parameters")
       if (parametersTrigger.isDefined && parametersTrigger.get(driverState)) {
-        val model = getModel(models, parameters)
+        val model = getModel(models, parameters, trainingModel)
         val parametersTable = model.getParametersTable()
         // Parallelize to create Histogram.
         Engine.default.invokeAndWait(
@@ -680,17 +685,20 @@ object DistriOptimizer {
   }
 
   /**
-   * Fetch current model to driver.
+   * Fetch current model parameters to driver, and copy to trainingModel.
    *
    * @param models cached models
    * @param parameters [[AllReduceParameter]]
-   * @return current model
+   * @param trainingModel the model is trained by optimizer
+   * @return trained model
    */
   private def getModel[T: ClassTag](
       models: RDD[Cache[T]],
-      parameters: AllReduceParameter[T]): Module[T] = {
+      parameters: AllReduceParameter[T],
+      trainingModel: Module[T]): Module[T] = {
     val partitionNum = models.partitions.length
-    val trainedModel = models.map(_.localModels.head.clearState()).first()
+    val extraState = models.map(_.localModels.head.getExtraState()).first()
+    Module.setExtraState(trainingModel, extraState)
     val (weights, gradients) = models.mapPartitions(iter => {
       val cached = iter.next()
       val curPartitionId = TaskContext.getPartitionId()
@@ -698,11 +706,11 @@ object DistriOptimizer {
         Map(curPartitionId -> parameters.gradientPartition)))
     }).reduce((a, b) => (a._1 ++ b._1, a._2 ++ b._2))
 
-    val parameterArray = trainedModel.parameters()
+    val parameterArray = trainingModel.parameters()
     (0 until parameterArray._2.length).foreach(i =>
       parameterArray._2(i).resizeAs(parameterArray._1(i))
     )
-    val (parameter, gradientParameter) = trainedModel.getParameters()
+    val (parameter, gradientParameter) = trainingModel.getParameters()
     val parameterLength = parameter.nElement()
     val taskSize = parameterLength / partitionNum
     require(taskSize != 0, "parameter length should not less than partition number")
@@ -715,7 +723,7 @@ object DistriOptimizer {
       gradientParameter.narrow(1, start + 1, length).copy(gradients(pid))
     })
 
-    trainedModel
+    trainingModel
   }
 }
 
@@ -821,6 +829,7 @@ class DistriOptimizer[T: ClassTag] (
     while (retryNum < maxRetry) {
       try {
         DistriOptimizer.optimize(
+          model,
           distDataset,
           coresPerNode,
           state,
@@ -882,9 +891,7 @@ class DistriOptimizer[T: ClassTag] (
       }
     }
 
-    val trainedModel = DistriOptimizer.getModel(models, parameters)
-
-    nn.Utils.copyModule(trainedModel, model)
+    DistriOptimizer.getModel(models, parameters, model)
 
     // Reset some internal states, so this or other optimizers can run optimize again
     clearState()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -697,8 +697,8 @@ object DistriOptimizer {
       parameters: AllReduceParameter[T],
       trainingModel: Module[T]): Module[T] = {
     val partitionNum = models.partitions.length
-    val extraState = models.map(_.localModels.head.getExtraState()).first()
-    Module.setExtraState(trainingModel, extraState)
+    val extraState = models.map(_.localModels.head.getExtraParameter()).first()
+    trainingModel.setExtraParameter(extraState)
     val (weights, gradients) = models.mapPartitions(iter => {
       val cached = iter.next()
       val curPartitionId = TaskContext.getPartitionId()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalOptimizer.scala
@@ -182,7 +182,7 @@ class LocalOptimizer[T: ClassTag] (
     }
 
     // copy running status from workingModels to model
-    model.copyStatus(workingModels.head)
+    model.setExtraParameter(workingModels.head.getExtraParameter())
 
     model
   }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/AbstractModuleSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/AbstractModuleSpec.scala
@@ -18,6 +18,7 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl._
 import org.scalatest.{FlatSpec, Matchers}
 import com.intel.analytics.bigdl.numeric.NumericFloat
+import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.{T, Table}
 
 class AbstractModuleSpec extends FlatSpec with Matchers {
@@ -275,5 +276,22 @@ class AbstractModuleSpec extends FlatSpec with Matchers {
     model("conv1x1").get.getScaleB() should be(1)
     model("conv3x3_1").get.getScaleW() should be(3)
     model("conv3x3_1").get.getScaleB() should be(1.5)
+  }
+
+  "get/set extra parameter" should "work fine" in {
+    val bn = SpatialBatchNormalization(5)
+    val model = Sequential()
+        .add(SpatialConvolution(3, 5, 3, 3))
+      .add(bn)
+      .add(SpatialConvolution(5, 2, 3, 3))
+      .add(BatchNormalization(2))
+
+    val model2 = model.cloneModule()
+    bn.runningMean.range(1, 5)
+    model2 should not be (model)
+    val extp = model.getExtraParameter()
+    extp(0) should be (Tensor().range(1, 5))
+    model2.setExtraParameter(extp)
+    model2 should be (model)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/AbstractModuleSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/AbstractModuleSpec.scala
@@ -294,4 +294,37 @@ class AbstractModuleSpec extends FlatSpec with Matchers {
     model2.setExtraParameter(extp)
     model2 should be (model)
   }
+
+  "get/set extra parameter" should "work fine 2" in {
+    val model = Sequential()
+      .add(SpatialConvolution(3, 5, 3, 3))
+      .add(SpatialConvolution(5, 2, 3, 3))
+
+    val model2 = model.cloneModule()
+    model2 should be (model)
+    val extp = model.getExtraParameter()
+    model2.setExtraParameter(extp)
+    model2 should be (model)
+  }
+
+  "get/set extra parameter" should "work fine 3" in {
+    val model = BatchNormalization(5)
+
+    val model2 = model.cloneModule()
+    model.runningMean.range(1, 5)
+    model2 should not be (model)
+    val extp = model.getExtraParameter()
+    model2.setExtraParameter(extp)
+    model2 should be (model)
+  }
+
+  "get/set extra parameter" should "work fine 4" in {
+    val model = SpatialConvolution(3, 5, 3, 3)
+
+    val model2 = model.cloneModule()
+    model2 should be (model)
+    val extp = model.getExtraParameter()
+    model2.setExtraParameter(extp)
+    model2 should be (model)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/TimeDistributedSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/TimeDistributedSpec.scala
@@ -22,7 +22,7 @@ import com.intel.analytics.bigdl.utils.RandomGenerator._
 import org.scalatest.{FlatSpec, Matchers}
 
 class TimeDistributedSpec extends FlatSpec with Matchers {
-  "A TimeDistributed Module" should "copyStatus correctly" in {
+  "A TimeDistributed Module" should "setExtraParam works correctly" in {
     RNG.setSeed(100)
     val batchSize = 5
     val times = 5
@@ -43,7 +43,8 @@ class TimeDistributedSpec extends FlatSpec with Matchers {
     model2.forward(input2)
     model2.backward(input2, gradOutput2)
 
-    model1.copyStatus(model2.asInstanceOf[AbstractModule[Activity, Activity, Float]])
+    model1.setExtraParameter(
+      model2.asInstanceOf[AbstractModule[Activity, Activity, Float]].getExtraParameter())
 
     bnorm1.runningMean should be (bnorm2.runningMean)
     bnorm1.runningVar should be (bnorm2.runningVar)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix #1908 caused by `val trainedModel = models.map(_.localModels.head.clearState()).first()`
When the training model is very large, it will throw OOMError.

## How was this patch tested?

unit tests

## Related links or issues (optional)
fixed #1908
