### PR TITLE
Fix reload model in python

### DIFF
--- a/pyspark/bigdl/keras/backend.py
+++ b/pyspark/bigdl/keras/backend.py
@@ -25,8 +25,9 @@ class KerasModelWrapper:
         show_bigdl_info_logs()
         self.bmodel = DefinitionLoader.from_kmodel(kmodel)
         WeightLoader.load_weights_from_kmodel(self.bmodel, kmodel)  # share the same weight.
-        self.criterion = OptimConverter.to_bigdl_criterion(kmodel.loss)
-        self.optim_method = OptimConverter.to_bigdl_optim_method(kmodel.optimizer)
+        self.criterion = OptimConverter.to_bigdl_criterion(kmodel.loss) if kmodel.loss else None
+        self.optim_method =\
+            OptimConverter.to_bigdl_optim_method(kmodel.optimizer) if kmodel.optimizer else None
         self.metrics = OptimConverter.to_bigdl_metrics(kmodel.metrics) if kmodel.metrics else None
 
     def evaluate(self, x, y, batch_size=32, sample_weight=None, is_distributed=False):

--- a/pyspark/bigdl/nn/keras/layer.py
+++ b/pyspark/bigdl/nn/keras/layer.py
@@ -16,7 +16,7 @@
 
 import sys
 
-from bigdl.nn.layer import Layer, Node
+from bigdl.nn.layer import Layer, Node, SharedStaticUtils, Container
 from bigdl.util.common import callBigDlFunc, JTensor, JavaValue
 
 if sys.version >= '3':

--- a/pyspark/bigdl/nn/keras/topology.py
+++ b/pyspark/bigdl/nn/keras/topology.py
@@ -19,8 +19,10 @@ from bigdl.dataset.dataset import *
 from bigdl.keras.optimization import OptimConverter
 import multiprocessing
 
+from bigdl.nn.layer import SharedStaticUtils, Container
 
-class KerasModel(KerasLayer):
+
+class KerasModel(KerasLayer, Container, SharedStaticUtils):
     def compile(self, optimizer, loss, metrics=None):
         """
         Configures the learning process. Must be called before fit.
@@ -143,8 +145,19 @@ class Sequential(KerasModel):
     >>> sequential = Sequential(name="seq1")
     creating: createKerasSequential
     """
-    def __init__(self, **kwargs):
-        super(Sequential, self).__init__(None, **kwargs)
+    def __init__(self, jvalue=None, **kwargs):
+        super(Sequential, self).__init__(jvalue, **kwargs)
+
+    @staticmethod
+    def from_jvalue(jvalue, bigdl_type="float"):
+        """
+        Create a Python Model base on the given java value
+        :param jvalue: Java object create by Py4j
+        :return: A Python Model
+        """
+        model = Sequential(jvalue=jvalue)
+        model.value = jvalue
+        return model
 
     def add(self, model):
         self.value.add(model.value)
