### PR TITLE
[backport] Fix Wrong labelSize at Sample.scala 411 (#2147)

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Sample.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Sample.scala
@@ -408,7 +408,7 @@ private[bigdl] class TensorSample[T: ClassTag](
       val features: Array[Tensor[T]],
       val labels: Array[Tensor[T]]) extends Sample[T] {
   val featureSize = features.map(_.size())
-  val labelSize = features.map(_.size())
+  val labelSize = labels.map(_.size())
 
   def featureLength(index: Int): Int = {
     features(0).size(1)


### PR DESCRIPTION
"val labelSize = features.map(_.size())"   -> "val labelSize = labels.map(_.size())"

## What changes were proposed in this pull request?

(Please fill in changes proposed in this patch)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If it is possible, please attach a screenshot; otherwise, remove this)

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

