### PR TITLE
Fix bug of SparseTensor.resize(size, nElement)

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/SparseTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/SparseTensor.scala
@@ -479,7 +479,7 @@ private[tensor] class SparseTensor[@specialized(Float, Double) T: ClassTag](
       val _addIndices = new Array[Storage[Int]](size.length - _indices.length)
       for (i <- _addIndices.indices) _addIndices(i) = Storage[Int](nElement + _storageOffset)
       _indicesOffset = new Array[Int](size.length - _indicesOffset.length) ++ _indicesOffset
-      _indices ++= _addIndices
+      _indices = _addIndices ++ _indices
     }
 
     // resize _indices's length

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/SparseTensorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/SparseTensorSpec.scala
@@ -19,6 +19,8 @@ package com.intel.analytics.bigdl.tensor
 import org.scalatest.{FlatSpec, Matchers}
 import com.intel.analytics.bigdl.numeric.NumericFloat
 
+import scala.util.Random
+
 @com.intel.analytics.bigdl.tags.Parallel
 class SparseTensorSpec  extends FlatSpec with Matchers {
   "dim, shape, nElement" should "return right result" in {
@@ -99,6 +101,14 @@ class SparseTensorSpec  extends FlatSpec with Matchers {
     sTensor.storageOffset() should be (1)
   }
 
+  "resize tensor to higher dim when nElement < sum(size)" should "return right result" in {
+    val indices = Array(Array(0, 4, 5, 7, 9))
+    val values = Array.fill(5)(Random.nextFloat())
+    val sTensor = Tensor.sparse(indices, values, Array(10))
+    sTensor.resize(Array(1, 10), 5)
+    Tensor.dense(sTensor).squeeze().toArray().sum should be (values.sum)
+  }
+  
   "resize narrowed tensor" should "return right result" in {
     val sTensor = Tensor.sparse(Tensor(30).range(1, 30, 1)).narrow(1, 6, 18)
     sTensor.resize(Array(6, 3), 18)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/SparseTensorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/SparseTensorSpec.scala
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.intel.analytics.bigdl.tensor
 
 import org.scalatest.{FlatSpec, Matchers}
@@ -108,7 +107,7 @@ class SparseTensorSpec  extends FlatSpec with Matchers {
     sTensor.resize(Array(1, 10), 5)
     Tensor.dense(sTensor).squeeze().toArray().sum should be (values.sum)
   }
-  
+
   "resize narrowed tensor" should "return right result" in {
     val sTensor = Tensor.sparse(Tensor(30).range(1, 30, 1)).narrow(1, 6, 18)
     sTensor.resize(Array(6, 3), 18)


### PR DESCRIPTION
According to the comment, if size.length > dimension,  additional indices should be in front of _indices array instead of behind it.

So, at SparseTensor.scala Line 482:
  >    _indices = _addIndices ++ _indices
should replace 
  >    _indices ++= _addIndices