### PR TITLE
multi optimMethods in Optimizer

### DIFF
--- a/pyspark/bigdl/optim/optimizer.py
+++ b/pyspark/bigdl/optim/optimizer.py
@@ -738,7 +738,9 @@ class Optimizer(BaseOptimizer):
         if not end_trigger:
             end_trigger = MaxEpoch(1)
         if not optim_method:
-            optim_method = SGD()
+            optim_method = {model.name: SGD()}
+        if isinstance(optim_method, OptimMethod):
+            optim_method = {model.name: optim_method}
         if isinstance(training_set, RDD) or isinstance(training_set, DataSet):
             return DistriOptimizer(model=model,
                                    training_rdd=training_set,
@@ -813,16 +815,19 @@ class DistriOptimizer(Optimizer):
         :param end_trigger: when to end the optimization
         :param batch_size: training batch size
         """
+        if not optim_method:
+            optim_method = {model.name: SGD()}
+        if isinstance(optim_method, OptimMethod):
+            optim_method = {model.name: optim_method}
         if isinstance(training_rdd, RDD):
             JavaValue.__init__(self, None, bigdl_type, model.value,
                                training_rdd, criterion,
-                               optim_method if optim_method else SGD(), end_trigger, batch_size)
+                               optim_method, end_trigger, batch_size)
         elif isinstance(training_rdd, DataSet):
             self.bigdl_type = bigdl_type
             self.value = callBigDlFunc(self.bigdl_type, "createDistriOptimizerFromDataSet",
                                        model.value, training_rdd, criterion,
-                                       optim_method if optim_method else SGD(),
-                                       end_trigger, batch_size)
+                                       optim_method, end_trigger, batch_size)
 
 
 class LocalOptimizer(BaseOptimizer):
@@ -850,6 +855,10 @@ class LocalOptimizer(BaseOptimizer):
                  optim_method=None,
                  cores=None,
                  bigdl_type="float"):
+        if not optim_method:
+            optim_method = {model.name: SGD()}
+        if isinstance(optim_method, OptimMethod):
+            optim_method = {model.name: optim_method}
         if cores is None:
             cores = multiprocessing.cpu_count()
         JavaValue.__init__(self, None, bigdl_type,
@@ -857,7 +866,7 @@ class LocalOptimizer(BaseOptimizer):
                            JTensor.from_ndarray(Y),
                            model.value,
                            criterion,
-                           optim_method if optim_method else SGD(), end_trigger, batch_size, cores)
+                           optim_method, end_trigger, batch_size, cores)
 
     def set_validation(self, batch_size, X_val, Y_val, trigger, val_method=None):
         """

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -907,7 +907,8 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag, 
     val (weightParameters, gradParameters) = this.parameters()
 
     // maybe null if not weights in this module.
-    require(weightParameters != null, s"model ${this.getName()} doesn't have any parameters.")
+    require(weightParameters != null && weightParameters.length > 0,
+      s"model ${this.getName()} doesn't have any trainable parameters.")
 
     // If some gradParameters are not allocated storage, allocate it
     require(weightParameters.size == gradParameters.size,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -906,6 +906,9 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag, 
   final private[bigdl] def getParameters(): (Tensor[T], Tensor[T]) = {
     val (weightParameters, gradParameters) = this.parameters()
 
+    // maybe null if not weights in this module.
+    require(weightParameters != null, s"model ${this.getName()} doesn't have any parameters.")
+
     // If some gradParameters are not allocated storage, allocate it
     require(weightParameters.size == gradParameters.size,
       "weights and gradient number are not match")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -390,9 +390,6 @@ object DistriOptimizer {
               optimMethod.state.update("score", driverState[Float]("score"))
             }
 
-            if (!parameters.contains(name)) {
-              println()
-            }
             val p = parameters(name)._3
             optimMethod.optimize(_ => (ev.fromType(value), p.gradientPartition),
               p.weightPartition)
@@ -961,7 +958,8 @@ class DistriOptimizer[T: ClassTag] (
         AllReduceParameter.newParameter[T](partitionNum, modelParameters._1.nElement()
         )))
     } else {
-      throw new IllegalArgumentException(s"optimMethods")
+      throw new IllegalArgumentException(s"${model.getName()} doesn't " +
+        s"have corresponding OptimMethod")
     }
 
     prepareInput()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -808,7 +808,8 @@ object DistriOptimizer {
     (0 until parameterArray._2.length).foreach(i =>
       parameterArray._2(i).resizeAs(parameterArray._1(i))
     )
-    trainingModel.getParameters()
+
+    val (parameter, gradientParameter) = trainingModel.getParameters()
 
     parameters.foreach { case (moduleName, (pOffset, pLength, p)) =>
       val currentModule = trainingModel(moduleName)
@@ -820,11 +821,9 @@ object DistriOptimizer {
           Map(curPartitionId -> p.gradientPartition)))
       }).reduce((a, b) => (a._1 ++ b._1, a._2 ++ b._2))
 
-      val (parameter, gradientParameter) = currentModule.get.getParameters()
-      val parameterLength = parameter.nElement()
-      val taskSize = parameterLength / partitionNum
+      val taskSize = pLength / partitionNum
       require(taskSize != 0, "parameter length should not less than partition number")
