### PR TITLE
Keras-like API Recurrent layers

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GRU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GRU.scala
@@ -24,6 +24,31 @@ import com.intel.analytics.bigdl.utils.Shape
 
 import scala.reflect.ClassTag
 
+/**
+ * Gated Recurrent Unit architecture.
+ * When you use this layer as the first layer of a model, you need to provide the argument
+ * inputShape (a Single Shape, does not include the batch dimension).
+ * The input of this layer should be 3D, i.e. (batch, time steps, input dim).
+ *
+ * @param outputDim Hidden unit size. Dimension of internal projections and final output.
+ * @param activation Activation function to use.
+ *                   You can also pass in corresponding string representations such as 'relu'
+ *                   or 'sigmoid', etc. for simple activations in the factory method.
+ *                   Default is 'tanh'.
+ * @param innerActivation Activation function for inner cells.
+ *                        You can also pass in corresponding string representations such as 'relu'
+ *                        or 'sigmoid', etc. for simple activations in the factory method.
+ *                        Default is 'hard_sigmoid'.
+ * @param returnSequences Whether to return the full sequence or only return the last output,
+ *                        in the output sequence. Default is false.
+ * @param goBackwards Whether the input sequence will be processed backwards. Default is false.
+ * @param wRegularizer An instance of [[Regularizer]], (eg. L1 or L2 regularization),
+ *                     applied to the input weights matrices. Default is null.
+ * @param uRegularizer An instance of [[Regularizer]], applied the recurrent weights matrices.
+ *                     Default is null.
+ * @param bRegularizer An instance of [[Regularizer]], applied to the bias. Default is null.
+ * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
+ */
 class GRU[T: ClassTag](
    outputDim: Int,
    val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GRU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GRU.scala
@@ -26,8 +26,8 @@ import scala.reflect.ClassTag
 
 class GRU[T: ClassTag](
    outputDim: Int,
-   val activation: TensorModule[T] = null,
-   val innerActivation: TensorModule[T] = null,
+   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
+   val innerActivation: AbstractModule[Tensor[T], Tensor[T], T] = null,
    returnSequences: Boolean = false,
    goBackwards: Boolean = false,
    var wRegularizer: Regularizer[T] = null,
@@ -41,8 +41,8 @@ class GRU[T: ClassTag](
     val layer = com.intel.analytics.bigdl.nn.GRU[T](
       inputSize = input(2),
       outputSize = outputDim,
-      activation = activation,
-      innerActivation = innerActivation,
+      activation = activation.asInstanceOf[TensorModule[T]],
+      innerActivation = innerActivation.asInstanceOf[TensorModule[T]],
       wRegularizer = wRegularizer,
       uRegularizer = uRegularizer,
       bRegularizer = bRegularizer)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GRU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GRU.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, TensorModule}
+import com.intel.analytics.bigdl.optim.Regularizer
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+class GRU[T: ClassTag](
+   outputDim: Int,
+   val activation: TensorModule[T] = null,
+   val innerActivation: TensorModule[T] = null,
+   returnSequences: Boolean = false,
+   goBackwards: Boolean = false,
+   var wRegularizer: Regularizer[T] = null,
+   var uRegularizer: Regularizer[T] = null,
+   var bRegularizer: Regularizer[T] = null,
+   inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends Recurrent[T](outputDim, returnSequences, goBackwards, inputShape) {
+
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+    val input = inputShape.toSingle().toArray
+    val layer = com.intel.analytics.bigdl.nn.GRU[T](
+      inputSize = input(2),
+      outputSize = outputDim,
+      activation = activation,
+      innerActivation = innerActivation,
+      wRegularizer = wRegularizer,
+      uRegularizer = uRegularizer,
+      bRegularizer = bRegularizer)
+    super.processParameters(layer)
+  }
+}
+
+object GRU {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    outputDim: Int,
+    activation: String = "tanh",
+    innerActivation: String = "hard_sigmoid",
+    returnSequences: Boolean = false,
+    goBackwards: Boolean = false,
+    wRegularizer: Regularizer[T] = null,
+    uRegularizer: Regularizer[T] = null,
+    bRegularizer: Regularizer[T] = null,
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]) : GRU[T] = {
+    new GRU(outputDim, KerasUtils.getActivation(activation),
+      KerasUtils.getActivation(innerActivation), returnSequences,
+      goBackwards, wRegularizer, uRegularizer, bRegularizer, inputShape)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Highway.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Highway.scala
@@ -24,6 +24,23 @@ import com.intel.analytics.bigdl.utils.Shape
 
 import scala.reflect.ClassTag
 
+/**
+ * Densely connected highway network.
+ * Highway layers are a natural extension of LSTMs to feedforward networks.
+ * When you use this layer as the first layer of a model, you need to provide the argument
+ * inputShape (a Single Shape, does not include the batch dimension).
+ * The input of this layer should be 2D, i.e. (batch, input dim).
+ *
+ * @param activation Activation function to use. Default is null.
+ *                   You can also pass in corresponding string representations such as 'relu'
+ *                   or 'sigmoid', etc. for simple activations in the factory method.
+ * @param wRegularizer An instance of [[Regularizer]], (eg. L1 or L2 regularization),
+ *                     applied to the input weights matrices. Default is null.
+ * @param bRegularizer An instance of [[Regularizer]], applied to the bias. Default is null.
+ * @param bias Whether to include a bias (i.e. make the layer affine rather than linear).
+ *             Default is true.
+ * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
+ */
 class Highway[T: ClassTag](
    val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
    var wRegularizer: Regularizer[T] = null,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Highway.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Highway.scala
@@ -24,20 +24,27 @@ import com.intel.analytics.bigdl.utils.Shape
 
 import scala.reflect.ClassTag
 
-class Highway[T: ClassTag](val activation: TensorModule[T] = null,
-                           var wRegularizer: Regularizer[T] = null,
-                           var bRegularizer: Regularizer[T] = null,
-                           val bias: Boolean = true,
-                           var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
-  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape))
-    with IdentityOutputShape {
+class Highway[T: ClassTag](
+   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
+   var wRegularizer: Regularizer[T] = null,
+   var bRegularizer: Regularizer[T] = null,
+   val bias: Boolean = true,
+   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val input = inputShape.toSingle().toArray
+    require(input.length == 2,
+      s"Highway requires 2D input, but got input dim ${input.length}")
+    inputShape
+  }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val input = inputShape.toSingle().toArray
     val layer = com.intel.analytics.bigdl.nn.Highway[T](
       size = input(1),
       withBias = bias,
-      activation = activation,
+      activation = activation.asInstanceOf[TensorModule[T]],
       wRegularizer = wRegularizer,
       bRegularizer = bRegularizer
     )

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Highway.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Highway.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, IdentityOutputShape, TensorModule}
+import com.intel.analytics.bigdl.optim.Regularizer
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+class Highway[T: ClassTag](val activation: TensorModule[T] = null,
+                           var wRegularizer: Regularizer[T] = null,
+                           var bRegularizer: Regularizer[T] = null,
+                           val bias: Boolean = true,
+                           var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape))
+    with IdentityOutputShape {
+
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+    val input = inputShape.toSingle().toArray
+    val layer = com.intel.analytics.bigdl.nn.Highway[T](
+      size = input(1),
+      withBias = bias,
+      activation = activation,
+      wRegularizer = wRegularizer,
+      bRegularizer = bRegularizer
+    )
+    layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+  }
+}
+
+object Highway {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    activation: String = null,
+    wRegularizer: Regularizer[T] = null,
+    bRegularizer: Regularizer[T] = null,
+    bias: Boolean = true,
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]) : Highway[T] = {
+    new Highway[T](KerasUtils.getActivation(activation),
+      wRegularizer, bRegularizer, bias, inputShape)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasUtils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasUtils.scala
@@ -64,4 +64,28 @@ object KerasUtils {
     }
   }
 