@@ -160,8 +173,18 @@ class Model(KerasModel):
     output: An output node or a list of output nodes.
     name: String to specify the name of the graph model. Default is None.
     """
-    def __init__(self, input, output, **kwargs):
-        super(Model, self).__init__(None,
+    def __init__(self, input, output, jvalue=None,  **kwargs):
+        super(Model, self).__init__(jvalue,
                                     to_list(input),
                                     to_list(output),
                                     **kwargs)
+    @staticmethod
+    def from_jvalue(jvalue, bigdl_type="float"):
+        """
+        Create a Python Model base on the given java value
+        :param jvalue: Java object create by Py4j
+        :return: A Python Model
+        """
+        model = Model([], [], jvalue=jvalue)
+        model.value = jvalue
+        return model

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -102,10 +102,8 @@ class SharedStaticUtils():
             base_module = importlib.import_module('bigdl.nn.keras.topology')
         elif "com.intel.analytics.bigdl.nn.keras" == jpackage_name:
             base_module = importlib.import_module('bigdl.nn.keras.layer')
-        elif "com.intel.analytics.bigdl.nn" == jpackage_name:
-            base_module = importlib.import_module('bigdl.nn.layer')
         else:
-            raise Exception("Not supported type: %s" % jname)
+            base_module = importlib.import_module('bigdl.nn.layer')
 
         realClassName = "Layer" # The top base class
         if pclass_name in dir(base_module):

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -16,6 +16,7 @@
 
 
 import sys
+import importlib
 
 import numpy as np
 import six
@@ -60,7 +61,62 @@ class Node(JavaValue):
         callJavaFunc(self.value.removeNextEdges)
 
 
-class Layer(JavaValue):
+class SharedStaticUtils():
+
+    @staticmethod
+    def load(path, bigdl_type="float"):
+        """
+        Load a pre-trained Bigdl model.
+
+        :param path: The path containing the pre-trained model.
+        :return: A pre-trained model.
+        """
+        jmodel = callBigDlFunc(bigdl_type, "loadBigDL", path)
+        return Layer.of(jmodel)
+
+
+    @staticmethod
+    def of(jvalue, bigdl_type="float"):
+        """
+        Create a Python Layer base on the given java value and the real type.
+        :param jvalue: Java object create by Py4j
+        :return: A Python Layer
+        """
+        def get_py_name(jclass_name):
+            if jclass_name == "StaticGraph" or jclass_name == "DynamicGraph":
+                return "Model"
+            elif jclass_name == "Input":
+                return "Layer"
+            else:
+                return jclass_name
+
+        jname = callBigDlFunc(bigdl_type,
+                                      "getRealClassNameOfJValue",
+                                      jvalue)
+
+        jpackage_name = ".".join(jname.split(".")[:-1])
+        pclass_name = get_py_name(jname.split(".")[-1])
+
+        if "com.intel.analytics.bigdl.nn.keras.Model" == jname or \
+                        "com.intel.analytics.bigdl.nn.keras.Sequential" == jname:
+            base_module = importlib.import_module('bigdl.nn.keras.topology')
+        elif "com.intel.analytics.bigdl.nn.keras" == jpackage_name:
+            base_module = importlib.import_module('bigdl.nn.keras.layer')
+        elif "com.intel.analytics.bigdl.nn" == jpackage_name:
+            base_module = importlib.import_module('bigdl.nn.layer')
+        else:
+            raise Exception("Not supported type: %s" % jname)
+
+        realClassName = "Layer" # The top base class
+        if pclass_name in dir(base_module):
+            realClassName = pclass_name
+        module = getattr(base_module, realClassName)
+        jvalue_creator = getattr(module, "from_jvalue")
+        model = jvalue_creator(jvalue, bigdl_type)
+        return model
+
+
+class Layer(JavaValue, SharedStaticUtils):
     """
     Layer is the basic component of a neural network
     and it's also the base class of layers.
@@ -118,14 +174,15 @@ class Layer(JavaValue):
                                      self,
                                      to_list(x)))
 
-    @classmethod
-    def of(cls, jvalue, bigdl_type="float"):
+    @staticmethod
+    def from_jvalue(jvalue, bigdl_type="float"):
         """
-        Create a Python Layer base on the given java value
+        Create a Python Model base on the given java value
         :param jvalue: Java object create by Py4j
-        :return: A Python Layer
+        :return: A Python Model
         """
-        model = Layer(jvalue, bigdl_type)
+        model = Layer(jvalue=jvalue, bigdl_type=bigdl_type)
+        model.value = jvalue
         return model
 
     def set_name(self, name):
@@ -686,16 +743,6 @@ class Model(Container):
     def __str__(self):
         return "->".join(self.layers())
 
-    @staticmethod
-    def load(path, bigdl_type="float"):
-        """
-        Load a pre-trained Bigdl model.
-
-        :param path: The path containing the pre-trained model.
-        :return: A pre-trained model.
-        """
-        jmodel = callBigDlFunc(bigdl_type, "loadBigDL", path)
-        return Layer.of(jmodel)
 
     @staticmethod
     def loadModel(modelPath, weightPath =None, bigdl_type="float"):
