### PR TITLE
make sure computePoolSize > 0 in object AllReduceParameter

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/parameters/AllReduceParameter.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/parameters/AllReduceParameter.scala
@@ -42,8 +42,8 @@ object AllReduceParameter {
     }
   })
 
-  private val computePoolSize: Int = System.getProperty("bigdl.Parameter.computePoolSize",
-    (Runtime.getRuntime().availableProcessors() / 2).toString).toInt
+  private val computePoolSize: Int = Math.max(System.getProperty("bigdl.Parameter.computePoolSize",
+    (Runtime.getRuntime().availableProcessors() / 2).toString).toInt, 1)
   val computePool: ExecutorService = Executors.newFixedThreadPool(computePoolSize,
     new ThreadFactory {
     override def newThread(r: Runnable): Thread = {


### PR DESCRIPTION
## What changes were proposed in this pull request?
When I run LeNet5 on MINST on a 7-node cluster (1 master and 6 slaves, each slave is configured with one core), an exception occurs: 
**2018-03-06 15:14:14 ERROR ApplicationMaster:91 - User class threw exception: java.lang.ExceptionInInitializerError
java.lang.ExceptionInInitializerError
	at com.intel.analytics.bigdl.optim.DistriOptimizer.optimize(DistriOptimizer.scala:899)
	at com.intel.analytics.bigdl.models.lenet.Train$$anonfun$main$1.apply(Train.scala:87)
	at com.intel.analytics.bigdl.models.lenet.Train$$anonfun$main$1.apply(Train.scala:36)
	at scala.Option.map(Option.scala:146)
	at com.intel.analytics.bigdl.models.lenet.Train$.main(Train.scala:36)
	at com.intel.analytics.bigdl.models.lenet.Train.main(Train.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.apache.spark.deploy.yarn.ApplicationMaster$$anon$2.run(ApplicationMaster.scala:635)
Caused by: java.lang.IllegalArgumentException
	at java.util.concurrent.ThreadPoolExecutor.<init>(ThreadPoolExecutor.java:1307)
	at java.util.concurrent.ThreadPoolExecutor.<init>(ThreadPoolExecutor.java:1230)
	at java.util.concurrent.Executors.newFixedThreadPool(Executors.java:151)
	at com.intel.analytics.bigdl.parameters.AllReduceParameter$.<init>(AllReduceParameter.scala:47)
	at com.intel.analytics.bigdl.parameters.AllReduceParameter$.<clinit>(AllReduceParameter.scala)
	... 11 more**

After the investigation, I found that java lang exceptionInInitializerError is thrown because variable computePoolSize in object AllReduceParameter is zero when the machine contains only one core.

To fix this, I change the way that computes computerPoolSize to make sure that this variable > 0

## How was this patch tested?
unit tests
computePoolSize = 1 when machine core = 1

## Related links or issues (optional)