+  private[keras] def computeConvOutputLength(
+    inputLength: Int,
+    filterSize: Int,
+    borderMode: String,
+    stride: Int,
+    dilation: Int = 1): Int = {
+    val dilatedFilterSize = filterSize + (filterSize - 1) * (dilation - 1)
+    val outputLength = borderMode match {
+      case "valid" => inputLength - dilatedFilterSize + 1
+      case "same" => inputLength
+    }
+    (outputLength + stride - 1) / stride
+  }
+
+  private[keras] def getPadsFromBorderMode3D
+  (borderMode: String = "valid"): (Int, Int, Int) = {
+    if (borderMode == "same") {
+      // padT, padH, padW
+      (-1, -1, -1)
+    } else {
+      (0, 0, 0)
+    }
+  }
+
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/LSTM.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/LSTM.scala
@@ -24,6 +24,31 @@ import com.intel.analytics.bigdl.utils.Shape
 
 import scala.reflect.ClassTag
 
+/**
+ * Long Short Term Memory unit architecture.
+ * When you use this layer as the first layer of a model, you need to provide the argument
+ * inputShape (a Single Shape, does not include the batch dimension).
+ * The input of this layer should be 3D, i.e. (batch, time steps, input dim).
+ *
+ * @param outputDim Hidden unit size. Dimension of internal projections and final output.
+ * @param activation Activation function to use.
+ *                   You can also pass in corresponding string representations such as 'relu'
+ *                   or 'sigmoid', etc. for simple activations in the factory method.
+ *                   Default is 'tanh'.
+ * @param innerActivation Activation function for inner cells.
+ *                        You can also pass in corresponding string representations such as 'relu'
+ *                        or 'sigmoid', etc. for simple activations in the factory method.
+ *                        dDefault is 'hard_sigmoid'.
+ * @param returnSequences Whether to return the full sequence or only return the last output,
+ *                        in the output sequence. Default is false.
+ * @param goBackwards Whether the input sequence will be processed backwards. Default is false.
+ * @param wRegularizer An instance of [[Regularizer]], (eg. L1 or L2 regularization),
+ *                     applied to the input weights matrices. Default is null.
+ * @param uRegularizer An instance of [[Regularizer]], applied the recurrent weights matrices.
+ *                     Default is null.
+ * @param bRegularizer An instance of [[Regularizer]], applied to the bias. Default is null.
+ * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
+ */
 class LSTM[T: ClassTag](
    outputDim: Int,
    val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/LSTM.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/LSTM.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, TensorModule}
