### PR TITLE
Add TensorOp

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ops/TensorOp.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ops/TensorOp.scala
@@ -1,0 +1,587 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.ops
+
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Table
+
+import scala.reflect.ClassTag
+
+/**
+ * [[TensorOp]] is an [[Operation]] with `Tensor[T]-formatted `input and output,
+ * which provides shortcuts to build Operations for `tensor transformation` by closures.
+ * <br></br>
+ * [[TensorOp]] will make a deep copy of input Tensor before transformation,
+ * so transformation will take no side effect. For now, `SparseTensors` are not supported.
+ * <br></br>
+ * Chained feature is supported in [[TensorOp]].
+ * And common tensor actions are provided with a chained style.
+ * <br></br>
+ * For instance:
+ * {{{
+ * one case:
+ *    val (transformer1, transformer2, transformer3) = ...
+ *    val (op1, op2, op3) = (TensorOp[Float](transformer1), .., ..)
+ *    val op = op1 -> op2 -> op3
+ *      `equals`
+ *    val op = TensorOp[Float]((t: Tensor[Float], ev: TensorNumeric[Float]) => {
+ *      transformer3(transformer2(transformer1(t, ev), ev), ev)
+ *     })
+ *
+ * another case:
+ *    val op = (TensorOp[Float]() * 2.3f + 1.23f) / 1.11f - 0.66f
+ *      `equals`
+ *    val transformer = (t: Tensor[T], _) => t.mul(2.3f).add(1.23f).div(1.11f).sub(0.66f)
+ *    val op = TensorOp[Float](transformer)
+ * }}}
+ *
+ * @param transformer closure of tensor transformation
+ * @tparam T Numeric type
+ */
+class TensorOp[T: ClassTag] private(
+  private[bigdl] val transformer: (Tensor[T], TensorNumeric[T]) => Tensor[T]
+)(implicit ev: TensorNumeric[T]) extends Operation[Tensor[T], Tensor[T], T] {
+
+  private lazy val buffer: Tensor[T] = Tensor[T]()
+
+  // TODO: support SparseTensor
+  final override def updateOutput(input: Tensor[T]): Tensor[T] = {
+    buffer.resizeAs(input).copy(input)
+    output = transformer(buffer, ev)
+    output
+  }
+
+  // scalastyle:off
+  final def ->(next: TensorOp[T]): TensorOp[T] = {
+    val chained = (in: Tensor[T], ev: TensorNumeric[T]) => {
+      next.transformer(transformer(in, ev), ev)
+    }
+    new TensorOp(chained)
+  }
+
+  /**
+   * append additional TensorOp to do element-wise `f(x) = x + a`
+   *
+   * @param value T a
+   * @return TensorOp[T]
+   */
+  final def +(value: T): TensorOp[T] = this -> TensorOp.add(value)
+
+  /**
+   * append additional TensorOp to do element-wise tensor addition
+   *
+   * @param tensor Tensor[T]
+   * @return TensorOp[T]
+   */
+  final def +(tensor: Tensor[T]): TensorOp[T] = this -> TensorOp.add(tensor)
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = x - a`
+   *
+   * @param value T a
+   * @return TensorOp[T]
+   */
+  final def -(value: T): TensorOp[T] = this -> TensorOp.sub(value)
+
+  /**
+   * build a TensorOp to do element-wise tensor subtraction
+   *
+   * @param tensor Tensor[T]
+   * @return TensorOp[T]
+   */
+  final def -(tensor: Tensor[T]): TensorOp[T] = this -> TensorOp.sub(tensor)
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = a * x`
+   *
+   * @param value T a
+   * @return TensorOp[T]
+   */
+  final def *(value: T): TensorOp[T] = this -> TensorOp.mul(value)
+
+  /**
+   * build a TensorOp to do element-wise multiplication
+   *
+   * @param tensor Tensor[T]
+   * @return TensorOp[T]
+   */
+  final def *(tensor: Tensor[T]): TensorOp[T] = this -> TensorOp.mul(tensor)
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = x / a`
+   *
+   * @param value T a
+   * @return TensorOp[T]
+   */
+  final def /(value: T): TensorOp[T] = this -> TensorOp.div(value)
+
+  /**
+   * build a TensorOp to do element-wise division
+   *
+   * @param tensor Tensor[T]
+   * @return TensorOp[T]
+   */
+  final def /(tensor: Tensor[T]): TensorOp[T] = this -> TensorOp.div(tensor)
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = x ^ n`
+   *
+   * @param n the order of power
+   * @return TensorOp[T]
+   */
+  final def **(n: T): TensorOp[T] = this -> TensorOp.pow(n)
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = if (x>=a) 1; else 0`
+   *
+   * @param value Double a
+   * @return TensorOp[T]
+   */
+  final def >=(value: Double): TensorOp[T] = this -> TensorOp.ge(value)
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = if (x==a) 1; else 0`
+   *
+   * @param value T a
+   * @return TensorOp[T]
+   */
+  final def ==(value: T): TensorOp[T] = this -> TensorOp.eq(value)
+  // scalastyle:on
+
+  /**
+   * build a TensorOp to do matrix transposition for 2d Tensors
+   *
+   * @return TensorOp[T]
+   */
+  final def t: TensorOp[T] = this -> TensorOp.t()
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = sqrt(x)`
+   *
+   * @return TensorOp[T]
+   */
+  final def sqrt: TensorOp[T] = this -> TensorOp.sqrt()
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = log(x)`
+   *
+   * @return TensorOp[T]
+   */
+  final def log: TensorOp[T] = this -> TensorOp.log()
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = log(x + 1)`
+   *
+   * @return TensorOp[T]
+   */
+  final def log1p: TensorOp[T] = this -> TensorOp.log1p()
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = exp(x)`
+   *
+   * @return TensorOp[T]
+   */
+  final def exp: TensorOp[T] = this -> TensorOp.exp()
+
+  /**
+   * build a TensorOp to do element-wise `floor`
+   *
+   * @return TensorOp[T]
+   */
+  final def floor: TensorOp[T] = this -> TensorOp.floor()
+
+  /**
+   * build a TensorOp to do element-wise `ceil`
+   *
+   * @return TensorOp[T]
+   */
+  final def ceil: TensorOp[T] = this -> TensorOp.ceil()
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = 1 / x`
+   *
+   * @return TensorOp[T]
+   */
+  final def inv: TensorOp[T] = this -> TensorOp.inv()
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = -x`
+   *
+   * @return TensorOp[T]
+   */
+  final def neg: TensorOp[T] = this -> TensorOp.negative()
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = |x|`
+   *
+   * @return TensorOp[T]
+   */
+  final def abs: TensorOp[T] = this -> TensorOp.abs()
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = tanh(x)`
+   *
+   * @return TensorOp[T]
+   */
+  final def tanh: TensorOp[T] = this -> TensorOp.tanh()
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = if (x>0) 1; if (x=0) 0; else -1`
+   *
+   * @return TensorOp[T]
+   */
+  final def sign: TensorOp[T] = this -> TensorOp.sign()
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = 1 / (1 + exp(-x))`
+   *
+   * @return TensorOp[T]
+   */
+  final def sigmoid: TensorOp[T] = this -> TensorOp.sigmoid()
+
+}
+
+object TensorOp {
+
+  /**
+   * build a TensorOp with user-defined transformer
+   *
+   * @param transformer user-defined tensor transformer
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def apply[T: ClassTag](transformer: (Tensor[T], TensorNumeric[T]) => Tensor[T]
+  )(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp(transformer)
+  }
+
+  /**
+   * build a TensorOp with identity transformer
+   *
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def apply[T: ClassTag]()(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], _) => t)
+  }
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = x + a`
+   *
+   * @param value T a
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def add[T: ClassTag](value: T)(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp[T]((t: Tensor[T], _) => t.add(value))
+  }
+
+  /**
+   * build a TensorOp to do element-wise tensor addition
+   *
+   * @param tensor Tensor[T]
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def add[T: ClassTag](tensor: Tensor[T])(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp[T]((t: Tensor[T], _) => t.add(tensor))
+  }
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = x - a`
+   *
+   * @param value T a
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def sub[T: ClassTag](value: T)(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp[T]((t: Tensor[T], _) => t.sub(value))
+  }
+
+  /**
+   * build a TensorOp to do element-wise tensor subtraction
+   *
+   * @param tensor Tensor[T]
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def sub[T: ClassTag](tensor: Tensor[T])(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp[T]((t: Tensor[T], _) => t.sub(tensor))
+  }
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = a * x`
+   *
+   * @param value T a
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def mul[T: ClassTag](value: T)(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp[T]((t: Tensor[T], _) => t.mul(value))
+  }
+
+  /**
+   * build a TensorOp to do element-wise multiplication
+   *
+   * @param tensor Tensor[T]
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def mul[T: ClassTag](tensor: Tensor[T])(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp[T]((t: Tensor[T], _) => t.cmul(tensor))
+  }
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = x / a`
+   *
+   * @param value T a
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def div[T: ClassTag](value: T)(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], _) => t.div(value))
+  }
+
+  /**
+   * build a TensorOp to do element-wise division
+   *
+   * @param tensor Tensor[T]
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def div[T: ClassTag](tensor: Tensor[T])(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], _) => t.div(tensor))
+  }
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = if (x>=a) 1; else 0`
+   *
+   * @param value Double a
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def ge[T: ClassTag](value: Double)(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], _) => t.ge(t, value))
+  }
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = if (x==a) 1; else 0`
+   *
+   * @param value T a
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def eq[T: ClassTag](value: T)(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], _) => t.eq(t, value))
+  }
+
+  /**
+   * build a TensorOp to do matrix transposition for 2d Tensors
+   *
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def t[T: ClassTag]()(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], _) => t.t())
+  }
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = sqrt(x)`
+   *
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def sqrt[T: ClassTag]()(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], _) => t.sqrt())
+  }
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = log(x)`
+   *
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def log[T: ClassTag]()(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], _) => t.log())
+  }
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = log(x + 1)`
+   *
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def log1p[T: ClassTag]()(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], _) => t.log1p())
+  }
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = exp(x)`
+   *
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def exp[T: ClassTag]()(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], _) => t.exp())
+  }
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = x ^ n`
+   *
+   * @param n the order of power
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def pow[T: ClassTag](n: T)(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], _) => t.pow(n))
+  }
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = x ^ 2`
+   *
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def square[T: ClassTag]()(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], _) => t.square())
+  }
+
+  /**
+   * build a TensorOp to do element-wise `floor`
+   *
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def floor[T: ClassTag]()(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], _) => t.floor())
+  }
+
+  /**
+   * build a TensorOp to do element-wise `ceil`
+   *
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def ceil[T: ClassTag]()(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], _) => t.ceil())
+  }
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = 1 / x`
+   *
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def inv[T: ClassTag]()(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], _) => t.inv())
+  }
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = -x`
+   *
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def negative[T: ClassTag]()(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], _) => t.negative(t))
+  }
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = |x|`
+   *
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def abs[T: ClassTag]()(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], _) => t.abs())
+  }
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = tanh(x)`
+   *
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def tanh[T: ClassTag]()(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], _) => t.tanh())
+  }
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = if (x>0) 1; if (x=0) 0; else -1`
+   *
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def sign[T: ClassTag]()(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], _) => t.sign())
+  }
+
+  /**
+   * build a TensorOp to do element-wise `f(x) = 1 / (1 + exp(-x))`
+   *
+   * @tparam T type param of TensorOp
+   * @return TensorOp[T]
+   */
+  def sigmoid[T: ClassTag]()(implicit ev: TensorNumeric[T]): TensorOp[T] = {
+    new TensorOp((t: Tensor[T], ev: TensorNumeric[T]) => {
+      t.negative(t).exp()
+        .add(ev.one)
+        .inv()
+    })
+  }
+
+}
+
+
+/**
+ * Select and copy a Tensor from a [[Table]] with [[key]].
+ * And do tensor transformation if [[transformer]] is defined.
+ *
+ * @param key the key of selected tensor
+ * @param transformer user-defined transformer
+ * @tparam T Numeric type
+ */
+class SelectTensor[T: ClassTag](
+  private val key: scala.Any,
+  private val transformer: TensorOp[T] = null
+)(implicit ev: TensorNumeric[T]) extends Operation[Table, Tensor[T], T] {
+
+  override def updateOutput(input: Table): Tensor[T] = {
+    val selected = input[Tensor[T]](key)
+    if (transformer != null) {
+      output = transformer.updateOutput(selected)
+    } else {
+      // TODO: support SparseTensor.copy
+      output.resizeAs(selected).copy(selected)
+    }
+
+    output
+  }
+
+}
+
+object SelectTensor {
+
+  def apply[T: ClassTag](
+    key: scala.Any,
+    transformer: TensorOp[T] = null
+  )(implicit ev: TensorNumeric[T]): SelectTensor[T] = {
+    new SelectTensor[T](key, transformer)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ops/TensorOpSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ops/TensorOpSpec.scala
@@ -111,10 +111,10 @@ class TensorOpSpec extends FlatSpec with Matchers {
 
   private val t1 = Tensor[Float](3, 4).randn()
   private val t2 = Tensor[Double](2, 3).randn()
-  private val table = T(t1, t2)
+  private val table = T().update(Tensor.scalar(1), t1).update(Tensor.scalar("2"), t2)
 
   "SelectedTensor without transformer" should "work correctly" in {
-    val t1Copy = SelectTensor[Float](1).forward(table)
+    val t1Copy = SelectTensor[Float](Tensor.scalar(1)).forward(table)
     t1Copy shouldEqual t1
     val t1Values = t1.storage().array().clone()
     t1Copy.square()
@@ -124,7 +124,7 @@ class TensorOpSpec extends FlatSpec with Matchers {
 
   "SelectedTensor with transformer" should "work correctly" in {
     val transformer = (TensorOp[Double]() ** 3 * 4.5).ceil
-    val select = SelectTensor(2, transformer)
+    val select = SelectTensor(Tensor.scalar("2"), transformer)
     val t2Values = t2.storage().array().clone()
     val t2Convert = select.forward(table)
     t2.storage().array() shouldEqual t2Values

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ops/TensorOpSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ops/TensorOpSpec.scala
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.ops
+
+import com.intel.analytics.bigdl.nn.Sigmoid
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.T
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.util.Random
+
+class TensorOpSpec extends FlatSpec with Matchers {
+
+  private val tt = Tensor[Float](2, 3).rand()
+  private val copiedTT = Tensor[Float]().resizeAs(tt).copy(tt)
+
+  private def ttCopy() = Tensor[Float]().resizeAs(copiedTT).copy(copiedTT)
+
+  "Common TensorOps" should "work correctly" in {
+    val rnd = Random.nextFloat()
+    TensorOp.add[Float](rnd).forward(tt) shouldEqual ttCopy().add(rnd)
+    TensorOp.sub[Float](rnd).forward(tt) shouldEqual ttCopy().sub(rnd)
+    TensorOp.mul[Float](rnd).forward(tt) shouldEqual ttCopy().mul(rnd)
+    TensorOp.div[Float](rnd).forward(tt) shouldEqual ttCopy().div(rnd)
+    TensorOp.pow[Float](rnd).forward(tt) shouldEqual ttCopy().pow(rnd)
+    TensorOp.ge[Float](rnd).forward(tt) shouldEqual ttCopy().ge(ttCopy(), rnd)
+    TensorOp.eq[Float](rnd).forward(tt) shouldEqual ttCopy().eq(ttCopy(), rnd)
+
+    val rndT = Tensor[Float](2, 3).rand()
+    TensorOp.add[Float](rndT).forward(tt) shouldEqual ttCopy().add(rndT)
+    TensorOp.sub[Float](rndT).forward(tt) shouldEqual ttCopy().sub(rndT)
+    TensorOp.mul[Float](rndT).forward(tt) shouldEqual ttCopy().cmul(rndT)
+    TensorOp.div[Float](rndT).forward(tt) shouldEqual ttCopy().div(rndT)
+
+    TensorOp.sign[Float]().forward(tt) shouldEqual ttCopy().sign()
+    TensorOp.sqrt[Float]().forward(tt) shouldEqual ttCopy().sqrt()
+    TensorOp.square[Float]().forward(tt) shouldEqual ttCopy().square()
+    TensorOp.t[Float]().forward(tt) shouldEqual ttCopy().t()
+    TensorOp.exp[Float]().forward(tt) shouldEqual ttCopy().exp()
+    TensorOp.abs[Float]().forward(tt) shouldEqual ttCopy().abs()
+    TensorOp.log[Float]().forward(tt) shouldEqual ttCopy().log()
+    TensorOp.log1p[Float]().forward(tt) shouldEqual ttCopy().log1p()
+    TensorOp.floor[Float]().forward(tt) shouldEqual ttCopy().floor()
+    TensorOp.ceil[Float]().forward(tt) shouldEqual ttCopy().ceil()
+    TensorOp.inv[Float]().forward(tt) shouldEqual ttCopy().inv()
+    TensorOp.negative[Float]().forward(tt) shouldEqual ttCopy().negative(ttCopy())
+    TensorOp.tanh[Float]().forward(tt) shouldEqual ttCopy().tanh()
+    TensorOp.sigmoid[Float]().forward(tt) shouldEqual Sigmoid[Float]().forward(ttCopy())
+  }
+
+  "Chaining user-defined TensorOps" should "work correctly" in {
+    val transformer1: (Tensor[Float], TensorNumeric[Float]) => Tensor[Float] = {
+      (t: Tensor[Float], _) => t.apply1((t: Float) => t * t)
+    }
+    val transformer2: (Tensor[Float], TensorNumeric[Float]) => Tensor[Float] = {
+      (t: Tensor[Float], _) => t.apply1((t: Float) => t + 1)
+    }
+    val transformer3: (Tensor[Float], TensorNumeric[Float]) => Tensor[Float] = {
+      (t: Tensor[Float], _) => t.apply1((t: Float) => math.sqrt(t).toFloat)
+    }
+    val op1 = TensorOp[Float](transformer1)
+    val op2 = TensorOp[Float](transformer2)
+    val op3 = TensorOp[Float](transformer3)
+
+    val op = TensorOp[Float]((t: Tensor[Float], ev: TensorNumeric[Float]) => {
+      transformer3(transformer2(transformer1(t, ev), ev), ev)
+    })
+
+    (op1 -> op2 -> op3).forward(tt) shouldEqual op.forward(tt)
+  }
+
+  "Chaining provided Common TensorOps" should "work correctly" in {
+    var op = (TensorOp[Float]() * 2.3f + 1.23f) / 1.11f - 0.66f
+    op.forward(tt) shouldEqual ttCopy().mul(2.3f).add(1.23f).div(1.11f).sub(0.66f)
+
+    var cpy = ttCopy()
+    op = TensorOp.negative()
+    op.forward(tt) shouldEqual cpy.negative(cpy)
+    op = op ** 3f
+    op.forward(tt) shouldEqual cpy.pow(3f)
+    op = op.abs.sqrt.log1p + 1.2f
+    op.forward(tt) shouldEqual cpy.abs().sqrt().log1p().add(1.2f)
+
+    cpy = ttCopy()
+    op = ((TensorOp.square[Float]() + 1.0f) * 2.5f) >= 3.0
+    op.forward(tt) shouldEqual {
+      val x = cpy.square().add(1.0f).mul(2.5f)
+      x.ge(x, 3.0)
+    }
+
+    val op1 = (op -> TensorOp.sigmoid[Float]()).inv.sqrt
+    op1.forward(tt) shouldEqual Sigmoid[Float]().forward(cpy).inv().sqrt()
+    val op2 = op -> TensorOp.sigmoid[Float]().inv.sqrt
+    op2.forward(tt) shouldEqual Sigmoid[Float]().forward(cpy).inv().sqrt()
+  }
+
+  private val t1 = Tensor[Float](3, 4).randn()
+  private val t2 = Tensor[Double](2, 3).randn()
+  private val table = T(t1, t2)
+
+  "SelectedTensor without transformer" should "work correctly" in {
+    val t1Copy = SelectTensor[Float](1).forward(table)
+    t1Copy shouldEqual t1
+    val t1Values = t1.storage().array().clone()
+    t1Copy.square()
+    t1.storage().array() shouldEqual t1Values
+    t1Copy.storage().array() shouldEqual t1Values.map(e => e * e)
+  }
+
+  "SelectedTensor with transformer" should "work correctly" in {
+    val transformer = (TensorOp[Double]() ** 3 * 4.5).ceil
+    val select = SelectTensor(2, transformer)
+    val t2Values = t2.storage().array().clone()
+    val t2Convert = select.forward(table)
+    t2.storage().array() shouldEqual t2Values
+    t2Convert.storage().array() shouldEqual
+      t2Values.map(e => math.ceil(math.pow(e, 3) * 4.5))
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/OperationSerializerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/OperationSerializerSpec.scala
@@ -21,7 +21,7 @@ import java.io.{File => JFile}
 import com.google.protobuf.{ByteString, CodedOutputStream}
 import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
-import com.intel.analytics.bigdl.nn.ops.{All, Any, ApproximateEqual, ArgMax, BatchMatMul, BucketizedCol, Cast, CategoricalColHashBucket, CategoricalColVocaList, Ceil, CrossEntropy, DepthwiseConv2D, DepthwiseConv2DBackpropFilter, DepthwiseConv2DBackpropInput, Digamma, Dilation2D, Dilation2DBackpropFilter, Dilation2DBackpropInput, Equal, Erf, Erfc, Expm1, Floor, FloorDiv, FloorMod, Greater, GreaterEqual, InTopK, IndicatorCol, Inv, InvGrad, IsFinite, IsInf, IsNan, Kv2Tensor, L2Loss, Less, LessEqual, Lgamma, LogicalAnd, LogicalNot, LogicalOr, Maximum, Minimum, Mod, ModuleToOperation, NotEqual, OneHot, Pad, Prod, RandomUniform, RangeOps, Rank, ResizeBilinearGrad, ResizeBilinearOps, Rint, Round, SegmentSum, Sign, Slice, SquaredDifference, Substr, TopK, TruncateDiv, TruncatedNormal, Exp => ExpOps, Pow => PowOps, Select => SelectOps, Sum => SumOps, Tile => TileOps}
+import com.intel.analytics.bigdl.nn.ops.{All, Any, ApproximateEqual, ArgMax, BatchMatMul, BucketizedCol, Cast, CategoricalColHashBucket, CategoricalColVocaList, Ceil, CrossEntropy, DepthwiseConv2D, DepthwiseConv2DBackpropFilter, DepthwiseConv2DBackpropInput, Digamma, Dilation2D, Dilation2DBackpropFilter, Dilation2DBackpropInput, Equal, Erf, Erfc, Expm1, Floor, FloorDiv, FloorMod, Greater, GreaterEqual, InTopK, IndicatorCol, Inv, InvGrad, IsFinite, IsInf, IsNan, Kv2Tensor, L2Loss, Less, LessEqual, Lgamma, LogicalAnd, LogicalNot, LogicalOr, Maximum, Minimum, Mod, ModuleToOperation, NotEqual, OneHot, Pad, Prod, RandomUniform, RangeOps, Rank, ResizeBilinearGrad, ResizeBilinearOps, Rint, Round, SegmentSum, SelectTensor, Sign, Slice, SquaredDifference, Substr, TensorOp, TopK, TruncateDiv, TruncatedNormal, Exp => ExpOps, Pow => PowOps, Select => SelectOps, Sum => SumOps, Tile => TileOps}
 import com.intel.analytics.bigdl.nn.tf.{Assert => AssertOps, BroadcastGradientArgs => BroadcastGradientArgsOps, DecodeGif => DecodeGifOps, DecodeJpeg => DecodeJpegOps, DecodePng => DecodePngOps, DecodeRaw => DecodeRawOps}
 import com.intel.analytics.bigdl.nn.tf._
 import com.intel.analytics.bigdl.nn.{SoftPlus => BigDLSoftPlus}
@@ -775,6 +775,15 @@ class OperationSerializerSpec extends SerializerSpecHelper {
     runSerializationTest(sign, input)
   }
 
+  "SelectTensor serializer" should "work properly" in {
+    val transformer = (TensorOp[Float]() ** 3 * 4.5f).ceil
+    val select = SelectTensor(Tensor.scalar("2"), transformer)
+    val t1 = Tensor[Float](3, 4).randn()
+    val t2 = Tensor[Float](2, 3).randn()
+    val input = T().update(Tensor.scalar(1), t1).update(Tensor.scalar("2"), t2)
+    runSerializationTest(select, input)
+  }
+
   "Slice serializer" should "work properly" in {
     val slice = Slice[Float](begin = Array(0, 1, 1),
       size = Array(2, -1, 1)).setName("slice")
@@ -832,6 +841,13 @@ class OperationSerializerSpec extends SerializerSpecHelper {
       Tensor[Int](T(2, 1, 2)))
     runSerializationTest(tileOps, input, tileOps.
       asInstanceOf[ModuleToOperation[Float]].module.getClass)
+  }
+
+  "TensorOp serializer" should "work properly" in {
+    val op = (((TensorOp[Float]() + 1.5f) ** 2) -> TensorOp.sigmoid()
+      ).setName("TensorOP")
+    val input = Tensor[Float](3, 3).apply1(_ => Random.nextFloat())
+    runSerializationTest(op, input)
   }
 
   "TopK serializer" should "work properly" in {


### PR DESCRIPTION
## What changes were proposed in this pull request?

 TensorOp is anOperation with Tensor[T]-formatted  input and output, which provides shortcuts to build Operations for tensor transformation by closures.

 TensorOp will make a deep copy of input Tensor before transformation, so the transformation will take no side effect. For now, SparseTensors are not supported.

 Chained feature is supported in TensorOp. And common tensor actions are provided with a chained style.

## How was this patch tested?

unit test