### PR TITLE
[Enhancement] Fix maven compile warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -450,6 +450,7 @@
                         <arg>-unchecked</arg>
                         <arg>-deprecation</arg>
                         <arg>-feature</arg>
+                        <arg>-Xfatal-warnings</arg>
                     </args>
                     <!-- The following plugin is required to use quasiquotes in Scala 2.10 and is used
                          by Spark SQL for code generation. -->

--- a/pom.xml
+++ b/pom.xml
@@ -448,7 +448,8 @@
                     <useZincServer>true</useZincServer>
                     <args>
                         <arg>-unchecked</arg>
-                        <arg>-deprecation</arg>
+                        <!-- Too many deprecation usage, let's suspend it temporary-->
+                        <!-- arg>-deprecation</arg-->
                         <arg>-feature</arg>
                         <arg>-Xfatal-warnings</arg>
                     </args>

--- a/pom.xml
+++ b/pom.xml
@@ -445,13 +445,14 @@
                 <configuration>
                     <scalaVersion>${scala.version}</scalaVersion>
                     <recompileMode>incremental</recompileMode>
-                    <useZincServer>true</useZincServer>
+                    <useZincServer>false</useZincServer>
                     <args>
                         <arg>-unchecked</arg>
                         <!-- Too many deprecation usage, let's suspend it temporary-->
                         <!-- arg>-deprecation</arg-->
                         <arg>-feature</arg>
-                        <arg>-Xfatal-warnings</arg>
+                        <!-- Not enable the fatal warnings for spark 1.6-->
+                        <!-- arg>-Xfatal-warnings</arg -->
                     </args>
                     <!-- The following plugin is required to use quasiquotes in Scala 2.10 and is used
                          by Spark SQL for code generation. -->
@@ -548,6 +549,74 @@
                 <scala.version>2.11.8</scala.version>
                 <scala.macros.version>2.1.0</scala.macros.version>
             </properties>
+            <build>
+                <plugins>
+                    <!-- Redefine the plugin to enable fatal warninings -->
+                    <plugin>
+                        <groupId>net.alchim31.maven</groupId>
+                        <artifactId>scala-maven-plugin</artifactId>
+                        <version>3.2.0</version>
+                        <executions>
+                            <execution>
+                                <id>eclipse-add-source</id>
+                                <goals>
+                                    <goal>add-source</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>scala-compile-first</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>scala-test-compile-first</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>testCompile</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>attach-scaladocs</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>doc-jar</goal>
+                                </goals>
+                                <configuration>
+                                    <args>
+                                        <!-- Do not change the arg orders. It is a weird way to pass in
+                                        this arg. Maybe it is a bug of the plugin. -->
+                                        <arg>-skip-packages</arg>
+                                        <arg>caffe:org.tensorflow:netty:org.apache.spark.sparkExtension:org.apache.spark.rdd:org.apache.spark.storage:org.apache.spark.bigdl</arg>
+                                    </args>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <scalaVersion>${scala.version}</scalaVersion>
+                            <recompileMode>incremental</recompileMode>
+                            <useZincServer>false</useZincServer>
+                            <args>
+                                <arg>-unchecked</arg>
+                                <!-- Too many deprecation usage, let's suspend it temporary-->
+                                <arg>-deprecation:false</arg>
+                                <arg>-feature</arg>
+                                <arg>-Xfatal-warnings</arg>
+                            </args>
+                            <!-- The following plugin is required to use quasiquotes in Scala 2.10 and is used
+                                 by Spark SQL for code generation. -->
+                            <compilerPlugins>
+                                <compilerPlugin>
+                                    <groupId>org.scalamacros</groupId>
+                                    <artifactId>paradise_${scala.version}</artifactId>
+                                    <version>${scala.macros.version}</version>
+                                </compilerPlugin>
+                            </compilerPlugins>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>scala_2.11</id>

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/text/Types.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/text/Types.scala
@@ -72,6 +72,7 @@ class LabeledSentence[T: ClassTag](
         Array.copy(rawLabel
           .asInstanceOf[Array[Float]], 0, _label
           .asInstanceOf[Array[Float]], 0, _labelLength)
+      case t => throw new NotImplementedError(s"$t is not supported")
     }
     this
   }
@@ -95,6 +96,7 @@ class LabeledSentence[T: ClassTag](
       case FloatType => Array.copy(_data
         .asInstanceOf[Array[Float]], 0, storage
         .asInstanceOf[Array[Float]], offset, _dataLength)
+      case t => throw new NotImplementedError(s"$t is not supported")
     }
   }
 
@@ -107,6 +109,7 @@ class LabeledSentence[T: ClassTag](
       case FloatType => Array.copy(_label
         .asInstanceOf[Array[Float]], 0, storage
         .asInstanceOf[Array[Float]], offset, _labelLength)
+      case t => throw new NotImplementedError(s"$t is not supported")
     }
   }
 
@@ -132,6 +135,7 @@ class LabeledSentence[T: ClassTag](
         Array.copy(other._label
           .asInstanceOf[Array[Float]], 0, this._label
           .asInstanceOf[Array[Float]], 0, _labelLength)
+      case t => throw new NotImplementedError(s"$t is not supported")
     }
     this
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dlframes/DLClassifier.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dlframes/DLClassifier.scala
@@ -34,7 +34,7 @@ import scala.reflect.ClassTag
  * @param criterion  BigDL criterion method
  * @param featureSize The size (Tensor dimensions) of the feature data.
  */
