### PR TITLE
DataFrame-based image reader and transformer

### DIFF
--- a/pyspark/bigdl/dlframes/dl_image_reader.py
+++ b/pyspark/bigdl/dlframes/dl_image_reader.py
@@ -1,0 +1,43 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+from bigdl.util.common import callBigDlFunc
+
+if sys.version >= '3':
+    long = int
+    unicode = str
+
+class DLImageReader:
+    """
+    Primary DataFrame-based image loading interface, defining API to read images from files
+    to DataFrame.
+    """
+
+    @staticmethod
+    def readImages(path, sc=None, minParitions = 1, bigdl_type="float"):
+        """
+        Read the directory of images into DataFrame from the local or remote source.
+        :param path Directory to the input data files, the path can be comma separated paths as the
+   *             list of inputs. Wildcards like "path/" are supported
+        :param sc SparkContext
+        :param min_partitions A suggestion value of the minimal splitting number for input data.
+        :return DataFrame with a single column "image"; Each record in the column represents one image
+                record: Row (uri, height, width, channels, CvType, bytes)
+        """
+        df = callBigDlFunc(bigdl_type, "dlReadImage", path, sc, minParitions)
+        df._sc._jsc = sc._jsc
+        return df

--- a/pyspark/bigdl/dlframes/dl_image_reader.py
+++ b/pyspark/bigdl/dlframes/dl_image_reader.py
@@ -32,8 +32,7 @@ class DLImageReader:
         """
         Read the directory of images into DataFrame from the local or remote source.
         :param path Directory to the input data files, the path can be comma separated paths as the
-   *             list of inputs. Wildcards like "path/" are supported
-        :param sc SparkContext
+                list of inputs. Wildcards path are supported similarly to sc.binaryFiles(path).
         :param min_partitions A suggestion value of the minimal splitting number for input data.
         :return DataFrame with a single column "image"; Each record in the column represents one image
                 record: Row (uri, height, width, channels, CvType, bytes)

--- a/pyspark/bigdl/dlframes/dl_image_transformer.py
+++ b/pyspark/bigdl/dlframes/dl_image_transformer.py
@@ -1,0 +1,52 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys
+from bigdl.util.common import JavaValue, callBigDlFunc
+from pyspark.ml.param.shared import *
+from pyspark.ml.wrapper import JavaTransformer
+
+if sys.version >= '3':
+    long = int
+    unicode = str
+
+class DLImageTransformer(JavaTransformer, HasInputCol, HasOutputCol, JavaValue):
+    """
+    Provides DataFrame-based API for image pre-processing and feature transformation.
+    DLImageTransformer follows the Spark Transformer API pattern and can be used as one stage
+    in Spark ML pipeline.
+
+    The input column can be either DLImageSchema.byteSchema or DLImageSchema.floatSchema. If
+    using DLImageReader, the default format is DLImageSchema.byteSchema
+    The output column is always DLImageSchema.floatSchema.
+    """
+
+    def __init__(self,  transformer, jvalue=None, bigdl_type="float"):
+        super(DLImageTransformer, self).__init__()
+        self.value = jvalue if jvalue else callBigDlFunc(
+            bigdl_type, self.jvm_class_constructor(), transformer)
+        self._java_obj = self.value
+        self.bigdl_type = bigdl_type
+
+    def transform(self, dataset):
+        """
+        Apply the transformer to the images in "inputCol" and store the transformed result
+        into "outputCols"
+        """
+        self._transfer_params_to_java()
+        return callBigDlFunc(self.bigdl_type, "dlImageTransform", self.value, dataset)
+
+

--- a/pyspark/test/bigdl/dlframes/test_dl_image_reader.py
+++ b/pyspark/test/bigdl/dlframes/test_dl_image_reader.py
@@ -27,7 +27,7 @@ class TestDLImageReader():
     def setup_method(self, method):
         """
         setup any state tied to the execution of the given method in a
-        class.  setup_method is invoked for every test method of a class.
+        class. setup_method is invoked for every test method of a class.
         """
         sparkConf = create_spark_conf().setMaster("local[1]").setAppName("test model")
         self.sc = get_spark_context(sparkConf)
@@ -36,7 +36,7 @@ class TestDLImageReader():
 
     def teardown_method(self, method):
         """
-         teardown any state that was previously setup with a setup_method
+        teardown any state that was previously setup with a setup_method
         call.
         """
         self.sc.stop()

--- a/pyspark/test/bigdl/dlframes/test_dl_image_reader.py
+++ b/pyspark/test/bigdl/dlframes/test_dl_image_reader.py
@@ -1,0 +1,58 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+from bigdl.dlframes.dl_image_reader import *
+from bigdl.transform.vision.image import *
+from bigdl.util.common import *
+from pyspark.sql.types import *
+
+
+class TestDLImageReader():
+
+    def setup_method(self, method):
+        """
+        setup any state tied to the execution of the given method in a
+        class.  setup_method is invoked for every test method of a class.
+        """
+        sparkConf = create_spark_conf().setMaster("local[1]").setAppName("test model")
+        self.sc = get_spark_context(sparkConf)
+        self.sqlContext = SQLContext(self.sc)
+        init_engine()
+        resource_path = os.path.join(os.path.split(__file__)[0], "../resources")
+        self.image_path = os.path.join(resource_path, "pascal/000025.jpg")
+
+    def teardown_method(self, method):
+        """
+         teardown any state that was previously setup with a setup_method
+        call.
+        """
+        self.sc.stop()
+
+    def test_get_image(self):
+        image_frame = DLImageReader.readImages(self.image_path, self.sc)
+        assert image_frame.count() == 1
+        assert type(image_frame).__name__ == 'DataFrame'
+        first_row = image_frame.take(1)[0][0]
+        assert first_row[0].endswith("pascal/000025.jpg")
+        assert first_row[1] == 375
+        assert first_row[2] == 500
+        assert first_row[3] == 3
+        assert first_row[4] == 16
+        assert len(first_row[5]) == 95959
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/pyspark/test/bigdl/dlframes/test_dl_image_reader.py
+++ b/pyspark/test/bigdl/dlframes/test_dl_image_reader.py
@@ -28,7 +28,7 @@ class TestDLImageReader():
         setup any state tied to the execution of the given method in a
         class.  setup_method is invoked for every test method of a class.
         """
