### PR TITLE
Handle classification output dimension > 2

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/ValidationMethod.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/ValidationMethod.scala
@@ -175,7 +175,7 @@ class Top1Accuracy[T](
     var correct = 0
     var count = 0
 
-    val _output = output.asInstanceOf[Tensor[T]]
+    val _output = output.asInstanceOf[Tensor[T]].squeeze
     val _target = target.asInstanceOf[Tensor[T]]
     if (_output.dim() == 2) {
       (if (_output.size(2) == 1) {
@@ -218,7 +218,7 @@ class Top1Accuracy[T](
 class Top5Accuracy[T] extends ValidationMethod[T] {
   override def apply(output: Activity, target: Activity):
   AccuracyResult = {
-    val _output = output.asInstanceOf[Tensor[T]]
+    val _output = output.asInstanceOf[Tensor[T]].squeeze
     val _target = target.asInstanceOf[Tensor[T]].squeezeNewTensor()
     var correct = 0
     var count = 0


### PR DESCRIPTION
## What changes were proposed in this pull request?

For some models like squeezenet, the output has more than 2 dimensions, we need to handle it

## How was this patch tested?

unit test

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/1688