-      val extraSize = parameterLength % partitionNum
+      val extraSize = pLength % partitionNum
 
       (0 until partitionNum).map(pid => {
         val start = pOffset + pid * taskSize + math.min(pid, extraSize)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -548,13 +548,14 @@ object DistriOptimizer {
     cacheTrigger.foreach { trigger =>
       cachePath.foreach { path =>
         if (trigger(state)) {
+          saveModel(getModel(models, parameters, trainingModel), cachePath, isOverWrite,
+            s".${state[Int]("neval")}")
+          logger.info(s"[Wall Clock ${wallClockTime / 1e9}s] Save model to $path")
           optimMethods.foreach{case (name, optimMethod) =>
-            logger.info(s"[Wall Clock ${wallClockTime / 1e9}s] Save model to $path")
-            saveModel(getModel(models, parameters, trainingModel), cachePath, isOverWrite,
-              s".${state[Int]("neval")}")
             optimMethod.state.update("epoch", state[Int]("epoch"))
             optimMethod.state.update("neval", state[Int]("neval"))
             saveOptimMethod(optimMethod, cachePath, isOverWrite, s"-$name.${state[Int]("neval")}")
+            logger.info(s"[Wall Clock ${wallClockTime / 1e9}s] Save optimMethod ${optimMethod} to $path")
           }
         }
       }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -17,9 +17,8 @@
 package com.intel.analytics.bigdl.optim
 
 import com.intel.analytics.bigdl.{Module, _}
-import com.intel.analytics.bigdl.dataset.{DataSet, DistributedDataSet,
-                        MiniBatch, SampleToMiniBatch, Sample, PaddingParam}
-import com.intel.analytics.bigdl.nn.{Module, Utils}
+import com.intel.analytics.bigdl.dataset.{DataSet, DistributedDataSet, MiniBatch, PaddingParam, Sample, SampleToMiniBatch}
+import com.intel.analytics.bigdl.nn.{Container, Module, Utils}
 import com.intel.analytics.bigdl.parameters.AllReduceParameter
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
@@ -29,6 +28,7 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 
 import com.intel.analytics.bigdl.models.utils.ModelBroadcast
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
 import org.apache.commons.lang.exception.ExceptionUtils
 import com.intel.analytics.bigdl.visualization.{TrainSummary, ValidationSummary}
 import org.apache.log4j.Logger
@@ -63,7 +63,7 @@ object DistriOptimizer {
     localStates: Array[Table],
     var moduleTimeList: Array[Long] = null,
     localMethods: Array[Option[Array[ValidationMethod[T]]]],
-    optimMethod: OptimMethod[T]
+    optimMethod: Map[String, OptimMethod[T]]
   )
 
   /**
@@ -75,7 +75,7 @@ object DistriOptimizer {
    * @param endWhen trigger to stop training
    * @param metrics metrics
    * @param models cached models
-   * @param optimMethod optimization method
+   * @param optimMethods optimization method
    * @param parameters [[AllReduceParameter]]
    * @param validationTrigger validation trigger
    * @param validationDataSet validation dataset
@@ -95,8 +95,8 @@ object DistriOptimizer {
     endWhen: Trigger,
     metrics: Metrics,
     models: RDD[Cache[T]],
-    optimMethod: OptimMethod[T],
-    parameters: AllReduceParameter[T],
+    optimMethods: Map[String, OptimMethod[T]],
+    parameters: Map[String, (Int, Int, AllReduceParameter[T])],
     validationTrigger: Option[Trigger],
     validationDataSet: Option[DataSet[MiniBatch[T]]],
     validationMethods: Option[Array[ValidationMethod[T]]],
@@ -113,20 +113,22 @@ object DistriOptimizer {
     var lastEpochTime = 0L
 
     // driverState is needed to prevent serializing the whole optimizer
-    if (!optimMethod.state.contains("epoch")) optimMethod.state.update("epoch", 1)
-    if (!optimMethod.state.contains("neval")) optimMethod.state.update("neval", 1)
-    if (!optimMethod.state.contains("Loss")) {
-      optimMethod.state.update("Loss", Float.PositiveInfinity)
-    }
-    if (!optimMethod.state.contains("score")) optimMethod.state.update("score", 0f)
-    if (!optimMethod.state.contains("recordsProcessedThisEpoch")) {
-      optimMethod.state.update("recordsProcessedThisEpoch", 0)
+    optimMethods.values.foreach{ optimMethod =>
+      if (!optimMethod.state.contains("epoch")) optimMethod.state.update("epoch", 1)
+      if (!optimMethod.state.contains("neval")) optimMethod.state.update("neval", 1)
+      if (!optimMethod.state.contains("Loss")) {
+        optimMethod.state.update("Loss", Float.PositiveInfinity)
+      }
+      if (!optimMethod.state.contains("score")) optimMethod.state.update("score", 0f)
+      if (!optimMethod.state.contains("recordsProcessedThisEpoch")) {
+        optimMethod.state.update("recordsProcessedThisEpoch", 0)
+      }
     }
     val driverState = T(
-      "epoch" -> optimMethod.state("epoch"),
-      "neval" -> optimMethod.state("neval"),
-      "Loss" -> optimMethod.state("Loss"),
-      "score" -> optimMethod.state("score")
+      "epoch" -> optimMethods.values.head.state("epoch"),
+      "neval" -> optimMethods.values.head.state("neval"),
+      "Loss" -> optimMethods.values.head.state("Loss"),
+      "score" -> optimMethods.values.head.state("score")
     )
 
     val _subModelNumber = Engine.getEngineType() match {
@@ -146,7 +148,7 @@ object DistriOptimizer {
     }
 
     logger.info(s"config $state")
-    var recordsProcessedThisEpoch = optimMethod.state[Int]("recordsProcessedThisEpoch")
+    var recordsProcessedThisEpoch = optimMethods.values.head.state[Int]("recordsProcessedThisEpoch")
     if (recordsProcessedThisEpoch == 0) {
       val shuffleBefore = System.nanoTime()
       logger.info("Shuffle data")
@@ -206,7 +208,9 @@ object DistriOptimizer {
             Note: All models in `cached` share the same storage for weights, so we only need to
             copy the weights from parameter server into the first model's weights.
            */
-          val weightsResult = parameters.getWeights(cached.modelWeights.head)
+          val weightsResult = parameters.values.toArray.map(p =>
+            p._3.getWeights(cached.modelWeights.head.narrow(1, p._1, p._2))
+          )
           val miniBatchBuffer = new Array[MiniBatch[T]](_subModelNumber)
           val batch = data.next()
           val stackSize = batch.size() / _subModelNumber
@@ -226,7 +230,7 @@ object DistriOptimizer {
             }
           })
           Engine.default.sync(tasks)
-          weightsResult.waitResult()
+          weightsResult.foreach(_.waitResult())
           val weightSyncTime = System.nanoTime() - syWStart
           driverMetrics.add("get weights average", weightSyncTime)
           driverMetrics.add("get weights for each node", weightSyncTime)
@@ -269,33 +273,37 @@ object DistriOptimizer {
 
           if (finishedThreads.nonEmpty) {
             val finishedGradients = finishedThreads.map(cached.modelGradients(_))
-            time = System.nanoTime()
-            val gradLength = finishedGradients(0).nElement()
-            val taskSize = gradLength / _subModelNumber
-            val extraTask = gradLength % _subModelNumber
+            parameters.values.foreach { case (pOffset, pLength, p) =>
+              time = System.nanoTime()
+              val taskSize = pLength / _subModelNumber
+              val extraTask = pLength % _subModelNumber
 
-            // Aggregate multi-model's gradient to the first model's gradient
-            val parallelNum = if (taskSize == 0) extraTask else _subModelNumber
-            Engine.default.invokeAndWait((0 until parallelNum).map(tid => () => {
-              val offset = tid * taskSize + math.min(tid, extraTask)
-              val length = taskSize + (if (tid < extraTask) 1 else 0)
-              var i = 1
-              while (i < finishedGradients.length) {
-                finishedGradients(0).narrow(1, offset + 1, length)
-                  .add(finishedGradients(i).narrow(1, offset + 1, length))
-                i += 1
-              }
-            }))
-            driverMetrics.add("aggregate gradient time", System.nanoTime() - time)
-            val putG = System.nanoTime()
-            // Put first finished model's gradient who aggregated
-            // all other models' gradient to AllReduceParameter
-            parameters.putGradients(finishedGradients(0))
-            driverMetrics.add("put gradient", System.nanoTime() - putG)
+              // Aggregate multi-model's gradient to the first model's gradient
+              val parallelNum = if (taskSize == 0) extraTask else _subModelNumber
+              Engine.default.invokeAndWait((0 until parallelNum).map(tid => () => {
+                val offset = pOffset + tid * taskSize + math.min(tid, extraTask)
+                val length = taskSize + (if (tid < extraTask) 1 else 0)
+                var i = 1
+                while (i < finishedGradients.length) {
+                  finishedGradients(0).narrow(1, offset, length)
+                    .add(finishedGradients(i).narrow(1, offset, length))
+                  i += 1
+                }
+              }))
+              driverMetrics.add("aggregate gradient time", System.nanoTime() - time)
+              val putG = System.nanoTime()
+              // Put first finished model's gradient who aggregated
+              // all other models' gradient to AllReduceParameter
+              p.putGradients(finishedGradients(0).narrow(1, pOffset, pLength))
+              driverMetrics.add("put gradient", System.nanoTime() - putG)
+            }
           } else {
             val putG = System.nanoTime()
             // zero gradient in BlockManager when no thread finished.
-            parameters.putGradients(cached.modelGradients(0).zero())
+            cached.modelGradients(0).zero()
+            parameters.values.foreach{case (pOffset, pLength, p) =>
+              p.putGradients(cached.modelGradients(0).narrow(1, pOffset, pLength))
+            }
             driverMetrics.add("put gradient", System.nanoTime() - putG)
           }
 
@@ -318,65 +326,81 @@ object DistriOptimizer {
         val value = lossSum.value / numFinishedModelUpdates
 
         var l2Norm = 0.0f
-        var scale = ev.fromType(numFinishedModelUpdates)
-        if (normClippingEnable) {
+        val scale = if (normClippingEnable) {
           val sumSquare = models.mapPartitions(modelIter => {
-            val getG = System.nanoTime()
-            parameters.aggregateGradientPartition()
-            driverMetrics.add("aggregrateGradientParition average executor",
-              System.nanoTime() - getG)
+            parameters.map { case (moduleName, (pOffset, pLength, p)) =>
+              val getG = System.nanoTime()
+              p.aggregateGradientPartition()
+              driverMetrics.add("aggregrateGradientParition average executor",
+                System.nanoTime() - getG)
 
-            val gradLength = parameters.gradientPartition.nElement()
-            val taskSize = gradLength / _subModelNumber
-            val extraTask = gradLength % _subModelNumber
-            val parallelNum = if (taskSize == 0) extraTask else _subModelNumber
-            val squares = new Array[Double](parallelNum)
-            Engine.default.invokeAndWait((0 until parallelNum).map(tid => () => {
-              val offset = tid * taskSize + math.min(tid, extraTask)
-              val length = taskSize + (if (tid < extraTask) 1 else 0)
-              squares(tid) = ev.toType[Double](
-                parameters.gradientPartition.narrow(1, offset + 1, length).sumSquare())
-            }))
-            var sum = 0.0
-            var i = 0
-            while (i < parallelNum) {
-              sum += squares(i)
-              i += 1
+              val taskSize = pLength / _subModelNumber
+              val extraTask = pLength % _subModelNumber
+              val parallelNum = if (taskSize == 0) extraTask else _subModelNumber
+              val squares = new Array[Double](parallelNum)
+              Engine.default.invokeAndWait((0 until parallelNum).map(tid => () => {
+                val offset = tid * taskSize + math.min(tid, extraTask)
+                val length = taskSize + (if (tid < extraTask) 1 else 0)
+                squares(tid) = ev.toType[Double](
+                  p.gradientPartition.narrow(1, offset + 1, length).sumSquare())
+              }))
+              var sum = 0.0
+              var i = 0
+              while (i < parallelNum) {
+                sum += squares(i)
+                i += 1
+              }
+              (moduleName, sum)
+            }.toIterator
+          }).reduceByKey(_ + _).collect()
+          sumSquare.map { case (name, sum) =>
+            l2Norm = (math.sqrt(sum) / numFinishedModelUpdates).toFloat
+            val currentScale = if (l2Norm > normValueClip) {
+              ev.fromType[Double]((l2Norm * numFinishedModelUpdates) / normValueClip)
+            } else {
+             ev.fromType(numFinishedModelUpdates)
             }
-            Iterator.single(sum)
-          }).reduce(_ + _)
-          l2Norm = (math.sqrt(sumSquare) / numFinishedModelUpdates).toFloat
-          if (l2Norm > normValueClip) {
-            scale = ev.fromType[Double]((l2Norm * numFinishedModelUpdates) / normValueClip)
-          }
+            (name, currentScale)
+          }.toMap
+        } else {
+          parameters.map(v => (v._1, ev.fromType(numFinishedModelUpdates)))
         }
 
         models.mapPartitions { modelIter =>
           val modelCache = modelIter.next()
           if (!normClippingEnable) {
             val getG = System.nanoTime()
-            parameters.aggregateGradientPartition()
+            parameters.values.foreach(_._3.aggregateGradientPartition())
             driverMetrics.add("aggregrateGradientParition average executor",
               System.nanoTime() - getG)
           }
-          parameters.gradientPartition.div(scale)
-          modelCache.optimMethod.state.update("epoch", driverState[Int]("epoch"))
-          modelCache.optimMethod.state.update("neval", driverState[Int]("neval"))
-          modelCache.optimMethod.state.update("Loss", driverState[Float]("Loss"))
-          if (validationMethods.isDefined) {
-            modelCache.optimMethod.state.update("score", driverState[Float]("score"))
+          parameters.foreach{ case (name, (pOffset, pLength, p)) =>
+            p.gradientPartition.div(scale(name))
+            // gradient clipping
+            if (constantClippingEnable) {
+              p.gradientPartition.clamp(minValueClip, maxValueClip)
+            }
           }
-          var time = System.nanoTime()
-          // gradient clipping
-          if (constantClippingEnable) {
-            parameters.gradientPartition.clamp(minValueClip, maxValueClip)
+          modelCache.optimMethod.foreach{ case (name, optimMethod) =>
+            var time = System.nanoTime()
+            optimMethod.state.update("epoch", driverState[Int]("epoch"))
+            optimMethod.state.update("neval", driverState[Int]("neval"))
+            optimMethod.state.update("Loss", driverState[Float]("Loss"))
+            if (validationMethods.isDefined) {
+              optimMethod.state.update("score", driverState[Float]("score"))
+            }
+
+            if (!parameters.contains(name)) {
+              println()
+            }
+            val p = parameters(name)._3
+            optimMethod.optimize(_ => (ev.fromType(value), p.gradientPartition),
+              p.weightPartition)
+            driverMetrics.add("compute weight average", System.nanoTime() - time)
+            time = System.nanoTime()
+            p.sendWeightPartition()
+            driverMetrics.add("send weights average", System.nanoTime() - time)
           }
-          modelCache.optimMethod.optimize(_ => (ev.fromType(value), parameters.gradientPartition),
-            parameters.weightPartition)
-          driverMetrics.add("compute weight average", System.nanoTime() - time)
-          time = System.nanoTime()
-          parameters.sendWeightPartition()
-          driverMetrics.add("send weights average", System.nanoTime() - time)
           Iterator.empty
         }.count()
 
@@ -384,14 +408,22 @@ object DistriOptimizer {
         val end = System.nanoTime()
         wallClockTime += end - start
         driverState("Loss") = lossSum.value.toFloat / numFinishedModelUpdates
-        optimMethod.updateHyperParameter()
+        val hyperParameterLog = optimMethods.map{ case (moduleName, optimMethod) =>
+          optimMethod.updateHyperParameter()
+          val log = optimMethod.getHyperParameter()
+          driverState(s"LearningRate-${moduleName}") = -optimMethod.getLearningRate().toFloat
+          if (log.isEmpty) {
+            log
+          } else {
+            s"${moduleName}'s hyper parameters: ${log} "
+          }
+        }.reduce(_ + _)
         driverState("Throughput") = recordsNum.value.toFloat / ((end - start) / 1e9f)
-        driverState("LearningRate") = -optimMethod.getLearningRate().toFloat
         val _header = header(driverState[Int]("epoch"), recordsProcessedThisEpoch, numSamples,
           driverState[Int]("neval"), wallClockTime)
         logger.info(s"${_header} Trained ${recordsNum.value} records in ${(end - start) / 1e9} " +
           s"seconds. Throughput is ${driverState("Throughput")} records/second. Loss is ${
-            driverState("Loss")}. ${optimMethod.getHyperParameter()}")
+            driverState("Loss")}. $hyperParameterLog")
         logger.debug("\n" + metrics.summary())
         logger.debug("Dropped modules: " + (driverSubModelNum - numFinishedModelUpdates))
         lossArray = new Array[Double](_subModelNumber)
@@ -441,13 +473,14 @@ object DistriOptimizer {
           recordsProcessedThisEpoch = 0
         }
 
-        optimMethod.state.update("recordsProcessedThisEpoch", recordsProcessedThisEpoch)
-
-        optimMethod.state.update("epoch", driverState[Int]("epoch"))
-        optimMethod.state.update("neval", driverState[Int]("neval"))
-        optimMethod.state.update("Loss", driverState[Float]("Loss"))
-        if (validationMethods.isDefined) {
-          optimMethod.state.update("score", driverState[Float]("score"))
+        optimMethods.map { case (moduleName, optimMethod) =>
+          optimMethod.state.update("recordsProcessedThisEpoch", recordsProcessedThisEpoch)
+          optimMethod.state.update("epoch", driverState[Int]("epoch"))
+          optimMethod.state.update("neval", driverState[Int]("neval"))
+          optimMethod.state.update("Loss", driverState[Float]("Loss"))
+          if (validationMethods.isDefined) {
+            optimMethod.state.update("score", driverState[Float]("score"))
+          }
         }
 
         validate(
@@ -479,7 +512,7 @@ object DistriOptimizer {
           models,
           driverState,
           parameters,
-          optimMethod,
+          optimMethods,
           trainingModel
         )
 
@@ -510,18 +543,20 @@ object DistriOptimizer {
     wallClockTime: Long,
     models: RDD[Cache[T]],
     state: Table,
-    parameters: AllReduceParameter[T],
-    optimMethod: OptimMethod[T],
+    parameters: Map[String, (Int, Int, AllReduceParameter[T])],
+    optimMethods: Map[String, OptimMethod[T]],
     trainingModel: Module[T]): Unit = {
     cacheTrigger.foreach { trigger =>
       cachePath.foreach { path =>
         if (trigger(state)) {
-          println(s"[Wall Clock ${wallClockTime / 1e9}s] Save model to $path")
-          saveModel(getModel(models, parameters, trainingModel), cachePath, isOverWrite,
-            s".${state[Int]("neval")}")
-          optimMethod.state.update("epoch", state[Int]("epoch"))
-          optimMethod.state.update("neval", state[Int]("neval"))
-          saveOptimMethod(optimMethod, cachePath, isOverWrite, s".${state[Int]("neval")}")
+          optimMethods.foreach{case (name, optimMethod) =>
+            println(s"[Wall Clock ${wallClockTime / 1e9}s] Save model to $path")
+            saveModel(getModel(models, parameters, trainingModel), cachePath, isOverWrite,
+              s".${state[Int]("neval")}")
+            optimMethod.state.update("epoch", state[Int]("epoch"))
+            optimMethod.state.update("neval", state[Int]("neval"))
+            saveOptimMethod(optimMethod, cachePath, isOverWrite, s"-$name.${state[Int]("neval")}")
+          }
         }
       }
     }
@@ -539,7 +574,7 @@ object DistriOptimizer {
     trainSummary: TrainSummary,
     models: RDD[Cache[T]],
     driverState: Table,
-    parameters: AllReduceParameter[T],
+    parameters: Map[String, (Int, Int, AllReduceParameter[T])],
     trainingModel: Module[T])(implicit ev: TensorNumeric[T]): Unit = {
     val currentIteration = driverState[Int]("neval") - 1
     val parametersTrigger = trainSummary.getSummaryTrigger("Parameters")
@@ -580,7 +615,6 @@ object DistriOptimizer {
    * @param coresPerNode cores per node
    * @param checkSingleton if checkSingleton
    * @param parameters all reduce parameter instance
-   * @param validationMethods validation methods
    * @return cached models
    */
   private def initThreadModels[T: ClassTag](
@@ -591,9 +625,9 @@ object DistriOptimizer {
     nodeNumber: Int,
     coresPerNode: Int,
     checkSingleton: Boolean,
-    parameters: AllReduceParameter[T],
+    parameters: Map[String, (Int, Int, AllReduceParameter[T])],
     validationMethods: Option[Array[ValidationMethod[T]]],
-    optimMethod: OptimMethod[T]
+    optimMethod: Map[String, OptimMethod[T]]
   )(implicit ev: TensorNumeric[T]) = {
     val sc = dataset.originRDD().sparkContext
     val broadcast = sc.broadcast((criterion, state, validationMethods, optimMethod))
@@ -647,7 +681,9 @@ object DistriOptimizer {
 
       logger.info("model thread pool size is " + Engine.model.getPoolSize)
       val weights = cached.head._2
-      parameters.init(weights)
+      parameters.foreach(v =>
+        v._2._3.init(weights.narrow(1, v._2._1, v._2._2))
+      )
 
       Iterator.single(Cache(
         cached.map(_._1), // models
@@ -657,7 +693,7 @@ object DistriOptimizer {
         cached.map(_._5), // states
         new Array[Long](_subModelNumber * computeThresholdbatchSize),
         cached.map(_._6),
-        broadcastOptim.clone()
+        broadcastOptim.map(v => (v._1, v._2.clone()))
       ))
     }).persist()
     models.setName("Thread Model RDD")
@@ -764,34 +800,42 @@ object DistriOptimizer {
    */
   private def getModel[T: ClassTag](
     models: RDD[Cache[T]],
-    parameters: AllReduceParameter[T],
+    parameters: Map[String, (Int, Int, AllReduceParameter[T])],
     trainingModel: Module[T]): Module[T] = {
     val partitionNum = models.partitions.length
     val extraState = models.map(_.localModels.head.getExtraParameter()).first()
     trainingModel.setExtraParameter(extraState)
-    val (weights, gradients) = models.mapPartitions(iter => {
-      val cached = iter.next()
-      val curPartitionId = TaskContext.getPartitionId()
-      Iterator.single((Map(curPartitionId -> parameters.weightPartition),
-        Map(curPartitionId -> parameters.gradientPartition)))
-    }).reduce((a, b) => (a._1 ++ b._1, a._2 ++ b._2))
 
+    // make sure gradient is as the same length as weight
     val parameterArray = trainingModel.parameters()
     (0 until parameterArray._2.length).foreach(i =>
       parameterArray._2(i).resizeAs(parameterArray._1(i))
     )
-    val (parameter, gradientParameter) = trainingModel.getParameters()
-    val parameterLength = parameter.nElement()
-    val taskSize = parameterLength / partitionNum
-    require(taskSize != 0, "parameter length should not less than partition number")
-    val extraSize = parameterLength % partitionNum
+    trainingModel.getParameters()
 
-    (0 until partitionNum).map(pid => {
-      val start = pid * taskSize + math.min(pid, extraSize)
-      val length = taskSize + (if (pid < extraSize) 1 else 0)
-      parameter.narrow(1, start + 1, length).copy(weights(pid))
-      gradientParameter.narrow(1, start + 1, length).copy(gradients(pid))
-    })
+    parameters.foreach { case (moduleName, (pOffset, pLength, p)) =>
+      val currentModule = trainingModel(moduleName)
+      require(currentModule.isDefined, s"Couldn't find $moduleName in $trainingModel")
+      val (weights, gradients) = models.mapPartitions(iter => {
+        val cached = iter.next()
+        val curPartitionId = TaskContext.getPartitionId()
+        Iterator.single((Map(curPartitionId -> p.weightPartition),
+          Map(curPartitionId -> p.gradientPartition)))
+      }).reduce((a, b) => (a._1 ++ b._1, a._2 ++ b._2))
+
+      val (parameter, gradientParameter) = currentModule.get.getParameters()
+      val parameterLength = parameter.nElement()
+      val taskSize = parameterLength / partitionNum
+      require(taskSize != 0, "parameter length should not less than partition number")
+      val extraSize = parameterLength % partitionNum
+
+      (0 until partitionNum).map(pid => {
+        val start = pOffset + pid * taskSize + math.min(pid, extraSize)
+        val length = taskSize + (if (pid < extraSize) 1 else 0)
+        parameter.narrow(1, start, length).copy(weights(pid))
+        gradientParameter.narrow(1, start, length).copy(gradients(pid))
+      })
+    }
 
     trainingModel
   }
@@ -830,10 +874,12 @@ class DistriOptimizer[T: ClassTag] (
   }
 
   private def endEpoch(): Unit = {
-    val records = this.optimMethod.state.get[Int]("recordsProcessedThisEpoch")
-    if (records.isDefined && records.get != 0) {
-      this.optimMethod.state("epoch") = this.optimMethod.state[Int]("epoch") + 1
-      this.optimMethod.state("recordsProcessedThisEpoch") = 0
+    optimMethods.foreach { case (moduleName, optimMethod) =>
+      val records = optimMethod.state.get[Int]("recordsProcessedThisEpoch")
+      if (records.isDefined && records.get != 0) {
+        optimMethod.state("epoch") = optimMethod.state[Int]("epoch") + 1
+        optimMethod.state("recordsProcessedThisEpoch") = 0
+      }
     }
   }
 
@@ -877,8 +923,10 @@ class DistriOptimizer[T: ClassTag] (
 
     val distDataset = dataset.asInstanceOf[DistributedDataSet[MiniBatch[T]]]
 
-    optimMethod.clearHistory()
-    optimMethod.loadFromTable(state)
+    optimMethods.foreach { case (moduleName, optimMethod) =>
+      optimMethod.clearHistory()
+      optimMethod.loadFromTable(state)
+    }
     state("dropPercentage") = dropPercentage
     state("warmupIterationNum") = warmupIterationNum
     state("computeThresholdbatchSize") = computeThresholdbatchSize
@@ -889,13 +937,37 @@ class DistriOptimizer[T: ClassTag] (
     val coresPerNode = Engine.coreNumber()
 
     val partitionNum = distDataset.originRDD().partitions.length
-    val size = model.getParameters()._1.nElement()
-    val parameters = AllReduceParameter.newParameter(partitionNum, size)
+    val modelParameters = model.getParameters()
+    // subModuleName -> (storageOffset, length, AllReduceParameter)
+    val parameters = if (optimMethods.size != 1) {
+      val p = optimMethods.map{case (subModuleName, optimMethods) =>
+        val subModule = model(subModuleName)
+        require(subModule.isDefined, s"Optimizer couldn't find $subModuleName in $model")
+        val subModuleWeights = subModule.get.getParameters()._1
+        (subModuleName, subModuleWeights)
+      }
+      val sortedWeights = p.values.toArray.sortWith((a, b) => a.storageOffset() < b.storageOffset())
+      val compactWeights = Module.isCompact(sortedWeights)
+      require(modelParameters._1 == compactWeights,
+        s"DistriOptimizer: All subModules should have an OptimMethod.")
+      p.map{case (subModuleName, weights) =>
+        (subModuleName, (weights.storageOffset(),
+          weights.nElement(),
+          AllReduceParameter.newParameter[T](partitionNum, weights.nElement())))
+      }
+    } else if (optimMethods.contains(model.getName())) {
+      Map(model.getName() -> (modelParameters._1.storageOffset(),
+        modelParameters._1.nElement(),
+        AllReduceParameter.newParameter[T](partitionNum, modelParameters._1.nElement()
+        )))
+    } else {
+      throw new IllegalArgumentException(s"optimMethods")
+    }
 
     prepareInput()
 
     models = DistriOptimizer.initThreadModels(model, distDataset, criterion, state,
-      nodeNumber, coresPerNode, checkSingleton, parameters, validationMethods, optimMethod)
+      nodeNumber, coresPerNode, checkSingleton, parameters, validationMethods, optimMethods)
 
     if (checkpointPath.isDefined) {
       val file = checkpointPath.get + "/" +
@@ -919,7 +991,7 @@ class DistriOptimizer[T: ClassTag] (
           endWhen,
           metrics,
           models,
-          optimMethod,
+          optimMethods,
           parameters,
           validationTrigger,
           validationDataSet,
@@ -952,23 +1024,32 @@ class DistriOptimizer[T: ClassTag] (
             }
             DistriOptimizer.logger.info(s"Retrying $retryNum times")
             lastFailureTimestamp = System.nanoTime()
-            val methodFile = getLatestFile(checkpointPath.get, "optimMethod")
-            val modelFile = getLatestFile(checkpointPath.get, "model")
-            clearState()
-            models.unpersist()
 
-            var newModel: Module[T] = null
-            if (methodFile != null && modelFile != null) {
-              newModel = Module.load[T](modelFile)
-              optimMethod = OptimMethod.load[T](methodFile)
-              DistriOptimizer.logger.info("Recover from last snapshot")
+            val modelFile = getLatestFile(checkpointPath.get, "model")
+            val newModel = if (modelFile != null) {
+              DistriOptimizer.logger.info("Model recover from last snapshot")
+              Module.load[T](modelFile)
             } else {
-              newModel = model
-              DistriOptimizer.logger.info("Recover from origin model")
+              DistriOptimizer.logger.info("Model recover from origin model")
+              model
             }
-            optimMethod.clearHistory()
+            optimMethods = optimMethods.map { case (moduleName, optimMethod) =>
+              val methodFile = getLatestFile(checkpointPath.get, s"optimMethod-$moduleName")
+              clearState()
+              models.unpersist()
+
+              val newOptimMethod = if (methodFile != null) {
+                DistriOptimizer.logger.info(s"$moduleName's OptimMethod recover from last snapshot")
+                OptimMethod.load[T](methodFile)
+              } else {
+                DistriOptimizer.logger.info(s"$moduleName's OptimMethod recover from origin model")
+                optimMethod
+              }
+              newOptimMethod.clearHistory()
+              (moduleName, newOptimMethod)
+            }
             models = DistriOptimizer.initThreadModels(newModel, distDataset, criterion, state,
-              nodeNumber, coresPerNode, checkSingleton, parameters, validationMethods, optimMethod)
+              nodeNumber, coresPerNode, checkSingleton, parameters, validationMethods, optimMethods)
           } else {
             throw t
           }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalOptimizer.scala
@@ -48,7 +48,7 @@ class LocalOptimizer[T: ClassTag] (
     model, dataset, criterion) {
 
   import LocalOptimizer._
-  import Optimizer._
+  import Optimizer.{header, saveModel, saveState}
 
   private val coreNumber = Engine.coreNumber()
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalOptimizer.scala
@@ -196,15 +196,6 @@ class LocalOptimizer[T: ClassTag] (
       val end = System.nanoTime()
       wallClockTime += end - start
       count += batch.size()
-      val hyperParameterLog = optimMethods.map{ case (moduleName, optimMethod) =>
-        optimMethod.updateHyperParameter()
-        val log = optimMethod.getHyperParameter()
-        if (log.isEmpty) {
-          log
-        } else {
-          s"${moduleName}'s hyper parameters: ${log} "
-        }
-      }.reduce(_ + _)
       val head = header(state[Int]("epoch"), count, numSamples, state[Int]("neval"), wallClockTime)
       logger.info(s"$head " +
         s"loss is $loss, iteration time is ${(end - start) / 1e9}s " +

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/parameters/AllReduceParameter.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/parameters/AllReduceParameter.scala
@@ -55,8 +55,11 @@ object AllReduceParameter {
 
   private val nextId = new AtomicLong(0)
 
-  def newParameter[T: ClassTag](partitionNum: Int, size: Int): AllReduceParameter[T] = {
-    new AllReduceParameter(nextId.getAndIncrement(), partitionNum, size)
+  def newParameter[T: ClassTag](
+        partitionNum: Int,
+        size: Int,
+        offset: Int = 0): AllReduceParameter[T] = {
+    new AllReduceParameter(nextId.getAndIncrement(), partitionNum, size, offset)
   }
 }
 
@@ -73,9 +76,13 @@ object AllReduceParameter {
  * @param id distinguish from other parameters
  * @param partitionNum how many partitions will use this parameter
  * @param size size of the parameter (1D vector)
+ * @param paramOffset start index in the origin parameter.
  * @tparam T Tensor element type
  */
-class AllReduceParameter[T: ClassTag](id: Long, partitionNum: Int, size: Int) extends Serializable {
+class AllReduceParameter[T: ClassTag](id: Long,
+                                      partitionNum: Int,
+                                      val size: Int,
+                                      val paramOffset: Int = 0) extends Serializable {
   import AllReduceParameter._
 
   @transient private var taskSize = 0

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -245,12 +245,13 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
     dataset -> SampleToMiniBatch[T](batchSize)
   }
 
-  private def enrichOptimizer[T](optimizer: Optimizer[T, MiniBatch[T]],
-                                 endTrigger: Trigger,
-                                 optimMethod: OptimMethod[T]): Optimizer[T, MiniBatch[T]] = {
+  private def enrichOptimizer[T](
+        optimizer: Optimizer[T, MiniBatch[T]],
+        endTrigger: Trigger,
+        optimMethod: Map[String, OptimMethod[T]]): Optimizer[T, MiniBatch[T]] = {
     optimizer.setEndWhen(endTrigger)
 
-    optimizer.setOptimMethod(optimMethod)
+    optimizer.setOptimMethods(optimMethod)
 
     // TODO: remove this
     optimizer.disableCheckSingleton()
@@ -2163,7 +2164,7 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
                            y: JTensor,
                            model: AbstractModule[Activity, Activity, T],
                            criterion: Criterion[T],
-                           optimMethod: OptimMethod[T],
+                           optimMethod: Map[String, OptimMethod[T]],
                            endTrigger: Trigger,
                            batchSize: Int,
                            localCores: Int): Optimizer[T, MiniBatch[T]] = {
@@ -2181,7 +2182,7 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   def createDistriOptimizer(model: AbstractModule[Activity, Activity, T],
                             trainingRdd: JavaRDD[Sample],
                             criterion: Criterion[T],
-                            optimMethod: OptimMethod[T],
+                            optimMethod: Map[String, OptimMethod[T]],
                             endTrigger: Trigger,
                             batchSize: Int): Optimizer[T, MiniBatch[T]] = {
     val sampleRDD = toJSample(trainingRdd)
@@ -2198,7 +2199,7 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   def createDistriOptimizerFromDataSet(model: AbstractModule[Activity, Activity, T],
     trainDataSet: DataSet[ImageFeature],
     criterion: Criterion[T],
-    optimMethod: OptimMethod[T],
+    optimMethod: Map[String, OptimMethod[T]],
     endTrigger: Trigger,
     batchSize: Int): Optimizer[T, MiniBatch[T]] = {
     val dataSet = trainDataSet -> ImageFeatureToMiniBatch[T](batchSize)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DistriOptimizerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DistriOptimizerSpec.scala
@@ -394,8 +394,9 @@ class DistriOptimizerSpec extends FlatSpec with Matchers with BeforeAndAfter {
     import com.intel.analytics.bigdl._
     plusOne = 1.0
     RandomGenerator.RNG.setSeed(10)
+    val model = cre
     val optimizer = new DistriOptimizer[Double](
-      cre,
+      model,
       dataSet,
       new ClassNLLCriterion[Double]()
     )
@@ -406,7 +407,7 @@ class DistriOptimizerSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     val numIterations = dataSet.data(train = false).count() / nodeNumber + 1
     val optimMethod = OptimMethod.load[Double](optimizer.getCheckpointPath().get +
-      s"/optimMethod.$numIterations")
+      s"/optimMethod-${model.getName()}.$numIterations")
 
     optimMethod.state.get[Int]("epoch").get should be (2)
     optimMethod.state.get[Int]("neval").get should be (numIterations)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/RefDistriOptimizer.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/RefDistriOptimizer.scala
@@ -42,7 +42,7 @@ class RefDistriOptimizer[T: ClassTag](
       model,
       dataset,
       criterion,
-      optimMethod,
+      optimMethods.head._2,
       state,
       endWhen,
       ev

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/RefLocalOptimizer.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/RefLocalOptimizer.scala
@@ -48,7 +48,7 @@ class RefLocalOptimizer[T: ClassTag](
       val output = model.forward(input).asInstanceOf[Tensor[T]]
       val loss = criterion.forward(output, target)
       model.backward(input, criterion.backward(output, target))
-      optimMethod.optimize(_ => (loss, g), w, state)
+      optimMethods.head._2.optimize(_ => (loss, g), w, state)
       count += batch.size()
       state("neval") = state[Int]("neval") + 1
       println(s"loss is $loss")

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/python/api/PythonSpec.scala
@@ -196,8 +196,9 @@ class PythonSpec extends FlatSpec with Matchers with BeforeAndAfter {
     model.add(LogSoftMax[Double]())
     val batchSize = 32
     val pp = PythonBigDL.ofDouble()
-    val optimMethod = new SGD[Double]()
-    optimMethod.learningRateSchedule = SGD.Poly(0.5, math.ceil(1281167.toDouble / batchSize).toInt)
+    val optimMethod = Map(model.getName -> new SGD[Double]())
+    optimMethod(model.getName()).learningRateSchedule =
+      SGD.Poly(0.5, math.ceil(1281167.toDouble / batchSize).toInt)
     val optimizer = pp.createDistriOptimizer(
       model,
       data.toJavaRDD(),
@@ -274,7 +275,7 @@ class PythonSpec extends FlatSpec with Matchers with BeforeAndAfter {
     model.add(ReLU[Double]())
     model.add(LogSoftMax[Double]())
     val batchSize = 32
-    val optimMethod = new SGD[Double]()
+    val optimMethod = Map(model.getName() -> new SGD[Double]())
     val optimizer = pp.createLocalOptimizer(
       List(X).asJava,
       y,
@@ -314,7 +315,7 @@ class PythonSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val optimizer = pythonBigDL.createDistriOptimizerFromDataSet(model,
       imageFrame,
       criterion = ClassNLLCriterion[Float](),
-      optimMethod = sgd,
+      optimMethod = Map(model.getName() -> sgd),
       endTrigger = Trigger.maxEpoch(2),
       batchSize = 8)
     optimizer.optimize()


### PR DESCRIPTION
## What changes were proposed in this pull request?

multi optimMethods support in Optimizer

Add a new interface `def setOptimMethods(method: Map[String, OptimMethod[T]])` to set multi OptimMethods in Optimizer.
With this API, user can set different optimMethods for each subModules with the subModules' name and optimMethod pair. 

## How was this patch tested?

unit tests

## Related links or issues (optional)
fixed #2171

