### PR TITLE
add notebook token to docker and update jdk8 downloading

### DIFF
--- a/docker/BigDL/Dockerfile
+++ b/docker/BigDL/Dockerfile
@@ -31,26 +31,26 @@ ENV JAVA_HOME 			/opt/jdk
 ENV PATH 			${JAVA_HOME}/bin:${PATH}
 
 RUN apt-get update && \
-    apt-get install -y vim curl nano wget unzip maven git && \
+    apt-get install -y vim curl nano wget unzip maven git
 #java
-    wget --no-cookies --no-check-certificate --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" "http://download.oracle.com/otn-pub/java/jdk/8u152-b16/aa0333dd3019491ca4f6ddbe78cdb6d0/jdk-8u152-linux-x64.tar.gz" && \
+RUN wget http://ftp.osuosl.org/pub/funtoo/distfiles/oracle-java/jdk-8u152-linux-x64.tar.gz && \
     gunzip jdk-8u152-linux-x64.tar.gz && \
     tar -xf jdk-8u152-linux-x64.tar -C /opt && \
     rm jdk-8u152-linux-x64.tar && \
-    ln -s /opt/jdk1.8.0_152 /opt/jdk && \
+    ln -s /opt/jdk1.8.0_152 /opt/jdk
 #python
-    apt-get install -y build-essential python python-setuptools python-dev && \
+RUN apt-get install -y build-essential python python-setuptools python-dev && \
     easy_install pip && \
     pip install numpy scipy pandas scikit-learn matplotlib seaborn jupyter wordcloud && \
     python2 -m pip install ipykernel && \
-    python2 -m ipykernel install --user && \
+    python2 -m ipykernel install --user
 #spark
-    wget https://d3kbcqa49mib13.cloudfront.net/spark-${SPARK_VERSION}-bin-hadoop2.7.tgz && \
+RUN wget https://d3kbcqa49mib13.cloudfront.net/spark-${SPARK_VERSION}-bin-hadoop2.7.tgz && \
     tar -zxvf spark-${SPARK_VERSION}-bin-hadoop2.7.tgz && \
     mv spark-${SPARK_VERSION}-bin-hadoop2.7 spark-${SPARK_VERSION} && \
-    rm spark-${SPARK_VERSION}-bin-hadoop2.7.tgz && \
+    rm spark-${SPARK_VERSION}-bin-hadoop2.7.tgz
 #bigdl
-    git clone https://github.com/intel-analytics/BigDL-Tutorials.git 
+RUN git clone https://github.com/intel-analytics/BigDL-Tutorials.git 
 
 ADD ./start-notebook.sh /opt/work
 ADD ./download-bigdl.sh /opt/work

--- a/docker/BigDL/README.md
+++ b/docker/BigDL/README.md
@@ -56,27 +56,27 @@
 
 ### To start a notebook directly with a specified port(e.g. 12345). You can view the notebook on http://[host-ip]:12345
 
-    sudo docker run -it --rm -p 12345:12345 -e NotebookPort=12345 bigdl/bigdl:default
+    sudo docker run -it --rm -p 12345:12345 -e NotebookPort=12345 -e NotebookToken=your-token bigdl/bigdl:default
 
-    sudo docker run -it --rm --net=host -e NotebookPort=12345 bigdl/bigdl:default
+    sudo docker run -it --rm --net=host -e NotebookPort=12345 -e NotebookToken=your-token bigdl/bigdl:default
 
-    sudo docker run -it --rm -p 12345:12345 -e NotebookPort=12345 bigdl/bigdl:0.2.0-spark-2.1.1
+    sudo docker run -it --rm -p 12345:12345 -e NotebookPort=12345 -e NotebookToken=your-token bigdl/bigdl:0.2.0-spark-2.1.1
 
-    sudo docker run -it --rm --net=host -e NotebookPort=12345 bigdl/bigdl:0.2.0-spark-2.1.1
+    sudo docker run -it --rm --net=host -e NotebookPort=12345 -e NotebookToken=your-token bigdl/bigdl:0.2.0-spark-2.1.1
 
 ### If you need http and https proxy in your environment:
 
