### PR TITLE
Optimize padding mechanism

### DIFF
--- a/pyspark/bigdl/nn/criterion.py
+++ b/pyspark/bigdl/nn/criterion.py
@@ -612,7 +612,7 @@ class TimeDistributedMaskCriterion(Criterion):
 
 
     >>> td = TimeDistributedMaskCriterion(ClassNLLCriterion())
-    creating: createTimeDistributedMaskCriterion
+    creating: createClassNLLCriterion
     creating: createTimeDistributedMaskCriterion
     '''
 

--- a/pyspark/bigdl/nn/criterion.py
+++ b/pyspark/bigdl/nn/criterion.py
@@ -596,6 +596,29 @@ class SoftmaxWithCriterion(Criterion):
                                                    ignore_label,
                                                    normalize_mode)
 
+class TimeDistributedMaskCriterion(Criterion):
+    '''
+    This class is intended to support inputs with 3 or more dimensions.
+    Apply Any Provided Criterion to every temporal slice of an input.
+    In addition, it supports padding mask.
+
+    eg. if the target is [ [-1, 1, 2, 3, -1], [5, 4, 3, -1, -1] ],
+      and set the paddingValue property to -1, then the loss of -1 would not
+      be accumulated and the loss is only divided by 6 (ont including the amount of
+      -1, in this case, we are only interested in 1, 2, 3, 5, 4, 3)
+
+    :param criterion: embedded criterion
+    :param padding_value: padding value
+
+
+    >>> td = TimeDistributedMaskCriterion(ClassNLLCriterion())
+    creating: createTimeDistributedMaskCriterion
+    creating: createTimeDistributedMaskCriterion
+    '''
+
+    def __init__(self, criterion, padding_value=0, bigdl_type="float"):
+        super(TimeDistributedMaskCriterion, self).__init__(
+            None, bigdl_type, criterion, padding_value)
 
 class TimeDistributedCriterion(Criterion):
     '''

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterion.scala
@@ -65,7 +65,8 @@ import com.intel.analytics.bigdl.utils.Engine
  */
 @SerialVersionUID(- 8696382776046599502L)
 class ClassNLLCriterion[@specialized(Float, Double) T: ClassTag]
