### PR TITLE
Concat check input size check

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Concat.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Concat.scala
@@ -71,7 +71,7 @@ class Concat[T: ClassTag](val dimension: Int)(
           if (size._2 != dimension -1) {
             require(size._1 == currentOutput.size(size._2 + 1),
             s"${this.modules(i).getName} output size at dimension ${size._2 + 1} mismatch," +
-              s"expected ${size._1}, actual : ${currentOutput.size(size._2)}")
+              s"expected ${size._1}, actual : ${currentOutput.size(size._2) + 1}")
           }
         })
       }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Concat.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Concat.scala
@@ -63,17 +63,20 @@ class Concat[T: ClassTag](val dimension: Int)(
       if (i == 0) {
         this.size = currentOutput.size()
       } else {
-        this.size(this.dimension - 1) += currentOutput.size(this.dimension)
         require(this.size.length == currentOutput.size.length,
         s"${this.modules(i).getName} output size mismatch, expected : ${this.size.length}," +
           s"actual ${currentOutput.size.length}")
-        this.size.zipWithIndex.foreach(size => {
-          if (size._2 != dimension -1) {
-            require(size._1 == currentOutput.size(size._2 + 1),
-            s"${this.modules(i).getName} output size at dimension ${size._2 + 1} mismatch," +
-              s"expected ${size._1}, actual : ${currentOutput.size(size._2) + 1}")
+        var index = 0
+        val ssize = this.size.length
+        while (index < ssize) {
+          if (index != dimension - 1) {
+            require(this.size(index) == currentOutput.size(index + 1),
+              s"${this.modules(i).getName} output size at dimension ${index + 1} mismatch," +
+                s"expected ${this.size(index)}, actual : ${currentOutput.size(index + 1)}")
           }
-        })
+          index += 1
+        }
+        this.size(this.dimension - 1) += currentOutput.size(this.dimension)
       }
       i += 1
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Concat.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Concat.scala
@@ -121,7 +121,7 @@ class Concat[T: ClassTag](val dimension: Int)(
       require(currSize.length == dim, s"output for each concat " +
         s"module should have the same dim, ${i}th output dim" +
         s"not equals to first output dim ${currSize.length} != ${dim}")
-      for (j <- 0 until dim) {
+      for (j <- 0 until dimension) {
         if (j != (dim - 1)) {
           require(size(j) == currSize(j), s"output for each concat module should be of the " +
             s"same size at dimension ${dim}, while ${i}th output at ${j} dimension not" +

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ConcatSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ConcatSpec.scala
@@ -17,6 +17,7 @@
 package com.intel.analytics.bigdl.nn
 
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
+import com.intel.analytics.bigdl.utils.LayerException
 import org.scalatest.{FlatSpec, Matchers}
 
 @com.intel.analytics.bigdl.tags.Parallel
@@ -72,5 +73,17 @@ class ConcatSpec extends FlatSpec with Matchers {
     val expectedGradInput = Tensor[Float](2, 2, 2, 2).apply1(_ => 5f)
     output should be (expectedOutput)
     gradInput should be (expectedGradInput)
+  }
+
+  "Concat with incorrec input" should "throw expected exception" in {
+    val model = Concat[Float](2)
+    model.add(Reshape[Float](Array(5, 2)))
+    model.add(Reshape[Float](Array(2, 5)))
+    val input = Tensor[Float](10)
+    val caught = intercept[LayerException] {
+      model.forward(input)
+    }
+    val contains = caught.error.getMessage.contains("output size at dimension 1 mismatch")
+    contains should be (true)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Each module output inside concat is supposed to have the same dim size exception the one for concatenating, this change is to do the sanity check to make it more user friendly when exception happens

## How was this patch tested?

Unit test

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/2027

