### PR TITLE
Fix optimizer state messed up when calling optimize() multiple times in DistriOptimizer

### DIFF
--- a/pyspark/bigdl/optim/optimizer.py
+++ b/pyspark/bigdl/optim/optimizer.py
@@ -630,6 +630,13 @@ class BaseOptimizer(JavaValue):
         print("Loading input ...")
         self.value.prepareInput()
 
+    def set_end_when(self, end_when):
+        """
+        When to stop, passed in a [[Trigger]]
+        """
+        self.value.setEndWhen(end_when.value)
+        return self
+
 
 class Optimizer(BaseOptimizer):
 

--- a/pyspark/test/bigdl/test_simple_integration.py
+++ b/pyspark/test/bigdl/test_simple_integration.py
@@ -259,6 +259,7 @@ class TestSimple():
                                         app_name="run1")
         optimizer.set_train_summary(train_summary)
         optimizer.set_val_summary(val_summary)
+        optimizer.set_end_when(MaxEpoch(epoch_num * 2))
 
         trained_model = optimizer.optimize()
         lr_result = train_summary.read_scalar("LearningRate")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -114,11 +114,11 @@ object DistriOptimizer {
 
     // driverState is needed to prevent serializing the whole optimizer
     if (!optimMethod.state.contains("epoch")) optimMethod.state.update("epoch", 1)
-    if (!optimMethod.state.contains("neval")) optimMethod.state.update("epoch", 1)
+    if (!optimMethod.state.contains("neval")) optimMethod.state.update("neval", 1)
     if (!optimMethod.state.contains("Loss")) {
-      optimMethod.state.update("epoch", Float.PositiveInfinity)
+      optimMethod.state.update("Loss", Float.PositiveInfinity)
     }
-    if (!optimMethod.state.contains("score")) optimMethod.state.update("epoch", 0f)
+    if (!optimMethod.state.contains("score")) optimMethod.state.update("score", 0f)
     if (!optimMethod.state.contains("recordsProcessedThisEpoch")) {
       optimMethod.state.update("recordsProcessedThisEpoch", 0)
     }
@@ -440,6 +440,8 @@ object DistriOptimizer {
           dataRDD = dataset.data(train = true)
           recordsProcessedThisEpoch = 0
         }
+
+        optimMethod.state.update("recordsProcessedThisEpoch", recordsProcessedThisEpoch)
 
         optimMethod.state.update("epoch", driverState[Int]("epoch"))
         optimMethod.state.update("neval", driverState[Int]("neval"))
@@ -827,10 +829,10 @@ class DistriOptimizer[T: ClassTag] (
   }
 
   private def endEpoch(): Unit = {
-    val records = this.state.get[Int]("recordsProcessedThisEpoch")
+    val records = this.optimMethod.state.get[Int]("recordsProcessedThisEpoch")
     if (records.isDefined && records.get != 0) {
-      this.state("epoch") = this.state[Int]("epoch") + 1
-      this.state("recordsProcessedThisEpoch") = 0
+      this.optimMethod.state("epoch") = this.optimMethod.state[Int]("epoch") + 1
+      this.optimMethod.state("recordsProcessedThisEpoch") = 0
     }
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -836,8 +836,6 @@ class DistriOptimizer[T: ClassTag] (
     }
   }
 
-
-
   override def setTrainData(sampleRDD: RDD[Sample[T]],
     batchSize: Int,
     miniBatch: MiniBatch[T]): this.type = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Optimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Optimizer.scala
@@ -224,6 +224,15 @@ abstract class Optimizer[T: ClassTag, D](
     this
   }
 
+  private def resetEpoch(): Unit = {
+    optimMethod.state.update("epoch", 1)
+    optimMethod.state.update("neval", 1)
+    optimMethod.state.update("Loss", Float.PositiveInfinity)
+    optimMethod.state.update("score", 0f)
+    optimMethod.state.update("recordsProcessedThisEpoch", 0)
+  }
+
+
   /**
    * Set a model to the optimizer
    *
@@ -231,6 +240,8 @@ abstract class Optimizer[T: ClassTag, D](
    */
   def setModel(newModel: Module[T]): this.type = {
     model = newModel
+    // if a new Model is set, then reset "epoch", "neval" .etc.
+    resetEpoch()
     this
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pr fixed the following issues:
1. Originally, when the call `optimize()` is ended , the "epoch" and 
"neval" state in optimMethod is not update for the last iteration.  So when `optimize` is called again, it will run for one more iteration or epoch then expected.

2. When `optimize()` is called multiple times, there will be multiple copy of models in executor.

3. When `setTrainData` is called and current epoch is not finished, the current implementation does not start a new epoch.

## How was this patch tested?

unit tests

