### PR TITLE
Enhance and refactor the logic of InferShape

### DIFF
--- a/pyspark/bigdl/nn/keras/layer.py
+++ b/pyspark/bigdl/nn/keras/layer.py
@@ -62,7 +62,7 @@ class KerasCreator(JavaValue):
         print("creating: " + name)
         return name
 
-class KerasLayer(Layer, KerasCreator):
+class KerasLayer(Layer, InferShape, KerasCreator):
     pass
 
 class KerasModel(KerasLayer):
@@ -87,9 +87,10 @@ class Sequential(KerasModel):
 
 class Model(KerasModel):
     def __init__(self, input, output, bigdl_type="float"):
-        super(Model, self).__init__(None, to_list(input),
+        super(Model, self).__init__(None, bigdl_type,
+                                    to_list(input),
                                     to_list(output),
-                                    bigdl_type=bigdl_type)
+                                    )
 
 
 class Input(Node, KerasCreator):

--- a/pyspark/bigdl/nn/keras/layer.py
+++ b/pyspark/bigdl/nn/keras/layer.py
@@ -66,6 +66,7 @@ class KerasLayer(Layer, KerasCreator):
     pass
 
 class KerasModel(KerasLayer):
+    # TODO: enrich the KerasModel related API here.
     pass
 
 

--- a/pyspark/bigdl/nn/keras/layer.py
+++ b/pyspark/bigdl/nn/keras/layer.py
@@ -80,6 +80,10 @@ class Sequential(KerasModel):
     def __init__(self, bigdl_type="float"):
         super(Sequential, self).__init__(None, bigdl_type=bigdl_type)
 
+    def add(self, model):
+        self.value.add(model.value)
+        return self
+
 
 class Model(KerasModel):
     def __init__(self, input, output, bigdl_type="float"):

--- a/pyspark/bigdl/nn/keras/layer.py
+++ b/pyspark/bigdl/nn/keras/layer.py
@@ -16,7 +16,7 @@
 
 import sys
 
-from bigdl.nn.layer import Layer, Sequential as TSequential, Model as TModel
+from bigdl.nn.layer import Layer, Node
 from bigdl.util.common import callBigDlFunc, JTensor, JavaValue, to_list
 
 if sys.version >= '3':
@@ -56,34 +56,38 @@ class InferShape(JavaValue):
                                self.value)
         return self.__process_shape(output)
 
-
-class KerasLayer(Layer):
+class KerasCreator(JavaValue):
     def jvm_class_constructor(self):
         name = "createKeras" + self.__class__.__name__
         print("creating: " + name)
         return name
 
+class KerasLayer(Layer, KerasCreator):
+    pass
 
-class Sequential(TSequential, InferShape):
+class KerasModel(KerasLayer):
+    pass
+
+
+class Sequential(KerasModel):
     """
     Container for a Sequential model.
-
-    >>> sequential = Sequential()
-    creating: createSequential
+    >>> import bigdl.nn.keras.layer
+    >>> sequential = bigdl.nn.keras.layer.Sequential()
+    creating: createKerasSequential
     """
     def __init__(self, bigdl_type="float"):
-        super(Sequential, self).__init__(bigdl_type, True)
+        super(Sequential, self).__init__(None, bigdl_type=bigdl_type)
 
 
-class Model(TModel, InferShape):
+class Model(KerasModel):
     def __init__(self, input, output, bigdl_type="float"):
