### PR TITLE
Fix a random failure in tf fused batch norm test

### DIFF
--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/loaders/FusedBatchNormGradSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/loaders/FusedBatchNormGradSpec.scala
@@ -16,6 +16,7 @@
 package com.intel.analytics.bigdl.utils.tf.loaders
 
 import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.RandomGenerator
 import com.intel.analytics.bigdl.utils.tf.Tensorflow.{booleanAttr, floatAttr, typeAttr}
 import com.intel.analytics.bigdl.utils.tf.{TensorflowDataFormat, TensorflowSpecHelper}
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -83,6 +84,7 @@ class FusedBatchNormGradSpec extends TensorflowSpecHelper {
   }
 
   "FusedBatchNormGrad gradInput" should "be correct when is training is false" in {
+    RandomGenerator.RNG.setSeed(1000)
     val x = Tensor[Float](4, 8, 8, 256).rand()
     val g = Tensor[Float](4, 8, 8, 256).rand()
     val scale = Tensor[Float](256).rand()

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/loaders/FusedBatchNormGradSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/loaders/FusedBatchNormGradSpec.scala
@@ -24,6 +24,7 @@ import org.tensorflow.framework.{DataType, NodeDef}
 class FusedBatchNormGradSpec extends TensorflowSpecHelper {
 
   "FusedBatchNormGrad gradInput" should "be correct when is training is true" in {
+    RandomGenerator.RNG.setSeed(2000)
     val x = Tensor[Float](4, 8, 8, 256).rand()
     val g = Tensor[Float](4, 8, 8, 256).rand()
     val scale = Tensor[Float](256).rand()
@@ -84,7 +85,7 @@ class FusedBatchNormGradSpec extends TensorflowSpecHelper {
   }
 
   "FusedBatchNormGrad gradInput" should "be correct when is training is false" in {
-    RandomGenerator.RNG.setSeed(1000)
+    RandomGenerator.RNG.setSeed(2000)
     val x = Tensor[Float](4, 8, 8, 256).rand()
     val g = Tensor[Float](4, 8, 8, 256).rand()
     val scale = Tensor[Float](256).rand()


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix a random failure in tf fused batch norm test by setting the random seed before generating input data. The failure is due to a high accuracy comparison.


## How was this patch tested?
unit test


