### PR TITLE
Module DenseToSparse support backward disable (or not) setting

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/DenseToSparse.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/DenseToSparse.scala
@@ -24,10 +24,10 @@ import scala.reflect.ClassTag
 
 /**
  * Convert DenseTensor to SparseTensor.
- * @param isBackward whether update gradInput during backward
+ * @param propagateBack whether propagate gradient back, default value is true
  * @tparam T The numeric type in the criterion, usually which are [[Float]] or [[Double]]
  */
-class DenseToSparse[T: ClassTag](val isBackward: Boolean = true
+class DenseToSparse[T: ClassTag](val propagateBack: Boolean = true // propagate gradient back
                                 )(implicit ev: TensorNumeric[T]) extends TensorModule[T] {
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
     require(input.getTensorType == DenseType, "DenseToSparse: input should be a DenseTensor," +
@@ -36,7 +36,7 @@ class DenseToSparse[T: ClassTag](val isBackward: Boolean = true
     output
   }
   override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
-    if (isBackward) {
+    if (propagateBack) {
       this.gradInput.resizeAs(input)
       Tensor.dense(gradOutput, gradInput)
     }
@@ -48,7 +48,7 @@ class DenseToSparse[T: ClassTag](val isBackward: Boolean = true
 
 object DenseToSparse {
   def apply[@specialized(Float, Double) T: ClassTag]
-  (isBackward: Boolean = true)(implicit ev: TensorNumeric[T]) : DenseToSparse[T] = {
-    new DenseToSparse(isBackward)
+  (propagateBack: Boolean = true)(implicit ev: TensorNumeric[T]) : DenseToSparse[T] = {
+    new DenseToSparse(propagateBack)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/DenseToSparse.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/DenseToSparse.scala
@@ -24,11 +24,11 @@ import scala.reflect.ClassTag
 
 /**
  * Convert DenseTensor to SparseTensor.
- * @param ev$1
- * @param ev
+ * @param isBackward whether update gradInput during backward
  * @tparam T The numeric type in the criterion, usually which are [[Float]] or [[Double]]
  */
-class DenseToSparse[T: ClassTag](implicit ev: TensorNumeric[T]) extends TensorModule[T] {
+class DenseToSparse[T: ClassTag](val isBackward: Boolean = true
+                                )(implicit ev: TensorNumeric[T]) extends TensorModule[T] {
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
     require(input.getTensorType == DenseType, "DenseToSparse: input should be a DenseTensor," +
       s"but got ${input.getTensorType}")
@@ -36,8 +36,10 @@ class DenseToSparse[T: ClassTag](implicit ev: TensorNumeric[T]) extends TensorMo
     output
   }
   override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
-    this.gradInput.resizeAs(input)
-    Tensor.dense(gradOutput, gradInput)
+    if (isBackward) {
+      this.gradInput.resizeAs(input)
+      Tensor.dense(gradOutput, gradInput)
+    }
     this.gradInput
   }
 
@@ -45,8 +47,8 @@ class DenseToSparse[T: ClassTag](implicit ev: TensorNumeric[T]) extends TensorMo
 }
 
 object DenseToSparse {
-  def apply[@specialized(Float, Double) T: ClassTag]()
-        (implicit ev: TensorNumeric[T]) : DenseToSparse[T] = {
-    new DenseToSparse()
+  def apply[@specialized(Float, Double) T: ClassTag]
+  (isBackward: Boolean = true)(implicit ev: TensorNumeric[T]) : DenseToSparse[T] = {
+    new DenseToSparse(isBackward)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/DenseToSparseSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/DenseToSparseSpec.scala
@@ -40,4 +40,23 @@ class DenseToSparseSpec extends FlatSpec with Matchers  {
     output should be (exceptedOutput)
   }
 
+  // It is useful when DenseToSparse layer is placed on the top of model,
+  // received gradient from sparselinear layer.
+  "A DenseToSparse backward" should "be able to work without gradOutput" in {
+    val mockInput = Tensor[Float](5, 10).rand()
+    val mockError = Tensor[Float](5, 10).rand()
+    var model = Sequential[Float]()
+      .add(DenseToSparse[Float](isBackward = true))
+      .add(SparseLinear[Float](10, 10))
+    model.forward(mockInput)
+    intercept[Exception] {
+      model.backward(mockInput, mockError)
+    }
+
+    model = Sequential[Float]()
+      .add(DenseToSparse[Float](isBackward = false))
+      .add(SparseLinear[Float](10, 10))
+    model.forward(mockInput)
+    model.backward(mockInput, mockError)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/DenseToSparseSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/DenseToSparseSpec.scala
@@ -46,7 +46,7 @@ class DenseToSparseSpec extends FlatSpec with Matchers  {
     val mockInput = Tensor[Float](5, 10).rand()
     val mockError = Tensor[Float](5, 10).rand()
     var model = Sequential[Float]()
-      .add(DenseToSparse[Float](isBackward = true))
+      .add(DenseToSparse[Float](propagateBack = true))
       .add(SparseLinear[Float](10, 10))
     model.forward(mockInput)
     intercept[Exception] {
@@ -54,7 +54,7 @@ class DenseToSparseSpec extends FlatSpec with Matchers  {
     }
 
     model = Sequential[Float]()
-      .add(DenseToSparse[Float](isBackward = false))
+      .add(DenseToSparse[Float](propagateBack = false))
       .add(SparseLinear[Float](10, 10))
     model.forward(mockInput)
     model.backward(mockInput, mockError)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This feature is useful when DenseToSparse layer is placed on the top of (sequential) model, received gradient from a SparseLinear layer.

After setting isBackward false(default: true), there is no need to do gradient backpropagation at SparseLinear layer, which will make whole backward procedure more efficient and convenient.


## How was this patch tested?

unit test

