### PR TITLE
Add image schema support for DLClassifier and python example for DLFrames

### DIFF
--- a/pyspark/bigdl/examples/dlframes/ImageInference/ImageInferenceExample.py
+++ b/pyspark/bigdl/examples/dlframes/ImageInference/ImageInferenceExample.py
@@ -26,7 +26,7 @@ from bigdl.nn.layer import Model
 if __name__ == "__main__":
 
     if len(sys.argv) != 3:
-        print("Need parameters: <model> <imagePath>", file=sys.stderr)
+        print("Need parameters: <model> <imagePath>")
         exit(-1)
 
     sc = SparkContext(appName="ImageInferenceExample", conf=create_spark_conf())

--- a/pyspark/bigdl/examples/dlframes/ImageInference/ImageInferenceExample.py
+++ b/pyspark/bigdl/examples/dlframes/ImageInference/ImageInferenceExample.py
@@ -1,0 +1,53 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pyspark.sql.functions import col, udf
+from pyspark.sql.types import StringType
+from bigdl.util.common import *
+from bigdl.dlframes.dl_image_reader import *
+from bigdl.dlframes.dl_image_transformer import *
+from bigdl.transform.vision.image import *
+from bigdl.dlframes.dl_classifier import *
+from bigdl.nn.layer import Model
+
+if __name__ == "__main__":
+
+    if len(sys.argv) != 3:
+        print("Need parameters: <model> <imagePath>", file=sys.stderr)
+        exit(-1)
+
+    sc = SparkContext(appName="ImageInferenceExample", conf=create_spark_conf())
+    redire_spark_logs()
+    show_bigdl_info_logs()
+    init_engine()
+
+    model_path = sys.argv[1]
+    image_path = sys.argv[2]
+
+    imageDF = DLImageReader.readImages(image_path, sc)
+    getName = udf(lambda row: row[0], StringType())
+    transformer = DLImageTransformer(
+        Pipeline([Resize(256, 256), CenterCrop(224, 224),
+                  ChannelNormalize(123.0, 117.0, 104.0),
+                  MatToTensor()])
+    ).setInputCol("image").setOutputCol("features")
+    featureDF = transformer.transform(imageDF).withColumn("name", getName(col("image")))
+
+    model = Model.loadModel(model_path)
+    classifierModel = DLClassifierModel(model, [3, 224, 224]).setBatchSize(4)
+
+    predictionDF = classifierModel.transform(featureDF)
+    predictionDF.select("name", "prediction").orderBy("name").show(20, False)

