### PR TITLE
Optimize BCECriterion

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BCECriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BCECriterion.scala
@@ -37,48 +37,92 @@ import scala.reflect.ClassTag
  */
 @SerialVersionUID(- 1953992758534446600L)
 class BCECriterion[@specialized(Float, Double) T: ClassTag]
-(var weights: Tensor[T] = null, sizeAverage: Boolean = true)
+(val weights: Tensor[T] = null, sizeAverage: Boolean = true)
   (implicit ev: TensorNumeric[T]) extends TensorCriterion[T] {
   private val eps = 1e-12
-  if (weights != null) require(weights.dim() == 1,
-    "weights input should be 1-D Tensor" +
-    s"weights input dim(${weights.dim()})")
+
+  val buffer: Tensor[T] = Tensor[T]
+
+  private var expendedWeights: Tensor[T] = null
 
   override def updateOutput(input: Tensor[T], target: Tensor[T]): T = {
-    require(input.nElement() == target.nElement())
+    require(input.size().sameElements(target.size()),
+      s"input size should be equal to target size, but got input size: ${input.size().toList}," +
+        s" target size: ${input.size().toList}")
 
-    if (null != weights && target.dim() != 1) {
-      weights = weights.view(1, target.size(2)).expandAs(target)
+    if (weights != null) {
+      if (weights.nDimension() < input.nDimension()) {
+        require(weights.size().sameElements(input.size().tail),
+          s"weights size should be equal to input size or input size's tail, but got" +
+            s" input size: ${input.size().toList}, weights size: ${weights.size().toList}")
+      } else if (weights.nDimension() == input.nDimension()) {
+        require(weights.size().sameElements(input.size().tail),
+          s"weights size should be equal to input size or input size's tail, but got" +
+            s" input size: ${input.size().toList}, weights size: ${weights.size().toList}")
+      } else {
+        throw new IllegalArgumentException(
+          s"weights size should be equal to input size or input size's tail, but got" +
+          s" input size: ${input.size().toList}, weights size: ${weights.size().toList}")
+      }
     }
+
+    val nElement = input.nElement()
 
     var sum = 0.0
     if (null != weights) {
-      val func = new TensorFunc6[T] {
-        override def apply(data1: Array[T], offset1: Int, data2: Array[T], offset2: Int,
-                           data3: Array[T], offset3: Int): Unit = {
-          val x = ev.toType[Double](data1(offset1))
-          val y = ev.toType[Double](data2(offset2))
-          val w = ev.toType[Double](data3(offset3))
-          sum -= (Math.log(x + eps) * y + Math.log(1.0 - x + eps) * (1.0 - y)) * w
-        }
-      }
-      DenseTensorApply.apply3(input, target, weights, func)
-    } else {
-      val func = new TensorFunc4[T] {
-        override def apply(data1: Array[T], offset1: Int,
-                           data2: Array[T], offset2: Int): Unit = {
-          val x = ev.toType[Double](data1(offset1))
-          val y = ev.toType[Double](data2(offset2))
-          sum -= Math.log(x + eps) * y + Math.log(1.0 - x + eps) * (1.0 - y)
-        }
-      }
-      DenseTensorApply.apply2(input, target, func)
+      if (weights.nElement() < 200) {
+        // simple heuristic, if the input tensor is small enough, the
+        // vectorized implementation is actually slower
 
+        if (target.dim() > weights.dim()) {
+          val size = target.size()
+          size(0) = 1
+          expendedWeights = weights.view(size).expandAs(target)
+        }
+
+        val func = new TensorFunc6[T] {
+          override def apply(data1: Array[T], offset1: Int, data2: Array[T], offset2: Int,
+                             data3: Array[T], offset3: Int): Unit = {
+            val x = ev.toType[Double](data1(offset1))
+            val y = ev.toType[Double](data2(offset2))
+            val w = ev.toType[Double](data3(offset3))
+            sum += (Math.log(x + eps) * y + Math.log(1.0 - x + eps) * (1.0 - y)) * w
+          }
+        }
+        DenseTensorApply.apply3(input, target, expendedWeights, func)
+      } else {
+        buffer.resizeAs(input).copy(input).add(ev.fromType(eps)).log()
+        // cmul support broadcasting
+        buffer.cmul(weights)
+        sum += ev.toType[Double](buffer.dot(target))
+        buffer.fill(ev.fromType(1.0)).sub(input).add(ev.fromType(eps)).log().cmul(weights)
+        sum -= ev.toType[Double](buffer.dot(target))
+        sum += ev.toType[Double](buffer.sum())
+      }
+
+    } else {
+      if (nElement < 200) {
+        val func = new TensorFunc4[T] {
+          override def apply(data1: Array[T], offset1: Int,
+                             data2: Array[T], offset2: Int): Unit = {
+            val x = ev.toType[Double](data1(offset1))
+            val y = ev.toType[Double](data2(offset2))
+            sum += Math.log(x + eps) * y + Math.log(1.0 - x + eps) * (1.0 - y)
+          }
+        }
+        DenseTensorApply.apply2(input, target, func)
+      } else {
+        buffer.resizeAs(input).copy(input).add(ev.fromType(eps)).log()
+        sum += ev.toType[Double](buffer.dot(target))
+        buffer.fill(ev.fromType(1.0)).sub(input).add(ev.fromType(eps)).log()
+        sum -= ev.toType[Double](buffer.dot(target))
+        sum += ev.toType[Double](buffer.sum())
+      }
     }
 
     if (sizeAverage) sum /= input.nElement()
 
-    output = ev.fromType[Double](sum)
+    output = ev.fromType[Double](-sum)
 
     output
   }
@@ -87,27 +131,32 @@ class BCECriterion[@specialized(Float, Double) T: ClassTag]
     require(input.nElement() == target.nElement(),
       "input and target should have the same dims." +
         s"input dim(${input.nElement()})" +
-        s"taget dim(${target.nElement()})")
+        s"target dim(${target.nElement()})")
 
-    if (null != weights && target.dim() != 1) {
-      weights = weights.view(1, target.size(2)).expandAs(target)
-    }
-
-    val norm = if (sizeAverage) 1.0 / input.nElement() else 1.0
+    val nElement = input.nElement()
+    val norm = if (sizeAverage) 1.0 / nElement else 1.0
 
     gradInput.resizeAs(input)
 
-    val func = new TensorFunc6[T] {
-      override def apply(data1: Array[T], offset1: Int, data2: Array[T], offset2: Int,
-                         data3: Array[T], offset3: Int): Unit = {
-        val x = ev.toType[Double](data2(offset2))
-        val y = ev.toType[Double](data3(offset3))
-        data1(offset1) = ev.fromType(-norm * (y - x) / ((1.0 - x + eps) * (x + eps)))
+    if (nElement < 200 || (null != weights && weights.nElement() < 200)) {
+      val func = new TensorFunc6[T] {
+        override def apply(data1: Array[T], offset1: Int, data2: Array[T], offset2: Int,
+                           data3: Array[T], offset3: Int): Unit = {
+          val x = ev.toType[Double](data2(offset2))
+          val y = ev.toType[Double](data3(offset3))
+          data1(offset1) = ev.fromType(-norm * (y - x) / ((1.0 - x + eps) * (x + eps)))
+        }
       }
+      DenseTensorApply.apply3(gradInput, input, target, func)
+    } else {
+      // - (1 - x + eps)*(x + eps) = x^2 - x - eps - eps^2
+      // eps^12 is negligible
+      buffer.copy(input).square().sub(input).sub(ev.fromType(eps))
+      gradInput.copy(target).sub(input).cdiv(buffer).mul(ev.fromType(norm))
     }
-    DenseTensorApply.apply3(gradInput, input, target, func)
 
     if (null != weights) {
+      // cmul support broadcasting
       gradInput.cmul(weights)
     }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BCECriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BCECriterion.scala
@@ -75,7 +75,7 @@ class BCECriterion[@specialized(Float, Double) T: ClassTag]
       buffer.fill(ev.fromType(1.0 + eps)).sub(input).log().cmul(weights)
       sum -= ev.toType[Double](buffer.dot(target))
       if (onesBuffer.nElement() != buffer.nElement()) {
-        onesBuffer.resizeAs(buffer).fill(ev.fromType(1.0))
+        onesBuffer.resizeAs(buffer).fill(ev.one)
       }
       sum += ev.toType[Double](buffer.dot(onesBuffer))
     } else {
@@ -84,7 +84,7 @@ class BCECriterion[@specialized(Float, Double) T: ClassTag]
       buffer.fill(ev.fromType(1.0 + eps)).sub(input).log()
       sum -= ev.toType[Double](buffer.dot(target))
       if (onesBuffer.nElement() != buffer.nElement()) {
-        onesBuffer.resizeAs(buffer).fill(ev.fromType(1.0))
+        onesBuffer.resizeAs(buffer).fill(ev.one)
       }
       sum += ev.toType[Double](buffer.sum())
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BCECriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BCECriterion.scala
@@ -74,14 +74,18 @@ class BCECriterion[@specialized(Float, Double) T: ClassTag]
       sum += ev.toType[Double](buffer.dot(target))
       buffer.fill(ev.fromType(1.0 + eps)).sub(input).log().cmul(weights)
       sum -= ev.toType[Double](buffer.dot(target))
-      onesBuffer.resizeAs(buffer).fill(ev.fromType(1.0))
+      if (onesBuffer.nElement() != buffer.nElement()) {
+        onesBuffer.resizeAs(buffer).fill(ev.fromType(1.0))
+      }
       sum += ev.toType[Double](buffer.dot(onesBuffer))
     } else {
       buffer.resizeAs(input).copy(input).add(ev.fromType(eps)).log()
       sum += ev.toType[Double](buffer.dot(target))
       buffer.fill(ev.fromType(1.0 + eps)).sub(input).log()
       sum -= ev.toType[Double](buffer.dot(target))
-      onesBuffer.resizeAs(buffer).fill(ev.fromType(1.0))
+      if (onesBuffer.nElement() != buffer.nElement()) {
+        onesBuffer.resizeAs(buffer).fill(ev.fromType(1.0))
+      }
       sum += ev.toType[Double](buffer.sum())
     }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/BCECriterionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/BCECriterionSpec.scala
@@ -45,6 +45,54 @@ class BCECriterionSpec extends FlatSpec with Matchers {
 
   }
 
+  "BCECriterion with more than two dimensions small input" should "" +
+    "return return right output and gradInput" in {
+
+    val weights = Tensor[Double](3, 2, 2).rand()
+    val criterion = new BCECriterion[Double](weights)
+    val input = Tensor[Double](4, 3, 2, 2).rand()
+    val target = Tensor[Double](4, 3, 2, 2).rand()
+
+    val weightsRef = Tensor[Double]().resizeAs(weights).copy(weights).reshape(Array(3 * 2 * 2))
+    val criterionRef = new BCECriterion[Double](weightsRef)
+    val inputRef = Tensor[Double]().resizeAs(input).copy(input).reshape(Array(4, 3 * 2 * 2))
+    val targetRef = Tensor[Double]().resizeAs(target).copy(target).reshape(Array(4, 3 * 2 * 2))
+
+    val output = criterion.forward(input, target)
+    val gradInput = criterion.backward(input, target).clone()
+
+    val outputRef = criterionRef.forward(inputRef, targetRef)
+    val gradInputRef = criterionRef.backward(inputRef, targetRef).clone()
+
+    output should be (outputRef +- 1e-7)
+    gradInput.almostEqual(gradInputRef, 1e-7) should be (true)
+
+  }
+
+  "BCECriterion with more than two dimensions large input" should "" +
+    "return return right output and gradInput" in {
+
+    val weights = Tensor[Double](3, 32, 32).rand()
+    val criterion = new BCECriterion[Double](weights)
+    val input = Tensor[Double](4, 3, 32, 32).rand()
+    val target = Tensor[Double](4, 3, 32, 32).rand()
+
+    val weightsRef = Tensor[Double]().resizeAs(weights).copy(weights).reshape(Array(3 * 32 * 32))
+    val criterionRef = new BCECriterion[Double](weightsRef)
+    val inputRef = Tensor[Double]().resizeAs(input).copy(input).reshape(Array(4, 3 * 32 * 32))
+    val targetRef = Tensor[Double]().resizeAs(target).copy(target).reshape(Array(4, 3 * 32 * 32))
+
+    val output = criterion.forward(input, target)
+    val gradInput = criterion.backward(input, target).clone()
+
+    val outputRef = criterionRef.forward(inputRef, targetRef)
+    val gradInputRef = criterionRef.backward(inputRef, targetRef).clone()
+
+    output should be (outputRef +- 1e-7)
+    gradInput.almostEqual(gradInputRef, 1e-7) should be (true)
+
+  }
+
   "Binary LR " should "converge correctly" in {
     def specifiedModel(): Module[Double] = {
       val model = new Sequential[Double]()
@@ -109,7 +157,7 @@ class BCECriterionSpec extends FlatSpec with Matchers {
           inputs.narrow(1, i, batchSize),
           targets
             .toTensor[Double]
-            .narrow(1, i, batchSize)),
+            .narrow(1, i, batchSize).addSingletonDimension(dim = 2)),
           masterWeights, config, config)
         l += loss(0)
         i += batchSize

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/BCECriterionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/BCECriterionSpec.scala
@@ -15,12 +15,8 @@
  */
 package com.intel.analytics.bigdl.torch
 
-import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.nn.BCECriterion
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.bigdl.utils.RandomGenerator._
-
-import scala.util.Random
 
 @com.intel.analytics.bigdl.tags.Serial
 class BCECriterionSpec extends TorchSpec{
@@ -29,10 +25,10 @@ class BCECriterionSpec extends TorchSpec{
     torchCheck()
     val criterion = new BCECriterion[Double]()
     val input = Tensor[Double](3, 1).rand()
-    val target = Tensor[Double](3)
-    target(Array(1)) = 1
-    target(Array(2)) = 0
-    target(Array(3)) = 1
+    val target = Tensor[Double](3, 1)
+    target(Array(1, 1)) = 1
+    target(Array(2, 1)) = 0
+    target(Array(3, 1)) = 1
 
     val start = System.nanoTime()
     val output1 = criterion.forward(input, target)
@@ -59,13 +55,16 @@ class BCECriterionSpec extends TorchSpec{
 
   "A BCECriterion with weights" should "generate correct output and grad" in {
     torchCheck()
-    val weights = Tensor[Double](3).rand()
+    val weights = Tensor[Double](2).rand()
     val criterion = new BCECriterion[Double](weights)
-    val input = Tensor[Double](3, 1).rand()
-    val target = Tensor[Double](3)
-    target(Array(1)) = 1
-    target(Array(2)) = 0
-    target(Array(3)) = 1
+    val input = Tensor[Double](3, 2).rand()
+    val target = Tensor[Double](3, 2)
+    target(Array(1, 1)) = 1
+    target(Array(2, 1)) = 0
+    target(Array(3, 1)) = 1
+    target(Array(1, 2)) = 1
+    target(Array(2, 2)) = 0
+    target(Array(3, 2)) = 1
 
     val start = System.nanoTime()
     val output1 = criterion.forward(input, target)
@@ -93,13 +92,16 @@ class BCECriterionSpec extends TorchSpec{
 
   "A BCECriterion with sizeAverage" should "generate correct output and grad" in {
     torchCheck()
-    val weights = Tensor[Double](3).rand()
-    val criterion = new BCECriterion[Double](weights, true)
-    val input = Tensor[Double](3, 1).rand()
-    val target = Tensor[Double](3)
-    target(Array(1)) = 1
-    target(Array(2)) = 0
-    target(Array(3)) = 1
+    val weights = Tensor[Double](2).rand()
+    val criterion = new BCECriterion[Double](weights)
+    val input = Tensor[Double](3, 2).rand()
+    val target = Tensor[Double](3, 2)
+    target(Array(1, 1)) = 1
+    target(Array(2, 1)) = 0
+    target(Array(3, 1)) = 1
+    target(Array(1, 2)) = 1
+    target(Array(2, 2)) = 0
+    target(Array(3, 2)) = 1
 
     val start = System.nanoTime()
     val output1 = criterion.forward(input, target)
@@ -120,6 +122,97 @@ class BCECriterionSpec extends TorchSpec{
 
     luaOutput1 should be(output1)
     luaOutput2 should be(output2)
+
+    println("Test case : BCECriterion, Torch : " + luaTime + " s, Scala : " +
+      scalaTime / 1e9 + " s")
+  }
+
+  "A BCECriterion with large input" should "generate correct output and grad" in {
+    torchCheck()
+    val criterion = new BCECriterion[Double]()
+    val input = Tensor[Double](3, 100).rand()
+    val target = Tensor[Double](3, 100).rand()
+
+    val start = System.nanoTime()
+    val output1 = criterion.forward(input, target)
+    val output2 = criterion.backward(input, target)
+    val end = System.nanoTime()
+    val scalaTime = end - start
+
+    val code = "criterion = nn.BCECriterion()\n" +
+      "output1 = criterion:forward(input, target)\n " +
+      "output2 = criterion:backward(input, target)"
+
+
+    val (luaTime, torchResult) = TH.run(code, Map("input" -> input, "target" -> target),
+      Array("output1", "output2"))
+    val luaOutput1 = torchResult("output1").asInstanceOf[Double]
+    val luaOutput2 = torchResult("output2").asInstanceOf[Tensor[Double]]
+
+    luaOutput1 should be(output1 +- 1e-7)
+    luaOutput2.almostEqual(output2, 1e-7) should be (true)
+
+    println("Test case : BCECriterion, Torch : " + luaTime + " s, Scala : " +
+      scalaTime / 1e9 + " s")
+  }
+
+  "A BCECriterion with weights and large input" should "generate correct output and grad" in {
+    torchCheck()
+    val weights = Tensor[Double](300).rand()
+    val criterion = new BCECriterion[Double](weights)
+    val input = Tensor[Double](3, 300).rand()
+    val target = Tensor[Double](3, 300).rand()
+
+    val start = System.nanoTime()
+    val output1 = criterion.forward(input, target)
+    val output2 = criterion.backward(input, target)
+    val end = System.nanoTime()
+    val scalaTime = end - start
+
+    val code = "criterion = nn.BCECriterion(weights)\n" +
+      "output1 = criterion:forward(input, target)\n " +
+      "output2 = criterion:backward(input, target)"
+
+
+    val (luaTime, torchResult) = TH.run(code,
+      Map("input" -> input, "target" -> target, "weights" -> weights),
+      Array("output1", "output2"))
+    val luaOutput1 = torchResult("output1").asInstanceOf[Double]
+    val luaOutput2 = torchResult("output2").asInstanceOf[Tensor[Double]]
+
+    luaOutput1 should be(output1 +- 1e-7)
+    luaOutput2.almostEqual(output2, 1e-7) should be (true)
+
+    println("Test case : BCECriterion, Torch : " + luaTime + " s, Scala : " +
+      scalaTime / 1e9 + " s")
+  }
+
+  "A BCECriterion with sizeAverage and large input" should "generate correct output and grad" in {
+    torchCheck()
+    val weights = Tensor[Double](300).rand()
+    val criterion = new BCECriterion[Double](weights, true)
+    val input = Tensor[Double](3, 300).rand()
+    val target = Tensor[Double](3, 300).rand()
+
+    val start = System.nanoTime()
+    val output1 = criterion.forward(input, target)
+    val output2 = criterion.backward(input, target)
+    val end = System.nanoTime()
+    val scalaTime = end - start
+
+    val code = "criterion = nn.BCECriterion(weights, true)\n" +
+      "output1 = criterion:forward(input, target)\n " +
+      "output2 = criterion:backward(input, target)"
+
+
+    val (luaTime, torchResult) = TH.run(code,
+      Map("input" -> input, "target" -> target, "weights" -> weights),
+      Array("output1", "output2"))
+    val luaOutput1 = torchResult("output1").asInstanceOf[Double]
+    val luaOutput2 = torchResult("output2").asInstanceOf[Tensor[Double]]
+
+    luaOutput1 should be(output1 +- 1e-7)
+    luaOutput2.almostEqual(output2, 1e-7) should be (true)
 
     println("Test case : BCECriterion, Torch : " + luaTime + " s, Scala : " +
       scalaTime / 1e9 + " s")

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/BCECriterionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/BCECriterionSpec.scala
@@ -46,8 +46,8 @@ class BCECriterionSpec extends TorchSpec{
     val luaOutput1 = torchResult("output1").asInstanceOf[Double]
     val luaOutput2 = torchResult("output2").asInstanceOf[Tensor[Double]]
 
-    luaOutput1 should be(output1)
-    luaOutput2 should be(output2)
+    luaOutput1 should be(output1 +- 1e-7)
+    luaOutput2.almostEqual(output2, 1e-7) should be(true)
 
     println("Test case : BCECriterion, Torch : " + luaTime + " s, Scala : " +
       scalaTime / 1e9 + " s")
@@ -83,8 +83,8 @@ class BCECriterionSpec extends TorchSpec{
     val luaOutput1 = torchResult("output1").asInstanceOf[Double]
     val luaOutput2 = torchResult("output2").asInstanceOf[Tensor[Double]]
 
-    luaOutput1 should be(output1)
-    luaOutput2 should be(output2)
+    luaOutput1 should be(output1 +- 1e-7)
+    luaOutput2.almostEqual(output2, 1e-7) should be(true)
 
     println("Test case : BCECriterion, Torch : " + luaTime + " s, Scala : " +
       scalaTime / 1e9 + " s")
@@ -120,8 +120,8 @@ class BCECriterionSpec extends TorchSpec{
     val luaOutput1 = torchResult("output1").asInstanceOf[Double]
     val luaOutput2 = torchResult("output2").asInstanceOf[Tensor[Double]]
 
-    luaOutput1 should be(output1)
-    luaOutput2 should be(output2)
+    luaOutput1 should be(output1 +- 1e-7)
+    luaOutput2.almostEqual(output2, 1e-7) should be(true)
 
     println("Test case : BCECriterion, Torch : " + luaTime + " s, Scala : " +
       scalaTime / 1e9 + " s")

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/MultiLabelMarginCriterionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/MultiLabelMarginCriterionSpec.scala
@@ -47,8 +47,8 @@ class MultiLabelMarginCriterionSpec extends TorchSpec {
     val luaOutput = torchResult("output").asInstanceOf[Double]
     val luaGradInput = torchResult("gradInput").asInstanceOf[Tensor[Double]]
 
-    output should be(luaOutput +- 1e-7)
-    gradInput.almostEqual(luaGradInput, 1e-7) should be(true)
+    output should be(luaOutput)
+    gradInput should be(luaGradInput)
 
     println("Test case : MultiLabelMarginCriterion, Torch : " + luaTime +
       " s, Scala : " + scalaTime / 1e9 + " s")
@@ -85,8 +85,8 @@ class MultiLabelMarginCriterionSpec extends TorchSpec {
     val luaOutput = torchResult("output").asInstanceOf[Double]
     val luaGradInput = torchResult("gradInput").asInstanceOf[Tensor[Double]]
 
-    output should be (luaOutput +- 1e-7)
-    gradInput.almostEqual(luaGradInput, 1e-7) should be (true)
+    output should be (luaOutput)
+    gradInput should be (luaGradInput)
 
     println("Test case : MultiLabelMarginCriterion, Torch : " + luaTime +
       " s, Scala : " + scalaTime / 1e9 + " s")

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/MultiLabelMarginCriterionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/MultiLabelMarginCriterionSpec.scala
@@ -47,8 +47,8 @@ class MultiLabelMarginCriterionSpec extends TorchSpec {
     val luaOutput = torchResult("output").asInstanceOf[Double]
     val luaGradInput = torchResult("gradInput").asInstanceOf[Tensor[Double]]
 
-    output should be(luaOutput)
-    gradInput should be(luaGradInput)
+    output should be(luaOutput +- 1e-7)
+    gradInput.almostEqual(luaGradInput, 1e-7) should be(true)
 
     println("Test case : MultiLabelMarginCriterion, Torch : " + luaTime +
       " s, Scala : " + scalaTime / 1e9 + " s")
@@ -85,8 +85,8 @@ class MultiLabelMarginCriterionSpec extends TorchSpec {
     val luaOutput = torchResult("output").asInstanceOf[Double]
     val luaGradInput = torchResult("gradInput").asInstanceOf[Tensor[Double]]
 
-    output should be (luaOutput)
-    gradInput should be (luaGradInput)
+    output should be (luaOutput +- 1e-7)
+    gradInput.almostEqual(luaGradInput, 1e-7) should be (true)
 
     println("Test case : MultiLabelMarginCriterion, Torch : " + luaTime +
       " s, Scala : " + scalaTime / 1e9 + " s")

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/MultiLabelSoftMarginCriterionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/MultiLabelSoftMarginCriterionSpec.scala
@@ -51,8 +51,8 @@ class MultiLabelSoftMarginCriterionSpec extends TorchSpec {
     val luaOutput1 = torchResult("output").asInstanceOf[Double]
     val luaOutput2 = torchResult("gradInput").asInstanceOf[Tensor[Double]]
 
-    luaOutput1 should be(output)
-    luaOutput2 should be(gradInput)
+    luaOutput1 should be(output +- 1e-7)
+    luaOutput2.almostEqual(gradInput, 1e-7) should be(true)
 
     println("Test case : MultiLabelSoftMarginCriterion, Torch : " +
       luaTime + " s, Scala : " + scalaTime / 1e9 + " s")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Optimize BCECriterion

1. Add vectorized implementation when input size is large

     when input size is the scale of thousands like (4 * 3 * 16 * 16), this will reduce runtime to half.

2. Support when input and target is more than two dimensions, which is common in vision.
3. Fix some bugs

## How was this patch tested?

unit tests

