### PR TITLE
support hdfs-cifar10 on resnet

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/resnet/Utils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/resnet/Utils.scala
@@ -20,6 +20,7 @@ import java.nio.ByteBuffer
 import java.nio.file.{Files, Path, Paths}
 
 import com.intel.analytics.bigdl.dataset.ByteRecord
+import com.intel.analytics.bigdl.utils.File
 import scopt.OptionParser
 
 import scala.collection.mutable.ArrayBuffer
@@ -118,11 +119,11 @@ object Utils {
 
   private[bigdl] def loadTrain(dataFile: String): Array[ByteRecord] = {
     val allFiles = Array(
-      Paths.get(dataFile, "data_batch_1.bin"),
-      Paths.get(dataFile, "data_batch_2.bin"),
-      Paths.get(dataFile, "data_batch_3.bin"),
-      Paths.get(dataFile, "data_batch_4.bin"),
-      Paths.get(dataFile, "data_batch_5.bin")
+      dataFile + "/data_batch_1.bin",
+      dataFile + "/data_batch_2.bin",
+      dataFile + "/data_batch_3.bin",
+      dataFile + "/data_batch_4.bin",
+      dataFile + "/data_batch_5.bin"
     )
 
     val result = new ArrayBuffer[ByteRecord]()
@@ -132,19 +133,30 @@ object Utils {
 
   private[bigdl] def loadTest(dataFile: String): Array[ByteRecord] = {
     val result = new ArrayBuffer[ByteRecord]()
-    val testFile = Paths.get(dataFile, "test_batch.bin")
+    val testFile = dataFile + "/test_batch.bin"
     load(testFile, result)
     result.toArray
   }
 
-  private[bigdl] def load(featureFile: Path, result : ArrayBuffer[ByteRecord]): Unit = {
+  /**
+    * load cifar data.
+    * read cifar from hdfs if data folder starts with "hdfs:", otherwise form local file.
+    * @param featureFile
+    * @param result
+    */
+  private[bigdl] def load(featureFile: String, result : ArrayBuffer[ByteRecord]): Unit = {
     val rowNum = 32
     val colNum = 32
     val imageOffset = rowNum * colNum * 3 + 1
     val channelOffset = rowNum * colNum
     val bufferOffset = 8
 
-    val featureBuffer = ByteBuffer.wrap(Files.readAllBytes(featureFile))
+    val featureBuffer = if (featureFile.startsWith(File.hdfsPrefix)) {
+      ByteBuffer.wrap(File.readHdfsByte(featureFile))
+    } else {
+      ByteBuffer.wrap(Files.readAllBytes(Paths.get(featureFile)))
+    }
+
     val featureArray = featureBuffer.array()
     val featureCount = featureArray.length / (rowNum * colNum * 3 + 1)
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/resnet/Utils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/resnet/Utils.scala
@@ -139,11 +139,11 @@ object Utils {
   }
 
   /**
-    * load cifar data.
-    * read cifar from hdfs if data folder starts with "hdfs:", otherwise form local file.
-    * @param featureFile
-    * @param result
-    */
+   * load cifar data.
+   * read cifar from hdfs if data folder starts with "hdfs:", otherwise form local file.
+   * @param featureFile
+   * @param result
+   */
   private[bigdl] def load(featureFile: String, result : ArrayBuffer[ByteRecord]): Unit = {
     val rowNum = 32
     val colNum = 32


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. changes three functions (loadTrain loadTest load) in com.intel.analytics.bigdl.models.resnet/Util.scala so that we can load cifar10 from hdfs when training resnet.
2. I changed the source code according to com.intel.analytics.bigdl.models.vgg/Util.scala since the vgg/Util.scala supports hdfs-cifar10 loading.

## How was this patch tested?
Runing Spark local, Spark standalone and Spark yarn client models with both local dir and hdfs dir

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/1333
BTW: yiheng closed this issue because of the size of cifar10. But I think we can support this in resnet/Util.scala just like vgg/Util.scala

Thanks

