### PR TITLE
Fix a failure in nightly build

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ops/DataFlowOps.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ops/DataFlowOps.scala
@@ -277,6 +277,11 @@ private[bigdl] class TensorArrayWrite[T: ClassTag, D: ClassTag]()(
     (Array[ClassTag[_]](scala.reflect.classTag[T], scala.reflect.classTag[D]),
       Array[TensorNumeric[_]](ev, ev2))
   }
+
+  override def clearState(): this.type = {
+    // Do nothing in clearState as we don't want to change the TensorArray.FlowOut object
+    this
+  }
 }
 
 /**
@@ -409,6 +414,11 @@ private[bigdl] class TensorArrayScatter[T: ClassTag, D: ClassTag]()(
     (Array[ClassTag[_]](scala.reflect.classTag[T], scala.reflect.classTag[D]),
       Array[TensorNumeric[_]](ev, ev2))
   }
+
+  override def clearState(): this.type = {
+    // Do nothing in clearState as we don't want to change the TensorArray.FlowOut object
+    this
+  }
 }
 
 /**
@@ -519,6 +529,11 @@ private[bigdl] class TensorArraySplit[T: ClassTag, D: ClassTag]()(
     (Array[ClassTag[_]](scala.reflect.classTag[T], scala.reflect.classTag[D]),
       Array[TensorNumeric[_]](ev, ev2))
   }
+
+  override def clearState(): this.type = {
+    // Do nothing in clearState as we don't want to change the TensorArray.FlowOut object
+    this
+  }
 }
 
 /**
@@ -554,6 +569,11 @@ private[bigdl] class TensorArrayClose[T: ClassTag]()(implicit ev: TensorNumeric[
     require(input.isScalar, "Handle of a TensorArray must be a scalar")
     TensorArray.release(input.value())
     output
+  }
+
+  override def clearState(): this.type = {
+    // Do nothing in clearState as we don't want to change the TensorArray.FlowOut object
+    this
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Nightly build always failed at some step recently, while PR validation runs well. The root cause is some TensorArray operations use a shared static object for output. And this output will be reset during graph building. This PR override the clearState method of these TensorArray operations

## How was this patch tested?
unit test