-(weights: Tensor[T] = null, sizeAverage: Boolean = true, logProbAsInput: Boolean = true)
+(weights: Tensor[T] = null, sizeAverage: Boolean = true,
+  logProbAsInput: Boolean = true, paddingValue: Int = -1)
   (implicit ev: TensorNumeric[T]) extends TensorCriterion[T] {
   private var total_weight = ev.fromType[Int](0)
   if (weights != null) require(weights.dim() == 1,
@@ -80,7 +81,6 @@ class ClassNLLCriterion[@specialized(Float, Double) T: ClassTag]
   private val epsilon: T = ev.fromType(1e-8)
 
   private val oneMinusEpsilon: T = ev.minus(ev.one, epsilon)
-
 
 
   override def updateOutput(input: Tensor[T], target: Tensor[T]): T = {
@@ -106,6 +106,7 @@ class ClassNLLCriterion[@specialized(Float, Double) T: ClassTag]
           ev.times(ev.negative(input.valueAt(curTarget)), total_weight)
         }
       }
+      sparseOutput.resize(Array[Int]())
       sparseOutput.setValue(output)
     } else if (input.dim() == 2) {
       val batchSize = input.size(1)
@@ -231,7 +232,9 @@ object ClassNLLCriterion {
   def apply[@specialized(Float, Double) T: ClassTag](
     weights: Tensor[T] = null,
     sizeAverage: Boolean = true,
-    logProbAsInput: Boolean = true)(implicit ev: TensorNumeric[T]) : ClassNLLCriterion[T] = {
-    new ClassNLLCriterion[T](weights, sizeAverage, logProbAsInput)
+    logProbAsInput: Boolean = true,
+    paddingValue: Int = -1
+  )(implicit ev: TensorNumeric[T]) : ClassNLLCriterion[T] = {
+    new ClassNLLCriterion[T](weights, sizeAverage, logProbAsInput, paddingValue)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterion.scala
@@ -130,7 +130,7 @@ class ClassNLLCriterion[@specialized(Float, Double) T: ClassTag]
           val curTarget = ev.toType[Int](target.valueAt(_i))
           assert(curTarget >= 1 && curTarget <= nClasses || curTarget == paddingValue,
             s"curTarget ${curTarget} is out of range 1 to ${nClasses}")
-          if (curTarget == paddingValue) (ev.zero, ev.one)
+          if (curTarget == paddingValue) (ev.zero, ev.zero)
           else {
             val curWeight = if (weights != null) weights.valueAt(curTarget) else ev.fromType[Int](1)
             if (!logProbAsInput) {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LookupTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LookupTable.scala
@@ -262,6 +262,38 @@ class LookupTable[T: ClassTag]
       s + s" ,maxNorm=$maxNorm)"
     }
   }
+
+  override def parameters(): (Array[Tensor[T]], Array[Tensor[T]]) = {
+    (Array(this.weight), Array(this.gradWeight))
+  }
+
+  override def clearState() : this.type = {
+    super.clearState()
+    inputBuffer.set()
+    countBuffer.set()
+    normBuffer.set()
+    this
+  }
+
+  override def canEqual(other: Any): Boolean = other.isInstanceOf[LookupTable[T]]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: LookupTable[T] =>
+      super.equals(that) &&
+        (that canEqual this) &&
+        weight == that.weight &&
+        gradWeight == that.gradWeight &&
+        nIndex == that.nIndex &&
+        nOutput == that.nOutput &&
+        paddingValue == that.paddingValue &&
+        maxNorm == that.maxNorm &&
+        normType == that.normType
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    def getHashCode(a: Any): Int = if (a == null) 0 else a.hashCode()
+    val state = Seq(super.hashCode(), weight, gradWeight, nIndex, nOutput,
       paddingValue, maxNorm, normType)
     state.map(getHashCode).foldLeft(0)((a, b) => 31 * a + b)
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LookupTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LookupTable.scala
@@ -47,12 +47,13 @@ class LookupTable[T: ClassTag]
   val maxNorm: Double = Double.MaxValue,
   val normType: Double = 2.0,
   shouldScaleGradByFreq: Boolean = false,
-  var wRegularizer: Regularizer[T] = null
+  var wRegularizer: Regularizer[T] = null,
+  val maskZero: Boolean = false
 )
-(implicit ev: TensorNumeric[T]) extends TensorModule[T] with Initializable {
+  (implicit ev: TensorNumeric[T]) extends TensorModule[T] with Initializable {
 
-  val weight = Tensor[T](nIndex, nOutput)
-  val gradWeight = Tensor[T](nIndex, nOutput).zero()
+  var weight = Tensor[T](nIndex, nOutput)
+  var gradWeight = Tensor[T](nIndex, nOutput).zero()
 
   private var inputBuffer = Tensor[T]()
   private var normBuffer = Tensor[T]()
@@ -120,7 +121,7 @@ class LookupTable[T: ClassTag]
   }
 
   private def renormRow(row_data: Array[T], offset: Int, stride: Int,
-                        maxNorm: Double, normType: Double): Unit = {
+    maxNorm: Double, normType: Double): Unit = {
     var norm = 0.0
     var j = 0
     while (j < stride) {
@@ -165,6 +166,9 @@ class LookupTable[T: ClassTag]
   }
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
+    if (maskZero && paddingValue != 0) {
+      weight.select(1, paddingValue.toInt).zero()
+    }
     require(input.dim() == 1 || input.dim() == 2,
       s"LookupTable: ${ErrorInfo.constrainInputAsVectorOrBatch}, input dim [${input.dim()}]"  )
     renorm(input)
@@ -180,7 +184,7 @@ class LookupTable[T: ClassTag]
       case e: IllegalArgumentException =>
         throw new IllegalArgumentException(
           s"LookupTable updateOutput get exception:${e.getMessage}\n" +
-          s"please ensure elements of your input will not exceed ${nIndex}")
+            s"please ensure elements of your input will not exceed ${nIndex}")
       case e: Exception =>
         throw e
     }
@@ -257,8 +261,16 @@ class LookupTable[T: ClassTag]
     }
   }
 
+  override def zeroGradParameters(): Unit = {
+    gradWeight.zero()
+  }
+
   override def parameters(): (Array[Tensor[T]], Array[Tensor[T]]) = {
     (Array(this.weight), Array(this.gradWeight))
+  }
+
+  override def getParametersTable(): Table = {
+    T(getName() -> T("weight" -> weight, "gradWeight" -> gradWeight))
   }
 
   override def clearState() : this.type = {
@@ -298,11 +310,11 @@ object LookupTable {
     nIndex: Int, nOutput: Int,
     paddingValue: Double = 0, maxNorm: Double = Double.MaxValue,
     normType: Double = 2.0, shouldScaleGradByFreq: Boolean = false,
-    wRegularizer: Regularizer[T] = null
+    wRegularizer: Regularizer[T] = null,
+    maskZero: Boolean = false
   )
-   (implicit ev: TensorNumeric[T]): LookupTable[T] =
+    (implicit ev: TensorNumeric[T]): LookupTable[T] =
     new LookupTable[T](nIndex, nOutput, paddingValue,
-      maxNorm, normType, shouldScaleGradByFreq, wRegularizer)
+      maxNorm, normType, shouldScaleGradByFreq, wRegularizer, maskZero)
 }
