### PR TITLE
bug fix: DLModel prediction

### DIFF
--- a/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
+++ b/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
@@ -391,7 +391,8 @@ class DLModel[@specialized(Float, Double) T: ClassTag](
     val localBatchSize = $(batchSize)
 
     val resultRDD = dataFrame.rdd.mapPartitions { rowIter =>
-      val localModel = modelBroadCast.value()
+      // call the evaluate method to enable DLModel.train=False during the predict process
+      val localModel = modelBroadCast.value().evaluate()
       rowIter.grouped(localBatchSize).flatMap { rowBatch =>
         val samples = rowBatch.map { row =>
           val features = featureFunc(row, featureColIndex)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLEstimatorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLEstimatorSpec.scala
@@ -91,27 +91,6 @@ class DLEstimatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     assert(correct > nRecords * 0.8)
   }
 
-  "An DLEstimator" should "throws exception when DLModel is predicting with DLModel.train=True" in {
-    val model = new Sequential().add(Linear[Float](6, 2))
-      .add(Dropout[Float](initP = 0.5))
-      .add(LogSoftMax[Float])
-    val criterion = ClassNLLCriterion[Float]()
-    val estimator = new DLEstimator[Float](model, criterion, Array(6), Array(1))
-      .setBatchSize(nRecords)
-      .setOptimMethod(new LBFGS[Float]())
-      .setLearningRate(0.1)
-      .setMaxEpoch(maxEpoch)
-    val data = sc.parallelize(smallData)
-    val df = sqlContext.createDataFrame(data).toDF("features", "label")
-    val dlModel = estimator.fit(df)
-    dlModel.isInstanceOf[DLModel[_]] should be(true)
-    val correct = dlModel.transform(df).select("label", "prediction").rdd.filter {
-      case Row(label: Double, prediction: Seq[Double]) =>
-        label == prediction.indexOf(prediction.max) + 1
-    }.count()
-    assert(correct > nRecords * 0.8)
-  }
-
   "An DLEstimator" should "support different FEATURE types" in {
     val model = new Sequential().add(Linear[Float](6, 2)).add(LogSoftMax[Float])
     val criterion = ClassNLLCriterion[Float]()


### PR DESCRIPTION
## What changes were proposed in this pull request?

1.  Make sure DLModel.train=False when predicting in pipeline API
2.  Broadcast transformer(SampleToMiniBatch) rather than initializing them on executors, which will cause exception in spark-cluster mode because of calling _Engine.nodeNumber()_ on executors.

## How was this patch tested?

manual test