### PR TITLE
add batchsize option for keras examples

### DIFF
--- a/pyspark/bigdl/examples/keras/README.md
+++ b/pyspark/bigdl/examples/keras/README.md
@@ -2,7 +2,7 @@
 
 We provide several simple examples here to show how to load a Keras model into BigDL and running the model in a distributed fashion.
 
-Note that the Keras version we support and test is [__Keras 1.2.2__](https://faroit.github.io/keras-docs/1.2.2/) with TensorFlow backend.
+Note that the Keras version we support and test is [__Keras 1.2.2__](https://faroit.github.io/keras-docs/1.2.2/) with TensorFlow backend. You may need to see the page [Keras Support](../../../../docs/docs/ProgrammingGuide/keras-support.md) for more guidance.
 
 For the sake of illustration, in these examples, we first define a model in Keras, then save it as a JSON/HDF5 file and load it into BigDL.
 
@@ -46,3 +46,4 @@ ${SPARK_HOME}/bin/spark-submit \
     --conf spark.executor.extraClassPath=bigdl-${BIGDL_VERSION}-jar-with-dependencies.jar \
     ${BigDL_HOME}/pyspark/bigdl/examples/keras/mnist_cnn.py
 ```
+* ```--batchSize``` an option that can be used to set batch size.

--- a/pyspark/bigdl/examples/keras/README.md
+++ b/pyspark/bigdl/examples/keras/README.md
@@ -2,9 +2,11 @@
 
 We provide several simple examples here to show how to load a Keras model into BigDL and running the model in a distributed fashion.
 
-Note that the Keras version we support and test is [__Keras 1.2.2__](https://faroit.github.io/keras-docs/1.2.2/) with TensorFlow backend. You may need to see the page [Keras Support](../../../../docs/docs/ProgrammingGuide/keras-support.md) first before going into these examples.
+You may need to see the page [Keras Support](../../../../docs/docs/ProgrammingGuide/keras-support.md) first before going into these examples.
 
-For the sake of illustration, in these examples, we first define a model in Keras, then save it as a JSON/HDF5 file and load it into BigDL.
+Note that the Keras version we support and test is [__Keras 1.2.2__](https://faroit.github.io/keras-docs/1.2.2/) with TensorFlow backend.
+
+For the sake of illustration, in these examples, we first define a model in Keras 1.2.2, then save it as a JSON/HDF5 file and load it into BigDL.
 
 You can directly run these examples if you [install BigDL from pip](../../../../docs/docs/PythonUserGuide/install-from-pip.md). After the training, good accuracy can be achieved.
 

--- a/pyspark/bigdl/examples/keras/README.md
+++ b/pyspark/bigdl/examples/keras/README.md
@@ -2,7 +2,7 @@
 
 We provide several simple examples here to show how to load a Keras model into BigDL and running the model in a distributed fashion.
 
-Note that the Keras version we support and test is [__Keras 1.2.2__](https://faroit.github.io/keras-docs/1.2.2/) with TensorFlow backend. You may need to see the page [Keras Support](../../../../docs/docs/ProgrammingGuide/keras-support.md) for more guidance.
+Note that the Keras version we support and test is [__Keras 1.2.2__](https://faroit.github.io/keras-docs/1.2.2/) with TensorFlow backend. You may need to see the page [Keras Support](../../../../docs/docs/ProgrammingGuide/keras-support.md) first before going into these examples.
 
 For the sake of illustration, in these examples, we first define a model in Keras, then save it as a JSON/HDF5 file and load it into BigDL.
 

--- a/pyspark/bigdl/examples/keras/imdb_cnn_lstm.py
+++ b/pyspark/bigdl/examples/keras/imdb_cnn_lstm.py
@@ -20,6 +20,9 @@
 # The Keras version we support and test is Keras 1.2.2 with TensorFlow backend.
 # See README.md for how to run this example.
 
+from optparse import OptionParser
+import sys
+
 
 def load_imdb():
     """
@@ -59,6 +62,10 @@ def build_keras_model():
 
 
 if __name__ == "__main__":
+    parser = OptionParser()
+    parser.add_option("-b", "--batchSize", type=int, dest="batchSize", default="32")
+    (options, args) = parser.parse_args(sys.argv)
+
     keras_model = build_keras_model()
     hdf5_path = "/tmp/imdb.h5"
     keras_model.save(hdf5_path)
@@ -86,9 +93,9 @@ if __name__ == "__main__":
         criterion=BCECriterion(),
         optim_method=Adam(),
         end_trigger=MaxEpoch(2),
-        batch_size=32)
+        batch_size=options.batchSize)
     optimizer.set_validation(
-        batch_size=32,
+        batch_size=options.batchSize,
         val_rdd=test_data,
         trigger=EveryEpoch(),
         val_method=[Top1Accuracy()]

--- a/pyspark/bigdl/examples/keras/mnist_cnn.py
+++ b/pyspark/bigdl/examples/keras/mnist_cnn.py
@@ -33,7 +33,7 @@ else:
 
 def get_mnist(sc, data_type="train", location="/tmp/mnist"):
     """
-    Download or load MNIST dataset to/from specified path.
+    Download or load MNIST dataset to/from the specified path.
     Normalize and transform input data into an RDD of Sample
     """
     from bigdl.dataset import mnist

--- a/pyspark/bigdl/examples/keras/mnist_cnn.py
+++ b/pyspark/bigdl/examples/keras/mnist_cnn.py
@@ -21,6 +21,7 @@
 # The Keras version we support and test is Keras 1.2.2 with TensorFlow backend.
 # See README.md for how to run this example.
 
+from optparse import OptionParser
 from bigdl.examples.keras.keras_utils import *
 
 import keras.backend
@@ -32,7 +33,7 @@ else:
 
 def get_mnist(sc, data_type="train", location="/tmp/mnist"):
     """
-    Download or load MNIST dataset.
+    Download or load MNIST dataset to/from specified path.
     Normalize and transform input data into an RDD of Sample
     """
     from bigdl.dataset import mnist
@@ -73,6 +74,11 @@ def build_keras_model():
 
 
 if __name__ == "__main__":
+    parser = OptionParser()
+    parser.add_option("-b", "--batchSize", type=int, dest="batchSize", default="128")
+    parser.add_option("-d", "--dataPath", dest="dataPath", default="/tmp/mnist")
+    (options, args) = parser.parse_args(sys.argv)
+
     keras_model = build_keras_model()
     json_path = "/tmp/lenet.json"
     save_keras_definition(keras_model, json_path)
@@ -90,8 +96,8 @@ if __name__ == "__main__":
     show_bigdl_info_logs()
     init_engine()
 
-    train_data = get_mnist(sc, "train")
-    test_data = get_mnist(sc, "test")
+    train_data = get_mnist(sc, "train", options.dataPath)
+    test_data = get_mnist(sc, "test", options.dataPath)
 
     optimizer = Optimizer(
         model=bigdl_model,
@@ -99,9 +105,9 @@ if __name__ == "__main__":
         criterion=ClassNLLCriterion(logProbAsInput=False),
         optim_method=Adadelta(),
         end_trigger=MaxEpoch(12),
-        batch_size=128)
+        batch_size=options.batchSize)
     optimizer.set_validation(
-        batch_size=128,
+        batch_size=options.batchSize,
         val_rdd=test_data,
         trigger=EveryEpoch(),
         val_method=[Top1Accuracy()]


### PR DESCRIPTION
## What changes were proposed in this pull request?

In case when using spark-submit, batch size should be a multiple of core number

## How was this patch tested?

Manual test and jenkins

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