+import com.intel.analytics.bigdl.optim.Regularizer
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+class LSTM[T: ClassTag](
+   outputDim: Int,
+   val activation: TensorModule[T] = null,
+   val innerActivation: TensorModule[T] = null,
+   returnSequences: Boolean = false,
+   goBackwards: Boolean = false,
+   var wRegularizer: Regularizer[T] = null,
+   var uRegularizer: Regularizer[T] = null,
+   var bRegularizer: Regularizer[T] = null,
+   inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends Recurrent[T](outputDim, returnSequences, goBackwards, inputShape) {
+
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+    val input = inputShape.toSingle().toArray
+    val layer = com.intel.analytics.bigdl.nn.LSTM[T](
+      inputSize = input(2),
+      hiddenSize = outputDim,
+      activation = activation,
+      innerActivation = innerActivation,
+      wRegularizer = wRegularizer,
+      uRegularizer = uRegularizer,
+      bRegularizer = bRegularizer)
+    super.processParameters(layer)
+  }
+}
+
+object LSTM {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    outputDim: Int,
+    activation: String = "tanh",
+    innerActivation: String = "hard_sigmoid",
+    returnSequences: Boolean = false,
+    goBackwards: Boolean = false,
+    wRegularizer: Regularizer[T] = null,
+    uRegularizer: Regularizer[T] = null,
+    bRegularizer: Regularizer[T] = null,
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]) : LSTM[T] = {
+    new LSTM(outputDim, KerasUtils.getActivation(activation),
+      KerasUtils.getActivation(innerActivation), returnSequences,
+      goBackwards, wRegularizer, uRegularizer, bRegularizer, inputShape)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/LSTM.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/LSTM.scala
@@ -26,8 +26,8 @@ import scala.reflect.ClassTag
 
 class LSTM[T: ClassTag](
    outputDim: Int,
-   val activation: TensorModule[T] = null,
-   val innerActivation: TensorModule[T] = null,
+   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
+   val innerActivation: AbstractModule[Tensor[T], Tensor[T], T] = null,
    returnSequences: Boolean = false,
    goBackwards: Boolean = false,
    var wRegularizer: Regularizer[T] = null,
@@ -41,8 +41,8 @@ class LSTM[T: ClassTag](
     val layer = com.intel.analytics.bigdl.nn.LSTM[T](
       inputSize = input(2),
       hiddenSize = outputDim,
-      activation = activation,
-      innerActivation = innerActivation,
+      activation = activation.asInstanceOf[TensorModule[T]],
+      innerActivation = innerActivation.asInstanceOf[TensorModule[T]],
       wRegularizer = wRegularizer,
       uRegularizer = uRegularizer,
       bRegularizer = bRegularizer)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Recurrent.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn.{Cell, Reverse, Select, Sequential => TSequential}
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+abstract class Recurrent[T: ClassTag](
+   val outputDim: Int,
+   val returnSequences: Boolean = false,
+   val goBackwards: Boolean = false,
+   var inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val input = inputShape.toSingle().toArray
+    if (returnSequences) Shape(input(0), input(1), outputDim)
+    else Shape(input(0), outputDim)
+  }
+
+  def processParameters(rnn: Cell[T]): AbstractModule[Tensor[T], Tensor[T], T] = {
+    val model = TSequential[T]()
+    if (goBackwards) model.add(Reverse(2))
+    val rec = com.intel.analytics.bigdl.nn.Recurrent[T]()
+    rec.add(rnn)
+    model.add(rec)
+    if (!returnSequences) model.add(Select(2, -1))
+    model.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+  }
+
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Recurrent.scala
@@ -24,6 +24,13 @@ import com.intel.analytics.bigdl.utils.Shape
 
 import scala.reflect.ClassTag
 
+/**
+ * This is the abstract base class for recurrent layers.
+ * Do not create a new instance of it or use it in a model.
+ * Please use its child classes, 'SimpleRNN', 'LSTM' and 'GRU' instead.
+ *
+ * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
+ */
 abstract class Recurrent[T: ClassTag](
    val outputDim: Int,
    val returnSequences: Boolean = false,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Recurrent.scala
@@ -33,6 +33,8 @@ abstract class Recurrent[T: ClassTag](
 
   override def computeOutputShape(inputShape: Shape): Shape = {
     val input = inputShape.toSingle().toArray
+    require(input.length == 3,
+      s"Recurrent layers require 3D input, but got input dim ${input.length}")
     if (returnSequences) Shape(input(0), input(1), outputDim)
     else Shape(input(0), outputDim)
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Recurrent.scala
@@ -28,8 +28,6 @@ import scala.reflect.ClassTag
  * This is the abstract base class for recurrent layers.
  * Do not create a new instance of it or use it in a model.
  * Please use its child classes, 'SimpleRNN', 'LSTM' and 'GRU' instead.
- *
- * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
  */
 abstract class Recurrent[T: ClassTag](
    val outputDim: Int,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SimpleRNN.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SimpleRNN.scala
@@ -27,7 +27,7 @@ import scala.reflect.ClassTag
 
 class SimpleRNN[T: ClassTag](
    outputDim: Int,
-   val activation: TensorModule[T] = null,
+   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
    returnSequences: Boolean = false,
    goBackwards: Boolean = false,
    var wRegularizer: Regularizer[T] = null,
@@ -41,7 +41,7 @@ class SimpleRNN[T: ClassTag](
     val layer = RnnCell(
       inputSize = input(2),
       hiddenSize = outputDim,
-      activation = activation,
+      activation = activation.asInstanceOf[TensorModule[T]],
       isInputWithBias = false,
       wRegularizer = wRegularizer,
       uRegularizer = uRegularizer,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SimpleRNN.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SimpleRNN.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.keras
+
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, TensorModule}
+import com.intel.analytics.bigdl.nn.RnnCell
+import com.intel.analytics.bigdl.optim.Regularizer
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+class SimpleRNN[T: ClassTag](
+   outputDim: Int,
+   val activation: TensorModule[T] = null,
+   returnSequences: Boolean = false,
+   goBackwards: Boolean = false,
+   var wRegularizer: Regularizer[T] = null,
+   var uRegularizer: Regularizer[T] = null,
+   var bRegularizer: Regularizer[T] = null,
+   inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends Recurrent[T](outputDim, returnSequences, goBackwards, inputShape) {
+
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+    val input = inputShape.toSingle().toArray
+    val layer = RnnCell(
+      inputSize = input(2),
+      hiddenSize = outputDim,
+      activation = activation,
+      isInputWithBias = false,
+      wRegularizer = wRegularizer,
+      uRegularizer = uRegularizer,
+      bRegularizer = bRegularizer)
+    super.processParameters(layer)
+  }
+}
+
+object SimpleRNN {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    outputDim: Int,
+    activation: String = "tanh",
+    returnSequences: Boolean = false,
+    goBackwards: Boolean = false,
+    wRegularizer: Regularizer[T] = null,
+    uRegularizer: Regularizer[T] = null,
+    bRegularizer: Regularizer[T] = null,
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]) : SimpleRNN[T] = {
+    new SimpleRNN[T](outputDim, KerasUtils.getActivation(activation),
+      returnSequences, goBackwards, wRegularizer,
+      uRegularizer, bRegularizer, inputShape)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SimpleRNN.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SimpleRNN.scala
@@ -25,9 +25,30 @@ import com.intel.analytics.bigdl.utils.Shape
 
 import scala.reflect.ClassTag
 
+/**
+ * A fully-connected recurrent neural network cell. The output is to be fed back to input.
+ * When you use this layer as the first layer of a model, you need to provide the argument
+ * inputShape (a Single Shape, does not include the batch dimension).
+ * The input of this layer should be 3D, i.e. (batch, time steps, input dim).
+ *
+ * @param outputDim Hidden unit size. Dimension of internal projections and final output.
+ * @param activation Activation function to use.
+ *                   You can also pass in corresponding string representations such as 'relu'
+ *                   or 'sigmoid', etc. for simple activations in the factory method.
+ *                   Default is 'tanh'.
+ * @param returnSequences Whether to return the full sequence or only return the last output,
+ *                        in the output sequence. Default is false.
+ * @param goBackwards Whether the input sequence will be processed backwards. Default is false.
+ * @param wRegularizer An instance of [[Regularizer]], (eg. L1 or L2 regularization),
+ *                     applied to the input weights matrices. Default is null.
+ * @param uRegularizer An instance of [[Regularizer]], applied the recurrent weights matrices.
+ *                     Default is null.
+ * @param bRegularizer An instance of [[Regularizer]], applied to the bias. Default is null.
+ * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now
+ */
 class SimpleRNN[T: ClassTag](
    outputDim: Int,
-   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
+   val activation: AbstractModule[Tensor[T], Tensor[T], T],
    returnSequences: Boolean = false,
    goBackwards: Boolean = false,
    var wRegularizer: Regularizer[T] = null,

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GRUSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GRUSpec.scala
@@ -24,14 +24,6 @@ import com.intel.analytics.bigdl.utils.Shape
 
 class GRUSpec extends KerasBaseSpec {
 
-  "GRU computeOutputShape" should "work properly" in {
-    val seq = KSequential[Float]()
-    val rnn = GRU[Float](32, inputShape = Shape(12, 12))
-    seq.add(rnn)
-    seq.add(Dense(10))
-    seq.getOutputShape().toSingle().toArray should be (Array(-1, 10))
-  }
-
   def weightConverter(in: Array[Tensor[Float]]): Array[Tensor[Float]] = {
     val w1 = Tensor[Float](in(0).size(2)*3, in(0).size(1))
     val w2 = Tensor[Float](in(2).size(1)*3)
@@ -58,6 +50,7 @@ class GRUSpec extends KerasBaseSpec {
     val seq = KSequential[Float]()
     val layer = GRU[Float](128, inputShape = Shape(28, 28))
     seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 128))
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
       kerasCode, weightConverter)
   }
@@ -67,18 +60,19 @@ class GRUSpec extends KerasBaseSpec {
       """
         |input_tensor = Input(shape=[32, 32])
         |input = np.random.random([2, 32, 32])
-        |output_tensor = GRU(32, return_sequences=True, activation="relu")(input_tensor)
+        |output_tensor = GRU(36, return_sequences=True, activation="relu")(input_tensor)
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = GRU[Float](32, returnSequences = true,
+    val layer = GRU[Float](36, returnSequences = true,
       activation = "relu", inputShape = Shape(32, 32))
     seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 32, 36))
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
       kerasCode, weightConverter)
   }
 
-  "GRU go backwards" should "be the same as Keras" in {
+  "GRU go backwards and return sequences" should "be the same as Keras" in {
     val kerasCode =
       """
         |input_tensor = Input(shape=[28, 32])
@@ -90,6 +84,7 @@ class GRUSpec extends KerasBaseSpec {
     val layer = GRU[Float](16, returnSequences = true,
       goBackwards = true, inputShape = Shape(28, 32))
     seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 28, 16))
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
       kerasCode, weightConverter)
   }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GRUSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GRUSpec.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.keras.KerasBaseSpec
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.nn.keras.{Dense, GRU, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+
+class GRUSpec extends KerasBaseSpec {
+
+  "GRU computeOutputShape" should "work properly" in {
+    val seq = KSequential[Float]()
+    val rnn = GRU[Float](32, inputShape = Shape(12, 12))
+    seq.add(rnn)
+    seq.add(Dense(10))
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 10))
+  }
+
+  def weightConverter(in: Array[Tensor[Float]]): Array[Tensor[Float]] = {
+    val w1 = Tensor[Float](in(0).size(2)*3, in(0).size(1))
+    val w2 = Tensor[Float](in(2).size(1)*3)
+    val w3 = Tensor[Float](in(1).size(2)*2, in(1).size(1))
+    w1.narrow(1, 1, in(0).size(2)).copy(in(3).t())
+    w1.narrow(1, 1 + in(0).size(2), in(0).size(2)).copy(in(0).t())
+    w1.narrow(1, 1 + 2*in(0).size(2), in(0).size(2)).copy(in(6).t())
+    w2.narrow(1, 1, in(2).size(1)).copy(in(5))
+    w2.narrow(1, 1 + in(2).size(1), in(2).size(1)).copy(in(2))
+    w2.narrow(1, 1 + 2*in(2).size(1), in(2).size(1)).copy(in(8))
+    w3.narrow(1, 1, in(1).size(2)).copy(in(4).t())
+    w3.narrow(1, 1 + in(1).size(2), in(1).size(2)).copy(in(1).t())
+    Array(w1, w2, w3, in(7).t())
+  }
+
+  "GRU not return sequences" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[28, 28])
+        |input = np.random.random([2, 28, 28])
+        |output_tensor = GRU(128)(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = GRU[Float](128, inputShape = Shape(28, 28))
+    seq.add(layer)
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode, weightConverter)
+  }
+
+  "GRU return sequences" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[32, 32])
+        |input = np.random.random([2, 32, 32])
+        |output_tensor = GRU(32, return_sequences=True, activation="relu")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = GRU[Float](32, returnSequences = true,
+      activation = "relu", inputShape = Shape(32, 32))
+    seq.add(layer)
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode, weightConverter)
+  }
+
+  "GRU go backwards" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[28, 32])
+        |input = np.random.random([1, 28, 32])
+        |output_tensor = GRU(16, return_sequences=True, go_backwards=True)(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = GRU[Float](16, returnSequences = true,
+      goBackwards = true, inputShape = Shape(28, 32))
+    seq.add(layer)
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode, weightConverter)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/HighwaySpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/HighwaySpec.scala
@@ -48,6 +48,7 @@ class HighwaySpec extends KerasBaseSpec {
     val seq = KSequential[Float]()
     val layer = Highway[Float](inputShape = Shape(10))
     seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 10))
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
       kerasCode, weightConverter)
   }
