### PR TITLE
Refine doc script

### DIFF
--- a/docs/docs/APIGuide/Engine.md
+++ b/docs/docs/APIGuide/Engine.md
@@ -1,4 +1,3 @@
-# Engine
 BigDL need some environment variables be set correctly to get a good performance. Engine.init method
 can help you set and verify them.
 

--- a/docs/docs/APIGuide/Layers/Activations.md
+++ b/docs/docs/APIGuide/Layers/Activations.md
@@ -1,5 +1,3 @@
-
----
 ## SoftSign ##
 
 **Scala:**

--- a/docs/docs/APIGuide/Layers/Sparse-Layers.md
+++ b/docs/docs/APIGuide/Layers/Sparse-Layers.md
@@ -1,5 +1,3 @@
-
----
 ## SparseLinear ##
 
 **Scala:**

--- a/docs/docs/APIGuide/Metrics.md
+++ b/docs/docs/APIGuide/Metrics.md
@@ -1,5 +1,3 @@
-
----
 ValidationMethod is a method to validate the model during model training or evaluation.
 The trait can be extended by user-defined method. Now we have defined Top1Accuracy, Top5Accuracy, Loss.
 You can use those methods to evaluate model, please refer to [Module](https://github.com/intel-analytics/BigDL/blob/master/docs/docs/APIdocs/Module.md) for details.

--- a/docs/docs/APIGuide/Transformer.md
+++ b/docs/docs/APIGuide/Transformer.md
@@ -1,8 +1,6 @@
-## **Transformer**
+Transformer is for pre-processing. In many deep learning workload, input data need to be pre-processed before fed into   model. For example, in CNN, the image file need to be decoded from some compressed format(e.g. jpeg) to float arrays,    normalized and cropped to some fixed shape. You can also find pre-processing in other types of deep learning work        load(e.g. NLP, speech recognition). In BigDL, we provide many pre-process procedures for user. They're implemented as    Transformer.
 
- Transformer is for pre-processing. In many deep learning workload, input data need to be pre-processed before fed into   model. For example, in CNN, the image file need to be decoded from some compressed format(e.g. jpeg) to float arrays,    normalized and cropped to some fixed shape. You can also find pre-processing in other types of deep learning work        load(e.g. NLP, speech recognition). In BigDL, we provide many pre-process procedures for user. They're implemented as    Transformer.
-
- The transformer interface is
+The transformer interface is
 ```scala
 
 trait Transformer[A, B] extends Serializable {
@@ -10,9 +8,9 @@ trait Transformer[A, B] extends Serializable {
  }
 ```
 
- It's simple, right? What a transformer do is convert a sequence of objects of Class A to a sequence of objects of Class  B.
+It's simple, right? What a transformer do is convert a sequence of objects of Class A to a sequence of objects of Class  B.
 
- Transformer is flexible. You can chain them together to do pre-processing. Let's still use the CNN example, say first    we need read image files from given paths, then extract the image binaries to array of float, then normalized the image  content and crop a fixed size from the image at a random position. Here we need 4 transformers, `PathToImage`,           `ImageToArray`, `Normalizor` and `Cropper`. And then chain them together.
+Transformer is flexible. You can chain them together to do pre-processing. Let's still use the CNN example, say first    we need read image files from given paths, then extract the image binaries to array of float, then normalized the image  content and crop a fixed size from the image at a random position. Here we need 4 transformers, `PathToImage`,           `ImageToArray`, `Normalizor` and `Cropper`. And then chain them together.
 
 ## **FeatureTransformer**
 `FeatureTransformer` is the transformer that transforms from `ImageFeature` to `ImageFeature`.

--- a/docs/docs/APIGuide/caffe_layer_list.md
+++ b/docs/docs/APIGuide/caffe_layer_list.md
@@ -1,5 +1,3 @@
-# Supported Caffe Layers
-
 * AbsVal
 * BatchNorm
 * Bias

--- a/docs/docs/APIGuide/keras-issues.md
+++ b/docs/docs/APIGuide/keras-issues.md
@@ -1,4 +1,3 @@
-# **Summary**
 Up to now, we have generally supported __ALL__ the layers of [__Keras 1.2.2__](https://faroit.github.io/keras-docs/1.2.2/) to be loaded into BigDL.
 
 Self-defined Keras layers or [`Lambda`](https://faroit.github.io/keras-docs/1.2.2/layers/core/#lambda) layers are not supported for now. Weight sharing is not supported for now.

--- a/docs/docs/APIGuide/tensorflow_ops_list.md
+++ b/docs/docs/APIGuide/tensorflow_ops_list.md
@@ -1,5 +1,3 @@
-# Supported Tensorflow Operations
-
 * Abs
 * Adapter
 * Add

--- a/docs/docs/ProgrammingGuide/keras-support.md
+++ b/docs/docs/ProgrammingGuide/keras-support.md
@@ -1,5 +1,3 @@
-# **Keras Support**
-
 For __Python__ users, BigDL supports loading pre-defined Keras models.
 
 The Keras version we support and test is [__Keras 1.2.2__](https://faroit.github.io/keras-docs/1.2.2/) with TensorFlow backend. Up to now, we have generally supported __ALL__ its layers.

--- a/docs/docs/ProgrammingGuide/run-on-k8s.md
+++ b/docs/docs/ProgrammingGuide/run-on-k8s.md
@@ -1,6 +1,3 @@
----
-# **Run BigDL on Kubernetes**
-
 The [Apache Spark on Kubernetes](https://apache-spark-on-k8s.github.io/userdocs/index.html) project enables
 native support for submitting Spark application to a kubernetes cluster. As a deep learning library for Apache
 Spark, BigDL can also run on Kubernetes by leveraging Spark on Kubernetes.

--- a/docs/docs/ProgrammingGuide/tensorflow-support.md
+++ b/docs/docs/ProgrammingGuide/tensorflow-support.md
@@ -1,5 +1,3 @@
-# Tensorflow Support
-
 BigDL supports loading and saving tensorflow models.
 This page will give you a basic introduction of this feature. For more
 interesting and sophisticated examples, please checkout [here](https://github.com/intel-analytics/BigDL/tree/master/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/tensorflow).

--- a/docs/docs/ProgrammingGuide/visualization.md
+++ b/docs/docs/ProgrammingGuide/visualization.md
@@ -1,6 +1,3 @@
-
----
-
 ## **Generating summary info in BigDL**
 To enable visualization support, you need first properly configure the `Optimizer` to collect statistics summary in different stages of training (i.e. training (`TrainSummary`) and validation (`ValidationSummary`),respectively). It should be done before the training starts (calling `Optimizer.optimize()`). See examples below: 
 

--- a/docs/docs/ScalaUserGuide/configuration.md
+++ b/docs/docs/ScalaUserGuide/configuration.md
@@ -1,4 +1,3 @@
-# BigDL Configuration
 BigDL uses Java properties to control its behavior. Here's the list of
 these properties.
 

--- a/docs/docs/known-issues.md
+++ b/docs/docs/known-issues.md
@@ -1,6 +1,3 @@
-
-
----
 * Currently, BigDL uses synchronous mini-batch SGD in model training. The mini-batch size is
 expected to be a multiple of **total cores** used in the job.
 

--- a/docs/docs/powered-by.md
+++ b/docs/docs/powered-by.md
@@ -1,7 +1,3 @@
-
-
----
-
 * __Cray__: [Cray Urika-XC Analytics Suite](http://www.cray.com/products/analytics/urika-xc) uses BigDL to provide AI support
 * __Databricks__: [Intel’s BigDL on Databricks](https://databricks.com/blog/2017/02/09/intels-bigdl-databricks.html)
 * __Azure__: [Use BigDL on AZure HDInsight](https://azure.microsoft.com/en-us/blog/use-bigdl-on-hdinsight-spark-for-distributed-deep-learning/)

--- a/docs/docs/presentations.md
+++ b/docs/docs/presentations.md
@@ -1,6 +1,3 @@
-
----
-
 ** Talks:**
 
 * [AI Conference 2017 San Francisco](https://conferences.oreilly.com/artificial-intelligence/ai-ca/public/schedule/detail/63197):Very large-scale distributed deep learning with BigDL [[Slides]](https://github.com/bigdl-project/bigdl-project.github.io/blob/master/presentations/AI_Conf_BigDL_Jason_Ding.pdf)

--- a/docs/docs/release-docs.md
+++ b/docs/docs/release-docs.md
@@ -1,5 +1,3 @@
-
----
 ## **Latest Master**
 
 [Master Docs](https://bigdl-project.github.io/master)

--- a/docs/docs/release-download.md
+++ b/docs/docs/release-download.md
@@ -1,5 +1,3 @@
-
-
 These are built BigDL packages including dependency and Python files. You can download these packages instead of building them by yourself. This is useful when you want to do something like run some examples or develop Python code.
 
 ---

--- a/docs/gen_site.py
+++ b/docs/gen_site.py
@@ -35,8 +35,10 @@ parser.add_argument('-m', '--startserver',
     help='Start server at PORT after building')
 parser.add_argument('-d', '--startmkdocserve',
     dest='debugport', type=int,
-    #dest='mkdocserveflag', action='store_true',
     help=argparse.SUPPRESS)
+parser.add_argument('-l', '--localdoc',
+    dest='local_doc', action='store_true',
+    help='Use local bigdl doc repo(if it exists) instead of downloading from remote')
 
 args = parser.parse_args()
 
@@ -44,32 +46,31 @@ scaladocs = args.scaladocsflag
 
 pythondocs = args.pythondocsflag
 
+local_doc = args.local_doc
 
 script_path = os.path.realpath(__file__)
 dir_name = os.path.dirname(script_path)
 os.chdir(dir_name)
 
-run_cmd(['rm', '-rf', '{}/mkdocs_windmill'.format(dir_name)],
-    'rm theme folder error')
-
 # check if mkdoc is installed
 run_cmd(['mkdocs', '--version'],
     'Please install mkdocs and run this script again\n\te.g., pip install mkdocs')
 
-# git clone docs
-run_cmd(['rm', '-rf', '/tmp/bigdl-doc'],
-    'rm theme repo error')
+# refresh local docs repo
+if not (local_doc and os.path.isdir("/tmp/bigdl-doc")):
+    run_cmd(['rm', '-rf', '/tmp/bigdl-doc'],
+        'rm doc repo error')
+    run_cmd(['git', 'clone', 'https://github.com/bigdl-project/bigdl-project.github.io.git', '/tmp/bigdl-doc'],
+        'git clone doc repo error')
 
-# run_cmd(['git', 'clone', 'https://github.com/helenlly/bigdl-project.github.io.git', '/tmp/bigdl-doc'],
-#     'git clone readthedocs error')
-#
-run_cmd(['git', 'clone', 'https://github.com/bigdl-project/bigdl-project.github.io.git', '/tmp/bigdl-doc'],
-    'git clone theme repo error')
-
-run_cmd(['mv', '/tmp/bigdl-doc/mkdocs_windmill', dir_name],
+# refresh theme folder
+run_cmd(['rm', '-rf', '{}/mkdocs_windmill'.format(dir_name)],
+    'rm theme folder error')
+run_cmd(['cp', '-r', '/tmp/bigdl-doc/mkdocs_windmill', dir_name],
     'mv theme foler error')
 
-run_cmd(['mv', '/tmp/bigdl-doc/extra.css', '{}/docs'.format(dir_name)],
+# refresh css file
+run_cmd(['cp', '/tmp/bigdl-doc/extra.css', '{}/docs'.format(dir_name)],
     'mv theme foler error')
 
 # mkdocs build
@@ -87,9 +88,6 @@ run_cmd(['cp', '/tmp/bigdl-doc/img/*', '{}/site/img'.format(dir_name)],
     'mv theme foler error', s=True)
 run_cmd(['cp', '/tmp/bigdl-doc/version-list', '{}/site'.format(dir_name)],
     'mv theme foler error', s=True)
-
-run_cmd(['rm', '-rf', '/tmp/bigdl-doc'],
-    'rm theme folder error')
 
 if scaladocs:
     print 'build scala doc'


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. The build doc script spends a lot of time on git clone latest doc repo. As the latest doc repo style files(css, html template) won't change frequently, this PR allow user to skip download bigdl doc repo to speed up build doc time
2. Automatically add a title to each document page. Users needn't add a doc title to each page. (remove the existed doc title on each md file)
3. Refine the doc style. Document content align left(refer other frameworks doc style) and use a different color as background, which makes it easier to read
4. hide the panel toggle button in large screen, just like the search button.

## How was this patch tested?
manual test


