### PR TITLE
Fix recurrent forward throwing exception after reset() 

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -469,6 +469,7 @@ class Recurrent[T : ClassTag](var batchNormParams: BatchNormParams[T] = null)
 
     modules.foreach(_.reset())
     cells.clear()
+    hidden = null
   }
 
   override def canEqual(other: Any): Boolean = other.isInstanceOf[Recurrent[T]]

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
@@ -631,4 +631,24 @@ class RecurrentSpec extends FlatSpec with Matchers {
     Recurrent.copy(arrInput, output2)
     output2 should be (input)
   }
+
+  "A Recurrent Module " should " work after reset " in {
+    val hiddenSize = 4
+    val inputSize = 5
+    val outputSize = 5
+    val seed = 100
+    RNG.setSeed(seed)
+
+    val model = Sequential[Double]()
+      .add(Recurrent[Double]()
+        .add(RnnCell[Double](inputSize, hiddenSize, Tanh())))
+      .add(Select(1, 1))
+      .add(Linear[Double](hiddenSize, outputSize))
+
+    val input = Tensor[Double](Array(1, 5, inputSize))
+    val output1 = model.forward(input).toTensor[Double].clone()
+    model.reset()
+    model.forward(input)
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix recurrent forward throwing exception after reset() 

The following code would throw an exception:
```scala
val model = Sequential[Double]()
      .add(Recurrent[Double]()
        .add(RnnCell[Double](inputSize, hiddenSize, Tanh())))
      .add(Select(1, 1))
      .add(Linear[Double](hiddenSize, outputSize))
model.forward(input)
model.reset()
model.forward(input)
```
This pr fixes this issue.

## How was this patch tested?

unit tests

