### PR TITLE
DLEstimator and DLModel should support deep copy

### DIFF
--- a/spark/dl/src/main/scala/org/apache/spark/ml/DLClassifier.scala
+++ b/spark/dl/src/main/scala/org/apache/spark/ml/DLClassifier.scala
@@ -54,7 +54,14 @@ class DLClassifier[@specialized(Float, Double) T: ClassTag](
   }
 
   override def copy(extra: ParamMap): DLClassifier[T] = {
-    copyValues(new DLClassifier(model, criterion, featureSize), extra)
+    val copied = copyValues(
+      new DLClassifier(model.cloneModule(), criterion.cloneCriterion(), featureSize.clone()), extra)
+
+    if (this.validationTrigger.isDefined) {
+      copied.setValidation(
+        validationTrigger.get, validationDF, validationMethods.clone(), validationBatchSize)
+    }
+    copied
   }
 }
 
@@ -78,6 +85,12 @@ class DLClassifierModel[@specialized(Float, Double) T: ClassTag](
   override def transformSchema(schema : StructType): StructType = {
     validateDataType(schema, $(featuresCol))
     SchemaUtils.appendColumn(schema, $(predictionCol), DoubleType)
+  }
+
+  override def copy(extra: ParamMap): DLModel[T] = {
+    val copied = new DLClassifierModel(model.cloneModule(), featureSize.clone(), uid)
+      .setParent(parent)
+    copyValues(copied, extra)
   }
 }
 

--- a/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
+++ b/spark/dl/src/main/scala/org/apache/spark/ml/DLEstimator.scala
@@ -227,10 +227,10 @@ class DLEstimator[@specialized(Float, Double) T: ClassTag](
     this
   }
 
-  @transient private var validationTrigger: Option[Trigger] = None
-  @transient private var validationDF: DataFrame = _
-  @transient private var validationMethods: Array[ValidationMethod[T]] = _
-  @transient private var validationBatchSize: Int = 0
+  @transient protected var validationTrigger: Option[Trigger] = None
+  @transient protected var validationDF: DataFrame = _
+  @transient protected var validationMethods: Array[ValidationMethod[T]] = _
+  @transient protected var validationBatchSize: Int = 0
   /**
    * Set a validate evaluation during training
    *
@@ -248,6 +248,15 @@ class DLEstimator[@specialized(Float, Double) T: ClassTag](
     this.validationMethods = vMethods
     this.validationBatchSize = batchSize
     this
+  }
+
+  def getValidation: Option[(Trigger, DataFrame, Array[ValidationMethod[T]], Int)] = {
+    if (validationTrigger.isDefined) {
+      Some(validationTrigger.get, validationDF, validationMethods, validationBatchSize)
+    }
+    else {
+      None
+    }
   }
 
   protected def validateParams(schema : StructType): Unit = {
@@ -340,8 +349,26 @@ class DLEstimator[@specialized(Float, Double) T: ClassTag](
     copyValues(dlModel.setParent(this))
   }
 
+  /**
+   * Return a deep copy for DLEstimator.
+   * Note that trainSummary and validationSummary will not be copied to the new instance since
+   * currently they are not thread-safe.
+   */
   override def copy(extra: ParamMap): DLEstimator[T] = {
-    copyValues(new DLEstimator(model, criterion, featureSize, labelSize), extra)
+    val copied = copyValues(
+      new DLEstimator(
+        model.cloneModule(),
+        criterion.cloneCriterion(),
+        featureSize.clone(),
+        labelSize.clone()
+      ),
+      extra)
+
+    if (this.validationTrigger.isDefined) {
+      copied.setValidation(
+        validationTrigger.get, validationDF, validationMethods.clone(), validationBatchSize)
+    }
+    copied
   }
 }
 