-
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -265,6 +265,8 @@ class Recurrent[T : ClassTag](
     initHidden(outputSize.drop(2))
     cloneCells()
     if (maskZero) {
+      require(input.dim == 3,
+        "If maskZero set to true, input should be a 3D Tensor, e.g [batch, times, nDim]")
       inputBuffer.resizeAs(input).abs(input).max(maskBuffer, indexBuffer, 3)
       minLength = ev.toType[Int](maskBuffer.sign().sum(2).min(1)._1(Array(1, 1, 1)))
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -179,31 +179,6 @@ class Recurrent[T : ClassTag](
     }
   }
 
-  // used for multirnncell, for internal test
-//  def initHidden2(sizes: Array[Int]): Unit = {
-//    val stepSizes = sizes
-//
-//    if (containMultiRNNCell) {
-//      if (hidden == null) {
-//        //      if (hiddenStates.getState().size == 0) {
-//        cells.clear()
-//        cells += topology
-//        hidden = T()
-//        gradHidden = T()
-//      }
-//
-//      val multiCells = topology.asInstanceOf[MultiRNNCell[T]].cells
-//      var i = 0
-//      while (i < multiCells.size) {
-//        //        hiddenStates(i) = multiCells(i).hidResize(null, batchSize, stepSizes)
-//        //        gradHiddenStates(i) = multiCells(i).hidResize(null, batchSize, stepSizes)
-//        hidden.toTable(i) = multiCells(i).hidResize(null, batchSize, stepSizes)
-//        gradHidden.toTable(i) = multiCells(i).hidResize(null, batchSize, stepSizes)
-//        i += 1
-//      }
-//    } else initHidden(sizes)
-//  }
-
   protected def cloneCells(): Unit = {
     var t = cells.length
     if (t < times) {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributedMaskCriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributedMaskCriterion.scala
@@ -36,6 +36,7 @@ import scala.reflect.ClassTag
  *     -1, in this case, we are only interested in 1, 2, 3, 5, 4, 3)
  *
  * @param critrn embedded criterion
+ * @param paddingValue padding value
  */
 
 class TimeDistributedMaskCriterion[T : ClassTag](

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributedMaskCriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributedMaskCriterion.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.nn
 
-import com.intel.analytics.bigdl.nn.abstractnn.TensorCriterion
+import com.intel.analytics.bigdl.nn.abstractnn.{SizeAverageStatus, TensorCriterion}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.Engine
@@ -36,16 +36,15 @@ import scala.reflect.ClassTag
  *     -1, in this case, we are only interested in 1, 2, 3, 5, 4, 3)
  *
  * @param critrn embedded criterion
- * @param dimension to compute criterion loss along the input and target dimension
  */
 
 class TimeDistributedMaskCriterion[T : ClassTag](
   val critrn : TensorCriterion[T],
-  val dimension: Int = 2,
   val paddingValue: Int = 0
 )
   (implicit ev: TensorNumeric[T]) extends TensorCriterion[T] {
 
+  val dimension: Int = 2
   private var fInput: Tensor[T] = Tensor[T]()
   private var fTarget: Tensor[T] = Tensor[T]()
   private var _gradInput = Tensor[T]()  // list of cell criterions cloned from added criterion
@@ -55,6 +54,8 @@ class TimeDistributedMaskCriterion[T : ClassTag](
   @transient
   protected var results: Array[Future[Unit]] = _
   private val mask = Tensor[T]()
+  private val sumBuffer = Tensor[T]()
+  private val gradInputBuffer = Tensor[T]()
 
   /**
    * Clone N criterions; N depends on the time dimension of the input
@@ -104,16 +105,22 @@ class TimeDistributedMaskCriterion[T : ClassTag](
     mask.resizeAs(target)
     mask.applyFun[T](target, x =>
       if (x != ev.fromType[Int](paddingValue)) ev.one else ev.zero)
-    val outputBuff = Tensor()
-    outputBuff.resizeAs(mask)
-    (0 until nstep).foreach(b => {
-      outputBuff
-        .select(2, b + 1)
-        .cmul(mask.select(2, b + 1),
-          cells(b).sparseOutput)
+
+    sumBuffer.sum(mask, dimension % 2 + 1)
+    var sum = ev.zero
+    (0 until nstep).foreach(t => {
+      val loss = critrn.sizeAverageStatus match {
+        case SizeAverageStatus.True =>
+          ev.times(cells(t).output, sumBuffer(Array(1, t + 1)))
+        case SizeAverageStatus.False => cells(t).output
+        case SizeAverageStatus.None =>
+          throw new RuntimeException("Using TimeDistributedMaskCriterion," +
+            " the embedded criterion should be set to True or False")
+      }
+      sum = ev.plus(sum, loss)
     })
 
-    output = ev.divide(outputBuff.sum(), mask.sum())
+    output = ev.divide(sum, mask.sum())
 
     output
   }
@@ -136,7 +143,18 @@ class TimeDistributedMaskCriterion[T : ClassTag](
         fInput = input.select(dimension, _i)
         fTarget = target.select(dimension, _i)
         _gradInput = gradInput.select(dimension, _i)
-        _gradInput.copy(cells(_i - 1).updateGradInput(fInput, fTarget).toTensor[T])
+        val _iGradInput = cells(_i - 1).updateGradInput(fInput, fTarget).toTensor[T]
+        _gradInput.copy(
+          critrn.sizeAverageStatus match {
+            case SizeAverageStatus.True =>
+              gradInputBuffer.resizeAs(_iGradInput).mul(
+                _iGradInput,
+                sumBuffer(Array(1, _i)))
+            case SizeAverageStatus.False => _iGradInput
+            case SizeAverageStatus.None =>
+              throw new RuntimeException("Using TimeDistributedMaskCriterion," +
+                " the embedded criterion should be set to True or False")
+          })
       })
       i += 1
     }
@@ -151,10 +169,9 @@ class TimeDistributedMaskCriterion[T : ClassTag](
 object TimeDistributedMaskCriterion {
   def apply[@specialized(Float, Double) T: ClassTag](
     critrn: TensorCriterion[T] = null,
-    dimension: Int = 2,
     paddingValue: Int = 0
   )
     (implicit ev: TensorNumeric[T]) : TimeDistributedMaskCriterion[T] = {
-    new TimeDistributedMaskCriterion[T](critrn, dimension, paddingValue)
+    new TimeDistributedMaskCriterion[T](critrn, paddingValue)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributedMaskCriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributedMaskCriterion.scala
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn
+
+import com.intel.analytics.bigdl.nn.abstractnn.TensorCriterion
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Engine
+
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.Future
+import scala.reflect.ClassTag
+
+/**
+ * This class is intended to support inputs with 3 or more dimensions.
+ * Apply Any Provided Criterion to every temporal slice of an input.
+ *
+ * @param critrn embedded criterion
+ * @param sizeAverage whether to divide the length of input along dimension.
+ * @param dimension to compute criterion loss along the input and target dimension
+ *                  if sizeAverage=true, and dimension=1, it means to divide the batch size;
+ *                  if sizeAverage=true, and dimension=2, it means to divide the sequence length
+ */
+
+class TimeDistributedMaskCriterion[T : ClassTag](
+  val critrn : TensorCriterion[T],
+  val sizeAverage: Boolean = false,
+  val dimension: Int = 2,
+  val padValue: Int = 0
+)
+  (implicit ev: TensorNumeric[T]) extends TensorCriterion[T] {
+
+  private var fInput: Tensor[T] = Tensor[T]()
+  private var fTarget: Tensor[T] = Tensor[T]()
+  private var _gradInput = Tensor[T]()  // list of cell criterions cloned from added criterion
+  private val cells: ArrayBuffer[TensorCriterion[T]]
+  = ArrayBuffer[TensorCriterion[T]]()
+
+  @transient
+  protected var results: Array[Future[Unit]] = _
+  private val mask = Tensor[T]()
+
+  /**
+   * Clone N criterions; N depends on the time dimension of the input
+   * @param times
+   */
+  private def extend(times: Int): Unit = {
+    var t = cells.length
+    while (t < times) {
+      cells += critrn.cloneCriterion()
+        .asInstanceOf[TensorCriterion[T]]
+      t += 1
+    }
+  }
+
+
+  override def updateOutput(input: Tensor[T], target: Tensor[T]): T = {
+    /**
+     * Take each time slice of input and target, and add up all outputs of slices
+     * Example with dimension=2:
+     * input.size = [B, T, D] => fInput.size = [B, D]
+     * target.size = [B, T] => fTarget.size = [B]
+     * If sizeAverage is true, the output is averaged through time dim
+     */
+    require(input.size(dimension) == target.size(dimension),
+      "target should have as many elements as input, " +
+        s"input ${input.size(dimension)}, target ${target.size(dimension)}")
+
+    output = ev.fromType[Int](0)
+    val nstep = input.size(dimension)
+    extend(nstep)
+
+    if (results == null || results.length != nstep) {
+      results = new Array[Future[Unit]](nstep)
+    }
+
+    var i = 0
+    while (i < nstep) {
+      val _i = i + 1
+      results(i) = Engine.model.invoke(() => {
+        fInput = input.select(dimension, _i)
+        fTarget = target.select(dimension, _i)
+        cells(_i - 1).updateOutput(fInput, fTarget)
+      })
+      i += 1
+    }
+    Engine.model.sync(results)
+
+    mask.resizeAs(target)
+    mask.applyFun[T](target, x =>
+      if (x != ev.fromType[Int](padValue)) ev.one else ev.zero)
+    val outputBuff = Tensor()
+    outputBuff.resizeAs(mask)
+    (0 until nstep).foreach(b => {
+      //      output = ev.plus(output, cells(b).output)
+      outputBuff
+        .select(2, b + 1)
+        .cmul(mask.select(2, b + 1), cells(b).asInstanceOf[ClassNLLCriterion[T]].sparseOutput)
+    })
+
+    output = ev.divide(outputBuff.sum(), mask.sum())
+
+    output
+  }
+
+  override def updateGradInput(input: Tensor[T], target: Tensor[T]): Tensor[T] = {
+    /**
+     * Take each time slice of input and target, and calculate gradInput of each slice
+     * If sizeAverage is true, the gradInput is also averaged through dimension
+     */
+    require(input.size(dimension) == target.size(dimension),
+      s"target should have as many elements as input, " +
+        s"input ${input.size(dimension)}, target ${target.size(dimension)}")
+    gradInput.resizeAs(input).zero()
+
+    val nstep = input.size(dimension)
+
+    var i = 0
+    while (i < nstep) {
+      val _i = i + 1
+      results(i) = Engine.model.invoke(() => {
+        fInput = input.select(dimension, _i)
+        fTarget = target.select(dimension, _i)
+        _gradInput = gradInput.select(dimension, _i)
+        _gradInput.copy(cells(_i - 1).updateGradInput(fInput, fTarget).toTensor[T])
+        //        if (sizeAverage) {
+        //          _gradInput = _gradInput.div(ev.fromType[Int](nstep))
+        //        }
+      })
+      i += 1
+    }
+    Engine.model.sync(results)
+    gradInput.div(mask.sum())
+    gradInput
+  }
+
+  override def canEqual(other: Any): Boolean = other.isInstanceOf[TimeDistributedCriterion[T]]
+}
+
+object TimeDistributedMaskCriterion {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    critrn: TensorCriterion[T] = null,
+    sizeAverage: Boolean = false,
+    dimension: Int = 2,
+    padValue: Int = 0
+  )
+    (implicit ev: TensorNumeric[T]) : TimeDistributedMaskCriterion[T] = {
+    new TimeDistributedMaskCriterion[T](critrn, sizeAverage, dimension, padValue)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractCriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractCriterion.scala
@@ -52,6 +52,9 @@ abstract class AbstractCriterion[A <: Activity: ClassTag, B <: Activity: ClassTa
   var gradInput: A = Activity.allocate[A, T]()
   var output: T = ev.fromType[Int](0)
 
+  var sparseOutput: Tensor[T] = Tensor()
+  var sparseGradInput: Tensor[T] = Tensor()
+
   private[nn] def allocateAs[D <: Activity](dest: D): D = dest match {
     case tensor: Tensor[T] => Tensor[T]().asInstanceOf[D]
     case table: Table => T().asInstanceOf[D]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractCriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractCriterion.scala
@@ -53,7 +53,6 @@ abstract class AbstractCriterion[A <: Activity: ClassTag, B <: Activity: ClassTa
   var output: T = ev.fromType[Int](0)
 
   var sparseOutput: Tensor[T] = Tensor()
-  var sparseGradInput: Tensor[T] = Tensor()
 
   private[nn] def allocateAs[D <: Activity](dest: D): D = dest match {
     case tensor: Tensor[T] => Tensor[T]().asInstanceOf[D]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractCriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractCriterion.scala
@@ -16,6 +16,7 @@
 
 package com.intel.analytics.bigdl.nn.abstractnn
 
+import com.intel.analytics.bigdl.nn.abstractnn.SizeAverageStatus.SizeAverageStatus
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.{T, Table}
@@ -52,7 +53,7 @@ abstract class AbstractCriterion[A <: Activity: ClassTag, B <: Activity: ClassTa
   var gradInput: A = Activity.allocate[A, T]()
   var output: T = ev.fromType[Int](0)
 
-  var sparseOutput: Tensor[T] = Tensor()
+  private[nn] var sizeAverageStatus: SizeAverageStatus = SizeAverageStatus.None
 
   private[nn] def allocateAs[D <: Activity](dest: D): D = dest match {
     case tensor: Tensor[T] => Tensor[T]().asInstanceOf[D]
@@ -129,4 +130,9 @@ abstract class AbstractCriterion[A <: Activity: ClassTag, B <: Activity: ClassTa
     val state = Seq(output)
     state.map(getHashCode).foldLeft(0)((a, b) => 31 * a + b)
   }
+}
+
+object SizeAverageStatus extends Enumeration {
+  type SizeAverageStatus = Value
+  val True, False, None = Value
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -338,7 +338,7 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
   }
 
   def createTimeDistributedMaskCriterion(critrn: TensorCriterion[T],
-    paddingValue: Int = 0): TimeDistributedCriterion[T] = {
+    paddingValue: Int = 0): TimeDistributedMaskCriterion[T] = {
     TimeDistributedMaskCriterion[T](critrn, paddingValue)
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -337,6 +337,11 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
       bRegularizer)
   }
 
+  def createTimeDistributedMaskCriterion(critrn: TensorCriterion[T],
+    paddingValue: Int = 0): TimeDistributedCriterion[T] = {
+    TimeDistributedMaskCriterion[T](critrn, paddingValue)
+  }
+
   def createTimeDistributedCriterion(critrn: TensorCriterion[T],
     sizeAverage: Boolean = false): TimeDistributedCriterion[T] = {
     TimeDistributedCriterion[T](critrn, sizeAverage)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterionSpec.scala
@@ -39,17 +39,17 @@ class ClassNLLCriterionSpec extends FlatSpec with Matchers {
     target(Array(1)) = -1
     target(Array(2)) = 2
     target(Array(3)) = 3
-    val expectedOutput = 0.8793184268272333
+    val expectedOutput = 1.31897764024085
     val expectedGrad = Tensor[Double](3, 3)
     expectedGrad(Array(1, 1)) = 0
     expectedGrad(Array(1, 2)) = 0
     expectedGrad(Array(1, 3)) = 0
     expectedGrad(Array(2, 1)) = 0
-    expectedGrad(Array(2, 2)) = -0.33333333333333
+    expectedGrad(Array(2, 2)) = -0.5
     expectedGrad(Array(2, 3)) = 0
     expectedGrad(Array(3, 1)) = 0
     expectedGrad(Array(3, 2)) = 0
-    expectedGrad(Array(3, 3)) = -0.33333333333333
+    expectedGrad(Array(3, 3)) = -0.5
     val output = criterion.forward(input, target)
     val gradInput = criterion.backward(input, target)
     assert(abs(expectedOutput - output) < 1e-6)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LookupTableSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LookupTableSpec.scala
@@ -27,6 +27,22 @@ import scala.util.Random
 @com.intel.analytics.bigdl.tags.Parallel
 class LookupTableSpec extends FlatSpec with Matchers {
 
+  "A LookupTable with padding input" should "generate correct output" in {
+    val seed = 100
+    RNG.setSeed(seed)
+    val module = LookupTable[Double](9, 4, paddingValue = 1, maskZero = true)
+    val input = Tensor[Double](5)
+    input(Array(1)) = 5
+    input(Array(2)) = 1
+    input(Array(3)) = 6
+    input(Array(4)) = 9
+    input(Array(5)) = 4
+
+    val output = module.forward(input)
+
+    output.select(1, 2).sum() should be (0.0)
+  }
+
   "A LookupTableSpec with scaleW" should "generate correct output and grad with input 1D" in {
     val seed = 100
     RNG.setSeed(seed)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/RecurrentSpec.scala
@@ -19,7 +19,7 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.optim.SGD
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import com.intel.analytics.bigdl.utils.RandomGenerator.RNG
-import com.intel.analytics.bigdl.utils.{Engine, T}
+import com.intel.analytics.bigdl.utils.{Engine, T, Table}
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.collection.mutable.ArrayBuffer
@@ -83,6 +83,57 @@ class RecurrentSpec extends FlatSpec with Matchers {
       forwardSum(i) should be (rnnCell1.getTimes()(i)._2)
       backwardSum(i) should be (rnnCell1.getTimes()(i)._3)
     }
+  }
+
+  "Recurrent" should "outputs correct hiddens" in {
+    val hiddenSize = 4
+    val batchSize = 3
+    val inputSize = 6
+    val seqLength = 5
+    val seed = 100
+
+    RNG.setSeed(seed)
+    val input = Tensor[Double](Array(batchSize, seqLength, inputSize)).rand()
+    input.select(1, 2).zero()
+
+    val rec = Recurrent[Double](maskZero = true)
+    val initHidden = T(
+      Tensor[Double](Array(batchSize, hiddenSize)).rand(),
+      Tensor[Double](Array(batchSize, hiddenSize)).rand()
+    )
+    rec.setHiddenState(initHidden)
+
+    val lstm = LSTM[Double](inputSize, hiddenSize)
+    val model = Sequential[Double]()
+      .add(rec
+        .add(lstm))
+
+    model.forward(input)
+
+    lstm.output.toTable[Table](2).toTable[Tensor[Double]](1)
+      .select(1, 2) should be (initHidden[Tensor[Double]](1).select(1, 2))
+  }
+
+  "Recurrent" should "ouputs correclty" in {
+    val hiddenSize = 4
+    val batchSize = 3
+    val inputSize = 6
+    val seqLength = 5
+    val seed = 100
+
+    RNG.setSeed(seed)
+    val input = Tensor[Double](Array(batchSize, seqLength, inputSize)).rand()
+    input.select(1, 2).select(1, seqLength).zero()
+
+    val rec = Recurrent[Double](maskZero = true)
+
+    val model = Sequential[Double]()
+      .add(rec
+        .add(LSTM[Double](inputSize, hiddenSize)))
+
+    val output = model.forward(input)
+
+    output.toTensor[Double].select(1, 2).select(1, seqLength).abs().max() should be (0)
   }
 
   "A Recurrent" should " call getTimes correctly" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/TimeDistributedMaskCriterionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/TimeDistributedMaskCriterionSpec.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn
+
+import com.intel.analytics.bigdl.tensor.Tensor
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.math._
+
+class TimeDistributedMaskCriterionSpec extends FlatSpec with Matchers {
+  "" should "" in {
+    val criterion = ClassNLLCriterion[Double](paddingValue = 0)
+    val layer = TimeDistributedMaskCriterion[Double](criterion, paddingValue = 0)
+
+    val input = Tensor[Double](3, 2, 3)
+    input(Array(1, 1, 1)) = -1.0262627674932
+    input(Array(1, 1, 2)) = -1.2412600935171
+    input(Array(1, 1, 3)) = -1.0423174168648
+    input(Array(1, 2, 1)) = -1.0262627674932
+    input(Array(1, 2, 2)) = -1.2412600935171
+    input(Array(1, 2, 3)) = -1.0423174168648
+    input(Array(2, 1, 1)) = -0.90330565804228
+    input(Array(2, 1, 2)) = -1.3686840144413
+    input(Array(2, 1, 3)) = -1.0778380454479
+    input(Array(2, 2, 1)) = -0.90330565804228
+    input(Array(2, 2, 2)) = -1.3686840144413
+    input(Array(2, 2, 3)) = -1.0778380454479
+    input(Array(3, 1, 1)) = -0.99131220658219
+    input(Array(3, 1, 2)) = -1.0559142847536
+    input(Array(3, 1, 3)) = -1.2692712660404
+    input(Array(3, 2, 1)) = -0.99131220658219
+    input(Array(3, 2, 2)) = -1.0559142847536
+    input(Array(3, 2, 3)) = -1.2692712660404
+
+    val target = Tensor[Double](3, 2)
+    target(Array(1, 1)) = 0
+    target(Array(1, 2)) = 1
+    target(Array(2, 1)) = 2
+    target(Array(2, 2)) = 2
+    target(Array(3, 1)) = 0
+    target(Array(3, 2)) = 3
+
+    val output = layer.forward(input, target)
+    val gradInput = layer.backward(input, target)
+
+    val expectedOutput = 1.25822551560405
+    val expectedGrad = Tensor[Double](3, 2, 3)
+    expectedGrad(Array(1, 1, 1)) = 0
+    expectedGrad(Array(1, 1, 2)) = 0
+    expectedGrad(Array(1, 1, 3)) = 0
+    expectedGrad(Array(1, 2, 1)) = -0.08333333333333333
+    expectedGrad(Array(1, 2, 2)) = 0
+    expectedGrad(Array(1, 2, 3)) = 0
+    expectedGrad(Array(2, 1, 1)) = 0
+    expectedGrad(Array(2, 1, 2)) = -0.08333333333333333
+    expectedGrad(Array(2, 1, 3)) = 0
+    expectedGrad(Array(2, 2, 1)) = 0
+    expectedGrad(Array(2, 2, 2)) = -0.08333333333333333
+    expectedGrad(Array(2, 2, 3)) = 0
+    expectedGrad(Array(3, 1, 1)) = 0
+    expectedGrad(Array(3, 1, 2)) = 0
+    expectedGrad(Array(3, 1, 3)) = 0
+    expectedGrad(Array(3, 2, 1)) = 0
+    expectedGrad(Array(3, 2, 2)) = 0
+    expectedGrad(Array(3, 2, 3)) = -0.08333333333333333
+    assert(abs(expectedOutput - output) < 1e-6)
+    expectedGrad.map(gradInput, (v1, v2) => {
+      assert(abs(v1 - v2) < 1e-6)
+      v1
+    })
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/TimeDistributedMaskCriterionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/TimeDistributedMaskCriterionSpec.scala
@@ -21,7 +21,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import scala.math._
 
 class TimeDistributedMaskCriterionSpec extends FlatSpec with Matchers {
-  "" should "" in {
+  "TimeDistributedMaskCriterion" should "works correctly" in {
     val criterion = ClassNLLCriterion[Double](paddingValue = 0)
     val layer = TimeDistributedMaskCriterion[Double](criterion, paddingValue = 0)
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/TimeDistributedMaskCriterionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/TimeDistributedMaskCriterionSpec.scala
@@ -61,21 +61,21 @@ class TimeDistributedMaskCriterionSpec extends FlatSpec with Matchers {
     expectedGrad(Array(1, 1, 1)) = 0
     expectedGrad(Array(1, 1, 2)) = 0
     expectedGrad(Array(1, 1, 3)) = 0
-    expectedGrad(Array(1, 2, 1)) = -0.08333333333333333
+    expectedGrad(Array(1, 2, 1)) = -0.25
     expectedGrad(Array(1, 2, 2)) = 0
     expectedGrad(Array(1, 2, 3)) = 0
     expectedGrad(Array(2, 1, 1)) = 0
-    expectedGrad(Array(2, 1, 2)) = -0.08333333333333333
+    expectedGrad(Array(2, 1, 2)) = -0.25
     expectedGrad(Array(2, 1, 3)) = 0
     expectedGrad(Array(2, 2, 1)) = 0
-    expectedGrad(Array(2, 2, 2)) = -0.08333333333333333
+    expectedGrad(Array(2, 2, 2)) = -0.25
     expectedGrad(Array(2, 2, 3)) = 0
     expectedGrad(Array(3, 1, 1)) = 0
     expectedGrad(Array(3, 1, 2)) = 0
     expectedGrad(Array(3, 1, 3)) = 0
     expectedGrad(Array(3, 2, 1)) = 0
     expectedGrad(Array(3, 2, 2)) = 0
-    expectedGrad(Array(3, 2, 3)) = -0.08333333333333333
+    expectedGrad(Array(3, 2, 3)) = -0.25
     assert(abs(expectedOutput - output) < 1e-6)
     expectedGrad.map(gradInput, (v1, v2) => {
       assert(abs(v1 - v2) < 1e-6)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Optimize padding mechanism
This PR make the paddings or zeros make no side effect on the training.

`LookupTable`: if `maskZero` is set to true, the input whose value equals `paddingValue`,  the output will be masked to zero vector.

`Recurrent`: The recurrent includes some mask mechanisms. if the `maskZero` variable is set to true, the `Recurrent` module will not consider zero vector inputs. For each time step input, if a certain row is a zero vector (all the elements of the vector equals zero), then output of certain row of this time step would be a zero vector, and the hidden state of the certain row of this time step would be the same as the corresponding row of the hidden state of the previous step.

`TimeDistributed': if `maskZero` is set to true, if the input including zero vectors, the corresponding output will be set to zero vecotrs.

`TimeDistributedMaskCriterion`: it supports padding mask. eg. if the target is [ [-1, 1, 2, 3, -1], [5, 4, 3, -1, -1] ],  and set the paddingValue property to -1, then the loss of -1 would not  be accumulated and the loss is only divided by 6 (not including the amount of -1, in this case, we are only interested in 1, 2, 3, 5, 4, 3)