-    sudo docker run -it --rm -p 12345:12345 -e NotebookPort=12345 -e http_proxy=http://your-proxy-host:your-proxy-port -e https_proxy=https://your-proxy-host:your-proxy-port bigdl/bigdl:default
+    sudo docker run -it --rm -p 12345:12345 -e NotebookPort=12345 -e NotebookToken=your-token -e http_proxy=http://your-proxy-host:your-proxy-port -e https_proxy=https://your-proxy-host:your-proxy-port bigdl/bigdl:default
 
-    sudo docker run -it --rm --net=host -e NotebookPort=12345 -e http_proxy=http://your-proxy-host:your-proxy-port -e https_proxy=https://your-proxy-host:your-proxy-port  bigdl/bigdl:default
+    sudo docker run -it --rm --net=host -e NotebookPort=12345 -e NotebookToken=your-token -e http_proxy=http://your-proxy-host:your-proxy-port -e https_proxy=https://your-proxy-host:your-proxy-port  bigdl/bigdl:default
 
-    sudo docker run -it --rm -p 12345:12345 -e NotebookPort=12345 -e http_proxy=http://your-proxy-host:your-proxy-port -e https_proxy=https://your-proxy-host:your-proxy-port  bigdl/bigdl:0.2.0-spark-2.1.1
+    sudo docker run -it --rm -p 12345:12345 -e NotebookPort=12345 -e NotebookToken=your-token -e http_proxy=http://your-proxy-host:your-proxy-port -e https_proxy=https://your-proxy-host:your-proxy-port  bigdl/bigdl:0.2.0-spark-2.1.1
 
-    sudo docker run -it --rm --net=host -e NotebookPort=12345 -e http_proxy=http://your-proxy-host:your-proxy-port -e https_proxy=https://your-proxy-host:your-proxy-port bigdl/bigdl:0.2.0-spark-2.1.1
+    sudo docker run -it --rm --net=host -e NotebookPort=12345 -e NotebookToken=your-token -e http_proxy=http://your-proxy-host:your-proxy-port -e https_proxy=https://your-proxy-host:your-proxy-port bigdl/bigdl:0.2.0-spark-2.1.1
 
 ### You can also start the container first
 
-    sudo docker run -it --rm --net=host bigdl/bigdl:default bash
+    sudo docker run -it --rm --net=host -e NotebookPort=12345 -e NotebookToken=your-token bigdl/bigdl:default bash
 
 ### In the container, after setting proxy and ports, you can start the Notebook by:
 

--- a/docker/BigDL/start-notebook.sh
+++ b/docker/BigDL/start-notebook.sh
@@ -23,7 +23,7 @@ SPARK_VERSION=${SPARK_VERSION_ENV}
 SPARK_MAJOR_VERSION=${SPARK_VERSION_ENV%%.[0-9]}
 
 export PYSPARK_DRIVER_PYTHON=jupyter
-export PYSPARK_DRIVER_PYTHON_OPTS="notebook --notebook-dir=$BIGDL_TUTORIALS_HOME/notebooks --ip=* --port=$NotebookPort --no-browser --NotebookApp.token='' --allow-root"
+export PYSPARK_DRIVER_PYTHON_OPTS="notebook --notebook-dir=$BIGDL_TUTORIALS_HOME/notebooks --ip=* --port=$NotebookPort --no-browser --NotebookApp.token=$NotebookToken --allow-root"
 
 #source ${BIGDL_HOME}/bin/bigdl.sh
 ${SPARK_HOME}/bin/pyspark \


### PR DESCRIPTION
## What changes were proposed in this pull request?
add notebook token to docker which is required by AWS marketplace
update jdk8 downloading

## How was this patch tested?
have tested for both 0.4.0 and 0.5.0-SNAPSHOT

