### PR TITLE
[WIP] Fix operation behavior

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/Activity.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/Activity.scala
@@ -40,6 +40,21 @@ trait Activity {
   def isTable: Boolean
 }
 
+class EmptyGradInput private[abstractnn] extends Activity with Serializable {
+
+  override def toTensor[D](implicit ev: TensorNumeric[D]): Tensor[D] =
+    throw new UnsupportedOperationException()
+
+  override def toTable: Table =
+    throw new UnsupportedOperationException()
+
+  override def isTensor: Boolean =
+    throw new UnsupportedOperationException()
+
+  override def isTable: Boolean =
+    throw new UnsupportedOperationException()
+}
+
 object Activity {
   /**
    * Allocate a data instance by given type D and numeric type T
@@ -86,4 +101,8 @@ object Activity {
     }
     buffer.asInstanceOf[D]
   }
+
+  private val emptyGradSinglton = new EmptyGradInput()
+
+  def emptyGradInput(): EmptyGradInput = emptyGradSinglton
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ops/Operation.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ops/Operation.scala
@@ -16,9 +16,7 @@
 package com.intel.analytics.bigdl.nn.ops
 
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
-import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
-import com.intel.analytics.bigdl.utils.Table
 
 import scala.reflect.ClassTag
 
@@ -33,8 +31,6 @@ import scala.reflect.ClassTag
 abstract class Operation[A <: Activity: ClassTag, B <: Activity: ClassTag, T: ClassTag]
 (implicit ev: TensorNumeric[T]) extends AbstractModule[A, B, T]{
 
-  gradInput = EmptyGradInput().asInstanceOf[A]
-
   override def updateGradInput(input: A, gradOutput: B): A = {
     throw new UnsupportedOperationException("Operation does not support updateGradInput() method")
   }
@@ -43,25 +39,3 @@ abstract class Operation[A <: Activity: ClassTag, B <: Activity: ClassTag, T: Cl
     throw new UnsupportedOperationException("Operation does not support backward() method")
   }
 }
-
-class EmptyGradInput private extends Activity {
-
-  override def toTensor[D](implicit ev: TensorNumeric[D]): Tensor[D] =
-    throw new UnsupportedOperationException()
-
-  override def toTable: Table =
-    throw new UnsupportedOperationException()
-
-  override def isTensor: Boolean =
-    throw new UnsupportedOperationException()
-
-  override def isTable: Boolean =
-    throw new UnsupportedOperationException()
-}
-
-object EmptyGradInput {
-  private val emptyGrad = new EmptyGradInput()
-
-  def apply(): EmptyGradInput = emptyGrad
-}
-

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ops/Operation.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ops/Operation.scala
@@ -18,6 +18,7 @@ package com.intel.analytics.bigdl.nn.ops
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Table
 
 import scala.reflect.ClassTag
 
@@ -32,16 +33,35 @@ import scala.reflect.ClassTag
 abstract class Operation[A <: Activity: ClassTag, B <: Activity: ClassTag, T: ClassTag]
 (implicit ev: TensorNumeric[T]) extends AbstractModule[A, B, T]{
 
-  override def updateGradInput(input: A, gradOutput: B): A = {
-    throw new UnsupportedOperationException("Operation does not support updateGradInput() method")
-  }
+  gradInput = EmptyGradInput().asInstanceOf[A]
 
-  override def accGradParameters(input: A, gradOutput: B): Unit = {
+  override def updateGradInput(input: A, gradOutput: B): A = {
     throw new UnsupportedOperationException("Operation does not support updateGradInput() method")
   }
 
   override def backward(input: A, gradOutput: B): A = {
     throw new UnsupportedOperationException("Operation does not support backward() method")
   }
+}
+
+class EmptyGradInput private extends Activity {
+
+  override def toTensor[D](implicit ev: TensorNumeric[D]): Tensor[D] =
+    throw new UnsupportedOperationException()
+
+  override def toTable: Table =
+    throw new UnsupportedOperationException()
+
+  override def isTensor: Boolean =
+    throw new UnsupportedOperationException()
+
+  override def isTable: Boolean =
+    throw new UnsupportedOperationException()
+}
+
+object EmptyGradInput {
+  private val emptyGrad = new EmptyGradInput()
+
+  def apply(): EmptyGradInput = emptyGrad
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change fixes some incorrect behavior in operation.
1. Operation will throw an exception when invoking its accGradParameter method. However, other layers which don't have parameter won't have this behavior. This PR will make the operation accGradParameter behavior consistent with other layers.

2. If operations are used in a Graph, or stop gradient is used in the graph, the graph may not generate  gradients of the inputs. However, the init gradInput of layers maybe empty table or tensor, which may cause an incorrect result instead of throwing exceptions, e.g. the graph is used in another container. The PR create an empty gradInput activity which cannot be converted to any tensor or table. So it will make sure an exception(maybe not that user-friendly...) is thrown.

## How was this patch tested?
unit test