-        sparkConf = create_spark_conf().setMaster("local[1]").setAppName("test model")
+        sparkConf = create_spark_conf().setMaster("local[1]").setAppName("testDLImageReader")
         self.sc = get_spark_context(sparkConf)
         self.sqlContext = SQLContext(self.sc)
         init_engine()

--- a/pyspark/test/bigdl/dlframes/test_dl_image_reader.py
+++ b/pyspark/test/bigdl/dlframes/test_dl_image_reader.py
@@ -15,6 +15,7 @@
 #
 
 import pytest
+import os
 from bigdl.dlframes.dl_image_reader import *
 from bigdl.transform.vision.image import *
 from bigdl.util.common import *
@@ -28,12 +29,10 @@ class TestDLImageReader():
         setup any state tied to the execution of the given method in a
         class.  setup_method is invoked for every test method of a class.
         """
-        sparkConf = create_spark_conf().setMaster("local[1]").setAppName("testDLImageReader")
+        sparkConf = create_spark_conf().setMaster("local[1]").setAppName("test model")
         self.sc = get_spark_context(sparkConf)
-        self.sqlContext = SQLContext(self.sc)
         init_engine()
-        resource_path = os.path.join(os.path.split(__file__)[0], "../resources")
-        self.image_path = os.path.join(resource_path, "pascal/000025.jpg")
+        self.resource_path = os.path.join(os.path.split(__file__)[0], "../resources")
 
     def teardown_method(self, method):
         """
@@ -42,8 +41,9 @@ class TestDLImageReader():
         """
         self.sc.stop()
 
-    def test_get_image(self):
-        image_frame = DLImageReader.readImages(self.image_path, self.sc)
+    def test_get_pascal_image(self):
+        image_path = os.path.join(self.resource_path, "pascal/000025.jpg")
+        image_frame = DLImageReader.readImages(image_path, self.sc)
         assert image_frame.count() == 1
         assert type(image_frame).__name__ == 'DataFrame'
         first_row = image_frame.take(1)[0][0]

--- a/pyspark/test/bigdl/dlframes/test_dl_image_transformer.py
+++ b/pyspark/test/bigdl/dlframes/test_dl_image_transformer.py
@@ -22,14 +22,14 @@ from bigdl.util.common import *
 from bigdl.transform.vision.image import *
 
 
-class TestLayer():
+class TestDLImageTransformer():
 
     def setup_method(self, method):
         """
         setup any state tied to the execution of the given method in a
         class.  setup_method is invoked for every test method of a class.
         """
-        sparkConf = create_spark_conf().setMaster("local[1]").setAppName("test model")
+        sparkConf = create_spark_conf().setMaster("local[1]").setAppName("testDLImageTransformer")
         self.sc = get_spark_context(sparkConf)
         init_engine()
         resource_path = os.path.join(os.path.split(__file__)[0], "../resources")

--- a/pyspark/test/bigdl/dlframes/test_dl_image_transformer.py
+++ b/pyspark/test/bigdl/dlframes/test_dl_image_transformer.py
@@ -1,0 +1,67 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+import os
+from bigdl.dlframes.dl_image_reader import *
+from bigdl.dlframes.dl_image_transformer import *
+from bigdl.util.common import *
+from bigdl.transform.vision.image import *
+
+
+class TestLayer():
+
+    def setup_method(self, method):
+        """
+        setup any state tied to the execution of the given method in a
+        class.  setup_method is invoked for every test method of a class.
+        """
+        sparkConf = create_spark_conf().setMaster("local[1]").setAppName("test model")
+        self.sc = get_spark_context(sparkConf)
+        init_engine()
+        resource_path = os.path.join(os.path.split(__file__)[0], "../resources")
+        self.image_path = os.path.join(resource_path, "pascal/000025.jpg")
+
+    def teardown_method(self, method):
+        """
+        teardown any state that was previously setup with a setup_method
+        call.
+        """
+        self.sc.stop()
+
+    def test_transform_image(self):
+        image_frame = DLImageReader.readImages(self.image_path, self.sc)
+        assert image_frame.count() == 1
+        assert type(image_frame).__name__ == 'DataFrame'
+
+        transformer = DLImageTransformer(
+            Pipeline([Resize(256, 256), CenterCrop(224, 224),
+                      ChannelNormalize(0.485, 0.456, 0.406, 0.229, 0.224, 0.225),
+                      MatToTensor(), ImageFrameToSample()])
+        ).setInputCol("image").setOutputCol("output")
+
+        result = transformer.transform(image_frame)
+        assert(result.count() == 1)
+        first_row = result.take(1)[0][0]
+        assert first_row[0].endswith("pascal/000025.jpg")
+        assert first_row[1] == 375
+        assert first_row[2] == 500
+        assert first_row[3] == 3
+        assert first_row[4] == 16
+        assert len(first_row[5]) == 95959
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/pyspark/test/bigdl/dlframes/test_dl_image_transformer.py
+++ b/pyspark/test/bigdl/dlframes/test_dl_image_transformer.py
@@ -31,6 +31,7 @@ class TestDLImageTransformer():
         """
         sparkConf = create_spark_conf().setMaster("local[1]").setAppName("testDLImageTransformer")
         self.sc = get_spark_context(sparkConf)