@@ -425,7 +452,7 @@ class DLModel[@specialized(Float, Double) T: ClassTag](
   }
 
   override def copy(extra: ParamMap): DLModel[T] = {
-    val copied = new DLModel(model, featureSize, uid).setParent(parent)
+    val copied = new DLModel(model.cloneModule(), featureSize.clone(), uid).setParent(parent)
     copyValues(copied, extra)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLClassifierSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLClassifierSpec.scala
@@ -22,11 +22,12 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric.NumericFloat
 import com.intel.analytics.bigdl.utils.Engine
 import com.intel.analytics.bigdl.utils.RandomGenerator.RNG
-import com.intel.analytics.bigdl.visualization.ValidationSummary
+import com.intel.analytics.bigdl.visualization.{TrainSummary, ValidationSummary}
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.ml.feature.MinMaxScaler
 import org.apache.spark.SparkContext
 import org.apache.spark.ml._
+import org.apache.spark.ml.param.ParamMap
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
@@ -216,6 +217,79 @@ class DLClassifierSpec extends FlatSpec with Matchers with BeforeAndAfter {
       pipelineModel.isInstanceOf[PipelineModel] should be(true)
       assert(pipelineModel.transform(df).where("prediction=label").count() > nRecords * 0.8)
     }
+  }
+
+  "An DLClassifier" should "supports deep copy" in {
+    val model = new Sequential().add(Linear[Float](6, 2)).add(LogSoftMax[Float])
+    val criterion = ClassNLLCriterion[Float]()
+    val data = sc.parallelize(
+      smallData.map(p => (org.apache.spark.mllib.linalg.Vectors.dense(p._1), p._2)))
+    val df: DataFrame = sqlContext.createDataFrame(data).toDF("features", "label")
+    val estimator = new DLClassifier[Float](model, criterion, Array(6))
+      .setBatchSize(31)
+      .setOptimMethod(new LBFGS[Float]())
+      .setLearningRate(0.123)
+      .setLearningRateDecay(0.432)
+      .setMaxEpoch(13)
+      .setFeaturesCol("abc")
+      .setTrainSummary(new TrainSummary("/tmp", "1"))
+      .setValidationSummary(new ValidationSummary("/tmp", "2"))
+      .setValidation(Trigger.maxIteration(3), df, Array(new Loss[Float]()), 2)
+    val copied = estimator.copy(ParamMap.empty)
+    assert(estimator.model ne copied.model)
+    assert(estimator.criterion ne copied.criterion)
+    assert(estimator.featureSize ne copied.featureSize)
+
+    assert(estimator.model == copied.model)
+    assert(estimator.criterion == copied.criterion)
+    assert(estimator.featureSize.deep == copied.featureSize.deep)
+    assert(estimator.getMaxEpoch == copied.getMaxEpoch)
+    assert(estimator.getBatchSize == copied.getBatchSize)
+    assert(estimator.getLearningRate == copied.getLearningRate)
+    assert(estimator.getLearningRateDecay == copied.getLearningRateDecay)
+    assert(estimator.getFeaturesCol == copied.getFeaturesCol)
+    assert(estimator.getLabelCol == copied.getLabelCol)
+    val estVal = estimator.getValidation.get
+    val copiedVal = copied.getValidation.get
+    assert(estVal._1 == copiedVal._1)
+    assert(estVal._2 == copiedVal._2)
+    assert(estVal._3.deep == copiedVal._3.deep)
+    assert(estVal._4 == copiedVal._4)
+
+    // train Summary and validation Summary are not copied since they are not thread-safe and cannot
+    // be shared among estimators
+    assert(copied.getTrainSummary.isEmpty)
+    assert(copied.getTrainSummary.isEmpty)
+  }
+
+  "A DLClassifierModel" should "supports deep copy" in {
+    val model = new Sequential().add(Linear[Float](6, 2)).add(LogSoftMax[Float])
+    val criterion = ClassNLLCriterion[Float]()
+    val data = sc.parallelize(
+      smallData.map(p => (org.apache.spark.mllib.linalg.Vectors.dense(p._1), p._2)))
+    val df: DataFrame = sqlContext.createDataFrame(data).toDF("abc", "la")
+    val estimator = new DLClassifier[Float](model, criterion, Array(6))
+      .setBatchSize(31)
+      .setOptimMethod(new LBFGS[Float]())
+      .setLearningRate(0.123)
+      .setLearningRateDecay(0.432)
+      .setMaxEpoch(3)
+      .setFeaturesCol("abc")
+      .setLabelCol("la")
+
+    val dlModel = estimator.fit(df)
+    val copied = dlModel.copy(ParamMap.empty)
+    assert(copied.isInstanceOf[DLClassifierModel[Float]])
+    assert(dlModel.model ne copied.model)
+    assert(dlModel.featureSize ne copied.featureSize)
+
+    assert(dlModel.model == copied.model)
+    assert(dlModel.featureSize.deep == copied.featureSize.deep)
+    assert(dlModel.getBatchSize == copied.getBatchSize)
+    assert(dlModel.getLearningRate == copied.getLearningRate)
+    assert(dlModel.getMaxEpoch == copied.getMaxEpoch)
+    assert(dlModel.getLearningRateDecay == copied.getLearningRateDecay)
+    assert(dlModel.getFeaturesCol == copied.getFeaturesCol)
   }
 }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLEstimatorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLEstimatorSpec.scala
