### PR TITLE
Move Keras-like API layers serial test

### DIFF
--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/ActivationSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/ActivationSpec.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.keras.nn
 
 import com.intel.analytics.bigdl.keras.KerasBaseSpec
 import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
-import com.intel.analytics.bigdl.nn.keras.{Activation, Sequential => KSequential}
+import com.intel.analytics.bigdl.nn.keras.{Activation, SoftMax, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
 import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
@@ -154,6 +154,15 @@ class ActivationSerialTest extends ModuleSerializationTest {
     val layer = Activation[Float]("tanh", inputShape = Shape(4, 5))
     layer.build(Shape(2, 4, 5))
     val input = Tensor[Float](2, 4, 5).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
+}
+
+class SoftMaxSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = SoftMax[Float](inputShape = Shape(4, 5))
+    layer.build(Shape(3, 4, 5))
+    val input = Tensor[Float](3, 4, 5).apply1(_ => Random.nextFloat())
     runSerializationTest(layer, input)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/ActivationSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/ActivationSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{Activation, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class ActivationSpec extends KerasBaseSpec{
 
@@ -144,4 +147,13 @@ class ActivationSpec extends KerasBaseSpec{
       kerasCode)
   }
 
+}
+
+class ActivationSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = Activation[Float]("tanh", inputShape = Shape(4, 5))
+    layer.build(Shape(2, 4, 5))
+    val input = Tensor[Float](2, 4, 5).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AtrousConvolution1DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AtrousConvolution1DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{AtrousConvolution1D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class AtrousConvolution1DSpec extends KerasBaseSpec {
 
@@ -48,4 +51,13 @@ class AtrousConvolution1DSpec extends KerasBaseSpec {
       kerasCode, weightConverter)
   }
 
+}
+
+class AtrousConvolution1DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = AtrousConvolution1D[Float](64, 3, inputShape = Shape(8, 32))
+    layer.build(Shape(2, 8, 32))
+    val input = Tensor[Float](2, 8, 32).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AtrousConvolution2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AtrousConvolution2DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{AtrousConvolution2D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class AtrousConvolution2DSpec extends KerasBaseSpec {
 
@@ -42,4 +45,14 @@ class AtrousConvolution2DSpec extends KerasBaseSpec {
       kerasCode, precision = 1e-2)
   }
 
+}
+
+class AtrousConvolution2DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = AtrousConvolution2D[Float](32, 2, 4, atrousRate = (2, 2),
+      inputShape = Shape(3, 64, 64))
+    layer.build(Shape(2, 3, 64, 64))
+    val input = Tensor[Float](2, 3, 64, 64).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AveragePooling1DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AveragePooling1DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{AveragePooling1D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class AveragePooling1DSpec extends KerasBaseSpec {
 
@@ -57,4 +60,13 @@ class AveragePooling1DSpec extends KerasBaseSpec {
       kerasCode)
   }
 
+}
+
+class AveragePooling1DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = AveragePooling1D[Float](inputShape = Shape(12, 16))
+    layer.build(Shape(2, 12, 16))
+    val input = Tensor[Float](2, 12, 16).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AveragePooling2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AveragePooling2DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
 import com.intel.analytics.bigdl.nn.keras.{AveragePooling2D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class AveragePooling2DSpec extends KerasBaseSpec {
 
@@ -58,4 +61,13 @@ class AveragePooling2DSpec extends KerasBaseSpec {
       kerasCode)
   }
 
+}
+
+class AveragePooling2DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = AveragePooling2D[Float](inputShape = Shape(3, 24, 24))
+    layer.build(Shape(2, 3, 24, 24))
+    val input = Tensor[Float](2, 3, 24, 24).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AveragePooling3DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/AveragePooling3DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{AveragePooling3D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class AveragePooling3DSpec extends KerasBaseSpec {
 
@@ -40,4 +43,13 @@ class AveragePooling3DSpec extends KerasBaseSpec {
       kerasCode)
   }
 
+}
+
+class AveragePooling3DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = AveragePooling3D[Float](inputShape = Shape(3, 12, 12, 12))
+    layer.build(Shape(2, 3, 12, 12, 12))
+    val input = Tensor[Float](2, 3, 12, 12, 12).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/BatchNormalizationSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/BatchNormalizationSpec.scala
@@ -20,6 +20,9 @@ import com.intel.analytics.bigdl.keras.KerasBaseSpec
 import com.intel.analytics.bigdl.nn.keras.{BatchNormalization, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class BatchNormalizationSpec extends KerasBaseSpec {
 
@@ -35,4 +38,13 @@ class BatchNormalizationSpec extends KerasBaseSpec {
     val gradInput = seq.backward(input, output)
   }
 
+}
+
+class BatchNormalizationSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = BatchNormalization[Float](inputShape = Shape(3, 12, 12))
+    layer.build(Shape(2, 3, 12, 12))
+    val input = Tensor[Float](2, 3, 12, 12).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/BidirectionalSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/BidirectionalSpec.scala
@@ -22,6 +22,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{Bidirectional, LSTM, SimpleRNN, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class BidirectionalSpec extends KerasBaseSpec {
 
@@ -81,4 +84,14 @@ class BidirectionalSpec extends KerasBaseSpec {
       kerasCode, weightConverter)
   }
 
+}
+
+class BidirectionalSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = Bidirectional[Float](SimpleRNN(4, returnSequences = true),
+      inputShape = Shape(8, 12))
+    layer.build(Shape(3, 8, 12))
+    val input = Tensor[Float](3, 8, 12).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/ConvLSTM2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/ConvLSTM2DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{ConvLSTM2D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class ConvLSTM2DSpec extends KerasBaseSpec {
 
@@ -68,4 +71,13 @@ class ConvLSTM2DSpec extends KerasBaseSpec {
       kerasCode, weightConverter, precision = 1e-2)
   }
 
+}
+
+class ConvLSTM2DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = ConvLSTM2D[Float](32, 4, inputShape = Shape(8, 40, 40, 32))
+    layer.build(Shape(2, 8, 40, 40, 32))
+    val input = Tensor[Float](2, 8, 40, 40, 32).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution1DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution1DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{Convolution1D, Conv1D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class Convolution1DSpec extends KerasBaseSpec {
 
@@ -62,4 +65,13 @@ class Convolution1DSpec extends KerasBaseSpec {
       kerasCode, weightConverter)
   }
 
+}
+
+class Convolution1DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = Convolution1D[Float](64, 3, inputShape = Shape(12, 20))
+    layer.build(Shape(2, 12, 20))
+    val input = Tensor[Float](2, 12, 20).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution2DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
 import com.intel.analytics.bigdl.nn.keras.{Conv2D, Convolution2D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class Convolution2DSpec extends KerasBaseSpec {
 
@@ -79,4 +82,13 @@ class Convolution2DSpec extends KerasBaseSpec {
       kerasCode, weightConverter, 1e-4)
   }
 
+}
+
+class Convolution2DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = Convolution2D[Float](64, 2, 5, inputShape = Shape(3, 24, 24))
+    layer.build(Shape(2, 3, 24, 24))
+    val input = Tensor[Float](2, 3, 24, 24).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution3DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Convolution3DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{Conv3D, Convolution3D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class Convolution3DSpec extends KerasBaseSpec {
 
@@ -58,4 +61,13 @@ class Convolution3DSpec extends KerasBaseSpec {
       kerasCode, precision = 1e-3)
   }
 
+}
+
+class Convolution3DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = Convolution3D[Float](12, 2, 1, 3, inputShape = Shape(3, 32, 32, 32))
+    layer.build(Shape(2, 3, 32, 32, 32))
+    val input = Tensor[Float](2, 3, 32, 32, 32).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Cropping1DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Cropping1DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{Cropping1D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class Cropping1DSpec extends KerasBaseSpec {
 
@@ -40,4 +43,13 @@ class Cropping1DSpec extends KerasBaseSpec {
       kerasCode)
   }
 
+}
+
+class Cropping1DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = Cropping1D[Float](inputShape = Shape(5, 6))
+    layer.build(Shape(2, 5, 6))
+    val input = Tensor[Float](2, 5, 6).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Cropping2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Cropping2DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
 import com.intel.analytics.bigdl.nn.keras.{Cropping2D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class Cropping2DSpec extends KerasBaseSpec {
 
@@ -55,4 +58,13 @@ class Cropping2DSpec extends KerasBaseSpec {
       kerasCode)
   }
 
+}
+
+class Cropping2DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = Cropping2D[Float](inputShape = Shape(3, 8, 12))
+    layer.build(Shape(2, 3, 8, 12))
+    val input = Tensor[Float](2, 3, 8, 12).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Deconvolution2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/Deconvolution2DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{Deconvolution2D, Deconv2D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class Deconvolution2DSpec extends KerasBaseSpec {
 
@@ -65,4 +68,13 @@ class Deconvolution2DSpec extends KerasBaseSpec {
       kerasCode, weightConverter, precision = 1e-3)
   }
 
+}
+
+class Deconvolution2DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = Deconvolution2D[Float](3, 3, 3, inputShape = Shape(3, 24, 24))
+    layer.build(Shape(2, 12, 24, 24))
+    val input = Tensor[Float](2, 12, 24, 24).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/ELUSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/ELUSpec.scala
@@ -22,6 +22,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.ELU
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class ELUSpec extends KerasBaseSpec{
 
@@ -55,4 +58,13 @@ class ELUSpec extends KerasBaseSpec{
       kerasCode)
   }
 
+}
+
+class ELUSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = ELU[Float](2.7, inputShape = Shape(3, 24))
+    layer.build(Shape(2, 3, 24))
+    val input = Tensor[Float](2, 3, 24).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/EmbeddingSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/EmbeddingSpec.scala
@@ -20,6 +20,9 @@ import com.intel.analytics.bigdl.keras.KerasBaseSpec
 import com.intel.analytics.bigdl.nn.keras.{Embedding, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class EmbeddingSpec extends KerasBaseSpec {
 
@@ -42,4 +45,21 @@ class EmbeddingSpec extends KerasBaseSpec {
     val gradInput = seq.backward(input, output)
   }
 
+}
+
+class EmbeddingSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = Embedding[Float](1000, 32, inputShape = Shape(4))
+    layer.build(Shape(2, 4))
+    val input = Tensor[Float](2, 4)
+    input(Array(1, 1)) = 1
+    input(Array(1, 2)) = 2
+    input(Array(1, 3)) = 4
+    input(Array(1, 4)) = 5
+    input(Array(2, 1)) = 4
+    input(Array(2, 2)) = 3
+    input(Array(2, 3)) = 2
+    input(Array(2, 4)) = 6
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GRUSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GRUSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{GRU, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class GRUSpec extends KerasBaseSpec {
 
@@ -89,4 +92,14 @@ class GRUSpec extends KerasBaseSpec {
       kerasCode, weightConverter)
   }
 
+}
+
+class GRUSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = GRU[Float](16, returnSequences = true,
+      goBackwards = true, inputShape = Shape(28, 32))
+    layer.build(Shape(2, 28, 32))
+    val input = Tensor[Float](2, 28, 32).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GaussianDropoutSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GaussianDropoutSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.keras.GaussianDropout
 import com.intel.analytics.bigdl.nn.keras.{Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class GaussianDropoutSpec extends KerasBaseSpec {
 
@@ -34,4 +37,13 @@ class GaussianDropoutSpec extends KerasBaseSpec {
     val gradInput = seq.backward(input, output)
   }
 
+}
+
+class GaussianDropoutSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = GaussianDropout[Float](0.6, inputShape = Shape(3, 4))
+    layer.build(Shape(2, 3, 4))
+    val input = Tensor[Float](2, 3, 4).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GaussianNoiseSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GaussianNoiseSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.keras.GaussianNoise
 import com.intel.analytics.bigdl.nn.keras.{Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class GaussianNoiseSpec extends KerasBaseSpec {
 
@@ -34,4 +37,13 @@ class GaussianNoiseSpec extends KerasBaseSpec {
     val gradInput = seq.backward(input, output)
   }
 
+}
+
+class GaussianNoiseSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = GaussianNoise[Float](0.8, inputShape = Shape(12, 24))
+    layer.build(Shape(2, 12, 24))
+    val input = Tensor[Float](2, 12, 24).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GlobalAveragePooling2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GlobalAveragePooling2DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
 import com.intel.analytics.bigdl.nn.keras.{GlobalAveragePooling2D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class GlobalAveragePooling2DSpec extends KerasBaseSpec {
 
@@ -57,4 +60,13 @@ class GlobalAveragePooling2DSpec extends KerasBaseSpec {
       kerasCode)
   }
 
+}
+
+class GlobalAveragePooling2DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = GlobalAveragePooling2D[Float](inputShape = Shape(4, 24, 32))
+    layer.build(Shape(2, 4, 24, 32))
+    val input = Tensor[Float](2, 4, 24, 32).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GlobalMaxPooling2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GlobalMaxPooling2DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
 import com.intel.analytics.bigdl.nn.keras.{GlobalMaxPooling2D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class GlobalMaxPooling2DSpec extends KerasBaseSpec {
 
@@ -56,4 +59,13 @@ class GlobalMaxPooling2DSpec extends KerasBaseSpec {
       kerasCode)
   }
 
+}
+
+class GlobalMaxPooling2DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = GlobalMaxPooling2D[Float](inputShape = Shape(4, 24, 32))
+    layer.build(Shape(2, 4, 24, 32))
+    val input = Tensor[Float](2, 4, 24, 32).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GlobalMaxPooling3DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/GlobalMaxPooling3DSpec.scala
@@ -22,6 +22,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.GlobalMaxPooling3D
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class GlobalMaxPooling3DSpec extends KerasBaseSpec{
 
@@ -41,4 +44,13 @@ class GlobalMaxPooling3DSpec extends KerasBaseSpec{
       kerasCode)
   }
 
+}
+
+class GlobalMaxPooling3DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = GlobalMaxPooling3D[Float](inputShape = Shape(12, 24, 3, 6))
+    layer.build(Shape(2, 12, 24, 3, 6))
+    val input = Tensor[Float](2, 12, 24, 3, 6).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/HighwaySpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/HighwaySpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{Dense, Highway, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class HighwaySpec extends KerasBaseSpec {
 
@@ -69,4 +72,13 @@ class HighwaySpec extends KerasBaseSpec {
       kerasCode, weightConverter)
   }
 
+}
+
+class HighwaySerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = Highway[Float](activation = "tanh", bias = false, inputShape = Shape(4))
+    layer.build(Shape(3, 4))
+    val input = Tensor[Float](3, 4).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/InputSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/InputSpec.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.nn.keras.InputLayer
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
+
+class InputSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val input = InputLayer[Float](inputShape = Shape(20))
+    val inputData = Tensor[Float](2, 20).apply1(_ => Random.nextFloat())
+    runSerializationTest(input, inputData)
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/LSTMSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/LSTMSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{LSTM, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class LSTMSpec extends KerasBaseSpec {
 
@@ -88,4 +91,14 @@ class LSTMSpec extends KerasBaseSpec {
       kerasCode, weightConverter)
   }
 
+}
+
+class LSTMSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = LSTM[Float](8, returnSequences = true,
+      innerActivation = "sigmoid", inputShape = Shape(32, 32))
+    layer.build(Shape(3, 32, 32))
+    val input = Tensor[Float](3, 32, 32).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/LeakyReLUSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/LeakyReLUSpec.scala
@@ -22,6 +22,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.LeakyReLU
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class LeakyReLUSpec extends KerasBaseSpec{
 
@@ -55,4 +58,13 @@ class LeakyReLUSpec extends KerasBaseSpec{
       kerasCode)
   }
 
+}
+
+class LeakyReLUSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = LeakyReLU[Float](1.27, inputShape = Shape(8, 24))
+    layer.build(Shape(2, 8, 24))
+    val input = Tensor[Float](2, 8, 24).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/LocallyConnected1DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/LocallyConnected1DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{LocallyConnected1D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class LocallyConnected1DSpec extends KerasBaseSpec {
 
@@ -77,4 +80,13 @@ class LocallyConnected1DSpec extends KerasBaseSpec {
       kerasCode, weightConverter)
   }
 
+}
+
+class LocallyConnected1DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = LocallyConnected1D[Float](32, 3, inputShape = Shape(12, 24))
+    layer.build(Shape(2, 12, 24))
+    val input = Tensor[Float](2, 12, 24).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/LocallyConnected2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/LocallyConnected2DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
 import com.intel.analytics.bigdl.nn.keras.{LocallyConnected2D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class LocallyConnected2DSpec extends KerasBaseSpec {
 
@@ -94,4 +97,14 @@ class LocallyConnected2DSpec extends KerasBaseSpec {
       kerasCode, weightConverter)
   }
 
+}
+
+class LocallyConnected2DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = LocallyConnected2D[Float](32, 2, 2, activation = "relu",
+      inputShape = Shape(12, 24, 24))
+    layer.build(Shape(2, 12, 24, 24))
+    val input = Tensor[Float](2, 12, 24, 24).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaskingSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaskingSpec.scala
@@ -22,6 +22,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.Masking
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class MaskingSpec extends KerasBaseSpec{
 
@@ -55,4 +58,13 @@ class MaskingSpec extends KerasBaseSpec{
       kerasCode)
   }
 
+}
+
+class MaskingSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = Masking[Float](0.0, inputShape = Shape(3, 12))
+    layer.build(Shape(2, 3, 12))
+    val input = Tensor[Float](2, 3, 12).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling1DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling1DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{MaxPooling1D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class MaxPooling1DSpec extends KerasBaseSpec {
 
@@ -57,4 +60,13 @@ class MaxPooling1DSpec extends KerasBaseSpec {
       kerasCode)
   }
 
+}
+
+class MaxPooling1DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = MaxPooling1D[Float](inputShape = Shape(12, 12))
+    layer.build(Shape(2, 12, 12))
+    val input = Tensor[Float](2, 12, 12).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling2DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
 import com.intel.analytics.bigdl.nn.keras.{MaxPooling2D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class MaxPooling2DSpec extends KerasBaseSpec{
 
@@ -73,4 +76,13 @@ class MaxPooling2DSpec extends KerasBaseSpec{
       kerasCode)
   }
 
+}
+
+class MaxPooling2DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = MaxPooling2D[Float](inputShape = Shape(3, 24, 24))
+    layer.build(Shape(2, 3, 24, 24))
+    val input = Tensor[Float](2, 3, 24, 24).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling3DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxPooling3DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{MaxPooling3D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class MaxPooling3DSpec extends KerasBaseSpec {
 
@@ -40,4 +43,13 @@ class MaxPooling3DSpec extends KerasBaseSpec {
       kerasCode)
   }
 
+}
+
+class MaxPooling3DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = MaxPooling3D[Float](inputShape = Shape(3, 20, 15, 35))
+    layer.build(Shape(2, 3, 20, 15, 35))
+    val input = Tensor[Float](2, 3, 20, 15, 35).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxoutDenseSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MaxoutDenseSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{MaxoutDense, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class MaxoutDenseSpec extends KerasBaseSpec {
 
@@ -70,4 +73,13 @@ class MaxoutDenseSpec extends KerasBaseSpec {
       kerasCode, weightConverter)
   }
 
+}
+
+class MaxoutDenseSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = MaxoutDense[Float](8, inputShape = Shape(12))
+    layer.build(Shape(3, 12))
+    val input = Tensor[Float](3, 12).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MergeSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/MergeSpec.scala
@@ -19,7 +19,10 @@ package com.intel.analytics.bigdl.keras.nn
 import com.intel.analytics.bigdl.keras.KerasBaseSpec
 import com.intel.analytics.bigdl.nn.keras.{Dense, InputLayer, Merge, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.bigdl.utils.{MultiShape, Shape, T}
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+import com.intel.analytics.bigdl.utils.{MultiShape, Shape, T, Table}
+
+import scala.util.Random
 
 class MergeSpec extends KerasBaseSpec {
 
@@ -102,4 +105,19 @@ class MergeSpec extends KerasBaseSpec {
     seq.forward(input)
   }
 
+}
+
+class MergeSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val l1 = InputLayer[Float](inputShape = Shape(4, 8))
+    val l2 = InputLayer[Float](inputShape = Shape(4, 8))
+    val layer = Merge[Float](layers = List(l1, l2), mode = "sum")
+    layer.build(Shape(List(Shape(2, 4, 8), Shape(2, 4, 8))))
+    val input1 = Tensor[Float](2, 4, 8).apply1(e => Random.nextFloat())
+    val input2 = Tensor[Float](2, 4, 8).apply1(e => Random.nextFloat())
+    val input = new Table()
+    input(1.toFloat) = input1
+    input(2.toFloat) = input2
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/RepeatVectorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/RepeatVectorSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{RepeatVector, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class RepeatVectorSpec extends KerasBaseSpec {
 
@@ -40,4 +43,13 @@ class RepeatVectorSpec extends KerasBaseSpec {
       kerasCode)
   }
 
+}
+
+class RepeatVectorSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = RepeatVector[Float](4, inputShape = Shape(12))
+    layer.build(Shape(2, 12))
+    val input = Tensor[Float](2, 12).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/SReLUSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/SReLUSpec.scala
@@ -22,6 +22,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.SReLU
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class SReLUSpec extends KerasBaseSpec{
 
@@ -55,4 +58,13 @@ class SReLUSpec extends KerasBaseSpec{
       kerasCode)
   }
 
+}
+
+class SReLUSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = SReLU[Float](sharedAxes = Array(1, 2), inputShape = Shape(4, 32))
+    layer.build(Shape(2, 4, 32))
+    val input = Tensor[Float](2, 4, 32).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/SeparableConvolution2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/SeparableConvolution2DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
 import com.intel.analytics.bigdl.nn.keras.{SeparableConvolution2D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class SeparableConvolution2DSpec extends KerasBaseSpec {
 
@@ -99,4 +102,13 @@ class SeparableConvolution2DSpec extends KerasBaseSpec {
       kerasCode, weightConverter)
   }
 
+}
+
+class SeparableConvolution2DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = SeparableConvolution2D[Float](1, 2, 2, inputShape = Shape(3, 128, 128))
+    layer.build(Shape(2, 3, 128, 128))
+    val input = Tensor[Float](2, 3, 128, 128).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/SequentialSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/SequentialSpec.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras.nn
+
+import com.intel.analytics.bigdl.nn.keras.{Dense, Sequential => KSequential}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
+
+class SequentialSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val dense = Dense[Float](10, inputShape = Shape(20))
+    val kseq = KSequential[Float]()
+    kseq.add(dense)
+    val input = Tensor[Float](2, 20).apply1(_ => Random.nextFloat())
+    runSerializationTest(kseq, input)
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/SimpleRNNSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/SimpleRNNSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{Dense, SimpleRNN, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class SimpleRNNSpec extends KerasBaseSpec {
 
@@ -84,4 +87,13 @@ class SimpleRNNSpec extends KerasBaseSpec {
       kerasCode, weightConverter)
   }
 
+}
+
+class SimpleRNNSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = SimpleRNN[Float](8, activation = "relu", inputShape = Shape(4, 5))
+    layer.build(Shape(3, 4, 5))
+    val input = Tensor[Float](3, 4, 5).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/SpatialDropout1DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/SpatialDropout1DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.keras.SpatialDropout1D
 import com.intel.analytics.bigdl.nn.keras.{Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class SpatialDropout1DSpec extends KerasBaseSpec {
 
@@ -34,4 +37,13 @@ class SpatialDropout1DSpec extends KerasBaseSpec {
     val gradInput = seq.backward(input, output)
   }
 
+}
+
+class SpatialDropout1DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = SpatialDropout1D[Float](0.5, inputShape = Shape(3, 4))
+    layer.build(Shape(2, 3, 4))
+    val input = Tensor[Float](2, 3, 4).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/SpatialDropout2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/SpatialDropout2DSpec.scala
@@ -22,6 +22,9 @@ import com.intel.analytics.bigdl.nn.keras.SpatialDropout2D
 import com.intel.analytics.bigdl.nn.keras.{Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class SpatialDropout2DSpec extends KerasBaseSpec {
 
@@ -45,4 +48,13 @@ class SpatialDropout2DSpec extends KerasBaseSpec {
     val gradInput = seq.backward(input, output)
   }
 
+}
+
+class SpatialDropout2DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = SpatialDropout2D[Float](0.5, "tf", inputShape = Shape(3, 64, 64))
+    layer.build(Shape(2, 3, 64, 64))
+    val input = Tensor[Float](2, 3, 64, 64).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/SpatialDropout3DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/SpatialDropout3DSpec.scala
@@ -22,6 +22,9 @@ import com.intel.analytics.bigdl.nn.keras.SpatialDropout3D
 import com.intel.analytics.bigdl.nn.keras.{Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class SpatialDropout3DSpec extends KerasBaseSpec {
 
@@ -45,4 +48,13 @@ class SpatialDropout3DSpec extends KerasBaseSpec {
     val gradInput = seq.backward(input, output)
   }
 
+}
+
+class SpatialDropout3DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = SpatialDropout3D[Float](0.5, "tf", inputShape = Shape(3, 4, 5, 6))
+    layer.build(Shape(2, 3, 4, 5, 6))
+    val input = Tensor[Float](2, 3, 4, 5, 6).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/ThresholdedReLUSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/ThresholdedReLUSpec.scala
@@ -22,6 +22,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.ThresholdedReLU
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class ThresholdedReLUSpec extends KerasBaseSpec{
 
@@ -55,4 +58,13 @@ class ThresholdedReLUSpec extends KerasBaseSpec{
       kerasCode)
   }
 
+}
+
+class ThresholdedReLUSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = ThresholdedReLU[Float](2.7, inputShape = Shape(3, 128))
+    layer.build(Shape(2, 3, 128))
+    val input = Tensor[Float](2, 3, 128).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/TimeDistributedSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/TimeDistributedSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{Convolution2D, Dense, TimeDistributed, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class TimeDistributedSpec extends KerasBaseSpec {
 
@@ -58,4 +61,13 @@ class TimeDistributedSpec extends KerasBaseSpec {
       kerasCode, precision = 1e-3)
   }
 
+}
+
+class TimeDistributedSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = TimeDistributed[Float](Dense(8), inputShape = Shape(10, 12))
+    layer.build(Shape(3, 10, 12))
+    val input = Tensor[Float](3, 10, 12).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/UpSampling1DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/UpSampling1DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{UpSampling1D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class UpSampling1DSpec extends KerasBaseSpec {
 
@@ -54,4 +57,13 @@ class UpSampling1DSpec extends KerasBaseSpec {
       kerasCode)
   }
 
+}
+
+class UpSampling1DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = UpSampling1D[Float](inputShape = Shape(4, 5))
+    layer.build(Shape(2, 4, 5))
+    val input = Tensor[Float](2, 4, 5).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/UpSampling2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/UpSampling2DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
 import com.intel.analytics.bigdl.nn.keras.{UpSampling2D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class UpSampling2DSpec extends KerasBaseSpec {
 
@@ -55,4 +58,13 @@ class UpSampling2DSpec extends KerasBaseSpec {
       kerasCode)
   }
 
+}
+
+class UpSampling2DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = UpSampling2D[Float](inputShape = Shape(4, 8, 8))
+    layer.build(Shape(2, 4, 8, 8))
+    val input = Tensor[Float](2, 4, 8, 8).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/UpSampling3DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/UpSampling3DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{UpSampling3D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class UpSampling3DSpec extends KerasBaseSpec {
 
@@ -54,4 +57,13 @@ class UpSampling3DSpec extends KerasBaseSpec {
       kerasCode)
   }
 
+}
+
+class UpSampling3DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = UpSampling3D[Float](inputShape = Shape(3, 8, 10, 12))
+    layer.build(Shape(2, 3, 8, 10, 12))
+    val input = Tensor[Float](2, 3, 8, 10, 12).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/ZeroPadding1DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/ZeroPadding1DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.nn.keras.{ZeroPadding1D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class ZeroPadding1DSpec extends KerasBaseSpec {
 
@@ -56,4 +59,13 @@ class ZeroPadding1DSpec extends KerasBaseSpec {
       kerasCode)
   }
 
+}
+
+class ZeroPadding1DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = ZeroPadding1D[Float](padding = 2, inputShape = Shape(4, 5))
+    layer.build(Shape(2, 4, 5))
+    val input = Tensor[Float](2, 4, 5).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/ZeroPadding2DSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/ZeroPadding2DSpec.scala
@@ -21,6 +21,9 @@ import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
 import com.intel.analytics.bigdl.nn.keras.{ZeroPadding2D, Sequential => KSequential}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+
+import scala.util.Random
 
 class ZeroPadding2DSpec extends KerasBaseSpec {
 
@@ -89,4 +92,13 @@ class ZeroPadding2DSpec extends KerasBaseSpec {
       kerasCode)
   }
 
+}
+
+class ZeroPadding2DSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val layer = ZeroPadding2D[Float](padding = (2, 1), inputShape = Shape(2, 8, 8))
+    layer.build(Shape(2, 2, 8, 8))
+    val input = Tensor[Float](2, 2, 8, 8).apply1(_ => Random.nextFloat())
+    runSerializationTest(layer, input)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/SerializerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/SerializerSpec.scala
@@ -62,6 +62,102 @@ class SerializerSpec extends BigDLSpecHelper {
       "com.intel.analytics.bigdl.nn.ops.TensorArraySerialTest",
 
     // Keras layers
+    "com.intel.analytics.bigdl.nn.keras.Activation" ->
+      "com.intel.analytics.bigdl.keras.nn.ActivationSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.AtrousConvolution1D" ->
+      "com.intel.analytics.bigdl.keras.nn.AtrousConvolution1DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.AtrousConvolution2D" ->
+      "com.intel.analytics.bigdl.keras.nn.AtrousConvolution2DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.AveragePooling1D" ->
+      "com.intel.analytics.bigdl.keras.nn.AveragePooling1DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.AveragePooling2D" ->
+      "com.intel.analytics.bigdl.keras.nn.AveragePooling2DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.AveragePooling3D" ->
+      "com.intel.analytics.bigdl.keras.nn.AveragePooling3DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.BatchNormalization" ->
+      "com.intel.analytics.bigdl.keras.nn.BatchNormalizationSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.Bidirectional" ->
+      "com.intel.analytics.bigdl.keras.nn.BidirectionalSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.ConvLSTM2D" ->
+      "com.intel.analytics.bigdl.keras.nn.ConvLSTM2DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.Convolution1D" ->
+      "com.intel.analytics.bigdl.keras.nn.Convolution1DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.Convolution2D" ->
+      "com.intel.analytics.bigdl.keras.nn.Convolution2DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.Convolution3D" ->
+      "com.intel.analytics.bigdl.keras.nn.Convolution3DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.Cropping1D" ->
+      "com.intel.analytics.bigdl.keras.nn.Cropping1DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.Cropping2D" ->
+      "com.intel.analytics.bigdl.keras.nn.Cropping2DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.Deconvolution2D" ->
+      "com.intel.analytics.bigdl.keras.nn.Deconvolution2DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.ELU" ->
+      "com.intel.analytics.bigdl.keras.nn.ELUSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.Embedding" ->
+      "com.intel.analytics.bigdl.keras.nn.EmbeddingSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.GaussianDropout" ->
+      "com.intel.analytics.bigdl.keras.nn.GaussianDropoutSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.GaussianNoise" ->
+      "com.intel.analytics.bigdl.keras.nn.GaussianNoiseSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.GlobalAveragePooling2D" ->
+      "com.intel.analytics.bigdl.keras.nn.GlobalAveragePooling2DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.GlobalMaxPooling2D" ->
+      "com.intel.analytics.bigdl.keras.nn.GlobalMaxPooling2DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.GlobalMaxPooling3D" ->
+      "com.intel.analytics.bigdl.keras.nn.GlobalMaxPooling3DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.GRU" ->
+      "com.intel.analytics.bigdl.keras.nn.GRUSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.Highway" ->
+      "com.intel.analytics.bigdl.keras.nn.HighwaySerialTest",
+    "com.intel.analytics.bigdl.nn.keras.LeakyReLU" ->
+      "com.intel.analytics.bigdl.keras.nn.LeakyReLUSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.LocallyConnected1D" ->
+      "com.intel.analytics.bigdl.keras.nn.LocallyConnected1DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.LocallyConnected2D" ->
+      "com.intel.analytics.bigdl.keras.nn.LocallyConnected2DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.LSTM" ->
+      "com.intel.analytics.bigdl.keras.nn.LSTMSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.Masking" ->
+      "com.intel.analytics.bigdl.keras.nn.MaskingSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.MaxoutDense" ->
+      "com.intel.analytics.bigdl.keras.nn.MaxoutDenseSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.MaxPooling1D" ->
+      "com.intel.analytics.bigdl.keras.nn.MaxPooling1DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.MaxPooling2D" ->
+      "com.intel.analytics.bigdl.keras.nn.MaxPooling2DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.MaxPooling3D" ->
+      "com.intel.analytics.bigdl.keras.nn.MaxPooling3DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.Merge" ->
+      "com.intel.analytics.bigdl.keras.nn.MergeSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.RepeatVector" ->
+      "com.intel.analytics.bigdl.keras.nn.RepeatVectorSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.SeparableConvolution2D" ->
+      "com.intel.analytics.bigdl.keras.nn.SeparableConvolution2DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.SimpleRNN" ->
+      "com.intel.analytics.bigdl.keras.nn.SimpleRNNSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.SpatialDropout1D" ->
+      "com.intel.analytics.bigdl.keras.nn.SpatialDropout1DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.SpatialDropout2D" ->
+      "com.intel.analytics.bigdl.keras.nn.SpatialDropout2DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.SpatialDropout3D" ->
+      "com.intel.analytics.bigdl.keras.nn.SpatialDropout3DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.SReLU" ->
+      "com.intel.analytics.bigdl.keras.nn.SReLUSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.ThresholdedReLU" ->
+      "com.intel.analytics.bigdl.keras.nn.ThresholdedReLUSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.TimeDistributed" ->
+      "com.intel.analytics.bigdl.keras.nn.TimeDistributedSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.UpSampling1D" ->
+      "com.intel.analytics.bigdl.keras.nn.UpSampling1DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.UpSampling2D" ->
+      "com.intel.analytics.bigdl.keras.nn.UpSampling2DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.UpSampling3D" ->
+      "com.intel.analytics.bigdl.keras.nn.UpSampling3DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.ZeroPadding1D" ->
+      "com.intel.analytics.bigdl.keras.nn.ZeroPadding1DSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.ZeroPadding2D" ->
+      "com.intel.analytics.bigdl.keras.nn.ZeroPadding2DSerialTest",
     "com.intel.analytics.bigdl.nn.keras.Dense" ->
       "com.intel.analytics.bigdl.keras.nn.DenseSerialTest",
     "com.intel.analytics.bigdl.nn.keras.Cropping3D" ->
@@ -80,10 +176,10 @@ class SerializerSpec extends BigDLSpecHelper {
       "com.intel.analytics.bigdl.keras.nn.ZeroPadding3DSerialTest",
     "com.intel.analytics.bigdl.nn.keras.Dropout" ->
       "com.intel.analytics.bigdl.keras.nn.DropoutSerialTest",
-    "module com.intel.analytics.bigdl.nn.keras.GlobalMaxPooling1D" ->
-      "module com.intel.analytics.bigdl.keras.nn.GlobalMaxPooling1D",
+    "com.intel.analytics.bigdl.nn.keras.GlobalMaxPooling1D" ->
+      "com.intel.analytics.bigdl.keras.nn.GlobalMaxPooling1DSerialTest",
     "com.intel.analytics.bigdl.nn.keras.Flatten" ->
-      "com.intel.analytics.bigdl.keras.nn.Flatten"
+      "com.intel.analytics.bigdl.keras.nn.FlattenSerialTest"
   )
 
   private val suffix = "SerialTest"

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/SerializerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/SerializerSpec.scala
@@ -62,8 +62,14 @@ class SerializerSpec extends BigDLSpecHelper {
       "com.intel.analytics.bigdl.nn.ops.TensorArraySerialTest",
 
     // Keras layers
+    "com.intel.analytics.bigdl.nn.keras.Input" ->
+      "com.intel.analytics.bigdl.keras.nn.InputSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.Sequential" ->
+      "com.intel.analytics.bigdl.keras.nn.SequentialSerialTest",
     "com.intel.analytics.bigdl.nn.keras.Activation" ->
       "com.intel.analytics.bigdl.keras.nn.ActivationSerialTest",
+    "com.intel.analytics.bigdl.nn.keras.SoftMax" ->
+      "com.intel.analytics.bigdl.keras.nn.SoftMaxSerialTest",
     "com.intel.analytics.bigdl.nn.keras.AtrousConvolution1D" ->
       "com.intel.analytics.bigdl.keras.nn.AtrousConvolution1DSerialTest",
     "com.intel.analytics.bigdl.nn.keras.AtrousConvolution2D" ->


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change each keras layers serialization test from KerasModuleSerializerSpec to each layer's unit test.

## How was this patch tested?
Jenkins.



