### PR TITLE
Add keras init_method & warning for unsupported init_method

### DIFF
--- a/pyspark/bigdl/keras/converter.py
+++ b/pyspark/bigdl/keras/converter.py
@@ -1763,8 +1763,13 @@ class LayerConverter:
     def combo_parameter_layer(self, blayer, config):
         blayer.set_name(config["name"])
         if hasattr(blayer, "set_init_method"):
-            blayer.set_init_method(self.to_bigdl_init(config["init"]),
-                                   BInit.Zeros())  # Keras always set this to be zeros
+            try:
+                blayer.set_init_method(self.to_bigdl_init(config["init"]),
+                                       BInit.Zeros())  # Keras always set this to be zeros
+            except Exception:
+                warning_msg = "We don't support initialization " + config["init"] + " for now. " \
+                    + "Using the default instead."
+                warnings.warn(warning_msg)
         # "linear" means doing nothing
         if config["activation"] != "linear":
             activation = get_activation_by_name(config["activation"],
@@ -1789,6 +1794,10 @@ class LayerConverter:
             init = BInit.Ones()
         elif kinit_method == "zero":
             init = BInit.Zeros()
+        elif kinit_method == "uniform":
+            init = BInit.RandomUniform(lower=-0.05, upper=0.05)
+        elif kinit_method == "normal":
+            init = BInit.RandomNormal(mean=0.0, stdv=0.05)
         else:
             raise Exception("Unsupported init type: %s" % kinit_method)
         return init

--- a/pyspark/test/bigdl/keras/test_layer.py
+++ b/pyspark/test/bigdl/keras/test_layer.py
@@ -79,6 +79,9 @@ class TestLayer(BigDLTestCase):
         self.modelTestSingleLayer(input_data2, layer3, dump_weights=True)
         layer4 = Dense(2, init='glorot_uniform', activation="hard_sigmoid", input_shape=(10, ))
         self.modelTestSingleLayer(input_data2, layer4, dump_weights=True)
+        # Test for unsupported init_method. Should get a warning not an exception.
+        layer5 = Dense(4, init='he_uniform', input_shape=(10, ))
+        self.modelTestSingleLayer(input_data2, layer5, dump_weights=True)
 
     def test_timedistributeddense(self):
         input_data = np.random.random_sample([2, 4, 5])


### PR DESCRIPTION
## What changes were proposed in this pull request?

For unsupported init methods, it's not reasonable if we just raise Exception and stop. Init_methods doesn't matter if users also load with weights.
So, raise a warning first for now if there's unsupported init_method.
To be discussed whether the init_methods in #1999 to be added in the next release.

## How was this patch tested?

Jenkins.

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

