### PR TITLE
Keras-like API functional merge and some fix

### DIFF
--- a/docs/docs/KerasStyleAPIGuide/Layers/core.md
+++ b/docs/docs/KerasStyleAPIGuide/Layers/core.md
@@ -12,7 +12,7 @@ InputLayer(input_shape=None, name=None)
 Parameters:
 
 * `inputShape`: For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
-* `name`: String to specify the name of the input layer. Default is null.
+* `name`: String to set the name of the input node. If not specified, its name will by default to be a generated string.
 
 
 ---

--- a/docs/docs/KerasStyleAPIGuide/keras-api-python.md
+++ b/docs/docs/KerasStyleAPIGuide/keras-api-python.md
@@ -37,11 +37,8 @@ The model is described as a linear stack of layers in the Sequential API. Layers
 
 To create a sequential container:
 ```python
-Sequential(name=None)
+Sequential()
 ```
-Parameters:
-
-* `name`: String to specify the name of the sequential model. Default is None.
 
 Example code to create a sequential model:
 ```python
@@ -65,21 +62,20 @@ Input(shape=None, name=None)
 Parameters:
 
 * `shape`: A shape tuple indicating the shape of the input node, not including batch.
-* `name`: String to specify the name of the input node. Default is None.
+* `name`: String to set the name of the input node. If not specified, its name will by default to be a generated string.
 
 To create a graph container:
 ```python
-Model(input, output, name=None)
+Model(input, output)
 ```
 Parameters:
 
 * `input`: An input node or a list of input nodes.
 * `output`: An output node or a list of output nodes.
-* `name`: String to specify the name of the graph model. Default is None.
 
 To merge a list of input __nodes__ (__NOT__ layers), following some merge mode in the Functional API:
 ```python
-merge(inputs, mode="sum", concat_axis=-1, name=None) # This will return an output NODE.
+merge(inputs, mode="sum", concat_axis=-1) # This will return an output NODE.
 ```
 
 Parameters:
@@ -87,7 +83,6 @@ Parameters:
 * `inputs`: A list of node instances. Must be more than one node.
 * `mode`: Merge mode. String, must be one of: 'sum', 'mul', 'concat', 'ave', 'cos','dot', 'max'. Default is 'sum'.
 * `concat_axis`: Int, axis to use when concatenating nodes. Only specify this when merge mode is 'concat'. Default is -1, meaning the last axis of the input.
-* `name`: String to specify the name of merge. Default is None.
 
 Example code to create a graph model:
 ```python

--- a/docs/docs/KerasStyleAPIGuide/keras-api-scala.md
+++ b/docs/docs/KerasStyleAPIGuide/keras-api-scala.md
@@ -89,19 +89,36 @@ Parameters:
 * `input`: An input node or an array of input nodes.
 * `output`: An output node or an array of output nodes.
 
+To merge a list of input __nodes__ (__NOT__ layers), following some merge mode in the Functional API:
+```scala
+import com.intel.analytics.bigdl.nn.keras.Merge.merge
+
+merge(inputs, mode = "sum", concat_axis = -1, name = null) // This will return an output NODE.
+```
+
+Parameters:
+
+* `inputs`: A list of node instances. Must be more than one node.
+* `mode`: Merge mode. String, must be one of: 'sum', 'mul', 'concat', 'ave', 'cos','dot', 'max'. Default is 'sum'.
+* `concat_axis`: Int, axis to use when concatenating nodes. Only specify this when merge mode is 'concat'. Default is -1, meaning the last axis of the input.
+* `name`: String to specify the name of merge. Default is null.
 
 Example code to create a graph model:
 ```scala
 import com.intel.analytics.bigdl.nn.keras.{Input, Dense, Model}
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.nn.keras.Merge.merge
 
-// instantiate an input node
-val input = Input[Float](inputShape = Shape(128))
+// instantiate input node
+val input1 = Input[Float](inputShape = Shape(8))
+val input2 = Input[Float](inputShape = Shape(6))
 // call inputs() with an input node and get an output node
-val dense = Dense[Float](32, activation = "relu").inputs(input)
-val output = Dense[Float](10).inputs(dense)
+val dense1 = Dense[Float](10).inputs(input1)
+val dense2 = Dense[Float](10).inputs(input2)
+// merge two nodes following some merge mode
+val output = merge(inputs = List(dense1, dense2), mode = "sum")
 // create a graph container
-val model = Model[Float](input, output)
+val model = Model[Float](Array(input1, input2), output)
 ```
 
 

--- a/docs/docs/KerasStyleAPIGuide/keras-api-scala.md
+++ b/docs/docs/KerasStyleAPIGuide/keras-api-scala.md
@@ -109,7 +109,7 @@ import com.intel.analytics.bigdl.nn.keras.{Input, Dense, Model}
 import com.intel.analytics.bigdl.utils.Shape
 import com.intel.analytics.bigdl.nn.keras.Merge.merge
 
-// instantiate input node
+// instantiate input nodes
 val input1 = Input[Float](inputShape = Shape(8))
 val input2 = Input[Float](inputShape = Shape(6))
 // call inputs() with an input node and get an output node

--- a/docs/docs/KerasStyleAPIGuide/keras-api-scala.md
+++ b/docs/docs/KerasStyleAPIGuide/keras-api-scala.md
@@ -78,7 +78,7 @@ Input(inputShape = null, name = null)
 Parameters:
 
 * `inputShape`: A [`Shape`](#shape) object indicating the shape of the input node, not including batch.
-* `name`: String to specify the name of the input node. Default is null.
+* `name`: String to set the name of the input node. If not specified, its name will by default to be a generated string.
 
 To create a graph container:
 ```scala
@@ -93,7 +93,7 @@ To merge a list of input __nodes__ (__NOT__ layers), following some merge mode i
 ```scala
 import com.intel.analytics.bigdl.nn.keras.Merge.merge
 
-merge(inputs, mode = "sum", concat_axis = -1, name = null) // This will return an output NODE.
+merge(inputs, mode = "sum", concat_axis = -1) // This will return an output NODE.
 ```
 
 Parameters:
@@ -101,7 +101,6 @@ Parameters:
 * `inputs`: A list of node instances. Must be more than one node.
 * `mode`: Merge mode. String, must be one of: 'sum', 'mul', 'concat', 'ave', 'cos','dot', 'max'. Default is 'sum'.
 * `concat_axis`: Int, axis to use when concatenating nodes. Only specify this when merge mode is 'concat'. Default is -1, meaning the last axis of the input.
-* `name`: String to specify the name of merge. Default is null.
 
 Example code to create a graph model:
 ```scala
@@ -126,7 +125,7 @@ val model = Model[Float](Array(input1, input2), output)
 ## **Layers**
 See [here](Layers/core.md) for all the available layers for the new set of Keras-Style API.
 
-To set the name of a layer, call the method `set_name(name)` of the layer.
+To set the name of a layer, call the method `setName(name)` of the layer.
 
 
 ---

--- a/pyspark/bigdl/nn/keras/layer.py
+++ b/pyspark/bigdl/nn/keras/layer.py
@@ -17,7 +17,7 @@
 import sys
 
 from bigdl.nn.layer import Layer, Node
-from bigdl.util.common import callBigDlFunc, JavaValue
+from bigdl.util.common import callBigDlFunc, JTensor, JavaValue
 
 if sys.version >= '3':
     long = int
@@ -85,7 +85,7 @@ class Input(Node, KerasCreator):
 
     # Arguments
     shape: A shape tuple, not including batch.
-    name: String to specify the name of the input node. Default is None.
+    name: String to set the name of the input node. If not specified, its name will by default to be a generated string.
 
     >>> input = Input(name="input1", shape=(3, 5))
     creating: createKerasInput
@@ -102,7 +102,7 @@ class InputLayer(KerasLayer):
 
     # Arguments
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the input layer. Default is None.
+    name: String to set the name of the input layer. If not specified, its name will by default to be a generated string.
 
     >>> inputlayer = InputLayer(input_shape=(3, 5))
     creating: createKerasInputLayer
@@ -134,7 +134,7 @@ class Dense(KerasLayer):
     input_dim: Dimensionality of the input for 2D input. For nD input, you can alternatively specify
                'input_shape' when using this layer as the first layer.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> dense = Dense(10, input_dim=8, name="dense1")
     creating: createKerasDense
@@ -174,7 +174,7 @@ class MaxoutDense(KerasLayer):
     input_dim: Dimensionality of the input. Alternatively, you can specify 'input_shape'
                when using this layer as the first layer.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> maxoutdense = MaxoutDense(6, input_shape=(10, ))
     creating: createKerasMaxoutDense
@@ -209,7 +209,7 @@ class Embedding(KerasLayer):
     W_regularizer: An instance of [[Regularizer]], (eg. L1 or L2 regularization),
                    applied to the embedding matrix. Default is None.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> embedding = Embedding(1000, 32, input_shape=(10, ), name="embedding1")
     creating: createKerasEmbedding
@@ -245,7 +245,7 @@ class BatchNormalization(KerasLayer):
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
                   For 'th', axis along which to normalize is 1. For 'tf', axis is 3.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> batchnormalization = BatchNormalization(input_shape=(3, 12, 12), name="bn1")
     creating: createKerasBatchNormalization
@@ -267,6 +267,38 @@ class BatchNormalization(KerasLayer):
                                                  list(input_shape) if input_shape else None,
                                                  **kwargs)
 
+    def set_running_mean(self, running_mean):
+        """
+        Set the running mean of the BatchNormalization layer.
+        :param running_mean: a Numpy array.
+        """
+        callBigDlFunc(self.bigdl_type, "setRunningMean",
+                      self.value, JTensor.from_ndarray(running_mean))
+        return self
+
+    def set_running_std(self, running_std):
+        """
+        Set the running variance of the BatchNormalization layer.
+        :param running_std: a Numpy array.
+        """
+        callBigDlFunc(self.bigdl_type, "setRunningStd",
+                      self.value, JTensor.from_ndarray(running_std))
+        return self
+
+    def get_running_mean(self):
+        """
+        Get the running meaning of the BatchNormalization layer.
+        """
+        return callBigDlFunc(self.bigdl_type, "getRunningMean",
+                             self.value).to_ndarray()
+
+    def get_running_std(self):
+        """
+        Get the running variance of the BatchNormalization layer.
+        """
+        return callBigDlFunc(self.bigdl_type, "getRunningStd",
+                             self.value).to_ndarray()
+
 
 class Merge(KerasLayer):
     """
@@ -283,7 +315,7 @@ class Merge(KerasLayer):
     concat_axis: Int, axis to use when concatenating layers. Only specify this when merge mode is 'concat'.
                  Default is -1, meaning the last axis of the input.
     input_shape: A list of shape tuples, each not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> l1 = InputLayer(input_shape=(3, 5))
     creating: createKerasInputLayer
@@ -314,7 +346,7 @@ def merge(inputs, mode="sum", concat_axis=-1, name=None):
           'dot', 'max'. Default is 'sum'.
     concat_axis: Int, axis to use when concatenating nodes. Only specify this when merge mode is 'concat'.
                  Default is -1, meaning the last axis of the input.
-    name: String to specify the name of merge. Default is None.
+    name: String to set the name of the merge. If not specified, its name will by default to be a generated string.
     """
     return Merge(mode=mode, concat_axis=concat_axis, name=name)(list(inputs))
 
@@ -330,7 +362,7 @@ class Dropout(KerasLayer):
     # Arguments
     p: Fraction of the input units to drop. Float between 0 and 1.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> dropout = Dropout(0.25, input_shape=(2, 3))
     creating: createKerasDropout
@@ -351,7 +383,7 @@ class Flatten(KerasLayer):
 
     # Arguments
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> flatten = Flatten(input_shape=(3, 10, 2))
     creating: createKerasFlatten
@@ -375,7 +407,7 @@ class Reshape(KerasLayer):
     # Arguments
     target_shape: A shape tuple. The target shape that you desire to have. Batch dimension should be excluded.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> reshape = Reshape((2, 10), input_shape=(5, 4))
     creating: createKerasReshape
@@ -398,7 +430,7 @@ class Activation(KerasLayer):
     # Arguments
     activation: Name of the activation function as string.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> activation = Activation("relu", input_shape=(3, 4))
     creating: createKerasActivation
@@ -423,7 +455,7 @@ class RepeatVector(KerasLayer):
     input_dim: Dimensionality of the input. Alternatively, you can specify 'input_shape'
                when using this layer as the first layer.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> repeatvector = RepeatVector(5, input_shape=(3, ))
     creating: createKerasRepeatVector
@@ -448,7 +480,7 @@ class Permute(KerasLayer):
     # Arguments
     dims: Tuple of int. Permutation pattern, does not include the samples dimension. Indexing starts at 1.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> permute = Permute((2, 1, 3), input_shape=(3, 4, 5))
     creating: createKerasPermute
@@ -479,7 +511,7 @@ class Highway(KerasLayer):
     input_dim: Dimensionality of the input. Alternatively, you can specify 'input_shape'
                when using this layer as the first layer.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> highway = Highway(activation='relu', input_shape=(8, ))
     creating: createKerasHighway
@@ -521,7 +553,7 @@ class Convolution1D(KerasLayer):
     bias: Whether to include a bias (i.e. make the layer affine rather than linear).
           Default is True.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> conv1d = Convolution1D(12, 4, input_shape=(3, 16))
     creating: createKerasConvolution1D
@@ -572,7 +604,7 @@ class Convolution2D(KerasLayer):
     bias: Whether to include a bias (i.e. make the layer affine rather than linear).
           Default is True.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> conv2d = Convolution2D(32, 3, 3, input_shape=(3, 128, 128), name="convolution2d_1")
     creating: createKerasConvolution2D
@@ -627,7 +659,7 @@ class Convolution3D(KerasLayer):
     bias: Whether to include a bias (i.e. make the layer affine rather than linear).
           Default is True.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> conv3d = Convolution3D(32, 3, 4, 5, input_shape=(3, 64, 64, 64))
     creating: createKerasConvolution3D
@@ -680,7 +712,7 @@ class AtrousConvolution1D(KerasLayer):
     b_regularizer: An instance of [[Regularizer]], applied to the bias. Default is None.
     bias: Only 'True' is supported for now.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> atrousconv1d = AtrousConvolution1D(8, 3, input_shape=(3, 12))
     creating: createKerasAtrousConvolution1D
@@ -738,7 +770,7 @@ class AtrousConvolution2D(KerasLayer):
     b_regularizer: An instance of [[Regularizer]], applied to the bias. Default is None.
     bias: Only 'True' is supported for now.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> atrousconv2d = AtrousConvolution2D(12, 4, 3, input_shape=(3, 64, 64))
     creating: createKerasAtrousConvolution2D
