### PR TITLE
[Enhancement] make SparseMiniBatch supporting TensorDataTypes other than T

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/MiniBatch.scala
@@ -620,32 +620,56 @@ class SparseMiniBatch[T: ClassTag](
     target
   }
 
+  private def initTensor(sample: Tensor[_]): Tensor[_] = sample match {
+    case s if s.getTensorType == SparseType =>
+      s.getType() match {
+        case tpe if tpe == BooleanType =>
+          Tensor.sparse[Boolean](Array(batchSize) ++ s.size())
+        case tpe if tpe == CharType =>
+          Tensor.sparse[Char](Array(batchSize) ++ s.size())
+        case tpe if tpe == StringType =>
+          Tensor.sparse[String](Array(batchSize) ++ s.size())
+        case tpe if tpe == IntType =>
+          Tensor.sparse[Int](Array(batchSize) ++ s.size())
+        case tpe if tpe == ShortType =>
+          Tensor.sparse[Short](Array(batchSize) ++ s.size())
+        case tpe if tpe == LongType =>
+          Tensor.sparse[Long](Array(batchSize) ++ s.size())
+        case tpe if tpe == FloatType =>
+          Tensor.sparse[Float](Array(batchSize) ++ s.size())
+        case tpe if tpe == DoubleType =>
+          Tensor.sparse[Double](Array(batchSize) ++ s.size())
+      }
+    case s if s.getTensorType == DenseType =>
+      s.getType() match {
+        case tpe if tpe == BooleanType =>
+          Tensor[Boolean](Array(batchSize) ++ s.size())
+        case tpe if tpe == CharType =>
+          Tensor[Char](Array(batchSize) ++ s.size())
+        case tpe if tpe == StringType =>
+          Tensor[String](Array(batchSize) ++ s.size())
+        case tpe if tpe == IntType =>
+          Tensor[Int](Array(batchSize) ++ s.size())
+        case tpe if tpe == ShortType =>
+          Tensor[Short](Array(batchSize) ++ s.size())
+        case tpe if tpe == LongType =>
+          Tensor[Long](Array(batchSize) ++ s.size())
+        case tpe if tpe == FloatType =>
+          Tensor[Float](Array(batchSize) ++ s.size())
+        case tpe if tpe == DoubleType =>
+          Tensor[Double](Array(batchSize) ++ s.size())
+      }
+    case s =>
+      throw new IllegalArgumentException(s"MiniBatchWithSparse: unsupported feature type " +
+        s"${s.getTensorType}")
+  }
+
   def init(features: Array[Tensor[T]], labels: Array[Tensor[T]]): Unit = {
-    var i = 0
-    while (i < inputData.length) {
-      val featureI = features(i)
-      inputData(i) = if (featureI.getTensorType == SparseType) {
-        Tensor.sparse[T](Array(batchSize) ++ featureI.size())
-      } else if (featureI.getTensorType == DenseType) {
-        Tensor[T](Array(batchSize) ++ featureI.size())
-      } else {
-        throw new IllegalArgumentException(s"MiniBatchWithSparse: unsupported feature type " +
-          s"${featureI.getTensorType}")
-      }
-      i += 1
+    features.zipWithIndex.foreach { case (feature, index) =>
+      inputData(index) = initTensor(feature).asInstanceOf[Tensor[T]]
     }
-    i = 0
-    while (i < targetData.length) {
-      val labelI = labels(i)
-      targetData(i) = if (labelI.getTensorType == SparseType) {
-        Tensor.sparse[T](Array(batchSize) ++ labelI.size())
-      } else if (labelI.getTensorType == DenseType) {
-        Tensor[T](Array(batchSize) ++ labelI.size())
-      } else {
-        throw new IllegalArgumentException(s"MiniBatchWithSparse: unsupported label type " +
-          s"${labelI.getTensorType}")
-      }
-      i += 1
+    labels.zipWithIndex.foreach { case (label, index) =>
+      targetData(index) = initTensor(label).asInstanceOf[Tensor[T]]
     }
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Sample.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/Sample.scala
@@ -516,4 +516,29 @@ object TensorSample {
     typeCheck(featureTensor)
     new TensorSample[T](Array(featureTensor), Array(Tensor(1).fill(label)))
   }
+
+  /**
+   * Create a TensorSample which is able to contains Tensors with different types.
+   *
+   * @tparam T main type
+   * @param featureTensors feature tensors
+   * @param labelTensors label tensors, can be null or empty, default value is null
+   * @return TensorSample
+   */
+  def create[T: ClassTag](
+      featureTensors: Array[Tensor[_]],
+      labelTensors: Array[Tensor[_]] = null)
+    (implicit ev: TensorNumeric[T]) : Sample[T] = {
+    if (labelTensors == null || labelTensors.isEmpty) {
+      TensorSample(wrapType(featureTensors))
+    } else {
+      TensorSample(wrapType(featureTensors), wrapType(labelTensors))
+    }
+  }
+
+  private def wrapType[T: ClassTag](tensor: Array[Tensor[_]])
+    (implicit ev: TensorNumeric[T]): Array[Tensor[T]] = {
+    tensor.map(_.asInstanceOf[Tensor[T]])
+  }
+
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/SparseTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/SparseTensor.scala
@@ -1146,7 +1146,7 @@ object SparseTensor{
       val curLength = currentTensor.nElement()
       val curTensorOffset = currentTensor.storageOffset() - 1
       // copy to concat _values
-      ev.arraycopy(currentTensor.storage().array(), curTensorOffset,
+      System.arraycopy(currentTensor.storage().array(), curTensorOffset,
         res.storage().array(), offset, curLength)
       // make new Indices
       var indicesIndex = 0

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/MiniBatchSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/MiniBatchSpec.scala
@@ -109,4 +109,34 @@ class MiniBatchSpec extends FlatSpec with Matchers {
     target should be (expectedTarget)
   }
 
+  "SparseTensorMiniBatch with different TensorTypes" should "return right result" in {
+    val a1 = Tensor.sparse(Tensor[Double](4).range(1, 4, 1)).asInstanceOf[Tensor[Float]]
+    val a2 = Tensor.sparse(Tensor[Double](4).range(5, 8, 1)).asInstanceOf[Tensor[Float]]
+    val b1 = Tensor[String](5)
+      .setValue(1, "a").setValue(2, "b").setValue(3, "c").setValue(4, "d").setValue(5, "e")
+      .asInstanceOf[Tensor[Float]]
+    val b2 = Tensor[String](5)
+      .setValue(1, "1").setValue(2, "2").setValue(3, "3").setValue(4, "4").setValue(5, "5")
+      .asInstanceOf[Tensor[Float]]
+    val c1 = Tensor[Double](1).fill(1).asInstanceOf[Tensor[Float]]
+    val c2 = Tensor[Double](1).fill(0).asInstanceOf[Tensor[Float]]
+    val sample1 = TensorSample[Float](Array(a1, b1), Array(c1))
+    val sample2 = TensorSample[Float](Array(a2, b2), Array(c2))
+    val miniBatch = SparseMiniBatch[Float](2, 1)
+    miniBatch.set(Array(sample1, sample2))
+
+    val input = miniBatch.getInput()
+    val target = miniBatch.getTarget()
+
+    val expectedInput1 = Tensor.sparse(Array(Array(0, 0, 0, 0, 1, 1, 1, 1),
+      Array(0, 1, 2, 3, 0, 1, 2, 3)),
+      Array.range(1, 9).map(_.toFloat), Array(2, 4))
+    input.toTable[Tensor[Double]](1) should be (expectedInput1)
+    input.toTable[Tensor[String]](2).storage().array() should be (Array(
+      "a", "b", "c", "d", "e", "1", "2", "3", "4", "5"))
+
+    val expectedTarget = Tensor[Double](T(1.0, 0.0)).reshape(Array(2, 1))
+    target should be (expectedTarget)
+  }
+
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/MiniBatchSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dataset/MiniBatchSpec.scala
@@ -110,18 +110,18 @@ class MiniBatchSpec extends FlatSpec with Matchers {
   }
 
   "SparseTensorMiniBatch with different TensorTypes" should "return right result" in {
-    val a1 = Tensor.sparse(Tensor[Double](4).range(1, 4, 1)).asInstanceOf[Tensor[Float]]
-    val a2 = Tensor.sparse(Tensor[Double](4).range(5, 8, 1)).asInstanceOf[Tensor[Float]]
+    val a1 = Tensor.sparse(Tensor[Double](4).range(1, 4, 1))
+    val a2 = Tensor.sparse(Tensor[Double](4).range(5, 8, 1))
     val b1 = Tensor[String](5)
-      .setValue(1, "a").setValue(2, "b").setValue(3, "c").setValue(4, "d").setValue(5, "e")
-      .asInstanceOf[Tensor[Float]]
+      .setValue(1, "a").setValue(2, "b")
+      .setValue(3, "c").setValue(4, "d").setValue(5, "e")
     val b2 = Tensor[String](5)
-      .setValue(1, "1").setValue(2, "2").setValue(3, "3").setValue(4, "4").setValue(5, "5")
-      .asInstanceOf[Tensor[Float]]
-    val c1 = Tensor[Double](1).fill(1).asInstanceOf[Tensor[Float]]
-    val c2 = Tensor[Double](1).fill(0).asInstanceOf[Tensor[Float]]
-    val sample1 = TensorSample[Float](Array(a1, b1), Array(c1))
-    val sample2 = TensorSample[Float](Array(a2, b2), Array(c2))
+      .setValue(1, "1").setValue(2, "2")
+      .setValue(3, "3").setValue(4, "4").setValue(5, "5")
+    val c1 = Tensor[Double](1).fill(1)
+    val c2 = Tensor[Double](1).fill(0)
+    val sample1 = TensorSample.create[Float](Array(a1, b1), Array(c1))
+    val sample2 = TensorSample.create[Float](Array(a2, b2), Array(c2))
     val miniBatch = SparseMiniBatch[Float](2, 1)
     miniBatch.set(Array(sample1, sample2))
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

As Modules(Operations) with Tensor types other than [T] added, it is necessary to support batching samples which contains Tensors of multi-types(some types other than [T]). 
For instances, 

     val t1 = Tensor[Double](3).rand()
     val t2 = Tensor[Float](3).rand()
     val sample = TensorSample.create[Float](Array(t1, t2))
     val miniBatch = SparseMiniBatch[Float](2, 0)
     miniBatch.set(Seq(sample))
   
## How was this patch tested?

unit test
