### PR TITLE
Keras-like API Validate Outputshape

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cropping2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cropping2D.scala
@@ -16,6 +16,7 @@
 package com.intel.analytics.bigdl.nn
 
 import com.intel.analytics.bigdl.nn.abstractnn.{DataFormat, TensorModule}
+import com.intel.analytics.bigdl.nn.keras.KerasUtils
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.Shape
@@ -52,7 +53,7 @@ class Cropping2D[T: ClassTag](
     val input = inputShape.toSingle().toArray
     require(input.length == 4,
       s"Cropping2D requires 4D input, but got input dim ${input.length}")
-    val outputShape = dataFormat match {
+    val output = dataFormat match {
       case DataFormat.NCHW =>
         Array(input(0), input(1), input(2)-heightCrop(0)-heightCrop(1),
           input(3)-widthCrop(0)-widthCrop(1))
@@ -60,7 +61,7 @@ class Cropping2D[T: ClassTag](
         Array(input(0), input(1)-heightCrop(0)-heightCrop(1),
           input(2)-widthCrop(0)-widthCrop(1), input(3))
     }
-    Shape(outputShape)
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cropping3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Cropping3D.scala
@@ -16,6 +16,7 @@
 package com.intel.analytics.bigdl.nn
 
 import com.intel.analytics.bigdl.nn.abstractnn.TensorModule
+import com.intel.analytics.bigdl.nn.keras.KerasUtils
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.Shape
@@ -55,7 +56,7 @@ class Cropping3D[T: ClassTag](
     val input = inputShape.toSingle().toArray
     require(input.length == 5,
       s"Cropping3D requires 5D input, but got input dim ${input.length}")
-    val outputShape = dataFormat match {
+    val output = dataFormat match {
       case Cropping3D.CHANNEL_FIRST =>
         Array(input(0), input(1), input(2)-dim1Crop(0)-dim1Crop(1),
           input(3)-dim2Crop(0)-dim2Crop(1), input(4)-dim3Crop(0)-dim3Crop(1))
@@ -63,7 +64,7 @@ class Cropping3D[T: ClassTag](
         Array(input(0), input(1)-dim1Crop(0)-dim1Crop(1),
           input(2)-dim2Crop(0)-dim2Crop(1), input(3)-dim3Crop(0)-dim3Crop(1), input(4))
     }
-    Shape(outputShape)
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LocallyConnected2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LocallyConnected2D.scala
@@ -16,6 +16,7 @@
 package com.intel.analytics.bigdl.nn
 
 import com.intel.analytics.bigdl.nn.abstractnn.{DataFormat, Initializable, TensorModule}
+import com.intel.analytics.bigdl.nn.keras.KerasUtils
 import com.intel.analytics.bigdl.optim.Regularizer
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.tensor.{DoubleType, FloatType, Tensor}
@@ -227,7 +228,8 @@ class LocallyConnected2D[T: ClassTag](
     require(outputWidth >= 1 && outputHeight >= 1,
       s"output size is too small. outputWidth: $outputWidth, outputHeight: $outputHeight")
     val outputShape = getOutputShape(outputHeight, outputWidth)
-    Shape(Array(input(0)) ++ outputShape)
+    val output = Array(input(0)) ++ outputShape
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Maxout.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Maxout.scala
@@ -17,6 +17,7 @@
 package com.intel.analytics.bigdl.nn
 
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, TensorModule}
+import com.intel.analytics.bigdl.nn.keras.KerasUtils
 import com.intel.analytics.bigdl.optim.Regularizer
 import com.intel.analytics.bigdl.serialization.Bigdl.{AttrValue, BigDLModule}
 import com.intel.analytics.bigdl.tensor.{DenseTensorApply, Tensor, TensorFunc6}
@@ -58,7 +59,8 @@ class Maxout[T: ClassTag](val inputSize: Int, val outputSize: Int, val maxoutNum
     val input = inputShape.toSingle().toArray
     require(input.length == 2,
       s"MaxoutDense requires 2D input, but got input dim ${input.length}")
-    Shape(input(0), outputSize)
+    val output = Array(input(0), outputSize)
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialConvolution.scala
@@ -18,6 +18,7 @@ package com.intel.analytics.bigdl.nn
 
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.{DataFormat, Initializable, TensorModule}
+import com.intel.analytics.bigdl.nn.keras.KerasUtils
 import com.intel.analytics.bigdl.nn.quantized.Quantizable
 import com.intel.analytics.bigdl.optim.Regularizer
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
@@ -193,8 +194,8 @@ class SpatialConvolution[T: ClassTag](
     val outputWidth = sizes(5)
     require(outputWidth >= 1 && outputHeight >= 1,
       s"output size is too small. outputWidth: $outputWidth, outputHeight: $outputHeight")
-    val outputShape = getOutputShape(outputHeight, outputWidth, input(0))
-    Shape(outputShape)
+    val output = getOutputShape(outputHeight, outputWidth, input(0))
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   // batchSize = -2 by default means no batch. -1 represents batch in shape inference

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialDilatedConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialDilatedConvolution.scala
@@ -18,6 +18,7 @@ package com.intel.analytics.bigdl.nn
 
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.{Initializable, TensorModule}
+import com.intel.analytics.bigdl.nn.keras.KerasUtils
 import com.intel.analytics.bigdl.optim.Regularizer
 import com.intel.analytics.bigdl.tensor.{DenseTensorBLAS, DoubleType, FloatType, Tensor}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
@@ -154,7 +155,8 @@ class SpatialDilatedConvolution[T: ClassTag](
       s"AtrousConvolution2D requires 4D input, but got input dim ${input.length}")
     val outputWidth = (input(3) + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1
     val outputHeight = (input(2) + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1
-    Shape(input(0), nOutputPlane, outputHeight, outputWidth)
+    val output = Array(input(0), nOutputPlane, outputHeight, outputWidth)
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialFullConvolution.scala
@@ -17,6 +17,7 @@
 package com.intel.analytics.bigdl.nn
 
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, Initializable}
+import com.intel.analytics.bigdl.nn.keras.KerasUtils
 import com.intel.analytics.bigdl.optim.Regularizer
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.tensor._
@@ -261,7 +262,8 @@ class SpatialFullConvolution[T: ClassTag](
     val inputWidth = input(3)
     val outputHeight = (inputHeight - 1) * dH - 2 * padH + kH + adjH
     val outputWidth = (inputWidth - 1) * dW - 2 * padW + kW + adjW
-    Shape(input(0), nOutputPlane, outputHeight, outputWidth)
+    val output = Array(input(0), nOutputPlane, outputHeight, outputWidth)
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def updateOutput(input: Activity): Tensor[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/UpSampling1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/UpSampling1D.scala
@@ -19,6 +19,7 @@ package com.intel.analytics.bigdl.nn
 import java.util
 
 import com.intel.analytics.bigdl.nn.abstractnn.TensorModule
+import com.intel.analytics.bigdl.nn.keras.KerasUtils
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.Shape
@@ -44,7 +45,8 @@ class UpSampling1D[T: ClassTag] (val length: Int)
     val input = inputShape.toSingle().toArray
     require(input.length == 3,
       s"UpSampling1D requires 3D input, but got input dim ${input.length}")
-    Shape(input(0), input(1) * length, input(2))
+    val output = Array(input(0), input(1) * length, input(2))
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/UpSampling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/UpSampling2D.scala
@@ -17,6 +17,7 @@
 package com.intel.analytics.bigdl.nn
 
 import com.intel.analytics.bigdl.nn.abstractnn.{DataFormat, TensorModule}
+import com.intel.analytics.bigdl.nn.keras.KerasUtils
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.Shape
@@ -44,12 +45,13 @@ class UpSampling2D[T: ClassTag] (val size: Array[Int], val format: DataFormat = 
     val input = inputShape.toSingle().toArray
     require(input.length == 4,
       s"UpSampling2D requires 4D input, but got input dim ${input.length}")
-    format match {
+    val output = format match {
       case DataFormat.NCHW =>
-        Shape(input(0), input(1), input(2)*size(0), input(3)*size(1))
+        Array(input(0), input(1), input(2)*size(0), input(3)*size(1))
       case DataFormat.NHWC =>
-        Shape(input(0), input(1)*size(0), input(2)*size(1), input(3))
+        Array(input(0), input(1)*size(0), input(2)*size(1), input(3))
     }
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/UpSampling3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/UpSampling3D.scala
@@ -17,6 +17,7 @@
 package com.intel.analytics.bigdl.nn
 
 import com.intel.analytics.bigdl.nn.abstractnn.TensorModule
+import com.intel.analytics.bigdl.nn.keras.KerasUtils
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.Shape
@@ -43,7 +44,8 @@ class UpSampling3D[T: ClassTag](val size: Array[Int])
     val input = inputShape.toSingle().toArray
     require(input.length == 5,
       s"UpSampling3D requires 5D input, but got input dim ${input.length}")
-    Shape(input(0), input(1), input(2)*size(0), input(3)*size(1), input(4)*size(2))
+    val output = Array(input(0), input(1), input(2)*size(0), input(3)*size(1), input(4)*size(2))
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/VolumetricConvolution.scala
@@ -17,6 +17,7 @@
 package com.intel.analytics.bigdl.nn
 
 import com.intel.analytics.bigdl.nn.abstractnn.{Initializable, TensorModule}
+import com.intel.analytics.bigdl.nn.keras.KerasUtils
 import com.intel.analytics.bigdl.optim.Regularizer
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.tensor.{DoubleType, FloatType, Tensor}
@@ -131,7 +132,8 @@ class VolumetricConvolution[T: ClassTag](
         s" Calculated output size:" +
         s" (${ nOutputPlane }x${ outputDepth }x${ outputHeight }x${ outputWidth })." +
         s" Output size is too small")
-    Shape(input(0), nOutputPlane, outputDepth, outputHeight, outputWidth)
+    val output = Array(input(0), nOutputPlane, outputDepth, outputHeight, outputWidth)
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   /**

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/IdentityOutputShape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/IdentityOutputShape.scala
@@ -18,7 +18,10 @@
 package com.intel.analytics.bigdl.nn.abstractnn
 
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.nn.keras.KerasUtils.validateSingleOutputShape
 
 trait IdentityOutputShape extends InferShape{
-  override def computeOutputShape(inputShape: Shape): Shape = inputShape
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    validateSingleOutputShape(inputShape.toSingle().toArray, this.toString)
+  }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AtrousConvolution1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AtrousConvolution1D.scala
@@ -71,7 +71,8 @@ class AtrousConvolution1D[T: ClassTag](
       s"AtrousConvolution1D requires 3D input, but got input dim ${input.length}")
     val length = KerasUtils.computeConvOutputLength(input(1), filterLength,
       "valid", subsampleLength, atrousRate)
-    Shape(input(0), length, nbFilter)
+    val output = Array(input(0), length, nbFilter)
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/BatchNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/BatchNormalization.scala
@@ -75,7 +75,7 @@ class BatchNormalization[T: ClassTag](
     val input = inputShape.toSingle().toArray
     require(input.length == 4,
       s"BatchNormalization requires 4D input, but got input dim ${input.length}")
-    inputShape
+    KerasUtils.validateSingleOutputShape(input, this.toString())
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Bidirectional.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Bidirectional.scala
@@ -53,13 +53,12 @@ class Bidirectional[T: ClassTag](
     s"Invalid merge mode: $mode")
 
   override def computeOutputShape(inputShape: Shape): Shape = {
-    val output = layer.build(inputShape)
-    if (mode == "concat") {
-      val outputArray = output.toSingle().toArray
-      outputArray(outputArray.length-1) = outputArray.last * 2
-      Shape(outputArray)
-    }
-    else output
+    val outputShape = layer.build(inputShape).toSingle().toArray
+    val output = if (mode == "concat") {
+      outputShape(outputShape.length-1) = outputShape.last * 2
+      outputShape
+    } else outputShape
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/ConvLSTM2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/ConvLSTM2D.scala
@@ -82,8 +82,9 @@ class ConvLSTM2D[T: ClassTag](
       s"ConvLSTM2D requires 5D input, but got input dim ${input.length}")
     val rows = KerasUtils.computeConvOutputLength(input(3), nbKernel, "same", subsample)
     val cols = KerasUtils.computeConvOutputLength(input(4), nbKernel, "same", subsample)
-    if (returnSequences) Shape(input(0), input(1), nbFilter, rows, cols)
-    else Shape(input(0), nbFilter, rows, cols)
+    val output = if (returnSequences) Array(input(0), input(1), nbFilter, rows, cols)
+    else Array(input(0), nbFilter, rows, cols)
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution1D.scala
@@ -70,7 +70,8 @@ class Convolution1D[T: ClassTag](
       s"Convolution1D requires 3D input, but got input dim ${input.length}")
     val outputLength = KerasUtils.computeConvOutputLength(input(1), filterLength,
       borderMode, subsampleLength)
-    Shape(input(0), outputLength, nbFilter)
+    val output = Array(input(0), outputLength, nbFilter)
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Cropping1D.scala
@@ -47,7 +47,8 @@ class Cropping1D[T: ClassTag](
     val input = inputShape.toSingle().toArray
     require(input.length == 3,
       s"Cropping1D requires 3D input, but got input dim ${input.length}")
-    Shape(input(0), input(1)-cropping(0)-cropping(1), input(2))
+    val output = Array(input(0), input(1)-cropping(0)-cropping(1), input(2))
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Dense.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Dense.scala
@@ -60,7 +60,8 @@ class Dense[T: ClassTag](
     val input = inputShape.toSingle().toArray
     require(inputShape.toSingle().size >=2,
       s"Dense requires input dim >=2, but got dim: ${inputShape.toSingle().length}")
-    Shape(input.slice(0, input.length -1) ++ Array(outputDim))
+    val output = input.slice(0, input.length -1) ++ Array(outputDim)
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/ELU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/ELU.scala
@@ -42,8 +42,7 @@ class ELU[T: ClassTag](
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val layer = com.intel.analytics.bigdl.nn.ELU(
-      alpha = alpha,
-      inplace = false)
+      alpha = alpha)
     layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Embedding.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Embedding.scala
@@ -53,7 +53,8 @@ class Embedding[T: ClassTag](
     val input = inputShape.toSingle().toArray
     require(input.length == 2,
       s"Embedding requires 2D input, but got input dim ${input.length}")
-    Shape(input(0), input(1), outputDim)
+    val output = Array(input(0), input(1), outputDim)
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Flatten.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Flatten.scala
@@ -37,7 +37,8 @@ class Flatten[T: ClassTag](
 
   override def computeOutputShape(inputShape: Shape): Shape = {
     val input = inputShape.toSingle().toArray
-    Shape(input(0), input.slice(1, input.length).product)
+    val output = Array(input(0), input.slice(1, input.length).product)
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalPooling1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalPooling1D.scala
@@ -35,6 +35,7 @@ abstract class GlobalPooling1D[T: ClassTag](
     val input = inputShape.toSingle().toArray
     require(input.length == 3,
       s"GlobalPooling1D requires 3D input, but got input dim ${input.length}")
-    Shape(input(0), input(2))
+    val output = Array(input(0), input(2))
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalPooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalPooling2D.scala
@@ -37,10 +37,11 @@ abstract class GlobalPooling2D[T: ClassTag](
     val input = inputShape.toSingle().toArray
     require(input.length == 4,
       s"GlobalPooling2D requires 4D input, but got input dim ${input.length}")
-    dimOrdering match {
-      case DataFormat.NCHW => Shape(input(0), input(1))
-      case DataFormat.NHWC => Shape(input(0), input(3))
+    val output = dimOrdering match {
+      case DataFormat.NCHW => Array(input(0), input(1))
+      case DataFormat.NHWC => Array(input(0), input(3))
     }
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalPooling3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/GlobalPooling3D.scala
@@ -39,6 +39,7 @@ abstract class GlobalPooling3D[T: ClassTag](
     val input = inputShape.toSingle().toArray
     require(input.length == 5,
       s"GlobalPooling3D requires 5D input, but got input dim ${input.length}")
-    Shape(input(0), input(1))
+    val output = Array(input(0), input(1))
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Highway.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Highway.scala
@@ -54,7 +54,7 @@ class Highway[T: ClassTag](
     val input = inputShape.toSingle().toArray
     require(input.length == 2,
       s"Highway requires 2D input, but got input dim ${input.length}")
-    inputShape
+    KerasUtils.validateSingleOutputShape(input, this.toString())
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasUtils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasUtils.scala
@@ -20,6 +20,7 @@ import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
 
 import scala.reflect.ClassTag
 
@@ -104,6 +105,14 @@ object KerasUtils {
       case "tf" => "CHANNEL_LAST"
       case "th" => "CHANNEL_FIRST"
     }
+  }
+
+  private[bigdl] def validateSingleOutputShape(shape: Array[Int], layerName: String): Shape = {
+    for (i <- shape.slice(1, shape.length)) {
+      require(i > 0, s"$layerName will result in an invalid " +
+        s"output shape (${shape.mkString(", ")}). Please check your layer parameters")
+    }
+    Shape(shape)
   }
 
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/LocallyConnected1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/LocallyConnected1D.scala
@@ -65,7 +65,8 @@ class LocallyConnected1D[T: ClassTag](
       s"LocallyConnected1D requires 3D input, but got input dim ${input.length}")
     val length = KerasUtils.computeConvOutputLength(input(1), filterLength,
       "valid", subsampleLength)
-    Shape(input(0), length, nbFilter)
+    val output = Array(input(0), length, nbFilter)
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Permute.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Permute.scala
@@ -80,13 +80,13 @@ class Permute[T: ClassTag](
 
   override def computeOutputShape(inputShape: Shape): Shape = {
     val input = inputShape.toSingle().toArray
-    val outputShape = input.clone()
+    val output = input.clone()
     var i = 0
     while (i < dims.length) {
-      outputShape(i + 1) = input(dims(i))
+      output(i + 1) = input(dims(i))
       i += 1
     }
-    Shape(outputShape)
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling1D.scala
@@ -44,6 +44,7 @@ abstract class Pooling1D[T: ClassTag](
       s"Pooling1D requires 3D input, but got input dim ${input.length}")
     val outputLength = KerasUtils.computeConvOutputLength(input(1), poolLength,
       borderMode, strideValue)
-    Shape(input(0), outputLength, input(2))
+    val output = Array(input(0), outputLength, input(2))
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling2D.scala
@@ -54,9 +54,10 @@ abstract class Pooling2D[T: ClassTag](
       borderMode, strideValues(0))
     val cols = KerasUtils.computeConvOutputLength(input(dimW -1), poolSize(1),
       borderMode, strideValues(1))
-    dimOrdering match {
-      case DataFormat.NCHW => Shape(input(0), input(1), rows, cols)
-      case DataFormat.NHWC => Shape(input(0), rows, cols, input(3))
+    val output = dimOrdering match {
+      case DataFormat.NCHW => Array(input(0), input(1), rows, cols)
+      case DataFormat.NHWC => Array(input(0), rows, cols, input(3))
     }
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling3D.scala
@@ -54,6 +54,7 @@ abstract class Pooling3D[T: ClassTag](
       "valid", strideValues(1))
     val dim3Length = KerasUtils.computeConvOutputLength(input(4), poolSize(2),
       "valid", strideValues(2))
-    Shape(input(0), input(1), dim1Length, dim2Length, dim3Length)
+    val output = Array(input(0), input(1), dim1Length, dim2Length, dim3Length)
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Recurrent.scala
@@ -40,8 +40,9 @@ abstract class Recurrent[T: ClassTag](
     val input = inputShape.toSingle().toArray
     require(input.length == 3,
       s"Recurrent layers require 3D input, but got input dim ${input.length}")
-    if (returnSequences) Shape(input(0), input(1), outputDim)
-    else Shape(input(0), outputDim)
+    val output = if (returnSequences) Array(input(0), input(1), outputDim)
+    else Array(input(0), outputDim)
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   def buildCell(input: Array[Int]): Cell[T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/RepeatVector.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/RepeatVector.scala
@@ -43,7 +43,8 @@ class RepeatVector[T: ClassTag](
     val input = inputShape.toSingle().toArray
     require(input.length == 2,
       s"RepeatVector requires 2D input, but got input dim ${input.length}")
-    Shape(input(0), n, input(1))
+    val output = Array(input(0), n, input(1))
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Reshape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Reshape.scala
@@ -81,7 +81,8 @@ class Reshape[T: ClassTag](
           s"original size is: ${ nonBatchInput.product }, " +
           s"reshape size is: ${ targetShape.product }")
     }
-    Shape(Array(input(0)) ++ targetShape)
+    val output = Array(input(0)) ++ targetShape
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SoftMax.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SoftMax.scala
@@ -35,7 +35,7 @@ class SoftMax[T: ClassTag](
     val input = inputShape.toSingle().toArray
     require(input.length == 2 || input.length == 3,
       s"SoftMax requires 2D or 3D input, but got input dim ${input.length}")
-    inputShape
+    KerasUtils.validateSingleOutputShape(input, this.toString())
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/TimeDistributed.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/TimeDistributed.scala
@@ -53,7 +53,7 @@ class TimeDistributed[T: ClassTag](
     val innerInput = getInnerInput(input)
     val innerOutput = layer.build(Shape(innerInput)).toSingle()
     val output = innerOutput.take(1) ++ List(input(1)) ++ innerOutput.drop(1)
-    Shape(output.toArray)
+    KerasUtils.validateSingleOutputShape(output.toArray, this.toString())
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/ZeroPadding1D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/ZeroPadding1D.scala
@@ -49,7 +49,8 @@ class ZeroPadding1D[T: ClassTag](
     val input = inputShape.toSingle().toArray
     require(input.length == 3,
       s"ZeroPadding1D requires 3D input, but got input dim ${input.length}")
-    Shape(input(0), input(1) + padding(0) + padding(1), input(2))
+    val output = Array(input(0), input(1) + padding(0) + padding(1), input(2))
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/ZeroPadding2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/ZeroPadding2D.scala
@@ -54,14 +54,15 @@ class ZeroPadding2D[T: ClassTag](
     val input = inputShape.toSingle().toArray
     require(input.length == 4,
       s"ZeroPadding2D requires 4D input, but got input dim ${input.length}")
-    dimOrdering match {
+    val output = dimOrdering match {
       case DataFormat.NCHW =>
-        Shape(input(0), input(1),
+        Array(input(0), input(1),
           input(2) + padding(0) + padding(1), input(3) + padding(2) + padding(3))
       case DataFormat.NHWC =>
-        Shape(input(0), input(1) + padding(0) + padding(1),
+        Array(input(0), input(1) + padding(0) + padding(1),
           input(2) + padding(2) + padding(3), input(3))
     }
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/ZeroPadding3D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/ZeroPadding3D.scala
@@ -55,14 +55,15 @@ class ZeroPadding3D[T: ClassTag](
     val input = inputShape.toSingle().toArray
     require(input.length == 5,
       s"ZeroPadding3D requires 5D input, but got input dim ${input.length}")
-    dimOrdering.toLowerCase() match {
+    val output = dimOrdering.toLowerCase() match {
       case "channel_first" =>
-        Shape(input(0), input(1), input(2) + 2 * padding(0),
+        Array(input(0), input(1), input(2) + 2 * padding(0),
           input(3) + 2 * padding(1), input(4) + 2 * padding(2))
       case "channel_last" =>
-        Shape(input(0), input(1) + 2 * padding(0), input(2) + 2 * padding(1),
+        Array(input(0), input(1) + 2 * padding(0), input(2) + 2 * padding(1),
           input(3) + 2 * padding(2), input(4))
     }
+    KerasUtils.validateSingleOutputShape(output, this.toString())
   }
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/HighwaySpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/HighwaySpec.scala
@@ -29,8 +29,8 @@ class HighwaySpec extends KerasBaseSpec {
 
   "Highway computeOutputShape" should "work properly" in {
     val seq = KSequential[Float]()
-    val klayer = Highway[Float](inputShape = Shape(6))
-    seq.add(klayer)
+    val layer = Highway[Float](inputShape = Shape(6))
+    seq.add(layer)
     seq.add(Dense(5))
     seq.getOutputShape().toSingle().toArray should be (Array(-1, 5))
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When computing output shape for new layers, ensure that the output shape has all positive entries (excluding batch). This can prevent cases such as too small input for cropping at the time of building a layer instead of at the time of doing forward.

After removing all computing output shape logic to new layers, we can put `computeOutputShape` before creating `labor` and this will save effort if the model will lead to an invalid output.

## How was this patch tested?

Jenkins