@@ -63,6 +64,7 @@ class HighwaySpec extends KerasBaseSpec {
     val seq = KSequential[Float]()
     val layer = Highway[Float](activation = "tanh", bias = false, inputShape = Shape(4))
     seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 4))
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
       kerasCode, weightConverter)
   }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/HighwaySpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/HighwaySpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.keras.KerasBaseSpec
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.nn.keras.{Dense, Highway, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+
+class HighwaySpec extends KerasBaseSpec {
+
+  "Highway computeOutputShape" should "work properly" in {
+    val seq = KSequential[Float]()
+    val klayer = Highway[Float](inputShape = Shape(6))
+    seq.add(klayer)
+    seq.add(Dense(5))
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 5))
+  }
+
+  def weightConverter(in: Array[Tensor[Float]]): Array[Tensor[Float]] = {
+    if (in.length == 2) Array(in(1).t(), in(0).t()) // without bias
+    else Array(in(1).t(), in(3), in(0).t(), in(2)) // with bias
+  }
+
+  "Highway" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[10])
+        |input = np.random.random([4, 10])
+        |output_tensor = Highway()(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = Highway[Float](inputShape = Shape(10))
+    seq.add(layer)
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode, weightConverter)
+  }
+
+  "Highway without bias" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[4])
+        |input = np.random.random([2, 4])
+        |output_tensor = Highway(activation="tanh", bias=False)(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = Highway[Float](activation = "tanh", bias = false, inputShape = Shape(4))
+    seq.add(layer)
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode, weightConverter)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/LSTMSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/LSTMSpec.scala
@@ -24,14 +24,6 @@ import com.intel.analytics.bigdl.utils.Shape
 
 class LSTMSpec extends KerasBaseSpec {
 
-  "LSTM computeOutputShape" should "work properly" in {
-    val seq = KSequential[Float]()
-    val rnn = LSTM[Float](12, inputShape = Shape(3, 6))
-    seq.add(rnn)
-    seq.add(Dense(5))
-    seq.getOutputShape().toSingle().toArray should be (Array(-1, 5))
-  }
-
   def weightConverter(in: Array[Tensor[Float]]): Array[Tensor[Float]] = {
     val w1 = Tensor[Float](in(0).size(2)*4, in(0).size(1))
     val w2 = Tensor[Float](in(2).size(1)*4)
@@ -57,6 +49,7 @@ class LSTMSpec extends KerasBaseSpec {
     val seq = KSequential[Float]()
     val layer = LSTM[Float](32, inputShape = Shape(10, 12))
     seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 32))
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
       kerasCode, weightConverter)
   }
