### PR TITLE
delete useless full build in doc

### DIFF
--- a/docs/docs/ScalaUserGuide/install-build-src.md
+++ b/docs/docs/ScalaUserGuide/install-build-src.md
@@ -50,43 +50,6 @@ It is highly recommended to use _**Java 8**_ when running with Spark 2.x; otherw
 ## **Build for Scala 2.10 or 2.11**
 
 By default, `make-dist.sh` uses Scala 2.10 for Spark 1.5.x or 1.6.x, and Scala 2.11 for Spark 2.0.x or 2.1.x. To override the default behaviors, you can pass `-P scala_2.10` or `-P scala_2.11` to `make-dist.sh` as appropriate.
-
----
-
-## **Build native libs**
-
-Note that the instructions above will skip the build of native library code, and pull the corresponding libraries from Maven Central. If you want to build the the native library code by yourself, follow the steps below:
-
- 1.  Download and install [Intel Parallel Studio XE](https://software.intel.com//qualify-for-free-software/opensourcecontributor) in your Linux box.
-
- 2.  Prepare build environment as follows:
- 
-```bash
-    $ source <install-dir>/bin/compilervars.sh intel64
-    $ source PATH_TO_MKL/bin/mklvars.sh intel64
-```
-    where the `PATH_TO_MKL` is the installation directory of the MKL.
-    
- 3. Full build
-   
-Clone BigDL as follows:
-```bash
-   git clone git@github.com:intel-analytics/BigDL.git --recursive 
-```
-For already cloned repos, just use:
-```bash
-   git submodule update --init --recursive 
-```
-If the Intel MKL is not installed to the default path `/opt/intel`, please pass your libiomp5.so's directory path to the `make-dist.sh` script:
-```bash
-   $ bash make-dist.sh -P full-build -DiompLibDir=<PATH_TO_LIBIOMP5_DIR> 
-```
-Otherwise, only pass `-P full-build` to the `make-dist.sh` script:
-```bash
-   $ bash make-dist.sh -P full-build
-```
-
-The defailts of building libraries on different platforms is at the end.
     
 ---
 ## **Build with Maven**


### PR DESCRIPTION
## What changes were proposed in this pull request?

delete useless full build in doc, we have **Build BigDL-core on different platforms** to instead.