-class DLClassifier[@specialized(Float, Double) T: ClassTag](
+class DLClassifier[T: ClassTag](
     @transient override val model: Module[T],
     override val criterion : Criterion[T],
     override val featureSize : Array[Int],
@@ -65,7 +65,7 @@ class DLClassifier[@specialized(Float, Double) T: ClassTag](
  * @param model BigDL module to be optimized
  * @param featureSize The size (Tensor dimensions) of the feature data.
  */
-class DLClassifierModel[@specialized(Float, Double) T: ClassTag](
+class DLClassifierModel[T: ClassTag](
     @transient override val model: Module[T],
     featureSize : Array[Int],
     override val uid: String = "DLClassifierModel"

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/treeLSTMSentiment/Utils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/treeLSTMSentiment/Utils.scala
@@ -29,6 +29,7 @@ import scopt.OptionParser
 
 import scala.io.Source
 import scala.language.existentials
+import scala.reflect.ClassTag
 import scala.util.control.Breaks._
 
 object Utils {
@@ -154,13 +155,15 @@ object Utils {
     labelRDD: RDD[Array[Float]],
     sentenceRDD: RDD[Array[Int]]
   ): RDD[Sample[Float]] = {
-    def indexAndSort(rdd: RDD[_]) = rdd.zipWithIndex.map(_.swap).sortByKey()
+    def indexAndSort[D: ClassTag, P <: Product2[Long, D]](rdd: RDD[D]) = {
+      rdd.zipWithIndex.map(r => r.swap).sortByKey()
+    }
 
     indexAndSort(sentenceRDD)
       .join(indexAndSort(labelRDD))
       .join(indexAndSort(treeRDD))
       .values
-      .map { case ((input: Array[Int], label: Array[Float]), tree: Tensor[Float]) =>
+      .map{ case ((input, label), tree) =>
         Sample(
           featureTensors =
             Array(Tensor(input.map(_.toFloat), Array(input.length, 1)),

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BinaryTreeLSTM.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/BinaryTreeLSTM.scala
@@ -17,7 +17,6 @@ package com.intel.analytics.bigdl.nn
 
 import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.nn.Graph.ModuleNode
-import com.intel.analytics.bigdl.nn.Input
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LeakyReLU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LeakyReLU.scala
@@ -52,6 +52,7 @@ class LeakyReLU[T: ClassTag](
         negval.toFloat, inplace)
       case DoubleType => updateOutputDouble(input.toTensor[Double], output.toTensor[Double],
         negval, inplace)
+      case t => throw new NotImplementedError(s"$t is not supported")
     }
     output
   }
@@ -67,6 +68,7 @@ class LeakyReLU[T: ClassTag](
         gradInput.toTensor[Float], negval.toFloat, inplace)
       case DoubleType => updateGradInputDouble(input.toTensor[Double], gradOutput.toTensor[Double],
         gradInput.toTensor[Double], negval, inplace)
+      case t => throw new NotImplementedError(s"$t is not supported")
     }
     gradInput
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Module.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Module.scala
@@ -39,7 +39,8 @@ object Module {
    * @tparam T numeric type
    * @return model loaded from path
    */
-  @deprecated("Java based serialization not recommended any more, please use loadModule instead")
+  @deprecated("Java based serialization not recommended any more, please use loadModule instead",
+    "0.3")
   def load[T: ClassTag](path : String) : AbstractModule[Activity, Activity, T] = {
     File.load[AbstractModule[Activity, Activity, T]](path)
   }
@@ -64,7 +65,7 @@ object Module {
     File.loadTorch[AbstractModule[Activity, Activity, T]](path)
   }
 
-  @deprecated
+  @deprecated("Please try to use the loadCaffeModel API", "0.2")
   def loadCaffe[T: ClassTag](model: AbstractModule[Activity, Activity, T],
     defPath: String, modelPath: String, matchAll: Boolean = true)(
     implicit ev: TensorNumeric[T]): AbstractModule[Activity, Activity, T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -652,7 +652,7 @@ object Recurrent extends ContainerSerializable {
    * @param src
    * @param dst
    */
-  private[bigdl] def copy[@specialized(Float, Double) T: ClassTag](
+  private[bigdl] def copy[T: ClassTag](
     src: ArrayBuffer[Tensor[T]], dst: Tensor[T]): Unit = {
     val timeSize = dst.size(timeDim)
     var t = 1
@@ -668,7 +668,7 @@ object Recurrent extends ContainerSerializable {
    * @param srcIndex the index of 2-th dimension from src
    * @param dst
    */
-  private[bigdl] def selectCopy[@specialized(Float, Double) T: ClassTag](
+  private[bigdl] def selectCopy[T: ClassTag](
     src: Tensor[T], srcIndex: Int, dst: Tensor[T]): Tensor[T] = {
     if (src.isContiguous() && dst.isContiguous()) {
       if ((dst.nElement() == 0) || (dst.nElement() != (src.nElement() / src.size(2)))) {
@@ -707,7 +707,7 @@ object Recurrent extends ContainerSerializable {
    * @param dst
    * @param dstIndex the index of 2-th dimension from dst
    */
-  private[bigdl] def copyToIndex[@specialized(Float, Double) T: ClassTag](
+  private[bigdl] def copyToIndex[T: ClassTag](
     src: Tensor[T], dst: Tensor[T], dstIndex: Int): Tensor[T] = {
     if (src.isContiguous() && dst.isContiguous()) {
       val batchSize = dst.size(batchDim)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialCrossMapLRN.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialCrossMapLRN.scala
@@ -236,7 +236,6 @@ object SpatialCrossMapLRN {
     scale.mul(ev.fromType(alpha / size)).add(ev.fromType(k))
     output.pow(scale, ev.fromType(-beta))
     output.cmul(input)
-    output
   }
 
   def forwardFrameNHWCFloat(
@@ -282,7 +281,6 @@ object SpatialCrossMapLRN {
         Math.pow(k + alpha / size * l2sum, -beta).toFloat
       i += 1
     }
-    output
   }
 
   private def backwardFrameNCHW[T](

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialDilatedConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialDilatedConvolution.scala
@@ -247,6 +247,7 @@ class SpatialDilatedConvolution[T: ClassTag](
           dH, dW,
           dilationH, dilationW
         )
+        case t => throw new NotImplementedError(s"$t is not supported")
       }
       im2colTime += System.nanoTime() - before
 
@@ -347,6 +348,7 @@ class SpatialDilatedConvolution[T: ClassTag](
           dH, dW,
           dilationH, dilationW
         )
+        case t => throw new NotImplementedError(s"$t is not supported")
       }
       col2imTime += System.nanoTime() - before
       elt += 1
@@ -421,6 +423,7 @@ class SpatialDilatedConvolution[T: ClassTag](
           dH, dW,
           dilationH, dilationW
         )
+        case t => throw new NotImplementedError(s"$t is not supported")
       }
       im2colTime += System.nanoTime() - before
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolution.scala
@@ -527,6 +527,7 @@ class SpatialFullConvolution[T: ClassTag](
         dH, dW,
         1, 1
       )
+      case t => throw new NotImplementedError(s"$t is not supported")
     }
     im2colTime += System.nanoTime() - before
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Transpose.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Transpose.scala
@@ -125,7 +125,7 @@ object Transpose extends ModuleSerializable {
     while (i < size) {
       val nextPermutationBuilder = AttrValue.newBuilder
       val arr : Array[Int] = Array(transpose.permutations(i)._1,
-        transpose.permutations(i)_2)
+        transpose.permutations(i)._2)
       DataConverter.setAttributeValue(context, nextPermutationBuilder,
         arr, universe.typeOf[Array[Int]])
       transposeBuilder.putAttr(s"permutation_$i", nextPermutationBuilder.build)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricConvolution.scala
@@ -317,6 +317,7 @@ object VolumetricConvolution {
           padFront, padLeft, padTop, padBack, padRight, padBottom,
           nInputPlane,
           inputDepth, inputWidth, inputHeight, outputDepth, outputWidth, outputHeight)
+      case t => throw new NotImplementedError(s"$t is not supported")
     }
 
     output2d.addmm(ev.zero, output2d, ev.one, weight, fInput)
@@ -430,6 +431,7 @@ object VolumetricConvolution {
           padFront, padLeft, padTop, padBack, padRight, padBottom,
           gradInput.size(1), gradInput.size(2), gradInput.size(4), gradInput.size(3),
           gradOutput.size(2), gradOutput.size(4), gradOutput.size(3))
+      case t => throw new NotImplementedError(s"$t is not supported")
     }
 
   }
@@ -521,6 +523,7 @@ object VolumetricConvolution {
           padFront, padLeft, padTop, padBack, padRight, padBottom,
           nInputPlane,
           inputDepth, inputWidth, inputHeight, outputDepth, outputWidth, outputHeight)
+      case t => throw new NotImplementedError(s"$t is not supported")
     }
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricFullConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricFullConvolution.scala
@@ -570,6 +570,7 @@ class VolumetricFullConvolution[T: ClassTag](
         1, 1, 1,
         columns.asInstanceOf[Tensor[Float]]
       )
+      case t => throw new NotImplementedError(s"$t is not supported")
     }
 
     // M,N,K are dims of matrix A and B

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ops/Kv2Tensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ops/Kv2Tensor.scala
@@ -72,6 +72,7 @@ class Kv2Tensor[T: ClassTag, D: ClassTag](
             values += kv.split(itemDelimiter)(1).toDouble.asInstanceOf[D]
           case FloatType =>
             values += kv.split(itemDelimiter)(1).toFloat.asInstanceOf[D]
+          case t => throw new NotImplementedError(s"$t is not supported")
         }
       }
       i += 1

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/SpatialConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/SpatialConvolution.scala
@@ -47,16 +47,6 @@ private[bigdl] class SpatialConvolution[T: ClassTag](
   require(nInputPlane % nGroup == 0, "Number of input channels should be multiples of group.")
   require(nOutputPlane % nGroup == 0, "Number of output channels should be multiples of group.")
 
-  val params = ConvWeightParams(nOutputPlane / nGroup, nInputPlane / nGroup, kernelH, kernelW,
-    quantFormat)
-  val weight: Array[Tensor[T]] = {
-    val array = new Array[Tensor[T]](nGroup)
-    for (i <- 0 until nGroup) {
-      array(i) = QuantizedTensor[T](Tensor[T](Array(nGroup, kernelH, kernelW, nInputPlane / nGroup,
-        nOutputPlane / nGroup)), params)
-    }
-    array
-  }
   private val data: QuantizedTensor[T] = QuantizedDummyTensor[T]()
   val bias: Tensor[T] = Tensor[T](nOutputPlane)
 
@@ -64,6 +54,18 @@ private[bigdl] class SpatialConvolution[T: ClassTag](
     BigQuant.NCHW
   } else {
     BigQuant.NHWC
+  }
+
+  val params = ConvWeightParams(nOutputPlane / nGroup, nInputPlane / nGroup, kernelH, kernelW,
+    quantFormat)
+
+  val weight: Array[Tensor[T]] = {
+    val array = new Array[Tensor[T]](nGroup)
+    for (i <- 0 until nGroup) {
+      array(i) = QuantizedTensor[T](Tensor[T](Array(nGroup, kernelH, kernelW, nInputPlane / nGroup,
+        nOutputPlane / nGroup)), params)
+    }
+    array
   }
 
   val dilationHeight = 1

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/tf/DataFlowOps.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/tf/DataFlowOps.scala
@@ -16,13 +16,11 @@
 package com.intel.analytics.bigdl.nn.tf
 
 import java.util
-import java.util.concurrent.ConcurrentHashMap
 
 import com.intel.analytics.bigdl.nn.ops.Operation
-import com.intel.analytics.bigdl.nn.tf.WithoutInput
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
-import com.intel.analytics.bigdl.utils.{RandomGenerator, T, Table}
+import com.intel.analytics.bigdl.utils.{T, Table}
 
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/tf/Log1p.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/tf/Log1p.scala
@@ -16,7 +16,6 @@
 
 package com.intel.analytics.bigdl.nn.tf
 
-import com.intel.analytics.bigdl.nn.Log
 import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/tf/ParsingOps.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/tf/ParsingOps.scala
@@ -85,6 +85,7 @@ private[bigdl] class ParseExample[T: ClassTag](val nDense: Int,
       case StringType =>
         val values = feature.getBytesList.getValueList.asScala.toArray
         Tensor(values, tensorShape)
+      case t => throw new NotImplementedError(s"$t is not supported")
     }
   }
 }
@@ -156,6 +157,7 @@ private[bigdl] object ParseExample extends ModuleSerializable {
       case LongType => "Long"
       case FloatType => "Float"
       case StringType => "String"
+      case t => throw new NotImplementedError(s"$t is not supported")
     }
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
@@ -2650,7 +2650,7 @@ object DenseTensor {
     gauss
   }
 
-  private[tensor] def canFastBroadcast[@specialized T](tensor: Tensor[T],
+  private[tensor] def canFastBroadcast[T](tensor: Tensor[T],
     other: Tensor[T]): Boolean = {
     if (tensor.nDimension < other.nDimension()) return false
 
@@ -2671,7 +2671,7 @@ object DenseTensor {
     return true
   }
 
-  private[tensor] def expandSize[@specialized T: ClassTag](tensor: Tensor[T],
+  private[tensor] def expandSize[T: ClassTag](tensor: Tensor[T],
     other: Tensor[T]): Array[Int] = {
     val errorMsg = s"tensor size not match ${tensor.size.mkString("x")} " +
       s"${other.size.mkString("x")}"

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensorApply.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensorApply.scala
@@ -29,7 +29,7 @@ object DenseTensorApply {
   def apply1[A, B](tensor1: Tensor[A], tensor2: Tensor[B],
     func: TensorDiffTypeFunc4[A, B]): Unit = {
 
-    if (tensor1.isEmpty == 0) {
+    if (tensor1.isEmpty) {
       return
     }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/SparseTensorBLAS.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/SparseTensorBLAS.scala
@@ -120,12 +120,14 @@ object SparseTensorBLAS {
         beta: T,
         r: Tensor[T])(implicit ev: TensorNumeric[T]): Unit = {
     (alpha, mat, vec, beta, r)  match {
-      case (alpha: Double, a: SparseTensor[Double], x: DenseTensor[Double],
-      beta: Double, y: DenseTensor[Double]) =>
-        dcoomv(alpha, a, x, beta, y)
-      case (alpha: Float, a: SparseTensor[Float], x: DenseTensor[Float],
-      beta: Float, y: DenseTensor[Float]) =>
-        scoomv(alpha, a, x, beta, y)
+      case (alpha: Double, a: SparseTensor[_], x: DenseTensor[_],
+      beta: Double, y: DenseTensor[_]) =>
+        dcoomv(alpha, a.asInstanceOf[SparseTensor[Double]], x.asInstanceOf[DenseTensor[Double]],
+          beta, y.asInstanceOf[DenseTensor[Double]])
+      case (alpha: Float, a: SparseTensor[_], x: DenseTensor[_],
+      beta: Float, y: DenseTensor[_]) =>
+        scoomv(alpha, a.asInstanceOf[SparseTensor[Float]], x.asInstanceOf[DenseTensor[Float]],
+          beta, y.asInstanceOf[DenseTensor[Float]])
       case _ =>
         throw new IllegalArgumentException(s"Sparse addmv doesn't support")
     }
@@ -206,18 +208,22 @@ object SparseTensorBLAS {
         beta: T,
         r: Tensor[T])(implicit ev: TensorNumeric[T]): Unit = {
     (alpha, mat1, mat2, beta, r)  match {
-      case (alpha: Float, a: SparseTensor[Float], x: DenseTensor[Float],
-            beta: Float, y: DenseTensor[Float]) =>
-        scoomm(alpha, a, x, beta, y)
-      case (alpha: Double, a: SparseTensor[Double], x: DenseTensor[Double],
-            beta: Double, y: DenseTensor[Double]) =>
-        dcoomm(alpha, a, x, beta, y)
-      case (alpha: Float, a: DenseTensor[Float], x: SparseTensor[Float],
-            beta: Float, y: DenseTensor[Float]) =>
-        scoomm(alpha, a, x, beta, y)
-      case (alpha: Double, a: DenseTensor[Double], x: SparseTensor[Double],
-            beta: Double, y: DenseTensor[Double]) =>
-        dcoomm(alpha, a, x, beta, y)
+      case (alpha: Float, a: SparseTensor[_], x: DenseTensor[_],
+            beta: Float, y: DenseTensor[_]) =>
+        scoomm(alpha, a.asInstanceOf[SparseTensor[Float]], x.asInstanceOf[DenseTensor[Float]],
+          beta, y.asInstanceOf[DenseTensor[Float]])
+      case (alpha: Double, a: SparseTensor[_], x: DenseTensor[_],
+            beta: Double, y: DenseTensor[_]) =>
+        dcoomm(alpha, a.asInstanceOf[SparseTensor[Double]], x.asInstanceOf[DenseTensor[Double]],
+          beta, y.asInstanceOf[DenseTensor[Double]])
+      case (alpha: Float, a: DenseTensor[_], x: SparseTensor[_],
+            beta: Float, y: DenseTensor[_]) =>
+        scoomm(alpha, a.asInstanceOf[DenseTensor[Float]], x.asInstanceOf[SparseTensor[Float]],
+          beta, y.asInstanceOf[DenseTensor[Float]])
+      case (alpha: Double, a: DenseTensor[_], x: SparseTensor[_],
+            beta: Double, y: DenseTensor[_]) =>
+        dcoomm(alpha, a.asInstanceOf[DenseTensor[Double]], x.asInstanceOf[SparseTensor[Double]],
+          beta, y.asInstanceOf[DenseTensor[Double]])
       case _ =>
         throw new IllegalArgumentException(s"Sparse addmm doesn't support")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/caffe/CaffeLoader.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/caffe/CaffeLoader.scala
@@ -173,7 +173,6 @@ class CaffeLoader[T: ClassTag](prototxtPath: String, modelPath: String,
 
   private def copyBlobs(from : GeneratedMessage, to : GeneratedMessage): GeneratedMessage = {
     import scala.language.existentials
-    
     val blobList = from match {
       case v1 : V1LayerParameter => v1.asInstanceOf[V1LayerParameter].getBlobsList.asScala
       case v2 : LayerParameter => v2.asInstanceOf[LayerParameter].getBlobsList.asScala

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/caffe/CaffeLoader.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/caffe/CaffeLoader.scala
@@ -172,6 +172,8 @@ class CaffeLoader[T: ClassTag](prototxtPath: String, modelPath: String,
   }
 
   private def copyBlobs(from : GeneratedMessage, to : GeneratedMessage): GeneratedMessage = {
+    import scala.language.existentials
+    
     val blobList = from match {
       case v1 : V1LayerParameter => v1.asInstanceOf[V1LayerParameter].getBlobsList.asScala
       case v2 : LayerParameter => v2.asInstanceOf[LayerParameter].getBlobsList.asScala

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/serializer/ModuleSerializer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/serializer/ModuleSerializer.scala
@@ -26,6 +26,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 
 import scala.collection.mutable
+import scala.language.existentials
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe
 
@@ -131,7 +132,8 @@ object ModuleSerializer extends ModuleSerializable{
       // to make it compatible with both 2.11 and 2.10
       val ctorCs = clsSymbol.toType.declaration(universe.nme.CONSTRUCTOR)
       val primary: Option[universe.MethodSymbol] = ctorCs.asTerm.alternatives.collectFirst {
-        case cstor: universe.MethodSymbol if cstor.isPrimaryConstructor => cstor
+        case cstor if cstor.asInstanceOf[universe.MethodSymbol].isPrimaryConstructor =>
+          cstor.asInstanceOf[universe.MethodSymbol]
       }
       cm.reflectConstructor(primary.get)
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/serializer/converters/DataConverter.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/serializer/converters/DataConverter.scala
@@ -83,7 +83,7 @@ object DataConverter extends DataConverter{
     : universe.Type = {
     if (value.isInstanceOf[Tensor[_]]) {
       ModuleSerializer.tensorType
-    } else if (value.isInstanceOf[AbstractModule[_, _, T]]) {
+    } else if (value.isInstanceOf[AbstractModule[_, _, _]]) {
       ModuleSerializer.abstractModuleType
     } else if (value.isInstanceOf[Regularizer[_]]) {
       ModuleSerializer.regularizerType
@@ -180,10 +180,10 @@ object DataConverter extends DataConverter{
       || valueType <:< universe.typeOf[AbstractModule[_, _, _]]
       ) {
       ModuleConverter.setAttributeValue(context, attributeBuilder, value)
-    } else if (value.isInstanceOf[mutable.Map[String, _ <: Any]]) {
+    } else if (value.isInstanceOf[mutable.Map[_, _]]) {
       NameListConverter.setAttributeValue(context, attributeBuilder, value)
     } else if (valueType <:< universe.typeOf[Array[_]] ||
-      valueType.typeSymbol == universe.typeOf[Array[_ ]].typeSymbol) {
+      valueType.typeSymbol == universe.typeOf[Array[_]].typeSymbol) {
       ArrayConverter.setAttributeValue(context, attributeBuilder, value, valueType)
     } else if (valueType =:= universe.typeOf[DataFormat]) {
       DataFormatConverter.setAttributeValue(context, attributeBuilder, value)
@@ -500,7 +500,7 @@ object DataConverter extends DataConverter{
           })
           arrayBuilder.setSize(modules.size)
         }
-      } else if (value.isInstanceOf[Array[Map[String, Any]]]) {
+      } else if (value.isInstanceOf[Array[Map[_, _]]]) {
         arrayBuilder.setDatatype(DataType.NAME_ATTR_LIST)
         value.asInstanceOf[Array[Map[String, Any]]].foreach(map => {
           val attrValueBuilder = AttrValue.newBuilder

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/serializer/converters/TensorConverter.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/serializer/converters/TensorConverter.scala
@@ -39,6 +39,7 @@ object TensorConverter extends DataConverter {
         tensor.storage == null
       case QuantizedType =>
         tensor.asInstanceOf[QuantizedTensor[_]].getStorage == null
+      case t => throw new NotImplementedError(s"$t is not supported")
     }
     emptyTensor
   }
@@ -279,6 +280,7 @@ object TensorConverter extends DataConverter {
             tensorBuilder.setTensorType(TensorType.DENSE)
           case QuantizedType =>
             tensorBuilder.setTensorType(TensorType.QUANT)
+          case t => throw new NotImplementedError(s"$t is not supported")
         }
 
         val tensorEmpty = isEmptyTensor(tensor)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/serializer/converters/TensorStorageManager.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/serializer/converters/TensorStorageManager.scala
@@ -37,6 +37,7 @@ trait TensorStorageManager {
         tensor.storage == null
       case QuantizedType =>
         tensor.asInstanceOf[QuantizedTensor[_]].getStorage == null
+      case t => throw new NotImplementedError(s"$t is not supported")
     }
     emptyTensor
   }
@@ -52,6 +53,7 @@ trait TensorStorageManager {
         } else {
           System.identityHashCode(tensor.asInstanceOf[QuantizedTensor[T]].getStorage)
         }
+      case t => throw new NotImplementedError(s"$t is not supported")
     }
   }
 
@@ -128,6 +130,7 @@ object BigDLTensorStorageManager extends TensorStorageManager {
         if (tensor.storage() == null) null else tensor.storage().array()
       case QuantizedType =>
         tensor.asInstanceOf[QuantizedTensor[Float]].getStorage
+      case t => throw new NotImplementedError(s"$t is not supported")
     }
 
     if (storage != null) {
@@ -183,6 +186,7 @@ object ProtoTensorStorageManager extends TensorStorageManager {
                 case LinearData => storageBuilder.addIntData(2)
                 case LinearWeight => storageBuilder.addIntData(3)
               }
+            case t => throw new NotImplementedError(s"$t is not supported")
           }
         }
       } else if (tensorNumeric == NumericDouble) {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/BigDLToTensorflow.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/BigDLToTensorflow.scala
@@ -105,6 +105,7 @@ object LinearToTF extends BigDLToTensorflow {
 object SpatialConvolutionToTF extends BigDLToTensorflow {
   override def toTFDef(module: AbstractModule[_, _, _], inputs: Seq[NodeDef],
                        byteOrder: ByteOrder): Seq[NodeDef] = {
+    import scala.language.existentials
     require(inputs.length == 1, "SpatialConvolution only accept one input")
     val spatialConv = module.asInstanceOf[SpatialConvolution[_]]
     if (spatialConv.nGroup == 1) {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoader.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoader.scala
@@ -113,6 +113,7 @@ object TensorflowLoader{
           tensor.size(), "float")
         case DoubleType => new JTensor(tensor.asInstanceOf[Tensor[Double]].storage().array()
           .map(_.toFloat), tensor.size(), "double")
+        case t => throw new NotImplementedError(s"$t is not supported")
       }
       save.put(n, saveTensor)
     })
@@ -126,6 +127,7 @@ object TensorflowLoader{
       val tensor = ev.getType() match {
         case FloatType => PythonBigDLUtils.toTensor(m(k), "float")
         case DoubleType => PythonBigDLUtils.toTensor(m(k), "double")
+        case t => throw new NotImplementedError(s"$t is not supported")
       }
 
       map(k) = (tensor, tensor.clone(), None)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/All.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/All.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.All
+import com.intel.analytics.bigdl.nn.ops.{All => AllOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -32,6 +32,6 @@ class All extends TensorflowOpsLoader {
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder, context: Context[T])
     (implicit ev: TensorNumeric[T]): Module[T] = {
     val keepDims = getBoolean(nodeDef.getAttrMap, "keep_dims")
-    All[T](keepDims, true)
+    AllOps[T](keepDims, true)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Any.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Any.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.Any
+import com.intel.analytics.bigdl.nn.ops.{Any => AnyOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -32,6 +32,6 @@ class Any extends TensorflowOpsLoader {
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder, context: Context[T])
     (implicit ev: TensorNumeric[T]): Module[T] = {
     val keepDims = getBoolean(nodeDef.getAttrMap, "keep_dims")
-    Any[T](keepDims, true)
+    AnyOps[T](keepDims, true)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/ApproximateEqual.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/ApproximateEqual.scala
@@ -20,7 +20,7 @@ import java.nio.ByteOrder
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import org.tensorflow.framework.NodeDef
-import com.intel.analytics.bigdl.nn.ops.ApproximateEqual
+import com.intel.analytics.bigdl.nn.ops.{ApproximateEqual => ApproximateEqualOps}
 import com.intel.analytics.bigdl.utils.tf.Context
 
 
@@ -32,6 +32,6 @@ class ApproximateEqual extends TensorflowOpsLoader {
                                   context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     val attributes = nodeDef.getAttrMap
     val tolerance = getFloat(attributes, "tolerance")
-    ApproximateEqual[T](tolerance)
+    ApproximateEqualOps[T](tolerance)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/ArrayOps.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/ArrayOps.scala
@@ -18,7 +18,6 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.Identity
 import com.intel.analytics.bigdl.nn.tf.{InvertPermutation => InvertPermutationOps,
   ConcatOffset => ConcatOffsetOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/AvgPoolGrad.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/AvgPoolGrad.scala
@@ -19,7 +19,7 @@ import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
-import com.intel.analytics.bigdl.nn.tf.AvgPoolGrad
+import com.intel.analytics.bigdl.nn.tf.{AvgPoolGrad => AvgPoolGradOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -52,7 +52,7 @@ class AvgPoolGrad extends TensorflowOpsLoader {
         val strideH = strideList(2)
         val kW = kernelSize(1)
         val kH = kernelSize(2)
-        AvgPoolGrad[T](kW, kH, strideW, strideH, pW, pH, DataFormat.NHWC)
+        AvgPoolGradOps[T](kW, kH, strideW, strideH, pW, pH, DataFormat.NHWC)
 
       case "NCHW" =>
         require(strideList(1) == 1, s"not support strides on depth")
@@ -60,7 +60,7 @@ class AvgPoolGrad extends TensorflowOpsLoader {
         val strideH = strideList(3)
         val kW = kernelSize(2)
         val kH = kernelSize(3)
-        AvgPoolGrad[T](kW, kH, strideW, strideH, pW, pH, DataFormat.NCHW)
+        AvgPoolGradOps[T](kW, kH, strideW, strideH, pW, pH, DataFormat.NCHW)
       case _ =>
         throw new IllegalArgumentException(s"not supported data format: $format")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/BatchMatMul.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/BatchMatMul.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.BatchMatMul
+import com.intel.analytics.bigdl.nn.ops.{BatchMatMul => BatchMatMulOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -35,9 +35,9 @@ class BatchMatMul extends TensorflowOpsLoader {
     val adjX = getBoolean(nodeDef.getAttrMap, "adj_x")
     val adjY = getBoolean(nodeDef.getAttrMap, "adj_y")
     if (t == DataType.DT_FLOAT) {
-      BatchMatMul[T, Float](adjX, adjY)
+      BatchMatMulOps[T, Float](adjX, adjY)
     } else if (t == DataType.DT_DOUBLE) {
-      BatchMatMul[T, Double](adjX, adjY)
+      BatchMatMulOps[T, Double](adjX, adjY)
     } else {
       throw new UnsupportedOperationException(s"Not support load ReLU6 when type is $t")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/BiasAddGrad.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/BiasAddGrad.scala
@@ -18,10 +18,8 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.Identity
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
-import com.intel.analytics.bigdl.nn.tf.BiasAddGrad
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.nn.tf.{BiasAddGrad => BiasAddGradOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -40,6 +38,6 @@ class BiasAddGrad extends TensorflowOpsLoader {
     } else {
       DataFormat.NCHW
     }
-    BiasAddGrad[T](format)
+    BiasAddGradOps[T](format)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/BroadcastGradientArgs.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/BroadcastGradientArgs.scala
@@ -18,9 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.Identity
 import com.intel.analytics.bigdl.nn.tf.{BroadcastGradientArgs => BroadcastGradientArgsOps}
-import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -28,9 +26,6 @@ import org.tensorflow.framework.NodeDef
 import scala.reflect.ClassTag
 
 class BroadcastGradientArgs extends TensorflowOpsLoader {
-
-  import Utils._
-
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     new BroadcastGradientArgsOps[T]()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Cast.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Cast.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.Cast
+import com.intel.analytics.bigdl.nn.ops.{Cast => CastOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -35,16 +35,16 @@ class Cast extends TensorflowOpsLoader {
     val dataType = getType(attr, "DstT")
 
     val layer = dataType match {
-      case DataType.DT_INT8 => Cast[T, Int]()
-      case DataType.DT_INT16 => Cast[T, Int]()
-      case DataType.DT_UINT8 => Cast[T, Int]()
-      case DataType.DT_UINT16 => Cast[T, Int]()
-      case DataType.DT_INT32 => Cast[T, Int]()
-      case DataType.DT_INT64 => Cast[T, Int]()
-      case DataType.DT_BOOL => Cast[T, Boolean]()
-      case DataType.DT_STRING => Cast[T, String]()
-      case DataType.DT_FLOAT => Cast[T, Float]()
-      case DataType.DT_DOUBLE => Cast[T, Double]()
+      case DataType.DT_INT8 => CastOps[T, Int]()
+      case DataType.DT_INT16 => CastOps[T, Int]()
+      case DataType.DT_UINT8 => CastOps[T, Int]()
+      case DataType.DT_UINT16 => CastOps[T, Int]()
+      case DataType.DT_INT32 => CastOps[T, Int]()
+      case DataType.DT_INT64 => CastOps[T, Int]()
+      case DataType.DT_BOOL => CastOps[T, Boolean]()
+      case DataType.DT_STRING => CastOps[T, String]()
+      case DataType.DT_FLOAT => CastOps[T, Float]()
+      case DataType.DT_DOUBLE => CastOps[T, Double]()
     }
     layer
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Ceil.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Ceil.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.Ceil
+import com.intel.analytics.bigdl.nn.ops.{Ceil => CeilOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -33,9 +33,9 @@ class Ceil extends TensorflowOpsLoader {
     (implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      Ceil[T, Float]()
+      CeilOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      Ceil[T, Double]()
+      CeilOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"not support load Cell operation for type $t")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Const.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Const.scala
@@ -19,8 +19,7 @@ import java.nio.ByteOrder
 
 import com.google.protobuf.ByteString
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
-import com.intel.analytics.bigdl.nn.tf.Const
+import com.intel.analytics.bigdl.nn.tf.{Const => ConstOps}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric.{NumericBoolean, NumericChar, NumericDouble, NumericFloat, NumericInt, NumericLong, NumericShort, NumericString}
@@ -35,15 +34,15 @@ class Const extends TensorflowOpsLoader {
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     val value = TFUtils.parseTensor(nodeDef.getAttrMap.get("value").getTensor, byteOrder)
     val const = value.getTensorNumeric() match {
-      case NumericFloat => Const[T, Float](value.asInstanceOf[Tensor[Float]])
-      case NumericDouble => Const[T, Double](value.asInstanceOf[Tensor[Double]])
-      case NumericInt => Const[T, Int](value.asInstanceOf[Tensor[Int]])
-      case NumericLong => Const[T, Long](value.asInstanceOf[Tensor[Long]])
-      case NumericChar => Const[T, Char](value.asInstanceOf[Tensor[Char]])
-      case NumericBoolean => Const[T, Boolean](value.asInstanceOf[Tensor[Boolean]])
-      case NumericShort => Const[T, Short](value.asInstanceOf[Tensor[Short]])
-      case NumericString => Const[T, String](value.asInstanceOf[Tensor[String]])
-      case NumericByteString => Const[T, ByteString](value.asInstanceOf[Tensor[ByteString]])
+      case NumericFloat => ConstOps[T, Float](value.asInstanceOf[Tensor[Float]])
+      case NumericDouble => ConstOps[T, Double](value.asInstanceOf[Tensor[Double]])
+      case NumericInt => ConstOps[T, Int](value.asInstanceOf[Tensor[Int]])
+      case NumericLong => ConstOps[T, Long](value.asInstanceOf[Tensor[Long]])
+      case NumericChar => ConstOps[T, Char](value.asInstanceOf[Tensor[Char]])
+      case NumericBoolean => ConstOps[T, Boolean](value.asInstanceOf[Tensor[Boolean]])
+      case NumericShort => ConstOps[T, Short](value.asInstanceOf[Tensor[Short]])
+      case NumericString => ConstOps[T, String](value.asInstanceOf[Tensor[String]])
+      case NumericByteString => ConstOps[T, ByteString](value.asInstanceOf[Tensor[ByteString]])
     }
     const.asInstanceOf[Module[T]]
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Conv2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Conv2D.scala
@@ -19,8 +19,7 @@ import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, DataFormat}
-import com.intel.analytics.bigdl.nn.tf.Conv2D
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.nn.tf.{Conv2D => Conv2DOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -49,13 +48,13 @@ class Conv2D extends TensorflowOpsLoader {
         require(strideList(3) == 1, s"not support strides on depth")
         val strideW = strideList(1)
         val strideH = strideList(2)
-        Conv2D[T](strideW, strideH, pW, pH, DataFormat.NHWC)
+        Conv2DOps[T](strideW, strideH, pW, pH, DataFormat.NHWC)
 
       case "NCHW" =>
         require(strideList(1) == 1, s"not support strides on depth")
         val strideW = strideList(2)
         val strideH = strideList(3)
-        Conv2D[T](strideW, strideH, pW, pH, DataFormat.NCHW)
+        Conv2DOps[T](strideW, strideH, pW, pH, DataFormat.NCHW)
       case _ =>
         throw new IllegalArgumentException(s"not supported data format: $format")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Conv2DBackpropFilter.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Conv2DBackpropFilter.scala
@@ -18,10 +18,8 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.Identity
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, DataFormat}
 import com.intel.analytics.bigdl.nn.tf.Conv2DBackFilter
-import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Conv3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Conv3D.scala
@@ -18,11 +18,9 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, DataFormat}
-import com.intel.analytics.bigdl.nn.tf.Conv3D
+import com.intel.analytics.bigdl.nn.tf.{Conv3D => Conv3DOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
-import com.intel.analytics.bigdl.utils.Node
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
 
@@ -52,13 +50,13 @@ class Conv3D extends TensorflowOpsLoader {
         val dW = strideList(2)
         val dH = strideList(3)
 
-        Conv3D[T](dT, dW, dH, pT, pW, pH, DataFormat.NHWC)
+        Conv3DOps[T](dT, dW, dH, pT, pW, pH, DataFormat.NHWC)
       case "NCDHW" =>
         require(strideList(1) == 1, s"not support strides on depth")
         val dT = strideList(2)
         val dW = strideList(3)
         val dH = strideList(4)
-        Conv3D[T](dT, dW, dH, pT, pW, pH, DataFormat.NCHW)
+        Conv3DOps[T](dT, dW, dH, pT, pW, pH, DataFormat.NCHW)
       case _ =>
         throw new IllegalArgumentException(s"not supported data format: $format")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Conv3DBackpropFilter.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Conv3DBackpropFilter.scala
@@ -19,7 +19,7 @@ import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
-import com.intel.analytics.bigdl.nn.tf.Conv3DBackpropFilter
+import com.intel.analytics.bigdl.nn.tf.{Conv3DBackpropFilter => Conv3DBackpropFilterOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -46,6 +46,6 @@ class Conv3DBackpropFilter extends TensorflowOpsLoader {
     val dT = strideList(1)
     val dW = strideList(2)
     val dH = strideList(3)
-    Conv3DBackpropFilter[T](dT, dW, dH, pT, pW, pH, DataFormat.NHWC)
+    Conv3DBackpropFilterOps[T](dT, dW, dH, pT, pW, pH, DataFormat.NHWC)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Conv3DBackpropFilterV2.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Conv3DBackpropFilterV2.scala
@@ -19,7 +19,7 @@ import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, DataFormat}
-import com.intel.analytics.bigdl.nn.tf.Conv3DBackpropFilterV2
+import com.intel.analytics.bigdl.nn.tf.{Conv3DBackpropFilterV2 => Conv3DBackpropFilterV2Ops}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -49,13 +49,13 @@ class Conv3DBackpropFilterV2 extends TensorflowOpsLoader {
         val dT = strideList(1)
         val dW = strideList(2)
         val dH = strideList(3)
-        Conv3DBackpropFilterV2[T](dT, dW, dH, pT, pW, pH, DataFormat.NHWC)
+        Conv3DBackpropFilterV2Ops[T](dT, dW, dH, pT, pW, pH, DataFormat.NHWC)
       case "NCDHW" =>
         require(strideList(1) == 1, s"not support strides on depth")
         val dT = strideList(2)
         val dW = strideList(3)
         val dH = strideList(4)
-        Conv3DBackpropFilterV2[T](dT, dW, dH, pT, pW, pH, DataFormat.NCHW)
+        Conv3DBackpropFilterV2Ops[T](dT, dW, dH, pT, pW, pH, DataFormat.NCHW)
       case _ =>
         throw new IllegalArgumentException(s"not supported data format: $format")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Conv3DBackpropInput.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Conv3DBackpropInput.scala
@@ -19,7 +19,7 @@ import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
-import com.intel.analytics.bigdl.nn.tf.Conv3DBackpropInput
+import com.intel.analytics.bigdl.nn.tf.{Conv3DBackpropInput => Conv3DBackpropInputOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -46,6 +46,6 @@ class Conv3DBackpropInput extends TensorflowOpsLoader {
     val dT = strideList(1)
     val dW = strideList(2)
     val dH = strideList(3)
-    Conv3DBackpropInput[T](dT, dW, dH, pT, pW, pH, DataFormat.NHWC)
+    Conv3DBackpropInputOps[T](dT, dW, dH, pT, pW, pH, DataFormat.NHWC)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Conv3DBackpropInputV2.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Conv3DBackpropInputV2.scala
@@ -19,7 +19,7 @@ import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, DataFormat}
-import com.intel.analytics.bigdl.nn.tf.Conv3DBackpropInputV2
+import com.intel.analytics.bigdl.nn.tf.{Conv3DBackpropInputV2 => Conv3DBackpropInputV2Ops}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -49,13 +49,13 @@ class Conv3DBackpropInputV2 extends TensorflowOpsLoader {
         val dT = strideList(1)
         val dW = strideList(2)
         val dH = strideList(3)
-        Conv3DBackpropInputV2[T](dT, dW, dH, pT, pW, pH, DataFormat.NHWC)
+        Conv3DBackpropInputV2Ops[T](dT, dW, dH, pT, pW, pH, DataFormat.NHWC)
       case "NCDHW" =>
         require(strideList(1) == 1, s"not support strides on depth")
         val dT = strideList(2)
         val dW = strideList(3)
         val dH = strideList(4)
-        Conv3DBackpropInputV2[T](dT, dW, dH, pT, pW, pH, DataFormat.NCHW)
+        Conv3DBackpropInputV2Ops[T](dT, dW, dH, pT, pW, pH, DataFormat.NCHW)
       case _ =>
         throw new IllegalArgumentException(s"not supported data format: $format")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Digamma.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Digamma.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.Digamma
+import com.intel.analytics.bigdl.nn.ops.{Digamma => DigammaOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -33,9 +33,9 @@ class Digamma extends TensorflowOpsLoader {
                                  (implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      Digamma[T, Float]()
+      DigammaOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      Digamma[T, Double]()
+      DigammaOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Digamma when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Dilation2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Dilation2D.scala
@@ -18,8 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ELU
-import com.intel.analytics.bigdl.nn.ops.Dilation2D
+import com.intel.analytics.bigdl.nn.ops.{Dilation2D => Dilation2DOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -39,9 +38,9 @@ class Dilation2D extends TensorflowOpsLoader {
     val t = getType(nodeDef.getAttrMap, "T")
 
     if (t == DataType.DT_FLOAT) {
-      Dilation2D[T, Float](strides, rates, padding)
+      Dilation2DOps[T, Float](strides, rates, padding)
     } else if (t == DataType.DT_DOUBLE) {
-      Dilation2D[T, Double](strides, rates, padding)
+      Dilation2DOps[T, Double](strides, rates, padding)
     } else {
       throw new UnsupportedOperationException(s"Not support load Dilation2D when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Dilation2DBackpropFilter.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Dilation2DBackpropFilter.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.Dilation2DBackpropFilter
+import com.intel.analytics.bigdl.nn.ops.{Dilation2DBackpropFilter => Dilation2DBackpropFilterOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -38,9 +38,9 @@ class Dilation2DBackpropFilter extends TensorflowOpsLoader {
     val t = getType(nodeDef.getAttrMap, "T")
 
     if (t == DataType.DT_FLOAT) {
-      Dilation2DBackpropFilter[T, Float](strides, rates, padding)
+      Dilation2DBackpropFilterOps[T, Float](strides, rates, padding)
     } else if (t == DataType.DT_DOUBLE) {
-      Dilation2DBackpropFilter[T, Double](strides, rates, padding)
+      Dilation2DBackpropFilterOps[T, Double](strides, rates, padding)
     } else {
       throw new UnsupportedOperationException(
         s"Not support load Dilation2DBackpropFilter when type is ${t}")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Dilation2DBackpropInput.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Dilation2DBackpropInput.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.Dilation2DBackpropInput
+import com.intel.analytics.bigdl.nn.ops.{Dilation2DBackpropInput => Dilation2DBackpropInputOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -38,9 +38,9 @@ class Dilation2DBackpropInput extends TensorflowOpsLoader {
     val t = getType(nodeDef.getAttrMap, "T")
 
     if (t == DataType.DT_FLOAT) {
-      Dilation2DBackpropInput[T, Float](strides, rates, padding)
+      Dilation2DBackpropInputOps[T, Float](strides, rates, padding)
     } else if (t == DataType.DT_DOUBLE) {
-      Dilation2DBackpropInput[T, Double](strides, rates, padding)
+      Dilation2DBackpropInputOps[T, Double](strides, rates, padding)
     } else {
       throw new UnsupportedOperationException(
         s"Not support load Dilation2DBackpropInput when type is ${t}")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/EluGrad.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/EluGrad.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.tf.EluGrad
+import com.intel.analytics.bigdl.nn.tf.{EluGrad => EluGradOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import com.intel.analytics.bigdl.utils.tf.loaders.Utils.getType
@@ -33,9 +33,9 @@ class EluGrad extends TensorflowOpsLoader {
                                   context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      EluGrad[T, Float]()
+      EluGradOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      EluGrad[T, Double]()
+      EluGradOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load ReLU6 when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Erf.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Erf.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.Erf
+import com.intel.analytics.bigdl.nn.ops.{Erf => ErfOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -33,9 +33,9 @@ class Erf extends TensorflowOpsLoader {
                                  (implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      Erf[T, Float]()
+      ErfOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      Erf[T, Double]()
+      ErfOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Erf when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Erfc.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Erfc.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.Erfc
+import com.intel.analytics.bigdl.nn.ops.{Erfc => ErfcOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -33,9 +33,9 @@ class Erfc extends TensorflowOpsLoader {
                                  (implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      Erfc[T, Float]()
+      ErfcOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      Erfc[T, Double]()
+      ErfcOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Erfc when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Exp.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Exp.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.{Exp, FloorDiv}
+import com.intel.analytics.bigdl.nn.ops.{Exp => ExpOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -33,9 +33,9 @@ class Exp extends TensorflowOpsLoader {
     (implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      Exp[T, Float]()
+      ExpOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      Exp[T, Double]()
+      ExpOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Exp when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Expm1.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Expm1.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.{Exp, Expm1}
+import com.intel.analytics.bigdl.nn.ops.{Expm1 => Expm1Ops}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -33,9 +33,9 @@ class Expm1 extends TensorflowOpsLoader {
     (implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      Expm1[T, Float]()
+      Expm1Ops[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      Expm1[T, Double]()
+      Expm1Ops[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Expm1 when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Fill.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Fill.scala
@@ -18,8 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.tf.Fill
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.nn.tf.{Fill => FillOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -29,7 +28,7 @@ import scala.reflect.ClassTag
 class Fill extends TensorflowOpsLoader {
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
-    Fill[T]()
+    FillOps[T]()
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Floor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Floor.scala
@@ -18,9 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.Identity
-import com.intel.analytics.bigdl.nn.ops.Floor
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.nn.ops.{Floor => FloorOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -28,11 +26,8 @@ import org.tensorflow.framework.NodeDef
 import scala.reflect.ClassTag
 
 class Floor extends TensorflowOpsLoader {
-
-  import Utils._
-
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
-    Floor[T]()
+    FloorOps[T]()
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/FloorDiv.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/FloorDiv.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.{FloorDiv, Round}
+import com.intel.analytics.bigdl.nn.ops.{FloorDiv => FloorDivOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -33,11 +33,11 @@ class FloorDiv extends TensorflowOpsLoader {
     (implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      FloorDiv[T, Float]()
+      FloorDivOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      FloorDiv[T, Double]()
+      FloorDivOps[T, Double]()
     } else if (t == DataType.DT_INT32) {
-      FloorDiv[T, Int]()
+      FloorDivOps[T, Int]()
     } else {
       throw new UnsupportedOperationException(s"Not support load FloorDiv when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/FloorMod.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/FloorMod.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.{FloorMod, Mod}
+import com.intel.analytics.bigdl.nn.ops.{FloorMod => FloorModOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -33,11 +33,11 @@ class FloorMod extends TensorflowOpsLoader {
     (implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      FloorMod[T, Float]()
+      FloorModOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      FloorMod[T, Double]()
+      FloorModOps[T, Double]()
     } else if (t == DataType.DT_INT32) {
-      FloorMod[T, Int]()
+      FloorModOps[T, Int]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Mod when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/FusedBatchNorm.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/FusedBatchNorm.scala
@@ -19,7 +19,7 @@ import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
-import com.intel.analytics.bigdl.nn.tf.FusedBatchNorm
+import com.intel.analytics.bigdl.nn.tf.{FusedBatchNorm => FusedBatchNormOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -38,9 +38,9 @@ class FusedBatchNorm extends TensorflowOpsLoader {
     val dataFormat = getString(nodeDef.getAttrMap, "data_format")
     val isTrain = getBoolean(nodeDef.getAttrMap, "is_training")
     if (dataFormat == "NHWC") {
-      FusedBatchNorm[T](eps, isTrain, dataFormat = DataFormat.NHWC)
+      FusedBatchNormOps[T](eps, isTrain, dataFormat = DataFormat.NHWC)
     } else {
-      FusedBatchNorm[T](eps, isTrain, dataFormat = DataFormat.NCHW)
+      FusedBatchNormOps[T](eps, isTrain, dataFormat = DataFormat.NCHW)
     }
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/FusedBatchNormGrad.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/FusedBatchNormGrad.scala
@@ -19,7 +19,7 @@ import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
-import com.intel.analytics.bigdl.nn.tf.FusedBatchNormGrad
+import com.intel.analytics.bigdl.nn.tf.{FusedBatchNormGrad => FusedBatchNormGradOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -35,7 +35,7 @@ class FusedBatchNormGrad extends TensorflowOpsLoader {
     val eps = getFloat(nodeDef.getAttrMap, "epsilon")
     val dataFormat = getString(nodeDef.getAttrMap, "data_format")
     val isTrain = getBoolean(nodeDef.getAttrMap, "is_training")
-    FusedBatchNormGrad[T](eps,
+    FusedBatchNormGradOps[T](eps,
       if (dataFormat == "NHWC") DataFormat.NHWC else DataFormat.NCHW,
       isTrain)
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/FusedBatchNormGradV2.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/FusedBatchNormGradV2.scala
@@ -19,7 +19,7 @@ import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
-import com.intel.analytics.bigdl.nn.tf.FusedBatchNormGrad
+import com.intel.analytics.bigdl.nn.tf.{FusedBatchNormGrad => FusedBatchNormGradOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -35,7 +35,7 @@ class FusedBatchNormGradV2 extends TensorflowOpsLoader {
     val eps = getFloat(nodeDef.getAttrMap, "epsilon")
     val dataFormat = getString(nodeDef.getAttrMap, "data_format")
     val isTrain = getBoolean(nodeDef.getAttrMap, "is_training")
-    FusedBatchNormGrad[T](eps,
+    FusedBatchNormGradOps[T](eps,
       if (dataFormat == "NHWC") DataFormat.NHWC else DataFormat.NCHW,
       isTrain)
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/FusedBatchNormV2.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/FusedBatchNormV2.scala
@@ -19,7 +19,7 @@ import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
-import com.intel.analytics.bigdl.nn.tf.FusedBatchNorm
+import com.intel.analytics.bigdl.nn.tf.{FusedBatchNorm => FusedBatchNormOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -40,9 +40,9 @@ class FusedBatchNormV2 extends TensorflowOpsLoader {
     val dataFormat = getString(nodeDef.getAttrMap, "data_format")
     val isTrain = getBoolean(nodeDef.getAttrMap, "is_training")
     if (dataFormat == "NHWC") {
-      FusedBatchNorm[T](eps, isTrain, dataFormat = DataFormat.NHWC)
+      FusedBatchNormOps[T](eps, isTrain, dataFormat = DataFormat.NHWC)
     } else {
-      FusedBatchNorm[T](eps, isTrain, dataFormat = DataFormat.NCHW)
+      FusedBatchNormOps[T](eps, isTrain, dataFormat = DataFormat.NCHW)
     }
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/GreaterEqual.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/GreaterEqual.scala
@@ -20,14 +20,14 @@ import java.nio.ByteOrder
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import org.tensorflow.framework.NodeDef
-import com.intel.analytics.bigdl.nn.ops.GreaterEqual
+import com.intel.analytics.bigdl.nn.ops.{GreaterEqual => GreaterEqualOps}
 import com.intel.analytics.bigdl.utils.tf.Context
 
 import scala.reflect.ClassTag
 
 class GreaterEqual extends TensorflowOpsLoader {
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
-                                  context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
-    GreaterEqual[T]()
+      context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
+    GreaterEqualOps[T]()
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/InTopK.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/InTopK.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.InTopK
+import com.intel.analytics.bigdl.nn.ops.{InTopK => InTopKOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -32,6 +32,6 @@ class InTopK extends TensorflowOpsLoader {
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder, context: Context[T])
     (implicit ev: TensorNumeric[T]): Module[T] = {
     val k = getInt(nodeDef.getAttrMap, "k")
-    InTopK[T](k, true)
+    InTopKOps[T](k, true)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Inv.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Inv.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.Inv
+import com.intel.analytics.bigdl.nn.ops.{Inv => InvOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -33,9 +33,9 @@ class Inv extends TensorflowOpsLoader {
     (implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      Inv[T, Float]()
+      InvOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      Inv[T, Double]()
+      InvOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Inv when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/InvGrad.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/InvGrad.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.{Inv, InvGrad}
+import com.intel.analytics.bigdl.nn.ops.{InvGrad => InvGradOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -33,9 +33,9 @@ class InvGrad extends TensorflowOpsLoader {
     (implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      InvGrad[T, Float]()
+      InvGradOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      InvGrad[T, Double]()
+      InvGradOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Inv when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/IsFinite.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/IsFinite.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.{Inv, IsFinite}
+import com.intel.analytics.bigdl.nn.ops.{IsFinite => IsFiniteOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -33,9 +33,9 @@ class IsFinite extends TensorflowOpsLoader {
     (implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      IsFinite[T, Float]()
+      IsFiniteOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      IsFinite[T, Double]()
+      IsFiniteOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Inv when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/IsInf.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/IsInf.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.{IsFinite, IsInf}
+import com.intel.analytics.bigdl.nn.ops.{IsInf => IsInfOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -33,9 +33,9 @@ class IsInf extends TensorflowOpsLoader {
     (implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      IsInf[T, Float]()
+      IsInfOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      IsInf[T, Double]()
+      IsInfOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Inv when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/IsNan.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/IsNan.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.{IsInf, IsNan}
+import com.intel.analytics.bigdl.nn.ops.{IsNan => IsNanOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -33,9 +33,9 @@ class IsNan extends TensorflowOpsLoader {
     (implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      IsNan[T, Float]()
+      IsNanOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      IsNan[T, Double]()
+      IsNanOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Inv when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/L2Loss.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/L2Loss.scala
@@ -18,9 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.Identity
-import com.intel.analytics.bigdl.nn.ops.L2Loss
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.nn.ops.{L2Loss => L2LossOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -28,11 +26,8 @@ import org.tensorflow.framework.NodeDef
 import scala.reflect.ClassTag
 
 class L2Loss extends TensorflowOpsLoader {
-
-  import Utils._
-
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
-    L2Loss[T]()
+    L2LossOps[T]()
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/LRNGrad.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/LRNGrad.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.tf.LRNGrad
+import com.intel.analytics.bigdl.nn.tf.{LRNGrad => LRNGradOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -36,6 +36,6 @@ class LRNGrad extends TensorflowOpsLoader {
     val alpha = getFloat(nodeDef.getAttrMap, "alpha")
     val beta = getFloat(nodeDef.getAttrMap, "beta")
 
-    LRNGrad[T](size, k, alpha, beta)
+    LRNGradOps[T](size, k, alpha, beta)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/LessEqual.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/LessEqual.scala
@@ -20,14 +20,14 @@ import java.nio.ByteOrder
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import org.tensorflow.framework.NodeDef
-import com.intel.analytics.bigdl.nn.ops.LessEqual
+import com.intel.analytics.bigdl.nn.ops.{LessEqual => LessEqualOps}
 import com.intel.analytics.bigdl.utils.tf.Context
 
 import scala.reflect.ClassTag
 
 class LessEqual extends TensorflowOpsLoader {
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
-                                  context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
-    LessEqual[T]()
+      context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
+    LessEqualOps[T]()
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Lgamma.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Lgamma.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.Lgamma
+import com.intel.analytics.bigdl.nn.ops.{Lgamma => LgammaOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -33,9 +33,9 @@ class Lgamma extends TensorflowOpsLoader {
                                  (implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      Lgamma[T, Float]()
+      LgammaOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      Lgamma[T, Double]()
+      LgammaOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Lgamma when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Log1p.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Log1p.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.tf.Log1p
+import com.intel.analytics.bigdl.nn.tf.{Log1p => Log1pOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import org.tensorflow.framework.{DataType, NodeDef}
 import com.intel.analytics.bigdl.utils.tf.Context
@@ -31,9 +31,9 @@ class Log1p extends TensorflowOpsLoader {
                                   context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      Log1p[T, Float]()
+      Log1pOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      Log1p[T, Double]()
+      Log1pOps[T, Double]()
     } else {
      throw new UnsupportedOperationException(s"Not support load Log1p when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/MaxPoolGrad.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/MaxPoolGrad.scala
@@ -19,9 +19,7 @@ import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
-import com.intel.analytics.bigdl.nn.tf.MaxPoolGrad
-import com.intel.analytics.bigdl.nn.{Identity, SpatialMaxPooling}
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.nn.tf.{MaxPoolGrad => MaxPoolGradOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -54,7 +52,7 @@ class MaxPoolGrad extends TensorflowOpsLoader {
         val strideH = strideList(2)
         val kW = kernelSize(1)
         val kH = kernelSize(2)
-        MaxPoolGrad[T](kW, kH, strideW, strideH, pW, pH, DataFormat.NHWC)
+        MaxPoolGradOps[T](kW, kH, strideW, strideH, pW, pH, DataFormat.NHWC)
 
       case "NCHW" =>
         require(strideList(1) == 1, s"not support strides on depth")
@@ -62,7 +60,7 @@ class MaxPoolGrad extends TensorflowOpsLoader {
         val strideH = strideList(3)
         val kW = kernelSize(2)
         val kH = kernelSize(3)
-        MaxPoolGrad[T](kW, kH, strideW, strideH, pW, pH, DataFormat.NCHW)
+        MaxPoolGradOps[T](kW, kH, strideW, strideH, pW, pH, DataFormat.NCHW)
       case _ =>
         throw new IllegalArgumentException(s"not supported data format: $format")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Maximum.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Maximum.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.Maximum
+import com.intel.analytics.bigdl.nn.ops.{Maximum => MaximumOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import org.tensorflow.framework.{DataType, NodeDef}
 import Utils._
@@ -31,9 +31,9 @@ class Maximum extends TensorflowOpsLoader {
                                   context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      Maximum[T, Float]()
+      MaximumOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      Maximum[T, Double]()
+      MaximumOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Maximum when type is $t")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Minimum.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Minimum.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.Minimum
+import com.intel.analytics.bigdl.nn.ops.{Minimum => MinimumOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import org.tensorflow.framework.{DataType, NodeDef}
 import Utils._
@@ -31,9 +31,9 @@ class Minimum extends TensorflowOpsLoader {
                                   context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      Minimum[T, Float]()
+      MinimumOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      Minimum[T, Double]()
+      MinimumOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Maximum when type is $t")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Mod.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Mod.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.{FloorDiv, Mod}
+import com.intel.analytics.bigdl.nn.ops.{Mod => ModOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -33,11 +33,11 @@ class Mod extends TensorflowOpsLoader {
     (implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      Mod[T, Float]()
+      ModOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      Mod[T, Double]()
+      ModOps[T, Double]()
     } else if (t == DataType.DT_INT32) {
-      Mod[T, Int]()
+      ModOps[T, Int]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Mod when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Neg.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Neg.scala
@@ -18,8 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.{Identity, Negative}
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.nn.{Negative => NegativeOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -27,11 +26,8 @@ import org.tensorflow.framework.NodeDef
 import scala.reflect.ClassTag
 
 class Neg extends TensorflowOpsLoader {
-
-  import Utils._
-
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
-    Negative[T]()
+    NegativeOps[T]()
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/OneHot.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/OneHot.scala
@@ -17,11 +17,9 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.Power
 import com.intel.analytics.bigdl.nn.ops.{OneHot => OneHotOp}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
-import com.intel.analytics.bigdl.utils.tf.loaders.{TensorflowOpsLoader, Utils}
 import org.tensorflow.framework.NodeDef
 
 import scala.reflect.ClassTag

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Pack.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Pack.scala
@@ -18,9 +18,8 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.Pack
+import com.intel.analytics.bigdl.nn.{Pack => PackOps}
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
-import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -31,7 +30,7 @@ class Pack extends TensorflowOpsLoader {
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     val dim = nodeDef.getAttrMap.get("axis").getI.toInt + 1
-    Pack[T](dim).asInstanceOf[AbstractModule[Activity, Activity, T]]
+    PackOps[T](dim).asInstanceOf[AbstractModule[Activity, Activity, T]]
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Placeholder.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Placeholder.scala
@@ -18,8 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.Identity
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.nn.{Identity => IdentityOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -27,12 +26,9 @@ import org.tensorflow.framework.NodeDef
 import scala.reflect.ClassTag
 
 class Placeholder extends TensorflowOpsLoader {
-
-  import Utils._
-
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
-    Identity[T]
+    IdentityOps[T]
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Pow.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Pow.scala
@@ -18,8 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.Pow
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.nn.ops.{Pow => PowOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -27,11 +26,8 @@ import org.tensorflow.framework.NodeDef
 import scala.reflect.ClassTag
 
 class Pow extends TensorflowOpsLoader {
-
-  import Utils._
-
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
-    Pow[T]()
+    PowOps[T]()
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Prod.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Prod.scala
@@ -18,9 +18,8 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.Identity
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
-import com.intel.analytics.bigdl.nn.ops.Prod
+import com.intel.analytics.bigdl.nn.ops.{Prod => ProdOps}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
@@ -29,9 +28,6 @@ import org.tensorflow.framework.NodeDef
 import scala.reflect.ClassTag
 
 class Prod extends TensorflowOpsLoader {
-
-  import Utils._
-
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     new ProdLoadTF[T]()
@@ -41,6 +37,6 @@ class Prod extends TensorflowOpsLoader {
 class ProdLoadTF[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends Adapter[T](Array(2)) {
   override def build(tensorArrays: Array[Tensor[_]]): AbstractModule[Activity, Activity, T] = {
     val axis = tensorArrays(0).asInstanceOf[Tensor[Int]].value() + 1
-    Prod[T](axis)
+    ProdOps[T](axis)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/RandomUniform.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/RandomUniform.scala
@@ -18,9 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.Identity
-import com.intel.analytics.bigdl.nn.ops.RandomUniform
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.nn.ops.{RandomUniform => RandomUniformOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -28,9 +26,6 @@ import org.tensorflow.framework.{DataType, NodeDef}
 import scala.reflect.ClassTag
 
 class RandomUniform extends TensorflowOpsLoader {
-
-  import Utils._
-
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     val seed = if (nodeDef.getAttrMap.containsKey("seed")) {
@@ -43,11 +38,11 @@ class RandomUniform extends TensorflowOpsLoader {
       case DataType.DT_FLOAT =>
         val min = 0
         val max = 1
-        RandomUniform[T, Float](min, max, seed)
+        RandomUniformOps[T, Float](min, max, seed)
       case DataType.DT_DOUBLE =>
         val min = 0
         val max = 1
-        RandomUniform[T, Double](min, max, seed)
+        RandomUniformOps[T, Double](min, max, seed)
       case _ =>
         throw new IllegalArgumentException("Not support data type")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Reciprocal.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Reciprocal.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.Inv
+import com.intel.analytics.bigdl.nn.ops.{Inv => InvOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -34,9 +34,9 @@ class Reciprocal extends TensorflowOpsLoader {
 
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      Inv[T, Float]()
+      InvOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      Inv[T, Double]()
+      InvOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Inv when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/ReciprocalGrad.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/ReciprocalGrad.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.InvGrad
+import com.intel.analytics.bigdl.nn.ops.{InvGrad => InvGradOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -34,9 +34,9 @@ class ReciprocalGrad extends TensorflowOpsLoader {
 
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      InvGrad[T, Float]()
+      InvGradOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      InvGrad[T, Double]()
+      InvGradOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Inv when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Relu6.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Relu6.scala
@@ -19,7 +19,6 @@ import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.tf.ReLU6
-import com.intel.analytics.bigdl.nn.tf.Log1p
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import com.intel.analytics.bigdl.utils.tf.loaders.Utils.getType

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Relu6Grad.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Relu6Grad.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.tf.{EluGrad, Relu6Grad}
+import com.intel.analytics.bigdl.nn.tf.{Relu6Grad => Relu6GradOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import com.intel.analytics.bigdl.utils.tf.loaders.Utils.getType
@@ -33,9 +33,9 @@ class Relu6Grad extends TensorflowOpsLoader {
                                   context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      Relu6Grad[T, Float]()
+      Relu6GradOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      Relu6Grad[T, Double]()
+      Relu6GradOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load ReLU6 when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/ReluGrad.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/ReluGrad.scala
@@ -18,9 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.tf.ReluGrad
-import com.intel.analytics.bigdl.nn.{Identity, ReLU}
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.nn.tf.{ReluGrad => ReluGradOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -28,11 +26,8 @@ import org.tensorflow.framework.NodeDef
 import scala.reflect.ClassTag
 
 class ReluGrad extends TensorflowOpsLoader {
-
-  import Utils._
-
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
-    ReluGrad[T]()
+    ReluGradOps[T]()
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Reshape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Reshape.scala
@@ -18,19 +18,16 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.Reshape
+import com.intel.analytics.bigdl.nn.{Reshape => ReshapeOps}
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
-import com.intel.analytics.bigdl.utils.tf.{Context, TFUtils}
+import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
 
 import scala.reflect.ClassTag
 
 class Reshape extends TensorflowOpsLoader {
-
-  import Utils._
-
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     new ReshapeLoadTF[T]()
@@ -55,7 +52,7 @@ class ReshapeLoadTF[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends Adapte
       k += 1
       i += 1
     }
-    Reshape[T](size = arraySize, Some(batchMode))
+    ReshapeOps[T](size = arraySize, Some(batchMode))
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/ResizeBilinear.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/ResizeBilinear.scala
@@ -18,8 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.{ResizeBilinearGrad, ResizeBilinearOps}
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.nn.ops.{ResizeBilinearOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/ResizeBilinearGrad.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/ResizeBilinearGrad.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.ResizeBilinearGrad
+import com.intel.analytics.bigdl.nn.ops.{ResizeBilinearGrad => ResizeBilinearGradOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -29,6 +29,6 @@ class ResizeBilinearGrad extends TensorflowOpsLoader {
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     val alignCorner = nodeDef.getAttrMap.get("align_corners").getB
-    ResizeBilinearGrad[T](alignCorner)
+    ResizeBilinearGradOps[T](alignCorner)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Rint.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Rint.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.Rint
+import com.intel.analytics.bigdl.nn.ops.{Rint => RintOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -26,11 +26,8 @@ import org.tensorflow.framework.NodeDef
 import scala.reflect.ClassTag
 
 class Rint extends TensorflowOpsLoader {
-
-  import Utils._
-
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder, context: Context[T])
     (implicit ev: TensorNumeric[T]): Module[T] = {
-    Rint[T]()
+    RintOps[T]()
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Round.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Round.scala
@@ -18,8 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.Abs
-import com.intel.analytics.bigdl.nn.ops.Round
+import com.intel.analytics.bigdl.nn.ops.{Round => RoundOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -34,11 +33,11 @@ class Round extends TensorflowOpsLoader {
     (implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      Round[T, Float]()
+      RoundOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      Round[T, Double]()
+      RoundOps[T, Double]()
     } else if (t == DataType.DT_INT32) {
-      Round[T, Int]()
+      RoundOps[T, Int]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Round when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/RsqrtGrad.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/RsqrtGrad.scala
@@ -18,8 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.tf.RsqrtGrad
-import com.intel.analytics.bigdl.nn.tf.Log1p
+import com.intel.analytics.bigdl.nn.tf.{RsqrtGrad => RsqrtGradOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import com.intel.analytics.bigdl.utils.tf.loaders.Utils.getType
@@ -32,9 +31,9 @@ class RsqrtGrad extends TensorflowOpsLoader {
                                   context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      RsqrtGrad[T, Float]()
+      RsqrtGradOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      RsqrtGrad[T, Double]()
+      RsqrtGradOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load RsqrtGrad when type is $t")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/SegmentSum.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/SegmentSum.scala
@@ -17,7 +17,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.SegmentSum
+import com.intel.analytics.bigdl.nn.ops.{SegmentSum => SegmentSumOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -27,7 +27,8 @@ import scala.reflect.ClassTag
 class SegmentSum extends TensorflowOpsLoader {
 
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
-                                  context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
-    SegmentSum[T]()
+    context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
+
+    SegmentSumOps[T]()
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Select.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Select.scala
@@ -18,9 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.Identity
-import com.intel.analytics.bigdl.nn.ops.Select
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.nn.ops.{Select => SelectOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -28,11 +26,8 @@ import org.tensorflow.framework.NodeDef
 import scala.reflect.ClassTag
 
 class Select extends TensorflowOpsLoader {
-
-  import Utils._
-
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
-    Select[T]()
+    SelectOps[T]()
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Shape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Shape.scala
@@ -18,8 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.tf.Shape
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.nn.tf.{Shape => ShapeOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -29,7 +28,7 @@ import scala.reflect.ClassTag
 class Shape extends TensorflowOpsLoader {
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
-    Shape[T]()
+    ShapeOps[T]()
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Sigmoid.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Sigmoid.scala
@@ -18,8 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.Sigmoid
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.nn.{Sigmoid => SigmoidOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -29,7 +28,7 @@ import scala.reflect.ClassTag
 class Sigmoid extends TensorflowOpsLoader {
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
-    Sigmoid[T]()
+    SigmoidOps[T]()
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/SigmoidGrad.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/SigmoidGrad.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.tf.SigmoidGrad
+import com.intel.analytics.bigdl.nn.tf.{SigmoidGrad => SigmoidGradOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import com.intel.analytics.bigdl.utils.tf.loaders.Utils.getType
@@ -31,9 +31,9 @@ class SigmoidGrad extends TensorflowOpsLoader {
                                   context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      SigmoidGrad[T, Float]()
+      SigmoidGradOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      SigmoidGrad[T, Double]()
+      SigmoidGradOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load SigmoidGrad when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Sign.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Sign.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.{IsInf, Sign}
+import com.intel.analytics.bigdl.nn.ops.{Sign => SignOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -33,9 +33,9 @@ class Sign extends TensorflowOpsLoader {
     (implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      Sign[T, Float]()
+      SignOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      Sign[T, Double]()
+      SignOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Inv when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Slice.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Slice.scala
@@ -18,9 +18,8 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.Identity
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
-import com.intel.analytics.bigdl.nn.ops.Slice
+import com.intel.analytics.bigdl.nn.ops.{Slice => SliceOps}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
@@ -42,7 +41,7 @@ class SliceLoadTF[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends Adapter[
 
   override def build(tensorArrays: Array[Tensor[_]]): AbstractModule[Activity, Activity, T] = {
     val size = tensorArrays(1).asInstanceOf[Tensor[Int]]
-    Slice[T](toArray(tensorArrays(0).asInstanceOf[Tensor[Int]]),
+    SliceOps[T](toArray(tensorArrays(0).asInstanceOf[Tensor[Int]]),
       toArray(tensorArrays(1).asInstanceOf[Tensor[Int]]))
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/SoftplusGrad.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/SoftplusGrad.scala
@@ -18,8 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.SoftPlus
-import com.intel.analytics.bigdl.nn.tf.SoftplusGrad
+import com.intel.analytics.bigdl.nn.tf.{SoftplusGrad => SoftplusGradOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import com.intel.analytics.bigdl.utils.tf.loaders.Utils.getType
@@ -33,9 +32,9 @@ class SoftplusGrad extends TensorflowOpsLoader {
                                   context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      SoftplusGrad[T, Float]()
+      SoftplusGradOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      SoftplusGrad[T, Double]()
+      SoftplusGradOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load SoftplusGrad when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/SoftsignGrad.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/SoftsignGrad.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.tf.{SoftplusGrad, SoftsignGrad}
+import com.intel.analytics.bigdl.nn.tf.{SoftsignGrad => SoftsignGradOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import com.intel.analytics.bigdl.utils.tf.loaders.Utils.getType
@@ -33,9 +33,9 @@ class SoftsignGrad extends TensorflowOpsLoader {
                                   context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      SoftsignGrad[T, Float]()
+      SoftsignGradOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      SoftsignGrad[T, Double]()
+      SoftsignGradOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load SoftsignGrad when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/SqrtGrad.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/SqrtGrad.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.tf.SqrtGrad
+import com.intel.analytics.bigdl.nn.tf.{SqrtGrad => SqrtGradOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import com.intel.analytics.bigdl.utils.tf.loaders.Utils.getType
@@ -31,9 +31,9 @@ class SqrtGrad extends TensorflowOpsLoader {
                                   context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      SqrtGrad[T, Float]()
+      SqrtGradOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      SqrtGrad[T, Double]()
+      SqrtGradOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load SqrtGrad when type is $t")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/SquaredDifference.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/SquaredDifference.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.SquaredDifference
+import com.intel.analytics.bigdl.nn.ops.{SquaredDifference => SquaredDifferenceOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -29,7 +29,7 @@ class SquaredDifference extends TensorflowOpsLoader {
 
 
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
-                                  context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
-    SquaredDifference[T]()
+      context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
+    SquaredDifferenceOps[T]()
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Squeeze.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Squeeze.scala
@@ -18,8 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.Squeeze
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.nn.{Squeeze => SqueezeOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -29,8 +28,6 @@ import scala.reflect.ClassTag
 
 class Squeeze extends TensorflowOpsLoader {
 
-  import Utils._
-
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
 
@@ -39,7 +36,7 @@ class Squeeze extends TensorflowOpsLoader {
 
     dims = if (dims.isEmpty) null else dims
 
-    Squeeze[T](dims, batchMode = false)
+    SqueezeOps[T](dims, batchMode = false)
 
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Sum.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Sum.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.Sum
+import com.intel.analytics.bigdl.nn.ops.{Sum => SumOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -36,21 +36,21 @@ class Sum extends TensorflowOpsLoader {
     val dataType = getType(attr, "T")
     dataType match {
       case DataType.DT_INT8 =>
-        Sum[T, Int](keepDims, startFromZero = true)
+        SumOps[T, Int](keepDims, startFromZero = true)
       case DataType.DT_INT16 =>
-        Sum[T, Int](keepDims, startFromZero = true)
+        SumOps[T, Int](keepDims, startFromZero = true)
       case DataType.DT_UINT8 =>
-        Sum[T, Int](keepDims, startFromZero = true)
+        SumOps[T, Int](keepDims, startFromZero = true)
       case DataType.DT_UINT16 =>
-        Sum[T, Int](keepDims, startFromZero = true)
+        SumOps[T, Int](keepDims, startFromZero = true)
       case DataType.DT_INT32 =>
-        Sum[T, Int](keepDims, startFromZero = true)
+        SumOps[T, Int](keepDims, startFromZero = true)
       case DataType.DT_INT64 =>
-        Sum[T, Int](keepDims, startFromZero = true)
+        SumOps[T, Int](keepDims, startFromZero = true)
       case DataType.DT_FLOAT =>
-        Sum[T, Float](keepDims, startFromZero = true)
+        SumOps[T, Float](keepDims, startFromZero = true)
       case DataType.DT_DOUBLE =>
-        Sum[T, Double](keepDims, startFromZero = true)
+        SumOps[T, Double](keepDims, startFromZero = true)
     }
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Tanh.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Tanh.scala
@@ -18,8 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.Tanh
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.nn.{Tanh => TanhOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -29,6 +28,6 @@ import scala.reflect.ClassTag
 class Tanh extends TensorflowOpsLoader {
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
-    Tanh[T]()
+    TanhOps[T]()
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/TanhGrad.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/TanhGrad.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.tf.TanhGrad
+import com.intel.analytics.bigdl.nn.tf.{TanhGrad => TanhGradOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import com.intel.analytics.bigdl.utils.tf.loaders.Utils.getType
@@ -31,9 +31,9 @@ class TanhGrad extends TensorflowOpsLoader {
                                   context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      TanhGrad[T, Float]()
+      TanhGradOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      TanhGrad[T, Double]()
+      TanhGradOps[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support load TanhGrad when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Tile.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Tile.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.Tile
+import com.intel.analytics.bigdl.nn.ops.{Tile => TileOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -28,6 +28,6 @@ import scala.reflect.ClassTag
 class Tile  extends TensorflowOpsLoader {
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
-    Tile[T]()
+    TileOps[T]()
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/TopK.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/TopK.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.{Sign, TopK}
+import com.intel.analytics.bigdl.nn.ops.{TopK => TopKOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -39,9 +39,9 @@ class TopK extends TensorflowOpsLoader {
     }
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      TopK[T, Float](k, s, startIndex = 0)
+      TopKOps[T, Float](k, s, startIndex = 0)
     } else if (t == DataType.DT_DOUBLE) {
-      TopK[T, Double](k, s, startIndex = 0)
+      TopKOps[T, Double](k, s, startIndex = 0)
     } else {
       throw new UnsupportedOperationException(s"Not support load Inv when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/TopKV2.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/TopKV2.scala
@@ -19,7 +19,7 @@ import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
-import com.intel.analytics.bigdl.nn.ops.TopK
+import com.intel.analytics.bigdl.nn.ops.{TopK => TopKOps}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
@@ -60,9 +60,9 @@ class TopKV2LoadTF[T: ClassTag](s: Boolean, t: String)(implicit ev: TensorNumeri
     val k = kTensor.value()
 
     if (t == "Float") {
-      TopK[T, Float](k, s, startIndex = 0)
+      TopKOps[T, Float](k, s, startIndex = 0)
     } else if (t == "Double") {
-      TopK[T, Double](k, s, startIndex = 0)
+      TopKOps[T, Double](k, s, startIndex = 0)
     } else {
       throw new UnsupportedOperationException(s"Not support load Inv when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Transpose.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Transpose.scala
@@ -19,7 +19,7 @@ import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
-import com.intel.analytics.bigdl.nn.{Contiguous, Sequential, Transpose}
+import com.intel.analytics.bigdl.nn.{Contiguous, Sequential, Transpose => TransposeLayer}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
@@ -85,7 +85,7 @@ class TransposeLoadTF[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends Adap
     val perm = tensorArrays(0).asInstanceOf[Tensor[Int]].storage().array()
     val paris = permToPair(perm)
     val layer = Sequential()
-    layer.add(Transpose[T](paris.map(x => (x._1 + 1, x._2 + 1))))
+    layer.add(TransposeLayer[T](paris.map(x => (x._1 + 1, x._2 + 1))))
     layer.add(Contiguous())
     layer
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/TruncateDiv.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/TruncateDiv.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.{FloorDiv, TruncateDiv}
+import com.intel.analytics.bigdl.nn.ops.{TruncateDiv => TruncateDivOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -33,7 +33,7 @@ class TruncateDiv extends TensorflowOpsLoader {
     (implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_INT32) {
-      TruncateDiv[T, Int]()
+      TruncateDivOps[T, Int]()
     } else {
       throw new UnsupportedOperationException(s"Not support load TruncateDiv when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/TruncateMod.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/TruncateMod.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.ops.Mod
+import com.intel.analytics.bigdl.nn.ops.{Mod => ModOps}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.{DataType, NodeDef}
@@ -33,11 +33,11 @@ class TruncateMod extends TensorflowOpsLoader {
     (implicit ev: TensorNumeric[T]): Module[T] = {
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
-      Mod[T, Float]()
+      ModOps[T, Float]()
     } else if (t == DataType.DT_DOUBLE) {
-      Mod[T, Double]()
+      ModOps[T, Double]()
     } else if (t == DataType.DT_INT32) {
-      Mod[T, Int]()
+      ModOps[T, Int]()
     } else {
       throw new UnsupportedOperationException(s"Not support load Mod when type is ${t}")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/VariableV2.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/VariableV2.scala
@@ -18,9 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.Identity
-import com.intel.analytics.bigdl.nn.tf.{Const, Variable, WithoutInput}
-import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.nn.tf.{Variable}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.tf.Context
 import org.tensorflow.framework.NodeDef
@@ -28,8 +26,6 @@ import org.tensorflow.framework.NodeDef
 import scala.reflect.ClassTag
 
 class VariableV2 extends TensorflowOpsLoader{
-
-  import Utils._
 
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
     context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {

--- a/spark/dl/src/main/scala/org/apache/spark/ml/DLClassifier.scala
+++ b/spark/dl/src/main/scala/org/apache/spark/ml/DLClassifier.scala
@@ -36,7 +36,7 @@ import scala.reflect.ClassTag
  */
 @deprecated("`DLClassifier` has been migrated to package `com.intel.analytics.bigdl.dlframes`." +
   "This will be removed in BigDL 0.6.", "0.5.0")
-class DLClassifier[@specialized(Float, Double) T: ClassTag](
+class DLClassifier[T: ClassTag](
     @transient override val model: Module[T],
     override val criterion : Criterion[T],
     override val featureSize : Array[Int],
@@ -69,7 +69,7 @@ class DLClassifier[@specialized(Float, Double) T: ClassTag](
  */
 @deprecated("`DLClassifierModel` is migrated to package `com.intel.analytics.bigdl.dlframes`." +
   "This will be removed in BigDL 0.6.", "0.5.0")
-class DLClassifierModel[@specialized(Float, Double) T: ClassTag](
+class DLClassifierModel[T: ClassTag](
     @transient override val model: Module[T],
     featureSize : Array[Int],
     override val uid: String = "DLClassifierModel"

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dlframes/DLEstimatorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dlframes/DLEstimatorSpec.scala
@@ -84,8 +84,8 @@ class DLEstimatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val dlModel = estimator.fit(df)
     dlModel.isInstanceOf[DLModel[_]] should be(true)
     val correct = dlModel.transform(df).select("label", "prediction").rdd.filter {
-      case Row(label: Double, prediction: Seq[Double]) =>
-        label == prediction.indexOf(prediction.max) + 1
+      case Row(label: Double, prediction: Seq[_]) =>
+        label == prediction.indexOf(prediction.asInstanceOf[Seq[Double]].max) + 1
     }.count()
     assert(correct > nRecords * 0.8)
   }
@@ -317,8 +317,8 @@ class DLEstimatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
       val pipelineModel = pipeline.fit(df)
       pipelineModel.isInstanceOf[PipelineModel] should be(true)
       val correct = pipelineModel.transform(df).select("label", "prediction").rdd.filter {
-        case Row(label: Double, prediction: Seq[Double]) =>
-          label == prediction.indexOf(prediction.max) + 1
+        case Row(label: Double, prediction: Seq[_]) =>
+          label == prediction.indexOf(prediction.asInstanceOf[Seq[Double]].max) + 1
       }.count()
       assert(correct > nRecords * 0.8)
     }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/BifurcateSplitTableSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/BifurcateSplitTableSpec.scala
@@ -15,7 +15,6 @@
  */
 package com.intel.analytics.bigdl.nn
 
-import com.intel.analytics.bigdl.nn.SplitTable
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.T
 import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ExpSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ExpSpec.scala
@@ -16,7 +16,6 @@
 
 package com.intel.analytics.bigdl.nn
 
-import com.intel.analytics.bigdl.nn.ops.Exp
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
 import org.scalatest.{FlatSpec, Matchers}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SumSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SumSpec.scala
@@ -15,7 +15,6 @@
  */
 package com.intel.analytics.bigdl.nn
 
-import com.intel.analytics.bigdl.nn.ops.Sum
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.T
 import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ops/SelectSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ops/SelectSpec.scala
@@ -15,13 +15,10 @@
  */
 package com.intel.analytics.bigdl.nn.ops
 
-import com.intel.analytics.bigdl.nn.Select
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.T
 import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
 import org.scalatest.{FlatSpec, Matchers}
-
-import scala.util.Random
 
 class SelectSpec extends FlatSpec with Matchers {
   "select" should "be correct when condition is true" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/tf/StackOpsSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/tf/StackOpsSpec.scala
@@ -16,7 +16,6 @@
 package com.intel.analytics.bigdl.nn.tf
 
 import com.intel.analytics.bigdl.nn.Graph
-import com.intel.analytics.bigdl.nn.tf.Const
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLEstimatorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DLEstimatorSpec.scala
@@ -87,8 +87,8 @@ class DLEstimatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val dlModel = estimator.fit(df)
     dlModel.isInstanceOf[DLModel[_]] should be(true)
     val correct = dlModel.transform(df).select("label", "prediction").rdd.filter {
-      case Row(label: Double, prediction: Seq[Double]) =>
-        label == prediction.indexOf(prediction.max) + 1
+      case Row(label: Double, prediction: Seq[_]) =>
+        label == prediction.indexOf(prediction.asInstanceOf[Seq[Double]].max) + 1
     }.count()
     assert(correct > nRecords * 0.8)
   }
@@ -320,8 +320,8 @@ class DLEstimatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
       val pipelineModel = pipeline.fit(df)
       pipelineModel.isInstanceOf[PipelineModel] should be(true)
       val correct = pipelineModel.transform(df).select("label", "prediction").rdd.filter {
-        case Row(label: Double, prediction: Seq[Double]) =>
-          label == prediction.indexOf(prediction.max) + 1
+        case Row(label: Double, prediction: Seq[_]) =>
+          label == prediction.indexOf(prediction.asInstanceOf[Seq[Double]].max) + 1
       }.count()
       assert(correct > nRecords * 0.8)
     }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/LSTMPeepholeSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/LSTMPeepholeSpec.scala
@@ -678,8 +678,8 @@ class LSTMPeepholeSpec  extends TorchSpec {
     val output = model.forward(input).toTensor.transpose(1, 2)
     model.backward(input, gradOutput)
 
-    rec.getHiddenState().toTable.foreach { case ((key: Int, value: Tensor[Double])) =>
-      value.map(luaState(key), (v1, v2) => {
+    rec.getHiddenState().toTable.foreach { case ((key: Int, value: Tensor[_])) =>
+      value.asInstanceOf[Tensor[Double]].map(luaState(key), (v1, v2) => {
         assert(abs(v1 - v2) <= 1e-8)
         v1
       })

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/GraphNodeSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/GraphNodeSpec.scala
@@ -22,14 +22,10 @@ import com.intel.analytics.bigdl.models.Inception
 import com.intel.analytics.bigdl.models.resnet.ResNet
 import com.intel.analytics.bigdl.models.resnet.ResNet.{DatasetType, ShortcutType}
 import com.intel.analytics.bigdl.nn._
-import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.RandomGenerator.RNG
 import org.scalatest.{FlatSpec, Matchers}
-import com.intel.analytics.bigdl.nn.Graph.ModuleNode
 import com.intel.analytics.bigdl.numeric.NumericFloat
-import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
-import com.intel.analytics.bigdl.utils.{RandomGenerator, T, Table}
-import spire.syntax.module
+import com.intel.analytics.bigdl.tensor.Tensor
 
 import scala.util.Random
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/ShapeSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/ShapeSpec.scala
@@ -38,6 +38,6 @@ class ShapeSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
   "singleShape not equal" should "be test" in {
     intercept[RuntimeException] {
-      assert(Shape(1, 2, 3) == List(Shape(1, 2, 4)))
+      assert(Shape(1, 2, 3) == Shape(1, 2, 4))
     }}
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/DataConverterSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/DataConverterSpec.scala
@@ -129,9 +129,9 @@ class DataConverterSpec extends FlatSpec with Matchers{
     map.clear()
     val retrievedValue = DataConverter.getAttributeValue(DeserializeContext(null, map, null),
       attriBulder.build)
-    retrievedValue.isInstanceOf[L1L2Regularizer[Float]] should be (true)
-    retrievedValue.asInstanceOf[L1L2Regularizer[Float]].l1 should be (regularizer.l1)
-    retrievedValue.asInstanceOf[L1L2Regularizer[Float]].l2 should be (regularizer.l2)
+    retrievedValue.isInstanceOf[L1L2Regularizer[_]] should be (true)
+    retrievedValue.asInstanceOf[L1L2Regularizer[_]].l1 should be (regularizer.l1)
+    retrievedValue.asInstanceOf[L1L2Regularizer[_]].l2 should be (regularizer.l2)
   }
 
   "L1Regularizer conversion" should  "work properly" in {
@@ -143,7 +143,7 @@ class DataConverterSpec extends FlatSpec with Matchers{
     map.clear()
     val retrievedValue = DataConverter.getAttributeValue(DeserializeContext(null, map, null),
       attriBulder.build)
-    retrievedValue.isInstanceOf[L1Regularizer[Float]] should be (true)
+    retrievedValue.isInstanceOf[L1Regularizer[_]] should be (true)
     retrievedValue.asInstanceOf[L1Regularizer[Float]].l1 should be (regularizer.l1)
   }
 
@@ -156,7 +156,7 @@ class DataConverterSpec extends FlatSpec with Matchers{
     map.clear()
     val retrievedValue = DataConverter.getAttributeValue(DeserializeContext(null, map, null),
       attriBulder.build)
-    retrievedValue.isInstanceOf[L2Regularizer[Float]] should be (true)
+    retrievedValue.isInstanceOf[L2Regularizer[_]] should be (true)
     retrievedValue.asInstanceOf[L2Regularizer[Float]].l2 should be (regularizer.l2)
   }
 
@@ -597,7 +597,7 @@ class DataConverterSpec extends FlatSpec with Matchers{
     map.clear()
     val retrievedValue = DataConverter.
       getAttributeValue(DeserializeContext(null, map, null), attr)
-    retrievedValue.isInstanceOf[Array[Tensor[Float]]] should be (true)
+    retrievedValue.isInstanceOf[Array[Tensor[_]]] should be (true)
     retrievedValue should be (tensorArray)
   }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowSpecHelper.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowSpecHelper.scala
@@ -28,6 +28,7 @@ import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, FileWriter, RandomGener
 import com.intel.analytics.bigdl.utils.tf.Tensorflow.const
 import org.tensorflow.framework.{GraphDef, NodeDef}
 
+import scala.language.postfixOps
 import scala.reflect.ClassTag
 import scala.sys.process._
 import scala.util.control.NonFatal


### PR DESCRIPTION
## What changes were proposed in this pull request?
There're too many warnings that we may ignore some useful information. This PR fix most of these warnings. Deprecation warnings will be skipped as sometimes we need to force to use some API.(e.g. some API desperate in Spark 2 but still need to be used in Spark 1)

The warnings will be treated as errors when compiling against Scala 2.11(Spark 2).

## How was this patch tested?
unit tests

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/1742

