### PR TITLE
Keras-like API compute outputshape, core layers, conv+pooling layers

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/keras/LeNet.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/keras/LeNet.scala
@@ -26,7 +26,7 @@ object LeNet {
     model.add(Reshape(Array(1, 28, 28), inputShape = Shape(28, 28, 1)))
     model.add(Convolution2D(32, 3, 3, activation = "relu"))
     model.add(Convolution2D(32, 3, 3, activation = "relu"))
-    model.add(MaxPooling2D(poolSize = Array(2, 2)))
+    model.add(MaxPooling2D(poolSize = (2, 2)))
     model.add(Dropout(0.25))
     model.add(Flatten())
     model.add(Dense(128, activation = "relu"))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/keras/LeNet.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/keras/LeNet.scala
@@ -26,7 +26,7 @@ object LeNet {
     model.add(Reshape(Array(1, 28, 28), inputShape = Shape(28, 28, 1)))
     model.add(Convolution2D(32, 3, 3, activation = "relu"))
     model.add(Convolution2D(32, 3, 3, activation = "relu"))
-    model.add(MaxPooling2D(poolSize = (2, 2)))
+    model.add(MaxPooling2D(poolSize = Array(2, 2)))
     model.add(Dropout(0.25))
     model.add(Flatten())
     model.add(Dense(128, activation = "relu"))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cropping2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cropping2D.scala
@@ -50,8 +50,8 @@ class Cropping2D[T: ClassTag](
 
   override def computeOutputShape(inputShape: Shape): Shape = {
     val input = inputShape.toSingle().toArray
-    require(input.length == 4, "input dimensions should be 4." +
-      " (batchSize, channels, first_axis_to_crop, second_axis_to_crop)")
+    require(input.length == 4,
+      s"Cropping2D requires 4D input, but got input dim ${input.length}")
     val outputShape = dataFormat match {
       case DataFormat.NCHW =>
         Array(input(0), input(1), input(2)-heightCrop(0)-heightCrop(1),

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cropping2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cropping2D.scala
@@ -59,8 +59,6 @@ class Cropping2D[T: ClassTag](
       case DataFormat.NHWC =>
         Array(input(0), input(1)-heightCrop(0)-heightCrop(1),
           input(2)-widthCrop(0)-widthCrop(1), input(3))
-      case _ =>
-        throw new IllegalArgumentException("Cropping2D: unsupported data format.")
     }
     Shape(outputShape)
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cropping2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cropping2D.scala
@@ -18,6 +18,7 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.nn.abstractnn.{DataFormat, TensorModule}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
 
 import scala.reflect.ClassTag
 
@@ -44,6 +45,26 @@ class Cropping2D[T: ClassTag](
     val dataFormat: DataFormat = DataFormat.NCHW
   )(implicit ev: TensorNumeric[T]) extends TensorModule[T] {
 
+  require(heightCrop.length == 2, "heightCrop should be an array of length 2")
+  require(widthCrop.length == 2, "widthCrop should be an array of length 2")
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val input = inputShape.toSingle().toArray
+    require(input.length == 4, "input dimensions should be 4." +
+      " (batchSize, channels, first_axis_to_crop, second_axis_to_crop)")
+    val outputShape = dataFormat match {
+      case DataFormat.NCHW =>
+        Array(input(0), input(1), input(2)-heightCrop(0)-heightCrop(1),
+          input(3)-widthCrop(0)-widthCrop(1))
+      case DataFormat.NHWC =>
+        Array(input(0), input(1)-heightCrop(0)-heightCrop(1),
+          input(2)-widthCrop(0)-widthCrop(1), input(3))
+      case _ =>
+        throw new IllegalArgumentException("Cropping2D: unsupported data format.")
+    }
+    Shape(outputShape)
+  }
+
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
     require(input.dim() == 4, "input dimensions should be 4." +
       " (batchSize, channels, first_axis_to_crop, second_axis_to_crop)")
@@ -67,6 +88,7 @@ class Cropping2D[T: ClassTag](
       .narrow(hdim, hStart, lenHCropped)
       .narrow(wdim, wStart, lenWCropped)
       .copy(gradOutput)
+    gradInput
   }
 
   /**

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cropping3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cropping3D.scala
@@ -53,8 +53,8 @@ class Cropping3D[T: ClassTag](
 
   override def computeOutputShape(inputShape: Shape): Shape = {
     val input = inputShape.toSingle().toArray
-    require(input.length == 5, "input dimensions should be 5." +
-      " (batchSize, channels, first_axis_to_crop, second_axis_to_crop, third_axis_to_crop)")
+    require(input.length == 5,
+      s"Cropping3D requires 5D input, but got input dim ${input.length}")
     val outputShape = dataFormat match {
       case Cropping3D.CHANNEL_FIRST =>
         Array(input(0), input(1), input(2)-dim1Crop(0)-dim1Crop(1),

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cropping3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cropping3D.scala
@@ -18,6 +18,7 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.nn.abstractnn.TensorModule
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
 
 import scala.reflect.ClassTag
 
@@ -45,6 +46,27 @@ class Cropping3D[T: ClassTag](
     val dim3Crop: Array[Int],
     val dataFormat: String = Cropping3D.CHANNEL_FIRST
   )(implicit ev: TensorNumeric[T]) extends TensorModule[T] {
+
+  require(dim1Crop.length == 2, "dim1Crop should be an array of length 2")
+  require(dim2Crop.length == 2, "dim2Crop should be an array of length 2")
+  require(dim3Crop.length == 2, "dim3Crop should be an array of length 2")
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val input = inputShape.toSingle().toArray
+    require(input.length == 5, "input dimensions should be 5." +
+      " (batchSize, channels, first_axis_to_crop, second_axis_to_crop, third_axis_to_crop)")
+    val outputShape = dataFormat match {
+      case Cropping3D.CHANNEL_FIRST =>
+        Array(input(0), input(1), input(2)-dim1Crop(0)-dim1Crop(1),
+          input(3)-dim2Crop(0)-dim2Crop(1), input(4)-dim3Crop(0)-dim3Crop(1))
+      case Cropping3D.CHANNEL_LAST =>
+        Array(input(0), input(1)-dim1Crop(0)-dim1Crop(1),
+          input(2)-dim2Crop(0)-dim2Crop(1), input(3)-dim3Crop(0)-dim3Crop(1), input(4))
+      case _ =>
+        throw new IllegalArgumentException("Cropping3D: unsupported data format.")
+    }
+    Shape(outputShape)
+  }
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
     require(input.dim() == 5, "input dimensions should be 5." +
@@ -76,6 +98,7 @@ class Cropping3D[T: ClassTag](
       .narrow(dim2, dim2Start, dim2Cropped)
       .narrow(dim3, dim3Start, dim3Cropped)
       .copy(gradOutput)
+    gradInput
   }
 
   /**

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cropping3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cropping3D.scala
@@ -62,8 +62,6 @@ class Cropping3D[T: ClassTag](
       case Cropping3D.CHANNEL_LAST =>
         Array(input(0), input(1)-dim1Crop(0)-dim1Crop(1),
           input(2)-dim2Crop(0)-dim2Crop(1), input(3)-dim3Crop(0)-dim3Crop(1), input(4))
-      case _ =>
-        throw new IllegalArgumentException("Cropping3D: unsupported data format.")
     }
     Shape(outputShape)
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LocallyConnected2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LocallyConnected2D.scala
@@ -19,7 +19,7 @@ import com.intel.analytics.bigdl.nn.abstractnn.{DataFormat, Initializable, Tenso
 import com.intel.analytics.bigdl.optim.Regularizer
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.tensor.{DoubleType, FloatType, Tensor}
-import com.intel.analytics.bigdl.utils.{Engine, T, Table}
+import com.intel.analytics.bigdl.utils.{Engine, Shape, T, Table}
 
 import scala.concurrent.Future
 import scala.reflect.ClassTag
@@ -217,9 +217,22 @@ class LocallyConnected2D[T: ClassTag](
     }
   }
 
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val input = inputShape.toSingle().toArray
+    require(input.length == 4,
+      "LocallyConnected2D: " + ErrorInfo.constrainInputAs3DOrBatch)
+    val (dimHeight, dimWidth, channelDim) = format.getHWCDims(input.length)
+    require(input(channelDim -1) == nInputPlane, s"input channel size " +
+      s"${input(channelDim -1)} is not the same as nInputPlane $nInputPlane")
+    require(outputWidth >= 1 && outputHeight >= 1,
+      s"output size is too small. outputWidth: $outputWidth, outputHeight: $outputHeight")
+    val outputShape = getOutputShape(outputHeight, outputWidth)
+    Shape(Array(input(0)) ++ outputShape)
+  }
+
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
     require(input.dim() == 3 || input.dim() == 4,
-      "SpatialConvolution: " + ErrorInfo.constrainInputAs3DOrBatch)
+      "LocallyConnected2D: " + ErrorInfo.constrainInputAs3DOrBatch)
     require(input.isContiguous())
 
     val (dimHeight, dimWidth, channelDim) = format.getHWCDims(input.dim())

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LocallyConnected2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LocallyConnected2D.scala
@@ -220,7 +220,7 @@ class LocallyConnected2D[T: ClassTag](
   override def computeOutputShape(inputShape: Shape): Shape = {
     val input = inputShape.toSingle().toArray
     require(input.length == 4,
-      "LocallyConnected2D: " + ErrorInfo.constrainInputAs3DOrBatch)
+      s"LocallyConnected2D requires 4D input, but got input dim ${input.length}")
     val (dimHeight, dimWidth, channelDim) = format.getHWCDims(input.length)
     require(input(channelDim -1) == nInputPlane, s"input channel size " +
       s"${input(channelDim -1)} is not the same as nInputPlane $nInputPlane")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialConvolution.scala
@@ -176,7 +176,7 @@ class SpatialConvolution[T: ClassTag](
   override def computeOutputShape(inputShape: Shape): Shape = {
     val input = inputShape.toSingle().toArray
     require(input.length == 4,
-      s"SpatialConvolution requires 4D input, but got input dim ${input.length}")
+      s"Convolution2D requires 4D input, but got input dim ${input.length}")
     val (dimHeight, dimWidth, channelDim) = format.getHWCDims(input.length)
     require(input(channelDim -1) == nInputPlane, s"input channel size " +
       s"${input(channelDim -1)} is not the same as nInputPlane $nInputPlane")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolution.scala
@@ -20,7 +20,7 @@ import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, Initia
 import com.intel.analytics.bigdl.optim.Regularizer
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.tensor._
-import com.intel.analytics.bigdl.utils.{Shape, T, Table, serializer}
+import com.intel.analytics.bigdl.utils.{T, Table, serializer}
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 import com.intel.analytics.bigdl.utils.serializer._
 import com.intel.analytics.bigdl.utils.serializer.converters.DataConverter
@@ -251,15 +251,6 @@ class SpatialFullConvolution[T: ClassTag](
     if (null != bias) {
       output2d.addr(ev.one, bias, onesBias)
     }
-  }
-
-  override def computeOutputShape(inputShape: Shape): Shape = {
-    val input = inputShape.toSingle().toArray
-    val inputHeight = input(2)
-    val inputWidth = input(3)
-    val outputHeight = (inputHeight - 1) * dH - 2 * padH + kH + adjH
-    val outputWidth = (inputWidth - 1) * dW - 2 * padW + kW + adjW
-    Shape(input(0), nOutputPlane, outputHeight, outputWidth)
   }
 
   override def updateOutput(input: Activity): Tensor[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolution.scala
@@ -20,7 +20,7 @@ import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, Initia
 import com.intel.analytics.bigdl.optim.Regularizer
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.tensor._
-import com.intel.analytics.bigdl.utils.{T, Table, serializer}
+import com.intel.analytics.bigdl.utils.{Shape, T, Table, serializer}
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 import com.intel.analytics.bigdl.utils.serializer._
 import com.intel.analytics.bigdl.utils.serializer.converters.DataConverter
@@ -251,6 +251,15 @@ class SpatialFullConvolution[T: ClassTag](
     if (null != bias) {
       output2d.addr(ev.one, bias, onesBias)
     }
+  }
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val input = inputShape.toSingle().toArray
+    val inputHeight = input(2)
+    val inputWidth = input(3)
+    val outputHeight = (inputHeight - 1) * dH - 2 * padH + kH + adjH
+    val outputWidth = (inputWidth - 1) * dW - 2 * padW + kW + adjW
+    Shape(input(0), nOutputPlane, outputHeight, outputWidth)
   }
 
   override def updateOutput(input: Activity): Tensor[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialMaxPooling.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialMaxPooling.scala
@@ -19,7 +19,7 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, DataFormat, TensorModule}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
-import com.intel.analytics.bigdl.utils.{Engine, Shape}
+import com.intel.analytics.bigdl.utils.Engine
 import com.intel.analytics.bigdl.utils.serializer._
 import com.intel.analytics.bigdl.utils.serializer.converters.DataConverter
 import com.intel.analytics.bigdl.serialization.Bigdl.{AttrValue, BigDLModule}
@@ -86,39 +86,6 @@ class SpatialMaxPooling[T: ClassTag](
   def floor(): SpatialMaxPooling[T] = {
     ceilMode = false
     this
-  }
-
-  override def computeOutputShape(inputShape: Shape): Shape = {
-    val input = inputShape.toSingle().toArray
-    require(input.length == 4,
-      s"SpatialMaxPooling requires 4D input, but got input dim ${input.length}")
-    val (dimh, dimw, dimc) = format.getHWCDims(input.length)
-    val nInputPlane = input(dimc -1)
-    val inputHeight = input(dimh -1)
-    val inputWidth = input(dimw -1)
-    val sizes =
-      if (padW == -1 && padH == -1) {
-        Utils.getSAMEOutSizeAndPadding(inputHeight, inputWidth, dH, dW, kH, kW)
-      } else {
-        require(inputWidth >= kW - padW && inputHeight >= kH - padH,
-          "input smaller than kernel size. " +
-            s"current input size($inputWidth, $inputHeight), " +
-            s"kernel size(${kW-padW}, ${kH-padH})")
-        require(kW / 2 >= padW && kH / 2 >= padH,
-          "pad should be smaller than half of kernel size. " +
-          s"current pad size($padW, $padH), " + s"kernel size($kW, $kH)")
-        Utils.getOutSizeAndPadding(inputHeight, inputWidth, dH, dW, kH, kW, padH, padW, ceilMode)
-      }
-    val oHeight = sizes(4)
-    val oWidth = sizes(5)
-
-    val outputShape = format match {
-      case DataFormat.NCHW =>
-        Array(input(0), nInputPlane, oHeight, oWidth)
-      case DataFormat.NHWC =>
-        Array(input(0), oHeight, oWidth, nInputPlane)
-    }
-    Shape(outputShape)
   }
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialSeperableConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialSeperableConvolution.scala
@@ -19,6 +19,7 @@ import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
 import com.intel.analytics.bigdl.optim.Regularizer
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
 
 import scala.reflect.ClassTag
 
@@ -128,6 +129,14 @@ class SpatialSeperableConvolution[T: ClassTag](
 
   override def parameters(): (Array[Tensor[T]], Array[Tensor[T]]) = {
     (Array(depthWeight, pointWeight, bias), Array(depthGradWeight, pointGradWeight, gradBias))
+  }
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val input = inputShape.toSingle().toArray
+    require(input.length == 4,
+      s"SeparableConvolution2D requires 4D input, but got input dim ${input.length}")
+    SpatialConvolution[T](nInputChannel, nOutputChannel, kW, kH,
+      sW, sH, pW, pH, format = dataFormat).computeOutputShape(inputShape)
   }
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricConvolution.scala
@@ -130,7 +130,7 @@ class VolumetricConvolution[T: ClassTag](
   override def computeOutputShape(inputShape: Shape): Shape = {
     val input = inputShape.toSingle().toArray
     require(input.length == 5,
-      s"4D or 5D (batch mode) tensor expected for input, but got: ${ input.length + 1 }d")
+      s"Convolution3D requires 5D input, but got input dim ${input.length}")
     require(input(1) == nInputPlane, s"input.size(1) should be equal to nInputPlane. " +
       s"But In ${this.getName()} : input.size(1) is: ${ input(1) } ," +
       s" nInputPlane is: ${ nInputPlane }")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricConvolution.scala
@@ -134,14 +134,9 @@ class VolumetricConvolution[T: ClassTag](
     require(input(1) == nInputPlane, s"input.size(1) should be equal to nInputPlane. " +
       s"But In ${this.getName()} : input.size(1) is: ${ input(1) } ," +
       s" nInputPlane is: ${ nInputPlane }")
-    val dimDepth = 3
-    val dimWidth = 5
-    val dimHeight = 4
-
-    val inputWidth = input(dimWidth -1)
-    val inputHeight = input(dimHeight -1)
-    val inputDepth = input(dimDepth -1)
-
+    val inputWidth = input(4)
+    val inputHeight = input(3)
+    val inputDepth = input(2)
     val sizes = if (padW == -1 && padH == -1 && padT == -1) {
       Utils.getSAMEOutSizeAndPadding(inputHeight, inputWidth, dH,
         dW, kH, kW, inputDepth, dT, kT)
@@ -153,7 +148,6 @@ class VolumetricConvolution[T: ClassTag](
     val outputDepth = sizes(6)
     val outputHeight = sizes(7)
     val outputWidth = sizes(8)
-
     require(outputWidth >= 1 && outputDepth >= 1 && outputHeight >= 1,
       s"Given input size: (${ input.mkString("x") })." +
         s" Calculated output size:" +

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricConvolution.scala
@@ -21,7 +21,7 @@ import com.intel.analytics.bigdl.optim.Regularizer
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.tensor.{DoubleType, FloatType, Tensor}
 import com.intel.analytics.bigdl.utils.RandomGenerator._
-import com.intel.analytics.bigdl.utils.{T, Table}
+import com.intel.analytics.bigdl.utils.{Shape, T, Table}
 import org.apache.spark.sql.catalyst.optimizer.OptimizeIn
 
 import scala.reflect.ClassTag
@@ -125,6 +125,41 @@ class VolumetricConvolution[T: ClassTag](
       T(getName() -> T("weight" -> weight,
         "gradWeight" -> gradWeight))
     }
+  }
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val input = inputShape.toSingle().toArray
+    require(input.length == 5,
+      s"4D or 5D (batch mode) tensor expected for input, but got: ${ input.length + 1 }d")
+    require(input(1) == nInputPlane, s"input.size(1) should be equal to nInputPlane. " +
+      s"But In ${this.getName()} : input.size(1) is: ${ input(1) } ," +
+      s" nInputPlane is: ${ nInputPlane }")
+    val dimDepth = 3
+    val dimWidth = 5
+    val dimHeight = 4
+
+    val inputWidth = input(dimWidth -1)
+    val inputHeight = input(dimHeight -1)
+    val inputDepth = input(dimDepth -1)
+
+    val sizes = if (padW == -1 && padH == -1 && padT == -1) {
+      Utils.getSAMEOutSizeAndPadding(inputHeight, inputWidth, dH,
+        dW, kH, kW, inputDepth, dT, kT)
+    } else {
+      Utils.getOutSizeAndPadding(inputHeight, inputWidth, dH,
+        dW, kH, kW, padH, padW, ceilMode = false, inputdepth = inputDepth,
+        dt = dT, kt = kT, padt = padT)
+    }
+    val outputDepth = sizes(6)
+    val outputHeight = sizes(7)
+    val outputWidth = sizes(8)
+
+    require(outputWidth >= 1 && outputDepth >= 1 && outputHeight >= 1,
+      s"Given input size: (${ input.mkString("x") })." +
+        s" Calculated output size:" +
+        s" (${ nOutputPlane }x${ outputDepth }x${ outputHeight }x${ outputWidth })." +
+        s" Output size is too small")
+    Shape(input(0), nOutputPlane, outputDepth, outputHeight, outputWidth)
   }
 
   /**

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Activation.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Activation.scala
@@ -36,7 +36,7 @@ import scala.reflect.ClassTag
  */
 class Activation[T: ClassTag](
    val activation: String,
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   require(activation != null, "The name of an activation function as a string is required")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling1D.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn._
+import com.intel.analytics.bigdl.nn.{Sequential => TSequential}
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+class AveragePooling1D[T: ClassTag](
+   poolLength: Int = 2,
+   stride: Option[Int] = None,
+   borderMode: String = "valid",
+   inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends Pooling1D[T](poolLength, stride, borderMode, inputShape) {
+
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+    val input = inputShape.toSingle().toArray
+    val pads = KerasUtils.getPadsFromBorderMode(borderMode)
+    val model = TSequential[T]()
+    model.add(Reshape(Array(input(1), 1, input(2)), Some(true)))
+    val layer = SpatialAveragePooling(
+      kW = 1,
+      kH = poolLength,
+      dW = 1,
+      dH = strideValue,
+      padW = pads._2,
+      padH = pads._1,
+      countIncludePad = false,
+      format = DataFormat.NHWC
+    )
+    model.add(layer)
+    model.add(Squeeze(3))
+    model.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+  }
+}
+
+object AveragePooling1D {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    poolLength: Int = 2,
+    stride: Option[Int] = None,
+    borderMode: String = "valid",
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]): AveragePooling1D[T] = {
+    new AveragePooling1D[T](poolLength, stride, borderMode, inputShape)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling1D.scala
@@ -36,7 +36,7 @@ class AveragePooling1D[T: ClassTag](
     val input = inputShape.toSingle().toArray
     val pads = KerasUtils.getPadsFromBorderMode(borderMode)
     val model = TSequential[T]()
-    model.add(Reshape(Array(input(1), 1, input(2)), Some(true)))
+    model.add(com.intel.analytics.bigdl.nn.Reshape(Array(input(1), 1, input(2)), Some(true)))
     val layer = SpatialAveragePooling(
       kW = 1,
       kH = poolLength,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling1D.scala
@@ -27,7 +27,7 @@ import scala.reflect.ClassTag
 
 class AveragePooling1D[T: ClassTag](
    poolLength: Int = 2,
-   stride: Option[Int] = None,
+   stride: Int = -1,
    borderMode: String = "valid",
    inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends Pooling1D[T](poolLength, stride, borderMode, inputShape) {
@@ -45,8 +45,7 @@ class AveragePooling1D[T: ClassTag](
       padW = pads._2,
       padH = pads._1,
       countIncludePad = false,
-      format = DataFormat.NHWC
-    )
+      format = DataFormat.NHWC)
     model.add(layer)
     model.add(Squeeze(3))
     model.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
@@ -56,7 +55,7 @@ class AveragePooling1D[T: ClassTag](
 object AveragePooling1D {
   def apply[@specialized(Float, Double) T: ClassTag](
     poolLength: Int = 2,
-    stride: Option[Int] = None,
+    stride: Int = -1,
     borderMode: String = "valid",
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): AveragePooling1D[T] = {
     new AveragePooling1D[T](poolLength, stride, borderMode, inputShape)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling2D.scala
@@ -49,12 +49,14 @@ class AveragePooling2D[T: ClassTag](
 
 object AveragePooling2D {
   def apply[@specialized(Float, Double) T: ClassTag](
-    poolSize: Array[Int] = Array(2, 2),
-    strides: Array[Int] = null,
+    poolSize: (Int, Int) = (2, 2),
+    strides: (Int, Int) = null,
     borderMode: String = "valid",
-    format: DataFormat = DataFormat.NCHW,
+    dimOrdering: String = "th",
     inputShape: Shape = null)
     (implicit ev: TensorNumeric[T]): AveragePooling2D[T] = {
-    new AveragePooling2D[T](poolSize, strides, borderMode, format, inputShape)
+    val strideValues = if (strides != null) Array(strides._1, strides._2) else null
+    new AveragePooling2D[T](Array(poolSize._1, poolSize._2), strideValues,
+      borderMode, KerasUtils.toBigDLFormat(dimOrdering), inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling2D.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn.SpatialAveragePooling
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, DataFormat}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+class AveragePooling2D[T: ClassTag](
+   poolSize: (Int, Int) = (2, 2),
+   strides: (Int, Int) = null,
+   borderMode: String = "valid",
+   format: DataFormat = DataFormat.NCHW,
+   inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends Pooling2D[T](poolSize, strides, borderMode, format, inputShape) {
+
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+    val pads = KerasUtils.getPadsFromBorderMode(borderMode)
+    val layer = SpatialAveragePooling(
+      kW = poolSize._2,
+      kH = poolSize._1,
+      dW = strideValues._2,
+      dH = strideValues._1,
+      padW = pads._2,
+      padH = pads._1,
+      countIncludePad = false,
+      format = format
+    )
+    layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+  }
+}
+
+object AveragePooling2D {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    poolSize: (Int, Int) = (2, 2),
+    strides: (Int, Int) = null,
+    borderMode: String = "valid",
+    format: DataFormat = DataFormat.NCHW,
+    inputShape: Shape = null)
+    (implicit ev: TensorNumeric[T]): AveragePooling2D[T] = {
+    new AveragePooling2D[T](poolSize, strides, borderMode, format, inputShape)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling2D.scala
@@ -53,8 +53,7 @@ object AveragePooling2D {
     strides: (Int, Int) = null,
     borderMode: String = "valid",
     dimOrdering: String = "th",
-    inputShape: Shape = null)
-    (implicit ev: TensorNumeric[T]): AveragePooling2D[T] = {
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]): AveragePooling2D[T] = {
     val strideValues = if (strides != null) Array(strides._1, strides._2) else null
     new AveragePooling2D[T](Array(poolSize._1, poolSize._2), strideValues,
       borderMode, KerasUtils.toBigDLFormat(dimOrdering), inputShape)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling2D.scala
@@ -25,8 +25,8 @@ import com.intel.analytics.bigdl.utils.Shape
 import scala.reflect.ClassTag
 
 class AveragePooling2D[T: ClassTag](
-   poolSize: (Int, Int) = (2, 2),
-   strides: (Int, Int) = null,
+   poolSize: Array[Int] = Array(2, 2),
+   strides: Array[Int] = null,
    borderMode: String = "valid",
    format: DataFormat = DataFormat.NCHW,
    inputShape: Shape = null)(implicit ev: TensorNumeric[T])
@@ -35,23 +35,22 @@ class AveragePooling2D[T: ClassTag](
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val pads = KerasUtils.getPadsFromBorderMode(borderMode)
     val layer = SpatialAveragePooling(
-      kW = poolSize._2,
-      kH = poolSize._1,
-      dW = strideValues._2,
-      dH = strideValues._1,
+      kW = poolSize(1),
+      kH = poolSize(0),
+      dW = strideValues(1),
+      dH = strideValues(0),
       padW = pads._2,
       padH = pads._1,
       countIncludePad = false,
-      format = format
-    )
+      format = format)
     layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
 }
 
 object AveragePooling2D {
   def apply[@specialized(Float, Double) T: ClassTag](
-    poolSize: (Int, Int) = (2, 2),
-    strides: (Int, Int) = null,
+    poolSize: Array[Int] = Array(2, 2),
+    strides: Array[Int] = null,
     borderMode: String = "valid",
     format: DataFormat = DataFormat.NCHW,
     inputShape: Shape = null)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling3D.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn.VolumetricAveragePooling
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+class AveragePooling3D[T: ClassTag](
+   poolSize: (Int, Int, Int) = (2, 2, 2),
+   strides: (Int, Int, Int) = null,
+   inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends Pooling3D[T](poolSize, strides, inputShape) {
+
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+    val layer = VolumetricAveragePooling(
+      kT = poolSize._1,
+      kW = poolSize._3,
+      kH = poolSize._2,
+      dT = strideValues._1,
+      dW = strideValues._3,
+      dH = strideValues._2,
+      countIncludePad = false
+    )
+    layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+  }
+}
+
+object AveragePooling3D {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    poolSize: (Int, Int, Int) = (2, 2, 2),
+    strides: (Int, Int, Int) = null,
+    inputShape: Shape = null)
+    (implicit ev: TensorNumeric[T]): AveragePooling3D[T] = {
+    new AveragePooling3D[T](poolSize, strides, inputShape)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling3D.scala
@@ -25,29 +25,28 @@ import com.intel.analytics.bigdl.utils.Shape
 import scala.reflect.ClassTag
 
 class AveragePooling3D[T: ClassTag](
-   poolSize: (Int, Int, Int) = (2, 2, 2),
-   strides: (Int, Int, Int) = null,
+   poolSize: Array[Int] = Array(2, 2, 2),
+   strides: Array[Int] = null,
    inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends Pooling3D[T](poolSize, strides, inputShape) {
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val layer = VolumetricAveragePooling(
-      kT = poolSize._1,
-      kW = poolSize._3,
-      kH = poolSize._2,
-      dT = strideValues._1,
-      dW = strideValues._3,
-      dH = strideValues._2,
-      countIncludePad = false
-    )
+      kT = poolSize(0),
+      kW = poolSize(2),
+      kH = poolSize(1),
+      dT = strideValues(0),
+      dW = strideValues(2),
+      dH = strideValues(1),
+      countIncludePad = false)
     layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
 }
 
 object AveragePooling3D {
   def apply[@specialized(Float, Double) T: ClassTag](
-    poolSize: (Int, Int, Int) = (2, 2, 2),
-    strides: (Int, Int, Int) = null,
+    poolSize: Array[Int] = Array(2, 2, 2),
+    strides: Array[Int] = null,
     inputShape: Shape = null)
     (implicit ev: TensorNumeric[T]): AveragePooling3D[T] = {
     new AveragePooling3D[T](poolSize, strides, inputShape)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling3D.scala
@@ -45,10 +45,12 @@ class AveragePooling3D[T: ClassTag](
 
 object AveragePooling3D {
   def apply[@specialized(Float, Double) T: ClassTag](
-    poolSize: Array[Int] = Array(2, 2, 2),
-    strides: Array[Int] = null,
-    inputShape: Shape = null)
-    (implicit ev: TensorNumeric[T]): AveragePooling3D[T] = {
-    new AveragePooling3D[T](poolSize, strides, inputShape)
+    poolSize: (Int, Int, Int) = (2, 2, 2),
+    strides: (Int, Int, Int) = null,
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]): AveragePooling3D[T] = {
+    val strideValues = if (strides != null) Array(strides._1, strides._2, strides._3)
+                       else null
+    new AveragePooling3D[T](Array(poolSize._1, poolSize._2, poolSize._3),
+      strideValues, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution1D.scala
@@ -87,7 +87,7 @@ object Convolution1D {
     wRegularizer: Regularizer[T] = null,
     bRegularizer: Regularizer[T] = null,
     bias: Boolean = true,
-    inputShape: Shape = null)(implicit ev: TensorNumeric[T]) : Convolution1D[T] = {
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Convolution1D[T] = {
     new Convolution1D[T](nbFilter, filterLength,
       KerasUtils.getInitMethod(init), KerasUtils.getActivation(activation),
       borderMode, subsampleLength, wRegularizer, bRegularizer, bias, inputShape)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution1D.scala
@@ -65,8 +65,7 @@ class Convolution1D[T: ClassTag](
       wRegularizer = wRegularizer,
       bRegularizer = bRegularizer,
       withBias = bias,
-      format = DataFormat.NHWC
-    )
+      format = DataFormat.NHWC)
     layer.setInitMethod(weightInitMethod = init, biasInitMethod = Zeros)
     model.add(layer)
     model.add(Squeeze(3))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution1D.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn._
+import com.intel.analytics.bigdl.nn.{Sequential => TSequential}
+import com.intel.analytics.bigdl.nn.abstractnn._
+import com.intel.analytics.bigdl.optim.Regularizer
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+class Convolution1D[T: ClassTag](
+   val nbFilter: Int,
+   val filterLength: Int,
+   val init: InitializationMethod = Xavier,
+   val activation: TensorModule[T] = null,
+   val borderMode: String = "valid",
+   val subsampleLength: Int = 1,
+   var wRegularizer: Regularizer[T] = null,
+   var bRegularizer: Regularizer[T] = null,
+   val bias: Boolean = true,
+   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val input = inputShape.toSingle().toArray
+    require(input.length == 3, "Convolution1D requires 3D input")
+    val outputLength = KerasUtils.computeConvOutputLength(input(1), filterLength,
+      borderMode, subsampleLength)
+    Shape(input(0), outputLength, nbFilter)
+  }
+
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+    val input = inputShape.toSingle().toArray
+    val pads = KerasUtils.getPadsFromBorderMode(borderMode)
+    val model = TSequential[T]()
+    model.add(Reshape(Array(input(1), 1, input(2)), Some(true)))
+    val layer = SpatialConvolution(
+      nInputPlane = input(2),
+      nOutputPlane = nbFilter,
+      kernelW = 1,
+      kernelH = filterLength,
+      strideW = 1,
+      strideH = subsampleLength,
+      padW = pads._2,
+      padH = pads._1,
+      wRegularizer = wRegularizer,
+      bRegularizer = bRegularizer,
+      withBias = bias,
+      format = DataFormat.NHWC
+    )
+    layer.setInitMethod(weightInitMethod = init, biasInitMethod = Zeros)
+    model.add(layer)
+    model.add(Squeeze(3))
+    if (activation != null) {
+      model.add(activation)
+    }
+    model.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+  }
+}
+
+object Convolution1D {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    nbFilter: Int,
+    filterLength: Int,
+    init: String = "glorot_uniform",
+    activation: String = null,
+    borderMode: String = "valid",
+    subsampleLength: Int = 1,
+    wRegularizer: Regularizer[T] = null,
+    bRegularizer: Regularizer[T] = null,
+    bias: Boolean = true,
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]) : Convolution1D[T] = {
+    new Convolution1D[T](nbFilter, filterLength,
+      KerasUtils.getInitMethod(init), KerasUtils.getActivation(activation),
+      borderMode, subsampleLength, wRegularizer, bRegularizer, bias, inputShape)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution1D.scala
@@ -30,7 +30,7 @@ class Convolution1D[T: ClassTag](
    val nbFilter: Int,
    val filterLength: Int,
    val init: InitializationMethod = Xavier,
-   val activation: TensorModule[T] = null,
+   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
    val borderMode: String = "valid",
    val subsampleLength: Int = 1,
    var wRegularizer: Regularizer[T] = null,
@@ -41,7 +41,8 @@ class Convolution1D[T: ClassTag](
 
   override def computeOutputShape(inputShape: Shape): Shape = {
     val input = inputShape.toSingle().toArray
-    require(input.length == 3, "Convolution1D requires 3D input")
+    require(input.length == 3,
+      s"Convolution1D requires 3D input, but got input dim ${input.length}")
     val outputLength = KerasUtils.computeConvOutputLength(input(1), filterLength,
       borderMode, subsampleLength)
     Shape(input(0), outputLength, nbFilter)
@@ -51,7 +52,7 @@ class Convolution1D[T: ClassTag](
     val input = inputShape.toSingle().toArray
     val pads = KerasUtils.getPadsFromBorderMode(borderMode)
     val model = TSequential[T]()
-    model.add(Reshape(Array(input(1), 1, input(2)), Some(true)))
+    model.add(com.intel.analytics.bigdl.nn.Reshape(Array(input(1), 1, input(2)), Some(true)))
     val layer = SpatialConvolution(
       nInputPlane = input(2),
       nOutputPlane = nbFilter,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution1D.scala
@@ -36,7 +36,7 @@ class Convolution1D[T: ClassTag](
    var wRegularizer: Regularizer[T] = null,
    var bRegularizer: Regularizer[T] = null,
    val bias: Boolean = true,
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   override def computeOutputShape(inputShape: Shape): Shape = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
@@ -48,7 +48,8 @@ import scala.reflect.ClassTag
  * @param wRegularizer An instance of [[Regularizer]], (eg. L1 or L2 regularization),
  *                     applied to the input weights matrices. Default is null.
  * @param bRegularizer An instance of [[Regularizer]], applied to the bias. Default is null.
- * @param format Format of input data. Either DataFormat.NCHW or DataFormat.NHWC. Default is NCHW.
+ * @param format Format of input data. Either DataFormat.NCHW (dimOrdering="th") or
+ *               DataFormat.NHWC (dimOrdering="tf"). Default is NCHW.
  * @param bias Whether to include a bias (i.e. make the layer affine rather than linear).
  *             Default is true.
  * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
@@ -65,7 +65,7 @@ class Convolution2D[T: ClassTag](
    var bRegularizer: Regularizer[T] = null,
    val format: DataFormat = DataFormat.NCHW,
    val bias: Boolean = true,
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   require(borderMode == "valid" || borderMode == "same", s"Invalid border mode for " +

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
@@ -48,8 +48,8 @@ import scala.reflect.ClassTag
  * @param wRegularizer An instance of [[Regularizer]], (eg. L1 or L2 regularization),
  *                     applied to the input weights matrices. Default is null.
  * @param bRegularizer An instance of [[Regularizer]], applied to the bias. Default is null.
- * @param format Format of input data. Either DataFormat.NCHW (dimOrdering="th") or
- *               DataFormat.NHWC (dimOrdering="tf"). Default is NCHW.
+ * @param format Format of input data. Either DataFormat.NCHW (dimOrdering='th') or
+ *               DataFormat.NHWC (dimOrdering='tf'). Default is NCHW.
  * @param bias Whether to include a bias (i.e. make the layer affine rather than linear).
  *             Default is true.
  * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
@@ -103,14 +103,15 @@ object Convolution2D {
     init: String = "glorot_uniform",
     activation: String = null,
     borderMode: String = "valid",
-    subsample: Array[Int] = Array(1, 1),
+    subsample: (Int, Int) = (1, 1),
     wRegularizer: Regularizer[T] = null,
     bRegularizer: Regularizer[T] = null,
-    format: DataFormat = DataFormat.NCHW,
+    dimOrdering: String = "th",
     bias: Boolean = true,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Convolution2D[T] = {
     new Convolution2D[T](nbFilter, nbRow, nbCol,
       KerasUtils.getInitMethod(init), KerasUtils.getActivation(activation),
-      borderMode, subsample, wRegularizer, bRegularizer, format, bias, inputShape)
+      borderMode, Array(subsample._1, subsample._2), wRegularizer,
+      bRegularizer, KerasUtils.toBigDLFormat(dimOrdering), bias, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
@@ -70,7 +70,8 @@ class Convolution2D[T: ClassTag](
 
   require(borderMode == "valid" || borderMode == "same", s"Invalid border mode for " +
     s"Convolution2D: $borderMode")
-  require(subsample.length == 2, "Subsample should be of length 2.")
+  require(subsample.length == 2,
+    s"For Convolution2D, subsample should be of length 2 but got length ${subsample.length}")
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val input = inputShape.toSingle().toArray
@@ -102,7 +103,7 @@ object Convolution2D {
     init: String = "glorot_uniform",
     activation: String = null,
     borderMode: String = "valid",
-    subsample: (Int, Int) = (1, 1),
+    subsample: Array[Int] = Array(1, 1),
     wRegularizer: Regularizer[T] = null,
     bRegularizer: Regularizer[T] = null,
     format: DataFormat = DataFormat.NCHW,
@@ -110,7 +111,6 @@ object Convolution2D {
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Convolution2D[T] = {
     new Convolution2D[T](nbFilter, nbRow, nbCol,
       KerasUtils.getInitMethod(init), KerasUtils.getActivation(activation),
-      borderMode, Array(subsample._1, subsample._2),
-      wRegularizer, bRegularizer, format, bias, inputShape)
+      borderMode, subsample, wRegularizer, bRegularizer, format, bias, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution3D.scala
@@ -33,7 +33,7 @@ class Convolution3D[T: ClassTag](
    val init: InitializationMethod = Xavier,
    val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
    val borderMode: String = "valid",
-   val subsample: (Int, Int, Int) = (1, 1, 1),
+   val subsample: Array[Int] = Array(1, 1, 1),
    val wRegularizer: Regularizer[T] = null,
    var bRegularizer: Regularizer[T] = null,
    val bias: Boolean = true,
@@ -42,6 +42,8 @@ class Convolution3D[T: ClassTag](
 
   require(borderMode == "valid" || borderMode == "same", s"Invalid border mode for " +
     s"Convolution3D: $borderMode")
+  require(subsample.length == 3,
+    s"For Convolution3D, subsample should be of length 3 but got length ${subsample.length}")
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val input = inputShape.toSingle().toArray
@@ -52,19 +54,17 @@ class Convolution3D[T: ClassTag](
       kT = kernelDim1,
       kW = kernelDim3,
       kH = kernelDim2,
-      dT = subsample._1,
-      dW = subsample._3,
-      dH = subsample._2,
+      dT = subsample(0),
+      dW = subsample(2),
+      dH = subsample(1),
       padT = pads._1,
       padW = pads._3,
       padH = pads._2,
       withBias = bias,
       wRegularizer = wRegularizer,
-      bRegularizer = bRegularizer
-    )
+      bRegularizer = bRegularizer)
     layer.setInitMethod(weightInitMethod = init, biasInitMethod = Zeros)
-    KerasLayer.fuse(layer,
-      activation,
+    KerasLayer.fuse(layer, activation,
       inputShape).asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
 }
@@ -78,7 +78,7 @@ object Convolution3D {
     init: String = "glorot_uniform",
     activation: String = null,
     borderMode: String = "valid",
-    subsample: (Int, Int, Int) = (1, 1, 1),
+    subsample: Array[Int] = Array(1, 1, 1),
     wRegularizer: Regularizer[T] = null,
     bRegularizer: Regularizer[T] = null,
     bias: Boolean = true,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution3D.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, TensorModule}
+import com.intel.analytics.bigdl.nn.{InitializationMethod, VolumetricConvolution, Xavier, Zeros}
+import com.intel.analytics.bigdl.optim.Regularizer
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+class Convolution3D[T: ClassTag](
+   val nbFilter: Int,
+   val kernelDim1: Int,
+   val kernelDim2: Int,
+   val kernelDim3: Int,
+   val init: InitializationMethod = Xavier,
+   val activation: TensorModule[T] = null,
+   val borderMode: String = "valid",
+   val subsample: (Int, Int, Int) = (1, 1, 1),
+   val wRegularizer: Regularizer[T] = null,
+   var bRegularizer: Regularizer[T] = null,
+   val bias: Boolean = true,
+   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+
+  require(borderMode == "valid" || borderMode == "same", s"Invalid border mode for " +
+    s"Convolution3D: $borderMode")
+
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+    val input = inputShape.toSingle().toArray
+    val pads = KerasUtils.getPadsFromBorderMode3D(borderMode)
+    val layer = VolumetricConvolution(
+      nInputPlane = input(1),
+      nOutputPlane = nbFilter,
+      kT = kernelDim1,
+      kW = kernelDim3,
+      kH = kernelDim2,
+      dT = subsample._1,
+      dW = subsample._3,
+      dH = subsample._2,
+      padT = pads._1,
+      padW = pads._3,
+      padH = pads._2,
+      withBias = bias,
+      wRegularizer = wRegularizer,
+      bRegularizer = bRegularizer
+    )
+    layer.setInitMethod(weightInitMethod = init, biasInitMethod = Zeros)
+    KerasLayer.fuse(layer,
+      activation,
+      inputShape).asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+  }
+}
+
+object Convolution3D {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    nbFilter: Int,
+    kernelDim1: Int,
+    kernelDim2: Int,
+    kernelDim3: Int,
+    init: String = "glorot_uniform",
+    activation: String = null,
+    borderMode: String = "valid",
+    subsample: (Int, Int, Int) = (1, 1, 1),
+    wRegularizer: Regularizer[T] = null,
+    bRegularizer: Regularizer[T] = null,
+    bias: Boolean = true,
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Convolution3D[T] = {
+    new Convolution3D[T](nbFilter, kernelDim1, kernelDim2, kernelDim3,
+      KerasUtils.getInitMethod(init), KerasUtils.getActivation(activation), borderMode, subsample,
+      wRegularizer, bRegularizer, bias, inputShape)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution3D.scala
@@ -31,7 +31,7 @@ class Convolution3D[T: ClassTag](
    val kernelDim2: Int,
    val kernelDim3: Int,
    val init: InitializationMethod = Xavier,
-   val activation: TensorModule[T] = null,
+   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
    val borderMode: String = "valid",
    val subsample: (Int, Int, Int) = (1, 1, 1),
    val wRegularizer: Regularizer[T] = null,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution3D.scala
@@ -37,7 +37,7 @@ class Convolution3D[T: ClassTag](
    val wRegularizer: Regularizer[T] = null,
    var bRegularizer: Regularizer[T] = null,
    val bias: Boolean = true,
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   require(borderMode == "valid" || borderMode == "same", s"Invalid border mode for " +

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution3D.scala
@@ -78,13 +78,14 @@ object Convolution3D {
     init: String = "glorot_uniform",
     activation: String = null,
     borderMode: String = "valid",
-    subsample: Array[Int] = Array(1, 1, 1),
+    subsample: (Int, Int, Int) = (1, 1, 1),
     wRegularizer: Regularizer[T] = null,
     bRegularizer: Regularizer[T] = null,
     bias: Boolean = true,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Convolution3D[T] = {
     new Convolution3D[T](nbFilter, kernelDim1, kernelDim2, kernelDim3,
-      KerasUtils.getInitMethod(init), KerasUtils.getActivation(activation), borderMode, subsample,
+      KerasUtils.getInitMethod(init), KerasUtils.getActivation(activation),
+      borderMode, Array(subsample._1, subsample._2, subsample._3),
       wRegularizer, bRegularizer, bias, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping1D.scala
@@ -47,8 +47,8 @@ class Cropping1D[T: ClassTag](
 
 object Cropping1D {
   def apply[@specialized(Float, Double) T: ClassTag](
-    cropping: Array[Int] = Array(1, 1),
+    cropping: (Int, Int) = (1, 1),
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Cropping1D[T] = {
-    new Cropping1D[T](cropping, inputShape)
+    new Cropping1D[T](Array(cropping._1, cropping._2), inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping1D.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn.SpatialZeroPadding
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+class Cropping1D[T: ClassTag](
+   val cropping: (Int, Int) = (1, 1),
+   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val input = inputShape.toSingle().toArray
+    require(input.length == 3, "Cropping1D requires 3D input")
+    Shape(input(0), input(1)-cropping._1-cropping._2, input(2))
+  }
+
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+    val layer = SpatialZeroPadding(0, 0, -cropping._1, -cropping._2)
+    layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+  }
+}
+
+object Cropping1D {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    cropping: (Int, Int) = (1, 1),
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Cropping1D[T] = {
+    new Cropping1D[T](cropping, inputShape)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping1D.scala
@@ -31,7 +31,8 @@ class Cropping1D[T: ClassTag](
 
   override def computeOutputShape(inputShape: Shape): Shape = {
     val input = inputShape.toSingle().toArray
-    require(input.length == 3, "Cropping1D requires 3D input")
+    require(input.length == 3,
+      s"Cropping1D requires 3D input, but got input dim ${input.length}")
     Shape(input(0), input(1)-cropping._1-cropping._2, input(2))
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping1D.scala
@@ -26,7 +26,7 @@ import scala.reflect.ClassTag
 
 class Cropping1D[T: ClassTag](
    val cropping: Array[Int] = Array(1, 1),
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   require(cropping.length == 2,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping1D.scala
@@ -25,26 +25,29 @@ import com.intel.analytics.bigdl.utils.Shape
 import scala.reflect.ClassTag
 
 class Cropping1D[T: ClassTag](
-   val cropping: (Int, Int) = (1, 1),
+   val cropping: Array[Int] = Array(1, 1),
    var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+
+  require(cropping.length == 2,
+    s"For Cropping1D, cropping values should be of length 2 but got length ${cropping.length}")
 
   override def computeOutputShape(inputShape: Shape): Shape = {
     val input = inputShape.toSingle().toArray
     require(input.length == 3,
       s"Cropping1D requires 3D input, but got input dim ${input.length}")
-    Shape(input(0), input(1)-cropping._1-cropping._2, input(2))
+    Shape(input(0), input(1)-cropping(0)-cropping(1), input(2))
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
-    val layer = SpatialZeroPadding(0, 0, -cropping._1, -cropping._2)
+    val layer = SpatialZeroPadding(0, 0, -cropping(0), -cropping(1))
     layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
 }
 
 object Cropping1D {
   def apply[@specialized(Float, Double) T: ClassTag](
-    cropping: (Int, Int) = (1, 1),
+    cropping: Array[Int] = Array(1, 1),
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Cropping1D[T] = {
     new Cropping1D[T](cropping, inputShape)
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping2D.scala
@@ -27,7 +27,7 @@ class Cropping2D[T: ClassTag](
    val heightCrop: Array[Int] = Array(0, 0),
    val widthCrop: Array[Int] = Array(0, 0),
    val format: DataFormat = DataFormat.NCHW,
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   require(heightCrop.length == 2,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping2D.scala
@@ -36,11 +36,10 @@ class Cropping2D[T: ClassTag](
     s"Cropping3D: width cropping values should be of length 2, but got ${widthCrop.length}")
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
-    val layer =
-      com.intel.analytics.bigdl.nn.Cropping2D(
-        heightCrop = heightCrop,
-        widthCrop = widthCrop,
-        format = format)
+    val layer = com.intel.analytics.bigdl.nn.Cropping2D(
+      heightCrop = heightCrop,
+      widthCrop = widthCrop,
+      format = format)
     layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping2D.scala
@@ -24,23 +24,22 @@ import com.intel.analytics.bigdl.utils.Shape
 import scala.reflect.ClassTag
 
 class Cropping2D[T: ClassTag](
-   val cropping: Array[Array[Int]] = Array(Array(0, 0), Array(0, 0)),
+   val heightCrop: Array[Int] = Array(0, 0),
+   val widthCrop: Array[Int] = Array(0, 0),
    val format: DataFormat = DataFormat.NCHW,
    var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
-  require(cropping.length == 2,
-    s"Cropping2D requires two cropping dimensions, but got ${cropping.length}")
-  require(cropping(0).length == 2,
-    s"Cropping values in height dimension should be of length 2, but got ${cropping(0).length}")
-  require(cropping(1).length == 2,
-    s"Cropping values in width dimension should be of length 2, but got ${cropping(1).length}")
+  require(widthCrop.length == 2,
+    s"Cropping values in height dimension should be of length 2, but got ${widthCrop.length}")
+  require(widthCrop.length == 2,
+    s"Cropping values in width dimension should be of length 2, but got ${widthCrop.length}")
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val layer =
       com.intel.analytics.bigdl.nn.Cropping2D(
-        heightCrop = cropping(0),
-        widthCrop = cropping(1),
+        heightCrop = heightCrop,
+        widthCrop = widthCrop,
         format = format)
     layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
@@ -53,6 +52,6 @@ object Cropping2D {
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Cropping2D[T] = {
     val heightCrop = Array(cropping._1._1, cropping._1._2)
     val widthCrop = Array(cropping._2._1, cropping._2._2)
-    new Cropping2D[T](Array(heightCrop, widthCrop), format, inputShape)
+    new Cropping2D[T](heightCrop, widthCrop, format, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping2D.scala
@@ -24,16 +24,23 @@ import com.intel.analytics.bigdl.utils.Shape
 import scala.reflect.ClassTag
 
 class Cropping2D[T: ClassTag](
-   val cropping: ((Int, Int), (Int, Int)) = ((0, 0), (0, 0)),
+   val cropping: Array[Array[Int]] = Array(Array(0, 0), Array(0, 0)),
    val format: DataFormat = DataFormat.NCHW,
    var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
+  require(cropping.length == 2,
+    s"Cropping2D requires two cropping dimensions, but got ${cropping.length}")
+  require(cropping(0).length == 2,
+    s"Cropping values in height dimension should be of length 2, but got ${cropping(0).length}")
+  require(cropping(1).length == 2,
+    s"Cropping values in width dimension should be of length 2, but got ${cropping(1).length}")
+
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val layer =
       com.intel.analytics.bigdl.nn.Cropping2D(
-        heightCrop = Array(cropping._1._1, cropping._1._2),
-        widthCrop = Array(cropping._2._1, cropping._2._2),
+        heightCrop = cropping(0),
+        widthCrop = cropping(1),
         format = format)
     layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
@@ -44,6 +51,8 @@ object Cropping2D {
     cropping: ((Int, Int), (Int, Int)) = ((0, 0), (0, 0)),
     format: DataFormat = DataFormat.NCHW,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Cropping2D[T] = {
-    new Cropping2D[T](cropping, format, inputShape)
+    val heightCrop = Array(cropping._1._1, cropping._1._2)
+    val widthCrop = Array(cropping._2._1, cropping._2._2)
+    new Cropping2D[T](Array(heightCrop, widthCrop), format, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping2D.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+class Cropping2D[T: ClassTag](
+   val cropping: ((Int, Int), (Int, Int)) = ((0, 0), (0, 0)),
+   val format: DataFormat = DataFormat.NCHW,
+   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+    val layer =
+      com.intel.analytics.bigdl.nn.Cropping2D(
+        heightCrop = Array(cropping._1._1, cropping._1._2),
+        widthCrop = Array(cropping._2._1, cropping._2._2),
+        format = format)
+    layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+  }
+}
+
+object Cropping2D {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    cropping: ((Int, Int), (Int, Int)) = ((0, 0), (0, 0)),
+    format: DataFormat = DataFormat.NCHW,
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Cropping2D[T] = {
+    new Cropping2D[T](cropping, format, inputShape)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping2D.scala
@@ -30,10 +30,10 @@ class Cropping2D[T: ClassTag](
    var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
+  require(heightCrop.length == 2,
+    s"Cropping3D: height cropping values should be of length 2, but got ${heightCrop.length}")
   require(widthCrop.length == 2,
-    s"Cropping values in height dimension should be of length 2, but got ${widthCrop.length}")
-  require(widthCrop.length == 2,
-    s"Cropping values in width dimension should be of length 2, but got ${widthCrop.length}")
+    s"Cropping3D: width cropping values should be of length 2, but got ${widthCrop.length}")
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val layer =

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping2D.scala
@@ -48,10 +48,11 @@ class Cropping2D[T: ClassTag](
 object Cropping2D {
   def apply[@specialized(Float, Double) T: ClassTag](
     cropping: ((Int, Int), (Int, Int)) = ((0, 0), (0, 0)),
-    format: DataFormat = DataFormat.NCHW,
+    dimOrdering: String = "th",
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Cropping2D[T] = {
     val heightCrop = Array(cropping._1._1, cropping._1._2)
     val widthCrop = Array(cropping._2._1, cropping._2._2)
-    new Cropping2D[T](heightCrop, widthCrop, format, inputShape)
+    new Cropping2D[T](heightCrop, widthCrop,
+      KerasUtils.toBigDLFormat(dimOrdering), inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping3D.scala
@@ -31,6 +31,12 @@ class Cropping3D[T: ClassTag](
    var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
+  require(dim1Crop.length == 2,
+    s"Cropping3D: kernel dim1 cropping values should be of length 2, but got ${dim1Crop.length}")
+  require(dim2Crop.length == 2,
+    s"Cropping3D: kernel dim2 cropping values should be of length 2, but got ${dim2Crop.length}")
+  require(dim3Crop.length == 2,
+    s"Cropping3D: kernel dim3 cropping values should be of length 2, but got ${dim3Crop.length}")
   require(format.toLowerCase() == "channel_first" || format.toLowerCase() == "channel_last",
   "Cropping3D only supports format channel_first or channel_last")
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping3D.scala
@@ -24,7 +24,9 @@ import com.intel.analytics.bigdl.utils.Shape
 import scala.reflect.ClassTag
 
 class Cropping3D[T: ClassTag](
-   val cropping: Array[Array[Int]] = Array(Array(1, 1), Array(1, 1), Array(1, 1)),
+   val dim1Crop: Array[Int] = Array(1, 1),
+   val dim2Crop: Array[Int] = Array(1, 1),
+   val dim3Crop: Array[Int] = Array(1, 1),
    val format: String = "CHANNEL_FIRST",
    var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
@@ -40,9 +42,9 @@ class Cropping3D[T: ClassTag](
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val layer =
       com.intel.analytics.bigdl.nn.Cropping3D(
-        dim1Crop = cropping(0),
-        dim2Crop = cropping(1),
-        dim3Crop = cropping(2),
+        dim1Crop = dim1Crop,
+        dim2Crop = dim2Crop,
+        dim3Crop = dim3Crop,
         format = dimOrdering)
     layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
@@ -56,6 +58,6 @@ object Cropping3D {
     val dim1Crop = Array(cropping._1._1, cropping._1._2)
     val dim2Crop = Array(cropping._2._1, cropping._2._2)
     val dim3Crop = Array(cropping._3._1, cropping._3._2)
-    new Cropping3D[T](Array(dim1Crop, dim2Crop, dim3Crop), format, inputShape)
+    new Cropping3D[T](dim1Crop, dim2Crop, dim3Crop, format, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping3D.scala
@@ -28,7 +28,7 @@ class Cropping3D[T: ClassTag](
    val dim2Crop: Array[Int] = Array(1, 1),
    val dim3Crop: Array[Int] = Array(1, 1),
    val format: String = "CHANNEL_FIRST",
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   require(dim1Crop.length == 2,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping3D.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+class Cropping3D[T: ClassTag](
+   val cropping: ((Int, Int), (Int, Int), (Int, Int)) = ((1, 1), (1, 1), (1, 1)),
+   val format: String = "CHANNEL_FIRST",
+   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+
+  require(format.toLowerCase() == "channel_first" || format.toLowerCase() == "channel_last",
+  "Cropping3D only supports format channel_first or channel_last")
+
+  private val dimOrdering = format.toLowerCase() match {
+    case "channel_first" => com.intel.analytics.bigdl.nn.Cropping3D.CHANNEL_FIRST
+    case "channel_last" => com.intel.analytics.bigdl.nn.Cropping3D.CHANNEL_LAST
+  }
+
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+    val layer =
+      com.intel.analytics.bigdl.nn.Cropping3D(
+        dim1Crop = Array(cropping._1._1, cropping._1._2),
+        dim2Crop = Array(cropping._2._1, cropping._2._2),
+        dim3Crop = Array(cropping._3._1, cropping._3._2),
+        format = dimOrdering
+      )
+    layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+  }
+}
+
+object Cropping3D {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    cropping: ((Int, Int), (Int, Int), (Int, Int)) = ((1, 1), (1, 1), (1, 1)),
+    format: String = "CHANNEL_FIRST",
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Cropping3D[T] = {
+    new Cropping3D[T](cropping, format, inputShape)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping3D.scala
@@ -46,12 +46,11 @@ class Cropping3D[T: ClassTag](
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
-    val layer =
-      com.intel.analytics.bigdl.nn.Cropping3D(
-        dim1Crop = dim1Crop,
-        dim2Crop = dim2Crop,
-        dim3Crop = dim3Crop,
-        format = dimOrdering)
+    val layer = com.intel.analytics.bigdl.nn.Cropping3D(
+      dim1Crop = dim1Crop,
+      dim2Crop = dim2Crop,
+      dim3Crop = dim3Crop,
+      format = dimOrdering)
     layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping3D.scala
@@ -24,7 +24,7 @@ import com.intel.analytics.bigdl.utils.Shape
 import scala.reflect.ClassTag
 
 class Cropping3D[T: ClassTag](
-   val cropping: ((Int, Int), (Int, Int), (Int, Int)) = ((1, 1), (1, 1), (1, 1)),
+   val cropping: Array[Array[Int]] = Array(Array(1, 1), Array(1, 1), Array(1, 1)),
    val format: String = "CHANNEL_FIRST",
    var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
@@ -40,11 +40,10 @@ class Cropping3D[T: ClassTag](
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val layer =
       com.intel.analytics.bigdl.nn.Cropping3D(
-        dim1Crop = Array(cropping._1._1, cropping._1._2),
-        dim2Crop = Array(cropping._2._1, cropping._2._2),
-        dim3Crop = Array(cropping._3._1, cropping._3._2),
-        format = dimOrdering
-      )
+        dim1Crop = cropping(0),
+        dim2Crop = cropping(1),
+        dim3Crop = cropping(2),
+        format = dimOrdering)
     layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
 }
@@ -54,6 +53,9 @@ object Cropping3D {
     cropping: ((Int, Int), (Int, Int), (Int, Int)) = ((1, 1), (1, 1), (1, 1)),
     format: String = "CHANNEL_FIRST",
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Cropping3D[T] = {
-    new Cropping3D[T](cropping, format, inputShape)
+    val dim1Crop = Array(cropping._1._1, cropping._1._2)
+    val dim2Crop = Array(cropping._2._1, cropping._2._2)
+    val dim3Crop = Array(cropping._3._1, cropping._3._2)
+    new Cropping3D[T](Array(dim1Crop, dim2Crop, dim3Crop), format, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping3D.scala
@@ -59,11 +59,12 @@ class Cropping3D[T: ClassTag](
 object Cropping3D {
   def apply[@specialized(Float, Double) T: ClassTag](
     cropping: ((Int, Int), (Int, Int), (Int, Int)) = ((1, 1), (1, 1), (1, 1)),
-    format: String = "CHANNEL_FIRST",
+    dimOrdering: String = "th",
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Cropping3D[T] = {
     val dim1Crop = Array(cropping._1._1, cropping._1._2)
     val dim2Crop = Array(cropping._2._1, cropping._2._2)
     val dim3Crop = Array(cropping._3._1, cropping._3._2)
-    new Cropping3D[T](dim1Crop, dim2Crop, dim3Crop, format, inputShape)
+    new Cropping3D[T](dim1Crop, dim2Crop, dim3Crop,
+      KerasUtils.toBigDLFormat5D(dimOrdering), inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Dense.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Dense.scala
@@ -52,7 +52,7 @@ class Dense[T: ClassTag](
    var wRegularizer: Regularizer[T] = null,
    var bRegularizer: Regularizer[T] = null,
    val bias: Boolean = true,
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   override def computeOutputShape(inputShape: Shape): Shape = {
@@ -64,7 +64,7 @@ class Dense[T: ClassTag](
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val inputShapeList = inputShape.toSingle()
-    var layer = Linear(
+    val layer = Linear(
       inputSize = inputShapeList.last,
       outputSize = outputDim,
       withBias = bias,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Dropout.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Dropout.scala
@@ -34,7 +34,7 @@ import scala.reflect.ClassTag
  */
 class Dropout[T: ClassTag](
    val p: Double,
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Flatten.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Flatten.scala
@@ -30,7 +30,8 @@ import scala.reflect.ClassTag
  *
  * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
  */
-class Flatten[T: ClassTag](val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+class Flatten[T: ClassTag](
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   override def computeOutputShape(inputShape: Shape): Shape = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Flatten.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Flatten.scala
@@ -30,7 +30,7 @@ import scala.reflect.ClassTag
  *
  * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
  */
-class Flatten[T: ClassTag](var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+class Flatten[T: ClassTag](val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   override def computeOutputShape(inputShape: Shape): Shape = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalAveragePooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalAveragePooling2D.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn.{SpatialAveragePooling, Squeeze, Sequential => TSequential}
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+class GlobalAveragePooling2D[T: ClassTag](
+   format: DataFormat = DataFormat.NCHW,
+   inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends GlobalPooling2D[T](format, inputShape) {
+
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+    val input = inputShape.toSingle().toArray
+    val (dimH, dimW, dimC) = format.getHWCDims(4)
+    val model = TSequential[T]()
+    val layer = SpatialAveragePooling(
+      kW = input(dimW -1),
+      kH = input(dimH -1),
+      dW = input(dimW -1),
+      dH = input(dimH -1),
+      countIncludePad = false,
+      format = format
+    )
+    model.add(layer)
+    model.add(Squeeze(dimW - 1, numInputDims = 3))
+    model.add(Squeeze(dimH - 1, numInputDims = 2))
+    model.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+  }
+}
+
+object GlobalAveragePooling2D {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    format: DataFormat = DataFormat.NCHW,
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]): GlobalAveragePooling2D[T] = {
+    new GlobalAveragePooling2D[T](format, inputShape)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalAveragePooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalAveragePooling2D.scala
@@ -49,8 +49,8 @@ class GlobalAveragePooling2D[T: ClassTag](
 
 object GlobalAveragePooling2D {
   def apply[@specialized(Float, Double) T: ClassTag](
-    format: DataFormat = DataFormat.NCHW,
+    dimOrdering: String = "th",
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): GlobalAveragePooling2D[T] = {
-    new GlobalAveragePooling2D[T](format, inputShape)
+    new GlobalAveragePooling2D[T](KerasUtils.toBigDLFormat(dimOrdering), inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalAveragePooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalAveragePooling2D.scala
@@ -39,11 +39,10 @@ class GlobalAveragePooling2D[T: ClassTag](
       dW = input(dimW -1),
       dH = input(dimH -1),
       countIncludePad = false,
-      format = format
-    )
+      format = format)
     model.add(layer)
-    model.add(Squeeze(dimW - 1, numInputDims = 3))
-    model.add(Squeeze(dimH - 1, numInputDims = 2))
+    model.add(Squeeze(dimW))
+    model.add(Squeeze(dimH))
     model.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalMaxPooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalMaxPooling2D.scala
@@ -48,8 +48,8 @@ class GlobalMaxPooling2D[T: ClassTag](
 
 object GlobalMaxPooling2D {
   def apply[@specialized(Float, Double) T: ClassTag](
-    format: DataFormat = DataFormat.NCHW,
+    dimOrdering: String = "th",
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): GlobalMaxPooling2D[T] = {
-    new GlobalMaxPooling2D[T](format, inputShape)
+    new GlobalMaxPooling2D[T](KerasUtils.toBigDLFormat(dimOrdering), inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalMaxPooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalMaxPooling2D.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
+import com.intel.analytics.bigdl.nn.{SpatialMaxPooling, Squeeze, Sequential => TSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+class GlobalMaxPooling2D[T: ClassTag](
+   format: DataFormat = DataFormat.NCHW,
+   inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends GlobalPooling2D[T](format, inputShape) {
+
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+    val input = inputShape.toSingle().toArray
+    val (dimH, dimW, dimC) = format.getHWCDims(4)
+    val model = TSequential[T]()
+    val layer = SpatialMaxPooling(
+      kW = input(dimW -1),
+      kH = input(dimH -1),
+      dW = input(dimW -1),
+      dH = input(dimH -1),
+      format = format
+    )
+    model.add(layer)
+    model.add(Squeeze(dimW - 1, numInputDims = 3))
+    model.add(Squeeze(dimH - 1, numInputDims = 2))
+    model.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+  }
+}
+
+object GlobalMaxPooling2D {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    format: DataFormat = DataFormat.NCHW,
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]): GlobalMaxPooling2D[T] = {
+    new GlobalMaxPooling2D[T](format, inputShape)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalMaxPooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalMaxPooling2D.scala
@@ -38,11 +38,10 @@ class GlobalMaxPooling2D[T: ClassTag](
       kH = input(dimH -1),
       dW = input(dimW -1),
       dH = input(dimH -1),
-      format = format
-    )
+      format = format)
     model.add(layer)
-    model.add(Squeeze(dimW - 1, numInputDims = 3))
-    model.add(Squeeze(dimH - 1, numInputDims = 2))
+    model.add(Squeeze(dimW))
+    model.add(Squeeze(dimH))
     model.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalPooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalPooling2D.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+abstract class GlobalPooling2D[T: ClassTag](
+   val format: DataFormat = DataFormat.NCHW,
+   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val input = inputShape.toSingle().toArray
+    require(input.length == 4, "GlobalPooling2D requires 4D input")
+    format match {
+      case DataFormat.NCHW => Shape(input(0), input(1))
+      case DataFormat.NHWC => Shape(input(0), input(3))
+    }
+  }
+
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalPooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalPooling2D.scala
@@ -25,7 +25,7 @@ import scala.reflect.ClassTag
 
 abstract class GlobalPooling2D[T: ClassTag](
    val format: DataFormat = DataFormat.NCHW,
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   override def computeOutputShape(inputShape: Shape): Shape = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalPooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalPooling2D.scala
@@ -30,7 +30,8 @@ abstract class GlobalPooling2D[T: ClassTag](
 
   override def computeOutputShape(inputShape: Shape): Shape = {
     val input = inputShape.toSingle().toArray
-    require(input.length == 4, "GlobalPooling2D requires 4D input")
+    require(input.length == 4,
+      s"GlobalPooling2D requires 4D input, but got input dim ${input.length}")
     format match {
       case DataFormat.NCHW => Shape(input(0), input(1))
       case DataFormat.NHWC => Shape(input(0), input(3))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Highway.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Highway.scala
@@ -46,7 +46,7 @@ class Highway[T: ClassTag](
    var wRegularizer: Regularizer[T] = null,
    var bRegularizer: Regularizer[T] = null,
    val bias: Boolean = true,
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   override def computeOutputShape(inputShape: Shape): Shape = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasUtils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasUtils.scala
@@ -91,7 +91,7 @@ object KerasUtils {
   private[keras] def toBigDLFormat(dimOrdering: String): DataFormat = {
     require(dimOrdering.toLowerCase() == "tf" || dimOrdering.toLowerCase() == "th",
       s"Dim ordering must be either tf or th, but got ${dimOrdering.toLowerCase()}")
-    dimOrdering match {
+    dimOrdering.toLowerCase() match {
       case "tf" => DataFormat.NHWC
       case "th" => DataFormat.NCHW
     }
@@ -100,7 +100,7 @@ object KerasUtils {
   private[keras] def toBigDLFormat5D(dimOrdering: String): String = {
     require(dimOrdering.toLowerCase() == "tf" || dimOrdering.toLowerCase() == "th",
       s"Dim ordering must be either tf or th, but got ${dimOrdering.toLowerCase()}")
-    dimOrdering match {
+    dimOrdering.toLowerCase() match {
       case "tf" => "CHANNEL_LAST"
       case "th" => "CHANNEL_FIRST"
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasUtils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasUtils.scala
@@ -17,7 +17,7 @@
 package com.intel.analytics.bigdl.nn.keras
 
 import com.intel.analytics.bigdl.nn._
-import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, TensorModule}
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 
@@ -78,13 +78,31 @@ object KerasUtils {
     (outputLength + stride - 1) / stride
   }
 
-  private[keras] def getPadsFromBorderMode3D
-  (borderMode: String = "valid"): (Int, Int, Int) = {
+  private[keras] def getPadsFromBorderMode3D(
+    borderMode: String = "valid"): (Int, Int, Int) = {
     if (borderMode == "same") {
       // padT, padH, padW
       (-1, -1, -1)
     } else {
       (0, 0, 0)
+    }
+  }
+
+  private[keras] def toBigDLFormat(dimOrdering: String): DataFormat = {
+    require(dimOrdering.toLowerCase() == "tf" || dimOrdering.toLowerCase() == "th",
+      s"Dim ordering must be either tf or th, but got ${dimOrdering.toLowerCase()}")
+    dimOrdering match {
+      case "tf" => DataFormat.NHWC
+      case "th" => DataFormat.NCHW
+    }
+  }
+
+  private[keras] def toBigDLFormat5D(dimOrdering: String): String = {
+    require(dimOrdering.toLowerCase() == "tf" || dimOrdering.toLowerCase() == "th",
+      s"Dim ordering must be either tf or th, but got ${dimOrdering.toLowerCase()}")
+    dimOrdering match {
+      case "tf" => "CHANNEL_LAST"
+      case "th" => "CHANNEL_FIRST"
     }
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling1D.scala
@@ -36,7 +36,7 @@ class MaxPooling1D[T: ClassTag](
     val input = inputShape.toSingle().toArray
     val pads = KerasUtils.getPadsFromBorderMode(borderMode)
     val model = TSequential[T]()
-    model.add(Reshape(Array(input(1), 1, input(2)), Some(true)))
+    model.add(com.intel.analytics.bigdl.nn.Reshape(Array(input(1), 1, input(2)), Some(true)))
     val layer = SpatialMaxPooling(
       kW = 1,
       kH = poolLength,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling1D.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn._
+import com.intel.analytics.bigdl.nn.{Sequential => TSequential}
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+class MaxPooling1D[T: ClassTag](
+   poolLength: Int = 2,
+   stride: Option[Int] = None,
+   borderMode: String = "valid",
+   inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends Pooling1D[T](poolLength, stride, borderMode, inputShape) {
+
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+    val input = inputShape.toSingle().toArray
+    val pads = KerasUtils.getPadsFromBorderMode(borderMode)
+    val model = TSequential[T]()
+    model.add(Reshape(Array(input(1), 1, input(2)), Some(true)))
+    val layer = SpatialMaxPooling(
+      kW = 1,
+      kH = poolLength,
+      dW = 1,
+      dH = strideValue,
+      padW = pads._2,
+      padH = pads._1,
+      format = DataFormat.NHWC
+    )
+    model.add(layer)
+    model.add(Squeeze(3))
+    model.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+  }
+}
+
+object MaxPooling1D {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    poolLength: Int = 2,
+    stride: Option[Int] = None,
+    borderMode: String = "valid",
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]): MaxPooling1D[T] = {
+    new MaxPooling1D[T](poolLength, stride, borderMode, inputShape)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling1D.scala
@@ -44,8 +44,7 @@ class MaxPooling1D[T: ClassTag](
       dH = strideValue,
       padW = pads._2,
       padH = pads._1,
-      format = DataFormat.NHWC
-    )
+      format = DataFormat.NHWC)
     model.add(layer)
     model.add(Squeeze(3))
     model.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling1D.scala
@@ -27,7 +27,7 @@ import scala.reflect.ClassTag
 
 class MaxPooling1D[T: ClassTag](
    poolLength: Int = 2,
-   stride: Option[Int] = None,
+   stride: Int = -1,
    borderMode: String = "valid",
    inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends Pooling1D[T](poolLength, stride, borderMode, inputShape) {
@@ -55,7 +55,7 @@ class MaxPooling1D[T: ClassTag](
 object MaxPooling1D {
   def apply[@specialized(Float, Double) T: ClassTag](
     poolLength: Int = 2,
-    stride: Option[Int] = None,
+    stride: Int = -1,
     borderMode: String = "valid",
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): MaxPooling1D[T] = {
     new MaxPooling1D[T](poolLength, stride, borderMode, inputShape)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling2D.scala
@@ -35,7 +35,8 @@ import scala.reflect.ClassTag
  * @param strides Int array of length 2. Stride values. Default is null, and in this case it will
  *                be equal to poolSize.
  * @param borderMode Either 'valid' or 'same'. Default is 'valid'.
- * @param format Format of input data. Either DataFormat.NCHW or DataFormat.NHWC. Default is NCHW.
+ * @param format Format of input data. Either DataFormat.NCHW (dimOrdering="th") or
+ *               DataFormat.NHWC (dimOrdering="tf"). Default is NCHW.
  * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
  */
 class MaxPooling2D[T: ClassTag] (

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling2D.scala
@@ -39,43 +39,35 @@ import scala.reflect.ClassTag
  * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
  */
 class MaxPooling2D[T: ClassTag] (
-   val poolSize: Array[Int] = Array(2, 2),
-   val strides: Array[Int] = null,
-   val borderMode: String = "valid",
-   val format: DataFormat = DataFormat.NCHW,
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
-  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
-
-  require(borderMode == "valid" || borderMode == "same", s"Invalid border mode for " +
-    s"MaxPooling2D: $borderMode")
-
-  private val stridesValue = if (strides != null) strides else poolSize
+   poolSize: Array[Int] = Array(2, 2),
+   strides: Array[Int] = null,
+   borderMode: String = "valid",
+   format: DataFormat = DataFormat.NCHW,
+   inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends Pooling2D[T](poolSize, strides, borderMode, format, inputShape) {
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val pads = KerasUtils.getPadsFromBorderMode(borderMode)
     val layer = SpatialMaxPooling(
       kW = poolSize(1),
       kH = poolSize(0),
-      dW = stridesValue(1),
-      dH = stridesValue(0),
+      dW = strideValues(1),
+      dH = strideValues(0),
       padW = pads._2,
       padH = pads._1,
-      format = format
-    )
+      format = format)
     layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
 }
 
 object MaxPooling2D {
   def apply[@specialized(Float, Double) T: ClassTag](
-    poolSize: (Int, Int) = (2, 2),
-    strides: (Int, Int) = null,
+    poolSize: Array[Int] = Array(2, 2),
+    strides: Array[Int] = null,
     borderMode: String = "valid",
     format: DataFormat = DataFormat.NCHW,
     inputShape: Shape = null)
     (implicit ev: TensorNumeric[T]): MaxPooling2D[T] = {
-    val stridesValue = if (strides != null) Array(strides._1, strides._2) else null
-    new MaxPooling2D[T](Array(poolSize._1, poolSize._2),
-      stridesValue, borderMode, format, inputShape)
+    new MaxPooling2D[T](poolSize, strides, borderMode, format, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling2D.scala
@@ -35,8 +35,8 @@ import scala.reflect.ClassTag
  * @param strides Int array of length 2. Stride values. Default is null, and in this case it will
  *                be equal to poolSize.
  * @param borderMode Either 'valid' or 'same'. Default is 'valid'.
- * @param format Format of input data. Either DataFormat.NCHW (dimOrdering="th") or
- *               DataFormat.NHWC (dimOrdering="tf"). Default is NCHW.
+ * @param format Format of input data. Either DataFormat.NCHW (dimOrdering='th') or
+ *               DataFormat.NHWC (dimOrdering='tf'). Default is NCHW.
  * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
  */
 class MaxPooling2D[T: ClassTag] (

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling2D.scala
@@ -65,11 +65,11 @@ object MaxPooling2D {
     poolSize: (Int, Int) = (2, 2),
     strides: (Int, Int) = null,
     borderMode: String = "valid",
-    format: DataFormat = DataFormat.NCHW,
+    dimOrdering: String = "th",
     inputShape: Shape = null)
     (implicit ev: TensorNumeric[T]): MaxPooling2D[T] = {
     val strideValues = if (strides != null) Array(strides._1, strides._2) else null
-    new MaxPooling2D[T](Array(poolSize._1, poolSize._2),
-      strideValues, borderMode, format, inputShape)
+    new MaxPooling2D[T](Array(poolSize._1, poolSize._2), strideValues,
+      borderMode, KerasUtils.toBigDLFormat(dimOrdering), inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling2D.scala
@@ -32,7 +32,7 @@ import scala.reflect.ClassTag
  *
  * @param poolSize Int array of length 2 corresponding to the downscale vertically and
  *                 horizontally. Default is (2, 2), which will halve the image in each dimension.
- * @param strides Stride values. Int array of length 2. Default is null, and in this case it will
+ * @param strides Int array of length 2. Stride values. Default is null, and in this case it will
  *                be equal to poolSize.
  * @param borderMode Either 'valid' or 'same'. Default is 'valid'.
  * @param format Format of input data. Either DataFormat.NCHW or DataFormat.NHWC. Default is NCHW.
@@ -62,12 +62,14 @@ class MaxPooling2D[T: ClassTag] (
 
 object MaxPooling2D {
   def apply[@specialized(Float, Double) T: ClassTag](
-    poolSize: Array[Int] = Array(2, 2),
-    strides: Array[Int] = null,
+    poolSize: (Int, Int) = (2, 2),
+    strides: (Int, Int) = null,
     borderMode: String = "valid",
     format: DataFormat = DataFormat.NCHW,
     inputShape: Shape = null)
     (implicit ev: TensorNumeric[T]): MaxPooling2D[T] = {
-    new MaxPooling2D[T](poolSize, strides, borderMode, format, inputShape)
+    val strideValues = if (strides != null) Array(strides._1, strides._2) else null
+    new MaxPooling2D[T](Array(poolSize._1, poolSize._2),
+      strideValues, borderMode, format, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling3D.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn.VolumetricMaxPooling
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+class MaxPooling3D[T: ClassTag](
+   poolSize: (Int, Int, Int) = (2, 2, 2),
+   strides: (Int, Int, Int) = null,
+   inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends Pooling3D[T](poolSize, strides, inputShape) {
+
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+    val layer = VolumetricMaxPooling(
+      kT = poolSize._1,
+      kW = poolSize._3,
+      kH = poolSize._2,
+      dT = strideValues._1,
+      dW = strideValues._3,
+      dH = strideValues._2
+    )
+    layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+  }
+}
+
+object MaxPooling3D {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    poolSize: (Int, Int, Int) = (2, 2, 2),
+    strides: (Int, Int, Int) = null,
+    inputShape: Shape = null)
+    (implicit ev: TensorNumeric[T]): MaxPooling3D[T] = {
+    new MaxPooling3D[T](poolSize, strides, inputShape)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling3D.scala
@@ -25,28 +25,27 @@ import com.intel.analytics.bigdl.utils.Shape
 import scala.reflect.ClassTag
 
 class MaxPooling3D[T: ClassTag](
-   poolSize: (Int, Int, Int) = (2, 2, 2),
-   strides: (Int, Int, Int) = null,
+   poolSize: Array[Int] = Array(2, 2, 2),
+   strides: Array[Int] = null,
    inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends Pooling3D[T](poolSize, strides, inputShape) {
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val layer = VolumetricMaxPooling(
-      kT = poolSize._1,
-      kW = poolSize._3,
-      kH = poolSize._2,
-      dT = strideValues._1,
-      dW = strideValues._3,
-      dH = strideValues._2
-    )
+      kT = poolSize(0),
+      kW = poolSize(2),
+      kH = poolSize(1),
+      dT = strideValues(0),
+      dW = strideValues(2),
+      dH = strideValues(1))
     layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
 }
 
 object MaxPooling3D {
   def apply[@specialized(Float, Double) T: ClassTag](
-    poolSize: (Int, Int, Int) = (2, 2, 2),
-    strides: (Int, Int, Int) = null,
+    poolSize: Array[Int] = Array(2, 2, 2),
+    strides: Array[Int] = null,
     inputShape: Shape = null)
     (implicit ev: TensorNumeric[T]): MaxPooling3D[T] = {
     new MaxPooling3D[T](poolSize, strides, inputShape)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling3D.scala
@@ -44,10 +44,12 @@ class MaxPooling3D[T: ClassTag](
 
 object MaxPooling3D {
   def apply[@specialized(Float, Double) T: ClassTag](
-    poolSize: Array[Int] = Array(2, 2, 2),
-    strides: Array[Int] = null,
-    inputShape: Shape = null)
-    (implicit ev: TensorNumeric[T]): MaxPooling3D[T] = {
-    new MaxPooling3D[T](poolSize, strides, inputShape)
+    poolSize: (Int, Int, Int) = (2, 2, 2),
+    strides: (Int, Int, Int) = null,
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]): MaxPooling3D[T] = {
+    val strideValues = if (strides != null) Array(strides._1, strides._2, strides._3)
+                       else null
+    new MaxPooling3D[T](Array(poolSize._1, poolSize._2, poolSize._3),
+      strideValues, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Permute.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Permute.scala
@@ -30,7 +30,6 @@ class Permute[T: ClassTag](
    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
-  // from TransposeLoadTF. TODO: put this into utils?
   private def permToPair(perm: Array[Int]): Array[(Int, Int)] = {
     val numToRank = perm.zipWithIndex.toMap
     val arr = perm.indices.toArray

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Permute.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Permute.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn.Transpose
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
+
+class Permute[T: ClassTag](
+   val dims: Array[Int],
+   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+
+  // from TransposeLoadTF. TODO: put this into utils?
+  private def permToPair(perm: Array[Int]): Array[(Int, Int)] = {
+    val numToRank = perm.zipWithIndex.toMap
+    val arr = perm.indices.toArray
+    val pairs = ArrayBuffer[(Int, Int)]()
+
+    def sort(arr: Array[Int], low: Int, high: Int): Unit = {
+      var i = low
+      var j = high
+      val pivot = arr(low + (high - low)/2)
+
+      while (i <= j) {
+        while (arr(i) < pivot) i += 1
+        while (arr(j) > pivot) j -= 1
+
+        if (i <= j) {
+          exchangeNumbers(arr, i, j)
+          i += 1
+          j -= 1
+        }
+      }
+
+      if (low < j) sort(arr, low, j)
+      if (i < high) sort(arr, i, high)
+    }
+
+    def exchangeNumbers(arr: Array[Int], i: Int, j: Int): Unit = {
+      val temp = arr(i)
+      arr(i) = arr(j)
+      arr(j) = temp
+      pairs += ((i, j))
+    }
+
+    sort(arr.map(numToRank), 0, arr.length-1)
+
+    pairs.filter(pair => pair._1 != pair._2).toArray
+  }
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val input = inputShape.toSingle().toArray
+    val outputShape = input.clone()
+    var i = 0
+    while (i < dims.length) {
+      outputShape(i + 1) = input(dims(i))
+      i += 1
+    }
+    Shape(outputShape)
+  }
+
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+    val swaps = permToPair(dims.map(x => x - 1)).map(pair => (pair._1 + 2, pair._2 + 2))
+    val layer = Transpose(swaps)
+    layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+  }
+}
+
+object Permute {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    dims: Array[Int],
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Permute[T] = {
+    new Permute[T](dims, inputShape)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Permute.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Permute.scala
@@ -27,7 +27,7 @@ import scala.reflect.ClassTag
 
 class Permute[T: ClassTag](
    val dims: Array[Int],
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   // from TransposeLoadTF. TODO: put this into utils?

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling1D.scala
@@ -33,7 +33,8 @@ abstract class Pooling1D[T: ClassTag](
 
   override def computeOutputShape(inputShape: Shape): Shape = {
     val input = inputShape.toSingle().toArray
-    require(input.length == 3, "Pooling1D requires 3D input")
+    require(input.length == 3,
+      s"Pooling1D requires 3D input, but got input dim ${input.length}")
     val outputLength = KerasUtils.computeConvOutputLength(input(1), poolLength,
       borderMode, strideValue)
     Shape(input(0), outputLength, input(2))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling1D.scala
@@ -24,12 +24,13 @@ import scala.reflect.ClassTag
 
 abstract class Pooling1D[T: ClassTag](
    val poolLength: Int = 2,
-   var stride: Option[Int] = None,
+   var stride: Int = -1,
    val borderMode: String = "valid",
    var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
-  def strideValue: Int = if (stride.nonEmpty) stride.get else poolLength
+  require(stride == -1 || stride > 0, s"Invalid stride value for Pooling1D: $stride")
+  def strideValue: Int = if (stride > 0) stride else poolLength
 
   override def computeOutputShape(inputShape: Shape): Shape = {
     val input = inputShape.toSingle().toArray

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling1D.scala
@@ -24,13 +24,13 @@ import scala.reflect.ClassTag
 
 abstract class Pooling1D[T: ClassTag](
    val poolLength: Int = 2,
-   var stride: Int = -1,
+   val stride: Int = -1,
    val borderMode: String = "valid",
    var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   require(stride == -1 || stride > 0, s"Invalid stride value for Pooling1D: $stride")
-  def strideValue: Int = if (stride > 0) stride else poolLength
+  val strideValue: Int = if (stride > 0) stride else poolLength
 
   override def computeOutputShape(inputShape: Shape): Shape = {
     val input = inputShape.toSingle().toArray

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling1D.scala
@@ -26,7 +26,7 @@ abstract class Pooling1D[T: ClassTag](
    val poolLength: Int = 2,
    val stride: Int = -1,
    val borderMode: String = "valid",
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   // -1 means stride default to be poolLength

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling1D.scala
@@ -29,7 +29,7 @@ abstract class Pooling1D[T: ClassTag](
    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
-  // -1 means stride default to be poolLength
+  // -1 means stride by default to be poolLength
   require(stride == -1 || stride > 0, s"Invalid stride value for Pooling1D: $stride")
   val strideValue: Int = if (stride > 0) stride else poolLength
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling1D.scala
@@ -29,6 +29,7 @@ abstract class Pooling1D[T: ClassTag](
    var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
+  // -1 means stride default to be poolLength
   require(stride == -1 || stride > 0, s"Invalid stride value for Pooling1D: $stride")
   val strideValue: Int = if (stride > 0) stride else poolLength
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling1D.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+abstract class Pooling1D[T: ClassTag](
+   val poolLength: Int = 2,
+   var stride: Option[Int] = None,
+   val borderMode: String = "valid",
+   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+
+  def strideValue: Int = if (stride.nonEmpty) stride.get else poolLength
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val input = inputShape.toSingle().toArray
+    require(input.length == 3, "Pooling1D requires 3D input")
+    val outputLength = KerasUtils.computeConvOutputLength(input(1), poolLength,
+      borderMode, strideValue)
+    Shape(input(0), outputLength, input(2))
+  }
+
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling2D.scala
@@ -28,7 +28,7 @@ abstract class Pooling2D[T: ClassTag](
    val strides: Array[Int] = null,
    val borderMode: String = "valid",
    val format: DataFormat = DataFormat.NCHW,
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   require(poolSize.length == 2,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling2D.scala
@@ -25,7 +25,7 @@ import scala.reflect.ClassTag
 
 abstract class Pooling2D[T: ClassTag](
    val poolSize: Array[Int] = Array(2, 2),
-   var strides: Array[Int] = null,
+   val strides: Array[Int] = null,
    val borderMode: String = "valid",
    val format: DataFormat = DataFormat.NCHW,
    var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
@@ -36,7 +36,7 @@ abstract class Pooling2D[T: ClassTag](
   require(borderMode == "valid" || borderMode == "same", s"Invalid border mode for " +
     s"Pooling2D: $borderMode")
 
-  def strideValues: Array[Int] = if (strides == null) poolSize else strides
+  val strideValues: Array[Int] = if (strides == null) poolSize else strides
   require(strideValues.length == 2,
     s"For Pooling2D, strides should be of length 2 but got length ${strideValues.length}")
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling2D.scala
@@ -38,7 +38,8 @@ abstract class Pooling2D[T: ClassTag](
 
   override def computeOutputShape(inputShape: Shape): Shape = {
     val input = inputShape.toSingle().toArray
-    require(input.length == 4, "Pooling2D requires 4D input")
+    require(input.length == 4,
+      s"Pooling2D requires 4D input, but got input dim ${input.length}")
     val (dimH, dimW, dimC) = format.getHWCDims(4)
     val rows = KerasUtils.computeConvOutputLength(input(dimH -1), poolSize._1,
       borderMode, strideValues._1)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling2D.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+abstract class Pooling2D[T: ClassTag](
+   val poolSize: (Int, Int) = (2, 2),
+   var strides: (Int, Int) = null,
+   val borderMode: String = "valid",
+   val format: DataFormat = DataFormat.NCHW,
+   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+
+  require(borderMode == "valid" || borderMode == "same", s"Invalid border mode for " +
+    s"Pooling2D: $borderMode")
+
+  def strideValues: (Int, Int) = if (strides == null) poolSize else strides
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val input = inputShape.toSingle().toArray
+    require(input.length == 4, "Pooling2D requires 4D input")
+    val (dimH, dimW, dimC) = format.getHWCDims(4)
+    val rows = KerasUtils.computeConvOutputLength(input(dimH -1), poolSize._1,
+      borderMode, strideValues._1)
+    val cols = KerasUtils.computeConvOutputLength(input(dimW -1), poolSize._2,
+      borderMode, strideValues._2)
+    format match {
+      case DataFormat.NCHW => Shape(input(0), input(1), rows, cols)
+      case DataFormat.NHWC => Shape(input(0), rows, cols, input(3))
+    }
+  }
+
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling3D.scala
@@ -32,7 +32,8 @@ abstract class Pooling3D[T: ClassTag](
 
   override def computeOutputShape(inputShape: Shape): Shape = {
     val input = inputShape.toSingle().toArray
-    require(input.length == 5, "Pooling3D requires 5D input")
+    require(input.length == 5,
+      s"Pooling3D requires 5D input, but got input dim ${input.length}")
     val dim1Length = KerasUtils.computeConvOutputLength(input(2), poolSize._1,
       "valid", strideValues._1)
     val dim2Length = KerasUtils.computeConvOutputLength(input(3), poolSize._2,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling3D.scala
@@ -25,7 +25,7 @@ import scala.reflect.ClassTag
 abstract class Pooling3D[T: ClassTag](
    val poolSize: Array[Int] = Array(2, 2, 2),
    val strides: Array[Int] = null,
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   require(poolSize.length == 3,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling3D.scala
@@ -31,7 +31,7 @@ abstract class Pooling3D[T: ClassTag](
   require(poolSize.length == 3,
     s"For Pooling3D, poolSize should be of length 3 but got length ${poolSize.length}")
 
-  def strideValues: Array[Int] = if (strides == null) poolSize else strides
+  val strideValues: Array[Int] = if (strides == null) poolSize else strides
   require(strideValues.length == 3,
     s"For Pooling3D, strides should be of length 3 but got length ${strideValues.length}")
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling3D.scala
@@ -23,23 +23,28 @@ import com.intel.analytics.bigdl.utils.Shape
 import scala.reflect.ClassTag
 
 abstract class Pooling3D[T: ClassTag](
-   val poolSize: (Int, Int, Int) = (2, 2, 2),
-   val strides: (Int, Int, Int) = null,
+   val poolSize: Array[Int] = Array(2, 2, 2),
+   val strides: Array[Int] = null,
    var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
-  def strideValues: (Int, Int, Int) = if (strides == null) poolSize else strides
+  require(poolSize.length == 3,
+    s"For Pooling3D, poolSize should be of length 3 but got length ${poolSize.length}")
+
+  def strideValues: Array[Int] = if (strides == null) poolSize else strides
+  require(strideValues.length == 3,
+    s"For Pooling3D, strides should be of length 3 but got length ${strideValues.length}")
 
   override def computeOutputShape(inputShape: Shape): Shape = {
     val input = inputShape.toSingle().toArray
     require(input.length == 5,
       s"Pooling3D requires 5D input, but got input dim ${input.length}")
-    val dim1Length = KerasUtils.computeConvOutputLength(input(2), poolSize._1,
-      "valid", strideValues._1)
-    val dim2Length = KerasUtils.computeConvOutputLength(input(3), poolSize._2,
-      "valid", strideValues._2)
-    val dim3Length = KerasUtils.computeConvOutputLength(input(4), poolSize._3,
-      "valid", strideValues._3)
+    val dim1Length = KerasUtils.computeConvOutputLength(input(2), poolSize(0),
+      "valid", strideValues(0))
+    val dim2Length = KerasUtils.computeConvOutputLength(input(3), poolSize(1),
+      "valid", strideValues(1))
+    val dim3Length = KerasUtils.computeConvOutputLength(input(4), poolSize(2),
+      "valid", strideValues(2))
     Shape(input(0), input(1), dim1Length, dim2Length, dim3Length)
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling3D.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+abstract class Pooling3D[T: ClassTag](
+   val poolSize: (Int, Int, Int) = (2, 2, 2),
+   val strides: (Int, Int, Int) = null,
+   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+
+  def strideValues: (Int, Int, Int) = if (strides == null) poolSize else strides
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val input = inputShape.toSingle().toArray
+    require(input.length == 5, "Pooling3D requires 5D input")
+    val dim1Length = KerasUtils.computeConvOutputLength(input(2), poolSize._1,
+      "valid", strideValues._1)
+    val dim2Length = KerasUtils.computeConvOutputLength(input(3), poolSize._2,
+      "valid", strideValues._2)
+    val dim3Length = KerasUtils.computeConvOutputLength(input(4), poolSize._3,
+      "valid", strideValues._3)
+    Shape(input(0), input(1), dim1Length, dim2Length, dim3Length)
+  }
+
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Recurrent.scala
@@ -33,7 +33,7 @@ abstract class Recurrent[T: ClassTag](
    val outputDim: Int,
    val returnSequences: Boolean = false,
    val goBackwards: Boolean = false,
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   override def computeOutputShape(inputShape: Shape): Shape = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/RepeatVector.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/RepeatVector.scala
@@ -26,7 +26,7 @@ import scala.reflect.ClassTag
 
 class RepeatVector[T: ClassTag](
    val n: Int,
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   override def computeOutputShape(inputShape: Shape): Shape = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/RepeatVector.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/RepeatVector.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn.{ErrorInfo, Replicate}
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+class RepeatVector[T: ClassTag](
+   val n: Int,
+   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val input = inputShape.toSingle().toArray
+    require(input.length == 2, "RepeatVector requires 2D input")
+    Shape(input(0), n, input(1))
+  }
+
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+    val layer = Replicate(nFeatures = n, nDim = 1)
+    layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+  }
+}
+
+object RepeatVector {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    n: Int,
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]): RepeatVector[T] = {
+    new RepeatVector[T](n, inputShape)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/RepeatVector.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/RepeatVector.scala
@@ -31,7 +31,8 @@ class RepeatVector[T: ClassTag](
 
   override def computeOutputShape(inputShape: Shape): Shape = {
     val input = inputShape.toSingle().toArray
-    require(input.length == 2, "RepeatVector requires 2D input")
+    require(input.length == 2,
+      s"RepeatVector requires 2D input, but got input dim ${input.length}")
     Shape(input(0), n, input(1))
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Reshape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Reshape.scala
@@ -71,12 +71,12 @@ class Reshape[T: ClassTag](
       val nElements = nonBatchInput.product
       val resizeElements = - targetShape.product
       require(nElements > resizeElements && nElements % resizeElements == 0,
-      "total size after reshape must be unchanged")
+      "Total size after reshape must be unchanged")
       targetShape(inferIndex) = nElements / resizeElements
     }
     else {
       require(targetShape.product == nonBatchInput.product,
-        s"total size after reshape must be unchanged. But In ${this.getName()} : " +
+        s"Total size after reshape must be unchanged. But In ${this.getName()} : " +
           s"original size is: ${ nonBatchInput.product }, " +
           s"reshape size is: ${ targetShape.product }")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Reshape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Reshape.scala
@@ -38,7 +38,7 @@ import scala.reflect.ClassTag
  */
 class Reshape[T: ClassTag](
    val targetShape: Array[Int],
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   private var infer = false

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SoftMax.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SoftMax.scala
@@ -29,7 +29,7 @@ import scala.reflect.ClassTag
  * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
  */
 class SoftMax[T: ClassTag](
-   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+   val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
   override def computeOutputShape(inputShape: Shape): Shape = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SoftMax.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SoftMax.scala
@@ -26,7 +26,6 @@ import scala.reflect.ClassTag
 
 /**
  * Just a wrapper class. Please use Activation('softmax') instead.
- * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
  */
 class SoftMax[T: ClassTag](
    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/package.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/package.scala
@@ -18,5 +18,7 @@ package com.intel.analytics.bigdl.nn
 
 package object keras {
   // Alias
+  val Conv1D = Convolution1D
   val Conv2D = Convolution2D
+  val Conv3D = Convolution3D
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/Cropping2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/Cropping2DSpec.scala
@@ -18,6 +18,7 @@ package com.intel.analytics.bigdl.keras
 
 import com.intel.analytics.bigdl.nn.{Cropping2D, _}
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
+import com.intel.analytics.bigdl.utils.{Shape, TestUtils}
 
 class Cropping2DSpec extends KerasBaseSpec {
   "Cropping2D" should "with NCHW work properly" in {
@@ -42,6 +43,16 @@ class Cropping2DSpec extends KerasBaseSpec {
       """.stripMargin
     val model = Cropping2D[Float](Array(1, 1), Array(1, 1), DataFormat.NHWC)
     checkOutputAndGrad(model, kerasCode)
+  }
+
+  "Cropping2D computeOutputShape NCHW" should "work properly" in {
+    val layer = Cropping2D[Float](Array(2, 3), Array(2, 4))
+    TestUtils.compareOutputShape(layer, Shape(3, 12, 12)) should be (true)
+  }
+
+  "Cropping2D computeOutputShape NHWC" should "work properly" in {
+    val layer = Cropping2D[Float](Array(1, 3), Array(2, 2), format = DataFormat.NHWC)
+    TestUtils.compareOutputShape(layer, Shape(18, 12, 3)) should be (true)
   }
 
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/Cropping3DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/Cropping3DSpec.scala
@@ -18,6 +18,7 @@ package com.intel.analytics.bigdl.keras
 
 import com.intel.analytics.bigdl.nn.{Cropping2D, _}
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
+import com.intel.analytics.bigdl.utils.{Shape, TestUtils}
 
 class Cropping3DSpec extends KerasBaseSpec {
   "Cropping3D" should "with CHANNEL_FIRST work properly" in {
@@ -44,6 +45,16 @@ class Cropping3DSpec extends KerasBaseSpec {
       """.stripMargin
     val model = Cropping3D[Float](Array(1, 1), Array(1, 1), Array(1, 1), Cropping3D.CHANNEL_LAST)
     checkOutputAndGrad(model, kerasCode)
+  }
+
+  "Cropping3D computeOutputShape CHANNEL_FIRST" should "work properly" in {
+    val layer = Cropping3D[Float](Array(2, 3), Array(2, 4), Array(1, 2))
+    TestUtils.compareOutputShape(layer, Shape(3, 24, 28, 32)) should be (true)
+  }
+
+  "Cropping3D computeOutputShape CHANNEL_LAST" should "work properly" in {
+    val layer = Cropping3D[Float](Array(1, 3), Array(2, 1), Array(4, 2), Cropping3D.CHANNEL_LAST)
+    TestUtils.compareOutputShape(layer, Shape(32, 32, 32, 4)) should be (true)
   }
 
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/LocallyConnected2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/LocallyConnected2DSpec.scala
@@ -19,11 +19,11 @@ package com.intel.analytics.bigdl.keras
 import com.intel.analytics.bigdl.nn.LocallyConnected2D
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.bigdl.utils.RandomGenerator
+import com.intel.analytics.bigdl.utils.{Shape, TestUtils}
 
 
 class LocallyConnected2DSpec extends KerasBaseSpec {
-  "LocallyConnected1D NHWC Float" should "be ok" in {
+  "LocallyConnected2D NHWC Float" should "be ok" in {
     ifskipTest()
     val kerasCode =
       """
@@ -31,13 +31,13 @@ class LocallyConnected2DSpec extends KerasBaseSpec {
         |input = np.array([[[[1,2], [2,3], [3,4],[4,5],[5,6],[6,7]],
         | [[2,3], [3,4],[4,5],[5,6],[6,7], [1,2]],
         | [[1,2], [2,3], [3,4],[4,5],[6,7],[5,6]]]])
-        |output_tensor = LocallyConnected2D(3, 2, 1,
+        |output_tensor = LocallyConnected2D(3, 2, 1, dim_ordering="tf",
         |input_shape=(3,6,2))(input_tensor)
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
-    val locallyConnected1d =
+    val locallyConnected2d =
       LocallyConnected2D[Float](2, 6, 3, 3, 1, 2, format = DataFormat.NHWC)
-    val a = locallyConnected1d.parameters()
+    val a = locallyConnected2d.parameters()
 
 
     val wc = (data: Array[Tensor[Float]]) => {
@@ -64,7 +64,17 @@ class LocallyConnected2DSpec extends KerasBaseSpec {
       out
     }
 
-    checkOutputAndGrad(locallyConnected1d, kerasCode, wc)
+    checkOutputAndGrad(locallyConnected2d, kerasCode, wc)
 
+  }
+
+  "LocallyConnected1D computeOutputShape NCHW" should "work properly" in {
+    val layer = LocallyConnected2D[Float](3, 12, 12, 3, 2, 2, 2, 1)
+    TestUtils.compareOutputShape(layer, Shape(3, 12, 12)) should be (true)
+  }
+
+  "LocallyConnected2D computeOutputShape NHWC" should "work properly" in {
+    val layer = LocallyConnected2D[Float](2, 16, 12, 4, 1, 2, format = DataFormat.NHWC)
+    TestUtils.compareOutputShape(layer, Shape(12, 16, 2)) should be (true)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AveragePooling1DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AveragePooling1DSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.keras.KerasBaseSpec
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.nn.keras.{AveragePooling1D, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+
+class AveragePooling1DSpec extends KerasBaseSpec {
+
+  "AveragePooling1D valid mode" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[12, 16])
+        |input = np.random.random([3, 12, 16])
+        |output_tensor = AveragePooling1D()(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = AveragePooling1D[Float](inputShape = Shape(12, 16))
+    seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 6, 16))
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode)
+  }
+
+  "AveragePooling1D same mode" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[32, 32])
+        |input = np.random.random([2, 32, 32])
+        |output_tensor = AveragePooling1D(pool_length=3, stride=1, border_mode="same")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = AveragePooling1D[Float](poolLength = 3, stride = Some(1),
+      borderMode = "same", inputShape = Shape(32, 32))
+    seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 32, 32))
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AveragePooling1DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AveragePooling1DSpec.scala
@@ -49,7 +49,7 @@ class AveragePooling1DSpec extends KerasBaseSpec {
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = AveragePooling1D[Float](poolLength = 3, stride = Some(1),
+    val layer = AveragePooling1D[Float](poolLength = 3, stride = 1,
       borderMode = "same", inputShape = Shape(32, 32))
     seq.add(layer)
     seq.getOutputShape().toSingle().toArray should be (Array(-1, 32, 32))

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AveragePooling2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AveragePooling2DSpec.scala
@@ -50,8 +50,8 @@ class AveragePooling2DSpec extends KerasBaseSpec {
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = AveragePooling2D[Float](poolSize = Array(2, 3), strides = Array(1, 2),
-      borderMode = "same", format = DataFormat.NHWC, inputShape = Shape(20, 32, 4))
+    val layer = AveragePooling2D[Float](poolSize = (2, 3), strides = (1, 2),
+      borderMode = "same", dimOrdering = "tf", inputShape = Shape(20, 32, 4))
     seq.add(layer)
     seq.getOutputShape().toSingle().toArray should be (Array(-1, 20, 16, 4))
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AveragePooling2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AveragePooling2DSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.keras.KerasBaseSpec
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
+import com.intel.analytics.bigdl.nn.keras.{AveragePooling2D, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+
+class AveragePooling2DSpec extends KerasBaseSpec {
+
+  "AveragePooling2D NCHW" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[3, 24, 24])
+        |input = np.random.random([2, 3, 24, 24])
+        |output_tensor = AveragePooling2D(dim_ordering="th")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = AveragePooling2D[Float](inputShape = Shape(3, 24, 24))
+    seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 3, 12, 12))
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode)
+  }
+
+  "AveragePooling2D NHWC" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[20, 32, 4])
+        |input = np.random.random([2, 20, 32, 4])
+        |output_tensor = AveragePooling2D(pool_size=(2, 3), strides=(1, 2),
+        |                                 border_mode="same", dim_ordering="tf")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = AveragePooling2D[Float](poolSize = (2, 3), strides = (1, 2),
+      borderMode = "same", format = DataFormat.NHWC, inputShape = Shape(20, 32, 4))
+    seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 20, 16, 4))
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AveragePooling2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AveragePooling2DSpec.scala
@@ -50,7 +50,7 @@ class AveragePooling2DSpec extends KerasBaseSpec {
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = AveragePooling2D[Float](poolSize = (2, 3), strides = (1, 2),
+    val layer = AveragePooling2D[Float](poolSize = Array(2, 3), strides = Array(1, 2),
       borderMode = "same", format = DataFormat.NHWC, inputShape = Shape(20, 32, 4))
     seq.add(layer)
     seq.getOutputShape().toSingle().toArray should be (Array(-1, 20, 16, 4))

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AveragePooling3DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AveragePooling3DSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.keras.KerasBaseSpec
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.nn.keras.{AveragePooling3D, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+
+class AveragePooling3DSpec extends KerasBaseSpec {
+
+  "AveragePooling3D" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[3, 12, 12, 12])
+        |input = np.random.random([2, 3, 12, 12, 12])
+        |output_tensor = AveragePooling3D(dim_ordering="th")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = AveragePooling3D[Float](inputShape = Shape(3, 12, 12, 12))
+    seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 3, 6, 6, 6))
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution1DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution1DSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.keras.KerasBaseSpec
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.nn.keras.{Convolution1D, Conv1D, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+
+class Convolution1DSpec extends KerasBaseSpec {
+
+  def weightConverter(in: Array[Tensor[Float]]): Array[Tensor[Float]] =
+    if (in.length == 1) { // without bias
+      in
+    }
+    else { // with bias
+      Array(in(0).resize(Array(1) ++ in(0).size()), in(1))
+    }
+
+  "Convolution1D" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[12, 20])
+        |input = np.random.random([2, 12, 20])
+        |output_tensor = Convolution1D(64, 3)(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = Convolution1D[Float](64, 3, inputShape = Shape(12, 20))
+    seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 10, 64))
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode, weightConverter)
+  }
+
+  "Convolution1D without bias" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[20, 32])
+        |input = np.random.random([2, 20, 32])
+        |output_tensor = Convolution1D(32, 4, activation="relu", bias=False,
+        |                              subsample_length=2)(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = Conv1D[Float](32, 4, activation = "relu", subsampleLength = 2,
+      bias = false, inputShape = Shape(20, 32))
+    seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 9, 32))
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode, weightConverter)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution1DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution1DSpec.scala
@@ -25,12 +25,8 @@ import com.intel.analytics.bigdl.utils.Shape
 class Convolution1DSpec extends KerasBaseSpec {
 
   def weightConverter(in: Array[Tensor[Float]]): Array[Tensor[Float]] =
-    if (in.length == 1) { // without bias
-      in
-    }
-    else { // with bias
-      Array(in(0).resize(Array(1) ++ in(0).size()), in(1))
-    }
+    if (in.length == 1) in // without bias
+    else Array(in(0).resize(Array(1) ++ in(0).size()), in(1)) // with bias
 
   "Convolution1D" should "be the same as Keras" in {
     val kerasCode =

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution2DSpec.scala
@@ -55,7 +55,7 @@ class Convolution2DSpec extends KerasBaseSpec {
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = Convolution2D[Float](32, 4, 6, format = DataFormat.NHWC,
+    val layer = Convolution2D[Float](32, 4, 6, dimOrdering = "tf",
       borderMode = "same", inputShape = Shape(24, 24, 3))
     seq.add(layer)
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
@@ -72,7 +72,7 @@ class Convolution2DSpec extends KerasBaseSpec {
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = Conv2D[Float](64, 2, 5, subsample = Array(2, 3), init = "normal",
+    val layer = Conv2D[Float](64, 2, 5, subsample = (2, 3), init = "normal",
       bias = false, inputShape = Shape(3, 24, 24))
     seq.add(layer)
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution2DSpec.scala
@@ -72,7 +72,7 @@ class Convolution2DSpec extends KerasBaseSpec {
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = Conv2D[Float](64, 2, 5, subsample = (2, 3), init = "normal",
+    val layer = Conv2D[Float](64, 2, 5, subsample = Array(2, 3), init = "normal",
       bias = false, inputShape = Shape(3, 24, 24))
     seq.add(layer)
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution3DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution3DSpec.scala
@@ -35,7 +35,7 @@ class Convolution3DSpec extends KerasBaseSpec {
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = Convolution3D[Float](12, 2, 1, 3, subsample = (1, 2, 3),
+    val layer = Convolution3D[Float](12, 2, 1, 3, subsample = Array(1, 2, 3),
       inputShape = Shape(3, 32, 32, 32))
     seq.add(layer)
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution3DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution3DSpec.scala
@@ -22,7 +22,6 @@ import com.intel.analytics.bigdl.nn.keras.{Conv3D, Convolution3D, Sequential => 
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
 
-
 class Convolution3DSpec extends KerasBaseSpec {
 
   "Convolution3D" should "be the same as Keras" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution3DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution3DSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.keras.KerasBaseSpec
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.nn.keras.{Conv3D, Convolution3D, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+
+
+class Convolution3DSpec extends KerasBaseSpec {
+
+  "Convolution3D" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[3, 32, 32, 32])
+        |input = np.random.random([1, 3, 32, 32, 32])
+        |output_tensor = Convolution3D(12, 2, 1, 3, subsample=(1, 2, 3),
+        |                              dim_ordering="th")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = Convolution3D[Float](12, 2, 1, 3, subsample = (1, 2, 3),
+      inputShape = Shape(3, 32, 32, 32))
+    seq.add(layer)
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode, precision = 1e-2)
+  }
+
+  "Convolution3D without bias" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[4, 16, 20, 32])
+        |input = np.random.random([1, 4, 16, 20, 32])
+        |output_tensor = Convolution3D(8, 2, 2, 4, activation="relu", bias=False,
+        |                              border_mode="same", dim_ordering="th")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = Convolution3D[Float](8, 2, 2, 4, activation = "relu", bias = false,
+      borderMode = "same", inputShape = Shape(4, 16, 20, 32))
+    seq.add(layer)
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode, precision = 1e-3)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution3DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution3DSpec.scala
@@ -35,7 +35,7 @@ class Convolution3DSpec extends KerasBaseSpec {
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = Convolution3D[Float](12, 2, 1, 3, subsample = Array(1, 2, 3),
+    val layer = Convolution3D[Float](12, 2, 1, 3, subsample = (1, 2, 3),
       inputShape = Shape(3, 32, 32, 32))
     seq.add(layer)
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Cropping1DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Cropping1DSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.keras.KerasBaseSpec
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.nn.keras.{Cropping1D, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+
+class Cropping1DSpec extends KerasBaseSpec {
+
+  "Cropping1D" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[5, 6])
+        |input = np.random.random([2, 5, 6])
+        |output_tensor = Cropping1D((1, 2))(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = Cropping1D[Float]((1, 2), inputShape = Shape(5, 6))
+    seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 2, 6))
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Cropping1DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Cropping1DSpec.scala
@@ -33,7 +33,7 @@ class Cropping1DSpec extends KerasBaseSpec {
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = Cropping1D[Float]((1, 2), inputShape = Shape(5, 6))
+    val layer = Cropping1D[Float](Array(1, 2), inputShape = Shape(5, 6))
     seq.add(layer)
     seq.getOutputShape().toSingle().toArray should be (Array(-1, 2, 6))
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Cropping1DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Cropping1DSpec.scala
@@ -33,7 +33,7 @@ class Cropping1DSpec extends KerasBaseSpec {
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = Cropping1D[Float](Array(1, 2), inputShape = Shape(5, 6))
+    val layer = Cropping1D[Float]((1, 2), inputShape = Shape(5, 6))
     seq.add(layer)
     seq.getOutputShape().toSingle().toArray should be (Array(-1, 2, 6))
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Cropping2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Cropping2DSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.keras.KerasBaseSpec
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
+import com.intel.analytics.bigdl.nn.keras.{Cropping2D, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+
+class Cropping2DSpec extends KerasBaseSpec {
+
+  "Cropping2D NCHW" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[3, 8, 12])
+        |input = np.random.random([2, 3, 8, 12])
+        |output_tensor = Cropping2D(((1, 2), (3, 1)), dim_ordering="th")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = Cropping2D[Float](((1, 2), (3, 1)), inputShape = Shape(3, 8, 12))
+    seq.add(layer)
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode)
+  }
+
+  "Cropping2D NHWC" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[4, 5, 3])
+        |input = np.random.random([2, 4, 5, 3])
+        |output_tensor = Cropping2D(((0, 1), (1, 1)), dim_ordering="tf")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = Cropping2D[Float](((0, 1), (1, 1)), format = DataFormat.NHWC,
+      inputShape = Shape(4, 5, 3))
+    seq.add(layer)
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Cropping2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Cropping2DSpec.scala
@@ -48,7 +48,7 @@ class Cropping2DSpec extends KerasBaseSpec {
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = Cropping2D[Float](((0, 1), (1, 1)), format = DataFormat.NHWC,
+    val layer = Cropping2D[Float](((0, 1), (1, 1)), dimOrdering = "tf",
       inputShape = Shape(4, 5, 3))
     seq.add(layer)
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Cropping3DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Cropping3DSpec.scala
@@ -50,7 +50,7 @@ class Cropping3DSpec extends KerasBaseSpec {
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = Cropping3D[Float](((1, 1), (2, 2), (0, 3)), format = "CHANNEL_LAST",
+    val layer = Cropping3D[Float](((1, 1), (2, 2), (0, 3)), dimOrdering = "tf",
       inputShape = Shape(32, 32, 32, 2))
     seq.add(layer)
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Cropping3DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Cropping3DSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.keras.KerasBaseSpec
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.nn.keras.{Cropping3D, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+
+class Cropping3DSpec extends KerasBaseSpec {
+
+  "Cropping3D channel_first" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[4, 12, 16, 20])
+        |input = np.random.random([2, 4, 12, 16, 20])
+        |output_tensor = Cropping3D(((2, 0), (1, 2), (3, 1)),
+        |                           dim_ordering="th")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = Cropping3D[Float](((2, 0), (1, 2), (3, 1)), inputShape = Shape(4, 12, 16, 20))
+    seq.add(layer)
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode)
+  }
+
+  "Cropping3D channel_last" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[32, 32, 32, 2])
+        |input = np.random.random([2, 32, 32, 32, 2])
+        |output_tensor = Cropping3D(((1, 1), (2, 2), (0, 3)),
+        |                           dim_ordering="tf")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = Cropping3D[Float](((1, 1), (2, 2), (0, 3)), format = "CHANNEL_LAST",
+      inputShape = Shape(32, 32, 32, 2))
+    seq.add(layer)
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GlobalAveragePooling2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GlobalAveragePooling2DSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.keras.KerasBaseSpec
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
+import com.intel.analytics.bigdl.nn.keras.{GlobalAveragePooling2D, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+
+class GlobalAveragePooling2DSpec extends KerasBaseSpec {
+
+  "GlobalAveragePooling2D NCHW" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[3, 16, 20])
+        |input = np.random.random([2, 3, 16, 20])
+        |output_tensor = GlobalAveragePooling2D(dim_ordering="th")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = GlobalAveragePooling2D[Float](inputShape = Shape(3, 16, 20))
+    seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 3))
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode)
+  }
+
+  "GlobalAveragePooling2D NHWC" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[32, 28, 6])
+        |input = np.random.random([3, 32, 28, 6])
+        |output_tensor = GlobalAveragePooling2D(dim_ordering="tf")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = GlobalAveragePooling2D[Float](format = DataFormat.NHWC,
+      inputShape = Shape(32, 28, 6))
+    seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 6))
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GlobalAveragePooling2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GlobalAveragePooling2DSpec.scala
@@ -49,7 +49,7 @@ class GlobalAveragePooling2DSpec extends KerasBaseSpec {
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = GlobalAveragePooling2D[Float](format = DataFormat.NHWC,
+    val layer = GlobalAveragePooling2D[Float](dimOrdering = "tf",
       inputShape = Shape(32, 28, 6))
     seq.add(layer)
     seq.getOutputShape().toSingle().toArray should be (Array(-1, 6))

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GlobalMaxPooling2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GlobalMaxPooling2DSpec.scala
@@ -49,7 +49,7 @@ class GlobalMaxPooling2DSpec extends KerasBaseSpec {
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = GlobalMaxPooling2D[Float](format = DataFormat.NHWC, inputShape = Shape(16, 16, 2))
+    val layer = GlobalMaxPooling2D[Float](dimOrdering = "tf", inputShape = Shape(16, 16, 2))
     seq.add(layer)
     seq.getOutputShape().toSingle().toArray should be (Array(-1, 2))
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GlobalMaxPooling2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GlobalMaxPooling2DSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.keras.KerasBaseSpec
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
+import com.intel.analytics.bigdl.nn.keras.{GlobalMaxPooling2D, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+
+class GlobalMaxPooling2DSpec extends KerasBaseSpec {
+
+  "GlobalMaxPooling2D NCHW" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[4, 24, 32])
+        |input = np.random.random([2, 4, 24, 32])
+        |output_tensor = GlobalMaxPooling2D(dim_ordering="th")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = GlobalMaxPooling2D[Float](inputShape = Shape(4, 24, 32))
+    seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 4))
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode)
+  }
+
+  "GlobalMaxPooling2D NHWC" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[16, 16, 2])
+        |input = np.random.random([3, 16, 16, 2])
+        |output_tensor = GlobalMaxPooling2D(dim_ordering="tf")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = GlobalMaxPooling2D[Float](format = DataFormat.NHWC, inputShape = Shape(16, 16, 2))
+    seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 2))
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling1DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling1DSpec.scala
@@ -49,7 +49,7 @@ class MaxPooling1DSpec extends KerasBaseSpec {
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = MaxPooling1D[Float](stride = Some(1), borderMode = "same",
+    val layer = MaxPooling1D[Float](stride = 1, borderMode = "same",
       inputShape = Shape(20, 32))
     seq.add(layer)
     seq.getOutputShape().toSingle().toArray should be (Array(-1, 20, 32))

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling1DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling1DSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.keras.KerasBaseSpec
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.nn.keras.{MaxPooling1D, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+
+class MaxPooling1DSpec extends KerasBaseSpec {
+
+  "MaxPooling1D valid mode" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[12, 12])
+        |input = np.random.random([3, 12, 12])
+        |output_tensor = MaxPooling1D(pool_length=3)(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = MaxPooling1D[Float](poolLength = 3, inputShape = Shape(12, 12))
+    seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 4, 12))
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode)
+  }
+
+  "MaxPooling1D same mode" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[20, 32])
+        |input = np.random.random([3, 20, 32])
+        |output_tensor = MaxPooling1D(stride=1, border_mode="same")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = MaxPooling1D[Float](stride = Some(1), borderMode = "same",
+      inputShape = Shape(20, 32))
+    seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 20, 32))
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling2DSpec.scala
@@ -50,7 +50,7 @@ class MaxPooling2DSpec extends KerasBaseSpec{
       """.stripMargin
     val seq = KSequential[Float]()
     val layer = MaxPooling2D[Float](poolSize = (2, 3), strides = (1, 2),
-      format = DataFormat.NHWC, inputShape = Shape(32, 28, 5))
+      dimOrdering = "tf", inputShape = Shape(32, 28, 5))
     seq.add(layer)
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
       kerasCode)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling2DSpec.scala
@@ -49,7 +49,7 @@ class MaxPooling2DSpec extends KerasBaseSpec{
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = MaxPooling2D[Float](poolSize = (2, 3), strides = (1, 2),
+    val layer = MaxPooling2D[Float](poolSize = Array(2, 3), strides = Array(1, 2),
       format = DataFormat.NHWC, inputShape = Shape(32, 28, 5))
     seq.add(layer)
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
@@ -66,7 +66,7 @@ class MaxPooling2DSpec extends KerasBaseSpec{
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = MaxPooling2D[Float](strides = (1, 2), borderMode = "same",
+    val layer = MaxPooling2D[Float](strides = Array(1, 2), borderMode = "same",
       inputShape = Shape(3, 24, 24))
     seq.add(layer)
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling2DSpec.scala
@@ -49,7 +49,7 @@ class MaxPooling2DSpec extends KerasBaseSpec{
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = MaxPooling2D[Float](poolSize = Array(2, 3), strides = Array(1, 2),
+    val layer = MaxPooling2D[Float](poolSize = (2, 3), strides = (1, 2),
       format = DataFormat.NHWC, inputShape = Shape(32, 28, 5))
     seq.add(layer)
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
@@ -66,7 +66,7 @@ class MaxPooling2DSpec extends KerasBaseSpec{
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = MaxPooling2D[Float](strides = Array(1, 2), borderMode = "same",
+    val layer = MaxPooling2D[Float](strides = (1, 2), borderMode = "same",
       inputShape = Shape(3, 24, 24))
     seq.add(layer)
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling3DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling3DSpec.scala
@@ -33,7 +33,7 @@ class MaxPooling3DSpec extends KerasBaseSpec {
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = MaxPooling3D[Float](poolSize = (2, 2, 3), inputShape = Shape(3, 20, 15, 35))
+    val layer = MaxPooling3D[Float](poolSize = Array(2, 2, 3), inputShape = Shape(3, 20, 15, 35))
     seq.add(layer)
     seq.getOutputShape().toSingle().toArray should be (Array(-1, 3, 10, 7, 11))
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling3DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling3DSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.keras.KerasBaseSpec
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.nn.keras.{MaxPooling3D, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+
+class MaxPooling3DSpec extends KerasBaseSpec {
+
+  "MaxPooling3D" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[3, 20, 15, 35])
+        |input = np.random.random([2, 3, 20, 15, 35])
+        |output_tensor = MaxPooling3D((2, 2, 3), dim_ordering="th")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = MaxPooling3D[Float](poolSize = (2, 2, 3), inputShape = Shape(3, 20, 15, 35))
+    seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 3, 10, 7, 11))
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling3DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling3DSpec.scala
@@ -33,7 +33,7 @@ class MaxPooling3DSpec extends KerasBaseSpec {
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = MaxPooling3D[Float](poolSize = Array(2, 2, 3), inputShape = Shape(3, 20, 15, 35))
+    val layer = MaxPooling3D[Float](poolSize = (2, 2, 3), inputShape = Shape(3, 20, 15, 35))
     seq.add(layer)
     seq.getOutputShape().toSingle().toArray should be (Array(-1, 3, 10, 7, 11))
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/PermuteSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/PermuteSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.keras.KerasBaseSpec
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.nn.keras.{Permute, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+
+class PermuteSpec extends KerasBaseSpec {
+
+  "Permute" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[3, 4, 5, 6])
+        |input = np.random.random([2, 3, 4, 5, 6])
+        |output_tensor = Permute((3, 1, 4, 2))(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = Permute[Float](Array(3, 1, 4, 2), inputShape = Shape(3, 4, 5, 6))
+    seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 5, 3, 6, 4))
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/RepeatVectorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/RepeatVectorSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.keras.KerasBaseSpec
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.nn.keras.{RepeatVector, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+
+class RepeatVectorSpec extends KerasBaseSpec {
+
+  "RepeatVector" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[12])
+        |input = np.random.random([2, 12])
+        |output_tensor = RepeatVector(4)(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = RepeatVector[Float](4, inputShape = Shape(12))
+    seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 4, 12))
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolutionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolutionSpec.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.nn
 
 import com.intel.analytics.bigdl.optim.{L2Regularizer, SGD}
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
-import com.intel.analytics.bigdl.utils.T
+import com.intel.analytics.bigdl.utils.{Shape, T, TestUtils}
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -222,5 +222,9 @@ class SpatialFullConvolutionSpec extends FlatSpec with Matchers {
 
   }
 
+  "SpatialFullConvolution computeOutputShape" should "work properly" in {
+    val layer = SpatialFullConvolution[Float](3, 5, 1, 2, 2)
+    TestUtils.compareOutputShape(layer, Shape(3, 28, 32)) should be (true)
+  }
 
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolutionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolutionSpec.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.nn
 
 import com.intel.analytics.bigdl.optim.{L2Regularizer, SGD}
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
-import com.intel.analytics.bigdl.utils.{Shape, T, TestUtils}
+import com.intel.analytics.bigdl.utils.T
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -222,9 +222,5 @@ class SpatialFullConvolutionSpec extends FlatSpec with Matchers {
 
   }
 
-  "SpatialFullConvolution computeOutputShape" should "work properly" in {
-    val layer = SpatialFullConvolution[Float](3, 5, 1, 2, 2)
-    TestUtils.compareOutputShape(layer, Shape(3, 28, 32)) should be (true)
-  }
 
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialMaxPoolingSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialMaxPoolingSpec.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.nn
 
-import com.intel.analytics.bigdl.utils.{RandomGenerator, Shape, TestUtils}
+import com.intel.analytics.bigdl.utils.RandomGenerator
 import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
 import org.scalatest.{FlatSpec, Matchers}
@@ -435,13 +435,4 @@ class SpatialMaxPoolingSpec extends FlatSpec with Matchers {
     }
   }
 
-  "SpatialMaxPooling computeOutputShape NCHW" should "work properly" in {
-    val layer = SpatialMaxPooling[Float](4, 5, 1, 2, 2, 2)
-    TestUtils.compareOutputShape(layer, Shape(3, 12, 16)) should be (true)
-  }
-
-  "SpatialMaxPooling computeOutputShape NHWC" should "work properly" in {
-    val layer = SpatialMaxPooling[Float](2, 4, 1, 2, 1, 1, format = DataFormat.NHWC)
-    TestUtils.compareOutputShape(layer, Shape(18, 20, 5)) should be (true)
-  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialSeperableConvolutionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialSeperableConvolutionSpec.scala
@@ -17,7 +17,7 @@ package com.intel.analytics.bigdl.nn
 
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.bigdl.utils.BigDLSpecHelper
+import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, Shape, TestUtils}
 
 class SpatialSeperableConvolutionSpec extends BigDLSpecHelper {
   "SpatialSeperableConvolution NHWC and NCHW" should "have same output" in {
@@ -94,4 +94,15 @@ class SpatialSeperableConvolutionSpec extends BigDLSpecHelper {
     conv.saveModule(file.getAbsolutePath, overWrite = true)
     val conv2 = Module.loadModule[Float](file.getAbsolutePath)
   }
+
+  "SpatialSeparableConvolution computeOutputShape NCHW" should "work properly" in {
+    val layer = SpatialSeperableConvolution[Float](3, 6, 1, 2, 2)
+    TestUtils.compareOutputShape(layer, Shape(3, 12, 12)) should be (true)
+  }
+
+  "SpatialSeparableConvolution computeOutputShape NHWC" should "work properly" in {
+    val layer = SpatialSeperableConvolution[Float](2, 5, 2, 2, 1, dataFormat = DataFormat.NHWC)
+    TestUtils.compareOutputShape(layer, Shape(24, 24, 2)) should be (true)
+  }
+
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/VolumetricConvolutionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/VolumetricConvolutionSpec.scala
@@ -21,7 +21,7 @@ import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.optim.{L2Regularizer, SGD}
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import com.intel.analytics.bigdl.utils.RandomGenerator._
-import com.intel.analytics.bigdl.utils.T
+import com.intel.analytics.bigdl.utils.{Shape, T, TestUtils}
 
 import scala.util.Random
 
@@ -474,6 +474,11 @@ class VolumetricConvolutionSpec extends TorchSpec {
     val output = layer.updateOutput(input)
     val gradInput = layer.backward(input, output)
     output.storage().array() should be (Array(0.0f, 2, 6, 8, 18, 20, 24, 26))
+  }
+
+  "VolumetricConvolution computeOutputShape" should "work properly" in {
+    val layer = VolumetricConvolution[Float](3, 8, 2, 1, 2)
+    TestUtils.compareOutputShape(layer, Shape(3, 24, 28, 32)) should be (true)
   }
 }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/KerasModuleSerializerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/KerasModuleSerializerSpec.scala
@@ -140,5 +140,103 @@ class KerasModuleSerializerSpec extends SerializerSpecHelper {
     runSerializationTest(layer, input)
   }
 
+  "Convolution1D serializer" should "work properly" in {
+    val layer = Convolution1D[Float](64, 3, inputShape = Shape(12, 20))
+    layer.build(Shape(2, 12, 20))
+    val input = Tensor[Float](2, 12, 20).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
+
+  "Convolution3D serializer" should "work properly" in {
+    val layer = Convolution3D[Float](12, 2, 1, 3, inputShape = Shape(3, 32, 32, 32))
+    layer.build(Shape(2, 3, 32, 32, 32))
+    val input = Tensor[Float](2, 3, 32, 32, 32).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
+
+  "MaxPooling1D serializer" should "work properly" in {
+    val layer = MaxPooling1D[Float](inputShape = Shape(12, 12))
+    layer.build(Shape(2, 12, 12))
+    val input = Tensor[Float](2, 12, 12).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
+
+  "MaxPooling3D serializer" should "work properly" in {
+    val layer = MaxPooling3D[Float](inputShape = Shape(3, 20, 15, 35))
+    layer.build(Shape(2, 3, 20, 15, 35))
+    val input = Tensor[Float](2, 3, 20, 15, 35).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
+
+  "AveragePooling1D serializer" should "work properly" in {
+    val layer = AveragePooling1D[Float](inputShape = Shape(12, 16))
+    layer.build(Shape(2, 12, 16))
+    val input = Tensor[Float](2, 12, 16).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
+
+  "AveragePooling2D serializer" should "work properly" in {
+    val layer = AveragePooling2D[Float](inputShape = Shape(3, 24, 24))
+    layer.build(Shape(2, 3, 24, 24))
+    val input = Tensor[Float](2, 3, 24, 24).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
+
+  "AveragePooling3D serializer" should "work properly" in {
+    val layer = AveragePooling3D[Float](inputShape = Shape(3, 12, 12, 12))
+    layer.build(Shape(2, 3, 12, 12, 12))
+    val input = Tensor[Float](2, 3, 12, 12, 12).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
+
+  "GlobalMaxPooling2D serializer" should "work properly" in {
+    val layer = GlobalMaxPooling2D[Float](inputShape = Shape(4, 24, 32))
+    layer.build(Shape(2, 4, 24, 32))
+    val input = Tensor[Float](2, 4, 24, 32).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
+
+  "GlobalAveragePooling2D serializer" should "work properly" in {
+    val layer = GlobalAveragePooling2D[Float](inputShape = Shape(4, 24, 32))
+    layer.build(Shape(2, 4, 24, 32))
+    val input = Tensor[Float](2, 4, 24, 32).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
+
+  "RepeatVector serializer" should "work properly" in {
+    val layer = RepeatVector[Float](4, inputShape = Shape(12))
+    layer.build(Shape(2, 12))
+    val input = Tensor[Float](2, 12).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
+
+  "Permute serializer" should "work properly" in {
+    val layer = Permute[Float](Array(3, 1, 4, 2), inputShape = Shape(3, 4, 5, 6))
+    layer.build(Shape(2, 3, 4, 5, 6))
+    val input = Tensor[Float](2, 3, 4, 5, 6).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
+
+  "Cropping1D serializer" should "work properly" in {
+    val layer = Cropping1D[Float](inputShape = Shape(5, 6))
+    layer.build(Shape(2, 5, 6))
+    val input = Tensor[Float](2, 5, 6).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
+
+  "Cropping2D serializer" should "work properly" in {
+    val layer = Cropping2D[Float](inputShape = Shape(3, 8, 12))
+    layer.build(Shape(2, 3, 8, 12))
+    val input = Tensor[Float](2, 3, 8, 12).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
+
+  "Cropping3D serializer" should "work properly" in {
+    val layer = Cropping3D[Float](inputShape = Shape(4, 12, 16, 20))
+    layer.build(Shape(2, 4, 12, 16, 20))
+    val input = Tensor[Float](2, 4, 12, 16, 20).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
+
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

ComputeOutputShape logic for almost all layers.
Added some core layers, convolution layers, pooling layers compatible with Keras.

Layers:
Convolution1D
Convolution3D
MaxPooling1D
MaxPooling3D
AveragePooling1D
AveragePooling2D
AveragePooling3D
GlobalMaxPooling2D
GlobalAveragePooling2D
RepeatVector
Permute
Cropping1D
Cropping2D
Cropping3D

## How was this patch tested?

Jenkins