@@ -73,11 +66,12 @@ class LSTMSpec extends KerasBaseSpec {
     val layer = LSTM[Float](8, returnSequences = true,
       innerActivation = "sigmoid", inputShape = Shape(32, 32))
     seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 32, 8))
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
       kerasCode, weightConverter)
   }
 
-  "LSTM go backwards" should "be the same as Keras" in {
+  "LSTM go backwards and return sequences" should "be the same as Keras" in {
     val kerasCode =
       """
         |input_tensor = Input(shape=[28, 32])
@@ -89,6 +83,7 @@ class LSTMSpec extends KerasBaseSpec {
     val layer = LSTM[Float](10, returnSequences = true,
       goBackwards = true, inputShape = Shape(28, 32))
     seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 28, 10))
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
       kerasCode, weightConverter)
   }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/LSTMSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/LSTMSpec.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.keras.KerasBaseSpec
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.nn.keras.{Dense, LSTM, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+
+class LSTMSpec extends KerasBaseSpec {
+
+  "LSTM computeOutputShape" should "work properly" in {
+    val seq = KSequential[Float]()
+    val rnn = LSTM[Float](12, inputShape = Shape(3, 6))
+    seq.add(rnn)
+    seq.add(Dense(5))
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 5))
+  }
+
+  def weightConverter(in: Array[Tensor[Float]]): Array[Tensor[Float]] = {
+    val w1 = Tensor[Float](in(0).size(2)*4, in(0).size(1))
+    val w2 = Tensor[Float](in(2).size(1)*4)
+    val w3 = Tensor[Float](in(1).size(2)*4, in(1).size(1))
+    var i = 0
+    while(i < 4) {
+      w1.narrow(1, 1 + i * in(0).size(2), in(0).size(2)).copy(in(3*i).t())
+      w2.narrow(1, 1 + i * in(2).size(1), in(2).size(1)).copy(in(2 + 3*i))
+      w3.narrow(1, 1 + i * in(1).size(2), in(1).size(2)).copy(in(1 + 3*i).t())
+      i += 1
+    }
+    Array(w1, w2, w3)
+  }
+
+  "LSTM not return sequences" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[10, 12])
+        |input = np.random.random([3, 10, 12])
+        |output_tensor = LSTM(32)(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = LSTM[Float](32, inputShape = Shape(10, 12))
+    seq.add(layer)
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode, weightConverter)
+  }
+
+  "LSTM return sequences" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[32, 32])
+        |input = np.random.random([2, 32, 32])
+        |output_tensor = LSTM(8, return_sequences=True, inner_activation="sigmoid")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = LSTM[Float](8, returnSequences = true,
+      innerActivation = "sigmoid", inputShape = Shape(32, 32))
+    seq.add(layer)
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode, weightConverter)
+  }
+
+  "LSTM go backwards" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[28, 32])
+        |input = np.random.random([1, 28, 32])
+        |output_tensor = LSTM(10, return_sequences=True, go_backwards=True)(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = LSTM[Float](10, returnSequences = true,
+      goBackwards = true, inputShape = Shape(28, 32))
+    seq.add(layer)
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode, weightConverter)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/SimpleRNNSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/SimpleRNNSpec.scala
@@ -24,19 +24,12 @@ import com.intel.analytics.bigdl.utils.Shape
 
 class SimpleRNNSpec extends KerasBaseSpec {
 
-  "SimpleRNN computeOutputShape not return sequences" should "work properly" in {
+  "SimpleRNN computeOutputShape" should "work properly" in {
     val seq = KSequential[Float]()
     val rnn = SimpleRNN[Float](10, inputShape = Shape(3, 6))
     seq.add(rnn)
     seq.add(Dense(5))
     seq.getOutputShape().toSingle().toArray should be (Array(-1, 5))
-  }
-
-  "SimpleRNN computeOutputShape return sequences" should "work properly" in {
-    val seq = KSequential[Float]()
-    val rnn = SimpleRNN[Float](8, returnSequences = true, inputShape = Shape(3, 6))
-    seq.add(rnn)
-    seq.getOutputShape().toSingle().toArray should be (Array(-1, 3, 8))
   }
 
   def weightConverter(in: Array[Tensor[Float]]): Array[Tensor[Float]] =
@@ -53,11 +46,12 @@ class SimpleRNNSpec extends KerasBaseSpec {
     val seq = KSequential[Float]()
     val layer = SimpleRNN[Float](8, activation = "relu", inputShape = Shape(4, 5))
     seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 8))
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
       kerasCode, weightConverter)
   }
 
-  "SimpleRNN with return sequences" should "be the same as Keras" in {
+  "SimpleRNN return sequences" should "be the same as Keras" in {
     val kerasCode =
       """
         |input_tensor = Input(shape=[5, 8])
@@ -68,11 +62,12 @@ class SimpleRNNSpec extends KerasBaseSpec {
     val seq = KSequential[Float]()
     val layer = SimpleRNN[Float](12, returnSequences = true, inputShape = Shape(5, 8))
     seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 5, 12))
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
       kerasCode, weightConverter)
   }
 