-        super(Model, self).__init__(to_list(input),
+        super(Model, self).__init__(None, to_list(input),
                                     to_list(output),
-                                    is_keras=True,
                                     bigdl_type=bigdl_type)
 
 
-class Input(KerasLayer):
+class Input(Node, KerasCreator):
     def __init__(self, name=None, input_shape=None, bigdl_type="float"):
         super(Input, self).__init__(None, bigdl_type,
                                     name,

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -654,7 +654,6 @@ class Model(Container):
     def __init__(self,
                  inputs,
                  outputs,
-                 is_keras=False,
                  jvalue=None,
                  bigdl_type="float", byte_order="little_endian", model_type="bigdl"):
         if jvalue:
@@ -663,8 +662,7 @@ class Model(Container):
         elif model_type == "bigdl":
             super(Model, self).__init__(None, bigdl_type,
                                         to_list(inputs),
-                                        to_list(outputs),
-                                        is_keras)
+                                        to_list(outputs))
         else:
             from bigdl.util.tf_utils import convert
             model = convert(to_list(inputs), to_list(outputs), byte_order, bigdl_type)
@@ -1062,8 +1060,8 @@ class Sequential(Container):
 
     '''
 
-    def __init__(self, bigdl_type="float", is_keras=False):
-        super(Sequential, self).__init__(None, bigdl_type, is_keras)
+    def __init__(self, bigdl_type="float"):
+        super(Sequential, self).__init__(None, bigdl_type)
 
 class TemporalConvolution(Layer):
 

--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -82,7 +82,7 @@ class JavaCreator(SingletonMixin):
         if isinstance(cclass, six.string_types):
             cclass = [cclass]
         with JavaCreator._lock:
-            JavaCreator.__creator_class = cclass
+            JavaCreator.__creator_class = [cclass]
             JavaCreator._instance = None
 
     def __init__(self, bigdl_type, gateway):

--- a/spark/dl/src/main/java/com/intel/analytics/bigdl/serialization/Bigdl.java
+++ b/spark/dl/src/main/java/com/intel/analytics/bigdl/serialization/Bigdl.java
@@ -1241,44 +1241,25 @@ public final class Bigdl {
      *output shape
      * </pre>
      *
-     * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
+     * <code>.com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
      */
-    java.util.List<com.intel.analytics.bigdl.serialization.Bigdl.Shape> 
-        getOutputShapeList();
+    boolean hasOutputShape();
     /**
      * <pre>
      *output shape
      * </pre>
      *
-     * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
+     * <code>.com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
      */
-    com.intel.analytics.bigdl.serialization.Bigdl.Shape getOutputShape(int index);
+    com.intel.analytics.bigdl.serialization.Bigdl.Shape getOutputShape();
     /**
      * <pre>
      *output shape
      * </pre>
      *
-     * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
+     * <code>.com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
      */
-    int getOutputShapeCount();
-    /**
-     * <pre>
-     *output shape
-     * </pre>
-     *
-     * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
-     */
-    java.util.List<? extends com.intel.analytics.bigdl.serialization.Bigdl.ShapeOrBuilder> 
-        getOutputShapeOrBuilderList();
-    /**
-     * <pre>
-     *output shape
-     * </pre>
-     *
-     * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
-     */
-    com.intel.analytics.bigdl.serialization.Bigdl.ShapeOrBuilder getOutputShapeOrBuilder(
-        int index);
+    com.intel.analytics.bigdl.serialization.Bigdl.ShapeOrBuilder getOutputShapeOrBuilder();
   }
   /**
    * Protobuf type {@code com.intel.analytics.bigdl.serialization.BigDLModule}
@@ -1302,7 +1283,6 @@ public final class Bigdl {
       train_ = false;
       namePostfix_ = "";
       id_ = 0;
-      outputShape_ = java.util.Collections.emptyList();
     }
 
     @java.lang.Override
@@ -1447,12 +1427,16 @@ public final class Bigdl {
               break;
             }
             case 114: {
-              if (!((mutable_bitField0_ & 0x00002000) == 0x00002000)) {
-                outputShape_ = new java.util.ArrayList<com.intel.analytics.bigdl.serialization.Bigdl.Shape>();
-                mutable_bitField0_ |= 0x00002000;
+              com.intel.analytics.bigdl.serialization.Bigdl.Shape.Builder subBuilder = null;
+              if (outputShape_ != null) {
+                subBuilder = outputShape_.toBuilder();
               }
-              outputShape_.add(
-                  input.readMessage(com.intel.analytics.bigdl.serialization.Bigdl.Shape.parser(), extensionRegistry));
+              outputShape_ = input.readMessage(com.intel.analytics.bigdl.serialization.Bigdl.Shape.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(outputShape_);
+                outputShape_ = subBuilder.buildPartial();
+              }
+
               break;
             }
           }
@@ -1471,9 +1455,6 @@ public final class Bigdl {
         }
         if (((mutable_bitField0_ & 0x00000020) == 0x00000020)) {
           nextModules_ = nextModules_.getUnmodifiableView();
-        }
-        if (((mutable_bitField0_ & 0x00002000) == 0x00002000)) {
-          outputShape_ = java.util.Collections.unmodifiableList(outputShape_);
         }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
@@ -2034,58 +2015,36 @@ public final class Bigdl {
     }
 
     public static final int OUTPUTSHAPE_FIELD_NUMBER = 14;
-    private java.util.List<com.intel.analytics.bigdl.serialization.Bigdl.Shape> outputShape_;
+    private com.intel.analytics.bigdl.serialization.Bigdl.Shape outputShape_;
     /**
      * <pre>
      *output shape
      * </pre>
      *
-     * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
+     * <code>.com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
      */
-    public java.util.List<com.intel.analytics.bigdl.serialization.Bigdl.Shape> getOutputShapeList() {
-      return outputShape_;
+    public boolean hasOutputShape() {
+      return outputShape_ != null;
     }
     /**
      * <pre>
      *output shape
      * </pre>
      *
-     * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
+     * <code>.com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
      */
-    public java.util.List<? extends com.intel.analytics.bigdl.serialization.Bigdl.ShapeOrBuilder> 
-        getOutputShapeOrBuilderList() {
-      return outputShape_;
+    public com.intel.analytics.bigdl.serialization.Bigdl.Shape getOutputShape() {
+      return outputShape_ == null ? com.intel.analytics.bigdl.serialization.Bigdl.Shape.getDefaultInstance() : outputShape_;
     }
     /**
      * <pre>
      *output shape
      * </pre>
      *
-     * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
+     * <code>.com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
      */
-    public int getOutputShapeCount() {
-      return outputShape_.size();
-    }
-    /**
-     * <pre>
-     *output shape
-     * </pre>
-     *
-     * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
-     */
-    public com.intel.analytics.bigdl.serialization.Bigdl.Shape getOutputShape(int index) {
-      return outputShape_.get(index);
-    }
-    /**
-     * <pre>
-     *output shape
-     * </pre>
-     *
-     * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
-     */
-    public com.intel.analytics.bigdl.serialization.Bigdl.ShapeOrBuilder getOutputShapeOrBuilder(
-        int index) {
-      return outputShape_.get(index);
+    public com.intel.analytics.bigdl.serialization.Bigdl.ShapeOrBuilder getOutputShapeOrBuilder() {
+      return getOutputShape();
     }
 
     private byte memoizedIsInitialized = -1;
@@ -2142,8 +2101,8 @@ public final class Bigdl {
       if (inputShape_ != null) {
         output.writeMessage(13, getInputShape());
       }
-      for (int i = 0; i < outputShape_.size(); i++) {
-        output.writeMessage(14, outputShape_.get(i));
+      if (outputShape_ != null) {
+        output.writeMessage(14, getOutputShape());
       }
       unknownFields.writeTo(output);
     }
@@ -2215,9 +2174,9 @@ public final class Bigdl {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(13, getInputShape());
       }
-      for (int i = 0; i < outputShape_.size(); i++) {
+      if (outputShape_ != null) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(14, outputShape_.get(i));
+          .computeMessageSize(14, getOutputShape());
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -2270,8 +2229,11 @@ public final class Bigdl {
         result = result && getInputShape()
             .equals(other.getInputShape());
       }
-      result = result && getOutputShapeList()
-          .equals(other.getOutputShapeList());
+      result = result && (hasOutputShape() == other.hasOutputShape());
+      if (hasOutputShape()) {
+        result = result && getOutputShape()
+            .equals(other.getOutputShape());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -2324,9 +2286,9 @@ public final class Bigdl {
         hash = (37 * hash) + INPUTSHAPE_FIELD_NUMBER;
         hash = (53 * hash) + getInputShape().hashCode();
       }
-      if (getOutputShapeCount() > 0) {
+      if (hasOutputShape()) {
         hash = (37 * hash) + OUTPUTSHAPE_FIELD_NUMBER;
-        hash = (53 * hash) + getOutputShapeList().hashCode();
+        hash = (53 * hash) + getOutputShape().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -2476,7 +2438,6 @@ public final class Bigdl {
         if (com.google.protobuf.GeneratedMessageV3
                 .alwaysUseFieldBuilders) {
           getSubModulesFieldBuilder();
-          getOutputShapeFieldBuilder();
         }
       }
       public Builder clear() {
@@ -2523,10 +2484,10 @@ public final class Bigdl {
           inputShapeBuilder_ = null;
         }
         if (outputShapeBuilder_ == null) {
-          outputShape_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00002000);
+          outputShape_ = null;
         } else {
-          outputShapeBuilder_.clear();
+          outputShape_ = null;
+          outputShapeBuilder_ = null;
         }
         return this;
       }
@@ -2595,10 +2556,6 @@ public final class Bigdl {
           result.inputShape_ = inputShapeBuilder_.build();
         }
         if (outputShapeBuilder_ == null) {
-          if (((bitField0_ & 0x00002000) == 0x00002000)) {
-            outputShape_ = java.util.Collections.unmodifiableList(outputShape_);
-            bitField0_ = (bitField0_ & ~0x00002000);
-          }
           result.outputShape_ = outputShape_;
         } else {
           result.outputShape_ = outputShapeBuilder_.build();
@@ -2724,31 +2681,8 @@ public final class Bigdl {
         if (other.hasInputShape()) {
           mergeInputShape(other.getInputShape());
         }
-        if (outputShapeBuilder_ == null) {
-          if (!other.outputShape_.isEmpty()) {
-            if (outputShape_.isEmpty()) {
-              outputShape_ = other.outputShape_;
-              bitField0_ = (bitField0_ & ~0x00002000);
-            } else {
-              ensureOutputShapeIsMutable();
-              outputShape_.addAll(other.outputShape_);
-            }
-            onChanged();
-          }
-        } else {
-          if (!other.outputShape_.isEmpty()) {
-            if (outputShapeBuilder_.isEmpty()) {
-              outputShapeBuilder_.dispose();
-              outputShapeBuilder_ = null;
-              outputShape_ = other.outputShape_;
-              bitField0_ = (bitField0_ & ~0x00002000);
-              outputShapeBuilder_ = 
-                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
-                   getOutputShapeFieldBuilder() : null;
-            } else {
-              outputShapeBuilder_.addAllMessages(other.outputShape_);
-            }
-          }
+        if (other.hasOutputShape()) {
+          mergeOutputShape(other.getOutputShape());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -4392,156 +4326,69 @@ public final class Bigdl {
         return inputShapeBuilder_;
       }
 
-      private java.util.List<com.intel.analytics.bigdl.serialization.Bigdl.Shape> outputShape_ =
-        java.util.Collections.emptyList();
-      private void ensureOutputShapeIsMutable() {
-        if (!((bitField0_ & 0x00002000) == 0x00002000)) {
-          outputShape_ = new java.util.ArrayList<com.intel.analytics.bigdl.serialization.Bigdl.Shape>(outputShape_);
-          bitField0_ |= 0x00002000;
-         }
-      }
-
-      private com.google.protobuf.RepeatedFieldBuilderV3<
+      private com.intel.analytics.bigdl.serialization.Bigdl.Shape outputShape_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.intel.analytics.bigdl.serialization.Bigdl.Shape, com.intel.analytics.bigdl.serialization.Bigdl.Shape.Builder, com.intel.analytics.bigdl.serialization.Bigdl.ShapeOrBuilder> outputShapeBuilder_;
+      /**
+       * <pre>
+       *output shape
+       * </pre>
+       *
+       * <code>.com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
+       */
+      public boolean hasOutputShape() {
+        return outputShapeBuilder_ != null || outputShape_ != null;
+      }
+      /**
+       * <pre>
+       *output shape
+       * </pre>
+       *
+       * <code>.com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
+       */
+      public com.intel.analytics.bigdl.serialization.Bigdl.Shape getOutputShape() {
+        if (outputShapeBuilder_ == null) {
+          return outputShape_ == null ? com.intel.analytics.bigdl.serialization.Bigdl.Shape.getDefaultInstance() : outputShape_;
+        } else {
+          return outputShapeBuilder_.getMessage();
+        }
+      }
+      /**
+       * <pre>
+       *output shape
+       * </pre>
+       *
+       * <code>.com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
+       */
+      public Builder setOutputShape(com.intel.analytics.bigdl.serialization.Bigdl.Shape value) {
+        if (outputShapeBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          outputShape_ = value;
+          onChanged();
+        } else {
+          outputShapeBuilder_.setMessage(value);
+        }
 
-      /**
-       * <pre>
-       *output shape
-       * </pre>
-       *
-       * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
-       */
-      public java.util.List<com.intel.analytics.bigdl.serialization.Bigdl.Shape> getOutputShapeList() {
-        if (outputShapeBuilder_ == null) {
-          return java.util.Collections.unmodifiableList(outputShape_);
-        } else {
-          return outputShapeBuilder_.getMessageList();
-        }
+        return this;
       }
       /**
        * <pre>
        *output shape
        * </pre>
        *
-       * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
-       */
-      public int getOutputShapeCount() {
-        if (outputShapeBuilder_ == null) {
-          return outputShape_.size();
-        } else {
-          return outputShapeBuilder_.getCount();
-        }
-      }
-      /**
-       * <pre>
-       *output shape
-       * </pre>
-       *
-       * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
-       */
-      public com.intel.analytics.bigdl.serialization.Bigdl.Shape getOutputShape(int index) {
-        if (outputShapeBuilder_ == null) {
-          return outputShape_.get(index);
-        } else {
-          return outputShapeBuilder_.getMessage(index);
-        }
-      }
-      /**
-       * <pre>
-       *output shape
-       * </pre>
-       *
-       * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
+       * <code>.com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
        */
       public Builder setOutputShape(
-          int index, com.intel.analytics.bigdl.serialization.Bigdl.Shape value) {
-        if (outputShapeBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureOutputShapeIsMutable();
-          outputShape_.set(index, value);
-          onChanged();
-        } else {
-          outputShapeBuilder_.setMessage(index, value);
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       *output shape
-       * </pre>
-       *
-       * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
-       */
-      public Builder setOutputShape(
-          int index, com.intel.analytics.bigdl.serialization.Bigdl.Shape.Builder builderForValue) {
-        if (outputShapeBuilder_ == null) {
-          ensureOutputShapeIsMutable();
-          outputShape_.set(index, builderForValue.build());
-          onChanged();
-        } else {
-          outputShapeBuilder_.setMessage(index, builderForValue.build());
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       *output shape
-       * </pre>
-       *
-       * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
-       */
-      public Builder addOutputShape(com.intel.analytics.bigdl.serialization.Bigdl.Shape value) {
-        if (outputShapeBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureOutputShapeIsMutable();
-          outputShape_.add(value);
-          onChanged();
-        } else {
-          outputShapeBuilder_.addMessage(value);
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       *output shape
-       * </pre>
-       *
-       * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
-       */
-      public Builder addOutputShape(
-          int index, com.intel.analytics.bigdl.serialization.Bigdl.Shape value) {
-        if (outputShapeBuilder_ == null) {
-          if (value == null) {
-            throw new NullPointerException();
-          }
-          ensureOutputShapeIsMutable();
-          outputShape_.add(index, value);
-          onChanged();
-        } else {
-          outputShapeBuilder_.addMessage(index, value);
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       *output shape
-       * </pre>
-       *
-       * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
-       */
-      public Builder addOutputShape(
           com.intel.analytics.bigdl.serialization.Bigdl.Shape.Builder builderForValue) {
         if (outputShapeBuilder_ == null) {
-          ensureOutputShapeIsMutable();
-          outputShape_.add(builderForValue.build());
+          outputShape_ = builderForValue.build();
           onChanged();
         } else {
-          outputShapeBuilder_.addMessage(builderForValue.build());
+          outputShapeBuilder_.setMessage(builderForValue.build());
         }
+
         return this;
       }
       /**
@@ -4549,17 +4396,21 @@ public final class Bigdl {
        *output shape
        * </pre>
        *
-       * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
+       * <code>.com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
        */
-      public Builder addOutputShape(
-          int index, com.intel.analytics.bigdl.serialization.Bigdl.Shape.Builder builderForValue) {
+      public Builder mergeOutputShape(com.intel.analytics.bigdl.serialization.Bigdl.Shape value) {
         if (outputShapeBuilder_ == null) {
-          ensureOutputShapeIsMutable();
-          outputShape_.add(index, builderForValue.build());
+          if (outputShape_ != null) {
+            outputShape_ =
+              com.intel.analytics.bigdl.serialization.Bigdl.Shape.newBuilder(outputShape_).mergeFrom(value).buildPartial();
+          } else {
+            outputShape_ = value;
+          }
           onChanged();
         } else {
-          outputShapeBuilder_.addMessage(index, builderForValue.build());
+          outputShapeBuilder_.mergeFrom(value);
         }
+
         return this;
       }
       /**
@@ -4567,35 +4418,17 @@ public final class Bigdl {
        *output shape
        * </pre>
        *
-       * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
-       */
-      public Builder addAllOutputShape(
-          java.lang.Iterable<? extends com.intel.analytics.bigdl.serialization.Bigdl.Shape> values) {
-        if (outputShapeBuilder_ == null) {
-          ensureOutputShapeIsMutable();
-          com.google.protobuf.AbstractMessageLite.Builder.addAll(
-              values, outputShape_);
-          onChanged();
-        } else {
-          outputShapeBuilder_.addAllMessages(values);
-        }
-        return this;
-      }
-      /**
-       * <pre>
-       *output shape
-       * </pre>
-       *
-       * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
+       * <code>.com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
        */
       public Builder clearOutputShape() {
         if (outputShapeBuilder_ == null) {
-          outputShape_ = java.util.Collections.emptyList();
-          bitField0_ = (bitField0_ & ~0x00002000);
+          outputShape_ = null;
           onChanged();
         } else {
-          outputShapeBuilder_.clear();
+          outputShape_ = null;
+          outputShapeBuilder_ = null;
         }
+
         return this;
       }
       /**
@@ -4603,56 +4436,26 @@ public final class Bigdl {
        *output shape
        * </pre>
        *
-       * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
+       * <code>.com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
        */
-      public Builder removeOutputShape(int index) {
-        if (outputShapeBuilder_ == null) {
-          ensureOutputShapeIsMutable();
-          outputShape_.remove(index);
-          onChanged();
-        } else {
-          outputShapeBuilder_.remove(index);
-        }
-        return this;
+      public com.intel.analytics.bigdl.serialization.Bigdl.Shape.Builder getOutputShapeBuilder() {
+        
+        onChanged();
+        return getOutputShapeFieldBuilder().getBuilder();
       }
       /**
        * <pre>
        *output shape
        * </pre>
        *
-       * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
+       * <code>.com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
        */
-      public com.intel.analytics.bigdl.serialization.Bigdl.Shape.Builder getOutputShapeBuilder(
-          int index) {
-        return getOutputShapeFieldBuilder().getBuilder(index);
-      }
-      /**
-       * <pre>
-       *output shape
-       * </pre>
-       *
-       * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
-       */
-      public com.intel.analytics.bigdl.serialization.Bigdl.ShapeOrBuilder getOutputShapeOrBuilder(
-          int index) {
-        if (outputShapeBuilder_ == null) {
-          return outputShape_.get(index);  } else {
-          return outputShapeBuilder_.getMessageOrBuilder(index);
-        }
-      }
-      /**
-       * <pre>
-       *output shape
-       * </pre>
-       *
-       * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
-       */
-      public java.util.List<? extends com.intel.analytics.bigdl.serialization.Bigdl.ShapeOrBuilder> 
-           getOutputShapeOrBuilderList() {
+      public com.intel.analytics.bigdl.serialization.Bigdl.ShapeOrBuilder getOutputShapeOrBuilder() {
         if (outputShapeBuilder_ != null) {
-          return outputShapeBuilder_.getMessageOrBuilderList();
+          return outputShapeBuilder_.getMessageOrBuilder();
         } else {
-          return java.util.Collections.unmodifiableList(outputShape_);
+          return outputShape_ == null ?
+              com.intel.analytics.bigdl.serialization.Bigdl.Shape.getDefaultInstance() : outputShape_;
         }
       }
       /**
@@ -4660,43 +4463,15 @@ public final class Bigdl {
        *output shape
        * </pre>
        *
-       * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
+       * <code>.com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
        */
-      public com.intel.analytics.bigdl.serialization.Bigdl.Shape.Builder addOutputShapeBuilder() {
-        return getOutputShapeFieldBuilder().addBuilder(
-            com.intel.analytics.bigdl.serialization.Bigdl.Shape.getDefaultInstance());
-      }
-      /**
-       * <pre>
-       *output shape
-       * </pre>
-       *
-       * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
-       */
-      public com.intel.analytics.bigdl.serialization.Bigdl.Shape.Builder addOutputShapeBuilder(
-          int index) {
-        return getOutputShapeFieldBuilder().addBuilder(
-            index, com.intel.analytics.bigdl.serialization.Bigdl.Shape.getDefaultInstance());
-      }
-      /**
-       * <pre>
-       *output shape
-       * </pre>
-       *
-       * <code>repeated .com.intel.analytics.bigdl.serialization.Shape outputShape = 14;</code>
-       */
-      public java.util.List<com.intel.analytics.bigdl.serialization.Bigdl.Shape.Builder> 
-           getOutputShapeBuilderList() {
-        return getOutputShapeFieldBuilder().getBuilderList();
-      }
-      private com.google.protobuf.RepeatedFieldBuilderV3<
+      private com.google.protobuf.SingleFieldBuilderV3<
           com.intel.analytics.bigdl.serialization.Bigdl.Shape, com.intel.analytics.bigdl.serialization.Bigdl.Shape.Builder, com.intel.analytics.bigdl.serialization.Bigdl.ShapeOrBuilder> 
           getOutputShapeFieldBuilder() {
         if (outputShapeBuilder_ == null) {
-          outputShapeBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+          outputShapeBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
               com.intel.analytics.bigdl.serialization.Bigdl.Shape, com.intel.analytics.bigdl.serialization.Bigdl.Shape.Builder, com.intel.analytics.bigdl.serialization.Bigdl.ShapeOrBuilder>(
-                  outputShape_,
-                  ((bitField0_ & 0x00002000) == 0x00002000),
+                  getOutputShape(),
                   getParentForChildren(),
                   isClean());
           outputShape_ = null;
@@ -21819,7 +21594,7 @@ public final class Bigdl {
       "\r\n\005train\030\n \001(\010\022\023\n\013namePostfix\030\013 \001(\t\022\n\n\002i" +
       "d\030\014 \001(\005\022B\n\ninputShape\030\r \001(\0132..com.intel." +
       "analytics.bigdl.serialization.Shape\022C\n\013o" +
-      "utputShape\030\016 \003(\0132..com.intel.analytics.b" +
+      "utputShape\030\016 \001(\0132..com.intel.analytics.b" +
       "igdl.serialization.Shape\032_\n\tAttrEntry\022\013\n" +
       "\003key\030\001 \001(\t\022A\n\005value\030\002 \001(\01322.com.intel.an" +
       "alytics.bigdl.serialization.AttrValue:\0028" +

--- a/spark/dl/src/main/resources/serialization/bigdl.proto
+++ b/spark/dl/src/main/resources/serialization/bigdl.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package serialization;
+package com.intel.analytics.bigdl.serialization;
 import "google/protobuf/any.proto";
 message BigDLModule
 {
@@ -16,7 +16,7 @@ message BigDLModule
     string namePostfix = 11; // name post fix
     int32 id = 12; // unique ID of this module , used for shared modules
     Shape inputShape = 13; // input shape
-    repeated Shape outputShape = 14; //output shape
+    Shape outputShape = 14; //output shape
 }
 enum VarFormat {
     EMPTY_FORMAT = 0;

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/AddConstant.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/AddConstant.scala
@@ -31,7 +31,7 @@ import scala.reflect.ClassTag
 class AddConstant[T: ClassTag](
    val constant_scalar: Double,
    val inplace: Boolean = false
-  )(implicit ev: TensorNumeric[T]) extends TensorModule[T]{
+  )(implicit ev: TensorNumeric[T]) extends TensorModule[T] {
   val scalar = ev.fromType[Double](constant_scalar)
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
@@ -16,7 +16,6 @@
 
 package com.intel.analytics.bigdl.nn
 
-import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
@@ -45,12 +44,6 @@ abstract class Container[A <: Activity : ClassTag,
   // list of sub modules
   val modules: ArrayBuffer[AbstractModule[Activity, Activity, T]]
   = ArrayBuffer[AbstractModule[Activity, Activity, T]]()
-
-  override private[bigdl] def isCompatibleWithKeras(): Boolean = false
-
-  override private[bigdl] def isCompatibleWithTorch(): Boolean = {
-    modules.filter(!_.isCompatibleWithTorch()).length <= 0
-  }
 
   override def reset(): Unit = {
     modules.foreach(_.reset())

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Contiguous.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Contiguous.scala
@@ -27,7 +27,7 @@ import scala.reflect.ClassTag
 
 @SerialVersionUID(- 4704727587714736531L)
 class Contiguous[T: ClassTag]
-(implicit ev: TensorNumeric[T]) extends TensorModule[T]{
+(implicit ev: TensorNumeric[T]) extends TensorModule[T] {
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
     output = input.contiguous()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CosineDistanceCriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CosineDistanceCriterion.scala
@@ -15,10 +15,9 @@
  */
 package com.intel.analytics.bigdl.nn
 
-import com.intel.analytics.bigdl.nn.abstractnn.{AbstractCriterion, TensorCriterion}
+import com.intel.analytics.bigdl.nn.abstractnn.TensorCriterion
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
-import com.intel.analytics.bigdl.utils.Table
 
 import scala.reflect.ClassTag
 
@@ -37,7 +36,7 @@ import scala.reflect.ClassTag
 @SerialVersionUID(- 4008475267198411701L)
 class CosineDistanceCriterion[@specialized(Float, Double) T: ClassTag]
 (val sizeAverage: Boolean = true)
-(implicit ev: TensorNumeric[T]) extends TensorCriterion[T]{
+(implicit ev: TensorNumeric[T]) extends TensorCriterion[T] {
   @transient
   private var buffer: Tensor[T] = null
   @transient

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CrossEntropyCriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CrossEntropyCriterion.scala
@@ -31,7 +31,7 @@ import scala.reflect.ClassTag
 class CrossEntropyCriterion[T: ClassTag](
   val weights: Tensor[T] = null,
   val sizeAverage: Boolean = true)
-  (implicit ev: TensorNumeric[T]) extends TensorCriterion[T]{
+  (implicit ev: TensorNumeric[T]) extends TensorCriterion[T] {
   private val lsm = new LogSoftMax[T]()
   private val nll = new ClassNLLCriterion[T](weights, sizeAverage)
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Dropout.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Dropout.scala
@@ -45,7 +45,7 @@ class Dropout[T: ClassTag](
   val initP: Double = 0.5,
   val inplace: Boolean = false,
   var scale: Boolean = true)(
-  implicit ev: TensorNumeric[T]) extends TensorModule[T] with IdentityOutputShape {
+  implicit ev: TensorNumeric[T]) extends TensorModule[T] {
   private var p = initP
   var noise = Tensor[T]()
   var isResampling = true

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/DynamicContainer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/DynamicContainer.scala
@@ -41,7 +41,7 @@ abstract class DynamicContainer[A <: Activity : ClassTag, B <: Activity : ClassT
     require(!module.isInstanceOf[Operation[_, _, _]],
       "Add operations to dynamic container is not allowed, as operations don't have backward. " +
         "Operation can only be used in Graph")
-    Util.excludeNotTorch[T](Seq(module))
+    validateInput[T](Seq(module))
     modules += module.asInstanceOf[AbstractModule[Activity, Activity, T]]
     checkDuplicate()
     this

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ELU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ELU.scala
@@ -32,7 +32,7 @@ class ELU[T: ClassTag](
   val alpha: Double = 1.0,
   val inplace: Boolean = false)(
   implicit ev: TensorNumeric[T])
-  extends TensorModule[T] with IdentityOutputShape {
+  extends TensorModule[T] {
 
   val _alpha = ev.fromType[Double](alpha)
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GaussianDropout.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GaussianDropout.scala
@@ -15,7 +15,7 @@
  */
 package com.intel.analytics.bigdl.nn
 
-import com.intel.analytics.bigdl.nn.abstractnn.{IdentityOutputShape, TensorModule}
+import com.intel.analytics.bigdl.nn.abstractnn.TensorModule
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 
@@ -37,7 +37,7 @@ import scala.reflect.ClassTag
 @SerialVersionUID(- 1575781981601306833L)
 class GaussianDropout[T: ClassTag](
    val rate: Double
-  )(implicit ev: TensorNumeric[T]) extends TensorModule[T] with IdentityOutputShape{
+  )(implicit ev: TensorNumeric[T]) extends TensorModule[T] {
 
   require(rate < 1 && rate >= 0, s"rate should be in range [0,1)")
   val stddev: Double = Math.sqrt(rate / (1.0-rate))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GaussianNoise.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/GaussianNoise.scala
@@ -15,7 +15,7 @@
  */
 package com.intel.analytics.bigdl.nn
 
-import com.intel.analytics.bigdl.nn.abstractnn.{IdentityOutputShape, TensorModule}
+import com.intel.analytics.bigdl.nn.abstractnn.TensorModule
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 
@@ -38,7 +38,7 @@ import scala.reflect.ClassTag
 @SerialVersionUID(- 2590701089601246637L)
 class GaussianNoise[T: ClassTag](
    val stddev: Double
-  )(implicit ev: TensorNumeric[T]) extends TensorModule[T] with IdentityOutputShape{
+  )(implicit ev: TensorNumeric[T]) extends TensorModule[T] {
 
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
@@ -592,7 +592,7 @@ trait GraphSerializable extends ContainerSerializable {
         context.storages, context.storageType))
       val moduleNode = bigDLModule.module match {
         case controlOps: ControlOps[T] => createControlNode(controlOps)
-        case _ => bigDLModule.module.inputs()
+        case _ => new ModuleNode[T](bigDLModule.module)
       }
       val preNodes = bigDLModule.pre
       layerMap(bigDLModule.module.getName) = (moduleNode, preNodes)
@@ -642,7 +642,7 @@ trait GraphSerializable extends ContainerSerializable {
         .asInstanceOf[Boolean]
       Graph.dynamic[T](inputs.toArray, outputs.toArray, sharedVariables, generateBackward)
     } else {
-      Graph[T](inputs.toArray, outputs.toArray, sharedVariables)
+      new StaticGraph[T](inputs, outputs, sharedVariables, false)
     }
     var serializedStopGradientLayers : Array[String] = null
     // this is to keep backward compatible

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/HardSigmoid.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/HardSigmoid.scala
@@ -30,7 +30,7 @@ import scala.reflect.ClassTag
  *           ⎩  0.2 * x + 0.5, otherwise
  */
 class HardSigmoid[T: ClassTag]
-(implicit ev: TensorNumeric[T]) extends TensorModule[T] with IdentityOutputShape {
+(implicit ev: TensorNumeric[T]) extends TensorModule[T] {
 
   val minValue = ev.fromType[Double](-2.5)
   val maxValue = ev.fromType[Double](2.5)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LeakyReLU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LeakyReLU.scala
@@ -36,7 +36,7 @@ import scala.reflect.ClassTag
 class LeakyReLU[T: ClassTag](
   private val negval: Double = 0.01,
   var inplace: Boolean = false)(
-  implicit ev: TensorNumeric[T]) extends TensorModule[T] with IdentityOutputShape {
+  implicit ev: TensorNumeric[T]) extends TensorModule[T] {
   import LeakyReLU._
 
   if (negval < 0) {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Linear.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Linear.scala
@@ -80,10 +80,6 @@ class Linear[T: ClassTag](
     zeroGradParameters()
   }
 
-  override def computeOutputShape(inputShape: Shape): Shape = {
-    inputShape.copyAndUpdate(-1, outputSize)
-  }
-
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
     require(input.dim() == 1 || input.dim() == 2,
       "Linear: " + ErrorInfo.constrainInputAsVectorOrBatch +

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Masking.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Masking.scala
@@ -16,8 +16,8 @@
 
 package com.intel.analytics.bigdl.nn
 
-import com.intel.analytics.bigdl.nn.abstractnn.{IdentityOutputShape, TensorModule}
-import com.intel.analytics.bigdl.tensor.{DenseTensorApply, Tensor, TensorFunc6}
+import com.intel.analytics.bigdl.nn.abstractnn.TensorModule
+import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 
 import scala.reflect.ClassTag
@@ -28,7 +28,7 @@ import scala.reflect.ClassTag
  * @param maskValue mask value
  */
 class Masking[T: ClassTag](maskValue: Double = 0.0)
-(implicit ev: TensorNumeric[T]) extends TensorModule[T] with IdentityOutputShape{
+(implicit ev: TensorNumeric[T]) extends TensorModule[T]{
   val batchDim = 1
   val timeDim = 2
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Maxout.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Maxout.scala
@@ -62,12 +62,12 @@ class Maxout[T: ClassTag](val inputSize: Int, val outputSize: Int, val maxoutNum
   }
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
-    output = layer.updateOutput(input)
+    output = layer.updateOutput(input).toTensor
     output
   }
 
   override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
-    gradInput = layer.updateGradInput(input, gradOutput)
+    gradInput = layer.updateGradInput(input, gradOutput).toTensor
     gradInput
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/PReLU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/PReLU.scala
@@ -40,7 +40,7 @@ import scala.reflect.ClassTag
 class PReLU[T: ClassTag](
   val nOutputPlane: Int = 0)
   (implicit ev: TensorNumeric[T]) extends TensorModule[T]
-    with Initializable with IdentityOutputShape {
+    with Initializable {
 
   val weight = if (nOutputPlane == 0) {
     Tensor[T](1)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ReLU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ReLU.scala
@@ -31,7 +31,7 @@ import scala.reflect.ClassTag
  */
 @SerialVersionUID(1208478077576570643L)
 class ReLU[T: ClassTag](ip: Boolean = false)(
-  implicit ev: TensorNumeric[T]) extends Threshold[T](0, 0, ip) with IdentityOutputShape{
+  implicit ev: TensorNumeric[T]) extends Threshold[T](0, 0, ip) {
 }
 
 object ReLU {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SReLU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SReLU.scala
@@ -49,7 +49,7 @@ import scala.reflect.ClassTag
 @SerialVersionUID(7173457290010080259L)
 class SReLU[T: ClassTag](val shape: Array[Int], val sharedAxes: Array[Int] = null)(
   implicit ev: TensorNumeric[T]) extends TensorModule[T]
-    with Initializable with IdentityOutputShape {
+    with Initializable {
   import SReLU._
   val weightsLen = 4
   val weights: Array[Tensor[T]] = Array.fill[Tensor[T]](4)(Tensor[T]())

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Sigmoid.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Sigmoid.scala
@@ -29,7 +29,7 @@ import scala.reflect.ClassTag
  */
 @SerialVersionUID(6855417348268610044L)
 class Sigmoid[T: ClassTag](
-  implicit ev: TensorNumeric[T]) extends TensorModule[T] with IdentityOutputShape {
+  implicit ev: TensorNumeric[T]) extends TensorModule[T] {
 
   private val buffer: Tensor[T] = Tensor[T]()
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftMax.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftMax.scala
@@ -31,7 +31,7 @@ import scala.reflect.ClassTag
  * where shift = max_i(x_i).
  */
 @SerialVersionUID(- 7842335603491194236L)
-class SoftMax[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends TensorModule[T]{
+class SoftMax[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends TensorModule[T] {
 
   @transient
   private var results: Array[Future[Unit]] = null

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftMin.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftMin.scala
@@ -30,7 +30,7 @@ import scala.reflect.ClassTag
  * where shift = max_i(-x_i).
  */
 @SerialVersionUID(- 8738615460960887232L)
-class SoftMin[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends TensorModule[T]{
+class SoftMin[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends TensorModule[T] {
 
   @transient
   private var results: Array[Future[Unit]] = null

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftPlus.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftPlus.scala
@@ -34,7 +34,7 @@ import scala.reflect.ClassTag
 class SoftPlus[T: ClassTag](
     val beta: Double = 1.0
   )( implicit ev: TensorNumeric[T])
-  extends TensorModule[T] with IdentityOutputShape {
+  extends TensorModule[T] {
 
   // Avoid floating point issues with exp(x), x>20
   private val threshold = ev.fromType[Double](20.0)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftSign.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftSign.scala
@@ -30,7 +30,7 @@ import scala.reflect.ClassTag
 @SerialVersionUID(- 3936698382129844874L)
 class SoftSign[T: ClassTag]()
     (implicit ev: TensorNumeric[T])
-  extends TensorModule[T] with IdentityOutputShape {
+  extends TensorModule[T] {
 
   @transient private var temp: Tensor[T] = null
   @transient private var tempGrad: Tensor[T] = null

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialDropout1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialDropout1D.scala
@@ -37,7 +37,7 @@ import scala.reflect.ClassTag
 @SerialVersionUID(- 4636332259181125718L)
 class SpatialDropout1D[T: ClassTag](
   val initP: Double = 0.5)(
-  implicit ev: TensorNumeric[T]) extends TensorModule[T] with IdentityOutputShape {
+  implicit ev: TensorNumeric[T]) extends TensorModule[T] {
   var p = initP
   var noise = Tensor[T]()
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialDropout2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialDropout2D.scala
@@ -41,7 +41,7 @@ import scala.reflect.ClassTag
 class SpatialDropout2D[T: ClassTag](
   val initP: Double = 0.5,
   val format: DataFormat = DataFormat.NCHW)(
-  implicit ev: TensorNumeric[T]) extends TensorModule[T] with IdentityOutputShape {
+  implicit ev: TensorNumeric[T]) extends TensorModule[T] {
   var p = initP
   var noise = Tensor[T]()
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialDropout3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialDropout3D.scala
@@ -41,7 +41,7 @@ import scala.reflect.ClassTag
 class SpatialDropout3D[T: ClassTag](
   val initP: Double = 0.5,
   val format: DataFormat = DataFormat.NCHW)(
-  implicit ev: TensorNumeric[T]) extends TensorModule[T] with IdentityOutputShape {
+  implicit ev: TensorNumeric[T]) extends TensorModule[T] {
   var p = initP
   var noise = Tensor[T]()
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolution.scala
@@ -18,15 +18,13 @@ package com.intel.analytics.bigdl.nn
 
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, Initializable}
 import com.intel.analytics.bigdl.optim.Regularizer
+import com.intel.analytics.bigdl.serialization.Bigdl.{AttrValue, BigDLModule}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.tensor._
-import com.intel.analytics.bigdl.utils.{Shape, T, Table, serializer}
-import com.intel.analytics.bigdl.utils.RandomGenerator._
 import com.intel.analytics.bigdl.utils.serializer._
 import com.intel.analytics.bigdl.utils.serializer.converters.DataConverter
-import com.intel.analytics.bigdl.serialization.Bigdl.{AttrValue, BigDLModule}
+import com.intel.analytics.bigdl.utils.{Shape, T, Table}
 
-import scala.concurrent.Future
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/StaticGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/StaticGraph.scala
@@ -36,7 +36,7 @@ class StaticGraph[T: ClassTag](
   private val _inputs : Seq[ModuleNode[T]],
   private val _outputs : Seq[ModuleNode[T]],
   private val _variables: Option[(Array[Tensor[T]], Array[Tensor[T]])] = None,
-  private val excludeKeras: Boolean = true
+  private val enableExcludeChecking: Boolean = true
 )(implicit ev: TensorNumeric[T]) extends Graph[T](_inputs, _outputs, _variables) {
   private val forwardExecution = forwardGraph.topologySort.reverse
   private var backwardExecution: Array[Node[AbstractModule[Activity, Activity, T]]] = _
@@ -44,9 +44,8 @@ class StaticGraph[T: ClassTag](
   private var backId2ForwardId: Array[Int] = _
   private var gradOutputCache: Array[Activity] = _
 
-  if (excludeKeras) {
-    Util.excludeNotTorch(inputs.map(_.element))
-    Util.excludeNotTorch(outputs.map(_.element))
+  if (enableExcludeChecking) {
+    excludeInvalidLayers(forwardExecution.map {_.element})
   }
 
   buildBackwardGraph()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Tanh.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Tanh.scala
@@ -30,7 +30,7 @@ import scala.reflect.ClassTag
  */
 @SerialVersionUID(9062199894710333035L)
 class Tanh[T: ClassTag](
-  implicit ev: TensorNumeric[T]) extends TensorModule[T] with IdentityOutputShape {
+  implicit ev: TensorNumeric[T]) extends TensorModule[T] {
 
   private val buffer: Tensor[T] = Tensor[T]()
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Threshold.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Threshold.scala
@@ -37,7 +37,7 @@ import scala.reflect.ClassTag
 @SerialVersionUID(3953292249027271493L)
 class Threshold[T: ClassTag](
   private val th: Double = 1e-6, private val v: Double = 0.0, private val ip: Boolean = false)(
-  implicit ev: TensorNumeric[T]) extends TensorModule[T] with IdentityOutputShape{
+  implicit ev: TensorNumeric[T]) extends TensorModule[T] {
   var threshold = th
   var value = v
   var inPlace = ip

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/UpSampling1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/UpSampling1D.scala
@@ -16,8 +16,6 @@
 
 package com.intel.analytics.bigdl.nn
 
-import java.util
-
 import com.intel.analytics.bigdl.nn.abstractnn.TensorModule
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricConvolution.scala
@@ -55,7 +55,8 @@ class VolumetricConvolution[T: ClassTag](
   val padT: Int = 0, val padW: Int = 0, val padH: Int = 0, withBias: Boolean = true,
   var wRegularizer: Regularizer[T] = null,
   var bRegularizer: Regularizer[T] = null
-)(implicit ev: TensorNumeric[T]) extends TensorModule[T] with Initializable {
+)(implicit ev: TensorNumeric[T]) extends TensorModule[T] with Initializable
+ {
 
   require(kT > 0 && kW > 0 && kH > 0, "kernel size should be greater than zero," +
     s" but got kT: $kT kH: $kH kW: $kW")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricConvolution.scala
@@ -55,8 +55,7 @@ class VolumetricConvolution[T: ClassTag](
   val padT: Int = 0, val padW: Int = 0, val padH: Int = 0, withBias: Boolean = true,
   var wRegularizer: Regularizer[T] = null,
   var bRegularizer: Regularizer[T] = null
-)(implicit ev: TensorNumeric[T]) extends TensorModule[T] with Initializable
- {
+)(implicit ev: TensorNumeric[T]) extends TensorModule[T] with Initializable {
 
   require(kT > 0 && kW > 0 && kH > 0, "kernel size should be greater than zero," +
     s" but got kT: $kT kH: $kH kW: $kW")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -742,17 +742,32 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag, 
     this
   }
 
+  protected def processInputs(nodes: Seq[ModuleNode[T]]): ModuleNode[T] = {
+    val curNode = new ModuleNode[T](this)
+    nodes.foreach(node => {
+      node.add(curNode, Edge())
+    })
+    curNode
+  }
+
+  protected def processInputs(first: (ModuleNode[T], Int),
+      nodesWithIndex : (ModuleNode[T], Int)*): ModuleNode[T] = {
+    val curNode = new ModuleNode[T](this)
+    first._1.add(curNode, Edge(first._2))
+    nodesWithIndex.foreach(nodeWithIndex => {
+      nodeWithIndex._1.add(curNode, Edge(nodeWithIndex._2))
+    })
+    curNode
+  }
+
   /**
    * Build graph: some other modules point to current module
    * @param nodes upstream module nodes
    * @return node containing current module
    */
   def inputs(nodes : ModuleNode[T]*): ModuleNode[T] = {
-    val curNode = new ModuleNode[T](this)
-    nodes.foreach(node => {
-      node.add(curNode, Edge())
-    })
-    curNode
+    validateInput(nodes.map(_.element))
+    processInputs(nodes)
   }
 
   /**
@@ -761,11 +776,8 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag, 
    * @return node containing current module
    */
   def inputs(nodes : Array[ModuleNode[T]]): ModuleNode[T] = {
-    val curNode = new ModuleNode[T](this)
-    nodes.foreach(node => {
-      node.add(curNode, Edge())
-    })
-    curNode
+    validateInput(nodes.map(_.element))
+    processInputs(nodes)
   }
 
   /**
@@ -774,14 +786,10 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag, 
    * @param nodesWithIndex upstream module nodes and the output tensor index. The start index is 1.
    * @return node containing current module
    */
-  def inputs(first: (ModuleNode[T], Int), nodesWithIndex : (ModuleNode[T], Int)*)
-  : ModuleNode[T] = {
-    val curNode = new ModuleNode[T](this)
-    first._1.add(curNode, Edge(first._2))
-    nodesWithIndex.foreach(nodeWithIndex => {
-      nodeWithIndex._1.add(curNode, Edge(nodeWithIndex._2))
-    })
-    curNode
+  def inputs(first: (ModuleNode[T], Int), nodesWithIndex : (ModuleNode[T], Int)*): ModuleNode[T] = {
+    validateInput(List(first._1.element))
+    validateInput(nodesWithIndex.map(_._1.element))
+    processInputs(first, nodesWithIndex: _*)
   }
 
   /**

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/InferShape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/InferShape.scala
@@ -16,11 +16,11 @@
 
 package com.intel.analytics.bigdl.nn.abstractnn
 
-import com.intel.analytics.bigdl.nn.keras.{Sequential => KSequential, Input => KInput}
+import com.intel.analytics.bigdl.nn.keras.{Input => KInput, Sequential => KSequential}
 import com.intel.analytics.bigdl.nn.{Input => TInput}
 import com.intel.analytics.bigdl.utils.Shape
-import scala.language.existentials
 
+import scala.language.existentials
 import scala.reflect.ClassTag
 
 class InvalidLayer(msg: String) extends RuntimeException(msg)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/InferShape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/InferShape.scala
@@ -19,6 +19,7 @@ package com.intel.analytics.bigdl.nn.abstractnn
 import com.intel.analytics.bigdl.nn.keras.{Sequential => KSequential, Input => KInput}
 import com.intel.analytics.bigdl.nn.{Input => TInput}
 import com.intel.analytics.bigdl.utils.Shape
+import scala.language.existentials
 
 import scala.reflect.ClassTag
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/InferShape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/InferShape.scala
@@ -16,24 +16,34 @@
 
 package com.intel.analytics.bigdl.nn.abstractnn
 
+import com.intel.analytics.bigdl.nn.keras.{Sequential => KSequential, Input => KInput}
+import com.intel.analytics.bigdl.nn.{Input => TInput}
 import com.intel.analytics.bigdl.utils.Shape
+
+import scala.reflect.ClassTag
+
+class InvalidLayer(msg: String) extends RuntimeException(msg)
 
 trait InferShape {
 
+  private[bigdl] var usedAsSrc = false
+
+  private[bigdl] var usedAsDest = false
+
   private[bigdl] var _inputShapeValue: Shape = null
 
-  private[bigdl] var _outputShapeValue: Array[Shape] = Array[Shape]()
+  private[bigdl] var _outputShapeValue: Shape = null
 
   private[bigdl] def inputShapeValue: Shape = _inputShapeValue
 
-  private[bigdl] def outputShapeValue: Array[Shape] = _outputShapeValue
+  private[bigdl] def outputShapeValue: Shape = _outputShapeValue
 
   // scalastyle:off
   private[bigdl] def inputShapeValue_=(value: Shape): Unit = {
     _inputShapeValue = value
   }
 
-  private[bigdl] def outputShapeValue_=(value: Array[Shape]): Unit = {
+  private[bigdl] def outputShapeValue_=(value: Shape): Unit = {
     _outputShapeValue = value
   }
   // scalastyle:on
@@ -41,28 +51,15 @@ trait InferShape {
   /**
    * We suppose the first dim is batch
    */
-  private[bigdl] def getInputShape(): Shape = {
+  private[bigdl] final def getInputShape(): Shape = {
     _inputShapeValue
-  }
-
-  /**
-   * Get the outputshape by index.
-   * @param index start from 0
-   * @return
-   */
-  private[bigdl] def getOutputShapeFor(index: Int): Shape = {
-    _outputShapeValue(index)
   }
 
   /**
    * We suppose the first dim is batch
    */
-  private[bigdl] def getOutputShape(): Shape = {
-    if (_outputShapeValue.length > 1) {
-      throw new RuntimeException(
-        "There are multiple outputs for this layer. Please use getInputShapeFor instead")
-    }
-    outputShapeValue(0)
+  private[bigdl] final def getOutputShape(): Shape = {
+    outputShapeValue
   }
 
   /**
@@ -71,24 +68,79 @@ trait InferShape {
    */
   private[bigdl] def build(inputShape: Shape): Shape = {
     val outputShape = computeOutputShape(inputShape)
-    this._outputShapeValue ++ Array(outputShape)
-    this._inputShapeValue = inputShape
-    isBuilt = true
+    this.outputShapeValue = outputShape
+    this.inputShapeValue = inputShape
     outputShape
   }
 
-  private[bigdl] var isBuilt: Boolean = false
+  private[bigdl] def isBuilt(): Boolean = outputShapeValue != null
 
+  private[bigdl] def isKerasStyle(): Boolean = false
 
-  private[bigdl] def isCompatibleWithKeras(): Boolean = true
-
-  private[bigdl] def isCompatibleWithTorch(): Boolean = true
+  private[bigdl] def allowRebuilt(): Boolean = false
 
   /**
    * We suppose the first dim is batch
    */
   private[bigdl] def computeOutputShape(inputShape: Shape): Shape = {
     throw new RuntimeException("Haven't been implemented yet. Do not use it with Keras Layer")
+  }
+
+
+
+  private def ensureNotShared[T: ClassTag](modules : Seq[AbstractModule[_, _, T]]): Unit = {
+    def skip(infer: InferShape): Boolean = {
+      infer.isInstanceOf[TInput[_]] || infer.isInstanceOf[KInput[_]]
+    }
+    // We can add module into Sequential multiple times.
+    if (this.isInstanceOf[KSequential[_]]) {
+      val submodules = this.asInstanceOf[KSequential[_]].getSubModules()
+      if (!submodules.isEmpty) {
+        if (!skip(submodules.last) && submodules.last.usedAsSrc == true) {
+          throw new RuntimeException(s"Reuse module as src is not allowed: $this")
+        }
+        submodules.last.usedAsSrc = true
+      }
+      modules.foreach{module =>
+        if (!skip(this) && module.usedAsDest == true) {
+          throw new RuntimeException(s"Reuse module as dest is not allowed: $this")
+        }
+        module.usedAsDest = true
+      }
+    } else {
+      if (!skip(this) && this.usedAsDest == true) {
+        throw new RuntimeException(s"Reuse module as dest is not allowed: $this")
+      }
+      this.usedAsDest = true
+      modules.foreach{module =>
+        if (!skip(module) && module.usedAsSrc == true) {
+          throw new RuntimeException(s"Reuse module as src is not allowed: $this")
+        }
+        module.usedAsSrc = true
+      }
+    }
+  }
+
+  private[bigdl] def excludeInvalidLayers[T: ClassTag]
+  (modules : Seq[AbstractModule[_, _, T]]): Unit = {
+    val invalidNodes = if (this.isKerasStyle()) {
+      modules.filter{!_.isKerasStyle()}
+    } else {
+      modules.filter{_.isKerasStyle()}
+    }
+    if (invalidNodes.length > 0) {
+      throw new InvalidLayer(s"""Do not mix ${this}(isKerasStyle=${isKerasStyle()}) with Layer
+                           (isKerasStyle=${invalidNodes(0).isKerasStyle()}):
+         ${invalidNodes.mkString(",")}""")
+    }
+  }
+
+  private[bigdl] def validateInput[T: ClassTag](modules : Seq[AbstractModule[_, _, T]]): Unit = {
+    if (this.isKerasStyle()) {
+      require(modules != null && !modules.isEmpty, "Empty input is not allowed")
+      ensureNotShared(modules)
+    }
+    excludeInvalidLayers(modules)
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Activation.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Activation.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.nn.keras
 
-import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, IdentityOutputShape}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.Shape
@@ -37,15 +37,14 @@ import scala.reflect.ClassTag
 class Activation[T: ClassTag](
    val activation: String,
    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
-  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape))
+    with IdentityOutputShape {
 
   require(activation != null, "The name of an activation function as a string is required")
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
-    val model = Sequential[T]()
-    model.add(InputLayer(inputShape = KerasLayer.removeBatch(inputShape)))
-    val layer = KerasUtils.getActivation(activation)
-    model.add(layer).asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+    val kerasActivation = KerasUtils.getKerasActivation(activation)
+    kerasActivation.doBuild(inputShape)
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AtrousConvolution1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AtrousConvolution1D.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.nn.keras
 
-import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.nn.{InitializationMethod, Xavier, Zeros}
 import com.intel.analytics.bigdl.nn.{SpatialDilatedConvolution, Squeeze, Transpose, Sequential => TSequential}
 import com.intel.analytics.bigdl.optim.Regularizer
@@ -57,7 +57,7 @@ class AtrousConvolution1D[T: ClassTag](
    val nbFilter: Int,
    val filterLength: Int,
    val init: InitializationMethod = Xavier,
-   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
+   val activation: KerasLayer[Tensor[T], Tensor[T], T] = null,
    val subsampleLength: Int = 1,
    val atrousRate: Int = 1,
    var wRegularizer: Regularizer[T] = null,
@@ -95,7 +95,7 @@ class AtrousConvolution1D[T: ClassTag](
     model.add(Transpose(Array((2, 3))))
     model.add(Squeeze(4))
     if (activation != null) {
-      model.add(activation)
+      model.add(activation.doBuild(inputShape))
     }
     model.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
@@ -113,7 +113,7 @@ object AtrousConvolution1D {
     bRegularizer: Regularizer[T] = null,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): AtrousConvolution1D[T] = {
     new AtrousConvolution1D[T](nbFilter, filterLength, KerasUtils.getInitMethod(init),
-      KerasUtils.getActivation(activation), subsampleLength, atrousRate,
+      KerasUtils.getKerasActivation(activation), subsampleLength, atrousRate,
       wRegularizer, bRegularizer, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AtrousConvolution2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AtrousConvolution2D.scala
@@ -62,7 +62,7 @@ class AtrousConvolution2D[T: ClassTag](
    val nbRow: Int,
    val nbCol: Int,
    val init: InitializationMethod = Xavier,
-   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
+   val activation: KerasLayer[Tensor[T], Tensor[T], T] = null,
    val subsample: Array[Int] = Array(1, 1),
    val atrousRate: Array[Int] = Array(1, 1),
    val dimOrdering: DataFormat = DataFormat.NCHW,
@@ -111,7 +111,7 @@ object AtrousConvolution2D {
     bRegularizer: Regularizer[T] = null,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): AtrousConvolution2D[T] = {
     new AtrousConvolution2D[T](nbFilter, nbRow, nbCol, KerasUtils.getInitMethod(init),
-      KerasUtils.getActivation(activation),
+      KerasUtils.getKerasActivation(activation),
       Array(subsample._1, subsample._2), Array(atrousRate._1, atrousRate._2),
       KerasUtils.toBigDLFormat(dimOrdering), wRegularizer, bRegularizer, inputShape)
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/ConvLSTM2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/ConvLSTM2D.scala
@@ -17,7 +17,7 @@
 package com.intel.analytics.bigdl.nn.keras
 
 import com.intel.analytics.bigdl.nn.{ConvLSTMPeephole, Reverse, Select, Sequential => TSequential}
-import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, TensorModule}
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, TensorModule}
 import com.intel.analytics.bigdl.optim.Regularizer
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
@@ -61,8 +61,8 @@ import scala.reflect.ClassTag
 class ConvLSTM2D[T: ClassTag](
    val nbFilter: Int,
    val nbKernel: Int,
-   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
-   val innerActivation: AbstractModule[Tensor[T], Tensor[T], T] = null,
+   val activation: KerasLayer[Tensor[T], Tensor[T], T] = null,
+   val innerActivation: KerasLayer[Tensor[T], Tensor[T], T] = null,
    val dimOrdering: String = "CHANNEL_FIRST",
    val subsample: Int = 1,
    var wRegularizer: Regularizer[T] = null,
@@ -97,8 +97,8 @@ class ConvLSTM2D[T: ClassTag](
       kernelI = nbKernel,
       kernelC = nbKernel,
       stride = subsample,
-      activation = activation.asInstanceOf[TensorModule[T]],
-      innerActivation = innerActivation.asInstanceOf[TensorModule[T]],
+      activation = activation.doBuild(inputShape).asInstanceOf[TensorModule[T]],
+      innerActivation = innerActivation.doBuild(inputShape).asInstanceOf[TensorModule[T]],
       wRegularizer = wRegularizer,
       uRegularizer = uRegularizer,
       bRegularizer = bRegularizer,
@@ -124,8 +124,8 @@ object ConvLSTM2D {
     returnSequences: Boolean = false,
     goBackwards: Boolean = false,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): ConvLSTM2D[T] = {
-    new ConvLSTM2D[T](nbFilter, nbKernel, KerasUtils.getActivation(activation),
-      KerasUtils.getActivation(innerActivation),
+    new ConvLSTM2D[T](nbFilter, nbKernel, KerasUtils.getKerasActivation(activation),
+      KerasUtils.getKerasActivation(innerActivation),
       KerasUtils.toBigDLFormat5D(dimOrdering),
       subsample, wRegularizer, uRegularizer, bRegularizer,
       returnSequences, goBackwards, inputShape)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution1D.scala
@@ -55,7 +55,7 @@ class Convolution1D[T: ClassTag](
    val nbFilter: Int,
    val filterLength: Int,
    val init: InitializationMethod = Xavier,
-   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
+   val activation: KerasLayer[Tensor[T], Tensor[T], T] = null,
    val borderMode: String = "valid",
    val subsampleLength: Int = 1,
    var wRegularizer: Regularizer[T] = null,
@@ -95,7 +95,7 @@ class Convolution1D[T: ClassTag](
     model.add(layer)
     model.add(Squeeze(3))
     if (activation != null) {
-      model.add(activation)
+      model.add(activation.doBuild(inputShape))
     }
     model.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
@@ -114,7 +114,7 @@ object Convolution1D {
     bias: Boolean = true,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Convolution1D[T] = {
     new Convolution1D[T](nbFilter, filterLength,
-      KerasUtils.getInitMethod(init), KerasUtils.getActivation(activation),
+      KerasUtils.getInitMethod(init), KerasUtils.getKerasActivation(activation),
       borderMode, subsampleLength, wRegularizer, bRegularizer, bias, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
@@ -60,7 +60,7 @@ class Convolution2D[T: ClassTag](
    val nbRow: Int,
    val nbCol: Int,
    val init: InitializationMethod = Xavier,
-   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
+   val activation: KerasLayer[Tensor[T], Tensor[T], T] = null,
    val borderMode: String = "valid",
    val subsample: Array[Int] = Array(1, 1),
    val dimOrdering: DataFormat = DataFormat.NCHW,
@@ -112,7 +112,7 @@ object Convolution2D {
     bias: Boolean = true,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Convolution2D[T] = {
     new Convolution2D[T](nbFilter, nbRow, nbCol,
-      KerasUtils.getInitMethod(init), KerasUtils.getActivation(activation),
+      KerasUtils.getInitMethod(init), KerasUtils.getKerasActivation(activation),
       borderMode, Array(subsample._1, subsample._2),
       KerasUtils.toBigDLFormat(dimOrdering), wRegularizer,
       bRegularizer, bias, inputShape)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution3D.scala
@@ -62,7 +62,7 @@ class Convolution3D[T: ClassTag](
    val kernelDim2: Int,
    val kernelDim3: Int,
    val init: InitializationMethod = Xavier,
-   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
+   val activation: KerasLayer[Tensor[T], Tensor[T], T] = null,
    val borderMode: String = "valid",
    val subsample: Array[Int] = Array(1, 1, 1),
    val dimOrdering: String = "CHANNEL_FIRST",
@@ -119,7 +119,7 @@ object Convolution3D {
     bias: Boolean = true,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Convolution3D[T] = {
     new Convolution3D[T](nbFilter, kernelDim1, kernelDim2, kernelDim3,
-      KerasUtils.getInitMethod(init), KerasUtils.getActivation(activation),
+      KerasUtils.getInitMethod(init), KerasUtils.getKerasActivation(activation),
       borderMode, Array(subsample._1, subsample._2, subsample._3),
       KerasUtils.toBigDLFormat5D(dimOrdering),
       wRegularizer, bRegularizer, bias, inputShape)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Deconvolution2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Deconvolution2D.scala
@@ -64,7 +64,7 @@ class Deconvolution2D[T: ClassTag](
    val nbRow: Int,
    val nbCol: Int,
    val init: InitializationMethod = Xavier,
-   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
+   val activation: KerasLayer[Tensor[T], Tensor[T], T] = null,
    val subsample: Array[Int] = Array(1, 1),
    val dimOrdering: DataFormat = DataFormat.NCHW,
    var wRegularizer: Regularizer[T] = null,
@@ -110,7 +110,7 @@ object Deconvolution2D {
     bias: Boolean = true,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Deconvolution2D[T] = {
     new Deconvolution2D[T](nbFilter, nbRow, nbCol, KerasUtils.getInitMethod(init),
-      KerasUtils.getActivation(activation), Array(subsample._1, subsample._2),
+      KerasUtils.getKerasActivation(activation), Array(subsample._1, subsample._2),
       KerasUtils.toBigDLFormat(dimOrdering), wRegularizer,
       bRegularizer, bias, inputShape)
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Dropout.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Dropout.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.nn.keras
 
-import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, IdentityOutputShape}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.Shape
@@ -36,7 +36,8 @@ import scala.reflect.ClassTag
 class Dropout[T: ClassTag](
    val p: Double,
    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
-  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape))
+    with IdentityOutputShape {
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val layer = com.intel.analytics.bigdl.nn.Dropout(p)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/ELU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/ELU.scala
@@ -38,7 +38,8 @@ import scala.reflect.ClassTag
 class ELU[T: ClassTag](
    val alpha: Double = 1.0,
    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
-  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape))
+    with IdentityOutputShape {
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val layer = com.intel.analytics.bigdl.nn.ELU(

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GRU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GRU.scala
@@ -53,8 +53,8 @@ import scala.reflect.ClassTag
  */
 class GRU[T: ClassTag](
    outputDim: Int,
-   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
-   val innerActivation: AbstractModule[Tensor[T], Tensor[T], T] = null,
+   val activation: KerasLayer[Tensor[T], Tensor[T], T] = null,
+   val innerActivation: KerasLayer[Tensor[T], Tensor[T], T] = null,
    returnSequences: Boolean = false,
    goBackwards: Boolean = false,
    var wRegularizer: Regularizer[T] = null,
@@ -67,8 +67,8 @@ class GRU[T: ClassTag](
     com.intel.analytics.bigdl.nn.GRU[T](
       inputSize = input(2),
       outputSize = outputDim,
-      activation = activation.asInstanceOf[TensorModule[T]],
-      innerActivation = innerActivation.asInstanceOf[TensorModule[T]],
+      activation = activation.doBuild(inputShape).asInstanceOf[TensorModule[T]],
+      innerActivation = innerActivation.doBuild(inputShape).asInstanceOf[TensorModule[T]],
       wRegularizer = wRegularizer,
       uRegularizer = uRegularizer,
       bRegularizer = bRegularizer)
@@ -86,8 +86,8 @@ object GRU {
     uRegularizer: Regularizer[T] = null,
     bRegularizer: Regularizer[T] = null,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]) : GRU[T] = {
-    new GRU(outputDim, KerasUtils.getActivation(activation),
-      KerasUtils.getActivation(innerActivation), returnSequences,
+    new GRU(outputDim, KerasUtils.getKerasActivation(activation),
+      KerasUtils.getKerasActivation(innerActivation), returnSequences,
       goBackwards, wRegularizer, uRegularizer, bRegularizer, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GaussianDropout.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GaussianDropout.scala
@@ -37,7 +37,8 @@ import scala.reflect.ClassTag
 class GaussianDropout[T: ClassTag](
    val p: Double,
    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
-  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape))
+    with IdentityOutputShape {
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val layer = com.intel.analytics.bigdl.nn.GaussianDropout(rate = p)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GaussianNoise.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GaussianNoise.scala
@@ -39,7 +39,8 @@ import scala.reflect.ClassTag
 class GaussianNoise[T: ClassTag](
    val sigma: Double,
    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
-  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape))  {
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape))
+    with IdentityOutputShape {
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val layer = com.intel.analytics.bigdl.nn.GaussianNoise(stddev = sigma)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Highway.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Highway.scala
@@ -43,7 +43,7 @@ import scala.reflect.ClassTag
  * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now.
  */
 class Highway[T: ClassTag](
-   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
+   val activation: KerasLayer[Tensor[T], Tensor[T], T] = null,
    var wRegularizer: Regularizer[T] = null,
    var bRegularizer: Regularizer[T] = null,
    val bias: Boolean = true,
@@ -59,10 +59,11 @@ class Highway[T: ClassTag](
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val input = inputShape.toSingle().toArray
+    activation.build(inputShape)
     val layer = com.intel.analytics.bigdl.nn.Highway[T](
       size = input(1),
       withBias = bias,
-      activation = activation.asInstanceOf[TensorModule[T]],
+      activation = activation.labor.asInstanceOf[TensorModule[T]],
       wRegularizer = wRegularizer,
       bRegularizer = bRegularizer
     )
@@ -77,7 +78,7 @@ object Highway {
     bRegularizer: Regularizer[T] = null,
     bias: Boolean = true,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]) : Highway[T] = {
-    new Highway[T](KerasUtils.getActivation(activation),
+    new Highway[T](KerasUtils.getKerasActivation(activation),
       wRegularizer, bRegularizer, bias, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Highway.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Highway.scala
@@ -59,11 +59,15 @@ class Highway[T: ClassTag](
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val input = inputShape.toSingle().toArray
-    activation.build(inputShape)
     val layer = com.intel.analytics.bigdl.nn.Highway[T](
       size = input(1),
       withBias = bias,
-      activation = activation.labor.asInstanceOf[TensorModule[T]],
+      activation = if (activation != null) {
+        activation.build(inputShape)
+        activation.labor.asInstanceOf[TensorModule[T]]
+      } else {
+        null
+      },
       wRegularizer = wRegularizer,
       bRegularizer = bRegularizer
     )

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Input.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Input.scala
@@ -25,20 +25,13 @@ import com.intel.analytics.bigdl.utils.{Node, Shape}
 import scala.reflect.ClassTag
 
 class Input[T: ClassTag](val inputShape: Shape)(implicit ev: TensorNumeric[T])
-  extends TInput[T]() {
-
-  private val batchInputShape = KerasLayer.addBatch(inputShape)
-
-  override def getInputShape(): Shape = {
-    batchInputShape
-  }
-
-  override def getOutputShape(): Shape = {
-    batchInputShape
-  }
+  extends KerasLayer[Activity, Activity, T](KerasLayer.addBatch(inputShape)) {
 
   override def computeOutputShape(inputShape: Shape): Shape = inputShape
 
+  override def doBuild(inputShape: Shape): TInput[T] = new TInput[T]()
+
+  override def allowRebuilt(): Boolean = true
 }
 
 object Input {
@@ -46,6 +39,7 @@ object Input {
     name : String = null,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): ModuleNode[T] = {
     val module = new Input(inputShape)
+    module.build(KerasLayer.addBatch(inputShape))
     if (name != null) {
       module.setName(name)
     }
@@ -56,7 +50,7 @@ object Input {
 object InputLayer {
   def apply[T: ClassTag](
     name : String = null,
-    inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Input[T] = {
+    inputShape: Shape = null)(implicit ev: TensorNumeric[T]): KerasLayer[Activity, Activity, T] = {
     val module = new Input(inputShape)
     if (name != null) {
       module.setName(name)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasLayer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasLayer.scala
@@ -18,16 +18,17 @@ package com.intel.analytics.bigdl.nn.keras
 
 import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.nn.Graph._
-import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, TensorModule}
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.nn.keras.{Sequential => KSequential}
-import com.intel.analytics.bigdl.nn.{Container, Sequential => TSequential}
+import com.intel.analytics.bigdl.nn.{Container => TContainer, Sequential => TSequential}
+import com.intel.analytics.bigdl.serialization.Bigdl.{AttrValue, BigDLModule}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.serializer._
 import com.intel.analytics.bigdl.utils.serializer.converters.DataConverter
-import com.intel.analytics.bigdl.utils.{Shape, SingleShape, Util}
-import serialization.Bigdl.{AttrValue, BigDLModule}
+import com.intel.analytics.bigdl.utils.{MultiShape, Shape, SingleShape}
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 
@@ -41,7 +42,21 @@ private[bigdl] trait TKerasSerializerHelper {
   }
 }
 
-object KerasLayerSerializer extends ContainerSerializable with TKerasSerializerHelper{
+object KerasLayerSerializer extends KerasLayerSerializable
+
+trait KerasLayerSerializable extends ContainerSerializable with TKerasSerializerHelper{
+
+  override def loadSubModules[T: ClassTag](context : DeserializeContext,
+      module : AbstractModule[Activity, Activity, T])
+    (implicit ev: TensorNumeric[T]) : Unit = {
+    val klayer = module.asInstanceOf[KerasLayer[Activity, Activity, T]]
+    val subModules = context.bigdlModule.getSubModulesList.asScala
+    subModules.foreach(module => {
+      val subModuleData = ModuleSerializer.load(DeserializeContext(module,
+        context.storages, context.storageType, _copyWeightAndBias))
+      klayer.labor = subModuleData.module
+    })
+  }
 
   override def doSerializeModule[T: ClassTag](context: SerializeContext[T],
                                               moduleBuilder : BigDLModule.Builder)
@@ -51,23 +66,69 @@ object KerasLayerSerializer extends ContainerSerializable with TKerasSerializerH
   }
 }
 
-private[bigdl] object KerasLayer {
-    def fuse[T: ClassTag](sLayer: AbstractModule[Activity, Activity, T],
-        activation: AbstractModule[Tensor[T], Tensor[T], T],
-        inputShape: Shape)
-        (implicit ev: TensorNumeric[T]): AbstractModule[Activity, Activity, T] = {
-      if (activation == null) {
-        return sLayer
-      }
-      val seq = KSequential[T]()
-      seq.add(InputLayer(inputShape = KerasLayer.removeBatch(inputShape)))
-      seq.add(sLayer)
-      seq.add(activation)
-      seq.setName(sLayer.getName())
-      seq
-    }
+/**
+ * Wrap a torch style layer to keras style layer.
+ * This layer can be built multiple times.
+ * We are supposing the inputshape and the outputshape keep the same in this layer.
+ * @param layer a torch style layer
+ * @return a keras compatible layer
+ */
+class KerasIdentityWrapper[T: ClassTag]
+(val layer: AbstractModule[Activity, Activity, T])(implicit ev: TensorNumeric[T])
+  extends KerasLayer[Activity, Activity, T](null) {
+  if (layer.isKerasStyle()) {
+    throw new RuntimeException(s"We only accept torch layer here, but got: $layer")
+  }
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    inputShape
+  }
+  override def doBuild(inputShape: Shape): AbstractModule[Activity, Activity, T] = layer
+}
 
-   def addBatch(shape: Shape): Shape = {
+/**
+ * Wrap a torch style layer to keras style layer.
+ * This layer can be built multiple times.
+ * @param torchLayer a torch style layer
+ *   i.e If the input data is (2, 3, 4) and 2 is the batch size, you should input: (3, 4) here.
+ * @return a keras compatible layer
+ */
+class KerasLayerWrapper[T: ClassTag]
+(val torchLayer: AbstractModule[Activity, Activity, T],
+    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
+  extends KerasLayer[Activity, Activity, T](KerasLayer.addBatch(inputShape)) {
+
+  require(!torchLayer.isKerasStyle(), s"We only accept torch layer here, but got: $torchLayer")
+
+  override def computeOutputShape(calcInputShape: Shape): Shape = {
+    val dummyOutTensor =
+      torchLayer.forward(Tensor[T](
+        (List(2) ++ KerasLayer.removeBatch(calcInputShape).toSingle()).toArray).rand())
+    val outSize = dummyOutTensor.toTensor.size()
+    KerasLayer.addBatch(Shape(outSize.slice(1, outSize.length)))
+  }
+
+  override def doBuild(inputShape: Shape): AbstractModule[Activity, Activity, T] = torchLayer
+}
+
+private[bigdl] object KerasLayer {
+  private[bigdl] def fuse[T: ClassTag](torchLayer: AbstractModule[Activity, Activity, T],
+        kerasActivation: KerasLayer[Tensor[T], Tensor[T], T],
+        batchInputShape: Shape)
+        (implicit ev: TensorNumeric[T]): AbstractModule[Activity, Activity, T] = {
+    if (kerasActivation == null) {
+      torchLayer
+    } else {
+      val wrapper = KSequential[T]()
+      wrapper.add(new KerasLayerWrapper[T](torchLayer,
+        KerasLayer.removeBatch(batchInputShape)))
+      wrapper.add(kerasActivation)
+      wrapper.setName(torchLayer.getName())
+      wrapper.build(batchInputShape)
+      wrapper
+    }
+  }
+
+  private[bigdl] def addBatch(shape: Shape): Shape = {
      // simply return null here as null is the default value
      if (shape == null) {
       return null
@@ -79,7 +140,7 @@ private[bigdl] object KerasLayer {
     }
   }
 
-  def removeBatch(shape: Shape): Shape = {
+  private[bigdl] def removeBatch(shape: Shape): Shape = {
     // simply return null here as null is the default value
     if (shape == null) {
       return null
@@ -87,7 +148,7 @@ private[bigdl] object KerasLayer {
     if (shape.isInstanceOf[SingleShape]) {
       Shape((shape.toSingle().slice(1, shape.toSingle().length)).toArray)
     } else {
-      Shape(shape.toMulti().map {addBatch(_)})
+      Shape(shape.toMulti().map {removeBatch(_)})
     }
   }
 }
@@ -102,7 +163,9 @@ private[bigdl] object KerasLayer {
  * @param batchInputShape the first dim is batch
  */
 abstract class KerasLayer[A <: Activity: ClassTag, B <: Activity: ClassTag, T: ClassTag]
-(batchInputShape: Shape = null)(implicit ev: TensorNumeric[T]) extends Container[A, B, T]{
+(batchInputShape: Shape = null)(implicit ev: TensorNumeric[T]) extends TContainer[A, B, T] {
+
+  inputShapeValue = batchInputShape
 
   def labor: AbstractModule[A, B, T] = {
     if (this.modules.isEmpty) {
@@ -118,22 +181,7 @@ abstract class KerasLayer[A <: Activity: ClassTag, B <: Activity: ClassTag, T: C
     modules.clear()
     modules.append(value)
   }
-  // scalastyle:on
-  override def inputShapeValue: Shape = labor.inputShapeValue
-
-  override def outputShapeValue: Array[Shape] = labor.outputShapeValue
-
-  // scalastyle:off
-  override def inputShapeValue_=(value: Shape): Unit = {
-    labor.inputShapeValue = value
-    this._inputShapeValue = value
-  }
-
-  override def outputShapeValue_=(value: Array[Shape]): Unit = {
-   labor.outputShapeValue = value
-   this._outputShapeValue = value
-  }
-  // scalastyle:on
+ // scalastyle:on
 
   override def updateOutput(input: A): B = {
     output = labor.updateOutput(input)
@@ -149,35 +197,39 @@ abstract class KerasLayer[A <: Activity: ClassTag, B <: Activity: ClassTag, T: C
     labor.accGradParameters(input, gradOutput)
   }
 
-  override def isCompatibleWithKeras(): Boolean = true
+  override def isBuilt(): Boolean = {
+    !this.modules.isEmpty && super.isBuilt()
+  }
 
-  override def isCompatibleWithTorch(): Boolean = false
+  override def isKerasStyle(): Boolean = true
 
-  override def getInputShape(): Shape = {
-    if (batchInputShape != null) {
-      batchInputShape
-    } else if (this.labor == null) {
-      null
-    } else {
-      this.labor.getInputShape()
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    labor.computeOutputShape(inputShape)
+  }
+
+  private[bigdl] def checkWithCurrentInputShape(calcInputShape: Shape): Unit = {
+    if (getInputShape() != null) {
+      val withoutBatchInputShape = KerasLayer.removeBatch(getInputShape())
+      val withoutBatchCalcInputShape = KerasLayer.removeBatch(calcInputShape)
+      require(withoutBatchInputShape == withoutBatchCalcInputShape,
+        s"InputShape from constructor ${withoutBatchInputShape}" +
+          s"should be the same with the calculated inputShape: ${withoutBatchCalcInputShape}")
     }
   }
 
-  override def computeOutputShape(inputShape: Shape): Shape = {
-    this.labor.computeOutputShape(inputShape)
+  override def build(calcInputShape: Shape): Shape = {
+    // Input would be reused multiple time in inputs for StaticGraph
+    if (isBuilt() && !this.allowRebuilt()) {
+      throw new RuntimeException(s"Should not build this module: $this multiple times")
+    }
+    labor = doBuild(calcInputShape)
+    checkWithCurrentInputShape(calcInputShape)
+    super.build(calcInputShape)
   }
 
-  override def getOutputShape(): Shape = labor.getOutputShape()
-
-  override def build(inputShape: Shape): Shape = {
-    this.labor = doBuild(inputShape)
-    val outputShape = computeOutputShape(inputShape)
-    this.outputShapeValue ++= Array(outputShape)
-    this.inputShapeValue = inputShape
-    isBuilt = true
-    outputShape // we cannot use getOutputShape here as it may containing multiple value
-  }
-
+  /**
+   * The value return by this method should be able to execute `forward` directly.
+   */
   def doBuild(inputShape: Shape): AbstractModule[A, B, T]
 
   /**
@@ -186,12 +238,13 @@ abstract class KerasLayer[A <: Activity: ClassTag, B <: Activity: ClassTag, T: C
    * @return node containing current module
    */
   override def inputs(nodes : ModuleNode[T]*): ModuleNode[T] = {
-    Util.excludeNotKeras(nodes.map(_.element))
-    if (!nodes.isEmpty) { // as there's  Identity().inputs() within Graph
+    validateInput(nodes.map(_.element))
+    if (!nodes.isEmpty) { // as there's Identity().inputs() within Graph
     val inputShape = Shape(nodes.map{_.element.getOutputShape()}.toList)
       this.build(inputShape)
     }
-    super.inputs(nodes: _*)
+
+    processInputs(nodes)
   }
 
   /**
@@ -200,12 +253,24 @@ abstract class KerasLayer[A <: Activity: ClassTag, B <: Activity: ClassTag, T: C
    * @return node containing current module
    */
   override def inputs(nodes : Array[ModuleNode[T]]): ModuleNode[T] = {
-    Util.excludeNotKeras(nodes.map(_.element))
-    if (!nodes.isEmpty) { // as there's  Identity().inputs() within Graph
+    validateInput(nodes.map(_.element))
+    if (!nodes.isEmpty) {
     val inputShape = Shape(nodes.map{_.element.getOutputShape()}.toList)
       this.build(inputShape)
     }
-    super.inputs(nodes)
+    processInputs(nodes)
+  }
+
+  private def getShapeByIndex(shape: Shape, index: Int): Shape = {
+    shape match {
+      case s: SingleShape =>
+        require(index == 1, s"Getting singleshape but with index: $index")
+        s
+      case m: MultiShape =>
+        val multiShape = m.toMulti()
+        require(index >= 1 && index <= multiShape.length)
+        multiShape(index - 1)
+    }
   }
 
   /**
@@ -216,14 +281,16 @@ abstract class KerasLayer[A <: Activity: ClassTag, B <: Activity: ClassTag, T: C
    */
   override def inputs(first: (ModuleNode[T], Int),
      nodesWithIndex : (ModuleNode[T], Int)*): ModuleNode[T] = {
-    Util.excludeNotKeras(List(first._1.element))
-    Util.excludeNotKeras(nodesWithIndex.map(_._1.element))
+    validateInput(List(first._1.element))
     val shapes = ArrayBuffer[Shape]()
-    shapes.append(first._1.element.getOutputShapeFor(first._2))
+    shapes += getShapeByIndex(first._1.element.getOutputShape(), first._2)
     if (!nodesWithIndex.isEmpty) {
-      shapes ++= nodesWithIndex.map{t => t._1.element.getOutputShapeFor(t._2)}
+      validateInput(nodesWithIndex.map(_._1.element))
+      shapes ++= nodesWithIndex.map{t =>
+        getShapeByIndex(first._1.element.getOutputShape(), first._2)
+      }
     }
     this.build(Shape(shapes.toList))
-    super.inputs(first, nodesWithIndex : _*)
+    processInputs(first, nodesWithIndex : _*)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasUtils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasUtils.scala
@@ -46,7 +46,19 @@ object KerasUtils {
     }
   }
 
-  private[bigdl] def getActivation[T : ClassTag] (activation: String)
+  private[bigdl] def getKerasActivation[T : ClassTag] (activation: String)
+    (implicit ev: TensorNumeric[T]): KerasLayer[Tensor[T], Tensor[T], T] = {
+    if (activation == null) { return null }
+    if (activation.toLowerCase() == "softmax") {
+      SoftMax[T]()
+    } else {
+      val torchActivation = getTorchActivation(activation)
+      new KerasIdentityWrapper[T](torchActivation)
+        .asInstanceOf[KerasLayer[Tensor[T], Tensor[T], T]]
+    }
+  }
+
+  private[keras] def getTorchActivation[T : ClassTag] (activation: String)
     (implicit ev: TensorNumeric[T]): AbstractModule[Tensor[T], Tensor[T], T] = {
     if (activation == null) null
     else {
@@ -54,7 +66,8 @@ object KerasUtils {
           case "tanh" => Tanh[T]()
           case "sigmoid" => Sigmoid[T]()
           case "relu" => ReLU[T]()
-          case "softmax" => SoftMax[T]().asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+          case "softmax" =>
+                com.intel.analytics.bigdl.nn.SoftMax[T]()
           case "softplus" => SoftPlus[T]()
           case "softsign" => SoftSign[T]()
           case "hard_sigmoid" => HardSigmoid[T]()
@@ -105,5 +118,4 @@ object KerasUtils {
       case "th" => "CHANNEL_FIRST"
     }
   }
-
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/LSTM.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/LSTM.scala
@@ -53,8 +53,8 @@ import scala.reflect.ClassTag
  */
 class LSTM[T: ClassTag](
    outputDim: Int,
-   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
-   val innerActivation: AbstractModule[Tensor[T], Tensor[T], T] = null,
+   val activation: KerasLayer[Tensor[T], Tensor[T], T] = null,
+   val innerActivation: KerasLayer[Tensor[T], Tensor[T], T] = null,
    returnSequences: Boolean = false,
    goBackwards: Boolean = false,
    var wRegularizer: Regularizer[T] = null,
@@ -67,8 +67,8 @@ class LSTM[T: ClassTag](
     com.intel.analytics.bigdl.nn.LSTM[T](
       inputSize = input(2),
       hiddenSize = outputDim,
-      activation = activation.asInstanceOf[TensorModule[T]],
-      innerActivation = innerActivation.asInstanceOf[TensorModule[T]],
+      activation = activation.doBuild(inputShape).asInstanceOf[TensorModule[T]],
+      innerActivation = innerActivation.doBuild(inputShape).asInstanceOf[TensorModule[T]],
       wRegularizer = wRegularizer,
       uRegularizer = uRegularizer,
       bRegularizer = bRegularizer)
@@ -86,8 +86,8 @@ object LSTM {
     uRegularizer: Regularizer[T] = null,
     bRegularizer: Regularizer[T] = null,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]) : LSTM[T] = {
-    new LSTM(outputDim, KerasUtils.getActivation(activation),
-      KerasUtils.getActivation(innerActivation), returnSequences,
+    new LSTM(outputDim, KerasUtils.getKerasActivation(activation),
+      KerasUtils.getKerasActivation(innerActivation), returnSequences,
       goBackwards, wRegularizer, uRegularizer, bRegularizer, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/LeakyReLU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/LeakyReLU.scala
@@ -38,7 +38,8 @@ import scala.reflect.ClassTag
 class LeakyReLU[T: ClassTag](
    private val alpha: Double = 0.01,
    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
-  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape))
+    with IdentityOutputShape {
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val layer = com.intel.analytics.bigdl.nn.LeakyReLU(

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/LocallyConnected1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/LocallyConnected1D.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.nn.keras
 
-import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, DataFormat}
 import com.intel.analytics.bigdl.nn.{Squeeze, Sequential => TSequential}
 import com.intel.analytics.bigdl.optim.Regularizer
 import com.intel.analytics.bigdl.tensor.Tensor
@@ -51,7 +51,7 @@ import scala.reflect.ClassTag
 class LocallyConnected1D[T: ClassTag](
    val nbFilter: Int,
    val filterLength: Int,
-   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
+   val activation: KerasLayer[Tensor[T], Tensor[T], T] = null,
    val subsampleLength: Int = 1,
    var wRegularizer: Regularizer[T] = null,
    var bRegularizer: Regularizer[T] = null,
@@ -88,7 +88,7 @@ class LocallyConnected1D[T: ClassTag](
     model.add(layer)
     model.add(Squeeze(3))
     if (activation != null) {
-      model.add(activation)
+      model.add(activation.doBuild(inputShape))
     }
     model.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
@@ -105,7 +105,7 @@ object LocallyConnected1D {
     bias: Boolean = true,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): LocallyConnected1D[T] = {
     new LocallyConnected1D[T](nbFilter, filterLength,
-      KerasUtils.getActivation(activation), subsampleLength,
+      KerasUtils.getKerasActivation(activation), subsampleLength,
       wRegularizer, bRegularizer, bias, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/LocallyConnected2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/LocallyConnected2D.scala
@@ -16,7 +16,8 @@
 
 package com.intel.analytics.bigdl.nn.keras
 
-import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat, TensorModule}
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
+import com.intel.analytics.bigdl.nn.{Container => TContainer, LocallyConnected2D => TLocallyConnected2D}
 import com.intel.analytics.bigdl.optim.Regularizer
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
@@ -55,7 +56,7 @@ class LocallyConnected2D[T: ClassTag](
    val nbFilter: Int,
    val nbRow: Int,
    val nbCol: Int,
-   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
+   val activation: KerasLayer[Tensor[T], Tensor[T], T] = null,
    val borderMode: String = "valid",
    val subsample: Array[Int] = Array(1, 1),
    val dimOrdering: DataFormat = DataFormat.NCHW,
@@ -109,7 +110,7 @@ object LocallyConnected2D {
     bias: Boolean = true,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): LocallyConnected2D[T] = {
     new LocallyConnected2D[T](nbFilter, nbRow, nbCol,
-      KerasUtils.getActivation(activation), borderMode, Array(subsample._1, subsample._2),
+      KerasUtils.getKerasActivation(activation), borderMode, Array(subsample._1, subsample._2),
       KerasUtils.toBigDLFormat(dimOrdering), wRegularizer, bRegularizer, bias, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Masking.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Masking.scala
@@ -39,7 +39,8 @@ import scala.reflect.ClassTag
 class Masking[T: ClassTag](
    val maskValue: Double = 0.0,
    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
-  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape))
+    with IdentityOutputShape {
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val layer = com.intel.analytics.bigdl.nn.Masking(maskValue = maskValue)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Merge.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Merge.scala
@@ -156,7 +156,11 @@ object Merge {
     val batchInputShape = KerasLayer.addBatch(inputShape)
     val actualInputShape =
       MultiShape(layers.map { layer =>
-      layer.build(layer.getInputShape())
+      if (layer.isBuilt()) {  // it's possible while reloaded from file
+        layer.getOutputShape()
+      } else {
+        layer.build(layer.getInputShape())
+      }
     }.toList)
     if (batchInputShape != null) {
       require(batchInputShape.isInstanceOf[MultiShape],

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SReLU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SReLU.scala
@@ -62,7 +62,8 @@ class SReLU[T: ClassTag](
    val aRightInit: InitializationMethod = Ones,
    val sharedAxes: Array[Int] = null,
    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
-  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape))
+    with IdentityOutputShape {
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val shape = inputShape.toSingle().toArray

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SeparableConvolution2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SeparableConvolution2D.scala
@@ -68,7 +68,7 @@ class SeparableConvolution2D[T: ClassTag](
    val nbRow: Int,
    val nbCol: Int,
    val init: InitializationMethod = Xavier,
-   val activation: AbstractModule[Tensor[T], Tensor[T], T] = null,
+   val activation: KerasLayer[Tensor[T], Tensor[T], T] = null,
    val borderMode: String = "valid",
    val subsample: Array[Int] = Array(1, 1),
    val depthMultiplier: Int = 1,
@@ -126,7 +126,7 @@ object SeparableConvolution2D {
     bias: Boolean = true,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]) : SeparableConvolution2D[T] = {
     new SeparableConvolution2D[T](nbFilter, nbRow, nbCol,
-      KerasUtils.getInitMethod(init), KerasUtils.getActivation(activation),
+      KerasUtils.getInitMethod(init), KerasUtils.getKerasActivation(activation),
       borderMode, Array(subsample._1, subsample._2), depthMultiplier,
       KerasUtils.toBigDLFormat(dimOrdering), depthwiseRegularizer,
       pointwiseRegularizer, bRegularizer, bias, inputShape)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SimpleRNN.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SimpleRNN.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.nn.keras
 
-import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, TensorModule}
+import com.intel.analytics.bigdl.nn.abstractnn.TensorModule
 import com.intel.analytics.bigdl.nn.{Cell, RnnCell}
 import com.intel.analytics.bigdl.optim.Regularizer
 import com.intel.analytics.bigdl.tensor.Tensor
@@ -49,7 +49,7 @@ import scala.reflect.ClassTag
  */
 class SimpleRNN[T: ClassTag](
    outputDim: Int,
-   val activation: AbstractModule[Tensor[T], Tensor[T], T],
+   val activation: KerasLayer[Tensor[T], Tensor[T], T],
    returnSequences: Boolean = false,
    goBackwards: Boolean = false,
    var wRegularizer: Regularizer[T] = null,
@@ -62,7 +62,7 @@ class SimpleRNN[T: ClassTag](
     RnnCell(
       inputSize = input(2),
       hiddenSize = outputDim,
-      activation = activation.asInstanceOf[TensorModule[T]],
+      activation = activation.doBuild(inputShape).asInstanceOf[TensorModule[T]],
       isInputWithBias = false,
       wRegularizer = wRegularizer,
       uRegularizer = uRegularizer,
@@ -80,7 +80,7 @@ object SimpleRNN {
     uRegularizer: Regularizer[T] = null,
     bRegularizer: Regularizer[T] = null,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]) : SimpleRNN[T] = {
-    new SimpleRNN[T](outputDim, KerasUtils.getActivation(activation),
+    new SimpleRNN[T](outputDim, KerasUtils.getKerasActivation(activation),
       returnSequences, goBackwards, wRegularizer,
       uRegularizer, bRegularizer, inputShape)
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SpatialDropout1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SpatialDropout1D.scala
@@ -43,7 +43,8 @@ import scala.reflect.ClassTag
 class SpatialDropout1D[T: ClassTag](
    val p: Double = 0.5,
    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
-  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape))
+    with IdentityOutputShape {
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val layer = com.intel.analytics.bigdl.nn.SpatialDropout1D(initP = p)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SpatialDropout2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SpatialDropout2D.scala
@@ -46,7 +46,8 @@ class SpatialDropout2D[T: ClassTag](
    val p: Double = 0.5,
    val dimOrdering: DataFormat = DataFormat.NCHW,
    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
-  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape))
+    with IdentityOutputShape {
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val layer = com.intel.analytics.bigdl.nn.SpatialDropout2D(

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SpatialDropout3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SpatialDropout3D.scala
@@ -46,7 +46,8 @@ class SpatialDropout3D[T: ClassTag](
    val p: Double = 0.5,
    val dimOrdering: String = "CHANNEL_FIRST",
    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
-  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape))
+    with IdentityOutputShape {
 
   require(dimOrdering.toLowerCase() == "channel_first" ||
           dimOrdering.toLowerCase() == "channel_last",

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/ThresholdedReLU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/ThresholdedReLU.scala
@@ -39,7 +39,8 @@ import scala.reflect.ClassTag
 class ThresholdedReLU[T: ClassTag](
    val theta: Double = 1.0,
    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
-  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
+  extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape))
+    with IdentityOutputShape {
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val layer = Threshold(

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/TimeDistributed.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/TimeDistributed.scala
@@ -51,7 +51,7 @@ class TimeDistributed[T: ClassTag](
     require(input.length >=3,
       s"TimeDistributed requires at least 3D input, but got input dim ${input.length}")
     val innerInput = getInnerInput(input)
-    val innerOutput = layer.build(Shape(innerInput)).toSingle()
+    val innerOutput = layer.computeOutputShape(Shape(innerInput)).toSingle()
     val output = innerOutput.take(1) ++ List(input(1)) ++ innerOutput.drop(1)
     Shape(output.toArray)
   }
@@ -59,9 +59,9 @@ class TimeDistributed[T: ClassTag](
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val input = inputShape.toSingle().toArray
     val innerInput = getInnerInput(input)
-    val klayer = layer.doBuild(Shape(innerInput))
-      .asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
-    val timedistributed = com.intel.analytics.bigdl.nn.TimeDistributed(klayer)
+    layer.build(Shape(innerInput))
+    layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+    val timedistributed = com.intel.analytics.bigdl.nn.TimeDistributed(layer)
     timedistributed.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Topology.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Topology.scala
@@ -18,37 +18,55 @@ package com.intel.analytics.bigdl.nn.keras
 
 import com.intel.analytics.bigdl.nn.Graph._
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
-import com.intel.analytics.bigdl.nn.{Graph, GraphSerializable, StaticGraph, Sequential => TSequential}
+import com.intel.analytics.bigdl.nn.{Container, Identity, StaticGraph, Sequential => TSequential}
 import com.intel.analytics.bigdl.serialization.Bigdl.BigDLModule
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
 import com.intel.analytics.bigdl.utils.serializer._
-import com.intel.analytics.bigdl.utils.{Shape, Util}
 
+import scala.collection.JavaConverters._
+import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
+
+abstract class KerasModel[T: ClassTag](implicit ev: TensorNumeric[T])
+  extends KerasLayer[Activity, Activity, T] {
+  // TODO: enrich fit, compile, evaluate etc here.
+
+  def getSubModules(): List[AbstractModule[Activity, Activity, T]] = {
+    require(this.labor.isInstanceOf[Container[Activity, Activity, T]],
+      "labor should be a container, but we got: $this")
+    this.labor.asInstanceOf[Container[Activity, Activity, T]].modules.toList
+  }
+}
 
 class Model[T: ClassTag](private val _inputs : Seq[ModuleNode[T]],
       private val _outputs : Seq[ModuleNode[T]])(implicit ev: TensorNumeric[T])
-  extends StaticGraph[T](_inputs, _outputs, None, false) {
+  extends KerasModel[T] {
+  this.labor = doBuild(null)
 
-  Util.excludeNotKeras(inputs.map(_.element))
-  Util.excludeNotKeras(outputs.map(_.element))
+  excludeInvalidLayers(this.labor.asInstanceOf[StaticGraph[T]].
+    getForwardExecutions().map {_.element})
 
-  this.inputShapeValue = Shape(inputs.map{n => n.element.getInputShape()}.toList)
+  this.inputShapeValue = Shape(_inputs.map{n => n.element.getInputShape()}.toList)
 
-  this.outputShapeValue = Array(outputs.map{_.element.getOutputShape()}: _*)
+  this.outputShapeValue = Shape(_outputs.map{_.element.getOutputShape()}.toList)
 
-  isBuilt = true
-
-  override private[bigdl] def isCompatibleWithKeras(): Boolean = true
-
-  override private[bigdl] def isCompatibleWithTorch(): Boolean = false
+  override def isKerasStyle(): Boolean = true
 
   override def computeOutputShape(inputShape: Shape): Shape = {
     getOutputShape()
   }
+
+  override def doBuild(inputShape: Shape): StaticGraph[T] =
+    new StaticGraph[T](_inputs, _outputs, None, false)
+
+  override def build(calcInputShape: Shape): Shape = {
+    checkWithCurrentInputShape(calcInputShape)
+    getOutputShape()
+  }
 }
 
-object Model extends ModelSerializer{
+object Model extends KerasLayerSerializable{
   /**
    * Build multiple inputs, multiple outputs graph container.
    * @param input input node
@@ -57,7 +75,7 @@ object Model extends ModelSerializer{
    */
   def apply[T: ClassTag](
       input : Array[ModuleNode[T]],
-      output : Array[ModuleNode[T]])(implicit ev: TensorNumeric[T]) : Graph[T] = {
+      output : Array[ModuleNode[T]])(implicit ev: TensorNumeric[T]) : Model[T] = {
     new Model[T](input, output)
   }
 
@@ -68,7 +86,7 @@ object Model extends ModelSerializer{
    * @return a graph container
    */
   def apply[T: ClassTag](input : ModuleNode[T], output : Array[ModuleNode[T]])
-                        (implicit ev: TensorNumeric[T]) : Graph[T] = {
+                        (implicit ev: TensorNumeric[T]) : Model[T] = {
     new Model[T](Seq(input), output)
   }
 
@@ -79,7 +97,7 @@ object Model extends ModelSerializer{
    * @return a graph container
    */
   def apply[T: ClassTag](input : Array[ModuleNode[T]], output : ModuleNode[T])
-                        (implicit ev: TensorNumeric[T]) : Graph[T] = {
+                        (implicit ev: TensorNumeric[T]) : Model[T] = {
     new Model[T](input, Seq(output))
   }
   /**
@@ -89,63 +107,56 @@ object Model extends ModelSerializer{
    * @return a graph container
    */
   def apply[T: ClassTag](input : ModuleNode[T], output : ModuleNode[T])
-                        (implicit ev: TensorNumeric[T]) : Graph[T] = {
+                        (implicit ev: TensorNumeric[T]) : Model[T] = {
     new Model[T](Seq(input), Seq(output))
   }
-}
-
-trait ModelSerializer extends GraphSerializable with TKerasSerializerHelper{
 
   override def doSerializeModule[T: ClassTag](context: SerializeContext[T],
-                                              moduleBuilder : BigDLModule.Builder)
-                                             (implicit ev: TensorNumeric[T]) : Unit = {
-    super.doSerializeModule(context, moduleBuilder)
-    appendKerasLabel(context, moduleBuilder)
+      builder: BigDLModule.Builder)
+    (implicit ev: TensorNumeric[T]): Unit = {
+    val labor = context.moduleData.module.
+      asInstanceOf[KerasLayer[Activity, Activity, T]].labor
+    val subModule = ModuleSerializer.serialize(SerializeContext(ModuleData(labor,
+      new ArrayBuffer[String](), new ArrayBuffer[String]()), context.storages,
+      context.storageType, _copyWeightAndBias))
+    builder.addSubModules(subModule.bigDLModule)
   }
 
   override def doLoadModule[T: ClassTag](context: DeserializeContext)
-    (implicit ev: TensorNumeric[T]) : AbstractModule[Activity, Activity, T] = {
-    val (module, inputs, outputs, generateBackwardValue, sharedVariables) =
-      prepareLoadModule(context)
-    require(generateBackwardValue == null, "there's no generateBackward for keras module")
-    require(module.containsAttr("is_keras_module")
-      && module.getAttrOrThrow("is_keras_module").getBoolValue(), "It should be a keras module")
-    Model(inputs.toArray, outputs.toArray)
+    (implicit ev: TensorNumeric[T]): AbstractModule[Activity, Activity, T] = {
+    val subProtoModules = context.bigdlModule.getSubModulesList.asScala
+    val subModules = subProtoModules.map(module => {
+      val subModuleData = ModuleSerializer.load(DeserializeContext(module,
+        context.storages, context.storageType, _copyWeightAndBias))
+      subModuleData.module
+    })
+    val tGraph = subModules(0).asInstanceOf[StaticGraph[T]]
+    Model(tGraph.inputs.toArray, tGraph.outputs.toArray)
   }
+
 }
 
-class Sequential[T: ClassTag](val stopInferShape: Boolean = false)
-(implicit ev: TensorNumeric[T]) extends TSequential[T] {
-
-  override private[bigdl] def isCompatibleWithKeras(): Boolean = true
-
-  override private[bigdl] def isCompatibleWithTorch(): Boolean = false
+class Sequential[T: ClassTag]()
+(implicit ev: TensorNumeric[T]) extends KerasModel[T] {
 
   private[bigdl] var frozen: Boolean = false
 
-  override def computeOutputShape(inputShape: Shape): Shape = {
-     getOutputShape()
-  }
-
-  override def getOutputShape(): Shape = {
-    require(outputShapeValue.length > 0, "Sequence should not be empty")
-    outputShapeValue(outputShapeValue.length -1) // For Seq, we only respect the last item as output
-  }
+  this.labor = doBuild(null)
 
   private def triggerBuilding(module: AbstractModule[_ <: Activity, _ <: Activity, T]): Unit = {
-    if (this.modules.isEmpty) {
+    if (this.getOutputShape() == null) {
       if (module.getInputShape() == null) {
         throw new RuntimeException("The first layer should explicitly declare inputshape")
       } else {
         val outputShape = module.build(module.getInputShape())
+        // The inputShape of Sequential should only be init here.
         this.inputShapeValue = module.getInputShape()
-        this.outputShapeValue = Array(outputShape)
+        this.outputShapeValue = outputShape
       }
     } else {
       val outputShape = module.build(this.getOutputShape())
-      this.outputShapeValue = Array(outputShape)
+      this.outputShapeValue = outputShape
     }
-    isBuilt = true
   }
 
   /**
@@ -154,7 +165,7 @@ class Sequential[T: ClassTag](val stopInferShape: Boolean = false)
    * @param module module to be add
    * @return this container
    */
-  override def add(module: AbstractModule[_ <: Activity, _ <: Activity, T]): this.type = {
+  def add(module: AbstractModule[_ <: Activity, _ <: Activity, T]): this.type = {
     if (frozen) {
       throw new RuntimeException(
         "This Sequential has been frozen, as it has been added into other container")
@@ -162,25 +173,34 @@ class Sequential[T: ClassTag](val stopInferShape: Boolean = false)
     if (module.isInstanceOf[Sequential[T]]) {
       module.asInstanceOf[Sequential[T]].frozen = true
     }
-    Util.excludeNotKeras[T](Seq(module))
-    if (!stopInferShape) {
-      triggerBuilding(module)
-    }
-    modules += module.asInstanceOf[AbstractModule[Activity, Activity, T]]
+    validateInput[T](Seq(module))
+
+    triggerBuilding(module)
+
+    labor.asInstanceOf[TSequential[T]].modules +=
+      module.asInstanceOf[AbstractModule[Activity, Activity, T]]
     this
+  }
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    if (labor.asInstanceOf[TSequential[T]].modules.isEmpty) {
+      inputShape
+    } else {
+      labor.asInstanceOf[TSequential[T]].modules.last.getOutputShape()
+    }
+  }
+
+  override def doBuild(inputShape: Shape): TSequential[T] = TSequential[T]()
+
+  override def build(calcInputShape: Shape): Shape = {
+    checkWithCurrentInputShape(calcInputShape)
+    getOutputShape()
   }
 }
 
-object Sequential extends ContainerSerializable with TKerasSerializerHelper{
+object Sequential extends KerasLayerSerializable{
   def apply[@specialized(Float, Double) T: ClassTag]()
      (implicit ev: TensorNumeric[T]) : Sequential[T] = {
     new Sequential[T]()
-  }
-
-  override def doSerializeModule[T: ClassTag](context: SerializeContext[T],
-                                              moduleBuilder : BigDLModule.Builder)
-                                             (implicit ev: TensorNumeric[T]) : Unit = {
-    super.doSerializeModule(context, moduleBuilder)
-    appendKerasLabel(context, moduleBuilder)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -258,13 +258,8 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
     optimizer
   }
 
-  def createSequential(isKeras: Boolean = false): Sequential[T] = {
-    if (isKeras) {
-      nn.keras.Sequential[T]()
-    }
-    else {
+  def createSequential(): Container[Activity, Activity, T] = {
       Sequential[T]()
-    }
   }
 
   def createLinear(inputSize: Int, outputSize: Int,
@@ -2316,14 +2311,8 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   }
 
   def createModel(input: JList[ModuleNode[T]],
-                  output: JList[ModuleNode[T]],
-                  isKeras: Boolean = false): Graph[T] = {
-    if (isKeras) {
-      nn.keras.Model(input.asScala.toArray, output.asScala.toArray)
-    }
-    else {
-      Graph(input.asScala.toArray, output.asScala.toArray)
-    }
+                  output: JList[ModuleNode[T]]): Graph[T] = {
+    Graph(input.asScala.toArray, output.asScala.toArray)
   }
 
   def createNode(module: AbstractModule[Activity, Activity, T],

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLKeras.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLKeras.scala
@@ -18,8 +18,9 @@ package com.intel.analytics.bigdl.python.api
 
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, Map => JMap}
 
+import com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.nn.Graph.ModuleNode
-import com.intel.analytics.bigdl.nn.{Container, SpatialBatchNormalization}
+import com.intel.analytics.bigdl.nn.{Container, Graph, SpatialBatchNormalization}
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.nn.keras._
 import com.intel.analytics.bigdl.numeric._
@@ -66,6 +67,15 @@ class PythonBigDLKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pytho
     }
   }
 
+  def createKerasModel(input: JList[ModuleNode[T]],
+      output: JList[ModuleNode[T]]): Model[T] = {
+      nn.keras.Model(input.asScala.toArray, output.asScala.toArray)
+  }
+
+  def createKerasSequential(): nn.keras.Sequential[T] = {
+      nn.keras.Sequential[T]()
+  }
+
   def createKerasInput(
     name : String = null,
     inputShape: JList[Int] = null): ModuleNode[T] = {
@@ -73,7 +83,7 @@ class PythonBigDLKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pytho
   }
 
   def createKerasInputLayer(
-    inputShape: JList[Int] = null): Input[T] = {
+    inputShape: JList[Int] = null): KerasLayer[Activity, Activity, T] = {
     InputLayer(inputShape = toScalaShape(inputShape))
   }
 
@@ -172,7 +182,7 @@ class PythonBigDLKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pytho
     bias: Boolean = true,
     inputShape: JList[Int] = null): Convolution2D[T] = {
     new Convolution2D(nbFilter, nbRow, nbCol, KerasUtils.getInitMethod(init),
-      KerasUtils.getActivation(activation), borderMode,
+      KerasUtils.getKerasActivation(activation), borderMode,
       toScalaArray(subsample), KerasUtils.toBigDLFormat(dimOrdering),
       wRegularizer, bRegularizer, bias, toScalaShape(inputShape))
   }
@@ -337,7 +347,7 @@ class PythonBigDLKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pytho
     bias: Boolean = true,
     inputShape: JList[Int] = null): Convolution3D[T] = {
     new Convolution3D(nbFilter, kernelDim1, kernelDim2, kernelDim3,
-      KerasUtils.getInitMethod(init), KerasUtils.getActivation(activation),
+      KerasUtils.getInitMethod(init), KerasUtils.getKerasActivation(activation),
       borderMode, toScalaArray(subsample), KerasUtils.toBigDLFormat5D(dimOrdering),
       wRegularizer, bRegularizer, bias, toScalaShape(inputShape))
   }
@@ -462,7 +472,7 @@ class PythonBigDLKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pytho
     bRegularizer: Regularizer[T] = null,
     inputShape: JList[Int] = null): AtrousConvolution2D[T] = {
     new AtrousConvolution2D(nbFilter, nbRow, nbCol, KerasUtils.getInitMethod(init),
-      KerasUtils.getActivation(activation), toScalaArray(subsample),
+      KerasUtils.getKerasActivation(activation), toScalaArray(subsample),
       toScalaArray(atrousRate), KerasUtils.toBigDLFormat(dimOrdering),
       wRegularizer, bRegularizer, toScalaShape(inputShape))
   }
@@ -480,7 +490,7 @@ class PythonBigDLKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pytho
     bias: Boolean = true,
     inputShape: JList[Int] = null): Deconvolution2D[T] = {
     new Deconvolution2D(nbFilter, nbRow, nbCol, KerasUtils.getInitMethod(init),
-      KerasUtils.getActivation(activation), toScalaArray(subsample),
+      KerasUtils.getKerasActivation(activation), toScalaArray(subsample),
       KerasUtils.toBigDLFormat(dimOrdering), wRegularizer, bRegularizer,
       bias, toScalaShape(inputShape))
   }
@@ -528,7 +538,7 @@ class PythonBigDLKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pytho
     bRegularizer: Regularizer[T] = null,
     bias: Boolean = true,
     inputShape: JList[Int] = null): LocallyConnected2D[T] = {
-    new LocallyConnected2D(nbFilter, nbRow, nbCol, KerasUtils.getActivation(activation),
+    new LocallyConnected2D(nbFilter, nbRow, nbCol, KerasUtils.getKerasActivation(activation),
       borderMode, toScalaArray(subsample), KerasUtils.toBigDLFormat(dimOrdering),
       wRegularizer, bRegularizer, bias, toScalaShape(inputShape))
   }
@@ -549,7 +559,7 @@ class PythonBigDLKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pytho
     bias: Boolean = true,
     inputShape: JList[Int] = null): SeparableConvolution2D[T] = {
     new SeparableConvolution2D(nbFilter, nbRow, nbCol, KerasUtils.getInitMethod(init),
-      KerasUtils.getActivation(activation), borderMode, toScalaArray(subsample),
+      KerasUtils.getKerasActivation(activation), borderMode, toScalaArray(subsample),
       depthMultiplier, KerasUtils.toBigDLFormat(dimOrdering),
       depthwiseRegularizer, pointwiseRegularizer, bRegularizer, bias, toScalaShape(inputShape))
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Util.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Util.scala
@@ -17,7 +17,6 @@
 package com.intel.analytics.bigdl.utils
 
 import com.intel.analytics.bigdl._
-import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.tensor.{QuantizedTensor, QuantizedType, Storage, Tensor}
 
@@ -174,22 +173,6 @@ object Util {
         }
       }
       i += 1
-    }
-  }
-
-  private[bigdl] def excludeNotTorch[T: ClassTag]
-  (modules : Seq[AbstractModule[_, _, T]]): Unit = {
-    val invalidNodes = modules.filter{!_.isCompatibleWithTorch()}
-    if (invalidNodes.length > 0) {
-      throw new RuntimeException(s"Do not mix with Layer: ${invalidNodes.mkString(",")}")
-    }
-  }
-
-  private[bigdl] def excludeNotKeras[T: ClassTag]
-  (modules : Seq[AbstractModule[_, _, T]]): Unit = {
-    val invalidNodes = modules.filter{!_.isCompatibleWithKeras()}
-    if (invalidNodes.length > 0) {
-      throw new RuntimeException(s"Do not mix with Layer: ${invalidNodes.mkString(",")}")
     }
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/serializer/ModuleSerializer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/serializer/ModuleSerializer.scala
@@ -185,6 +185,7 @@ object ModuleSerializer extends ModuleSerializable{
     registerModule("com.intel.analytics.bigdl.nn.DynamicGraph", Graph)
     registerModule("com.intel.analytics.bigdl.nn.keras.Model", Model)
     registerModule("com.intel.analytics.bigdl.nn.keras.Sequential", KSequential)
+    registerModule("com.intel.analytics.bigdl.nn.keras.KerasLayerWrapper", KerasLayerSerializer)
     registerModule("com.intel.analytics.bigdl.nn.MapTable", MapTable)
     registerModule("com.intel.analytics.bigdl.nn.Maxout", Maxout)
     registerModule("com.intel.analytics.bigdl.nn.MaskedSelect", MaskedSelect)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Deconvolution2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Deconvolution2DSpec.scala
@@ -73,8 +73,8 @@ class Deconvolution2DSpec extends KerasBaseSpec {
 class Deconvolution2DSerialTest extends ModuleSerializationTest {
   override def test(): Unit = {
     val layer = Deconvolution2D[Float](3, 3, 3, inputShape = Shape(3, 24, 24))
-    layer.build(Shape(2, 12, 24, 24))
-    val input = Tensor[Float](2, 12, 24, 24).apply1(_ => Random.nextFloat())
+    layer.build(Shape(2, 3, 24, 24))
+    val input = Tensor[Float](2, 3, 24, 24).apply1(_ => Random.nextFloat())
     runSerializationTest(layer, input)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/HighwaySpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/HighwaySpec.scala
@@ -45,11 +45,11 @@ class HighwaySpec extends KerasBaseSpec {
       """
         |input_tensor = Input(shape=[10])
         |input = np.random.random([4, 10])
-        |output_tensor = Highway()(input_tensor)
+        |output_tensor = Highway(activation="relu")(input_tensor)
         |model = Model(input=input_tensor, output=output_tensor)
       """.stripMargin
     val seq = KSequential[Float]()
-    val layer = Highway[Float](inputShape = Shape(10))
+    val layer = Highway[Float](inputShape = Shape(10), activation = "relu")
     seq.add(layer)
     seq.getOutputShape().toSingle().toArray should be (Array(-1, 10))
     checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/InputSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/InputSpec.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.keras.nn
 
-import com.intel.analytics.bigdl.nn.keras.InputLayer
+import com.intel.analytics.bigdl.nn.keras.{InputLayer, Sequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
 import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
@@ -26,7 +26,9 @@ import scala.util.Random
 class InputSerialTest extends ModuleSerializationTest {
   override def test(): Unit = {
     val input = InputLayer[Float](inputShape = Shape(20))
+    val seq = Sequential[Float]()
+    seq.add(input)
     val inputData = Tensor[Float](2, 20).apply1(_ => Random.nextFloat())
-    runSerializationTest(input, inputData)
+    runSerializationTest(seq, inputData)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/KerasLayerWrapperSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/KerasLayerWrapperSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.keras.KerasBaseSpec
+import com.intel.analytics.bigdl.nn.Linear
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.nn.keras.{Dense, KerasLayerWrapper, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
+
+class KerasLayerWrapperSpec extends KerasBaseSpec {
+
+  def weightConverter(in: Array[Tensor[Float]]): Array[Tensor[Float]] = Array(in(0).t(), in(1))
+
+  "KerasLayerWrapper" should "be test" in {
+    val kerasCode =
+      """
+        |input_tensor = Input(shape=[3])
+        |input = np.random.uniform(0, 1, [1, 3])
+        |output_tensor = Dense(2)(input_tensor)
+        |model = Model(input=input_tensor, output=output_tensor)
+      """.stripMargin
+    val seq = KSequential[Float]()
+    val dense = new KerasLayerWrapper[Float](Linear[Float](3, 2), inputShape = Shape(3))
+    seq.add(dense)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 2))
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode, weightConverter)
+  }
+
+  "Compute outputshape of KerasLayerWrapper " should "be test" in {
+    val seq = KSequential[Float]()
+    val dense = new KerasLayerWrapper[Float](Linear[Float](3, 2), inputShape = Shape(3))
+    seq.add(dense)
+    seq.add(Dense(10))
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 10))
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/KerasStyleSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/KerasStyleSpec.scala
@@ -17,11 +17,12 @@
 package com.intel.analytics.bigdl.keras.nn
 
 import com.intel.analytics.bigdl.example.loadmodel.AlexNet_OWT
-import com.intel.analytics.bigdl.nn.keras.{Dense, Input, Model, Sequential => KSequential}
-import com.intel.analytics.bigdl.nn.{Sequential => TSequential, _}
+import com.intel.analytics.bigdl.nn.abstractnn.InvalidLayer
+import com.intel.analytics.bigdl.nn.keras.{Activation, Dense, Input, InputLayer, KerasIdentityWrapper, KerasLayerWrapper, Model, Sequential => KSequential}
+import com.intel.analytics.bigdl.nn.{Input => TInput, Sequential => TSequential, _}
 import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, Shape}
+import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, Shape, T, TestUtils}
 
 
 class KerasStyleSpec extends BigDLSpecHelper {
@@ -60,26 +61,54 @@ class KerasStyleSpec extends BigDLSpecHelper {
     }
   }
 
-  "Sequential: shared relu" should "work correctly" in {
-    val sharedRelu = ReLU[Float]()
-    val seq1 = KSequential[Float]()
-    seq1.add(Dense[Float](20, inputShape = Shape(10)))
-    seq1.add(sharedRelu)
-    require(seq1.getOutputShape().toSingle().sameElements(Array(-1, 20)))
+  "Sequential: shared relu" should "not work correctly" in {
+    val thrown = intercept[Exception] {
+      val sharedRelu = new KerasIdentityWrapper(ReLU[Float]())
+      val seq1 = KSequential[Float]()
+      seq1.add(Dense[Float](20, inputShape = Shape(10)))
+      seq1.add(sharedRelu)
+      assert(seq1.getOutputShape().toSingle().sameElements(Array(-1, 20)))
 
-    val seq2 = KSequential[Float]()
-    seq2.add(Dense[Float](5, inputShape = Shape(20)))
-    seq2.add(sharedRelu)
-    require(seq2.getOutputShape().toSingle().sameElements(Array(-1, 5)))
+      val seq2 = KSequential[Float]()
+      seq2.add(Dense[Float](5, inputShape = Shape(20)))
+      seq2.add(sharedRelu)
+      assert(seq2.getOutputShape().toSingle().sameElements(Array(-1, 5)))
 
-    val seq = KSequential[Float]()
-    seq.add(seq1)
-    seq.add(seq2)
+      val seq = KSequential[Float]()
+      seq.add(seq1)
+      seq.add(seq2)
 
-    val inputData = Tensor[Float](Array(20, 10)).rand()
-    val output = seq.forward(inputData)
-    require(seq.getInputShape().toSingle().sameElements(Array(-1, 10)))
-    require(seq.getOutputShape().toSingle().sameElements(Array(-1, 5)))
+      val inputData = Tensor[Float](Array(20, 10)).rand()
+      val output = seq.forward(inputData)
+      assert(seq.getInputShape().toSingle().sameElements(Array(-1, 10)))
+      assert(seq.getOutputShape().toSingle().sameElements(Array(-1, 5)))
+    }
+    assert(thrown.getMessage().contains("Reuse module as dest is not allowed"))
+  }
+
+  "Graph: shared relu" should "not work correctly" in {
+    val thrown = intercept[Exception] {
+      val input = Input(inputShape = Shape(10, 20))
+      val sharedRelu = new Activation("relu")
+      val out1 = sharedRelu.inputs(input)
+
+      val seq = KSequential[Float]()
+      seq.add(InputLayer(inputShape = Shape(10, 20)))
+      seq.add(sharedRelu)
+      val out2 = seq.inputs(out1)
+      val model = Model(input, out2)
+    }
+    assert(thrown.getMessage().contains("Reuse module as dest is not allowed"))
+  }
+
+  "Graph: shared relu as dest" should "not work correctly" in {
+    val thrown = intercept[Exception] {
+      val input = Input(inputShape = Shape(10, 20))
+      val sharedRelu = new Activation("relu")
+      val out1 = sharedRelu.inputs(input)
+      val out2 = sharedRelu.inputs(Input(inputShape = Shape(10, 20)))
+    }
+    assert(thrown.getMessage().contains("Reuse module as dest is not allowed"))
   }
 
   "TSequential" should "work with alex" in {
@@ -88,23 +117,61 @@ class KerasStyleSpec extends BigDLSpecHelper {
   }
 
   "TSequential" should "not work with dense" in {
-    intercept[RuntimeException] {
+    intercept[InvalidLayer] {
       val seq = TSequential[Float]()
       val d1 = Dense[Float](20, inputShape = Shape(10)).setName("dense1")
       seq.add(d1)
     }
   }
 
-  "TGraph" should "not work with dense" in {
+  "Incompatible inputShape" should "not work" in {
     intercept[RuntimeException] {
-      val d1 = Dense[Float](20, inputShape = Shape(10)).setName("dense1").inputs(Input())
+      val seq = KSequential[Float]()
+      val d1 = Dense[Float](20, inputShape = Shape(10)).setName("dense1")
+      seq.add(InputLayer(inputShape = Shape(5)))
+      seq.add(d1)
+    }
+  }
+
+  "TGraph" should "not work with dense" in {
+    intercept[InvalidLayer] {
+      val d1 = Dense[Float](20).setName("dense1").inputs(Input(inputShape = Shape(10)))
       val l1 = Linear(2, 3).inputs(d1)
+    }
+  }
+
+  "KGraph" should "not work with shared layers" in {
+    val thrown = intercept[RuntimeException] {
+      val input = Input(inputShape = Shape(10))
+      val dense1 = Dense(10, inputShape = Shape(10))
+      val node1 = dense1.inputs(input)
+      val seq = KSequential[Float]().add(dense1).inputs(node1)
+      Model(input, seq)
+    }
+    assert(thrown.getMessage().contains("Reuse module as dest is not allowed"))
+  }
+
+  "Torch style linear and seq and linear" should "not work with keras Model" in {
+    intercept[InvalidLayer] {
+      val input = Input(inputShape = Shape(10))
+      val l1 = Linear(10, 3).inputs(input)
+      val seq = TSequential[Float]().inputs(l1)
+      val l2 = Linear(3, 4).inputs(seq)
+      Model(input, l2)
+    }
+  }
+
+  "Torch style inputs in Model constructor" should "not work" in {
+    intercept[InvalidLayer] {
+      val tinput = TInput()
+      val l1 = Linear(10, 3).inputs(tinput)
+      Model(tinput, l1)
     }
   }
 
   "TSequential" should "not works with container containing Dense" in {
     val seq = TSequential[Float]()
-    intercept[RuntimeException] {
+    intercept[InvalidLayer] {
       val parallelTable = ParallelTable[Float]()
       val d1 = Dense[Float](20, inputShape = Shape(10)).setName("dense1")
       parallelTable.add(d1)
@@ -113,7 +180,7 @@ class KerasStyleSpec extends BigDLSpecHelper {
   }
 
   "TSequential" should "not work with container with dense" in {
-    intercept[RuntimeException] {
+    intercept[InvalidLayer] {
       val seq = TSequential[Float]()
       val seq2 = TSequential[Float]()
       val d1 = Dense[Float](20, inputShape = Shape(10)).setName("dense1")
@@ -149,5 +216,37 @@ class KerasStyleSpec extends BigDLSpecHelper {
     val reloadedModel = Module.loadModule(absPath)
     val inputData = Tensor[Float](Array(20, 10)).rand()
     val output = reloadedModel.forward(inputData)
+  }
+
+  "multiple outputs with index" should "be test" in {
+    val input1 = Input[Float](inputShape = Shape(10))
+    val input2 = Input[Float](inputShape = Shape(10))
+    val d1 = Dense[Float](20).setName("dense1").inputs(input1)
+    val d2 = Dense[Float](5).setName("dense2").inputs(input2)
+    val multiOutput = Model[Float](Array(input1, input2), Array(d1, d2))
+      .inputs(Array(input1, input2))
+
+
+    val relu1 = Activation[Float]("relu").inputs(multiOutput(1))
+    val model = Model[Float](Array(input1, input2), relu1)
+    model.forward(T(Tensor[Float](Array(2, 10)).rand(), Tensor[Float](Array(2, 10)).rand()))
+    assert(model.getOutputShape().toSingle().sameElements(Array(-1, 20)))
+  }
+
+  "Empty inputs is not allow" should "be test" in {
+    val thrown = intercept[Exception] {
+      val d1 = Dense[Float](20).setName("dense1").inputs()
+    }
+    assert(thrown.getMessage().contains("Empty input is not allow"))
+  }
+
+  "InputLayer" should "be test" in {
+    val inputLayer = InputLayer(inputShape = Shape(2, 3))
+    val seq = KSequential[Float]()
+    seq.add(inputLayer)
+    val inputData = Tensor[Float](Array(2, 2, 3)).rand()
+    val output = seq.forward(inputData)
+    seq.forward(output)
+    TestUtils.compareOutputShape(seq, Shape(2, 3)) should be (true)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LinearSpec.scala
@@ -410,11 +410,6 @@ class LinearSpec extends FlatSpec with Matchers {
     linear.weight should be (exceptedWeight)
     linear.bias should be (exceptedBias)
   }
-
-  "Linear computeOutputShape" should "work properly" in {
-    val linear = Linear[Float](3, 5)
-    TestUtils.compareOutputShape(linear, Shape(3)) should be (true)
-  }
 }
 
 class LinearSerialTest extends ModuleSerializationTest {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/TestUtils.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/TestUtils.scala
@@ -18,7 +18,8 @@ package com.intel.analytics.bigdl.utils
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import com.intel.analytics.bigdl.nn.keras.{InputLayer, Sequential => KSequential}
+import com.intel.analytics.bigdl.nn.Sequential
+import com.intel.analytics.bigdl.nn.keras.{InputLayer, KerasLayer, Sequential => KSequential}
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, TensorModule}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
@@ -32,13 +33,19 @@ object TestUtils {
    * Compare the output of `computeOutputShape` with the `forward` result
    */
   def compareOutputShape(layer: AbstractModule[Activity, Activity, Float],
-                         inputShape: Shape): Boolean = {
-    val inputData = Tensor[Float](Array(2) ++ inputShape.toSingle()).randn()
-    val seq = KSequential[Float]()
-    seq.add(InputLayer[Float](inputShape = inputShape))
-    seq.add(layer)
-    val calcOutputShape = seq.getOutputShape().toSingle()
-    val forwardOutputShape = seq.forward(inputData).toTensor[Float].size()
+                         inputShapeWithoutBatch: Shape): Boolean = {
+    val inputData = Tensor[Float](Array(2) ++ inputShapeWithoutBatch.toSingle()).randn()
+    val runnableLayer = layer match {
+      case k: KerasLayer[_, _, _] =>
+        if (!k.isBuilt()) {
+          k.build(KerasLayer.addBatch(inputShapeWithoutBatch))
+        }
+        k
+      case a: AbstractModule[_, _, _] => a
+    }
+    val calcOutputShape = runnableLayer.computeOutputShape(
+      KerasLayer.addBatch(inputShapeWithoutBatch)).toSingle()
+    val forwardOutputShape = runnableLayer.forward(inputData).toTensor[Float].size()
     calcOutputShape.slice(1, calcOutputShape.length).sameElements(
       forwardOutputShape.slice(1, forwardOutputShape.length))
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Enhance the checking for mix use of keras layer and torch layer.
- Change the outputShape from Array[Shape] to be Shape.
- final `getInputShape` and `getOutputShape` as we do not go through building process while reload model from file. `InputShapeValue` and `outputShapeValue` is the final answer.
- Compare the inputShape from user with the shape from the building stage. 
- Add flag into `InferShape` to identify if this layer being used or not
- `Sequential` should be frozen once being used in `add` or `inputs` 
## How was this patch tested?
unittest
## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/2281

