### PR TITLE
Tensor.dense() support narrowed SparseTensor

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
@@ -2701,16 +2701,16 @@ object DenseTensor {
         sparseTensor: SparseTensor[T],
         res: Tensor[T] = null)(implicit ev: TensorNumeric[T]): Tensor[T] = {
     val dt = if (null == res) Tensor(sparseTensor.size()) else res
-    var i = 0
-    val index = new Array[Int](dt.dim())
-    while (i < sparseTensor._indices(0).length) {
-      var j = 0
-      while (j < index.length) {
-        index(j) = sparseTensor._indices(j)(i) + 1
-        j += 1
+    val srcIndex = new Array[Int](dt.dim())
+    val tgtIndex = new Array[Int](dt.dim())
+    // fill DenseTensor with sparseTensors' active values one by one
+    (0 until sparseTensor._nElement).foreach { i =>
+      // targetIndex = sourceIndex - indicesOffset
+      srcIndex.indices.foreach { j =>
+        srcIndex(j) = sparseTensor._indices(j)(i + sparseTensor._storageOffset) + 1
+        tgtIndex(j) = srcIndex(j) - sparseTensor._indicesOffset(j)
       }
-      dt(index) = sparseTensor(index)
-      i += 1
+      dt(tgtIndex) = sparseTensor(srcIndex)
     }
     dt
   }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/SparseTensorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/SparseTensorSpec.scala
@@ -109,7 +109,7 @@ class SparseTensorSpec  extends FlatSpec with Matchers {
     sTensor.storage().array.length should be (30)
     sTensor.storageOffset() should be (6)
   }
-  
+
   "Tensor.dense narrowed tensor" should "return right result" in {
     val values = Array.fill(30)(Random.nextFloat())
     val sTensor = Tensor.sparse(Tensor(values, Array(6, 5)))

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/SparseTensorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/SparseTensorSpec.scala
@@ -19,6 +19,8 @@ package com.intel.analytics.bigdl.tensor
 import org.scalatest.{FlatSpec, Matchers}
 import com.intel.analytics.bigdl.numeric.NumericFloat
 
+import scala.util.Random
+
 @com.intel.analytics.bigdl.tags.Parallel
 class SparseTensorSpec  extends FlatSpec with Matchers {
   "dim, shape, nElement" should "return right result" in {
@@ -106,6 +108,14 @@ class SparseTensorSpec  extends FlatSpec with Matchers {
     sTensor.nElement() should be (18)
     sTensor.storage().array.length should be (30)
     sTensor.storageOffset() should be (6)
+  }
+  
+  "Tensor.dense narrowed tensor" should "return right result" in {
+    val values = Array.fill(30)(Random.nextFloat())
+    val sTensor = Tensor.sparse(Tensor(values, Array(6, 5)))
+    val narrowed = sTensor.narrow(1, 2, 4)
+    val narrowedSum = values.slice(5, 25).sum
+    Tensor.dense(narrowed).resize(20).toArray().sum shouldEqual narrowedSum
   }
 
 }


### PR DESCRIPTION
Current implementation can not work properly when nElement  is not equal to _indices.length. It usually happens after narrow a SparseTensor. 
This commit solve this problem by taking account of offsets(_indicesOffset, _storageOffset) and nElement.