### PR TITLE
[Bug fix] Use new dump_model method in the export_tf_checkpoint.py

### DIFF
--- a/scripts/export_tf_checkpoint.py
+++ b/scripts/export_tf_checkpoint.py
@@ -26,7 +26,7 @@ def main():
     saver = tf.train.import_meta_graph(argv[1])
     with tf.Session() as sess:
         saver.restore(sess, argv[2])
-        dump_model(argv[3], sess)
+        dump_model(argv[3], None, sess, argv[2])
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## What changes were proposed in this pull request?
In this commit(https://github.com/intel-analytics/BigDL/commit/ac64b7bd3b969dacbc3181d2688c79e024dc87a4#diff-3d29fec1deddd4fa984992de26dcf901), the dump_model method is changed while export_tf_checkpoint.py is not changed. This PR fixes this issue.

## How was this patch tested?
manual test. unit test.