-  "SimpleRNN with go backwards" should "be the same as Keras" in {
+  "SimpleRNN go backwards" should "be the same as Keras" in {
     val kerasCode =
       """
         |input_tensor = Input(shape=[12, 12])
@@ -84,6 +79,7 @@ class SimpleRNNSpec extends KerasBaseSpec {
     val layer = SimpleRNN[Float](4, goBackwards = true,
       activation = "sigmoid", inputShape = Shape(12, 12))
     seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 4))
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
       kerasCode, weightConverter)
   }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/SimpleRNNSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/SimpleRNNSpec.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.keras.KerasBaseSpec
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.nn.keras.{Dense, SimpleRNN, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+
+class SimpleRNNSpec extends KerasBaseSpec {
+
+  "SimpleRNN computeOutputShape not return sequences" should "work properly" in {
+    val seq = KSequential[Float]()
+    val rnn = SimpleRNN[Float](10, inputShape = Shape(3, 6))
+    seq.add(rnn)
+    seq.add(Dense(5))
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 5))
+  }
+
+  "SimpleRNN computeOutputShape return sequences" should "work properly" in {
+    val seq = KSequential[Float]()
+    val rnn = SimpleRNN[Float](8, returnSequences = true, inputShape = Shape(3, 6))
+    seq.add(rnn)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 3, 8))
+  }
+
+  def weightConverter(in: Array[Tensor[Float]]): Array[Tensor[Float]] =
+    Array(in(0).t(), in(1).t(), in(2))
+
+  "SimpleRNN not return sequences" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[4, 5])
+        |input = np.random.random([2, 4, 5])
+        |output_tensor = SimpleRNN(8, activation="relu")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = SimpleRNN[Float](8, activation = "relu", inputShape = Shape(4, 5))
+    seq.add(layer)
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode, weightConverter)
+  }
+
+  "SimpleRNN with return sequences" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[5, 8])
+        |input = np.random.random([3, 5, 8])
+        |output_tensor = SimpleRNN(12, return_sequences=True)(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = SimpleRNN[Float](12, returnSequences = true, inputShape = Shape(5, 8))
+    seq.add(layer)
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode, weightConverter)
+  }
+
+  "SimpleRNN with go backwards" should "be the same as Keras" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[12, 12])
+        |input = np.random.random([3, 12, 12])
+        |output_tensor = SimpleRNN(4, go_backwards=True, activation="sigmoid")(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val layer = SimpleRNN[Float](4, goBackwards = true,
+      activation = "sigmoid", inputShape = Shape(12, 12))
+    seq.add(layer)
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode, weightConverter)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/KerasModuleSerializerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/KerasModuleSerializerSpec.scala
@@ -110,5 +110,35 @@ class KerasModuleSerializerSpec extends SerializerSpecHelper {
     runSerializationTest(layer, input)
   }
 
+  "SimpleRNN serializer" should "work properly" in {
+    val layer = SimpleRNN[Float](8, activation = "relu", inputShape = Shape(4, 5))
+    layer.build(Shape(3, 4, 5))
+    val input = Tensor[Float](3, 4, 5).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
+
+  "LSTM serializer" should "work properly" in {
+    val layer = LSTM[Float](8, returnSequences = true,
+      innerActivation = "sigmoid", inputShape = Shape(32, 32))
+    layer.build(Shape(3, 32, 32))
+    val input = Tensor[Float](3, 32, 32).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
+
+  "GRU serializer" should "work properly" in {
+    val layer = GRU[Float](16, returnSequences = true,
+      goBackwards = true, inputShape = Shape(28, 32))
+    layer.build(Shape(2, 28, 32))
+    val input = Tensor[Float](2, 28, 32).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
+
+  "Highway serializer" should "work properly" in {
+    val layer = Highway[Float](activation = "tanh", bias = false, inputShape = Shape(4))
+    layer.build(Shape(3, 4))
+    val input = Tensor[Float](3, 4).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
+
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add Recurrent layers (SimpleRNN, LSTM, GRU, Highway) for new API.
KerasUtils redundant for several PRs, will rebase afterwards.

## How was this patch tested?

Jenkins.

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