@@ -801,7 +833,7 @@ class Deconvolution2D(KerasLayer):
     bias: Whether to include a bias (i.e. make the layer affine rather than linear).
           Default is True.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> deconv2d = Deconvolution2D(3, 3, 3, output_shape=(None, 3, 14, 14), input_shape=(3, 12, 12))
     creating: createKerasDeconvolution2D
@@ -862,7 +894,7 @@ class SeparableConvolution2D(KerasLayer):
     bias: Whether to include a bias (i.e. make the layer affine rather than linear).
           Default is True.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> separableconv2d = SeparableConvolution2D(12, 3, 4, input_shape=(3, 32, 32))
     creating: createKerasSeparableConvolution2D
@@ -910,7 +942,7 @@ class Cropping1D(KerasLayer):
     cropping: Int tuple of length 2. How many units should be trimmed off at the beginning and
               end of the cropping dimension. Default is (1, 1).
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> cropping1d = Cropping1D(cropping=(1, 2), input_shape=(8, 8))
     creating: createKerasCropping1D
@@ -934,7 +966,7 @@ class Cropping2D(KerasLayer):
     cropping: Int tuple of tuple of length 2. How many units should be trimmed off at the beginning and
               end of the 2 cropping dimensions (i.e. height and width). Default is ((0, 0), (0, 0)).
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> cropping2d = Cropping2D(cropping=((1, 2), (0, 1)), input_shape=(12, 12, 12))
     creating: createKerasCropping2D
@@ -962,7 +994,7 @@ class Cropping3D(KerasLayer):
               end of the 3 cropping dimensions (i.e. kernel_dim1, kernel_dim2 and kernel_dim3).
               Default is ((1, 1), (1, 1), (1, 1)).
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> cropping3d = Cropping3D(cropping=((0, 2), (1, 1), (3, 1)), input_shape=(4, 12, 12, 16))
     creating: createKerasCropping3D
@@ -990,7 +1022,7 @@ class UpSampling1D(KerasLayer):
     # Arguments
     length: Int. UpSampling factor. Default is 2.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> upsampling1d = UpSampling1D(length=3, input_shape=(3, 12))
     creating: createKerasUpSampling1D
@@ -1015,7 +1047,7 @@ class UpSampling2D(KerasLayer):
     size: Int tuple of length 2. UpSampling factors for rows and columns. Default is (2, 2).
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> upsampling2d = UpSampling2D(size=(1, 3), input_shape=(3, 16, 16))
     creating: createKerasUpSampling2D
@@ -1042,7 +1074,7 @@ class UpSampling3D(KerasLayer):
     size: Int tuple of length 3. UpSampling factors for dim1, dim2 and dim3. Default is (2, 2, 2).
     dim_ordering: Format of input data. Only 'th' (Channel First) is supported for now.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> upsampling3d = UpSampling3D(size=(1, 2, 3), input_shape=(3, 16, 16, 16))
     creating: createKerasUpSampling3D
@@ -1069,7 +1101,7 @@ class ZeroPadding1D(KerasLayer):
              If tuple of length 2, how many zeros to add in the order '(left_pad, right_pad)'.
              Default is 1.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> zeropadding1d = ZeroPadding1D(padding=2, input_shape=(3, 6))
     creating: createKerasZeroPadding1D
@@ -1098,7 +1130,7 @@ class ZeroPadding2D(KerasLayer):
              Default is (1, 1).
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> zeropadding2d = ZeroPadding2D(padding=(2, 1), input_shape=(2, 8, 8))
     creating: createKerasZeroPadding2D
@@ -1126,7 +1158,7 @@ class ZeroPadding3D(KerasLayer):
              Symmetric padding will be applied to each dimension. Default is (1, 1, 1).
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> zeropadding3d = ZeroPadding3D(padding=(2, 1, 2), input_shape=(2, 8, 8, 10))
     creating: createKerasZeroPadding3D
@@ -1153,7 +1185,7 @@ class MaxPooling1D(KerasLayer):
              Default is None, and in this case it will be equal to pool_length..
     border_mode: Either 'valid' or 'same'. Default is 'valid'.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> maxpooling1d = MaxPooling1D(3, input_shape=(3, 24))
     creating: createKerasMaxPooling1D
@@ -1185,7 +1217,7 @@ class MaxPooling2D(KerasLayer):
     border_mode: Either 'valid' or 'same'. Default is 'valid'.
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> maxpooling2d = MaxPooling2D((2, 2), input_shape=(3, 32, 32), name="maxpooling2d_1")
     creating: createKerasMaxPooling2D
@@ -1219,7 +1251,7 @@ class MaxPooling3D(KerasLayer):
     border_mode: Only 'valid' is supported for now.
     dim_ordering: Format of input data. Only 'th' (Channel First) is supported for now.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> maxpooling3d = MaxPooling3D((2, 1, 3), input_shape=(3, 32, 32, 32))
     creating: createKerasMaxPooling3D
@@ -1250,7 +1282,7 @@ class AveragePooling1D(KerasLayer):
              Default is None, and in this case it will be equal to pool_length..
     border_mode: Either 'valid' or 'same'. Default is 'valid'.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> averagepooling1d = AveragePooling1D(input_shape=(3, 24))
     creating: createKerasAveragePooling1D
@@ -1282,7 +1314,7 @@ class AveragePooling2D(KerasLayer):
     border_mode: Either 'valid' or 'same'. Default is 'valid'.
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> averagepooling2d = AveragePooling2D((1, 2), input_shape=(2, 28, 32))
     creating: createKerasAveragePooling2D
@@ -1315,7 +1347,7 @@ class AveragePooling3D(KerasLayer):
     border_mode: Only 'valid' is supported for now.
     dim_ordering: Format of input data. Only 'th' (Channel First) is supported for now.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> averagepooling3d = AveragePooling3D((1, 1, 2), input_shape=(3, 28, 32, 36))
     creating: createKerasAveragePooling3D
@@ -1342,7 +1374,7 @@ class GlobalMaxPooling1D(KerasLayer):
 
     # Arguments
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> globalmaxpooling1d = GlobalMaxPooling1D(input_shape=(4, 8))
     creating: createKerasGlobalMaxPooling1D
@@ -1363,7 +1395,7 @@ class GlobalAveragePooling1D(KerasLayer):
 
     # Arguments
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> globalaveragepooling1d = GlobalAveragePooling1D(input_shape=(12, 12))
     creating: createKerasGlobalAveragePooling1D
@@ -1385,7 +1417,7 @@ class GlobalMaxPooling2D(KerasLayer):
     # Arguments
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> globalmaxpooling2d = GlobalMaxPooling2D(input_shape=(4, 32, 32))
     creating: createKerasGlobalMaxPooling2D
@@ -1408,7 +1440,7 @@ class GlobalAveragePooling2D(KerasLayer):
     # Arguments
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> globalaveragepooling2d = GlobalAveragePooling2D(input_shape=(4, 32, 32))
     creating: createKerasGlobalAveragePooling2D
@@ -1433,7 +1465,7 @@ class GlobalMaxPooling3D(KerasLayer):
     # Arguments
     dim_ordering: Format of input data. Only 'th' (Channel First) is supported for now.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> globalmaxpooling3d = GlobalMaxPooling3D(input_shape=(4, 32, 32, 32))
     creating: createKerasGlobalMaxPooling3D
@@ -1458,7 +1490,7 @@ class GlobalAveragePooling3D(KerasLayer):
     # Arguments
     dim_ordering: Format of input data. Only 'th' (Channel First) is supported for now.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> globalaveragepooling3d = GlobalAveragePooling3D(input_shape=(4, 16, 16, 20))
     creating: createKerasGlobalAveragePooling3D
@@ -1490,7 +1522,7 @@ class SimpleRNN(KerasLayer):
     U_regularizer: An instance of [[Regularizer]], applied the recurrent weights matrices. Default is None.
     b_regularizer: An instance of [[Regularizer]], applied to the bias. Default is None.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> simplernn = SimpleRNN(16, input_shape=(3, 32))
     creating: createKerasSimpleRNN
@@ -1531,7 +1563,7 @@ class LSTM(KerasLayer):
     U_regularizer: An instance of [[Regularizer]], applied the recurrent weights matrices. Default is None.
     b_regularizer: An instance of [[Regularizer]], applied to the bias. Default is None.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> lstm = LSTM(32, input_shape=(8, 16), name="lstm1")
     creating: createKerasLSTM
@@ -1573,7 +1605,7 @@ class GRU(KerasLayer):
     U_regularizer: An instance of [[Regularizer]], applied the recurrent weights matrices. Default is None.
     b_regularizer: An instance of [[Regularizer]], applied to the bias. Default is None.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> gru = GRU(24, input_shape=(32, 32))
     creating: createKerasGRU
@@ -1624,7 +1656,7 @@ class ConvLSTM2D(KerasLayer):
                       Default is False.
     go_backwards: Whether the input sequence will be processed backwards. Default is False.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> convlstm2d = ConvLSTM2D(24, 3, 3, input_shape=(4, 32, 32, 32))
     creating: createKerasConvLSTM2D
@@ -1678,7 +1710,7 @@ class LocallyConnected1D(KerasLayer):
     bias: Whether to include a bias (i.e. make the layer affine rather than linear).
           Default is True.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> locallyconnected1d = LocallyConnected1D(6, 3, input_shape=(8, 12))
     creating: createKerasLocallyConnected1D
@@ -1725,7 +1757,7 @@ class LocallyConnected2D(KerasLayer):
     bias: Whether to include a bias (i.e. make the layer affine rather than linear).
           Default is True.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> locallyconnected2d = LocallyConnected2D(12, 3, 4, input_shape=(3, 128, 128))
     creating: createKerasLocallyConnected2D
@@ -1765,7 +1797,7 @@ class SpatialDropout1D(KerasLayer):
     # Arguments
     p: Fraction of the input units to drop. Float between 0 and 1.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> spatialdropout1d = SpatialDropout1D(0.4, input_shape=(10, 12))
     creating: createKerasSpatialDropout1D
@@ -1794,7 +1826,7 @@ class SpatialDropout2D(KerasLayer):
     p: Fraction of the input units to drop. Float between 0 and 1.
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> spatialdropout2d = SpatialDropout2D(0.25, input_shape=(5, 12, 12))
     creating: createKerasSpatialDropout2D
@@ -1824,7 +1856,7 @@ class SpatialDropout3D(KerasLayer):
     p: Fraction of the input units to drop. Float between 0 and 1.
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> spatialdropout3d = SpatialDropout3D(0.6, input_shape=(4, 12, 12, 16))
     creating: createKerasSpatialDropout3D
@@ -1849,7 +1881,7 @@ class GaussianDropout(KerasLayer):
     p: Drop probability. Float between 0 and 1.
        The multiplicative noise will have standard deviation 'sqrt(p/(1-p))'.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> gaussiandropout = GaussianDropout(0.45, input_shape=(4, 8))
     creating: createKerasGaussianDropout
@@ -1874,7 +1906,7 @@ class GaussianNoise(KerasLayer):
     # Arguments
     sigma: Float, standard deviation of the noise distribution.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> gaussiannoise = GaussianNoise(0.45, input_shape=(3, 4, 5), name="gaussiannoise1")
     creating: createKerasGaussianNoise
@@ -1899,7 +1931,7 @@ class Masking(KerasLayer):
                 if all values in the input tensor at that timestep are equal to `mask_value`,
                 then the timestep will masked (skipped) in all downstream layers.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> masking = Masking(0.3, input_shape=(6, 8))
     creating: createKerasMasking
@@ -1937,7 +1969,7 @@ class SReLU(KerasLayer):
                  (batch, height, width, channels), and you wish to share parameters across space so that
                  each filter only has one set of parameters, set 'SharedAxes=(1,2)'.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> srelu = SReLU(input_shape=(4, 5))
     creating: createKerasSReLU
@@ -1968,7 +2000,7 @@ class ELU(KerasLayer):
     # Arguments
     alpha: Float, scale for the negative factor.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> elu = ELU(1.2, input_shape=(4, 5))
     creating: createKerasELU
@@ -1993,7 +2025,7 @@ class LeakyReLU(KerasLayer):
     # Arguments
     alpha: Float >= 0. Negative slope coefficient.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> leakyrelu = LeakyReLU(0.02, input_shape=(4, 5))
     creating: createKerasLeakyReLU
@@ -2018,7 +2050,7 @@ class ThresholdedReLU(KerasLayer):
     # Arguments
     theta: Float >= 0. Threshold location of activation.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the layer. Default is None.
+    name: String to set the name of the layer. If not specified, its name will by default to be a generated string.
 
     >>> thresholdedrelu = ThresholdedReLU(input_shape=(10, 12))
     creating: createKerasThresholdedReLU
@@ -2043,6 +2075,7 @@ class TimeDistributed(KerasLayer):
     # Arguments
     layer: A layer instance.
     input_shape: A shape tuple, not including batch.
+    name: String to set the name of the wrapper. If not specified, its name will by default to be a generated string.
 
     >>> timedistributed = TimeDistributed(Dense(8), input_shape=(10, 12), name="timedistributeddense")
     creating: createKerasDense
@@ -2071,7 +2104,7 @@ class Bidirectional(KerasLayer):
     merge_mode: Mode by which outputs of the forward and backward RNNs will be combined.
                 Must be one of: 'sum', 'mul', 'concat', 'ave'. Default is 'concat'.
     input_shape: A shape tuple, not including batch.
-    name: String to specify the name of the wrapper. Default is None.
+    name: String to set the name of the wrapper. If not specified, its name will by default to be a generated string.
 
     >>> bidiretional = Bidirectional(LSTM(10, return_sequences=True), input_shape=(12, 16), name="bidirectionallstm")
     creating: createKerasLSTM

--- a/pyspark/bigdl/nn/keras/layer.py
+++ b/pyspark/bigdl/nn/keras/layer.py
@@ -316,7 +316,7 @@ def merge(inputs, mode="sum", concat_axis=-1, name=None):
                  Default is -1, meaning the last axis of the input.
     name: String to specify the name of merge. Default is None.
     """
-    return Merge(mode=mode, concat_axis=concat_axis, name=name)(list(reversed(inputs)))
+    return Merge(mode=mode, concat_axis=concat_axis, name=name)(list(inputs))
 
 
 class Dropout(KerasLayer):

--- a/pyspark/bigdl/nn/keras/layer.py
+++ b/pyspark/bigdl/nn/keras/layer.py
@@ -69,24 +69,25 @@ class KerasLayer(Layer, InferShape, KerasCreator):
 
 
 class Input(Node, KerasCreator):
-    def __init__(self, name=None, input_shape=None, bigdl_type="float"):
+    def __init__(self, name=None, shape=None, bigdl_type="float"):
         super(Input, self).__init__(None, bigdl_type,
                                     name,
-                                    list(input_shape) if input_shape else None)
+                                    list(shape) if shape else None)
 
 
 class InputLayer(KerasLayer):
     """
-    Layer to be used as an entry point into a model.
+    Used as an entry point into a model.
 
     # Arguments