@@ -1063,8 +1110,19 @@ class Sequential(Container):
 
     '''
 
-    def __init__(self, bigdl_type="float"):
-        super(Sequential, self).__init__(None, bigdl_type)
+    def __init__(self, jvalue=None, bigdl_type="float"):
+        super(Sequential, self).__init__(jvalue, bigdl_type)
+
+    @staticmethod
+    def from_jvalue(jvalue, bigdl_type="float"):
+        """
+        Create a Python Model base on the given java value
+        :param jvalue: Java object create by Py4j
+        :return: A Python Model
+        """
+        model = Sequential(jvalue=jvalue)
+        model.value = jvalue
+        return model
 
 class TemporalConvolution(Layer):
 

--- a/pyspark/test/bigdl/keras/test_backend.py
+++ b/pyspark/test/bigdl/keras/test_backend.py
@@ -37,6 +37,11 @@ class TestBackend(BigDLTestCase):
 
         self.assert_allclose(keras_output, bigdl_output, rtol=rtol, atol=atol)
 
+    def test_lenet_local_predict(self):
+        kmodel, X_train, y_train = TestModels.kmodel_seq_lenet_mnist()
+        model = with_bigdl_backend(kmodel)
+        model.predict(X_train)
+
     def test_lenet_local(self):
         kmodel, X_train, y_train = TestModels.kmodel_seq_lenet_mnist()
         self.modelTest(X_train, kmodel, dump_weights=True)

--- a/pyspark/test/bigdl/test_simple_integration.py
+++ b/pyspark/test/bigdl/test_simple_integration.py
@@ -73,7 +73,55 @@ class TestSimple():
         print(cadd.get_weights()[0])
         assert_allclose(cadd.get_weights()[0],
                         np.array([1, 2, 3, 4, 5]).reshape((5, 1)),
+
                         rtol=1.e-1)
+
+    def test_load_keras_model_of(self):
+        from bigdl.nn.keras.topology import Model as KModel
+        from bigdl.nn.keras.layer import Input as KInput
+        from bigdl.nn.keras.layer import Dense
+
+        input = KInput(shape=[2, 3])
+        fc1 = Dense(2)(input)
+        model = KModel(input, fc1)
+        tmp_path = tempfile.mktemp()
+        model.save(tmp_path, True)
+        model_loaded = KModel.load(tmp_path)
+        assert "bigdl.nn.keras.topology.Model" in str(type(model_loaded))
+        assert len(model_loaded.layers) == 2
+
+    def test_load_keras_seq_of(self):
+        from bigdl.nn.keras.topology import Sequential as KSequential
+        from bigdl.nn.keras.layer import Dense
+
+        model = KSequential()
+        fc1 = Dense(2, input_shape=[2, 3])
+        model.add(fc1)
+        tmp_path = tempfile.mktemp()
+        model.save(tmp_path, True)
+        model_loaded = KSequential.load(tmp_path)
+        assert "bigdl.nn.keras.topology.Sequential" in str(type(model_loaded))
+        assert len(model_loaded.layers) == 1
+
+    def test_load_model_of(self):
+        input = Input()
+        fc1 = Linear(4, 2)(input)
+        model = Model(input, fc1)
+        tmp_path = tempfile.mktemp()
+        model.save(tmp_path, True)
+        model_loaded = Model.load(tmp_path)
+        assert "Model" in str(type(model_loaded))
+        assert len(model_loaded.layers) == 2
+
+    def test_load_sequential_of(self):
+        fc1 = Linear(4, 2)
+        model = Sequential()
+        model.add(fc1)
+        tmp_path = tempfile.mktemp()
+        model.save(tmp_path, True)
+        model_loaded = Model.load(tmp_path)
+        assert "Sequential" in str(type(model_loaded))
+        assert len(model_loaded.layers) == 1
 
     def test_load_model(self):
         fc1 = Linear(4, 2)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasLayer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasLayer.scala
@@ -20,7 +20,7 @@ import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.nn.Graph._
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.nn.keras.{Sequential => KSequential}
-import com.intel.analytics.bigdl.nn.{Container => TContainer, Sequential => TSequential}
+import com.intel.analytics.bigdl.nn.{Container => TContainer}
 import com.intel.analytics.bigdl.serialization.Bigdl.{AttrValue, BigDLModule}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric


### PR DESCRIPTION
## What changes were proposed in this pull request?
- This code
```
        model_loaded = Model.load(tmp_path)
        model_loaded.layers 
```
would fail as model_loaded is treated as `Layer` instead of `Model` or other subclass.

Fix #2362 #2168

- Fix exception in: #2388 
```
bmodel = with_bigdl_backend(kmodel)
bmodel.predict(xxx)
```
## How was this patch tested?

unittest

