### PR TITLE
update mkdocs.yml to fix a doc generation error

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -80,7 +80,7 @@ pages:
     - Optimization Algorithms: APIGuide/Optimizers/Optim-Methods.md
   - Triggers: APIGuide/Triggers.md
   - Metrics:  APIGuide/Metrics.md
-  - ML Pipeline: APIGuide/MLPipeline/DLEstimator_DLClassifier.md
+  - ML Pipeline: APIGuide/DLFrames/DLEstimator_DLClassifier.md
   - Supported Caffe Layers: APIGuide/caffe_layer_list.md
   - Supported Tensorflow Operations: APIGuide/tensorflow_ops_list.md
   - Keras Issues: APIGuide/keras-issues.md


### PR DESCRIPTION
## What changes were proposed in this pull request?
update mkdocs.yml to fix a doc generation error
http://172.168.2.101:8080/view/NightlyBuild(new)-Pipeline/job/BigDL-NB-Doc-Generation/18/console
ERROR   -  File not found: /opt/work/jenkins/workspace/BigDL-NB-Doc-Generation/BigDL/docs/docs/APIGuide/MLPipeline/DLEstimator_DLClassifier.md 
ERROR   -  Error building page APIGuide/MLPipeline/DLEstimator_DLClassifier.md 

## How was this patch tested?