-    input_shape: A shape tuple, not including the batch axis.
+    input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the input layer. Default is None.
 
     >>> inputlayer = InputLayer(input_shape=(3, 5))
     creating: createKerasInputLayer
     """
-    def __init__(self, input_shape=None, bigdl_type="float"):
-        super(InputLayer, self).__init__(None, bigdl_type,
+    def __init__(self, input_shape=None, name=None, bigdl_type="float"):
+        super(InputLayer, self).__init__(None, bigdl_type, name,
                                          list(input_shape) if input_shape else None)
 
 
@@ -100,23 +101,28 @@ class Dense(KerasLayer):
 
     # Arguments
     output_dim: The size of output dimension.
-    init: String representations of initialization method for the weights of the layer.
+    init: String representation of the initialization method for the weights of the layer.
           Default is 'glorot_uniform'.
-    activation: String representations of activation function to use (such as 'relu' or 'sigmoid').
+    activation: String representation of the activation function to use (such as 'relu' or 'sigmoid').
                 Default is None.
     W_regularizer: An instance of [[Regularizer]], (eg. L1 or L2 regularization),
                    applied to the input weights matrices. Default is None.
     b_regularizer: An instance of [[Regularizer]], applied to the bias. Default is None.
     bias: Whether to include a bias (i.e. make the layer affine rather than linear). Default is True.
+    input_dim: Dimensionality of the input for 2D input. For nD input, you can alternatively specify
+               'input_shape' when using this layer as the first layer.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
-    >>> dense = Dense(10, input_shape=(3, 4))
+    >>> dense = Dense(10, input_dim=8, name="dense1")
     creating: createKerasDense
     """
     def __init__(self, output_dim, init="glorot_uniform", activation=None,
                  W_regularizer=None, b_regularizer=None,
-                 bias=True, input_shape=None, bigdl_type="float"):
-        super(Dense, self).__init__(None, bigdl_type,
+                 bias=True, input_dim=None, input_shape=None, name=None, bigdl_type="float"):
+        if input_dim:
+            input_shape = (input_dim, )
+        super(Dense, self).__init__(None, bigdl_type, name,
                                     output_dim,
                                     init,
                                     activation,
@@ -142,14 +148,19 @@ class MaxoutDense(KerasLayer):
                    applied to the input weights matrices. Default is None.
     b_regularizer: An instance of [[Regularizer]], applied to the bias. Default is None.
     bias: Whether to include a bias (i.e. make the layer affine rather than linear). Default is True.
+    input_dim: Dimensionality of the input. Alternatively, you can specify 'input_shape'
+               when using this layer as the first layer.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> maxoutdense = MaxoutDense(6, input_shape=(10, ))
     creating: createKerasMaxoutDense
     """
-    def __init__(self, output_dim, nb_feature=4, W_regularizer=None,
-                 b_regularizer=None, bias=True, input_shape=None, bigdl_type="float"):
-        super(MaxoutDense, self).__init__(None, bigdl_type,
+    def __init__(self, output_dim, nb_feature=4, W_regularizer=None, b_regularizer=None,
+                 bias=True, input_dim=None, input_shape=None, name=None, bigdl_type="float"):
+        if input_dim:
+            input_shape = (input_dim, )
+        super(MaxoutDense, self).__init__(None, bigdl_type, name,
                                           output_dim,
                                           nb_feature,
                                           W_regularizer,
@@ -169,18 +180,19 @@ class Embedding(KerasLayer):
     # Arguments
     input_dim: Size of the vocabulary. Int > 0.
     output_dim: Dimension of the dense embedding. Int >= 0.
-    init: String representations of initialization method for the weights of the layer.
+    init: String representation of the initialization method for the weights of the layer.
           Default is 'uniform'.
     W_regularizer: An instance of [[Regularizer]], (eg. L1 or L2 regularization),
                    applied to the embedding matrix. Default is None.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> embedding = Embedding(1000, 32, input_shape=(10, ))
     creating: createKerasEmbedding
     """
-    def __init__(self, input_dim, output_dim, init="uniform",
-                 W_regularizer=None, input_shape=None, bigdl_type="float"):
-        super(Embedding, self).__init__(None, bigdl_type,
+    def __init__(self, input_dim, output_dim, init="uniform", W_regularizer=None,
+                 input_shape=None, name=None, bigdl_type="float"):
+        super(Embedding, self).__init__(None, bigdl_type, name,
                                         input_dim,
                                         output_dim,
                                         init,
@@ -203,18 +215,25 @@ class BatchNormalization(KerasLayer):
     epsilon: Small float > 0. Fuzz parameter. Default is 0.001.
     momentum: Float. Momentum in the computation of the exponential average of the mean and
               standard deviation of the data, for feature-wise normalization. Default is 0.99.
-    beta_init: Name of initialization function for shift parameter. Default is 'zero'.
-    gamma_init: Name of initialization function for scale parameter. Default is 'one'.
+    beta_init: Name of the initialization function for shift parameter. Default is 'zero'.
+    gamma_init: Name of the initialization function for scale parameter. Default is 'one'.
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
                   For 'th', axis along which to normalize is 1. For 'tf', axis is 3.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
-    >>> batchnormalization = BatchNormalization(input_shape=(3, 12, 12))
+    >>> batchnormalization = BatchNormalization(input_shape=(3, 12, 12), name="bn1")
     creating: createKerasBatchNormalization
     """
-    def __init__(self, epsilon=0.001, momentum=0.99, beta_init="zero", gamma_init="one",
-                 dim_ordering="th", input_shape=None, bigdl_type="float"):
-        super(BatchNormalization, self).__init__(None, bigdl_type,
+    def __init__(self, epsilon=0.001, mode=0, axis=1, momentum=0.99, beta_init="zero", gamma_init="one",
+                 dim_ordering="th", input_shape=None, name=None, bigdl_type="float"):
+        if mode != 0:
+            raise ValueError("For BatchNormalization, only mode=0 is supported for now")
+        if dim_ordering == "th" and axis != 1:
+            raise ValueError("For BatchNormalization with th dim ordering, only axis=1 is supported for now")
+        if dim_ordering == "tf" and axis != -1 and axis != 3:
+            raise ValueError("For BatchNormalization with tf dim ordering, only axis=-1 is supported for now")
+        super(BatchNormalization, self).__init__(None, bigdl_type, name,
                                                  float(epsilon),
                                                  float(momentum),
                                                  beta_init,
@@ -222,28 +241,10 @@ class BatchNormalization(KerasLayer):
                                                  dim_ordering,
                                                  list(input_shape) if input_shape else None)
 
-    def set_running_mean(self, running_mean):
-        callBigDlFunc(self.bigdl_type, "setKerasRunningMean",
-                      self.value, JTensor.from_ndarray(running_mean))
-        return self
-
-    def set_running_std(self, running_std):
-        callBigDlFunc(self.bigdl_type, "setKerasRunningStd",
-                      self.value, JTensor.from_ndarray(running_std))
-        return self
-
-    def get_running_mean(self):
-        return callBigDlFunc(self.bigdl_type, "getKerasRunningMean",
-                             self.value).to_ndarray()
-
-    def get_running_std(self):
-        return callBigDlFunc(self.bigdl_type, "getKerasRunningStd",
-                             self.value).to_ndarray()
-
 
 class Merge(KerasLayer):
     """
-    Used to merge a list of tensors into a single tensor, following some merge mode.
+    Used to merge a list of inputs into a single output, following some merge mode.
     Merge must have at least two input layers.
 
     When using this layer as the first layer in a model, you need to provide the argument
@@ -253,9 +254,10 @@ class Merge(KerasLayer):
     layers: A list of layer instances. Must be more than one layer.
     mode: Merge mode. String, must be one of: 'sum', 'mul', 'concat', 'ave', 'cos',
           'dot', 'max'. Default is 'sum'.
-    concat_axis: Int, axis to use in mode concat. Only specify this when mode is 'concat'.
+    concat_axis: Int, axis to use when concatenating layers. Only specify this when merge mode is 'concat'.
                  Default is -1, meaning the last axis of the input.
     input_shape: A list of shape tuples, each not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> l1 = InputLayer(input_shape=(3, 5))
     creating: createKerasInputLayer
@@ -265,12 +267,29 @@ class Merge(KerasLayer):
     creating: createKerasMerge
     """
     def __init__(self, layers=None, mode="sum", concat_axis=-1,
-                 input_shape=None, bigdl_type="float"):
-        super(Merge, self).__init__(None, bigdl_type,
+                 input_shape=None, name=None, bigdl_type="float"):
+        super(Merge, self).__init__(None, bigdl_type, name,
                                     list(layers) if layers else None,
                                     mode,
                                     concat_axis,
                                     input_shape)
+
+
+def merge(inputs, mode="sum", concat_axis=-1, name=None):
+    """
+    Functional merge. Only use this method if you are defining a graph model.
+    Used to merge a list of input nodes into a single output node (NOT layers!),
+    following some merge mode.
+
+    # Arguments
+    inputs: A list of node instances. Must be more than one node.
+    mode: Merge mode. String, must be one of: 'sum', 'mul', 'concat', 'ave', 'cos',
+          'dot', 'max'. Default is 'sum'.
+    concat_axis: Int, axis to use when concatenating nodes. Only specify this when merge mode is 'concat'.
+                 Default is -1, meaning the last axis of the input.
+    name: String to specify the name of merge. Default is None.
+    """
+    return Merge(mode=mode, concat_axis=concat_axis, name=name)(list(reversed(inputs)))
 
 
 class Dropout(KerasLayer):
@@ -284,12 +303,13 @@ class Dropout(KerasLayer):
     # Arguments
     p: Fraction of the input units to drop. Float between 0 and 1.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> dropout = Dropout(0.25, input_shape=(2, 3))
     creating: createKerasDropout
     """
-    def __init__(self, p, input_shape=None, bigdl_type="float"):
-        super(Dropout, self).__init__(None, bigdl_type,
+    def __init__(self, p, input_shape=None, name=None, bigdl_type="float"):
+        super(Dropout, self).__init__(None, bigdl_type, name,
                                       float(p),
                                       list(input_shape) if input_shape else None)
 
@@ -303,12 +323,13 @@ class Flatten(KerasLayer):
 
     # Arguments
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> flatten = Flatten(input_shape=(3, 10, 2))
     creating: createKerasFlatten
     """
-    def __init__(self, input_shape=None, bigdl_type="float"):
-        super(Flatten, self).__init__(None, bigdl_type,
+    def __init__(self, input_shape=None, name=None, bigdl_type="float"):
+        super(Flatten, self).__init__(None, bigdl_type, name,
                                       list(input_shape) if input_shape else None)
 
 
@@ -325,12 +346,13 @@ class Reshape(KerasLayer):
     # Arguments
     target_shape: A shape tuple. The target shape that you desire to have. Batch dimension should be excluded.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> reshape = Reshape((2, 10), input_shape=(5, 4))
     creating: createKerasReshape
     """
-    def __init__(self, target_shape, input_shape=None, bigdl_type="float"):
-        super(Reshape, self).__init__(None, bigdl_type,
+    def __init__(self, target_shape, input_shape=None, name=None, bigdl_type="float"):
+        super(Reshape, self).__init__(None, bigdl_type, name,
                                       target_shape,
                                       list(input_shape) if input_shape else None)
 
@@ -346,12 +368,13 @@ class Activation(KerasLayer):
     # Arguments
     activation: Name of the activation function as string.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> activation = Activation("relu", input_shape=(3, 4))
     creating: createKerasActivation
     """
-    def __init__(self, activation, input_shape=None, bigdl_type="float"):
-        super(Activation, self).__init__(None, bigdl_type,
+    def __init__(self, activation, input_shape=None, name=None, bigdl_type="float"):
+        super(Activation, self).__init__(None, bigdl_type, name,
                                          activation,
                                          list(input_shape) if input_shape else None)
 
@@ -366,13 +389,18 @@ class RepeatVector(KerasLayer):
 
     # Arguments
     n: Repetition factor. Int.
+    input_dim: Dimensionality of the input. Alternatively, you can specify 'input_shape'
+               when using this layer as the first layer.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> repeatvector = RepeatVector(5, input_shape=(3, ))
     creating: createKerasRepeatVector
     """
-    def __init__(self, n, input_shape=None, bigdl_type="float"):
-        super(RepeatVector, self).__init__(None, bigdl_type,
+    def __init__(self, n, input_dim=None, input_shape=None, name=None, bigdl_type="float"):
+        if input_dim:
+            input_shape = (input_dim, )
+        super(RepeatVector, self).__init__(None, bigdl_type, name,
                                            n,
                                            list(input_shape) if input_shape else None)
 
@@ -388,12 +416,13 @@ class Permute(KerasLayer):
     # Arguments
     dims: Tuple of int. Permutation pattern, does not include the samples dimension. Indexing starts at 1.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> permute = Permute((2, 1, 3), input_shape=(3, 4, 5))
     creating: createKerasPermute
     """
-    def __init__(self, dims, input_shape=None, bigdl_type="float"):
-        super(Permute, self).__init__(None, bigdl_type,
+    def __init__(self, dims, input_shape=None, name=None, bigdl_type="float"):
+        super(Permute, self).__init__(None, bigdl_type, name,
                                       dims,
                                       list(input_shape) if input_shape else None)
 
@@ -407,21 +436,26 @@ class Highway(KerasLayer):
     input_shape (a shape tuple, does not include the batch dimension).
 
     # Arguments
-    activation: String representations of activation function to use (such as 'relu' or 'sigmoid').
+    activation: String representation of the activation function to use (such as 'relu' or 'sigmoid').
                 Default is None.
     W_regularizer: An instance of [[Regularizer]], (eg. L1 or L2 regularization),
                    applied to the input weights matrices. Default is None.
     b_regularizer: An instance of [[Regularizer]], applied to the bias. Default is None.
     bias: Whether to include a bias (i.e. make the layer affine rather than linear).
           Default is True.
+    input_dim: Dimensionality of the input. Alternatively, you can specify 'input_shape'
+               when using this layer as the first layer.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> highway = Highway(activation='relu', input_shape=(8, ))
     creating: createKerasHighway
     """
     def __init__(self, activation=None, W_regularizer=None, b_regularizer=None,
-                 bias=True, input_shape=None, bigdl_type="float"):
-        super(Highway, self).__init__(None, bigdl_type,
+                 bias=True, input_dim=None, input_shape=None, name=None, bigdl_type="float"):
+        if input_dim:
+            input_shape = (input_dim, )
+        super(Highway, self).__init__(None, bigdl_type, name,
                                       activation,
                                       W_regularizer,
                                       b_regularizer,
@@ -441,9 +475,9 @@ class Convolution1D(KerasLayer):
     # Arguments
     nb_filter: Number of convolution filters to use.
     filter_length: The extension (spatial or temporal) of each filter.
-    init: String representations of initialization method for the weights of the layer.
+    init: String representation of the initialization method for the weights of the layer.
           Default is 'glorot_uniform'.
-    activation: String representations of activation function to use (such as 'relu' or 'sigmoid').
+    activation: String representation of the activation function to use (such as 'relu' or 'sigmoid').
                 Default is None.
     border_mode: Either 'valid' or 'same'. Default is 'valid'.
     subsample_length: Factor by which to subsample output. Int. Default is 1.
@@ -453,6 +487,7 @@ class Convolution1D(KerasLayer):
     bias: Whether to include a bias (i.e. make the layer affine rather than linear).
           Default is True.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> conv1d = Convolution1D(12, 4, input_shape=(3, 16))
     creating: createKerasConvolution1D
@@ -460,8 +495,8 @@ class Convolution1D(KerasLayer):
     def __init__(self, nb_filter, filter_length, init="glorot_uniform",
                  activation=None, border_mode="valid", subsample_length=1,
                  W_regularizer=None, b_regularizer=None, bias=True,
-                 input_shape=None, bigdl_type="float"):
-        super(Convolution1D, self).__init__(None, bigdl_type,
+                 input_shape=None, name=None, bigdl_type="float"):
+        super(Convolution1D, self).__init__(None, bigdl_type, name,
                                             nb_filter,
                                             filter_length,
                                             init,
@@ -488,9 +523,9 @@ class Convolution2D(KerasLayer):
     nb_filter: Number of convolution filters to use.
     nb_row: Number of rows in the convolution kernel.
     nb_col: Number of cols in the convolution kernel.
-    init: String representations of initialization method for the weights of the layer.
+    init: String representation of the initialization method for the weights of the layer.
           Default is 'glorot_uniform'.
-    activation: String representations of activation function to use (such as 'relu' or 'sigmoid').
+    activation: String representation of the activation function to use (such as 'relu' or 'sigmoid').
                 Default is None.
     border_mode: Either 'valid' or 'same'. Default is 'valid'.
     subsample: Int tuple of length 2 corresponding to the step of the convolution in the
@@ -502,6 +537,7 @@ class Convolution2D(KerasLayer):
     bias: Whether to include a bias (i.e. make the layer affine rather than linear).
           Default is True.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> conv2d = Convolution2D(32, 3, 3, input_shape=(3, 128, 128))
     creating: createKerasConvolution2D
@@ -510,8 +546,8 @@ class Convolution2D(KerasLayer):
                  init="glorot_uniform", activation=None,
                  border_mode="valid", subsample=(1, 1), dim_ordering="th",
                  W_regularizer=None, b_regularizer=None, bias=True,
-                 input_shape=None, bigdl_type="float"):
-        super(Convolution2D, self).__init__(None, bigdl_type,
+                 input_shape=None, name=None, bigdl_type="float"):
+        super(Convolution2D, self).__init__(None, bigdl_type, name,
                                             nb_filter,
                                             nb_row,
                                             nb_col,
@@ -541,9 +577,9 @@ class Convolution3D(KerasLayer):
     kernel_dim1: Length of the first dimension in the convolution kernel.
     kernel_dim2: Length of the second dimension in the convolution kernel.
     kernel_dim3: Length of the third dimension in the convolution kernel.
-    init: String representations of initialization method for the weights of the layer.
+    init: String representation of the initialization method for the weights of the layer.
           Default is 'glorot_uniform'.
-    activation: String representations of activation function to use (such as 'relu' or 'sigmoid').
+    activation: String representation of the activation function to use (such as 'relu' or 'sigmoid').
                 Default is None.
     border_mode: Either 'valid' or 'same'. Default is 'valid'.
     subsample: Int tuple of length 3. Factor by which to subsample output.
@@ -555,6 +591,7 @@ class Convolution3D(KerasLayer):
     bias: Whether to include a bias (i.e. make the layer affine rather than linear).
           Default is True.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> conv3d = Convolution3D(32, 3, 4, 5, input_shape=(3, 64, 64, 64))
     creating: createKerasConvolution3D
@@ -562,8 +599,8 @@ class Convolution3D(KerasLayer):
     def __init__(self, nb_filter, kernel_dim1, kernel_dim2, kernel_dim3,
                  init="glorot_uniform", activation=None, border_mode="valid",
                  subsample=(1, 1, 1), dim_ordering="th", W_regularizer=None,
-                 b_regularizer=None, bias=True, input_shape=None, bigdl_type="float"):
-        super(Convolution3D, self).__init__(None, bigdl_type,
+                 b_regularizer=None, bias=True, input_shape=None, name=None, bigdl_type="float"):
+        super(Convolution3D, self).__init__(None, bigdl_type, name,
                                             nb_filter,
                                             kernel_dim1,
                                             kernel_dim2,
@@ -594,9 +631,9 @@ class AtrousConvolution1D(KerasLayer):
     # Arguments
     nb_filter: Number of convolution filters to use.
     filter_length: The extension (spatial or temporal) of each filter.
-    init: String representations of initialization method for the weights of the layer.
+    init: String representation of the initialization method for the weights of the layer.
           Default is 'glorot_uniform'.
-    activation: String representations of activation function to use (such as 'relu' or 'sigmoid').
+    activation: String representation of the activation function to use (such as 'relu' or 'sigmoid').
                 Default is None.
     border_mode: Only 'valid' is supported for now.
     subsample_length: Factor by which to subsample output. Int. Default is 1.
@@ -606,18 +643,19 @@ class AtrousConvolution1D(KerasLayer):
     b_regularizer: An instance of [[Regularizer]], applied to the bias. Default is None.
     bias: Only 'True' is supported for now.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> atrousconv1d = AtrousConvolution1D(8, 3, input_shape=(3, 12))
     creating: createKerasAtrousConvolution1D
     """
-    def __init__(self, nb_filter, filter_length, init="glorot_uniform",
-                 activation=None, border_mode='valid', subsample_length=1, atrous_rate=1,
-                 W_regularizer=None, b_regularizer=None, bias=True, input_shape=None, bigdl_type="float"):
+    def __init__(self, nb_filter, filter_length, init="glorot_uniform", activation=None,
+                 border_mode='valid', subsample_length=1, atrous_rate=1, W_regularizer=None,
+                 b_regularizer=None, bias=True, input_shape=None, name=None, bigdl_type="float"):
         if border_mode != "valid":
             raise ValueError("For AtrousConvolution1D, only border_mode='valid' is supported for now")
         if not bias:
             raise ValueError("For AtrousConvolution1D, only bias=True is supported for now")
-        super(AtrousConvolution1D, self).__init__(None, bigdl_type,
+        super(AtrousConvolution1D, self).__init__(None, bigdl_type, name,
                                                   nb_filter,
                                                   filter_length,
                                                   init,
@@ -647,9 +685,9 @@ class AtrousConvolution2D(KerasLayer):
     nb_filter: Number of convolution filters to use.
     nb_row: Number of rows in the convolution kernel.
     nb_col: Number of cols in the convolution kernel.
-    init: String representations of initialization method for the weights of the layer.
+    init: String representation of the initialization method for the weights of the layer.
           Default is 'glorot_uniform'.
-    activation: String representations of activation function to use (such as 'relu' or 'sigmoid').
+    activation: String representation of the activation function to use (such as 'relu' or 'sigmoid').
                 Default is None.
     border_mode: Only 'valid' is supported for now.
     subsample: Int tuple of length 2 corresponding to the step of the convolution in the
@@ -662,6 +700,7 @@ class AtrousConvolution2D(KerasLayer):
     b_regularizer: An instance of [[Regularizer]], applied to the bias. Default is None.
     bias: Only 'True' is supported for now.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> atrousconv2d = AtrousConvolution2D(12, 4, 3, input_shape=(3, 64, 64))
     creating: createKerasAtrousConvolution2D
@@ -669,12 +708,12 @@ class AtrousConvolution2D(KerasLayer):
     def __init__(self, nb_filter, nb_row, nb_col, init="glorot_uniform",
                  activation=None, border_mode="valid", subsample=(1, 1),
                  atrous_rate=(1, 1), dim_ordering="th", W_regularizer=None,
-                 b_regularizer=None, bias=True, input_shape=None, bigdl_type="float"):
+                 b_regularizer=None, bias=True, input_shape=None, name=None, bigdl_type="float"):
         if border_mode != "valid":
             raise ValueError("For AtrousConvolution2D, only border_mode='valid' is supported for now")
         if not bias:
             raise ValueError("For AtrousConvolution2D, only bias=True is supported for now")
-        super(AtrousConvolution2D, self).__init__(None, bigdl_type,
+        super(AtrousConvolution2D, self).__init__(None, bigdl_type, name,
                                                   nb_filter,
                                                   nb_row,
                                                   nb_col,
@@ -709,9 +748,9 @@ class Deconvolution2D(KerasLayer):
     nb_row: Number of rows in the convolution kernel.
     nb_col: Number of cols in the convolution kernel.
     output_shape: Output shape of the transposed convolution operation. Tuple of int.
-    init: String representations of initialization method for the weights of the layer.
+    init: String representation of the initialization method for the weights of the layer.
           Default is 'glorot_uniform'.
-    activation: String representations of activation function to use (such as 'relu' or 'sigmoid').
+    activation: String representation of the activation function to use (such as 'relu' or 'sigmoid').
                 Default is None.
     border_mode: Only 'valid' is supported for now.
     subsample: Int tuple of length 2 corresponding to the step of the convolution in the
@@ -723,16 +762,17 @@ class Deconvolution2D(KerasLayer):
     bias: Whether to include a bias (i.e. make the layer affine rather than linear).
           Default is True.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> deconv2d = Deconvolution2D(3, 3, 3, output_shape=(None, 3, 14, 14), input_shape=(3, 12, 12))
     creating: createKerasDeconvolution2D
     """
     def __init__(self, nb_filter, nb_row, nb_col, output_shape, init="glorot_uniform",
                  activation=None, border_mode="valid", subsample=(1, 1), dim_ordering="th",
-                 W_regularizer=None, b_regularizer=None, bias=True, input_shape=None, bigdl_type="float"):
+                 W_regularizer=None, b_regularizer=None, bias=True, input_shape=None, name=None, bigdl_type="float"):
         if border_mode != "valid":
             raise ValueError("For Deconvolution2D, only border_mode='valid' is supported for now")
-        super(Deconvolution2D, self).__init__(None, bigdl_type,
+        super(Deconvolution2D, self).__init__(None, bigdl_type, name,
                                               nb_filter,
                                               nb_row,
                                               nb_col,
@@ -764,9 +804,9 @@ class SeparableConvolution2D(KerasLayer):
     nb_filter: Number of convolution filters to use.
     nb_row: Number of rows in the convolution kernel.
     nb_col: Number of cols in the convolution kernel.
-    init: String representations of initialization method for the weights of the layer.
+    init: String representation of the initialization method for the weights of the layer.
           Default is 'glorot_uniform'.
-    activation: String representations of activation function to use (such as 'relu' or 'sigmoid').
+    activation: String representation of the activation function to use (such as 'relu' or 'sigmoid').
                 Default is None.
     border_mode: Either 'valid' or 'same'. Default is 'valid'.
     subsample: Int tuple of length 2 corresponding to the step of the convolution in the
@@ -782,6 +822,7 @@ class SeparableConvolution2D(KerasLayer):
     bias: Whether to include a bias (i.e. make the layer affine rather than linear).
           Default is True.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> separableconv2d = SeparableConvolution2D(12, 3, 4, input_shape=(3, 32, 32))
     creating: createKerasSeparableConvolution2D
@@ -789,8 +830,8 @@ class SeparableConvolution2D(KerasLayer):
     def __init__(self, nb_filter, nb_row, nb_col, init="glorot_uniform",
                  activation=None, border_mode="valid", subsample=(1, 1), depth_multiplier=1,
                  dim_ordering="th", depthwise_regularizer=None, pointwise_regularizer=None,
-                 b_regularizer=None, bias=True, input_shape=None, bigdl_type="float"):
-        super(SeparableConvolution2D, self).__init__(None, bigdl_type,
+                 b_regularizer=None, bias=True, input_shape=None, name=None, bigdl_type="float"):
+        super(SeparableConvolution2D, self).__init__(None, bigdl_type, name,
                                                      nb_filter,
                                                      nb_row,
                                                      nb_col,
@@ -828,12 +869,13 @@ class Cropping1D(KerasLayer):
     cropping: Int tuple of length 2. How many units should be trimmed off at the beginning and
               end of the cropping dimension. Default is (1, 1).
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> cropping1d = Cropping1D(cropping=(1, 2), input_shape=(8, 8))
     creating: createKerasCropping1D
     """
-    def __init__(self, cropping=(1, 1), input_shape=None, bigdl_type="float"):
-        super(Cropping1D, self).__init__(None, bigdl_type,
+    def __init__(self, cropping=(1, 1), input_shape=None, name=None, bigdl_type="float"):
+        super(Cropping1D, self).__init__(None, bigdl_type, name,
                                          cropping,
                                          list(input_shape) if input_shape else None)
 
@@ -850,13 +892,14 @@ class Cropping2D(KerasLayer):
     cropping: Int tuple of tuple of length 2. How many units should be trimmed off at the beginning and
               end of the 2 cropping dimensions (i.e. height and width). Default is ((0, 0), (0, 0)).
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> cropping2d = Cropping2D(cropping=((1, 2), (0, 1)), input_shape=(12, 12, 12))
     creating: createKerasCropping2D
     """
     def __init__(self, cropping=((0, 0), (0, 0)), dim_ordering="th",
-                 input_shape=None, bigdl_type="float"):
-        super(Cropping2D, self).__init__(None, bigdl_type,
+                 input_shape=None, name=None, bigdl_type="float"):
+        super(Cropping2D, self).__init__(None, bigdl_type, name,
                                          cropping[0],
                                          cropping[1],
                                          dim_ordering,
@@ -876,13 +919,14 @@ class Cropping3D(KerasLayer):
               end of the 3 cropping dimensions (i.e. kernel_dim1, kernel_dim2 and kernel_dim3).
               Default is ((1, 1), (1, 1), (1, 1)).
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> cropping3d = Cropping3D(cropping=((0, 2), (1, 1), (3, 1)), input_shape=(4, 12, 12, 16))
     creating: createKerasCropping3D
     """
     def __init__(self, cropping=((1, 1), (1, 1), (1, 1)), dim_ordering="th",
-                 input_shape=None, bigdl_type="float"):
-        super(Cropping3D, self).__init__(None, bigdl_type,
+                 input_shape=None, name=None, bigdl_type="float"):
+        super(Cropping3D, self).__init__(None, bigdl_type, name,
                                          cropping[0],
                                          cropping[1],
                                          cropping[2],
@@ -902,12 +946,13 @@ class UpSampling1D(KerasLayer):
     # Arguments
     length: Int. UpSampling factor. Default is 2.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> upsampling1d = UpSampling1D(length=3, input_shape=(3, 12))
     creating: createKerasUpSampling1D
     """
-    def __init__(self, length=2, input_shape=None, bigdl_type="float"):
-        super(UpSampling1D, self).__init__(None, bigdl_type,
+    def __init__(self, length=2, input_shape=None, name=None, bigdl_type="float"):
+        super(UpSampling1D, self).__init__(None, bigdl_type, name,
                                            length,
                                            list(input_shape) if input_shape else None)
 
@@ -925,12 +970,13 @@ class UpSampling2D(KerasLayer):
     size: Int tuple of length 2. UpSampling factors for rows and columns. Default is (2, 2).
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> upsampling2d = UpSampling2D(size=(1, 3), input_shape=(3, 16, 16))
     creating: createKerasUpSampling2D
     """
-    def __init__(self, size=(2, 2), dim_ordering="th", input_shape=None, bigdl_type="float"):
-        super(UpSampling2D, self).__init__(None, bigdl_type,
+    def __init__(self, size=(2, 2), dim_ordering="th", input_shape=None, name=None, bigdl_type="float"):
+        super(UpSampling2D, self).__init__(None, bigdl_type, name,
                                            size,
                                            dim_ordering,
                                            list(input_shape) if input_shape else None)
@@ -950,12 +996,13 @@ class UpSampling3D(KerasLayer):
     size: Int tuple of length 3. UpSampling factors for dim1, dim2 and dim3. Default is (2, 2, 2).
     dim_ordering: Format of input data. Only 'th' (Channel First) is supported for now.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> upsampling3d = UpSampling3D(size=(1, 2, 3), input_shape=(3, 16, 16, 16))
     creating: createKerasUpSampling3D
     """
-    def __init__(self, size=(2, 2, 2), dim_ordering="th", input_shape=None, bigdl_type="float"):
-        super(UpSampling3D, self).__init__(None, bigdl_type,
+    def __init__(self, size=(2, 2, 2), dim_ordering="th", input_shape=None, name=None, bigdl_type="float"):
+        super(UpSampling3D, self).__init__(None, bigdl_type, name,
                                            size,
                                            dim_ordering,
                                            list(input_shape) if input_shape else None)
@@ -975,14 +1022,15 @@ class ZeroPadding1D(KerasLayer):
              If tuple of length 2, how many zeros to add in the order '(left_pad, right_pad)'.
              Default is 1.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> zeropadding1d = ZeroPadding1D(padding=2, input_shape=(3, 6))
     creating: createKerasZeroPadding1D
     """
-    def __init__(self, padding=1, input_shape=None, bigdl_type="float"):
+    def __init__(self, padding=1, input_shape=None, name=None, bigdl_type="float"):
         if isinstance(padding, int):
             padding = (padding, padding)
-        super(ZeroPadding1D, self).__init__(None, bigdl_type,
+        super(ZeroPadding1D, self).__init__(None, bigdl_type, name,
                                             padding,
                                             list(input_shape) if input_shape else None)
 
@@ -1002,14 +1050,15 @@ class ZeroPadding2D(KerasLayer):
              Default is (1, 1).
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> zeropadding2d = ZeroPadding2D(padding=(2, 1), input_shape=(2, 8, 8))
     creating: createKerasZeroPadding2D
     """
-    def __init__(self, padding=(1, 1), dim_ordering="th", input_shape=None, bigdl_type="float"):
+    def __init__(self, padding=(1, 1), dim_ordering="th", input_shape=None, name=None, bigdl_type="float"):
         if len(padding) == 2:
             padding = (padding[0], padding[0], padding[1], padding[1])
-        super(ZeroPadding2D, self).__init__(None, bigdl_type,
+        super(ZeroPadding2D, self).__init__(None, bigdl_type, name,
                                             padding,
                                             dim_ordering,
                                             list(input_shape) if input_shape else None)
@@ -1028,12 +1077,13 @@ class ZeroPadding3D(KerasLayer):
              Symmetric padding will be applied to each dimension. Default is (1, 1, 1).
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> zeropadding3d = ZeroPadding3D(padding=(2, 1, 2), input_shape=(2, 8, 8, 10))
     creating: createKerasZeroPadding3D
     """
-    def __init__(self, padding=(1, 1, 1), dim_ordering="th", input_shape=None, bigdl_type="float"):
-        super(ZeroPadding3D, self).__init__(None, bigdl_type,
+    def __init__(self, padding=(1, 1, 1), dim_ordering="th", input_shape=None, name=None, bigdl_type="float"):
+        super(ZeroPadding3D, self).__init__(None, bigdl_type, name,
                                             padding,
                                             dim_ordering,
                                             list(input_shape) if input_shape else None)
@@ -1053,15 +1103,16 @@ class MaxPooling1D(KerasLayer):
              Default is None, and in this case it will be equal to pool_length..
     border_mode: Either 'valid' or 'same'. Default is 'valid'.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> maxpooling1d = MaxPooling1D(3, input_shape=(3, 24))
     creating: createKerasMaxPooling1D
     """
     def __init__(self, pool_length=2, stride=None, border_mode="valid",
-                 input_shape=None, bigdl_type="float"):
+                 input_shape=None, name=None, bigdl_type="float"):
         if not stride:
             stride = -1
-        super(MaxPooling1D, self).__init__(None, bigdl_type,
+        super(MaxPooling1D, self).__init__(None, bigdl_type, name,
                                            pool_length,
                                            stride,
                                            border_mode,
@@ -1083,14 +1134,15 @@ class MaxPooling2D(KerasLayer):
     border_mode: Either 'valid' or 'same'. Default is 'valid'.
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> maxpooling2d = MaxPooling2D((2, 2), input_shape=(3, 32, 32))
     creating: createKerasMaxPooling2D
     """
     def __init__(self, pool_size=(2, 2), strides=None,
                  border_mode='valid', dim_ordering='th',
-                 input_shape=None, bigdl_type="float"):
-        super(MaxPooling2D, self).__init__(None, bigdl_type,
+                 input_shape=None, name=None, bigdl_type="float"):
+        super(MaxPooling2D, self).__init__(None, bigdl_type, name,
                                            pool_size,
                                            strides,
                                            border_mode,
@@ -1115,15 +1167,16 @@ class MaxPooling3D(KerasLayer):
     border_mode: Only 'valid' is supported for now.
     dim_ordering: Format of input data. Only 'th' (Channel First) is supported for now.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> maxpooling3d = MaxPooling3D((2, 1, 3), input_shape=(3, 32, 32, 32))
     creating: createKerasMaxPooling3D
     """
     def __init__(self, pool_size=(2, 2, 2), strides=None, border_mode="valid",
-                 dim_ordering="th", input_shape=None, bigdl_type="float"):
+                 dim_ordering="th", input_shape=None, name=None, bigdl_type="float"):
         if border_mode != "valid":
             raise ValueError("For MaxPooling3D, only border_mode='valid' is supported for now")
-        super(MaxPooling3D, self).__init__(None, bigdl_type,
+        super(MaxPooling3D, self).__init__(None, bigdl_type, name,
                                            pool_size,
                                            strides,
                                            dim_ordering,
@@ -1144,15 +1197,16 @@ class AveragePooling1D(KerasLayer):
              Default is None, and in this case it will be equal to pool_length..
     border_mode: Either 'valid' or 'same'. Default is 'valid'.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> averagepooling1d = AveragePooling1D(input_shape=(3, 24))
     creating: createKerasAveragePooling1D
     """
     def __init__(self, pool_length=2, stride=None, border_mode="valid",
-                 input_shape=None, bigdl_type="float"):
+                 input_shape=None, name=None, bigdl_type="float"):
         if not stride:
             stride = -1
-        super(AveragePooling1D, self).__init__(None, bigdl_type,
+        super(AveragePooling1D, self).__init__(None, bigdl_type, name,
                                                pool_length,
                                                stride,
                                                border_mode,
@@ -1174,13 +1228,14 @@ class AveragePooling2D(KerasLayer):
     border_mode: Either 'valid' or 'same'. Default is 'valid'.
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> averagepooling2d = AveragePooling2D((1, 2), input_shape=(2, 28, 32))
     creating: createKerasAveragePooling2D
     """
     def __init__(self, pool_size=(2, 2), strides=None, border_mode="valid",
-                 dim_ordering="th", input_shape=None, bigdl_type="float"):
-        super(AveragePooling2D, self).__init__(None, bigdl_type,
+                 dim_ordering="th", input_shape=None, name=None, bigdl_type="float"):
+        super(AveragePooling2D, self).__init__(None, bigdl_type, name,
                                                pool_size,
                                                strides,
                                                border_mode,
@@ -1205,15 +1260,16 @@ class AveragePooling3D(KerasLayer):
     border_mode: Only 'valid' is supported for now.
     dim_ordering: Format of input data. Only 'th' (Channel First) is supported for now.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> averagepooling3d = AveragePooling3D((1, 1, 2), input_shape=(3, 28, 32, 36))
     creating: createKerasAveragePooling3D
     """
     def __init__(self, pool_size=(2, 2, 2), strides=None, border_mode="valid",
-                 dim_ordering="th", input_shape=None, bigdl_type="float"):
+                 dim_ordering="th", input_shape=None, name=None, bigdl_type="float"):
         if border_mode != "valid":
             raise ValueError("For AveragePooling3D, only border_mode='valid' is supported for now")
-        super(AveragePooling3D, self).__init__(None, bigdl_type,
+        super(AveragePooling3D, self).__init__(None, bigdl_type, name,
                                                pool_size,
                                                strides,
                                                dim_ordering,
@@ -1230,12 +1286,13 @@ class GlobalMaxPooling1D(KerasLayer):
 
     # Arguments
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> globalmaxpooling1d = GlobalMaxPooling1D(input_shape=(4, 8))
     creating: createKerasGlobalMaxPooling1D
     """
-    def __init__(self, input_shape=None, bigdl_type="float"):
-        super(GlobalMaxPooling1D, self).__init__(None, bigdl_type,
+    def __init__(self, input_shape=None, name=None, bigdl_type="float"):
+        super(GlobalMaxPooling1D, self).__init__(None, bigdl_type, name,
                                                  list(input_shape) if input_shape else None)
 
 
@@ -1249,12 +1306,13 @@ class GlobalAveragePooling1D(KerasLayer):
 
     # Arguments
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> globalaveragepooling1d = GlobalAveragePooling1D(input_shape=(12, 12))
     creating: createKerasGlobalAveragePooling1D
     """
-    def __init__(self, input_shape=None, bigdl_type="float"):
-        super(GlobalAveragePooling1D, self).__init__(None, bigdl_type,
+    def __init__(self, input_shape=None, name=None, bigdl_type="float"):
+        super(GlobalAveragePooling1D, self).__init__(None, bigdl_type, name,
                                                      list(input_shape) if input_shape else None)
 
 
@@ -1269,12 +1327,13 @@ class GlobalMaxPooling2D(KerasLayer):
     # Arguments
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> globalmaxpooling2d = GlobalMaxPooling2D(input_shape=(4, 32, 32))
     creating: createKerasGlobalMaxPooling2D
     """
-    def __init__(self, dim_ordering="th", input_shape=None, bigdl_type="float"):
-        super(GlobalMaxPooling2D, self).__init__(None, bigdl_type,
+    def __init__(self, dim_ordering="th", input_shape=None, name=None, bigdl_type="float"):
+        super(GlobalMaxPooling2D, self).__init__(None, bigdl_type, name,
                                                  dim_ordering,
                                                  list(input_shape) if input_shape else None)
 
@@ -1290,12 +1349,13 @@ class GlobalAveragePooling2D(KerasLayer):
     # Arguments
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> globalaveragepooling2d = GlobalAveragePooling2D(input_shape=(4, 32, 32))
     creating: createKerasGlobalAveragePooling2D
     """
-    def __init__(self, dim_ordering="th", input_shape=None, bigdl_type="float"):
-        super(GlobalAveragePooling2D, self).__init__(None, bigdl_type,
+    def __init__(self, dim_ordering="th", input_shape=None, name=None, bigdl_type="float"):
+        super(GlobalAveragePooling2D, self).__init__(None, bigdl_type, name,
                                                      dim_ordering,
                                                      list(input_shape) if input_shape else None)
 
@@ -1313,12 +1373,13 @@ class GlobalMaxPooling3D(KerasLayer):
     # Arguments
     dim_ordering: Format of input data. Only 'th' (Channel First) is supported for now.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> globalmaxpooling3d = GlobalMaxPooling3D(input_shape=(4, 32, 32, 32))
     creating: createKerasGlobalMaxPooling3D
     """
-    def __init__(self, dim_ordering="th", input_shape=None, bigdl_type="float"):
-        super(GlobalMaxPooling3D, self).__init__(None, bigdl_type,
+    def __init__(self, dim_ordering="th", input_shape=None, name=None, bigdl_type="float"):
+        super(GlobalMaxPooling3D, self).__init__(None, bigdl_type, name,
                                                  dim_ordering,
                                                  list(input_shape) if input_shape else None)
 
@@ -1336,12 +1397,13 @@ class GlobalAveragePooling3D(KerasLayer):
     # Arguments
     dim_ordering: Format of input data. Only 'th' (Channel First) is supported for now.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> globalaveragepooling3d = GlobalAveragePooling3D(input_shape=(4, 16, 16, 20))
     creating: createKerasGlobalAveragePooling3D
     """
-    def __init__(self, dim_ordering="th", input_shape=None, bigdl_type="float"):
-        super(GlobalAveragePooling3D, self).__init__(None, bigdl_type,
+    def __init__(self, dim_ordering="th", input_shape=None, name=None, bigdl_type="float"):
+        super(GlobalAveragePooling3D, self).__init__(None, bigdl_type, name,
                                                      dim_ordering,
                                                      list(input_shape) if input_shape else None)
 
@@ -1356,7 +1418,7 @@ class SimpleRNN(KerasLayer):
 
     # Arguments
     output_dim: Hidden unit size. Dimension of internal projections and final output.
-    activation: String representations of activation function to use (such as 'relu' or 'sigmoid').
+    activation: String representation of the activation function to use (such as 'relu' or 'sigmoid').
                 Default is 'tanh'.
     return_sequences: Whether to return the full sequence or only return the last output in the output sequence.
                       Default is False.
@@ -1366,14 +1428,15 @@ class SimpleRNN(KerasLayer):
     U_regularizer: An instance of [[Regularizer]], applied the recurrent weights matrices. Default is None.
     b_regularizer: An instance of [[Regularizer]], applied to the bias. Default is None.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> simplernn = SimpleRNN(16, input_shape=(3, 32))
     creating: createKerasSimpleRNN
     """
     def __init__(self, output_dim, activation="tanh", return_sequences=False,
                  go_backwards=False, W_regularizer=None, U_regularizer=None,
-                 b_regularizer=None, input_shape=None, bigdl_type="float"):
-        super(SimpleRNN, self).__init__(None, bigdl_type,
+                 b_regularizer=None, input_shape=None, name=None, bigdl_type="float"):
+        super(SimpleRNN, self).__init__(None, bigdl_type, name,
                                         output_dim,
                                         activation,
                                         return_sequences,
@@ -1394,9 +1457,9 @@ class LSTM(KerasLayer):
 
     # Arguments
     output_dim: Hidden unit size. Dimension of internal projections and final output.
-    activation: String representations of activation function to use (such as 'relu' or 'sigmoid').
+    activation: String representation of the activation function to use (such as 'relu' or 'sigmoid').
                 Default is 'tanh'.
-    inner_activation: String representations of activation function for inner cells. Default is 'hard_sigmoid'.
+    inner_activation: String representation of the activation function for inner cells. Default is 'hard_sigmoid'.
     return_sequences: Whether to return the full sequence or only return the last output in the output sequence.
                       Default is False.
     go_backwards: Whether the input sequence will be processed backwards. Default is False.
@@ -1405,14 +1468,15 @@ class LSTM(KerasLayer):
     U_regularizer: An instance of [[Regularizer]], applied the recurrent weights matrices. Default is None.
     b_regularizer: An instance of [[Regularizer]], applied to the bias. Default is None.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> lstm = LSTM(32, input_shape=(8, 16))
     creating: createKerasLSTM
     """
     def __init__(self, output_dim, activation="tanh", inner_activation="hard_sigmoid",
                  return_sequences=False, go_backwards=False, W_regularizer=None,
-                 U_regularizer=None, b_regularizer=None, input_shape=None, bigdl_type="float"):
-        super(LSTM, self).__init__(None, bigdl_type,
+                 U_regularizer=None, b_regularizer=None, input_shape=None, name=None, bigdl_type="float"):
+        super(LSTM, self).__init__(None, bigdl_type, name,
                                    output_dim,
                                    activation,
                                    inner_activation,
@@ -1434,9 +1498,9 @@ class GRU(KerasLayer):
 
     # Arguments
     output_dim: Hidden unit size. Dimension of internal projections and final output.
-    activation: String representations of activation function to use (such as 'relu' or 'sigmoid').
+    activation: String representation of the activation function to use (such as 'relu' or 'sigmoid').
                 Default is 'tanh'.
-    inner_activation: String representations of activation function for inner cells. Default is 'hard_sigmoid'.
+    inner_activation: String representation of the activation function for inner cells. Default is 'hard_sigmoid'.
     return_sequences: Whether to return the full sequence or only return the last output in the output sequence.
                       Default is False.
     go_backwards: Whether the input sequence will be processed backwards. Default is False.
@@ -1445,14 +1509,15 @@ class GRU(KerasLayer):
     U_regularizer: An instance of [[Regularizer]], applied the recurrent weights matrices. Default is None.
     b_regularizer: An instance of [[Regularizer]], applied to the bias. Default is None.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> gru = GRU(24, input_shape=(32, 32))
     creating: createKerasGRU
     """
     def __init__(self, output_dim, activation="tanh", inner_activation="hard_sigmoid",
                  return_sequences=False, go_backwards=False, W_regularizer=None,
-                 U_regularizer=None, b_regularizer=None, input_shape=None, bigdl_type="float"):
-        super(GRU, self).__init__(None, bigdl_type,
+                 U_regularizer=None, b_regularizer=None, input_shape=None, name=None, bigdl_type="float"):
+        super(GRU, self).__init__(None, bigdl_type, name,
                                   output_dim,
                                   activation,
                                   inner_activation,
@@ -1479,9 +1544,9 @@ class ConvLSTM2D(KerasLayer):
     nb_filter: Number of convolution filters to use.
     nb_row: Number of rows in the convolution kernel.
     nb_col: Number of cols in the convolution kernel. Should be equal to nb_row as for a square kernel.
-    activation: String representations of activation function to use (such as 'relu' or 'sigmoid').
+    activation: String representation of the activation function to use (such as 'relu' or 'sigmoid').
                 Default is 'tanh'.
-    inner_activation: String representations of activation function for inner cells. Default is 'hard_sigmoid'.
+    inner_activation: String representation of the activation function for inner cells. Default is 'hard_sigmoid'.
     dim_ordering: Format of input data. Only 'th' (Channel First) is supported for now.
     border_mode: Only 'same' is supported for now.
     subsample: Tuple of length 2. Factor by which to subsample output. Also called strides elsewhere.
@@ -1494,6 +1559,7 @@ class ConvLSTM2D(KerasLayer):
                       Default is False.
     go_backwards: Whether the input sequence will be processed backwards. Default is False.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> convlstm2d = ConvLSTM2D(24, 3, 3, input_shape=(4, 32, 32, 32))
     creating: createKerasConvLSTM2D
@@ -1501,14 +1567,14 @@ class ConvLSTM2D(KerasLayer):
     def __init__(self, nb_filter, nb_row, nb_col, activation="tanh",
                  inner_activation="hard_sigmoid", dim_ordering="th", border_mode="same",
                  subsample=(1, 1), W_regularizer=None, U_regularizer=None, b_regularizer=None,
-                 return_sequences=False, go_backwards=False, input_shape=None, bigdl_type="float"):
+                 return_sequences=False, go_backwards=False, input_shape=None, name=None, bigdl_type="float"):
         if nb_row != nb_col:
             raise ValueError("For ConvLSTM2D, only square kernel is supported for now")
         if border_mode != "same":
             raise ValueError("For ConvLSTM2D, only border_mode='same' is supported for now")
         if subsample[0] != subsample[1]:
             raise ValueError("For ConvLSTM2D, only equal strides is supported for now")
-        super(ConvLSTM2D, self).__init__(None, bigdl_type,
+        super(ConvLSTM2D, self).__init__(None, bigdl_type, name,
                                          nb_filter,
                                          nb_row,
                                          activation,
@@ -1536,7 +1602,7 @@ class LocallyConnected1D(KerasLayer):
     # Arguments
     nb_filter: Dimensionality of the output.
     filter_length: The extension (spatial or temporal) of each filter.
-    activation: String representations of activation function to use (such as 'relu' or 'sigmoid').
+    activation: String representation of the activation function to use (such as 'relu' or 'sigmoid').
                 Default is None.
     border_mode: Only 'valid' is supported for now.
     subsample_length: Factor by which to subsample output. Int. Default is 1.
@@ -1546,16 +1612,17 @@ class LocallyConnected1D(KerasLayer):
     bias: Whether to include a bias (i.e. make the layer affine rather than linear).
           Default is True.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> locallyconnected1d = LocallyConnected1D(6, 3, input_shape=(8, 12))
     creating: createKerasLocallyConnected1D
     """
     def __init__(self, nb_filter, filter_length, activation=None, border_mode="valid",
                  subsample_length=1, W_regularizer=None, b_regularizer=None,
-                 bias=True, input_shape=None, bigdl_type="float"):
+                 bias=True, input_shape=None, name=None, bigdl_type="float"):
         if border_mode != "valid":
             raise ValueError("For LocallyConnected1D, only border_mode='valid' is supported for now")
-        super(LocallyConnected1D, self).__init__(None, bigdl_type,
+        super(LocallyConnected1D, self).__init__(None, bigdl_type, name,
                                                  nb_filter,
                                                  filter_length,
                                                  activation,
@@ -1579,7 +1646,7 @@ class LocallyConnected2D(KerasLayer):
     nb_filter: Number of convolution filters to use.
     nb_row: Number of rows in the convolution kernel.
     nb_col: Number of cols in the convolution kernel.
-    activation: String representations of activation function to use (such as 'relu' or 'sigmoid').
+    activation: String representation of the activation function to use (such as 'relu' or 'sigmoid').
                 Default is None.
     border_mode: Either 'valid' or 'same'. Default is 'valid'.
     subsample: Int tuple of length 2 corresponding to the step of the convolution in the
@@ -1591,6 +1658,7 @@ class LocallyConnected2D(KerasLayer):
     bias: Whether to include a bias (i.e. make the layer affine rather than linear).
           Default is True.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> locallyconnected2d = LocallyConnected2D(12, 3, 4, input_shape=(3, 128, 128))
     creating: createKerasLocallyConnected2D
@@ -1598,8 +1666,8 @@ class LocallyConnected2D(KerasLayer):
     def __init__(self, nb_filter, nb_row, nb_col, activation=None,
                  border_mode="valid", subsample=(1, 1), dim_ordering="th",
                  W_regularizer=None, b_regularizer=None, bias=True,
-                 input_shape=None, bigdl_type="float"):
-        super(LocallyConnected2D, self).__init__(None, bigdl_type,
+                 input_shape=None, name=None, bigdl_type="float"):
+        super(LocallyConnected2D, self).__init__(None, bigdl_type, name,
                                                  nb_filter,
                                                  nb_row,
                                                  nb_col,
@@ -1629,12 +1697,13 @@ class SpatialDropout1D(KerasLayer):
     # Arguments
     p: Fraction of the input units to drop. Float between 0 and 1.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> spatialdropout1d = SpatialDropout1D(0.4, input_shape=(10, 12))
     creating: createKerasSpatialDropout1D
     """
-    def __init__(self, p=0.5, input_shape=None, bigdl_type="float"):
-        super(SpatialDropout1D, self).__init__(None, bigdl_type,
+    def __init__(self, p=0.5, input_shape=None, name=None, bigdl_type="float"):
+        super(SpatialDropout1D, self).__init__(None, bigdl_type, name,
                                                float(p),
                                                list(input_shape) if input_shape else None)
 
@@ -1656,12 +1725,13 @@ class SpatialDropout2D(KerasLayer):
     p: Fraction of the input units to drop. Float between 0 and 1.
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> spatialdropout2d = SpatialDropout2D(0.25, input_shape=(5, 12, 12))
     creating: createKerasSpatialDropout2D
     """
-    def __init__(self, p=0.5, dim_ordering="th", input_shape=None, bigdl_type="float"):
-        super(SpatialDropout2D, self).__init__(None, bigdl_type,
+    def __init__(self, p=0.5, dim_ordering="th", input_shape=None, name=None, bigdl_type="float"):
+        super(SpatialDropout2D, self).__init__(None, bigdl_type, name,
                                                float(p),
                                                dim_ordering,
                                                list(input_shape) if input_shape else None)
@@ -1684,12 +1754,13 @@ class SpatialDropout3D(KerasLayer):
     p: Fraction of the input units to drop. Float between 0 and 1.
     dim_ordering: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> spatialdropout3d = SpatialDropout3D(0.6, input_shape=(4, 12, 12, 16))
     creating: createKerasSpatialDropout3D
     """
-    def __init__(self, p=0.5, dim_ordering="th", input_shape=None, bigdl_type="float"):
-        super(SpatialDropout3D, self).__init__(None, bigdl_type,
+    def __init__(self, p=0.5, dim_ordering="th", input_shape=None, name=None, bigdl_type="float"):
+        super(SpatialDropout3D, self).__init__(None, bigdl_type, name,
                                                float(p),
                                                dim_ordering,
                                                list(input_shape) if input_shape else None)
@@ -1707,12 +1778,13 @@ class GaussianDropout(KerasLayer):
     p: Drop probability. Float between 0 and 1.
        The multiplicative noise will have standard deviation 'sqrt(p/(1-p))'.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> gaussiandropout = GaussianDropout(0.45, input_shape=(4, 8))
     creating: createKerasGaussianDropout
     """
-    def __init__(self, p, input_shape=None, bigdl_type="float"):
-        super(GaussianDropout, self).__init__(None, bigdl_type,
+    def __init__(self, p, input_shape=None, name=None, bigdl_type="float"):
+        super(GaussianDropout, self).__init__(None, bigdl_type, name,
                                               float(p),
                                               list(input_shape) if input_shape else None)
 
@@ -1730,12 +1802,13 @@ class GaussianNoise(KerasLayer):
     # Arguments
     sigma: Float, standard deviation of the noise distribution.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> gaussiannoise = GaussianNoise(0.45, input_shape=(3, 4, 5))
     creating: createKerasGaussianNoise
     """
-    def __init__(self, sigma, input_shape=None, bigdl_type="float"):
-        super(GaussianNoise, self).__init__(None, bigdl_type,
+    def __init__(self, sigma, input_shape=None, name=None, bigdl_type="float"):
+        super(GaussianNoise, self).__init__(None, bigdl_type, name,
                                             float(sigma),
                                             list(input_shape) if input_shape else None)
 
@@ -1753,12 +1826,13 @@ class Masking(KerasLayer):
                 if all values in the input tensor at that timestep are equal to `mask_value`,
                 then the timestep will masked (skipped) in all downstream layers.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> masking = Masking(0.3, input_shape=(6, 8))
     creating: createKerasMasking
     """
-    def __init__(self, mask_value=0.0, input_shape=None, bigdl_type="float"):
-        super(Masking, self).__init__(None, bigdl_type,
+    def __init__(self, mask_value=0.0, input_shape=None, name=None, bigdl_type="float"):
+        super(Masking, self).__init__(None, bigdl_type, name,
                                       float(mask_value),
                                       list(input_shape) if input_shape else None)
 
@@ -1775,13 +1849,13 @@ class SReLU(KerasLayer):
     input_shape (a shape tuple, does not include the batch dimension).
 
     # Arguments
-    t_left_init: String representations of initialization method for the left part intercept.
+    t_left_init: String representation of the initialization method for the left part intercept.
                  Default is 'zero'.
-    a_left_init: String representations of initialization method for the left part slope.
+    a_left_init: String representation of the initialization method for the left part slope.
                  Default is 'glorot_uniform'.
-    t_right_init: String representations of initialization method for the right part intercept.
+    t_right_init: String representation of ithe nitialization method for the right part intercept.
                   Default is 'glorot_uniform'.
-    a_right_init: String representations of initialization method for the right part slope.
+    a_right_init: String representation of the initialization method for the right part slope.
                   Default is 'one'.
     shared_axes: Int tuple. The axes along which to share learnable parameters for the activation function.
                  Default is None.
@@ -1789,14 +1863,15 @@ class SReLU(KerasLayer):
                  (batch, height, width, channels), and you wish to share parameters across space so that
                  each filter only has one set of parameters, set 'SharedAxes=(1,2)'.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> srelu = SReLU(input_shape=(4, 5))
     creating: createKerasSReLU
     """
     def __init__(self, t_left_init='zero', a_left_init='glorot_uniform',
                  t_right_init='glorot_uniform', a_right_init='one',
-                 shared_axes=None, input_shape=None, bigdl_type="float"):
-        super(SReLU, self).__init__(None, bigdl_type,
+                 shared_axes=None, input_shape=None, name=None, bigdl_type="float"):
+        super(SReLU, self).__init__(None, bigdl_type, name,
                                     t_left_init,
                                     a_left_init,
                                     t_right_init,
@@ -1818,12 +1893,13 @@ class ELU(KerasLayer):
     # Arguments
     alpha: Float, scale for the negative factor.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> elu = ELU(1.2, input_shape=(4, 5))
     creating: createKerasELU
     """
-    def __init__(self, alpha=1.0, input_shape=None, bigdl_type="float"):
-        super(ELU, self).__init__(None, bigdl_type,
+    def __init__(self, alpha=1.0, input_shape=None, name=None, bigdl_type="float"):
+        super(ELU, self).__init__(None, bigdl_type, name,
                                   float(alpha),
                                   list(input_shape) if input_shape else None)
 
@@ -1841,12 +1917,13 @@ class LeakyReLU(KerasLayer):
     # Arguments
     alpha: Float >= 0. Negative slope coefficient.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> leakyrelu = LeakyReLU(0.02, input_shape=(4, 5))
     creating: createKerasLeakyReLU
     """
-    def __init__(self, alpha=0.01, input_shape=None, bigdl_type="float"):
-        super(LeakyReLU, self).__init__(None, bigdl_type,
+    def __init__(self, alpha=0.01, input_shape=None, name=None, bigdl_type="float"):
+        super(LeakyReLU, self).__init__(None, bigdl_type, name,
                                         float(alpha),
                                         list(input_shape) if input_shape else None)
 
@@ -1864,12 +1941,13 @@ class ThresholdedReLU(KerasLayer):
     # Arguments
     theta: Float >= 0. Threshold location of activation.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the layer. Default is None.
 
     >>> thresholdedrelu = ThresholdedReLU(input_shape=(10, 12))
     creating: createKerasThresholdedReLU
     """
-    def __init__(self, theta=1.0, input_shape=None, bigdl_type="float"):
-        super(ThresholdedReLU, self).__init__(None, bigdl_type,
+    def __init__(self, theta=1.0, input_shape=None, name=None, bigdl_type="float"):
+        super(ThresholdedReLU, self).__init__(None, bigdl_type, name,
                                               float(theta),
                                               list(input_shape) if input_shape else None)
 
@@ -1882,6 +1960,7 @@ class TimeDistributed(KerasLayer):
 
     When you use this layer as the first layer of a model, you need to provide the argument
     input_shape (a shape tuple, does not include the batch dimension).
+    name: String to specify the name of the wrapper. Default is None.
 
     # Arguments
     layer: A layer instance.
@@ -1891,8 +1970,8 @@ class TimeDistributed(KerasLayer):
     creating: createKerasDense
     creating: createKerasTimeDistributed
     """
-    def __init__(self, layer, input_shape=None, bigdl_type="float"):
-        super(TimeDistributed, self).__init__(None, bigdl_type,
+    def __init__(self, layer, input_shape=None, name=None, bigdl_type="float"):
+        super(TimeDistributed, self).__init__(None, bigdl_type, name,
                                               layer,
                                               list(input_shape) if input_shape else None)
 
@@ -1913,13 +1992,14 @@ class Bidirectional(KerasLayer):
     merge_mode: Mode by which outputs of the forward and backward RNNs will be combined.
                 Must be one of: 'sum', 'mul', 'concat', 'ave'. Default is 'concat'.
     input_shape: A shape tuple, not including batch.
+    name: String to specify the name of the wrapper. Default is None.
 
     >>> bidiretional = Bidirectional(LSTM(10, return_sequences=True), input_shape=(12, 16))
     creating: createKerasLSTM
     creating: createKerasBidirectional
     """
-    def __init__(self, layer, merge_mode="concat", input_shape=None, bigdl_type="float"):
-        super(Bidirectional, self).__init__(None, bigdl_type,
+    def __init__(self, layer, merge_mode="concat", input_shape=None, name=None, bigdl_type="float"):
+        super(Bidirectional, self).__init__(None, bigdl_type, name,
                                             layer,
                                             merge_mode,
                                             list(input_shape) if input_shape else None)

--- a/pyspark/bigdl/nn/keras/topology.py
+++ b/pyspark/bigdl/nn/keras/topology.py
@@ -135,13 +135,16 @@ class KerasModel(KerasLayer):
 
 class Sequential(KerasModel):
     """
-    Container for a Sequential model.
+    Container for a sequential model.
 
-    >>> sequential = Sequential()
+    # Arguments
+    name: String to specify the name of the sequential model. Default is None.
+
+    >>> sequential = Sequential(name="seq1")
     creating: createKerasSequential
     """
-    def __init__(self, bigdl_type="float"):
-        super(Sequential, self).__init__(None, bigdl_type=bigdl_type)
+    def __init__(self, **kwargs):
+        super(Sequential, self).__init__(None, **kwargs)
 
     def add(self, model):
         self.value.add(model.value)
@@ -149,7 +152,16 @@ class Sequential(KerasModel):
 
 
 class Model(KerasModel):
-    def __init__(self, input, output, bigdl_type="float"):
-        super(Model, self).__init__(None, bigdl_type,
+    """
+    Container for a graph model.
+
+    # Arguments
+    input: An input node or a list of input nodes.
+    output: An output node or a list of output nodes.
+    name: String to specify the name of the graph model. Default is None.
+    """
+    def __init__(self, input, output, **kwargs):
+        super(Model, self).__init__(None,
                                     to_list(input),
-                                    to_list(output))
+                                    to_list(output),
+                                    **kwargs)

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -78,6 +78,8 @@ class Layer(JavaValue):
 
     def set_running_mean(self, running_mean):
         """
+        Set the running mean of the layer.
+        Only use this method for a BatchNormalization layer.
         :param running_mean: a ndarray
         """
         callBigDlFunc(self.bigdl_type, "setRunningMean",
@@ -86,11 +88,29 @@ class Layer(JavaValue):
 
     def set_running_std(self, running_std):
         """
-        :param running_mean: a ndarray
+        Set the running variance of the layer.
+        Only use this method for a BatchNormalization layer.
+        :param running_std: a ndarray
         """
         callBigDlFunc(self.bigdl_type, "setRunningStd",
                       self.value, JTensor.from_ndarray(running_std))
         return self
+
+    def get_running_mean(self):
+        """
+        Get the running meaning of the layer.
+        Only use this method for a BatchNormalization layer.
+        """
+        return callBigDlFunc(self.bigdl_type, "getRunningMean",
+                             self.value).to_ndarray()
+
+    def get_running_std(self):
+        """
+        Get the running variance of the layer.
+        Only use this method for a BatchNormalization layer.
+        """
+        return callBigDlFunc(self.bigdl_type, "getRunningStd",
+                             self.value).to_ndarray()
 
     def __str__(self):
         """

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -80,7 +80,7 @@ class Layer(JavaValue):
         """
         Set the running mean of the layer.
         Only use this method for a BatchNormalization layer.
-        :param running_mean: a ndarray
+        :param running_mean: a Numpy array.
         """
         callBigDlFunc(self.bigdl_type, "setRunningMean",
                       self.value, JTensor.from_ndarray(running_mean))
@@ -90,27 +90,11 @@ class Layer(JavaValue):
         """
         Set the running variance of the layer.
         Only use this method for a BatchNormalization layer.
-        :param running_std: a ndarray
+        :param running_std: a Numpy array.
         """
         callBigDlFunc(self.bigdl_type, "setRunningStd",
                       self.value, JTensor.from_ndarray(running_std))
         return self
-
-    def get_running_mean(self):
-        """
-        Get the running meaning of the layer.
-        Only use this method for a BatchNormalization layer.
-        """
-        return callBigDlFunc(self.bigdl_type, "getRunningMean",
-                             self.value).to_ndarray()
-
-    def get_running_std(self):
-        """
-        Get the running variance of the layer.
-        Only use this method for a BatchNormalization layer.
-        """
-        return callBigDlFunc(self.bigdl_type, "getRunningStd",
-                             self.value).to_ndarray()
 
     def __str__(self):
         """

--- a/pyspark/test/bigdl/keras/test_application.py
+++ b/pyspark/test/bigdl/keras/test_application.py
@@ -31,13 +31,7 @@ class TestApplication(BigDLTestCase):
 
     def assert_model(self, input_data, kmodel, rtol=1e-5, atol=1e-5):
         bmodel = DefinitionLoader.from_kmodel(kmodel)
-        WeightLoader.load_weights_from_kmodel(bmodel, kmodel)
-
-        keras_output = kmodel.predict(input_data)
-        bmodel.training(is_training=False)
-        bigdl_output = bmodel.forward(input_data)
-
-        self.assert_allclose(keras_output, bigdl_output, rtol=rtol, atol=atol)
+        self.compare_model(bmodel, kmodel, input_data, rtol, atol)
 
     def test_lenet(self):
         K.set_image_dim_ordering("th")

--- a/pyspark/test/bigdl/keras/test_newapi.py
+++ b/pyspark/test/bigdl/keras/test_newapi.py
@@ -174,12 +174,13 @@ class TestNewAPI(BigDLTestCase):
         model.fit(data_set, batch_size=8, nb_epoch=2, validation_data=data_set)
 
     def test_merge_method(self):
+        from bigdl.nn.keras.topology import Model as BModel
         bx1 = BLayer.Input(shape=(8, ))
         bx2 = BLayer.Input(shape=(6, ))
         by1 = BLayer.Dense(10)(bx1)
         by2 = BLayer.Dense(10)(bx2)
         z = BLayer.merge([by1, by2], mode="sum")
-        bmodel = BLayer.Model([bx1, bx2], z)
+        bmodel = BModel([bx1, bx2], z, name="graph1")
 
         from keras.engine import merge, Model
         kx1 = KLayer.Input(shape=(8, ))
@@ -193,6 +194,14 @@ class TestNewAPI(BigDLTestCase):
         def weight_converter(kmodel, weights):
             return [weights[0].T, weights[1], weights[2].T, weights[3]]
         self.compare_newapi(kmodel, bmodel, input_data, weight_converter)
+
+    def test_name(self):
+        from bigdl.nn.keras.topology import Sequential as BSequential
+        model = BSequential(name="seq")
+        input = BLayer.InputLayer(input_shape=(8, ), name="input111")
+        model.add(input)
+        dense = BLayer.Dense(10, input_dim=8, name="dense1")
+        model.add(dense)
 
 
 if __name__ == "__main__":

--- a/pyspark/test/bigdl/keras/test_newapi.py
+++ b/pyspark/test/bigdl/keras/test_newapi.py
@@ -138,8 +138,11 @@ class TestNewAPI(BigDLTestCase):
         y2 = BLayer.Dense(10)(x2)
         model = BModel([x1, x2], [y1, y2])
         input_shapes = model.get_input_shape()
+        output_shapes = model.get_output_shape()
         np.testing.assert_allclose((8, ), input_shapes[0][1:])
         np.testing.assert_allclose((6, ), input_shapes[1][1:])
+        np.testing.assert_allclose((10, ), output_shapes[0][1:])
+        np.testing.assert_allclose((10, ), output_shapes[1][1:])
 
     def test_train(self):
         x = np.random.random([32, 10])
@@ -240,7 +243,6 @@ class TestNewAPI(BigDLTestCase):
 
         input_data = [np.random.random([2, 10]), np.random.random([2, 10])]
         self.compare_newapi(kmodel, bmodel, input_data, self.convert_two_dense_model)
-
 
 
 if __name__ == "__main__":

--- a/pyspark/test/bigdl/test_utils.py
+++ b/pyspark/test/bigdl/test_utils.py
@@ -329,7 +329,8 @@ class BigDLTestCase(TestCase):
         kmodel = KSequential()
         kmodel.add(klayer)
         koutput = kmodel.predict(input_data)
-        if isinstance(blayer, BLayer.BatchNormalization):
+        from bigdl.nn.keras.layer import BatchNormalization
+        if isinstance(blayer, BatchNormalization):
             k_running_mean = K.eval(klayer.running_mean)
             k_running_std = K.eval(klayer.running_std)
             blayer.set_running_mean(k_running_mean)
@@ -339,3 +340,10 @@ class BigDLTestCase(TestCase):
         bmodel.training(is_training)
         boutput = bmodel.forward(input_data)
         self.assert_allclose(boutput, koutput, rtol=rtol, atol=atol)
+
+    def compare_model(self, bmodel, kmodel, input_data, rtol=1e-5, atol=1e-5):
+        WeightLoader.load_weights_from_kmodel(bmodel, kmodel)
+        bmodel.training(is_training=False)
+        bigdl_output = bmodel.forward(input_data)
+        keras_output = kmodel.predict(input_data)
+        self.assert_allclose(bigdl_output, keras_output, rtol=rtol, atol=atol)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Input.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Input.scala
@@ -36,8 +36,8 @@ class Input[T: ClassTag](val inputShape: Shape)(implicit ev: TensorNumeric[T])
 
 object Input {
   def apply[T: ClassTag](
-    name : String = null,
-    inputShape: Shape = null)(implicit ev: TensorNumeric[T]): ModuleNode[T] = {
+    inputShape: Shape = null,
+    name : String = null)(implicit ev: TensorNumeric[T]): ModuleNode[T] = {
     val module = new Input(inputShape)
     module.build(KerasLayer.addBatch(inputShape))
     if (name != null) {
@@ -49,8 +49,8 @@ object Input {
 
 object InputLayer {
   def apply[T: ClassTag](
-    name : String = null,
-    inputShape: Shape = null)(implicit ev: TensorNumeric[T]): KerasLayer[Activity, Activity, T] = {
+    inputShape: Shape = null,
+    name : String = null)(implicit ev: TensorNumeric[T]): KerasLayer[Activity, Activity, T] = {
     val module = new Input(inputShape)
     if (name != null) {
       module.setName(name)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Merge.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Merge.scala
@@ -16,6 +16,7 @@
 
 package com.intel.analytics.bigdl.nn.keras
 
+import com.intel.analytics.bigdl.nn.Graph.ModuleNode
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.nn.{CAddTable, CAveTable, CMaxTable, CMulTable, CosineDistance, DotProduct, JoinTable, ParallelTable, Sequential => TSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
@@ -184,5 +185,12 @@ object Merge {
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Merge[T] = {
     val layersArray = if (layers != null) layers.toArray else null
     new Merge[T](layersArray, mode, concatAxis, inputShape)
+  }
+
+  def merge[@specialized(Float, Double) T: ClassTag](
+    inputs: List[ModuleNode[T]],
+    mode: String = "sum",
+    concatAxis: Int = -1)(implicit ev: TensorNumeric[T]): ModuleNode[T] = {
+    new Merge[T](mode = mode, concatAxis = concatAxis).inputs(inputs.toArray)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Merge.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Merge.scala
@@ -25,7 +25,7 @@ import com.intel.analytics.bigdl.utils.{MultiShape, Shape}
 import scala.reflect.ClassTag
 
 /**
- * Used to merge a list of tensors into a single tensor, following some merge mode.
+ * Used to merge a list of inputs into a single output, following some merge mode.
  * Merge must have at least two input layers.
  *
  * When using this layer as the first layer in a model, you need to provide the argument
@@ -34,8 +34,8 @@ import scala.reflect.ClassTag
  * @param layers A list of layer instances. Must be more than one layer.
  * @param mode Merge mode. String, must be one of: 'sum', 'mul', 'concat', 'ave', 'cos',
  *             'dot', 'max'. Default is 'sum'.
- * @param concatAxis Integer, axis to use in mode concat. Only specify this when mode is 'concat'.
- *                   Default is -1, meaning the last axis of the input.
+ * @param concatAxis Integer, axis to use when concatenating layers. Only specify this when merge
+ *                   mode is 'concat'. Default is -1, meaning the last axis of the input.
  * @tparam T The numeric type of parameter(e.g. weight, bias). Only support float/double now.
  */
 class Merge[T: ClassTag](
@@ -52,8 +52,10 @@ class Merge[T: ClassTag](
   require(mergeMode == "sum" || mergeMode == "mul" || mergeMode == "concat" || mergeMode == "ave"
   || mergeMode == "cos" || mergeMode == "dot" || mergeMode == "max",
   s"Invalid merge mode: $mergeMode")
-  require(layers.length >= 2, s"Merge must have at least two input layers " +
-    s"but found ${layers.length}")
+  if (layers != null) {
+    require(layers.length >= 2, s"Merge must have at least two input layers " +
+      s"but found ${layers.length}")
+  }
 
   private def computeOutputShapeForConcat(input: List[Shape]): Shape = {
     import scala.util.control.Breaks._
@@ -116,25 +118,15 @@ class Merge[T: ClassTag](
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val input = inputShape.toMulti()
-    val model = TSequential[T]()
-    val parallel = ParallelTable()
-    var i = 0
-    while(i < layers.length) {
-      val tlayer = layers(i) match {
-        case k: KerasLayer[_, _, T] => k.labor
-        case t: AbstractModule[Activity, Activity, T] => t
-      }
-      parallel.add(tlayer)
-      i += 1
-    }
-    model.add(parallel)
     val seq = TSequential[T]()
     val layer = mergeMode match {
       case "sum" => CAddTable()
       case "mul" => CMulTable()
       case "max" => CMaxTable()
       case "ave" => CAveTable()
-      case "concat" => JoinTable(axis, input.length)
+      case "concat" =>
+        val input1 = input.head.toSingle().toArray
+        JoinTable(axis, input1.length -1)
       case "dot" =>
         seq.add(DotProduct())
         seq.add(com.intel.analytics.bigdl.nn.Reshape(Array(1), Some(true)))
@@ -144,8 +136,25 @@ class Merge[T: ClassTag](
         seq.add(com.intel.analytics.bigdl.nn.Reshape(Array(1, 1), Some(true)))
         seq
     }
-    model.add(layer)
-    model.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+    if (layers != null) {
+      val model = TSequential[T]()
+      val parallel = ParallelTable()
+      var i = 0
+      while(i < layers.length) {
+        val tlayer = layers(i) match {
+          case k: KerasLayer[_, _, T] => k.labor
+          case t: AbstractModule[Activity, Activity, T] => t
+        }
+        parallel.add(tlayer)
+        i += 1
+      }
+      model.add(parallel)
+      model.add(layer)
+      model.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+    }
+    else {
+      layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+    }
   }
 }
 
@@ -154,7 +163,7 @@ object Merge {
     inputShape: Shape = null,
     layers: Array[AbstractModule[Activity, Activity, T]]): Shape = {
     val batchInputShape = KerasLayer.addBatch(inputShape)
-    val actualInputShape =
+    val actualInputShape = if (layers != null) {
       MultiShape(layers.map { layer =>
       if (layer.isBuilt()) {  // it's possible while reloaded from file
         layer.getOutputShape()
@@ -162,6 +171,8 @@ object Merge {
         layer.build(layer.getInputShape())
       }
     }.toList)
+    }
+    else null
     if (batchInputShape != null) {
       require(batchInputShape.isInstanceOf[MultiShape],
         "Merge requires inputShape to be MultiShape")
@@ -176,6 +187,7 @@ object Merge {
     mode: String = "sum",
     concatAxis: Int = -1,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Merge[T] = {
-    new Merge[T](layers.toArray, mode, concatAxis, inputShape)
+    val layersArray = if (layers != null) layers.toArray else null
+    new Merge[T](layersArray, mode, concatAxis, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Merge.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Merge.scala
@@ -190,7 +190,8 @@ object Merge {
   def merge[@specialized(Float, Double) T: ClassTag](
     inputs: List[ModuleNode[T]],
     mode: String = "sum",
-    concatAxis: Int = -1)(implicit ev: TensorNumeric[T]): ModuleNode[T] = {
-    new Merge[T](mode = mode, concatAxis = concatAxis).inputs(inputs.toArray)
+    concatAxis: Int = -1,
+    name: String = null)(implicit ev: TensorNumeric[T]): ModuleNode[T] = {
+    new Merge[T](mode = mode, concatAxis = concatAxis).setName(name).inputs(inputs.toArray)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Reshape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Reshape.scala
@@ -90,7 +90,7 @@ class Reshape[T: ClassTag](
       layer = InferReshape(targetShape)
     }
     else {
-      layer = com.intel.analytics.bigdl.nn.Reshape(targetShape)
+      layer = com.intel.analytics.bigdl.nn.Reshape(targetShape, batchMode = Some(true))
     }
     layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -2635,6 +2635,14 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
     module.runningVar.set(toTensor(runningStd))
   }
 
+  def getRunningMean(module: BatchNormalization[T]): JTensor = {
+    toJTensor(module.runningMean)
+  }
+
+  def getRunningStd(module: BatchNormalization[T]): JTensor = {
+    toJTensor(module.runningVar)
+  }
+
   def createMasking(maskValue: Double)
   : Masking[T] = {
     Masking[T](maskValue)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLKeras.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLKeras.scala
@@ -164,7 +164,7 @@ class PythonBigDLKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pytho
   }
 
   def createKerasMerge(
-    layers: JList[AbstractModule[Activity, Activity, T]] = null,
+    layers: JList[KerasLayer[Activity, Activity, T]] = null,
     mode: String = "sum",
     concatAxis: Int = -1,
     inputShape: JList[JList[Int]]): Merge[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLKeras.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLKeras.scala
@@ -143,22 +143,22 @@ class PythonBigDLKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pytho
       gammaInit, dimOrdering, toScalaShape(inputShape))
   }
 
-  def setKerasRunningMean(module: BatchNormalization[T], runningMean: JTensor): Unit = {
+  def setRunningMean(module: BatchNormalization[T], runningMean: JTensor): Unit = {
     module.labor.asInstanceOf[SpatialBatchNormalization[T]]
       .runningMean.set(toTensor(runningMean))
   }
 
-  def setKerasRunningStd(module: BatchNormalization[T], runningStd: JTensor): Unit = {
+  def setRunningStd(module: BatchNormalization[T], runningStd: JTensor): Unit = {
     module.labor.asInstanceOf[SpatialBatchNormalization[T]]
       .runningVar.set(toTensor(runningStd))
   }
 
-  def getKerasRunningMean(module: BatchNormalization[T]): JTensor = {
+  def getRunningMean(module: BatchNormalization[T]): JTensor = {
     toJTensor(module.labor.asInstanceOf[SpatialBatchNormalization[T]]
       .runningMean)
   }
 
-  def getKerasRunningStd(module: BatchNormalization[T]): JTensor = {
+  def getRunningStd(module: BatchNormalization[T]): JTensor = {
     toJTensor(module.labor.asInstanceOf[SpatialBatchNormalization[T]]
       .runningVar)
   }
@@ -168,7 +168,9 @@ class PythonBigDLKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pytho
     mode: String = "sum",
     concatAxis: Int = -1,
     inputShape: JList[JList[Int]]): Merge[T] = {
-    Merge[T](layers.asScala.toList, mode, concatAxis, toScalaMultiShape(inputShape))
+    val layersList = if (layers != null) layers.asScala.toList
+                     else null
+    Merge[T](layersList, mode, concatAxis, toScalaMultiShape(inputShape))
   }
 
   def createKerasConvolution2D(

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLKeras.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLKeras.scala
@@ -164,7 +164,7 @@ class PythonBigDLKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pytho
   }
 
   def createKerasMerge(
-    layers: JList[KerasLayer[Activity, Activity, T]] = null,
+    layers: JList[AbstractModule[Activity, Activity, T]] = null,
     mode: String = "sum",
     concatAxis: Int = -1,
     inputShape: JList[JList[Int]]): Merge[T] = {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/LeNetSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/LeNetSpec.scala
@@ -34,4 +34,12 @@ class LeNetSpec extends FlatSpec with Matchers {
     val gradInput = cnn.backward(input, output)
   }
 
+  "LeNet forward with incompatible input tensor" should "raise an exception" in {
+    intercept[RuntimeException] {
+      val cnn = LeNet()
+      val input = Tensor[Float](Array(28, 28, 1)).rand()
+      val output = cnn.forward(input)
+    }
+  }
+
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MergeSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MergeSpec.scala
@@ -18,6 +18,7 @@ package com.intel.analytics.bigdl.keras.nn
 
 import com.intel.analytics.bigdl.keras.KerasBaseSpec
 import com.intel.analytics.bigdl.nn.keras.{Dense, Input, InputLayer, Merge, Model, Sequential => KSequential}
+import com.intel.analytics.bigdl.nn.keras.Merge._
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
 import com.intel.analytics.bigdl.utils.{MultiShape, Shape, T, Table}
@@ -42,8 +43,7 @@ class MergeSpec extends KerasBaseSpec {
   "merge method" should "work correctly" in {
     val l1 = Input[Float](inputShape = Shape(10))
     val l2 = Input[Float](inputShape = Shape(10))
-    // equivalent to output = merge(inputs=[l1, l2], mode="sum") on python side
-    val output = Merge[Float](mode = "sum").inputs(Array(l1, l2))
+    val output = merge(inputs = List(l1, l2), mode = "sum")
     val model = Model[Float](Array(l1, l2), output)
     val input1 = Tensor[Float](2, 4, 8).rand(0, 1)
     val input2 = Tensor[Float](2, 4, 8).rand(0, 1)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MergeSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MergeSpec.scala
@@ -17,7 +17,7 @@
 package com.intel.analytics.bigdl.keras.nn
 
 import com.intel.analytics.bigdl.keras.KerasBaseSpec
-import com.intel.analytics.bigdl.nn.keras.{Dense, InputLayer, Merge, Sequential => KSequential}
+import com.intel.analytics.bigdl.nn.keras.{Dense, Input, InputLayer, Merge, Model, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
 import com.intel.analytics.bigdl.utils.{MultiShape, Shape, T, Table}
@@ -37,6 +37,20 @@ class MergeSpec extends KerasBaseSpec {
     seq.add(layer)
     seq.getOutputShape().toSingle().toArray should be (Array(-1, 4, 8))
     seq.forward(input) should be (input1 + input2)
+  }
+
+  "merge method" should "work correctly" in {
+    val l1 = Input[Float](inputShape = Shape(10))
+    val l2 = Input[Float](inputShape = Shape(10))
+    // equivalent to output = merge(inputs=[l1, l2], mode="sum") on python side
+    val output = Merge[Float](mode = "sum").inputs(Array(l1, l2))
+    val model = Model[Float](Array(l1, l2), output)
+    val input1 = Tensor[Float](2, 4, 8).rand(0, 1)
+    val input2 = Tensor[Float](2, 4, 8).rand(0, 1)
+    val inputData = T(1 -> input1, 2 -> input2)
+    val outputData = model.forward(inputData)
+    require(model.getOutputShape().toSingle().sameElements(Array(-1, 10)))
+    outputData should be (input1 + input2)
   }
 
   "Merge with incompatible input shapes" should "raise an exception" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MergeSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MergeSpec.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.keras.nn
 
 import com.intel.analytics.bigdl.keras.KerasBaseSpec
 import com.intel.analytics.bigdl.nn.keras.{Dense, Input, InputLayer, Merge, Model, Sequential => KSequential}
-import com.intel.analytics.bigdl.nn.keras.Merge._
+import com.intel.analytics.bigdl.nn.keras.Merge.merge
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
 import com.intel.analytics.bigdl.utils.{MultiShape, Shape, T, Table}
@@ -41,16 +41,17 @@ class MergeSpec extends KerasBaseSpec {
   }
 
   "merge method" should "work correctly" in {
-    val l1 = Input[Float](inputShape = Shape(10))
-    val l2 = Input[Float](inputShape = Shape(10))
-    val output = merge(inputs = List(l1, l2), mode = "sum")
+    val input1 = Tensor[Float](2, 8).rand(0, 1)
+    val input2 = Tensor[Float](2, 12).rand(0, 1)
+    val input = T(1 -> input1, 2 -> input2)
+    val l1 = Input[Float](inputShape = Shape(8))
+    val l2 = Input[Float](inputShape = Shape(12))
+    val dense1 = Dense[Float](10).inputs(l1)
+    val dense2 = Dense[Float](10).inputs(l2)
+    val output = merge(inputs = List(dense1, dense2), mode = "sum")
     val model = Model[Float](Array(l1, l2), output)
-    val input1 = Tensor[Float](2, 4, 8).rand(0, 1)
-    val input2 = Tensor[Float](2, 4, 8).rand(0, 1)
-    val inputData = T(1 -> input1, 2 -> input2)
-    val outputData = model.forward(inputData)
-    require(model.getOutputShape().toSingle().sameElements(Array(-1, 10)))
-    outputData should be (input1 + input2)
+    model.forward(input)
+    model.getOutputShape().toSingle().toArray should be (Array(-1, 10))
   }
 
   "Merge with incompatible input shapes" should "raise an exception" in {
@@ -105,7 +106,7 @@ class MergeSpec extends KerasBaseSpec {
     seq.forward(input)
   }
 
-  "Merge complicated" should "work properly" in {
+  "Merge dense" should "work properly" in {
     val input1 = Tensor[Float](3, 8).rand(0, 1)
     val input2 = Tensor[Float](3, 6).rand(0, 1)
     val input = T(1 -> input1, 2 -> input2)


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Functional `merge` method in Keras.
Different from `Merge` layer, it merges a list of tensors (NOT layers) in a graph.
2. Refactor Python Keras layer **kwargs accept `name`, `bigdl_type`.
3. Fix some layer arguments to sync with Keras API.
4. Fix a bug in Merge concat and Reshape.
5. Fix some grammar issues in docs.

ResNet50, VGG16, VGG19, InceptionV3 models in Keras (with trained weights) can be written in BigDL use the new API with compatible prediction results.

## How was this patch tested?

Jenkins

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