@@ -25,7 +25,8 @@ import com.intel.analytics.bigdl.visualization.{TrainSummary, ValidationSummary}
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.SparkContext
 import org.apache.spark.ml.feature.MinMaxScaler
-import org.apache.spark.ml.{DLEstimator, DLModel, Pipeline, PipelineModel}
+import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.ml._
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
@@ -323,6 +324,78 @@ class DLEstimatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
       }.count()
       assert(correct > nRecords * 0.8)
     }
+  }
+
+  "An DLEstimator" should "supports deep copy" in {
+    val model = new Sequential().add(Linear[Float](6, 2)).add(LogSoftMax[Float])
+    val criterion = ClassNLLCriterion[Float]()
+    val data = sc.parallelize(
+      smallData.map(p => (org.apache.spark.mllib.linalg.Vectors.dense(p._1), p._2)))
+    val df: DataFrame = sqlContext.createDataFrame(data).toDF("features", "label")
+    val estimator = new DLEstimator[Float](model, criterion, Array(6), Array(1))
+      .setBatchSize(31)
+      .setOptimMethod(new LBFGS[Float]())
+      .setLearningRate(0.123)
+      .setLearningRateDecay(0.432)
+      .setMaxEpoch(13)
+      .setFeaturesCol("abc")
+      .setTrainSummary(new TrainSummary("/tmp", "1"))
+      .setValidationSummary(new ValidationSummary("/tmp", "2"))
+      .setValidation(Trigger.maxIteration(3), df, Array(new Loss[Float]()), 2)
+    val copied = estimator.copy(ParamMap.empty)
+    assert(estimator.model ne copied.model)
+    assert(estimator.criterion ne copied.criterion)
+    assert(estimator.featureSize ne copied.featureSize)
+
+    assert(estimator.model == copied.model)
+    assert(estimator.criterion == copied.criterion)
+    assert(estimator.featureSize.deep == copied.featureSize.deep)
+    assert(estimator.getMaxEpoch == copied.getMaxEpoch)
+    assert(estimator.getBatchSize == copied.getBatchSize)
+    assert(estimator.getLearningRate == copied.getLearningRate)
+    assert(estimator.getLearningRateDecay == copied.getLearningRateDecay)
+    assert(estimator.getFeaturesCol == copied.getFeaturesCol)
+    assert(estimator.getLabelCol == copied.getLabelCol)
+    val estVal = estimator.getValidation.get
+    val copiedVal = copied.getValidation.get
+    assert(estVal._1 == copiedVal._1)
+    assert(estVal._2 == copiedVal._2)
+    assert(estVal._3.deep == copiedVal._3.deep)
+    assert(estVal._4 == copiedVal._4)
+
+    // train Summary and validation Summary are not copied since they are not thread-safe and cannot
+    // be shared among estimators
+    assert(copied.getTrainSummary.isEmpty)
+    assert(copied.getTrainSummary.isEmpty)
+  }
+
+  "An DLModel" should "supports deep copy" in {
+    val model = new Sequential().add(Linear[Float](6, 2)).add(LogSoftMax[Float])
+    val criterion = ClassNLLCriterion[Float]()
+    val data = sc.parallelize(
+      smallData.map(p => (org.apache.spark.mllib.linalg.Vectors.dense(p._1), p._2)))
+    val df: DataFrame = sqlContext.createDataFrame(data).toDF("abc", "la")
+    val estimator = new DLEstimator[Float](model, criterion, Array(6), Array(1))
+      .setBatchSize(31)
+      .setOptimMethod(new LBFGS[Float]())
+      .setLearningRate(0.123)
+      .setLearningRateDecay(0.432)
+      .setMaxEpoch(3)
+      .setFeaturesCol("abc")
+      .setLabelCol("la")
+
+    val dlModel = estimator.fit(df)
+    val copied = dlModel.copy(ParamMap.empty)
+    assert(dlModel.model ne copied.model)
+    assert(dlModel.featureSize ne copied.featureSize)
+
+    assert(dlModel.model == copied.model)
+    assert(dlModel.featureSize.deep == copied.featureSize.deep)
+    assert(dlModel.getBatchSize == copied.getBatchSize)
+    assert(dlModel.getLearningRate == copied.getLearningRate)
+    assert(dlModel.getMaxEpoch == copied.getMaxEpoch)
+    assert(dlModel.getLearningRateDecay == copied.getLearningRateDecay)
+    assert(dlModel.getFeaturesCol == copied.getFeaturesCol)
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
when copy() is invoked for DLModel and DLEstimator, it should be a deep copy.

## How was this patch tested?
new unit test 

