### PR TITLE
Fix SparseMinibatch when batching DenseTensor

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
@@ -729,22 +729,7 @@ object SparseMiniBatch{
       val current = tensors(i)
       val target = result.select(dim, i + 1)
 
-      if (target.isContiguous() || dim > 2) {
-        // Copy directly when target is Contiguous or dimension is larger than 2
-        // in which case the contiguous region in target tensor is fairly small in practice
-        target.copy(current)
-      } else {
-        // Divide target into contiguous frames when target isn't contiguous
-        var f = 1
-        while (f <= target.size(1)) {
-          val curFrame = target.select(1, f)
-          val outputFrame = current.select(1, f)
-          require(curFrame.isContiguous())
-          require(outputFrame.isContiguous())
-          curFrame.copy(outputFrame)
-          f += 1
-        }
-      }
+      target.copy(current)
 
       i += 1
     }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/MiniBatchSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/MiniBatchSpec.scala
@@ -101,11 +101,11 @@ class MiniBatchSpec extends FlatSpec with Matchers {
     val expectedInput1 = Tensor.sparse(Array(Array(0, 0, 0, 0, 1, 1, 1, 1),
       Array(0, 1, 2, 3, 0, 1, 2, 3)),
       Array.range(1, 9).map(_.toFloat), Array(2, 4))
-    val expectedInput2 = Tensor[Float].range(1, 10)
+    val expectedInput2 = Tensor[Float].range(1, 10).reshape(Array(2, 5))
     input.toTable[Tensor[Float]](1) should be (expectedInput1)
     input.toTable[Tensor[Float]](2) should be (expectedInput2)
 
-    val expectedTarget = Tensor[Float](T(1.0f, 0.0f))
+    val expectedTarget = Tensor[Float](T(1.0f, 0.0f)).reshape(Array(2, 1))
     target should be (expectedTarget)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When batch multiple tensors, it should add another dimension instead of concat on the original dimension.

## How was this patch tested?

unit tests

