### PR TITLE
[BugFix] TensorOp & SelectTensor

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Util.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Util.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.utils
 
-import java.io.{ByteArrayInputStream, IOException, ObjectInputStream, ObjectStreamClass}
+import java.io._
 
 import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
@@ -24,7 +24,6 @@ import com.intel.analytics.bigdl.tensor.{QuantizedTensor, QuantizedType, Storage
 import org.apache.commons.lang3.SerializationException
 
 import scala.reflect.ClassTag
-import scala.tools.nsc.interpreter.InputStream
 import scala.util.Try
 
 object Util {
@@ -147,8 +146,8 @@ object Util {
   }
 
   private[bigdl] def putWeightBias[T: ClassTag](
-    broadcastWeightBias: Array[Tensor[T]],
-    localModel: Module[T])(implicit ev: TensorNumeric[T]): Unit = {
+      broadcastWeightBias: Array[Tensor[T]],
+      localModel: Module[T])(implicit ev: TensorNumeric[T]): Unit = {
     val localWeightBias = localModel.parameters()._1
     var i = 0
     while (i < localWeightBias.length) {
@@ -160,8 +159,8 @@ object Util {
   }
 
   private[bigdl] def initGradWeightBias[T: ClassTag](
-    broadcastWeightBias: Array[Tensor[T]],
-    localModel: Module[T])(implicit ev: TensorNumeric[T]): Unit = {
+      broadcastWeightBias: Array[Tensor[T]],
+      localModel: Module[T])(implicit ev: TensorNumeric[T]): Unit = {
     val (localWeightBias, localGradWeightBias) = localModel.parameters()
     // init gradient with a compacted storage
     val storage = Storage[T](localGradWeightBias.map(_.nElement()).sum)
@@ -178,23 +177,6 @@ object Util {
         }
       }
       i += 1
-    }
-  }
-
-
-  private[bigdl] def excludeNotTorch[T: ClassTag]
-  (modules : Seq[AbstractModule[_, _, T]]): Unit = {
-    val invalidNodes = modules.filter{!_.isCompatibleWithTorch()}
-    if (invalidNodes.length > 0) {
-      throw new RuntimeException(s"Do not mix with Layer: ${invalidNodes.mkString(",")}")
-    }
-  }
-
-  private[bigdl] def excludeNotKeras[T: ClassTag]
-  (modules : Seq[AbstractModule[_, _, T]]): Unit = {
-    val invalidNodes = modules.filter{!_.isCompatibleWithKeras()}
-    if (invalidNodes.length > 0) {
-      throw new RuntimeException(s"Do not mix with Layer: ${invalidNodes.mkString(",")}")
     }
   }
 
@@ -238,6 +220,5 @@ object Util {
       if (in != null) Try(in.close())
     }
   }
-
 
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ops/SelectTensorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ops/SelectTensorSpec.scala
@@ -18,12 +18,68 @@ package com.intel.analytics.bigdl.nn.ops
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.T
 import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+import org.scalatest.{FlatSpec, Matchers}
 
+
+class SelectTensorSpec extends FlatSpec with Matchers  {
+
+  private val t1 = Tensor[Double](2, 3).randn()
+  private val t2 = Tensor[Double](2, 3).randn()
+  private val t3 = Tensor[Double](2, 3).randn()
+  private val t4 = Tensor[Double](2, 3).randn()
+  private val t5 = Tensor[Double](2, 3).randn()
+  private val table = T()
+    .update(Tensor.scalar(1), t1)
+    .update(Tensor.scalar("2"), t2)
+    .update(3, t3)
+    .update(4.0f, t4)
+    .update("5", t5)
+
+  "SelectedTensor with TensorKey" should "work correctly" in {
+    val t1Copy = SelectTensor[Double](Tensor.scalar(1)).forward(table)
+    t1Copy shouldEqual t1
+    val t1Values = t1.storage().array().clone()
+    t1Copy.square()
+    t1.storage().array() shouldEqual t1Values
+    t1Copy.storage().array() shouldEqual t1Values.map(e => e * e)
+
+    val t2Copy = SelectTensor[Double](Tensor.scalar("2"), true).forward(table)
+    t2Copy shouldEqual t2
+  }
+
+  "SelectedTensor with primitive Key" should "work correctly" in {
+    val t3Copy = SelectTensor[Double, Int](3).forward(table)
+    t3Copy shouldEqual t3
+
+    val t4Copy = SelectTensor[Double](Tensor.scalar(4.0f), false).forward(table)
+    t4Copy shouldEqual t4
+
+    val t5Copy = SelectTensor[Double, String]("5").forward(table)
+    t5Copy shouldEqual t5
+  }
+
+  "SelectedTensor with transformer" should "work correctly" in {
+    val transformer = (TensorOp[Double]() ** 3 * 4.5).ceil
+    var select = SelectTensor(Tensor.scalar("2"), transformer = transformer)
+    val t2Values = t2.storage().array().clone()
+    val t2Convert = select.forward(table)
+    t2Convert.storage().array() shouldEqual
+      t2Values.map(e => math.ceil(math.pow(e, 3) * 4.5))
+
+    val transformer2 = TensorOp[Double]().abs.ceil.inv * 3.0
+    select = SelectTensor(Tensor.scalar("5"), false, transformer = transformer2)
+    val t5Values = t5.storage().array().clone()
+    val t5Convert = select.forward(table)
+    t5Convert.storage().array() shouldEqual
+      t5Values.map(e => 3.0 / math.ceil(math.abs(e)))
+  }
+
+}
 
 class SelectTensorSerialTest extends ModuleSerializationTest {
   override def test(): Unit = {
     val transformer = (TensorOp[Float]() ** 3 * 4.5f).ceil
-    val select = SelectTensor(Tensor.scalar("2"), transformer)
+    val select = SelectTensor(Tensor.scalar("2"), transformer = transformer)
     val t1 = Tensor[Float](3, 4).randn()
     val t2 = Tensor[Float](2, 3).randn()
     val input = T().update(Tensor.scalar(1), t1).update(Tensor.scalar("2"), t2)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ops/TensorOpSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ops/TensorOpSpec.scala
@@ -19,7 +19,6 @@ package com.intel.analytics.bigdl.nn.ops
 import com.intel.analytics.bigdl.nn.Sigmoid
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
-import com.intel.analytics.bigdl.utils.T
 import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -108,29 +107,6 @@ class TensorOpSpec extends FlatSpec with Matchers {
     op1.forward(tt) shouldEqual Sigmoid[Float]().forward(cpy).inv().sqrt()
     val op2 = op -> TensorOp.sigmoid[Float]().inv.sqrt
     op2.forward(tt) shouldEqual Sigmoid[Float]().forward(cpy).inv().sqrt()
-  }
-
-  private val t1 = Tensor[Float](3, 4).randn()
-  private val t2 = Tensor[Double](2, 3).randn()
-  private val table = T().update(Tensor.scalar(1), t1).update(Tensor.scalar("2"), t2)
-
-  "SelectedTensor without transformer" should "work correctly" in {
-    val t1Copy = SelectTensor[Float](Tensor.scalar(1)).forward(table)
-    t1Copy shouldEqual t1
-    val t1Values = t1.storage().array().clone()
-    t1Copy.square()
-    t1.storage().array() shouldEqual t1Values
-    t1Copy.storage().array() shouldEqual t1Values.map(e => e * e)
-  }
-
-  "SelectedTensor with transformer" should "work correctly" in {
-    val transformer = (TensorOp[Double]() ** 3 * 4.5).ceil
-    val select = SelectTensor(Tensor.scalar("2"), transformer)
-    val t2Values = t2.storage().array().clone()
-    val t2Convert = select.forward(table)
-    t2.storage().array() shouldEqual t2Values
-    t2Convert.storage().array() shouldEqual
-      t2Values.map(e => math.ceil(math.pow(e, 3) * 4.5))
   }
 
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/OperationSerializerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/serializer/OperationSerializerSpec.scala
@@ -787,7 +787,7 @@ class OperationSerializerSpec extends SerializerSpecHelper {
 
   "SelectTensor serializer" should "work properly" in {
     val transformer = (TensorOp[Float]() ** 3 * 4.5f).ceil
-    val select = SelectTensor(Tensor.scalar("2"), transformer)
+    val select = SelectTensor(Tensor.scalar("2"), transformer = transformer)
     val t1 = Tensor[Float](3, 4).randn()
     val t2 = Tensor[Float](2, 3).randn()
     val input = T().update(Tensor.scalar(1), t1).update(Tensor.scalar("2"), t2)


### PR DESCRIPTION
## What changes were proposed in this pull request?

1.  __ClassNotFoundException__ were caught occasionally when deserializing TensorOp$.ClosureWrapper, which may be caused by _latestUserDefinedloader_  in _ObjectInputStream.resolveClass_ .
  So, re-implement a Java deserialize Method , in which _ObjectInputStream.resolveClass_ is overridden. 

2.  __SelectTensor__ couldn't be used to fetch _Tensor_ from _Table_ with incremental keys. 
   So,  add an option(_isTensorKey_) to let user decide whether  the key is a primitive type or a scalar tensor. 

## How was this patch tested?

unit test