--- a/pyspark/bigdl/examples/dlframes/ImageInference/README.md
+++ b/pyspark/bigdl/examples/dlframes/ImageInference/README.md
@@ -1,0 +1,68 @@
+# Summary
+
+Python demo of image classification: inference with a pre-trained Inception_V1 model based on Spark DataFrame (Dataset).
+
+BigDL provides the DataFrame-based API for image reading, preprocessing, model training and inference. The related
+classes followed the typical estimator/transformer pattern of Spark ML and can be used in a standard Spark ML pipeline.
+
+# Preparation
+
+## Make sure Spark, BigDL are successfully installed
+
+Please refer to [BigDL](https://bigdl-project.github.io/) for installation
+
+## Get the imagenet ILSVRC2012 validation datasets
+
+Download the validation dataset from http://image-net.org/download-images. For this demo, you may take the top 100 images to save time.
+
+## Get the pre-trained Inception-V1 model
+
+Download the pre-trained Inception-V1 model from [BigDL Zoo](https://s3-ap-southeast-1.amazonaws.com/bigdl-models/imageclassification/imagenet/bigdl_inception-v1_imagenet_0.4.0.model)
+
+Alternatively, user may also download pre-trained caffe/Tensorflow/keras model. Please refer to
+programming guide in [BigDL](https://bigdl-project.github.io/) 
+
+# Inference for image classification
+
+ImageInferenceExample.py takes 2 parameters:
+1. Path to the pre-trained models. (E.g. path/to/model/bigdl_inception-v1_imagenet_0.4.0.model)
+2. Path to the folder of the images. (E.g. path/to/data/imagenet/validation)
+
+User may submit ImageInferenceExample.py via spark-submit.
+E.g.
+```
+BigDL/dist/bin/spark-submit-with-bigdl.sh --master local[1] ../bigdl/examples/dlframes/ImageInference/ImageInferenceExample.py path/to/model/bigdl_inception-v1_imagenet_0.4.0.model path/to/data/imagenet/validation
+```
+
+or run the script in Jupyter notebook or Pyspark and manually set parameters
+
+After inference, you should see something like this in the console:
+
+```
++-------------------------------------------------------------------------------+----------+
+|name                                                                           |prediction|
++-------------------------------------------------------------------------------+----------+
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000001.JPEG|59.0      |
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000002.JPEG|796.0     |
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000003.JPEG|231.0     |
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000004.JPEG|969.0     |
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000005.JPEG|521.0     |
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000006.JPEG|59.0      |
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000007.JPEG|283.0     |
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000008.JPEG|697.0     |
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000009.JPEG|48.0      |
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000010.JPEG|812.0     |
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000011.JPEG|956.0     |
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000012.JPEG|287.0     |
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000013.JPEG|371.0     |
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000014.JPEG|758.0     |
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000015.JPEG|596.0     |
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000016.JPEG|148.0     |
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000017.JPEG|981.0     |
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000018.JPEG|22.0      |
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000019.JPEG|479.0     |
+|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000020.JPEG|518.0     |
++-------------------------------------------------------------------------------+----------+
+
+```
+To map the class to human readable text, please refer to https://github.com/Lasagne/Recipes/blob/master/examples/resnet50/imagenet_classes.txt 

--- a/pyspark/bigdl/examples/dlframes/ImageInference/README.md
+++ b/pyspark/bigdl/examples/dlframes/ImageInference/README.md
@@ -39,30 +39,30 @@ or run the script in Jupyter notebook or Pyspark and manually set parameters
 After inference, you should see something like this in the console:
 
 ```
-+-------------------------------------------------------------------------------+----------+
-|name                                                                           |prediction|
-+-------------------------------------------------------------------------------+----------+
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000001.JPEG|59.0      |
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000002.JPEG|796.0     |
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000003.JPEG|231.0     |
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000004.JPEG|969.0     |
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000005.JPEG|521.0     |
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000006.JPEG|59.0      |
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000007.JPEG|283.0     |
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000008.JPEG|697.0     |
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000009.JPEG|48.0      |
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000010.JPEG|812.0     |
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000011.JPEG|956.0     |
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000012.JPEG|287.0     |
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000013.JPEG|371.0     |
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000014.JPEG|758.0     |
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000015.JPEG|596.0     |
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000016.JPEG|148.0     |
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000017.JPEG|981.0     |
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000018.JPEG|22.0      |
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000019.JPEG|479.0     |
-|file:/home/yuhao/workspace/data/imagenet/predict_s/ILSVRC2012_val_00000020.JPEG|518.0     |
-+-------------------------------------------------------------------------------+----------+
++-----------------------------------------------------------------------------+----------+
+|name                                                                         |prediction|
++-----------------------------------------------------------------------------+----------+
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000001.JPEG|59.0      |
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000002.JPEG|796.0     |
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000003.JPEG|231.0     |
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000004.JPEG|810.0     |
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000005.JPEG|521.0     |
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000006.JPEG|59.0      |
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000007.JPEG|335.0     |
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000008.JPEG|456.0     |
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000009.JPEG|675.0     |
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000010.JPEG|851.0     |
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000011.JPEG|110.0     |
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000012.JPEG|287.0     |
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000013.JPEG|371.0     |
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000014.JPEG|758.0     |
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000015.JPEG|596.0     |
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000016.JPEG|148.0     |
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000017.JPEG|2.0       |
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000018.JPEG|22.0      |
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000019.JPEG|479.0     |
+|hdfs://Gondolin-Node-056:9000/imagenet/predict_s/ILSVRC2012_val_00000020.JPEG|518.0     |
++-----------------------------------------------------------------------------+----------+
 
 ```
 To map the class to human readable text, please refer to https://github.com/Lasagne/Recipes/blob/master/examples/resnet50/imagenet_classes.txt 

--- a/pyspark/bigdl/examples/dlframes/ImageTransferLearning/ImageTransferLearningExample.py
+++ b/pyspark/bigdl/examples/dlframes/ImageTransferLearning/ImageTransferLearningExample.py
@@ -1,0 +1,82 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import re
+from bigdl.util.common import *
+from bigdl.dlframes.dl_image_reader import *
+from bigdl.dlframes.dl_image_transformer import *
+from bigdl.transform.vision.image import *
+from bigdl.dlframes.dl_classifier import *
+from pyspark.sql.functions import col, udf
+from pyspark.sql.types import FloatType, StringType
+from bigdl.nn.layer import *
+from bigdl.nn.criterion import *
+from pyspark.ml.evaluation import MulticlassClassificationEvaluator
+
+if __name__ == "__main__":
+
+    if len(sys.argv) != 3:
+        print("Need parameters: <model> <imagePath>", file=sys.stderr)
+        exit(-1)
+
+    sc = SparkContext(appName="ImageTransferLearningExample", conf=create_spark_conf())
+    redire_spark_logs()
+    show_bigdl_info_logs()
+    init_engine()
+
+    model_path = sys.argv[1]
+    image_path = sys.argv[2]
+    imageDF = DLImageReader.readImages(image_path, sc)
+
+    # the original dataset contains 25000 images, we only take the first 2400 images for this demo.
+    # training data contains 1000 cats images and 1000 dog images (id 1 ~ 1000)
+    # validation data contains 200 cats images and 200 dog images (id 1000 ~ 1200)
+    getName = udf(lambda row: re.search(r'(cat|dog)\.([\d]*)\.jpg', row[0], re.IGNORECASE).group(0), StringType())
+    getID = udf(lambda name: re.search(r'([\d]+)', name).group(0), StringType())
+    getLabel = udf(lambda name: 1.0 if name.startswith('cat') else 2.0, FloatType())
+    labelDF = imageDF.withColumn("name", getName(col("image"))) \
+        .withColumn("id", getID(col('name'))) \
+        .withColumn("label", getLabel(col('name'))) \
+        .filter('id<1200')
+
+    transformer = DLImageTransformer(
+        Pipeline([Resize(256, 256), CenterCrop(224, 224),
+                  ChannelNormalize(123.0, 117.0, 104.0)])
+    ).setInputCol("image").setOutputCol("features")
+    featureDF = transformer.transform(labelDF)
+
+    preTrainedModel = Model.loadModel(model_path)
+    preTrainedDLModel = DLModel(preTrainedModel, [3,224,224])
+    embeddingDF = preTrainedDLModel.transform(featureDF).drop('features') \
+        .withColumnRenamed('prediction', 'features') \
+        .cache()
+
+    trainingDF = embeddingDF.filter('id<1000')
+    validationDF = embeddingDF.filter('id>1000 and id<1200')
+
+    lrModel = Sequential().add(Linear(1000, 2)).add(LogSoftMax())
+    classifier = DLClassifier(lrModel, ClassNLLCriterion(), [1000]) \
+        .setLearningRate(0.003).setBatchSize(40).setMaxEpoch(20)
+
+    catdogModel = classifier.fit(trainingDF)
+    predictionDF = catdogModel.transform(validationDF).cache()
+    predictionDF.show()
+
+    evaluator = MulticlassClassificationEvaluator(
+        labelCol="label", predictionCol="prediction", metricName="accuracy")
+    accuracy = evaluator.evaluate(predictionDF)
+    # expected error should be less than 10%
+    print("Test Error = %g " % (1.0 - accuracy))

--- a/pyspark/bigdl/examples/dlframes/ImageTransferLearning/ImageTransferLearningExample.py
+++ b/pyspark/bigdl/examples/dlframes/ImageTransferLearning/ImageTransferLearningExample.py
@@ -29,7 +29,7 @@ from pyspark.ml.evaluation import MulticlassClassificationEvaluator
 if __name__ == "__main__":
 
     if len(sys.argv) != 3:
-        print("Need parameters: <model> <imagePath>", file=sys.stderr)
+        print("Need parameters: <model> <imagePath>")
         exit(-1)
 
     sc = SparkContext(appName="ImageTransferLearningExample", conf=create_spark_conf())

--- a/pyspark/bigdl/examples/dlframes/ImageTransferLearning/ImageTransferLearningExample.py
+++ b/pyspark/bigdl/examples/dlframes/ImageTransferLearning/ImageTransferLearningExample.py
@@ -21,7 +21,7 @@ from bigdl.dlframes.dl_image_transformer import *
 from bigdl.transform.vision.image import *
 from bigdl.dlframes.dl_classifier import *
 from pyspark.sql.functions import col, udf
-from pyspark.sql.types import FloatType, StringType
+from pyspark.sql.types import DoubleType, StringType
 from bigdl.nn.layer import *
 from bigdl.nn.criterion import *
 from pyspark.ml.evaluation import MulticlassClassificationEvaluator
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     # validation data contains 200 cats images and 200 dog images (id 1000 ~ 1200)
     getName = udf(lambda row: re.search(r'(cat|dog)\.([\d]*)\.jpg', row[0], re.IGNORECASE).group(0), StringType())
     getID = udf(lambda name: re.search(r'([\d]+)', name).group(0), StringType())
-    getLabel = udf(lambda name: 1.0 if name.startswith('cat') else 2.0, FloatType())
+    getLabel = udf(lambda name: 1.0 if name.startswith('cat') else 2.0, DoubleType())
     labelDF = imageDF.withColumn("name", getName(col("image"))) \
         .withColumn("id", getID(col('name'))) \
         .withColumn("label", getLabel(col('name'))) \
@@ -76,7 +76,7 @@ if __name__ == "__main__":
     predictionDF.show()
 
     evaluator = MulticlassClassificationEvaluator(
-        labelCol="label", predictionCol="prediction", metricName="accuracy")
+        labelCol="label", predictionCol="prediction", metricName="weightedPrecision")
     accuracy = evaluator.evaluate(predictionDF)
     # expected error should be less than 10%
     print("Test Error = %g " % (1.0 - accuracy))

--- a/pyspark/bigdl/examples/dlframes/ImageTransferLearning/README.md
+++ b/pyspark/bigdl/examples/dlframes/ImageTransferLearning/README.md
@@ -1,0 +1,76 @@
+# Summary
+
+Python demo of transfer Learning based on Spark DataFrame (Dataset). 
+
+BigDL provides the DataFrame-based API for image reading, preprocessing, model training and inference. The related
+classes followed the typical estimator/transformer pattern of Spark ML and can be used in a standard Spark ML pipeline.
+
+In this example, we will show you how to use a pre-trained inception-v1 model trained on
+imagenet dataset to solve the dogs-vs-cats classification problem by transfer learning with BigDL.
+For transfer learning, we will treat the inception-v1 model as a feature extractor and only
+train a linear model on these features.
+
+# Preparation
+
+## Make sure Spark, BigDL are successfully installed
+
+Please refer to [BigDL](https://bigdl-project.github.io/master/) for installation
+
+## Get the dogs-vs-cats datasets
+
+Download the training dataset from https://www.kaggle.com/c/dogs-vs-cats and extract it.
+
+## Get the pre-trained Inception-V1 model
+
+Download the pre-trained Inception-V1 model from [BigDL Zoo](https://s3-ap-southeast-1.amazonaws.com/bigdl-models/imageclassification/imagenet/bigdl_inception-v1_imagenet_0.4.0.model)
+
+Alternatively, user may also download pre-trained caffe/Tensorflow/keras model. Please refer to
+programming guide in [BigDL](https://bigdl-project.github.io/) 
+
+# Training for flowers classification
+
+ImageTransferLearningExample.py takes 2 parameters:
+1. Path to the pre-trained models. (E.g. path/to/model/bigdl_inception-v1_imagenet_0.4.0.model)
+2. Path to the folder of the training images. (E.g. path/to/data/dogs-vs-cats/train)
+
+User may submit ImageInferenceExample.py via spark-submit.
+E.g.
+```
+BigDL/dist/bin/spark-submit-with-bigdl.sh --master local[4] path/BigDL/pyspark/bigdl/examples/dlframes/ImageTransferLearning/ImageTransferLearningExample.py path/to/model/bigdl_inception-v1_imagenet_0.4.0.model path/to/data/dogs-vs-cats/train
+```
+
+or run the script in Jupyter notebook or Pyspark and manually set parameters
+
+After training, you should see something like this in the console:
+
+```
++--------------------+------------+----+-----+--------------------+----------+
+|               image|        name|  id|label|            features|prediction|
++--------------------+------------+----+-----+--------------------+----------+
+|[file:/home/yuhao...|dog.1160.jpg|1160|  2.0|[3.94537119063898...|       2.0|
+|[file:/home/yuhao...|cat.1001.jpg|1001|  1.0|[2.54570932156639...|       1.0|
+|[file:/home/yuhao...|cat.1063.jpg|1063|  1.0|[4.04352831537835...|       1.0|
+|[file:/home/yuhao...|cat.1087.jpg|1087|  1.0|[8.14869622445257...|       1.0|
+|[file:/home/yuhao...|dog.1053.jpg|1053|  2.0|[3.28330497723072...|       2.0|
+|[file:/home/yuhao...|cat.1020.jpg|1020|  1.0|[4.32902561442460...|       1.0|
+|[file:/home/yuhao...|dog.1166.jpg|1166|  2.0|[4.99538046483394...|       2.0|
+|[file:/home/yuhao...|dog.1192.jpg|1192|  2.0|[9.30676947064057...|       2.0|
+|[file:/home/yuhao...|dog.1199.jpg|1199|  2.0|[7.06547325535211...|       2.0|
+|[file:/home/yuhao...|dog.1129.jpg|1129|  2.0|[8.93531591827923...|       2.0|
+|[file:/home/yuhao...|dog.1158.jpg|1158|  2.0|[1.99210080609191...|       2.0|
+|[file:/home/yuhao...|cat.1143.jpg|1143|  1.0|[1.40288739203242...|       1.0|
+|[file:/home/yuhao...|dog.1096.jpg|1096|  2.0|[4.43188264398486...|       2.0|
+|[file:/home/yuhao...|dog.1086.jpg|1086|  2.0|[2.48919695877702...|       1.0|
+|[file:/home/yuhao...|dog.1061.jpg|1061|  2.0|[3.77082142222207...|       2.0|
+|[file:/home/yuhao...|cat.1038.jpg|1038|  1.0|[2.61234094978135...|       1.0|
+|[file:/home/yuhao...|cat.1123.jpg|1123|  1.0|[4.18379180189276...|       2.0|
+|[file:/home/yuhao...|dog.1025.jpg|1025|  2.0|[2.42323076236061...|       2.0|
+|[file:/home/yuhao...|cat.1114.jpg|1114|  1.0|[4.40081894339527...|       1.0|
+|[file:/home/yuhao...|cat.1127.jpg|1127|  1.0|[1.06505949588608...|       1.0|
++--------------------+------------+----+-----+--------------------+----------+
+only showing top 20 rows
+
+Test Error = 0.0376884 
+```
+With master = local[4]. The transfer learning can finish in 8 minutes. As we can see,
+the model from transfer learning can achieve a 96.3% accuracy on the validation set.

--- a/pyspark/test/bigdl/dlframes/test_dl_image_transformer.py
+++ b/pyspark/test/bigdl/dlframes/test_dl_image_transformer.py
@@ -42,6 +42,24 @@ class TestDLImageTransformer():
         """
         self.sc.stop()
 
+    def test_non_default_output_column(self):
+        # Current the unit test does not work under Spark 1.5, The error message:
+        #   "java.lang.IllegalStateException: Cannot call methods on a stopped SparkContext"
+        # Yet the transformer works during manual test in 1.5, thus we bypass the 1.5 unit
+        # test, and withhold the support for Spark 1.5, until the unit test failure reason
+        # is clarified.
+
+        if not self.sc.version.startswith("1.5"):
+            image_frame = DLImageReader.readImages(self.image_path, self.sc)
+            transformer = DLImageTransformer(
+                Pipeline([Resize(256, 256), CenterCrop(224, 224),
+                          ChannelNormalize(0.485, 0.456, 0.406, 0.229, 0.224, 0.225),
+                          MatToTensor()])
+            ).setInputCol("image").setOutputCol("transformed")
+
+            result = transformer.transform(image_frame)
+            result.select("transformed").take(1)[0][0]
+
     def test_transform_image(self):
         # Current the unit test does not work under Spark 1.5, The error message:
         #   "java.lang.IllegalStateException: Cannot call methods on a stopped SparkContext"

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/dlframes/DLClassifierSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/dlframes/DLClassifierSpec.scala
@@ -63,7 +63,7 @@ class DLClassifierSpec extends FlatSpec with Matchers with BeforeAndAfter {
     }
   }
 
-  "An DLClassifier" should "has correct default params" in {
+  "DLClassifier" should "has correct default params" in {
     val model = Linear[Float](10, 1)
     val criterion = ClassNLLCriterion[Float]()
     val estimator = new DLClassifier[Float](model, criterion, Array(10))
@@ -75,7 +75,7 @@ class DLClassifierSpec extends FlatSpec with Matchers with BeforeAndAfter {
     assert(estimator.getLearningRateDecay == 0)
   }
 
-  "An DLClassifier" should "get reasonale accuracy" in {
+  "DLClassifier" should "get reasonale accuracy" in {
     val model = new Sequential().add(Linear[Float](6, 2)).add(LogSoftMax[Float])
     val criterion = ClassNLLCriterion[Float]()
     val classifier = new DLClassifier[Float](model, criterion, Array(6))
@@ -91,7 +91,7 @@ class DLClassifierSpec extends FlatSpec with Matchers with BeforeAndAfter {
     assert(dlModel.transform(df).where("prediction=label").count() > nRecords * 0.8)
   }
 
-  "An DLClassifier" should "support different FEATURE types" in {
+  "DLClassifier" should "support different FEATURE types" in {
     val model = new Sequential().add(Linear[Float](6, 2)).add(LogSoftMax[Float])
     val criterion = ClassNLLCriterion[Float]()
     val classifier = new DLClassifier[Float](model, criterion, Array(6))
@@ -113,7 +113,7 @@ class DLClassifierSpec extends FlatSpec with Matchers with BeforeAndAfter {
     }
   }
 
-  "An DLClassifier" should "support scalar FEATURE" in {
+  "DLClassifier" should "support scalar FEATURE" in {
     val model = new Sequential().add(Linear[Float](1, 2)).add(LogSoftMax[Float])
     val criterion = ClassNLLCriterion[Float]()
     val classifier = new DLClassifier[Float](model, criterion, Array(1))
@@ -133,7 +133,7 @@ class DLClassifierSpec extends FlatSpec with Matchers with BeforeAndAfter {
     }
   }
 
-  "An DLClasifier" should "support image FEATURE types" in {
+  "DLClasifier" should "support image FEATURE types" in {
     val pascalResource = getClass.getClassLoader.getResource("pascal/")
     val imageDF = DLImageReader.readImages(pascalResource.getFile, sc)
     assert(imageDF.count() == 1)
@@ -151,7 +151,7 @@ class DLClassifierSpec extends FlatSpec with Matchers with BeforeAndAfter {
     estimator.fit(transformedDF)
   }
 
-  "An DLClassifier" should "fit with adam and LBFGS" in {
+  "DLClassifier" should "fit with adam and LBFGS" in {
     val model = new Sequential().add(Linear[Float](6, 2)).add(LogSoftMax[Float])
     val criterion = ClassNLLCriterion[Float]()
     Seq(new LBFGS[Float], new Adam[Float]).foreach { optimMethod =>
@@ -167,7 +167,7 @@ class DLClassifierSpec extends FlatSpec with Matchers with BeforeAndAfter {
     }
   }
 
-  "An DLClassifier" should "supports validation data and summary" in {
+  "DLClassifier" should "supports validation data and summary" in {
     val data = sc.parallelize(smallData)
     val df = sqlContext.createDataFrame(data).toDF("features", "label")
 
@@ -189,7 +189,7 @@ class DLClassifierSpec extends FlatSpec with Matchers with BeforeAndAfter {
     logdir.deleteOnExit()
   }
 
-  "An DLClassifier" should "get the same classification result with BigDL model" in {
+  "DLClassifier" should "get the same classification result with BigDL model" in {
     Logger.getLogger("org").setLevel(Level.WARN)
     Logger.getLogger("akka").setLevel(Level.WARN)
 
@@ -216,7 +216,7 @@ class DLClassifierSpec extends FlatSpec with Matchers with BeforeAndAfter {
     tensorBuffer.clear()
   }
 
-  "An DLClassifier" should "works in ML pipeline" in {
+  "DLClassifier" should "works in ML pipeline" in {
     var appSparkVersion = org.apache.spark.SPARK_VERSION
     if (appSparkVersion.trim.startsWith("1")) {
       val data = sc.parallelize(


### PR DESCRIPTION
## What changes were proposed in this pull request?

add support of image schema for DLClassifier/DLEstimator.
add imageInference example for python DLFrames.
add imageTransferLearning example for python DLFrames.

## How was this patch tested?
manual tests for examples
extra unit test was added for DLImageTransformer

