### PR TITLE
Add NCHW support for resizebilinear

### DIFF
--- a/docs/docs/APIGuide/Layers/Convolution-Layers.md
+++ b/docs/docs/APIGuide/Layers/Convolution-Layers.md
@@ -2210,3 +2210,61 @@ val output = module.forward(input)
 [com.intel.analytics.bigdl.tensor.DenseTensor of size 1x2x4x4x4]
 
 ```
+
+---
+## ResizeBilinear ##
+
+**Scala:**
+```scala
+val module = ResizeBilinear(outputHeight, outputWidth,
+                      alignCorners=false, dataFormat = DataFormat.NCHW)
+```
+**Python:**
+```python
+m = ResizeBilinear(outputHeight, outputWidth,
+               alignCorners=False, dataFormat="NCHW")
+```
+
+Resize the input image with bilinear interpolation. The input image must be a float tensor with
+NHWC or NCHW layout.
+ 
+**Scala example:**
+```scala
+
+scala>
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric.NumericFloat
+import com.intel.analytics.bigdl.nn._
+import com.intel.analytics.bigdl.tensor._
+
+val module = ResizeBilinear(4, 4)
+val input = Tensor(1, 1, 2, 2).range(1, 4)
+val output = module.forward(input)
+
+> output
+(1,1,.,.) =
+1.0	1.5	2.0	2.0	
+2.0	2.5	3.0	3.0	
+3.0	3.5	4.0	4.0	
+3.0	3.5	4.0	4.0	
+
+[com.intel.analytics.bigdl.tensor.DenseTensor$mcF$sp of size 1x1x4x4]
+
+```
+
+**Python example:**
+```python
+from bigdl.nn.layer import *
+import numpy as np
+
+module = ResizeBilinear(4, 4)
+input = np.arange(1, 5).reshape(1, 1, 2, 2)
+output = module.forward(input)
+print output
+```
+The output is 
+```python
+[[[[ 1.   1.5  2.   2. ]
+   [ 2.   2.5  3.   3. ]
+   [ 3.   3.5  4.   4. ]
+   [ 3.   3.5  4.   4. ]]]]
+```

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -5085,17 +5085,19 @@ class MultiRNNCell(Layer):
 class ResizeBilinear(Layer):
     """
     Resize the input image with bilinear interpolation. The input image must be a float tensor with
-    NHWC layout
+    NHWC or NCHW layout
 
     :param output_height: output height
     :param output_width: output width
     :param align_corner: align corner or not
+    :param data_format: the data format of the input image, NHWC or NCHW
 
-    >>> resizeBilinear = ResizeBilinear(10, 20, False)
+    >>> resizeBilinear = ResizeBilinear(10, 20, False, "NCHW")
     creating: createResizeBilinear
     """
-    def __init__(self, output_height, output_width, align_corner, bigdl_type="float"):
-        super(ResizeBilinear, self).__init__(None, bigdl_type, output_height, output_width, align_corner)
+    def __init__(self, output_height, output_width, align_corner, data_format="NCHW", bigdl_type="float"):
+        super(ResizeBilinear, self).__init__(None, bigdl_type, output_height,
+                                             output_width, align_corner, data_format)
 
 class GaussianSampler(Layer):
     """

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -5095,7 +5095,7 @@ class ResizeBilinear(Layer):
     >>> resizeBilinear = ResizeBilinear(10, 20, False, "NCHW")
     creating: createResizeBilinear
     """
-    def __init__(self, output_height, output_width, align_corner, data_format="NCHW", bigdl_type="float"):
+    def __init__(self, output_height, output_width, align_corner=False, data_format="NCHW", bigdl_type="float"):
         super(ResizeBilinear, self).__init__(None, bigdl_type, output_height,
                                              output_width, align_corner, data_format)
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ResizeBilinear.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ResizeBilinear.scala
@@ -403,19 +403,18 @@ object ResizeBilinear {
 
   @inline
   private def resizeImageBackprop(
-                                 batchSize: Int,
-                                 channels: Int,
-                                 inHeight: Int,
-                                 inWidth: Int,
-                                 outputHeight: Int,
-                                 outputWidth: Int,
-                                 heightScale: Float,
-                                 widthScale: Float,
-                                 gradInputData: Array[Float],
-                                 gradInputOffset: Int,
-                                 gradOutputData: Array[Float],
-                                 gradOutputOffset: Int
-                                 ): Unit = {
+    batchSize: Int,
+    channels: Int,
+    inHeight: Int,
+    inWidth: Int,
+    outputHeight: Int,
+    outputWidth: Int,
+    heightScale: Float,
+    widthScale: Float,
+    gradInputData: Array[Float],
+    gradInputOffset: Int,
+    gradOutputData: Array[Float],
+    gradOutputOffset: Int): Unit = {
     val inRowSize = inWidth * channels
     val inBatchNum = inHeight * inRowSize
     val outRowSize = outputWidth * channels
@@ -462,19 +461,18 @@ object ResizeBilinear {
 
   @inline
   private def resizeImageBackprop(
-                                   batchSize: Int,
-                                   channels: Int,
-                                   inHeight: Int,
-                                   inWidth: Int,
-                                   outputHeight: Int,
-                                   outputWidth: Int,
-                                   heightScale: Float,
-                                   widthScale: Float,
-                                   gradInputData: Array[Double],
-                                   gradInputOffset: Int,
-                                   gradOutputData: Array[Double],
-                                   gradOutputOffset: Int
-                                 ): Unit = {
+    batchSize: Int,
+    channels: Int,
+    inHeight: Int,
+    inWidth: Int,
+    outputHeight: Int,
+    outputWidth: Int,
+    heightScale: Float,
+    widthScale: Float,
+    gradInputData: Array[Double],
+    gradInputOffset: Int,
+    gradOutputData: Array[Double],
+    gradOutputOffset: Int): Unit = {
     val inRowSize = inWidth * channels
     val inBatchNum = inHeight * inRowSize
     val outRowSize = outputWidth * channels

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ResizeBilinear.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ResizeBilinear.scala
@@ -266,8 +266,7 @@ object ResizeBilinear {
     bottomLeft: Double,
     bottomRight: Double,
     xLERP: Double,
-    yLERP: Double
-                         ): Double = {
+    yLERP: Double): Double = {
     val top = topLeft + (topRight - topLeft) * xLERP
     val bottom = bottomLeft + (bottomRight - bottomLeft) * xLERP
     top + (bottom - top) * yLERP

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ResizeBilinear.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ResizeBilinear.scala
@@ -16,8 +16,8 @@
 package com.intel.analytics.bigdl.nn
 
 import com.intel.analytics.bigdl.nn.ResizeBilinear.InterpolationWeight
-import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
+import com.intel.analytics.bigdl.tensor.{DoubleType, FloatType, Tensor}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 
 import scala.reflect.ClassTag
@@ -32,18 +32,74 @@ import scala.reflect.ClassTag
  * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
  */
 class ResizeBilinear[T: ClassTag](val outputHeight: Int, val outputWidth: Int,
-  val alignCorners: Boolean)(implicit ev: TensorNumeric[T])
-  extends AbstractModule[Tensor[Float], Tensor[Float], T]{
+  val alignCorners: Boolean,
+  val dataFormat: DataFormat = DataFormat.NCHW)(implicit ev: TensorNumeric[T])
+  extends AbstractModule[Tensor[T], Tensor[T], T]{
 
   private val ys = (1 to (outputHeight + 1)).map(i => InterpolationWeight(0, 0, 0)).toArray
   private val xs = (1 to (outputWidth + 1)).map(i => InterpolationWeight(0, 0, 0)).toArray
 
   import ResizeBilinear._
 
-  override def updateOutput(input: Tensor[Float]): Tensor[Float] = {
+  override def updateOutput(input: Tensor[T]): Tensor[T] = {
     require(input.nDimension() == 4, "only accept 4D input")
     require(input.isContiguous(), "only accept contiguous input")
 
+    dataFormat match {
+      case DataFormat.NHWC => updateOutputNHWC(input)
+      case DataFormat.NCHW => updateOutputNCHW(input)
+    }
+
+    output
+  }
+
+  private def updateOutputNCHW(input: Tensor[T]): Tensor[T] = {
+    val batchSize = input.size(1)
+    val channels = input.size(2)
+    val inHeight = input.size(3)
+    val inWidth = input.size(4)
+
+    if (inHeight == outputHeight && inWidth == outputWidth) {
+      output = input
+      output
+    } else {
+      computeInterpolationWeights(outputHeight, inHeight,
+        calculateResizeScale(inHeight, outputHeight, alignCorners), ys)
+      computeInterpolationWeights(outputWidth, inWidth,
+        calculateResizeScale(inWidth, outputWidth, alignCorners), xs)
+
+      output.resize(batchSize, channels, outputHeight, outputWidth)
+
+      var i = 0
+      while (i < batchSize * channels) {
+        val inputOffset = (input.storageOffset() - 1) + i * inHeight * inWidth
+        val outputOffset = (output.storageOffset() - 1) + i * outputHeight * outputWidth
+
+        if (input.getType() == FloatType) {
+          resizeImage(input.asInstanceOf[Tensor[Float]].storage().array(),
+            inputOffset, 1, inHeight, inWidth,
+            outputHeight, outputWidth, 1, xs, ys,
+            output.asInstanceOf[Tensor[Float]].storage().array(),
+            outputOffset)
+        } else if (input.getType() == DoubleType) {
+          resizeImage(input.asInstanceOf[Tensor[Double]].storage().array(),
+            inputOffset, 1, inHeight, inWidth,
+            outputHeight, outputWidth, 1, xs, ys,
+            output.asInstanceOf[Tensor[Double]].storage().array(),
+            outputOffset)
+        } else {
+          throw new IllegalArgumentException(
+            s"ResizeBilinear does not support type ${input.getType()}")
+        }
+
+        i += 1
+      }
+
+      output
+    }
+  }
+
+  private def updateOutputNHWC(input: Tensor[T]): Tensor[T] = {
     val batchSize = input.size(1)
     val inHeight = input.size(2)
     val inWidth = input.size(3)
@@ -66,27 +122,45 @@ class ResizeBilinear[T: ClassTag](val outputHeight: Int, val outputWidth: Int,
       }
 
       output.resize(batchSize, outputHeight, outputWidth, channels)
-      resizeImage(input.storage().array(), input.storageOffset() - 1, batchSize, inHeight, inWidth,
-        outputHeight, outputWidth, channels, xs, ys, output.storage().array(),
-        output.storageOffset() - 1)
+      if (input.getType() == FloatType) {
+        resizeImage(input.asInstanceOf[Tensor[Float]].storage().array(),
+          input.storageOffset() - 1, batchSize, inHeight, inWidth,
+          outputHeight, outputWidth, channels, xs, ys,
+          output.asInstanceOf[Tensor[Float]].storage().array(),
+          output.storageOffset() - 1)
+      } else if (input.getType() == DoubleType) {
+        resizeImage(input.asInstanceOf[Tensor[Double]].storage().array(),
+          input.storageOffset() - 1, batchSize, inHeight, inWidth,
+          outputHeight, outputWidth, channels, xs, ys,
+          output.asInstanceOf[Tensor[Double]].storage().array(),
+          output.storageOffset() - 1)
+      } else {
+        throw new IllegalArgumentException(
+          s"ResizeBilinear does not support type ${input.getType()}")
+      }
+
       output
     }
   }
 
-  override def updateGradInput(input: Tensor[Float], gradOutput: Tensor[Float]): Tensor[Float] = {
+  override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
     require(input.nDimension() == 4, "only accept 4D input")
     require(gradOutput.nDimension() == 4, "only accept 4D gradOutput")
     require(input.isContiguous(), "only accept contiguous input")
     require(gradOutput.isContiguous(), "only accept contiguous gradOutput")
 
+    dataFormat match {
+      case DataFormat.NHWC => updateGradInputNHWC(input, gradOutput)
+      case DataFormat.NCHW => updateGradInputNCHW(input, gradOutput)
+    }
+    gradInput
+  }
+
+  private def updateGradInputNHWC(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
     val batchSize = input.size(1)
     val inHeight = input.size(2)
     val inWidth = input.size(3)
     val channels = input.size(4)
-    val inRowSize = inWidth * channels
-    val inBatchNum = inHeight * inRowSize
-    val outRowSize = outputWidth * channels
-    val outBatchNum = outputHeight * outRowSize
 
     require(gradOutput.size(2) == outputHeight, "output height is not match")
     require(gradOutput.size(3) == outputWidth, "output width is not match")
@@ -102,53 +176,75 @@ class ResizeBilinear[T: ClassTag](val outputHeight: Int, val outputWidth: Int,
     val gradOutputData = gradOutput.storage().array()
     val gradOutputOffset = gradOutput.storageOffset() - 1
 
-    var b = 0
-    while(b < batchSize) {
-      var y = 0
-      while(y < outputHeight) {
-        val inY = y * heightScale
-        val topY = inY.toInt
-        val bottomY = math.min(math.ceil(inY).toInt, inHeight - 1)
-        val yLERP = inY - topY
-        val inverseYLERP = (1.0f - yLERP)
-        var x = 0
-        while(x < outputWidth) {
-          val inX = x * widthScale
-          val leftX = inX.toInt
-          val rightX = math.min(math.ceil(inX).toInt, inWidth - 1)
-          val xLERP = inX - leftX
-          val inverseXLERP = (1.0f - xLERP)
-          var c = 0
-          while(c < channels) {
-            gradInputData(gradInputOffset + b * inBatchNum + topY * inRowSize +
-              leftX * channels + c) += gradOutputData(gradOutputOffset + b * outBatchNum +
-              y * outRowSize + x * channels + c) * inverseYLERP * inverseXLERP
-            gradInputData(gradInputOffset + b * inBatchNum + topY * inRowSize +
-              rightX * channels + c) += gradOutputData(gradOutputOffset + b * outBatchNum +
-              y * outRowSize + x * channels + c) * inverseYLERP * xLERP
-            gradInputData(gradInputOffset + b * inBatchNum + bottomY * inRowSize +
-              leftX * channels + c) += gradOutputData(gradOutputOffset + b * outBatchNum +
-              y * outRowSize + x * channels + c) * yLERP * inverseXLERP
-            gradInputData(gradInputOffset + b * inBatchNum + bottomY * inRowSize +
-              rightX * channels + c) += gradOutputData(gradOutputOffset + b * outBatchNum +
-              y * outRowSize + x * channels + c) * yLERP * xLERP
-            c += 1
-          }
-          x += 1
-        }
-        y += 1
-      }
-      b += 1
+    if (input.getType() == FloatType) {
+      resizeImageBackprop(batchSize, channels, inHeight, inWidth,
+        outputHeight, outputWidth, heightScale, widthScale,
+        gradInputData.asInstanceOf[Array[Float]], gradInputOffset,
+        gradOutputData.asInstanceOf[Array[Float]], gradOutputOffset)
+    } else if (input.getType() == DoubleType) {
+      resizeImageBackprop(batchSize, channels, inHeight, inWidth,
+        outputHeight, outputWidth, heightScale, widthScale,
+        gradInputData.asInstanceOf[Array[Double]], gradInputOffset,
+        gradOutputData.asInstanceOf[Array[Double]], gradOutputOffset)
+    } else {
+      throw new IllegalArgumentException(
+        s"ResizeBilinear does not support type ${input.getType()}")
     }
+
+    gradInput
+  }
+
+  private def updateGradInputNCHW(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
+    val batchSize = input.size(1)
+    val channels = input.size(2)
+    val inHeight = input.size(3)
+    val inWidth = input.size(4)
+
+    require(gradOutput.size(3) == outputHeight, "output height is not match")
+    require(gradOutput.size(4) == outputWidth, "output width is not match")
+
+    val heightScale = calculateResizeScale(inHeight, outputHeight, alignCorners)
+    val widthScale = calculateResizeScale(inWidth, outputWidth, alignCorners)
+
+    gradInput.resizeAs(input)
+    gradInput.zero()
+
+    val gradInputData = gradInput.storage().array()
+    val gradInputOffset = gradInput.storageOffset() - 1
+    val gradOutputData = gradOutput.storage().array()
+    val gradOutputOffset = gradOutput.storageOffset() - 1
+
+    var i = 0
+    while (i < batchSize * channels) {
+      val inOffset = gradInputOffset + i * (inHeight * inWidth)
+      val outOffset = gradOutputOffset + i * (outputHeight * outputWidth)
+      if (input.getType() == FloatType) {
+        resizeImageBackprop(1, 1, inHeight, inWidth,
+          outputHeight, outputWidth, heightScale, widthScale,
+          gradInputData.asInstanceOf[Array[Float]], inOffset,
+          gradOutputData.asInstanceOf[Array[Float]], outOffset)
+      } else if (input.getType() == DoubleType) {
+        resizeImageBackprop(1, 1, inHeight, inWidth,
+          outputHeight, outputWidth, heightScale, widthScale,
+          gradInputData.asInstanceOf[Array[Double]], inOffset,
+          gradOutputData.asInstanceOf[Array[Double]], outOffset)
+      } else {
+        throw new IllegalArgumentException(
+          s"ResizeBilinear does not support type ${input.getType()}")
+      }
+      i += 1
+    }
+
     gradInput
   }
 }
 
 object ResizeBilinear {
 
-  def apply[T: ClassTag](outputHeight: Int, outputWidth: Int, alignCorners: Boolean = false)
+  def apply[T: ClassTag](outputHeight: Int, outputWidth: Int, alignCorners: Boolean = false,
+                         dataFormat: DataFormat = DataFormat.NCHW)
     (implicit ev: TensorNumeric[T]): ResizeBilinear[T] = {
-    new ResizeBilinear[T](outputHeight, outputWidth, alignCorners)
+    new ResizeBilinear[T](outputHeight, outputWidth, alignCorners, dataFormat)
   }
 
   private def computeLERP(
@@ -159,6 +255,19 @@ object ResizeBilinear {
     xLERP: Float,
     yLERP: Float
   ): Float = {
+    val top = topLeft + (topRight - topLeft) * xLERP
+    val bottom = bottomLeft + (bottomRight - bottomLeft) * xLERP
+    top + (bottom - top) * yLERP
+  }
+
+  private def computeLERP(
+    topLeft: Double,
+    topRight: Double,
+    bottomLeft: Double,
+    bottomRight: Double,
+    xLERP: Double,
+    yLERP: Double
+                         ): Double = {
     val top = topLeft + (topRight - topLeft) * xLERP
     val bottom = bottomLeft + (bottomRight - bottomLeft) * xLERP
     top + (bottom - top) * yLERP
@@ -240,6 +349,172 @@ object ResizeBilinear {
         y += 1
       }
       _imageOffset += inBatchNumber
+      b += 1
+    }
+  }
+
+  @inline
+  private def resizeImage(
+    image: Array[Double], imageOffset: Int,
+    batchSize: Int,
+    inHeight: Int, inWidth: Int,
+    outHeight: Int, outWidth: Int,
+    channels: Int,
+    xs: Array[InterpolationWeight],
+    ys: Array[InterpolationWeight],
+    output: Array[Double], outputOffset: Int): Unit = {
+    val inRowSize = inWidth * channels
+    val inBatchNumber = inHeight * inRowSize
+    val outRowSize = outWidth * channels
+    var _imageOffset = imageOffset
+    var _outputOffset = outputOffset
+
+    // Todo: use multiple thread to speed up this
+    var b = 0
+    while(b < batchSize) {
+      var y = 0
+      while(y < outHeight) {
+        val ysLERP = ys(y).lerp
+        var x = 0
+        while(x < outWidth) {
+          val xsLower = xs(x).lower
+          val xsUpper = xs(x).upper
+          val xsLERP = xs(x).lerp
+
+          var c = 0
+          while(c < channels) {
+            val topLeft = image(_imageOffset + ys(y).lower * inRowSize + xsLower + c)
+            val topRight = image(_imageOffset + ys(y).lower * inRowSize + xsUpper + c)
+            val bottomLeft = image(_imageOffset + ys(y).upper * inRowSize + xsLower + c)
+            val bottomRight = image(_imageOffset + ys(y).upper * inRowSize + xsUpper + c)
+            output(_outputOffset + x * channels + c) = computeLERP(topLeft, topRight, bottomLeft,
+              bottomRight, xsLERP, ysLERP)
+            c += 1
+          }
+          x += 1
+        }
+        _outputOffset += outRowSize
+        y += 1
+      }
+      _imageOffset += inBatchNumber
+      b += 1
+    }
+  }
+
+  @inline
+  private def resizeImageBackprop(
+                                 batchSize: Int,
+                                 channels: Int,
+                                 inHeight: Int,
+                                 inWidth: Int,
+                                 outputHeight: Int,
+                                 outputWidth: Int,
+                                 heightScale: Float,
+                                 widthScale: Float,
+                                 gradInputData: Array[Float],
+                                 gradInputOffset: Int,
+                                 gradOutputData: Array[Float],
+                                 gradOutputOffset: Int
+                                 ): Unit = {
+    val inRowSize = inWidth * channels
+    val inBatchNum = inHeight * inRowSize
+    val outRowSize = outputWidth * channels
+    val outBatchNum = outputHeight * outRowSize
+    var b = 0
+    while(b < batchSize) {
+      var y = 0
+      while(y < outputHeight) {
+        val inY = y * heightScale
+        val topY = inY.toInt
+        val bottomY = math.min(math.ceil(inY).toInt, inHeight - 1)
+        val yLERP = inY - topY
+        val inverseYLERP = (1.0f - yLERP)
+        var x = 0
+        while(x < outputWidth) {
+          val inX = x * widthScale
+          val leftX = inX.toInt
+          val rightX = math.min(math.ceil(inX).toInt, inWidth - 1)
+          val xLERP = inX - leftX
+          val inverseXLERP = (1.0f - xLERP)
+          var c = 0
+          while(c < channels) {
+            gradInputData(gradInputOffset + b * inBatchNum + topY * inRowSize +
+              leftX * channels + c) += gradOutputData(gradOutputOffset + b * outBatchNum +
+              y * outRowSize + x * channels + c) * inverseYLERP * inverseXLERP
+            gradInputData(gradInputOffset + b * inBatchNum + topY * inRowSize +
+              rightX * channels + c) += gradOutputData(gradOutputOffset + b * outBatchNum +
+              y * outRowSize + x * channels + c) * inverseYLERP * xLERP
+            gradInputData(gradInputOffset + b * inBatchNum + bottomY * inRowSize +
+              leftX * channels + c) += gradOutputData(gradOutputOffset + b * outBatchNum +
+              y * outRowSize + x * channels + c) * yLERP * inverseXLERP
+            gradInputData(gradInputOffset + b * inBatchNum + bottomY * inRowSize +
+              rightX * channels + c) += gradOutputData(gradOutputOffset + b * outBatchNum +
+              y * outRowSize + x * channels + c) * yLERP * xLERP
+            c += 1
+          }
+          x += 1
+        }
+        y += 1
+      }
+      b += 1
+    }
+  }
+
+  @inline
+  private def resizeImageBackprop(
+                                   batchSize: Int,
+                                   channels: Int,
+                                   inHeight: Int,
+                                   inWidth: Int,
+                                   outputHeight: Int,
+                                   outputWidth: Int,
+                                   heightScale: Float,
+                                   widthScale: Float,
+                                   gradInputData: Array[Double],
+                                   gradInputOffset: Int,
+                                   gradOutputData: Array[Double],
+                                   gradOutputOffset: Int
+                                 ): Unit = {
+    val inRowSize = inWidth * channels
+    val inBatchNum = inHeight * inRowSize
+    val outRowSize = outputWidth * channels
+    val outBatchNum = outputHeight * outRowSize
+    var b = 0
+    while(b < batchSize) {
+      var y = 0
+      while(y < outputHeight) {
+        val inY = y * heightScale
+        val topY = inY.toInt
+        val bottomY = math.min(math.ceil(inY).toInt, inHeight - 1)
+        val yLERP = inY - topY
+        val inverseYLERP = (1.0f - yLERP)
+        var x = 0
+        while(x < outputWidth) {
+          val inX = x * widthScale
+          val leftX = inX.toInt
+          val rightX = math.min(math.ceil(inX).toInt, inWidth - 1)
+          val xLERP = inX - leftX
+          val inverseXLERP = (1.0f - xLERP)
+          var c = 0
+          while(c < channels) {
+            gradInputData(gradInputOffset + b * inBatchNum + topY * inRowSize +
+              leftX * channels + c) += gradOutputData(gradOutputOffset + b * outBatchNum +
+              y * outRowSize + x * channels + c) * inverseYLERP * inverseXLERP
+            gradInputData(gradInputOffset + b * inBatchNum + topY * inRowSize +
+              rightX * channels + c) += gradOutputData(gradOutputOffset + b * outBatchNum +
+              y * outRowSize + x * channels + c) * inverseYLERP * xLERP
+            gradInputData(gradInputOffset + b * inBatchNum + bottomY * inRowSize +
+              leftX * channels + c) += gradOutputData(gradOutputOffset + b * outBatchNum +
+              y * outRowSize + x * channels + c) * yLERP * inverseXLERP
+            gradInputData(gradInputOffset + b * inBatchNum + bottomY * inRowSize +
+              rightX * channels + c) += gradOutputData(gradOutputOffset + b * outBatchNum +
+              y * outRowSize + x * channels + c) * yLERP * xLERP
+            c += 1
+          }
+          x += 1
+        }
+        y += 1
+      }
       b += 1
     }
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ResizeBilinear.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ResizeBilinear.scala
@@ -29,6 +29,7 @@ import scala.reflect.ClassTag
  * @param outputHeight output height
  * @param outputWidth output width
  * @param alignCorners align corner or not
+ * @param dataFormat the data format of the input image, NHWC or NCHW
  * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
  */
 class ResizeBilinear[T: ClassTag](val outputHeight: Int, val outputWidth: Int,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -2386,11 +2386,12 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   def createResizeBilinear(
     outputHeight: Int,
     outputWidth: Int,
-    alignCorner: Boolean
+    alignCorner: Boolean,
+    dataFormat: String
   ): ResizeBilinear[T] = {
     ResizeBilinear[T](outputHeight,
       outputWidth,
-      alignCorner)
+      alignCorner, DataFormat.apply(dataFormat))
   }
 
   def createMultiRNNCell(cells: JList[Cell[T]]): MultiRNNCell[T] = {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ResizeBilinearSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ResizeBilinearSpec.scala
@@ -15,6 +15,7 @@
  */
 package com.intel.analytics.bigdl.nn
 
+import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.T
 import org.scalatest.{FlatSpec, Matchers}
@@ -37,7 +38,7 @@ class ResizeBilinearSpec extends FlatSpec with Matchers {
 
   "ResizeBilinear forward" should "not change content while input/output width/height match" in {
     println(input)
-    val layer = ResizeBilinear[Float](3, 2)
+    val layer = ResizeBilinear[Float](3, 2, dataFormat = DataFormat.NHWC)
     val output = layer.forward(input)
     println(output)
     input should be(output)
@@ -45,7 +46,7 @@ class ResizeBilinearSpec extends FlatSpec with Matchers {
 
   "ResizeBilinear forward" should "be correct while double height" in {
     println(input)
-    val layer = ResizeBilinear[Float](6, 2)
+    val layer = ResizeBilinear[Float](6, 2, dataFormat = DataFormat.NHWC)
     val output = layer.forward(input)
     println(output)
     val expectOutput = Tensor[Float](T(T(
@@ -79,7 +80,7 @@ class ResizeBilinearSpec extends FlatSpec with Matchers {
 
   "ResizeBilinear forward" should "be correct while double width" in {
     println(input)
-    val layer = ResizeBilinear[Float](3, 4)
+    val layer = ResizeBilinear[Float](3, 4, dataFormat = DataFormat.NHWC)
     val output = layer.forward(input)
     println(output)
     val expectOutput = Tensor[Float](T(T(
@@ -103,5 +104,30 @@ class ResizeBilinearSpec extends FlatSpec with Matchers {
       )
     )))
     output should be(expectOutput)
+  }
+
+  "ResizeBilinear forward and backward" should "be correct with NCHW" in {
+
+    val inputCFirst = Tensor[Float](Array(1, 3, 4, 4)).rand()
+    val inputCLast = inputCFirst.clone().transpose(2, 4).transpose(2, 3).contiguous()
+
+    val gradOutputCFirst = Tensor[Float](Array(1, 3, 8, 8)).rand()
+    val gradOutputCLast = gradOutputCFirst.clone().transpose(2, 4).transpose(2, 3).contiguous()
+    val layerCLast = ResizeBilinear[Float](8, 8, dataFormat = DataFormat.NHWC)
+    val layerCFirst = ResizeBilinear[Float](8, 8, dataFormat = DataFormat.NCHW)
+    // NCHW
+    val outputCFirst = layerCFirst.forward(inputCFirst)
+    val gradInputCFirst = layerCFirst.backward(inputCFirst, gradOutputCFirst)
+
+    val outputCLast = layerCLast.forward(inputCLast)
+    val gradInputCLast = layerCLast.backward(inputCLast, gradOutputCLast)
+
+    outputCFirst
+      .transpose(2, 4)
+      .transpose(2, 3).contiguous() should be(outputCLast)
+
+    gradInputCFirst
+      .transpose(2, 4)
+      .transpose(2, 3).contiguous() should be(gradInputCLast)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

### Add nchw support for resizebilinear

ResizeBilinear layer is commonly used in computer vision models for upsampling. However, current implementation only support nhwc format with float data.

This pr extends ResizeBilinear to support NCHW format (which is the default format in BigDL) and double data.

## How was this patch tested?

unit tests