+        self.sqlContext = SQLContext(self.sc)
         init_engine()
         resource_path = os.path.join(os.path.split(__file__)[0], "../resources")
         self.image_path = os.path.join(resource_path, "pascal/000025.jpg")

--- a/pyspark/test/bigdl/dlframes/test_dl_image_transformer.py
+++ b/pyspark/test/bigdl/dlframes/test_dl_image_transformer.py
@@ -29,9 +29,8 @@ class TestDLImageTransformer():
         setup any state tied to the execution of the given method in a
         class.  setup_method is invoked for every test method of a class.
         """
-        sparkConf = create_spark_conf().setMaster("local[1]").setAppName("testDLImageTransformer")
+        sparkConf = create_spark_conf().setMaster("local[2]").setAppName("test model")
         self.sc = get_spark_context(sparkConf)
-        self.sqlContext = SQLContext(self.sc)
         init_engine()
         resource_path = os.path.join(os.path.split(__file__)[0], "../resources")
         self.image_path = os.path.join(resource_path, "pascal/000025.jpg")
@@ -45,9 +44,6 @@ class TestDLImageTransformer():
 
     def test_transform_image(self):
         image_frame = DLImageReader.readImages(self.image_path, self.sc)
-        assert image_frame.count() == 1
-        assert type(image_frame).__name__ == 'DataFrame'
-
         transformer = DLImageTransformer(
             Pipeline([Resize(256, 256), CenterCrop(224, 224),
                       ChannelNormalize(0.485, 0.456, 0.406, 0.229, 0.224, 0.225),
@@ -56,13 +52,13 @@ class TestDLImageTransformer():
 
         result = transformer.transform(image_frame)
         assert(result.count() == 1)
-        first_row = result.take(1)[0][0]
+        first_row = result.select("output").take(1)[0][0]
         assert first_row[0].endswith("pascal/000025.jpg")
-        assert first_row[1] == 375
-        assert first_row[2] == 500
+        assert first_row[1] == 224
+        assert first_row[2] == 224
         assert first_row[3] == 3
-        assert first_row[4] == 16
-        assert len(first_row[5]) == 95959
+        assert first_row[4] == 21
+        assert len(first_row[5]) == 224 * 224 * 3
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dlframes/DLImageReader.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dlframes/DLImageReader.scala
@@ -21,6 +21,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.opencv.core.CvType
+import scala.language.existentials
 
 /**
  * Definition for image data in a DataFrame

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dlframes/DLImageReader.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dlframes/DLImageReader.scala
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.dlframes
+
+import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
+import com.intel.analytics.bigdl.transform.vision.image.{BytesToMat, ImageFeature, ImageFrame}
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+import org.opencv.core.CvType
+
+/**
+ * Definition for image data in a DataFrame
+ */
+object DLImageSchema {
+
+  /**
+   * Schema for the image column in a DataFrame. Image data is saved in an array of Bytes.
+   * The format is compatible with Spark Image format in v2.3
+   */
+  val byteSchema = StructType(
+    StructField("origin", StringType, true) ::
+      StructField("height", IntegerType, false) ::
+      StructField("width", IntegerType, false) ::
+      StructField("nChannels", IntegerType, false) ::
+      // OpenCV-compatible type: CV_8UC3, CV_32FC3 in most cases
+      StructField("mode", IntegerType, false) ::
+      // Bytes in OpenCV-compatible order: row-wise BGR in most cases
+      StructField("data", BinaryType, false) :: Nil)
+
+  /**
+   * Schema for the image column in a DataFrame. Image data is saved in an array of Floats.
+   */
+  val floatSchema = StructType(
+    StructField("origin", StringType, true) ::
+      StructField("height", IntegerType, false) ::
+      StructField("width", IntegerType, false) ::
+      StructField("nChannels", IntegerType, false) ::
+      // OpenCV-compatible type: CV_8UC3, CV_32FC3 in most cases
+      StructField("mode", IntegerType, false) ::
+      // floats in OpenCV-compatible order: row-wise BGR in most cases
+      StructField("data", new ArrayType(FloatType, false), false) :: Nil)
+
+  private[dlframes] def imf2Row(imf: ImageFeature): Row = {
+    val (mode, data) = if (imf.contains(ImageFeature.imageTensor)) {
+      val floatData = imf(ImageFeature.imageTensor).asInstanceOf[Tensor[Float]].storage().array()
+      val cvType = imf.getChannel() match {
+        case 1 => CvType.CV_32FC1
+        case 3 => CvType.CV_32FC3
+        case 4 => CvType.CV_32FC4
+        case other => throw new IllegalArgumentException(s"Unsupported number of channels:" +
+          s" $other in ${imf.uri()}. Only 1, 3 and 4 are supported.")
+      }
+      (cvType, floatData)
+    } else if (imf.contains(ImageFeature.bytes)) {
+      val bytesData = imf.bytes()
+      val cvType = imf.getChannel() match {
+        case 1 => CvType.CV_8UC1
+        case 3 => CvType.CV_8UC3
+        case 4 => CvType.CV_8UC4
+        case other => throw new IllegalArgumentException(s"Unsupported number of channels:" +
+          s" $other in ${imf.uri()}. Only 1, 3 and 4 are supported.")
+      }
+      (cvType, bytesData)
+    } else {
+      throw new IllegalArgumentException(s"ImageFeature should have imageTensor or bytes.")
+    }
+
+    Row(
+      imf.uri(),
+      imf.getHeight(),
+      imf.getWidth(),
+      imf.getChannel(),
+      mode,
+      data
+    )
+  }
+
+  private[dlframes] def row2IMF(row: Row): ImageFeature = {
+    val (origin, h, w, c) = (row.getString(0), row.getInt(1), row.getInt(2), row.getInt(3))
+    val imf = ImageFeature()
+    imf.update(ImageFeature.uri, origin)
+    imf.update(ImageFeature.size, (h, w, c))
+    val storageType = row.getInt(4)
+    storageType match {
+      case CvType.CV_8UC3 | CvType.CV_8UC1 | CvType.CV_8UC4 =>
+        imf.update(ImageFeature.bytes, row.getAs[Array[Byte]](5))
+        BytesToMat().transform(imf)
+      case CvType.CV_32FC3 | CvType.CV_32FC1 | CvType.CV_32FC4 =>
+        val data = row.getSeq[Float](5).toArray
+        val size = Array(h, w, c)
+        val ten = Tensor(Storage(data)).resize(size)
+        imf.update(ImageFeature.imageTensor, ten)
+      case _ =>
+        throw new IllegalArgumentException(s"Unsupported data type in imageColumn: $storageType")
+    }
+    imf
+  }
+}
+
+/**
+ * Primary DataFrame-based image loading interface, defining API to read images into DataFrame.
+ */
+object DLImageReader {
+
+  /**
+   * DataFrame with a single column of images named "image" (nullable)
+   */
+  private val imageColumnSchema =
+    StructType(StructField("image", DLImageSchema.byteSchema, true) :: Nil)
+
+  /**
+   * Read the directory of images into DataFrame from the local or remote source.
+   *
+   * @param path Directory to the input data files, the path can be comma separated paths as the
+   *             list of inputs. Wildcards like "path/" are supported
+   * @param sc SparkContext to be used.
+   * @param minPartitions Number of the DataFrame partitions,
+   *                      if omitted uses defaultParallelism instead
+   * @return DataFrame with a single column "image" of images;
+   *         see DLImageSchema for the details
+   */
+  def readImages(path: String, sc: SparkContext, minPartitions: Int = 1): DataFrame = {
+    val imageFrame = ImageFrame.read(path, sc, minPartitions)
+    val rowRDD = imageFrame.toDistributed().rdd.map { imf =>
+      Row(DLImageSchema.imf2Row(imf))
+    }
+    SQLContext.getOrCreate(sc).createDataFrame(rowRDD, imageColumnSchema)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dlframes/DLImageReader.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dlframes/DLImageReader.scala
@@ -126,7 +126,7 @@ object DLImageReader {
    * Read the directory of images into DataFrame from the local or remote source.
    *
    * @param path Directory to the input data files, the path can be comma separated paths as the
-   *             list of inputs. Wildcards like "path/" are supported
+   *             list of inputs. Wildcards path are supported similarly to sc.binaryFiles(path).
    * @param sc SparkContext to be used.
    * @param minPartitions Number of the DataFrame partitions,
    *                      if omitted uses defaultParallelism instead

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dlframes/DLImageTransformer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dlframes/DLImageTransformer.scala
@@ -48,6 +48,7 @@ class DLImageTransformer (
   setDefault(inputCol -> "image")
   def setInputCol(value: String): this.type = set(inputCol, value)
 
+  setDefault(outputCol -> "output")
   def setOutputCol(value: String): this.type = set(outputCol, value)
 
   protected def validateInputType(inputType: DataType): Unit = {
@@ -60,10 +61,6 @@ class DLImageTransformer (
   override def transformSchema(schema: StructType): StructType = {
     val inputType = schema($(inputCol)).dataType
     validateInputType(inputType)
-    if (schema.fieldNames.contains($(outputCol))) {
-      throw new IllegalArgumentException(s"Output column ${$(outputCol)} already exists.")
-    }
-
     val outputFields = schema.fields :+
       StructField($(outputCol), DLImageSchema.floatSchema, nullable = false)
     StructType(outputFields)
@@ -81,7 +78,7 @@ class DLImageTransformer (
       val result = transformerValue.apply(Iterator(imf)).toArray.head
 
       if (!result.contains(ImageFeature.imageTensor)) {
-        MatToTensor[Float]().transform(result)
+        MatToTensor[Float](shareBuffer = true).transform(result)
       }
       DLImageSchema.imf2Row(result)
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dlframes/DLImageTransformer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dlframes/DLImageTransformer.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.dlframes
+
+import com.intel.analytics.bigdl.dataset.Transformer
+import com.intel.analytics.bigdl.transform.vision.image.{FeatureTransformer, ImageFeature,
+  MatToTensor}
+import org.apache.spark.ml.DLTransformerBase
+import org.apache.spark.ml.adapter.{HasInputCol, HasOutputCol, SchemaUtils}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, Row}
+
+/**
+ * Provides DataFrame-based API for image pre-processing and feature transformation.
+ * DLImageTransformer follows the Spark Transformer API pattern and can be used as one stage
+ * in Spark ML pipeline.
+ *
+ * The input column can be either DLImageSchema.byteSchema or DLImageSchema.floatSchema. If
+ * using DLImageReader, the default format is DLImageSchema.byteSchema
+ * The output column is always DLImageSchema.floatSchema.
+ *
+ * @param transformer Single or a sequence of BigDL FeatureTransformers to be used. E.g.
+ *                    Resize(256, 256) -> CenterCrop(224, 224) ->
+ *                    ChannelNormalize(123, 117, 104, 1, 1, 1) -> MatToTensor()
+ */
+class DLImageTransformer (
+    val transformer: Transformer[ImageFeature, ImageFeature],
+    override val uid: String)
+  extends DLTransformerBase with HasInputCol with HasOutputCol {
+
+  def this(transformer: FeatureTransformer) =
+    this(transformer, Identifiable.randomUID("DLImageTransformer"))
+
+  setDefault(inputCol -> "image")
+  def setInputCol(value: String): this.type = set(inputCol, value)
+
+  def setOutputCol(value: String): this.type = set(outputCol, value)
+
+  protected def validateInputType(inputType: DataType): Unit = {
+    val validTypes = Array(DLImageSchema.floatSchema, DLImageSchema.byteSchema)
+
+    require(validTypes.exists(t => SchemaUtils.sameType(inputType, t)),
+      s"Bad input type: $inputType. Requires ${validTypes.mkString(", ")}")
+  }
+
+  override def transformSchema(schema: StructType): StructType = {
+    val inputType = schema($(inputCol)).dataType
+    validateInputType(inputType)
+    if (schema.fieldNames.contains($(outputCol))) {
+      throw new IllegalArgumentException(s"Output column ${$(outputCol)} already exists.")
+    }
+
+    val outputFields = schema.fields :+
+      StructField($(outputCol), DLImageSchema.floatSchema, nullable = false)
+    StructType(outputFields)
+  }
+
+  protected override def internalTransform(dataFrame: DataFrame): DataFrame = {
+    transformSchema(dataFrame.schema, logging = true)
+    val sc = dataFrame.sqlContext.sparkContext
+    val localTransformer = this.transformer
+    val transformerBC = sc.broadcast(localTransformer)
+
+    val transformUDF = udf ({ row: Row =>
+      val transformerValue = transformerBC.value
+      val imf = DLImageSchema.row2IMF(row)
+      val result = transformerValue.apply(Iterator(imf)).toArray.head
+
+      if (!result.contains(ImageFeature.imageTensor)) {
+        MatToTensor[Float]().transform(result)
+      }
+      DLImageSchema.imf2Row(result)
+    }, DLImageSchema.floatSchema)
+
+    dataFrame.withColumn($(outputCol), transformUDF(dataFrame($(inputCol))))
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dlframes/SharedParamsAdapter.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dlframes/SharedParamsAdapter.scala
@@ -23,10 +23,14 @@ trait HasPredictionCol extends org.apache.spark.ml.param.shared.HasPredictionCol
 
 trait HasFeaturesCol extends org.apache.spark.ml.param.shared.HasFeaturesCol
 
+trait HasInputCol extends org.apache.spark.ml.param.shared.HasInputCol
+
+trait HasOutputCol extends org.apache.spark.ml.param.shared.HasOutputCol
+
 object SchemaUtils {
 
   /**
-   * Appends a new column to the input schema. This fails if the given output column already exists.
+   * Appends a new column to the input schema. This fails if the given output column already exists
    * @param schema input schema
    * @param colName new column name. If this column name is an empty string "", this method returns
    *                the input schema unchanged. This allows users to disable output columns.
@@ -40,4 +44,7 @@ object SchemaUtils {
       nullable: Boolean = false): StructType = {
     org.apache.spark.ml.util.SchemaUtils.appendColumn(schema, colName, dataType)
   }
+
+  def sameType(a: DataType, b: DataType): Boolean = a.sameType(b)
+
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -33,7 +33,7 @@ import org.apache.spark.rdd.RDD
 import java.lang.{Boolean => JBoolean}
 import java.nio.ByteOrder
 
-import com.intel.analytics.bigdl.dlframes.{DLClassifier, DLClassifierModel, DLEstimator, DLModel}
+import com.intel.analytics.bigdl.dlframes._
 import com.intel.analytics.bigdl.nn.Graph._
 import com.intel.analytics.bigdl.optim.SGD.{LearningRateSchedule, SequentialSchedule}
 import com.intel.analytics.bigdl.transform.vision.image._
@@ -3016,6 +3016,19 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
 
   def createDatasetFromImageFrame(imageFrame: ImageFrame): DataSet[ImageFeature] = {
     DataSet.imageFrame(imageFrame)
+  }
+
+  def dlReadImage(path: String, sc: JavaSparkContext, minParitions: Int): DataFrame = {
+    val df = DLImageReader.readImages(path, sc.sc, minParitions)
+    df
+  }
+
+  def createDLImageTransformer(transformer: FeatureTransformer): DLImageTransformer = {
+    new DLImageTransformer(transformer)
+  }
+
+  def dlImageTransform(dlImageTransformer: DLImageTransformer, dataSet: DataFrame): DataFrame = {
+    dlImageTransformer.transform(dataSet)
   }
 }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dlframes/DLImageReaderSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dlframes/DLImageReaderSpec.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.dlframes
+
+import com.intel.analytics.bigdl.transform.vision.image.{ImageFrame, MatToTensor}
+import com.intel.analytics.bigdl.transform.vision.image.augmentation.Resize
+import com.intel.analytics.bigdl.utils.Engine
+import com.intel.analytics.bigdl.utils.RandomGenerator.RNG
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.{Row, SQLContext}
+import org.opencv.core.CvType
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+
+import scala.util.Random
+
+class DLImageReaderSpec extends FlatSpec with Matchers with BeforeAndAfter {
+
+  var sc : SparkContext = _
+  var sQLContext: SQLContext = _
+  val pascalResource = getClass.getClassLoader.getResource("pascal/")
+  private val imageNetResource = getClass.getClassLoader.getResource("imagenet/")
+
+  before {
+    Random.setSeed(42)
+    RNG.setSeed(42)
+    val conf = Engine.createSparkConf().setAppName("Test DLEstimator").setMaster("local[1]")
+    sc = SparkContext.getOrCreate(conf)
+    sQLContext = SQLContext.getOrCreate(sc)
+    Engine.init
+  }
+
+  after{
+    if (sc != null) {
+      sc.stop()
+    }
+  }
+
+  "DLImageReader" should "has correct result for pascal" in {
+    val imageDF = DLImageReader.readImages(pascalResource.getFile, sc)
+    assert(imageDF.count() == 1)
+    val r = imageDF.head().getAs[Row](0)
+    assert(r.getString(0).endsWith("000025.jpg"))
+    assert(r.getInt(1) == 375)
+    assert(r.getInt(2) == 500)
+    assert(r.getInt(3) == 3)
+    assert(r.getInt(4) == CvType.CV_8UC3)
+    assert(r.getAs[Array[Byte]](5).length == 95959)
+  }
+
+  "DLImageReader" should "has correct result for imageNet" in {
+    val imageDirectory = imageNetResource + "n02110063/"
+    val imageDF = DLImageReader.readImages(imageDirectory, sc)
+    assert(imageDF.count() == 3)
+    val expectedRows = Seq(
+      (imageDirectory + "n02110063_8651.JPEG", 99, 129, 3, CvType.CV_8UC3),
+      (imageDirectory + "n02110063_11239.JPEG", 333, 500, 3, CvType.CV_8UC3),
+      (imageDirectory + "n02110063_15462.JPEG", 332, 500, 3, CvType.CV_8UC3)
+    )
+    val actualRows = imageDF.rdd.collect().map(r => r.getAs[Row](0)).map { r =>
+      (r.getString(0), r.getInt(1), r.getInt(2), r.getInt(3), r.getInt(4))
+    }
+    assert (expectedRows.toSet == actualRows.toSet)
+  }
+
+  "DLImageReader" should "has correct result for imageNet with channel 1 and 4" in {
+    val imageDirectory = imageNetResource + "n99999999/"
+    val imageDF = DLImageReader.readImages(imageDirectory, sc)
+    assert(imageDF.count() == 3)
+    val expectedRows = Seq(
+      (imageDirectory + "n02105855_2933.JPEG", 189, 213, 4, CvType.CV_8UC4),
+      (imageDirectory + "n02105855_test1.bmp", 527, 556, 1, CvType.CV_8UC1),
+      (imageDirectory + "n03000134_4970.JPEG", 480, 640, 3, CvType.CV_8UC3)
+    )
+    val actualRows = imageDF.rdd.collect().map(r => r.getAs[Row](0)).map { r =>
+      (r.getString(0), r.getInt(1), r.getInt(2), r.getInt(3), r.getInt(4))
+    }
+    assert (expectedRows.toSet == actualRows.toSet)
+  }
+
+  "DLImageReader" should "read recursively by wildcard path" in {
+    val imageDF = DLImageReader.readImages(imageNetResource.getFile + "*", sc)
+    assert(imageDF.count() == 11)
+  }
+
+  "DLImageReader" should "read from multiple path" in {
+    val imageDirectory1 = imageNetResource + "n02110063/"
+    val imageDirectory2 = imageNetResource + "n99999999/"
+    val imageDF = DLImageReader.readImages(imageDirectory1 + "," + imageDirectory2, sc)
+    assert(imageDF.count() == 6)
+  }
+
+  "DLImageReader" should "has correct #partitions" in {
+    val imageDF = DLImageReader.readImages(imageNetResource.getFile + "*", sc, 4)
+    assert(imageDF.count() == 11)
+    assert(imageDF.rdd.partitions.length >= 4)
+  }
+
+  "read gray scale image" should "work" in {
+    val resource = getClass().getClassLoader().getResource("gray/gray.bmp")
+    val df = DLImageReader.readImages(resource.getFile, sc)
+    assert(df.count() == 1)
+    val r = df.head().getAs[Row](0)
+    assert(r.getString(0).endsWith("gray.bmp"))
+    assert(r.getInt(1) == 50)
+    assert(r.getInt(2) == 50)
+    assert(r.getInt(3) == 1)
+    assert(r.getInt(4) == CvType.CV_8UC1)
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dlframes/DLImageReaderSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dlframes/DLImageReaderSpec.scala
@@ -34,11 +34,13 @@ class DLImageReaderSpec extends FlatSpec with Matchers with BeforeAndAfter {
   private val imageNetResource = getClass.getClassLoader.getResource("imagenet/")
 
   before {
+    val conf = Engine.createSparkConf().setAppName("Test DLImageReader").setMaster("local[1]")
+    sc = SparkContext.getOrCreate(conf)
+    sQLContext = new SQLContext(sc)
+
     Random.setSeed(42)
     RNG.setSeed(42)
-    val conf = Engine.createSparkConf().setAppName("Test DLEstimator").setMaster("local[1]")
-    sc = SparkContext.getOrCreate(conf)
-    sQLContext = SQLContext.getOrCreate(sc)
+
     Engine.init
   }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dlframes/DLImageReaderSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dlframes/DLImageReaderSpec.scala
@@ -104,12 +104,6 @@ class DLImageReaderSpec extends FlatSpec with Matchers with BeforeAndAfter {
     assert(imageDF.count() == 6)
   }
 
-  "DLImageReader" should "has correct #partitions" in {
-    val imageDF = DLImageReader.readImages(imageNetResource.getFile + "*", sc, 4)
-    assert(imageDF.count() == 11)
-    assert(imageDF.rdd.partitions.length >= 4)
-  }
-
   "read gray scale image" should "work" in {
     val resource = getClass().getClassLoader().getResource("gray/gray.bmp")
     val df = DLImageReader.readImages(resource.getFile, sc)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dlframes/DLImageTransformerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dlframes/DLImageTransformerSpec.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.dlframes
+
+import com.intel.analytics.bigdl.transform.vision.image.{ImageFrame, ImageFrameToSample, MatToTensor}
+import com.intel.analytics.bigdl.transform.vision.image.augmentation.{CenterCrop, ChannelNormalize, Resize}
+import com.intel.analytics.bigdl.utils.Engine
+import com.intel.analytics.bigdl.utils.RandomGenerator.RNG
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.Row
+import org.opencv.core.CvType
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric.NumericFloat
+
+import scala.util.Random
+
+class DLImageTransformerSpec extends FlatSpec with Matchers with BeforeAndAfter {
+  private var sc : SparkContext = _
+  private val pascalResource = getClass.getClassLoader.getResource("pascal/")
+  private val imageNetResource = getClass.getClassLoader.getResource("imagenet/")
+
+  before {
+    Random.setSeed(42)
+    RNG.setSeed(42)
+    val conf = Engine.createSparkConf().setAppName("Test DLEstimator").setMaster("local[1]")
+    sc = SparkContext.getOrCreate(conf)
+    Engine.init
+  }
+
+  after{
+    if (sc != null) {
+      sc.stop()
+    }
+  }
+
+  "DLTransformer" should "setters work" in {
+    val transformer = Resize(256, 256) -> CenterCrop(224, 224) ->
+      ChannelNormalize(123, 117, 104, 1, 1, 1) -> MatToTensor()
+    val trans = new DLImageTransformer(transformer)
+      .setInputCol("image1")
+      .setOutputCol("features1")
+    assert(trans.getInputCol == "image1")
+    assert(trans.getOutputCol == "features1")
+  }
+
+  "DLTransformer" should "has correct result with pascal images" in {
+    val imageDF = DLImageReader.readImages(pascalResource.getFile, sc)
+    assert(imageDF.count() == 1)
+    val transformer = Resize(256, 256) -> CenterCrop(224, 224) ->
+      ChannelNormalize(123, 117, 104, 1, 1, 1) -> MatToTensor()
+    val transformedDF = new DLImageTransformer(transformer)
+      .setInputCol("image")
+      .setOutputCol("features")
+      .transform(imageDF)
+    val r = transformedDF.select("features").rdd.first().getAs[Row](0)
+    assert(r.getString(0).endsWith("pascal/000025.jpg"))
+    assert(r.getInt(1) == 224)
+    assert(r.getInt(2) == 224)
+    assert(r.getInt(3) == 3)
+    assert(r.getInt(4) == CvType.CV_32FC3)
+    assert(r.getSeq[Float](5).take(6).toArray.deep == Array(-30, -50, -69, -84, -46, -25).deep)
+  }
+
+  "DLTransformer" should "has correct result without MatToTensor" in {
+    val imageDF = DLImageReader.readImages(pascalResource.getFile, sc)
+    assert(imageDF.count() == 1)
+    val transformer = Resize(256, 256) -> CenterCrop(224, 224) ->
+      ChannelNormalize(123, 117, 104, 1, 1, 1)
+    val transformedDF = new DLImageTransformer(transformer)
+      .setInputCol("image")
+      .setOutputCol("features")
+      .transform(imageDF)
+    val r = transformedDF.select("features").rdd.first().getAs[Row](0)
+    assert(r.getString(0).endsWith("pascal/000025.jpg"))
+    assert(r.getInt(1) == 224)
+    assert(r.getInt(2) == 224)
+    assert(r.getInt(3) == 3)
+    assert(r.getInt(4) == CvType.CV_32FC3)
+    assert(r.getSeq[Float](5).take(6).toArray.deep == Array(-30, -50, -69, -84, -46, -25).deep)
+  }
+
+  "DLTransformer" should "ensure imf2Row and Row2Imf reversible" in {
+    val imageDF = DLImageReader.readImages(pascalResource.getFile, sc)
+    assert(imageDF.count() == 1)
+    val transformer = Resize(256, 256) -> CenterCrop(224, 224) ->
+      ChannelNormalize(123, 117, 104, 1, 1, 1) -> MatToTensor()
+    val transformedDF = new DLImageTransformer(transformer)
+      .setInputCol("image")
+      .setOutputCol("features")
+      .transform(imageDF)
+    val r = transformedDF.select("features").rdd.first().getAs[Row](0)
+    val convertedR = DLImageSchema.imf2Row(DLImageSchema.row2IMF(r))
+
+    assert(r.getSeq[Float](5).toArray.deep == convertedR.getAs[Array[Float]](5).deep)
+  }
+
+  "transform gray scale image" should "work" in {
+    val resource = getClass().getClassLoader().getResource("gray/gray.bmp")
+    val df = DLImageReader.readImages(resource.getFile, sc)
+    val dlTransformer = new DLImageTransformer(Resize(28, 28) -> MatToTensor[Float]())
+      .setInputCol("image")
+      .setOutputCol("features")
+    val r = dlTransformer.transform(df).select("features").rdd.first().getAs[Row](0)
+    assert(r.getString(0).endsWith("gray.bmp"))
+    assert(r.getInt(1) == 28)
+    assert(r.getInt(2) == 28)
+    assert(r.getInt(3) == 1)
+    assert(r.getInt(4) == CvType.CV_8UC1)
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dlframes/DLImageTransformerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dlframes/DLImageTransformerSpec.scala
@@ -124,20 +124,15 @@ class DLImageTransformerSpec extends FlatSpec with Matchers with BeforeAndAfter 
     assert(r.getInt(4) == CvType.CV_32FC1)
   }
 
-  "DLTransformer" should "support same input and output columns" in {
+  "DLTransformer" should "report error with same input and output columns" in {
     val resource = getClass().getClassLoader().getResource("gray/gray.bmp")
     val df = DLImageReader.readImages(resource.getFile, sc)
     val dlTransformer = new DLImageTransformer(Resize(28, 28) -> MatToTensor[Float]())
       .setInputCol("image")
       .setOutputCol("image")
-    val transformed = dlTransformer.transform(df)
-    transformed.show(false)
-    val r = transformed.select("image").rdd.first().getAs[Row](0)
-    assert(r.getString(0).endsWith("gray.bmp"))
-    assert(r.getInt(1) == 28)
-    assert(r.getInt(2) == 28)
-    assert(r.getInt(3) == 1)
-    assert(r.getInt(4) == CvType.CV_32FC1)
+    intercept[IllegalArgumentException] {
+      val transformed = dlTransformer.transform(df)
+    }
   }
 
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dlframes/DLImageTransformerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dlframes/DLImageTransformerSpec.scala
@@ -21,7 +21,7 @@ import com.intel.analytics.bigdl.transform.vision.image.augmentation.{CenterCrop
 import com.intel.analytics.bigdl.utils.Engine
 import com.intel.analytics.bigdl.utils.RandomGenerator.RNG
 import org.apache.spark.SparkContext
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{Row, SQLContext}
 import org.opencv.core.CvType
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric.NumericFloat
@@ -30,14 +30,16 @@ import scala.util.Random
 
 class DLImageTransformerSpec extends FlatSpec with Matchers with BeforeAndAfter {
   private var sc : SparkContext = _
+  private var sqlContext : SQLContext = _
   private val pascalResource = getClass.getClassLoader.getResource("pascal/")
   private val imageNetResource = getClass.getClassLoader.getResource("imagenet/")
 
   before {
+    val conf = Engine.createSparkConf().setAppName("Test DLImageTransfomer").setMaster("local[1]")
+    sc = SparkContext.getOrCreate(conf)
+    sqlContext = new SQLContext(sc)
     Random.setSeed(42)
     RNG.setSeed(42)
-    val conf = Engine.createSparkConf().setAppName("Test DLEstimator").setMaster("local[1]")
-    sc = SparkContext.getOrCreate(conf)
     Engine.init
   }
 
@@ -119,6 +121,6 @@ class DLImageTransformerSpec extends FlatSpec with Matchers with BeforeAndAfter 
     assert(r.getInt(1) == 28)
     assert(r.getInt(2) == 28)
     assert(r.getInt(3) == 1)
-    assert(r.getInt(4) == CvType.CV_8UC1)
+    assert(r.getInt(4) == CvType.CV_32FC1)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dlframes/DLImageTransformerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dlframes/DLImageTransformerSpec.scala
@@ -110,7 +110,7 @@ class DLImageTransformerSpec extends FlatSpec with Matchers with BeforeAndAfter 
     assert(r.getSeq[Float](5).toArray.deep == convertedR.getAs[Array[Float]](5).deep)
   }
 
-  "transform gray scale image" should "work" in {
+  "DLTransformer" should "transform gray scale image" in {
     val resource = getClass().getClassLoader().getResource("gray/gray.bmp")
     val df = DLImageReader.readImages(resource.getFile, sc)
     val dlTransformer = new DLImageTransformer(Resize(28, 28) -> MatToTensor[Float]())
@@ -123,4 +123,21 @@ class DLImageTransformerSpec extends FlatSpec with Matchers with BeforeAndAfter 
     assert(r.getInt(3) == 1)
     assert(r.getInt(4) == CvType.CV_32FC1)
   }
+
+  "DLTransformer" should "support same input and output columns" in {
+    val resource = getClass().getClassLoader().getResource("gray/gray.bmp")
+    val df = DLImageReader.readImages(resource.getFile, sc)
+    val dlTransformer = new DLImageTransformer(Resize(28, 28) -> MatToTensor[Float]())
+      .setInputCol("image")
+      .setOutputCol("image")
+    val transformed = dlTransformer.transform(df)
+    transformed.show(false)
+    val r = transformed.select("image").rdd.first().getAs[Row](0)
+    assert(r.getString(0).endsWith("gray.bmp"))
+    assert(r.getInt(1) == 28)
+    assert(r.getInt(2) == 28)
+    assert(r.getInt(3) == 1)
+    assert(r.getInt(4) == CvType.CV_32FC1)
+  }
+
 }

--- a/spark/spark-version/1.5-plus/src/main/scala/org/apache/spark/sql/SqlAdapter.scala
+++ b/spark/spark-version/1.5-plus/src/main/scala/org/apache/spark/sql/SqlAdapter.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.sql.types.DataType
+
+object SqlAdapter {
+
+  def getUDF(f: AnyRef, dataType: DataType): UserDefinedFunction = {
+    UserDefinedFunction(f, dataType)
+  }
+
+}

--- a/spark/spark-version/2.0/src/main/scala/org/apache/spark/sql/SqlAdapter.scala
+++ b/spark/spark-version/2.0/src/main/scala/org/apache/spark/sql/SqlAdapter.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.types.DataType
+
+object SqlAdapter {
+
+  def getUDF(f: AnyRef, dataType: DataType): UserDefinedFunction = {
+    UserDefinedFunction(f, dataType, None)
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Provides DataFrame-based image reader and feature transformer. 
Both Scala and Python interface are provided.

More unit tests will be added.

## How was this patch tested?

new unit tests.

