### PR TITLE
Define existing models using Keras-Style API

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/languagemodel/PTBWordLM.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/languagemodel/PTBWordLM.scala
@@ -66,7 +66,18 @@ object PTBWordLM {
 
       val model = if (param.modelSnapshot.isDefined) {
         Module.loadModule[Float](param.modelSnapshot.get)
-      } else {
+      } else if (param.kerasModel) {
+        println("Using Keras-Style API for model definition")
+        val curModel = PTBModel.keras(
+          inputSize = param.vocabSize,
+          hiddenSize = param.hiddenSize,
+          outputSize = param.vocabSize,
+          numLayers = param.numLayers,
+          keepProb = param.keepProb)
+        curModel.reset()
+        curModel
+      }
+      else {
         val curModel = PTBModel(
           inputSize = param.vocabSize,
           hiddenSize = param.hiddenSize,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/languagemodel/Utils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/languagemodel/Utils.scala
@@ -50,7 +50,8 @@ object Utils {
                           numLayers: Int = 2,
                           numSteps: Int = 20,
                           overWriteCheckpoint: Boolean = false,
-                          keepProb: Float = 2.0f)
+                          keepProb: Float = 2.0f,
+                          kerasModel: Boolean = false)
 
   val trainParser = new OptionParser[TrainParams]("BigDL ptbModel Train Example") {
     opt[String]('f', "dataFolder")
@@ -109,5 +110,9 @@ object Utils {
     opt[Double]("keepProb")
       .text("the probability p to do dropout")
       .action((x, c) => c.copy(keepProb = x.toFloat))
+
+    opt[Unit]('k', "kerasModel")
+      .text("use Keras-Style API for model definition")
+      .action((x, c) => c.copy(kerasModel = true))
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/textclassification/TextClassifier.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/textclassification/TextClassifier.scala
@@ -55,6 +55,9 @@ object TextClassifier {
       opt[Int]('l', "learningRate")
         .text("learningRate")
         .action((x, c) => c.copy(learningRate = x))
+      opt[Unit]('k', "kerasModel")
+        .text("use Keras-Style API for model definition")
+        .action((x, c) => c.copy(kerasModel = true))
     }
 
     localParser.parse(args, TextClassificationParams()).map { param =>

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/autoencoder/Autoencoder.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/autoencoder/Autoencoder.scala
@@ -43,4 +43,26 @@ object Autoencoder {
     val output = Sigmoid().inputs(linear2)
     Graph(input, output)
   }
+
+  def keras(classNum: Int): nn.keras.Sequential[Float] = {
+    import com.intel.analytics.bigdl.nn.keras._
+    import com.intel.analytics.bigdl.utils.Shape
+
+    val model = Sequential[Float]()
+    model.add(Reshape(Array(featureSize), inputShape = Shape(28, 28)))
+    model.add(Dense(classNum, activation = "relu"))
+    model.add(Dense(featureSize, activation = "sigmoid"))
+    model
+  }
+
+  def kerasGraph(classNum: Int): nn.keras.Model[Float] = {
+    import com.intel.analytics.bigdl.nn.keras._
+    import com.intel.analytics.bigdl.utils.Shape
+
+    val input = Input(inputShape = Shape(28, 28))
+    val reshape = Reshape(Array(featureSize)).inputs(input)
+    val dense1 = Dense(classNum, activation = "relu").inputs(reshape)
+    val output = Dense(featureSize, activation = "sigmoid").inputs(dense1)
+    Model[Float](input, output)
+  }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/autoencoder/Train.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/autoencoder/Train.scala
@@ -70,7 +70,14 @@ object Train {
       val model = if (param.modelSnapshot.isDefined) {
         Module.load[Float](param.modelSnapshot.get)
       } else {
-        if (param.graphModel) Autoencoder.graph(classNum = 32) else Autoencoder(classNum = 32)
+        if (param.kerasModel) {
+          println("Using Keras-Style API for model definition")
+          if (param.graphModel) Autoencoder.kerasGraph(classNum = 32)
+          else Autoencoder.keras(classNum = 32)
+        }
+        else {
+          if (param.graphModel) Autoencoder.graph(classNum = 32) else Autoencoder(classNum = 32)
+        }
       }
 
       val optimMethod = if (param.stateSnapshot.isDefined) {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/autoencoder/Utils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/autoencoder/Utils.scala
@@ -34,6 +34,7 @@ object Utils {
     stateSnapshot: Option[String] = None,
     batchSize: Int = 150,
     maxEpoch: Int = 10,
+    kerasModel: Boolean = false,
     graphModel: Boolean = false
   )
 
@@ -56,6 +57,9 @@ object Utils {
     opt[Int]('e', "maxEpoch")
       .text("max epoch")
       .action((x, c) => c.copy(maxEpoch = x))
+    opt[Unit]('k', "kerasModel")
+      .text("use Keras-Style API for model definition")
+      .action((x, c) => c.copy(kerasModel = true))
     opt[Unit]('g', "graphModel")
       .text("use graph model")
       .action((x, c) => c.copy(graphModel = true))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/inception/Inception_v1.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/inception/Inception_v1.scala
@@ -98,18 +98,18 @@ object Inception_Layer_v1 {
     import com.intel.analytics.bigdl.nn.keras._
     import com.intel.analytics.bigdl.nn.keras.Merge.merge
 
-    val conv1x1 = Convolution2D(config[Table](1)[Int](1), 1, 1)
+    val conv1x1 = Convolution2D(config[Table](1)(1), 1, 1)
       .setName(namePrefix + "1x1").inputs(input)
     val relu1x1 = Activation("relu").setName(namePrefix + "relu_1x1").inputs(conv1x1)
 
-    val conv3x3_1 = Convolution2D(config[Table](2)[Int](1), 1, 1)
+    val conv3x3_1 = Convolution2D(config[Table](2)(1), 1, 1)
       .setName(namePrefix + "3x3_reduce").inputs(input)
     val relu3x3_1 = Activation("relu").setName(namePrefix + "relu_3x3_reduce").inputs(conv3x3_1)
     val conv3x3_2 = Convolution2D(config[Table](2)[Int](2), 3, 3, padH = 1, padW = 1)
       .setName(namePrefix + "3x3").inputs(relu3x3_1)
     val relu3x3_2 = Activation("relu").setName(namePrefix + "relu_3x3").inputs(conv3x3_2)
 
-    val conv5x5_1 = Convolution2D(config[Table](3)[Int](1), 1, 1)
+    val conv5x5_1 = Convolution2D(config[Table](3)(1), 1, 1)
       .setName(namePrefix + "5x5_reduce").inputs(input)
     val relu5x5_1 = Activation("relu").setName(namePrefix + "relu_5x5_reduce").inputs(conv5x5_1)
     val conv5x5_2 = Convolution2D(config[Table](3)[Int](2), 5, 5, padH = 2, padW = 2)
@@ -118,7 +118,7 @@ object Inception_Layer_v1 {
 
     val pool = MaxPooling2D(poolSize = (3, 3), strides = (1, 1), borderMode = "same", ceil = true)
       .setName(namePrefix + "pool").inputs(input)
-    val convPool = Convolution2D(config[Table](4)[Int](1), 1, 1)
+    val convPool = Convolution2D(config[Table](4)(1), 1, 1)
       .setName(namePrefix + "pool_proj").inputs(pool)
     val reluPool = Activation("relu").setName(namePrefix + "relu_pool_proj").inputs(convPool)
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/inception/Options.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/inception/Options.scala
@@ -35,6 +35,7 @@ object Options {
     weightDecay: Double = 0.0001,
     checkpointIteration: Int = 620,
     graphModel: Boolean = false,
+    kerasModel: Boolean = false,
     maxLr: Option[Double] = None,
     warmupEpoch: Option[Int] = None,
     gradientL2NormThreshold: Option[Double] = None,
@@ -81,6 +82,9 @@ object Options {
     opt[Int]("checkpointIteration")
       .text("checkpoint interval of iterations")
       .action((x, c) => c.copy(checkpointIteration = x))
+    opt[Unit]('k', "kerasModel")
+      .text("use Keras-Style API for model definition")
+      .action((x, c) => c.copy(kerasModel = true))
     opt[Unit]('g', "graphModel")
       .text("use graph model")
       .action((x, c) => c.copy(graphModel = true))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/inception/Train.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/inception/Train.scala
@@ -58,6 +58,9 @@ object TrainInceptionV1 {
 
       val model = if (param.modelSnapshot.isDefined) {
         Module.load[Float](param.modelSnapshot.get)
+      } else if (param.kerasModel) {
+        println("Using Keras-Style API for model definition")
+        Inception_v1_NoAuxClassifier.keras(classNum = param.classNumber)
       } else if (param.graphModel) {
         Inception_v1_NoAuxClassifier.graph(classNum = param.classNumber)
       } else {
@@ -84,10 +87,13 @@ object TrainInceptionV1 {
           learningRateSchedule = lrSchedule)
       }
 
+      val criterion = if (param.kerasModel) ClassNLLCriterion[Float](logProbAsInput = false)
+      else ClassNLLCriterion[Float]()
+
       val optimizer = Optimizer(
         model = model,
         dataset = trainSet,
-        criterion = new ClassNLLCriterion[Float]()
+        criterion = criterion
       )
 
       val (checkpointTrigger, testTrigger, endTrigger) = if (param.maxEpoch.isDefined) {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/SimpleRNN.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/SimpleRNN.scala
@@ -31,4 +31,19 @@ object SimpleRNN {
       .add(TimeDistributed[Float](Linear[Float](hiddenSize, outputSize)))
     model
   }
+
+  def keras(
+  inputSize: Int,
+  hiddenSize: Int,
+  outputSize: Int): com.intel.analytics.bigdl.nn.keras.Sequential[Float] = {
+    import com.intel.analytics.bigdl.nn.keras._
+    import com.intel.analytics.bigdl.nn.keras.{SimpleRNN => RNN}
+    import com.intel.analytics.bigdl.utils.Shape
+
+    val model = Sequential[Float]()
+    model.add(RNN(hiddenSize, returnSequences = true, bias = true,
+      inputShape = Shape(25, inputSize)))
+    model.add(TimeDistributed(Dense(outputSize)))
+    model
+  }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Train.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Train.scala
@@ -93,10 +93,19 @@ object Train {
       val model = if (param.modelSnapshot.isDefined) {
         Module.load[Float](param.modelSnapshot.get)
       } else {
-        val curModel = SimpleRNN(
-          inputSize = totalVocabLength,
-          hiddenSize = param.hiddenSize,
-          outputSize = totalVocabLength)
+        val curModel = if (param.kerasModel) {
+          println("Using Keras-Style API for model definition")
+          SimpleRNN.keras(
+            inputSize = totalVocabLength,
+            hiddenSize = param.hiddenSize,
+            outputSize = totalVocabLength)
+        }
+        else {
+          SimpleRNN(
+            inputSize = totalVocabLength,
+            hiddenSize = param.hiddenSize,
+            outputSize = totalVocabLength)
+        }
         curModel.reset()
         curModel
       }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Utils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/rnn/Utils.scala
@@ -51,7 +51,8 @@ object Utils {
                           nEpochs: Int = 30,
                           sentFile: Option[String] = None,
                           tokenFile: Option[String] = None,
-                          overWriteCheckpoint: Boolean = false)
+                          overWriteCheckpoint: Boolean = false,
+                          kerasModel: Boolean = false)
 
   val trainParser = new OptionParser[TrainParams]("BigDL SimpleRNN Train Example") {
     opt[String]('f', "dataFolder")
@@ -123,6 +124,10 @@ object Utils {
     opt[Unit]("overWrite")
       .text("overwrite checkpoint files")
       .action( (_, c) => c.copy(overWriteCheckpoint = true) )
+
+    opt[Unit]('k', "kerasModel")
+      .text("use Keras-Style API for model definition")
+      .action((x, c) => c.copy(kerasModel = true))
   }
 
   case class TestParams(

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/Train.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/Train.scala
@@ -68,13 +68,13 @@ object Train {
           learningRateSchedule = SGD.EpochStep(25, 0.5))
       }
 
-//      val criterion = if (param.kerasModel) ClassNLLCriterion[Float](logProbAsInput = false)
-//      else ClassNLLCriterion[Float]()
+      val criterion = if (param.kerasModel) ClassNLLCriterion[Float](logProbAsInput = false)
+      else ClassNLLCriterion[Float]()
 
       val optimizer = Optimizer(
         model = model,
         dataset = trainDataSet,
-        criterion = new ClassNLLCriterion[Float]()
+        criterion = criterion
       )
 
       val validateSet = DataSet.array(Utils.loadTest(param.folder), sc) ->

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/Train.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/Train.scala
@@ -68,13 +68,13 @@ object Train {
           learningRateSchedule = SGD.EpochStep(25, 0.5))
       }
 
-      val criterion = if (param.kerasModel) ClassNLLCriterion[Float](logProbAsInput = false)
-      else ClassNLLCriterion[Float]()
+//      val criterion = if (param.kerasModel) ClassNLLCriterion[Float](logProbAsInput = false)
+//      else ClassNLLCriterion[Float]()
 
       val optimizer = Optimizer(
         model = model,
         dataset = trainDataSet,
-        criterion = criterion
+        criterion = new ClassNLLCriterion[Float]()
       )
 
       val validateSet = DataSet.array(Utils.loadTest(param.folder), sc) ->

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/Utils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/Utils.scala
@@ -43,6 +43,7 @@ object Utils {
     overWriteCheckpoint: Boolean = false,
     learningRate: Double = 0.01,
     weightDecay: Double = 0.0005,
+    kerasModel: Boolean = false,
     graphModel: Boolean = false
   )
 
@@ -77,6 +78,9 @@ object Utils {
     opt[Double]('l', "learningRate")
       .text("inital learning rate")
       .action((x, c) => c.copy(learningRate = x))
+    opt[Unit]('k', "kerasModel")
+      .text("use Keras-Style API for model definition")
+      .action((x, c) => c.copy(kerasModel = true))
     opt[Unit]('g', "graphModel")
       .text("use graph model")
       .action((x, c) => c.copy(graphModel = true))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/VggForCifar10.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/VggForCifar10.scala
@@ -137,7 +137,7 @@ object VggForCifar10 {
     def convBNReLU(nOutPutPlane: Int)
     : Sequential[Float] = {
       vggBnDo.add(Convolution2D(nOutPutPlane, 3, 3, padH = 1, padW = 1))
-      vggBnDo.add(BatchNormalization())
+      vggBnDo.add(BatchNormalization(momentum = 0.1))
       vggBnDo.add(Activation("relu"))
       vggBnDo
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/VggForCifar10.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/VggForCifar10.scala
@@ -32,7 +32,7 @@ object VggForCifar10 {
       vggBnDo
     }
     convBNReLU(3, 64)
-    if (hasDropout) vggBnDo.add(Dropout((0.3)))
+    if (hasDropout) vggBnDo.add(Dropout(0.3))
     convBNReLU(64, 64)
     vggBnDo.add(SpatialMaxPooling(2, 2, 2, 2).ceil())
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/VggForCifar10.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/VggForCifar10.scala
@@ -136,7 +136,7 @@ object VggForCifar10 {
 
     def convBNReLU(nOutPutPlane: Int)
     : Sequential[Float] = {
-      vggBnDo.add(Convolution2D(nOutPutPlane, 3, 3, padH = 1, padW = 1))
+      vggBnDo.add(Convolution2D(nOutPutPlane, 3, 3, borderMode = "same"))
       vggBnDo.add(BatchNormalization(momentum = 0.1))
       vggBnDo.add(Activation("relu"))
       vggBnDo
@@ -195,7 +195,7 @@ object VggForCifar10 {
 
     def convBNReLU(nOutPutPlane: Int)(input: ModuleNode[Float])
     : ModuleNode[Float] = {
-      val conv = Convolution2D(nOutPutPlane, 3, 3, padH = 1, padW = 1).inputs(input)
+      val conv = Convolution2D(nOutPutPlane, 3, 3, borderMode = "same").inputs(input)
       val bn = BatchNormalization().inputs(conv)
       Activation("relu").inputs(bn)
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/VggForCifar10.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/VggForCifar10.scala
@@ -181,7 +181,7 @@ object VggForCifar10 {
     classifier.add(Activation("relu"))
     if (hasDropout) classifier.add(Dropout(0.5))
     classifier.add(Dense(classNum))
-    classifier.add(Activation("log_softmax"))
+    classifier.add(Activation("softmax"))
     vggBnDo.add(classifier)
 
     vggBnDo
@@ -237,7 +237,7 @@ object VggForCifar10 {
     val relu = Activation("relu").inputs(bn)
     val drop10 = if (hasDropout) Dropout(0.5).inputs(relu) else relu
     val linear2 = Dense(classNum).inputs(drop10)
-    val output = Activation("log_softmax").inputs(linear2)
+    val output = Activation("softmax").inputs(linear2)
     Model(input, output)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/VggForCifar10.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/VggForCifar10.scala
@@ -126,6 +126,120 @@ object VggForCifar10 {
     val output = LogSoftMax().inputs(linear2)
     Graph(input, output)
   }
+
+  def keras(classNum: Int, hasDropout: Boolean = true): nn.keras.Sequential[Float] = {
+    import com.intel.analytics.bigdl.nn.keras._
+    import com.intel.analytics.bigdl.utils.Shape
+
+    val vggBnDo = Sequential[Float]()
+    vggBnDo.add(InputLayer(inputShape = Shape(3, 32, 32)))
+
+    def convBNReLU(nOutPutPlane: Int)
+    : Sequential[Float] = {
+      vggBnDo.add(Convolution2D(nOutPutPlane, 3, 3, padH = 1, padW = 1))
+      vggBnDo.add(BatchNormalization())
+      vggBnDo.add(Activation("relu"))
+      vggBnDo
+    }
+    convBNReLU(64)
+    if (hasDropout) vggBnDo.add(Dropout(0.3))
+    convBNReLU(64)
+    vggBnDo.add(MaxPooling2D(ceil = true))
+
+    convBNReLU(128)
+    if (hasDropout) vggBnDo.add(Dropout(0.4))
+    convBNReLU(128)
+    vggBnDo.add(MaxPooling2D(ceil = true))
+
+    convBNReLU(256)
+    if (hasDropout) vggBnDo.add(Dropout(0.4))
+    convBNReLU(256)
+    if (hasDropout) vggBnDo.add(Dropout(0.4))
+    convBNReLU(256)
+    vggBnDo.add(MaxPooling2D(ceil = true))
+
+    convBNReLU(512)
+    if (hasDropout) vggBnDo.add(Dropout(0.4))
+    convBNReLU(512)
+    if (hasDropout) vggBnDo.add(Dropout(0.4))
+    convBNReLU(512)
+    vggBnDo.add(MaxPooling2D(ceil = true))
+
+    convBNReLU(512)
+    if (hasDropout) vggBnDo.add(Dropout(0.4))
+    convBNReLU(512)
+    if (hasDropout) vggBnDo.add(Dropout(0.4))
+    convBNReLU(512)
+    vggBnDo.add(MaxPooling2D(ceil = true))
+    vggBnDo.add(Reshape(Array(512)))
+
+    val classifier = Sequential[Float]()
+    classifier.add(InputLayer(inputShape = Shape(512)))
+    if (hasDropout) classifier.add(Dropout(0.5))
+    classifier.add(Dense(512))
+    classifier.add(BatchNormalization(epsilon = 1e-5, momentum = 0.1))
+    classifier.add(Activation("relu"))
+    if (hasDropout) classifier.add(Dropout(0.5))
+    classifier.add(Dense(classNum))
+    classifier.add(Activation("softmax"))
+    vggBnDo.add(classifier)
+
+    vggBnDo
+  }
+
+  def kerasGraph(classNum: Int, hasDropout: Boolean = true): nn.keras.Model[Float] = {
+    import com.intel.analytics.bigdl.nn.keras._
+    import com.intel.analytics.bigdl.utils.Shape
+
+    val input = Input(inputShape = Shape(3, 32, 32))
+
+    def convBNReLU(nOutPutPlane: Int)(input: ModuleNode[Float])
+    : ModuleNode[Float] = {
+      val conv = Convolution2D(nOutPutPlane, 3, 3, padH = 1, padW = 1).inputs(input)
+      val bn = BatchNormalization().inputs(conv)
+      Activation("relu").inputs(bn)
+    }
+    val relu1 = convBNReLU(64)(input)
+    val drop1 = if (hasDropout) Dropout(0.3).inputs(relu1) else relu1
+    val relu2 = convBNReLU(64)(drop1)
+    val pool1 = MaxPooling2D(ceil = true).inputs(relu2)
+
+    val relu3 = convBNReLU(128)(pool1)
+    val drop2 = if (hasDropout) Dropout(0.4).inputs(relu3) else relu3
+    val relu4 = convBNReLU(128)(drop2)
+    val pool2 = MaxPooling2D(ceil = true).inputs(relu4)
+
+    val relu5 = convBNReLU(256)(pool2)
+    val drop3 = if (hasDropout) Dropout(0.4).inputs(relu5) else relu5
+    val relu6 = convBNReLU(256)(drop3)
+    val drop4 = if (hasDropout) Dropout(0.4).inputs(relu6) else relu6
+    val relu7 = convBNReLU(256)(drop4)
+    val pool3 = MaxPooling2D(ceil = true).inputs(relu7)
+
+    val relu8 = convBNReLU(512)(pool3)
+    val drop5 = if (hasDropout) Dropout(0.4).inputs(relu8) else relu8
+    val relu9 = convBNReLU(512)(drop5)
+    val drop6 = if (hasDropout) Dropout(0.4).inputs(relu9) else relu9
+    val relu10 = convBNReLU(512)(drop6)
+    val pool4 = MaxPooling2D(ceil = true).inputs(relu10)
+
+    val relu11 = convBNReLU(512)(pool4)
+    val drop7 = if (hasDropout) Dropout(0.4).inputs(relu11) else relu11
+    val relu12 = convBNReLU(512)(drop7)
+    val drop8 = if (hasDropout) Dropout(0.4).inputs(relu12) else relu12
+    val relu13 = convBNReLU(512)(drop8)
+    val pool5 = MaxPooling2D(ceil = true).inputs(relu13)
+    val reshape = Reshape(Array(512)).inputs(pool5)
+
+    val drop9 = if (hasDropout) Dropout(0.5).inputs(reshape) else reshape
+    val linear1 = Dense(512).inputs(drop9)
+    val bn = BatchNormalization(epsilon = 1e-5, momentum = 0.1).inputs(linear1)
+    val relu = Activation("relu").inputs(bn)
+    val drop10 = if (hasDropout) Dropout(0.5).inputs(relu) else relu
+    val linear2 = Dense(classNum).inputs(drop10)
+    val output = Activation("softmax").inputs(linear2)
+    Model(input, output)
+  }
 }
 
 object Vgg_16 {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/VggForCifar10.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/vgg/VggForCifar10.scala
@@ -181,7 +181,7 @@ object VggForCifar10 {
     classifier.add(Activation("relu"))
     if (hasDropout) classifier.add(Dropout(0.5))
     classifier.add(Dense(classNum))
-    classifier.add(Activation("softmax"))
+    classifier.add(Activation("log_softmax"))
     vggBnDo.add(classifier)
 
     vggBnDo
@@ -237,7 +237,7 @@ object VggForCifar10 {
     val relu = Activation("relu").inputs(bn)
     val drop10 = if (hasDropout) Dropout(0.5).inputs(relu) else relu
     val linear2 = Dense(classNum).inputs(drop10)
-    val output = Activation("softmax").inputs(linear2)
+    val output = Activation("log_softmax").inputs(linear2)
     Model(input, output)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/AveragePooling2D.scala
@@ -45,8 +45,9 @@ class AveragePooling2D[T: ClassTag](
    strides: Array[Int] = null,
    borderMode: String = "valid",
    dimOrdering: DataFormat = DataFormat.NCHW,
+   ceil: Boolean = false,
    inputShape: Shape = null)(implicit ev: TensorNumeric[T])
-  extends Pooling2D[T](poolSize, strides, borderMode, dimOrdering, inputShape) {
+  extends Pooling2D[T](poolSize, strides, borderMode, dimOrdering, ceil, inputShape) {
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val pads = KerasUtils.getPadsFromBorderMode(borderMode)
@@ -60,6 +61,8 @@ class AveragePooling2D[T: ClassTag](
       countIncludePad = false,
       format = dimOrdering)
     layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+    if (ceil) layer.ceil().asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+    else layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
 }
 
@@ -69,9 +72,10 @@ object AveragePooling2D {
     strides: (Int, Int) = null,
     borderMode: String = "valid",
     dimOrdering: String = "th",
+    ceil: Boolean = false,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): AveragePooling2D[T] = {
     val strideValues = if (strides != null) Array(strides._1, strides._2) else null
     new AveragePooling2D[T](Array(poolSize._1, poolSize._2), strideValues,
-      borderMode, KerasUtils.toBigDLFormat(dimOrdering), inputShape)
+      borderMode, KerasUtils.toBigDLFormat(dimOrdering), ceil, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/BatchNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/BatchNormalization.scala
@@ -82,17 +82,17 @@ class BatchNormalization[T: ClassTag](
         nOutput = nChannel,
         eps = epsilon,
         momentum = momentum,
-        initWeight = getInit(gammaInit, nChannel),
-        initBias = getInit(betaInit, nChannel),
+//        initWeight = getInit(gammaInit, nChannel),
+//        initBias = getInit(betaInit, nChannel),
         dataFormat = dimOrdering)
     }
     else {
       com.intel.analytics.bigdl.nn.BatchNormalization(
         nOutput = input(1),
         eps = epsilon,
-        momentum = momentum,
-        initWeight = getInit(gammaInit, input(1)),
-        initBias = getInit(betaInit, input(1)))
+        momentum = momentum)
+//        initWeight = getInit(gammaInit, input(1)),
+//        initBias = getInit(betaInit, input(1)))
     }
     layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/BatchNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/BatchNormalization.scala
@@ -82,17 +82,17 @@ class BatchNormalization[T: ClassTag](
         nOutput = nChannel,
         eps = epsilon,
         momentum = momentum,
-//        initWeight = getInit(gammaInit, nChannel),
-//        initBias = getInit(betaInit, nChannel),
+        initWeight = getInit(gammaInit, nChannel),
+        initBias = getInit(betaInit, nChannel),
         dataFormat = dimOrdering)
     }
     else {
       com.intel.analytics.bigdl.nn.BatchNormalization(
         nOutput = input(1),
         eps = epsilon,
-        momentum = momentum)
-//        initWeight = getInit(gammaInit, input(1)),
-//        initBias = getInit(betaInit, input(1)))
+        momentum = momentum,
+        initWeight = getInit(gammaInit, input(1)),
+        initBias = getInit(betaInit, input(1)))
     }
     layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
@@ -94,7 +94,7 @@ class Convolution2D[T: ClassTag](
       bRegularizer = bRegularizer,
       withBias = bias,
       format = dimOrdering)
-//    layer.setInitMethod(weightInitMethod = init, biasInitMethod = Zeros)
+    layer.setInitMethod(weightInitMethod = init, biasInitMethod = Zeros)
     KerasLayer.fuse(layer, activation,
       inputShape).asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
@@ -69,6 +69,7 @@ class Convolution2D[T: ClassTag](
    val bias: Boolean = true,
    val padH: Int = 0,
    val padW: Int = 0,
+   val propagateBack: Boolean = true,
    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
@@ -90,6 +91,7 @@ class Convolution2D[T: ClassTag](
       strideH = subsample(0),
       padW = pads._2,
       padH = pads._1,
+      propagateBack = propagateBack,
       wRegularizer = wRegularizer,
       bRegularizer = bRegularizer,
       withBias = bias,
@@ -115,11 +117,12 @@ object Convolution2D {
     bias: Boolean = true,
     padH: Int = 0,
     padW: Int = 0,
+    propagateBack: Boolean = true,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Convolution2D[T] = {
     new Convolution2D[T](nbFilter, nbRow, nbCol,
       KerasUtils.getInitMethod(init), KerasUtils.getKerasActivation(activation),
       borderMode, Array(subsample._1, subsample._2),
       KerasUtils.toBigDLFormat(dimOrdering), wRegularizer,
-      bRegularizer, bias, padH, padW, inputShape)
+      bRegularizer, bias, padH, padW, propagateBack, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
@@ -67,6 +67,8 @@ class Convolution2D[T: ClassTag](
    var wRegularizer: Regularizer[T] = null,
    var bRegularizer: Regularizer[T] = null,
    val bias: Boolean = true,
+   val padH: Int = 0,
+   val padW: Int = 0,
    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
@@ -77,7 +79,8 @@ class Convolution2D[T: ClassTag](
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val input = inputShape.toSingle().toArray
-    val pads = KerasUtils.getPadsFromBorderMode(borderMode)
+    val pads = if (padH == 0 && padW == 0) KerasUtils.getPadsFromBorderMode(borderMode)
+    else (padH, padW)
     val layer = SpatialConvolution(
       nInputPlane = input(dimOrdering.getHWCDims(4)._3 - 1),
       nOutputPlane = nbFilter,
@@ -110,11 +113,13 @@ object Convolution2D {
     wRegularizer: Regularizer[T] = null,
     bRegularizer: Regularizer[T] = null,
     bias: Boolean = true,
+    padH: Int = 0,
+    padW: Int = 0,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Convolution2D[T] = {
     new Convolution2D[T](nbFilter, nbRow, nbCol,
       KerasUtils.getInitMethod(init), KerasUtils.getKerasActivation(activation),
       borderMode, Array(subsample._1, subsample._2),
       KerasUtils.toBigDLFormat(dimOrdering), wRegularizer,
-      bRegularizer, bias, inputShape)
+      bRegularizer, bias, padH, padW, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Convolution2D.scala
@@ -94,7 +94,7 @@ class Convolution2D[T: ClassTag](
       bRegularizer = bRegularizer,
       withBias = bias,
       format = dimOrdering)
-    layer.setInitMethod(weightInitMethod = init, biasInitMethod = Zeros)
+//    layer.setInitMethod(weightInitMethod = init, biasInitMethod = Zeros)
     KerasLayer.fuse(layer, activation,
       inputShape).asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Dense.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Dense.scala
@@ -71,7 +71,7 @@ class Dense[T: ClassTag](
       withBias = bias,
       wRegularizer = wRegularizer,
       bRegularizer = bRegularizer)
-    layer.setInitMethod(weightInitMethod = init, biasInitMethod = Zeros)
+//    layer.setInitMethod(weightInitMethod = init, biasInitMethod = Zeros)
 
     var torchLayer: AbstractModule[Tensor[T], Tensor[T], T] = layer
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Dense.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Dense.scala
@@ -71,7 +71,7 @@ class Dense[T: ClassTag](
       withBias = bias,
       wRegularizer = wRegularizer,
       bRegularizer = bRegularizer)
-//    layer.setInitMethod(weightInitMethod = init, biasInitMethod = Zeros)
+    layer.setInitMethod(weightInitMethod = init, biasInitMethod = Zeros)
 
     var torchLayer: AbstractModule[Tensor[T], Tensor[T], T] = layer
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Flatten.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Flatten.scala
@@ -43,7 +43,8 @@ class Flatten[T: ClassTag](
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val input = inputShape.toSingle().toArray
     val layer =
-      com.intel.analytics.bigdl.nn.Reshape(Array(input.slice(1, input.length).product))
+      com.intel.analytics.bigdl.nn.Reshape(Array(input.slice(1, input.length).product),
+        batchMode = Some(true))
     layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasUtils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasUtils.scala
@@ -67,7 +67,7 @@ object KerasUtils {
       activation.toLowerCase() match {
           case "tanh" => Tanh[T]()
           case "sigmoid" => Sigmoid[T]()
-          case "relu" => ReLU[T]()
+          case "relu" => ReLU[T](true)
           case "softmax" =>
                 com.intel.analytics.bigdl.nn.SoftMax[T]()
           case "softplus" => SoftPlus[T]()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasUtils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasUtils.scala
@@ -84,13 +84,15 @@ object KerasUtils {
     filterSize: Int,
     borderMode: String,
     stride: Int,
-    dilation: Int = 1): Int = {
+    dilation: Int = 1,
+    ceil: Boolean = false): Int = {
     val dilatedFilterSize = filterSize + (filterSize - 1) * (dilation - 1)
     val outputLength = borderMode match {
       case "valid" => inputLength - dilatedFilterSize + 1
       case "same" => inputLength
     }
-    (outputLength + stride - 1) / stride
+    if (ceil) math.ceil((outputLength + stride - 1f) / stride).toInt
+    else (outputLength + stride - 1) / stride
   }
 
   private[keras] def getPadsFromBorderMode3D(

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasUtils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasUtils.scala
@@ -67,13 +67,12 @@ object KerasUtils {
       activation.toLowerCase() match {
           case "tanh" => Tanh[T]()
           case "sigmoid" => Sigmoid[T]()
-          case "relu" => ReLU[T](true)
+          case "relu" => ReLU[T]()
           case "softmax" =>
                 com.intel.analytics.bigdl.nn.SoftMax[T]()
           case "softplus" => SoftPlus[T]()
           case "softsign" => SoftSign[T]()
           case "hard_sigmoid" => HardSigmoid[T]()
-          case "log_softmax" => LogSoftMax[T]()
           case _ => throw new IllegalArgumentException(s"Invalid activation: " +
             s"${activation.toLowerCase}. Only simple activations can be constructed using string")
       }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasUtils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasUtils.scala
@@ -73,6 +73,7 @@ object KerasUtils {
           case "softplus" => SoftPlus[T]()
           case "softsign" => SoftSign[T]()
           case "hard_sigmoid" => HardSigmoid[T]()
+          case "log_softmax" => LogSoftMax[T]()
           case _ => throw new IllegalArgumentException(s"Invalid activation: " +
             s"${activation.toLowerCase}. Only simple activations can be constructed using string")
       }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling2D.scala
@@ -47,7 +47,7 @@ class MaxPooling2D[T: ClassTag] (
    dimOrdering: DataFormat = DataFormat.NCHW,
    ceil: Boolean = false,
    inputShape: Shape = null)(implicit ev: TensorNumeric[T])
-  extends Pooling2D[T](poolSize, strides, borderMode, dimOrdering, inputShape) {
+  extends Pooling2D[T](poolSize, strides, borderMode, dimOrdering, ceil, inputShape) {
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val pads = KerasUtils.getPadsFromBorderMode(borderMode)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/MaxPooling2D.scala
@@ -45,6 +45,7 @@ class MaxPooling2D[T: ClassTag] (
    strides: Array[Int] = null,
    borderMode: String = "valid",
    dimOrdering: DataFormat = DataFormat.NCHW,
+   ceil: Boolean = false,
    inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends Pooling2D[T](poolSize, strides, borderMode, dimOrdering, inputShape) {
 
@@ -58,7 +59,8 @@ class MaxPooling2D[T: ClassTag] (
       padW = pads._2,
       padH = pads._1,
       format = dimOrdering)
-    layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+    if (ceil) layer.ceil().asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+    else layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
 }
 
@@ -68,10 +70,11 @@ object MaxPooling2D {
     strides: (Int, Int) = null,
     borderMode: String = "valid",
     dimOrdering: String = "th",
+    ceil: Boolean = false,
     inputShape: Shape = null)
     (implicit ev: TensorNumeric[T]): MaxPooling2D[T] = {
     val strideValues = if (strides != null) Array(strides._1, strides._2) else null
     new MaxPooling2D[T](Array(poolSize._1, poolSize._2), strideValues,
-      borderMode, KerasUtils.toBigDLFormat(dimOrdering), inputShape)
+      borderMode, KerasUtils.toBigDLFormat(dimOrdering), ceil, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling2D.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Pooling2D.scala
@@ -33,6 +33,7 @@ abstract class Pooling2D[T: ClassTag](
    val strides: Array[Int] = null,
    val borderMode: String = "valid",
    val dimOrdering: DataFormat = DataFormat.NCHW,
+   val ceil: Boolean = false,
    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape)) {
 
@@ -51,9 +52,9 @@ abstract class Pooling2D[T: ClassTag](
       s"Pooling2D requires 4D input, but got input dim ${input.length}")
     val (dimH, dimW, dimC) = dimOrdering.getHWCDims(4)
     val rows = KerasUtils.computeConvOutputLength(input(dimH -1), poolSize(0),
-      borderMode, strideValues(0))
+      borderMode, strideValues(0), ceil = ceil)
     val cols = KerasUtils.computeConvOutputLength(input(dimW -1), poolSize(1),
-      borderMode, strideValues(1))
+      borderMode, strideValues(1), ceil = ceil)
     dimOrdering match {
       case DataFormat.NCHW => Shape(input(0), input(1), rows, cols)
       case DataFormat.NHWC => Shape(input(0), rows, cols, input(3))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SimpleRNN.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/SimpleRNN.scala
@@ -55,6 +55,7 @@ class SimpleRNN[T: ClassTag](
    var wRegularizer: Regularizer[T] = null,
    var uRegularizer: Regularizer[T] = null,
    var bRegularizer: Regularizer[T] = null,
+   val bias: Boolean = false,
    inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends Recurrent[T](outputDim, returnSequences, goBackwards, inputShape) {
 
@@ -63,7 +64,7 @@ class SimpleRNN[T: ClassTag](
       inputSize = input(2),
       hiddenSize = outputDim,
       activation = activation.doBuild(inputShape).asInstanceOf[TensorModule[T]],
-      isInputWithBias = false,
+      isInputWithBias = bias,
       wRegularizer = wRegularizer,
       uRegularizer = uRegularizer,
       bRegularizer = bRegularizer)
@@ -79,9 +80,10 @@ object SimpleRNN {
     wRegularizer: Regularizer[T] = null,
     uRegularizer: Regularizer[T] = null,
     bRegularizer: Regularizer[T] = null,
+    bias: Boolean = false,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]) : SimpleRNN[T] = {
     new SimpleRNN[T](outputDim, KerasUtils.getKerasActivation(activation),
       returnSequences, goBackwards, wRegularizer,
-      uRegularizer, bRegularizer, inputShape)
+      uRegularizer, bRegularizer, bias, inputShape)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/TimeDistributed.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/TimeDistributed.scala
@@ -67,7 +67,7 @@ class TimeDistributed[T: ClassTag](
 }
 
 object TimeDistributed {
-    def apply[@specialized(Float, Double) T: ClassTag](
+  def apply[@specialized(Float, Double) T: ClassTag](
     layer: KerasLayer[Tensor[T], Tensor[T], T],
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): TimeDistributed[T] = {
     new TimeDistributed[T](layer, inputShape)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLKeras.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLKeras.scala
@@ -187,11 +187,12 @@ class PythonBigDLKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pytho
     bias: Boolean = true,
     padH: Int = 0,
     padW: Int = 0,
+    propagateBack: Boolean = true,
     inputShape: JList[Int] = null): Convolution2D[T] = {
     new Convolution2D(nbFilter, nbRow, nbCol, KerasUtils.getInitMethod(init),
       KerasUtils.getKerasActivation(activation), borderMode,
       toScalaArray(subsample), KerasUtils.toBigDLFormat(dimOrdering),
-      wRegularizer, bRegularizer, bias, padH, padW, toScalaShape(inputShape))
+      wRegularizer, bRegularizer, bias, padH, padW, propagateBack, toScalaShape(inputShape))
   }
 
   def createKerasMaxPooling2D(
@@ -391,9 +392,10 @@ class PythonBigDLKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pytho
     strides: JList[Int],
     borderMode: String = "valid",
     dimOrdering: String = "th",
+    ceil: Boolean = false,
     inputShape: JList[Int] = null): AveragePooling2D[T] = {
     new AveragePooling2D(toScalaArray(poolSize), toScalaArray(strides),
-      borderMode, KerasUtils.toBigDLFormat(dimOrdering), toScalaShape(inputShape))
+      borderMode, KerasUtils.toBigDLFormat(dimOrdering), ceil, toScalaShape(inputShape))
   }
 
   def createKerasAveragePooling3D(

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLKeras.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLKeras.scala
@@ -185,11 +185,13 @@ class PythonBigDLKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pytho
     wRegularizer: Regularizer[T] = null,
     bRegularizer: Regularizer[T] = null,
     bias: Boolean = true,
+    padH: Int = 0,
+    padW: Int = 0,
     inputShape: JList[Int] = null): Convolution2D[T] = {
     new Convolution2D(nbFilter, nbRow, nbCol, KerasUtils.getInitMethod(init),
       KerasUtils.getKerasActivation(activation), borderMode,
       toScalaArray(subsample), KerasUtils.toBigDLFormat(dimOrdering),
-      wRegularizer, bRegularizer, bias, toScalaShape(inputShape))
+      wRegularizer, bRegularizer, bias, padH, padW, toScalaShape(inputShape))
   }
 
   def createKerasMaxPooling2D(
@@ -197,9 +199,10 @@ class PythonBigDLKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pytho
     strides: JList[Int],
     borderMode: String = "valid",
     dimOrdering: String = "th",
+    ceil: Boolean = false,
     inputShape: JList[Int] = null): MaxPooling2D[T] = {
     new MaxPooling2D[T](toScalaArray(poolSize), toScalaArray(strides),
-      borderMode, KerasUtils.toBigDLFormat(dimOrdering), toScalaShape(inputShape))
+      borderMode, KerasUtils.toBigDLFormat(dimOrdering), ceil, toScalaShape(inputShape))
   }
 
   def createKerasActivation(

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLKeras.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDLKeras.scala
@@ -236,9 +236,10 @@ class PythonBigDLKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pytho
     wRegularizer: Regularizer[T] = null,
     uRegularizer: Regularizer[T] = null,
     bRegularizer: Regularizer[T] = null,
+    bias: Boolean = false,
     inputShape: JList[Int] = null): SimpleRNN[T] = {
     SimpleRNN(outputDim, activation, returnSequences, goBackwards,
-      wRegularizer, uRegularizer, bRegularizer, toScalaShape(inputShape))
+      wRegularizer, uRegularizer, bRegularizer, bias, toScalaShape(inputShape))
   }
 
   def createKerasLSTM(

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/AutoencoderSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/AutoencoderSpec.scala
@@ -22,6 +22,16 @@ import com.intel.analytics.bigdl.utils.RandomGenerator
 
 class AutoencoderSpec extends KerasBaseSpec {
 
+  "Autoencoder sequential" should "generate the correct outputShape" in {
+    val autoencoder = Autoencoder.keras(classNum = 32)
+    autoencoder.getOutputShape().toSingle().toArray should be (Array(-1, 784))
+  }
+
+  "Autoencoder graph" should "generate the correct outputShape" in {
+    val autoencoder = Autoencoder.kerasGraph(classNum = 32)
+    autoencoder.getOutputShape().toSingle().toArray should be (Array(-1, 784))
+  }
+
   "Autoencoder Sequential Keras-Style definition" should
     "be the same as Torch-Style definition" in {
     RandomGenerator.RNG.setSeed(1000)
@@ -29,7 +39,7 @@ class AutoencoderSpec extends KerasBaseSpec {
     RandomGenerator.RNG.setSeed(1000)
     val tmodel = Autoencoder(classNum = 32)
     val input = Tensor[Float](Array(32, 28, 28)).rand()
-    compareKerasTorchModels(kmodel, tmodel, input)
+    compareModels(kmodel, tmodel, input)
   }
 
   "Autoencoder Graph Keras-Style definition" should
@@ -37,7 +47,16 @@ class AutoencoderSpec extends KerasBaseSpec {
     val kmodel = Autoencoder.kerasGraph(classNum = 32)
     val tmodel = Autoencoder.graph(classNum = 32)
     val input = Tensor[Float](Array(32, 28, 28)).rand()
-    compareKerasTorchModels(kmodel, tmodel, input)
+    compareModels(kmodel, tmodel, input)
+  }
+
+  "Autoencoder sequential definition" should "be the same as graph definition" in {
+    RandomGenerator.RNG.setSeed(1000)
+    val kseq = Autoencoder.keras(classNum = 32)
+    RandomGenerator.RNG.setSeed(1000)
+    val kgraph = Autoencoder.kerasGraph(classNum = 32)
+    val input = Tensor[Float](Array(2, 28, 28, 1)).rand()
+    compareModels(kseq, kgraph, input)
   }
 
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/AutoencoderSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/AutoencoderSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras
+
+import com.intel.analytics.bigdl.models.autoencoder.Autoencoder
+import com.intel.analytics.bigdl.tensor.Tensor
+
+class AutoencoderSpec extends KerasBaseSpec {
+
+  "Autoencoder Sequential Keras-Style definition" should
+    "be the same as Torch-Style definition" in {
+    val kmodel = Autoencoder.keras(classNum = 32)
+    val tmodel = Autoencoder(classNum = 32)
+    val input = Tensor[Float](Array(32, 28, 28)).rand()
+    compareKerasTorchModels(kmodel, tmodel, input)
+  }
+
+  "Autoencoder Graph Keras-Style definition" should
+    "be the same as Torch-Style definition" in {
+    val kmodel = Autoencoder.kerasGraph(classNum = 32)
+    val tmodel = Autoencoder.graph(classNum = 32)
+    val input = Tensor[Float](Array(32, 28, 28)).rand()
+    compareKerasTorchModels(kmodel, tmodel, input)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/AutoencoderSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/AutoencoderSpec.scala
@@ -18,12 +18,15 @@ package com.intel.analytics.bigdl.keras
 
 import com.intel.analytics.bigdl.models.autoencoder.Autoencoder
 import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.RandomGenerator
 
 class AutoencoderSpec extends KerasBaseSpec {
 
   "Autoencoder Sequential Keras-Style definition" should
     "be the same as Torch-Style definition" in {
+    RandomGenerator.RNG.setSeed(1000)
     val kmodel = Autoencoder.keras(classNum = 32)
+    RandomGenerator.RNG.setSeed(1000)
     val tmodel = Autoencoder(classNum = 32)
     val input = Tensor[Float](Array(32, 28, 28)).rand()
     compareKerasTorchModels(kmodel, tmodel, input)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/Inception_v1Spec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/Inception_v1Spec.scala
@@ -26,8 +26,7 @@ class Inception_v1Spec extends KerasBaseSpec {
     inception.getOutputShape().toSingle().toArray should be (Array(-1, 1000))
   }
 
-  "Inception_v1_NoAuxClassifier forward and backward" should
-    "work properly" in {
+  "Inception_v1_NoAuxClassifier forward and backward" should "work properly" in {
     val inception = Inception_v1_NoAuxClassifier.keras(classNum = 1000)
     val input = Tensor[Float](Array(10, 3, 224, 224)).rand()
     val output = inception.forward(input)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/Inception_v1Spec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/Inception_v1Spec.scala
@@ -16,24 +16,22 @@
 
 package com.intel.analytics.bigdl.keras
 
-import com.intel.analytics.bigdl.models.rnn.SimpleRNN
+import com.intel.analytics.bigdl.models.inception._
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.bigdl.utils.RandomGenerator
 
-class SimpleRNNSpec extends KerasBaseSpec {
+class Inception_v1Spec extends KerasBaseSpec {
 
-  "SimpleRNN" should "generate the correct outputShape" in {
-    val rnn = SimpleRNN.keras(4001, 40, 4001)
-    rnn.getOutputShape().toSingle().toArray should be (Array(-1, 25, 4001))
+  "Inception_v1_NoAuxClassifier" should "generate the correct outputShape" in {
+    val inception = Inception_v1_NoAuxClassifier.keras(classNum = 1000)
+    inception.getOutputShape().toSingle().toArray should be (Array(-1, 1000))
   }
 
-  "SimpleRNN Keras-Style definition" should "be the same as Torch-Style definition" in {
-    RandomGenerator.RNG.setSeed(1000)
-    val kmodel = SimpleRNN.keras(4001, 40, 4001)
-    RandomGenerator.RNG.setSeed(1000)
-    val tmodel = SimpleRNN(4001, 40, 4001)
-    val input = Tensor[Float](Array(3, 25, 4001)).rand()
-    compareModels(kmodel, tmodel, input)
+  "Inception_v1_NoAuxClassifier forward and backward" should
+    "work properly" in {
+    val inception = Inception_v1_NoAuxClassifier.keras(classNum = 1000)
+    val input = Tensor[Float](Array(10, 3, 224, 224)).rand()
+    val output = inception.forward(input)
+    val gradInput = inception.backward(input, output)
   }
 
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/KerasBaseSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/KerasBaseSpec.scala
@@ -86,7 +86,6 @@ abstract class KerasBaseSpec extends BigDLSpecHelper {
                               tmodel: Module[Float],
                               input: Tensor[Float],
                               precision: Double = 1e-5): Unit = {
-    kmodel.setWeightsBias(tmodel.getWeightsBias())
     val koutput = kmodel.forward(input)
     val toutput = tmodel.forward(input)
     val kgradInput = kmodel.backward(input, koutput)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/KerasBaseSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/KerasBaseSpec.scala
@@ -81,7 +81,7 @@ abstract class KerasBaseSpec extends BigDLSpecHelper {
     bgradInput.almostEqual(kgradInput, precision) should be(true)
   }
 
-  // compare the output and gradInput of Keras-Style API against Torch-Style API
+  // compare the output and gradInput of two supposedly compatible model definitions
   def compareModels(model1: Module[Float],
                     model2: Module[Float],
                     input: Tensor[Float],

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/KerasBaseSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/KerasBaseSpec.scala
@@ -86,6 +86,9 @@ abstract class KerasBaseSpec extends BigDLSpecHelper {
                               tmodel: Module[Float],
                               input: Tensor[Float],
                               precision: Double = 1e-5): Unit = {
+    (kmodel.getWeightsBias(), tmodel.getWeightsBias()).zipped.foreach { (kw, tw) =>
+      kw.almostEqual(tw, precision) should be(true)
+    }
     val koutput = kmodel.forward(input)
     val toutput = tmodel.forward(input)
     val kgradInput = kmodel.backward(input, koutput)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/KerasBaseSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/KerasBaseSpec.scala
@@ -82,19 +82,16 @@ abstract class KerasBaseSpec extends BigDLSpecHelper {
   }
 
   // compare the output and gradInput of Keras-Style API against Torch-Style API
-  def compareKerasTorchModels(kmodel: KerasModel[Float],
-                              tmodel: Module[Float],
-                              input: Tensor[Float],
-                              precision: Double = 1e-5): Unit = {
-    (kmodel.getWeightsBias(), tmodel.getWeightsBias()).zipped.foreach { (kw, tw) =>
-      kw.almostEqual(tw, precision) should be(true)
-    }
-    val koutput = kmodel.forward(input)
-    val toutput = tmodel.forward(input)
-    val kgradInput = kmodel.backward(input, koutput)
-    val tgradInput = tmodel.backward(input, toutput)
-    koutput.toTensor[Float].almostEqual(toutput.toTensor[Float], precision) should be(true)
+  def compareModels(model1: Module[Float],
+                    model2: Module[Float],
+                    input: Tensor[Float],
+                    precision: Double = 1e-5): Unit = {
+    model1.setWeightsBias(model2.getWeightsBias())
+    val output1 = model1.forward(input)
+    val output2 = model2.forward(input)
+    val kgradInput = model1.backward(input, output1)
+    val tgradInput = model2.backward(input, output2)
+    output1.toTensor[Float].almostEqual(output2.toTensor[Float], precision) should be(true)
     kgradInput.toTensor[Float].almostEqual(tgradInput.toTensor[Float], precision) should be(true)
   }
 }
-

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/LeNetSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/LeNetSpec.scala
@@ -18,9 +18,9 @@ package com.intel.analytics.bigdl.keras
 
 import com.intel.analytics.bigdl.models.lenet.LeNet5
 import com.intel.analytics.bigdl.tensor.Tensor
-import org.scalatest.{FlatSpec, Matchers}
+import com.intel.analytics.bigdl.utils.RandomGenerator
 
-class LeNetSpec extends FlatSpec with Matchers {
+class LeNetSpec extends KerasBaseSpec {
 
   "LeNet sequential" should "generate the correct outputShape" in {
     val lenet = LeNet5.keras(classNum = 10)
@@ -32,18 +32,13 @@ class LeNetSpec extends FlatSpec with Matchers {
     lenet.getOutputShape().toSingle().toArray should be (Array(-1, 10))
   }
 
-  "LeNet sequential forward and backward" should "work properly" in {
-    val lenet = LeNet5.keras(classNum = 10)
+  "LeNet sequential definition" should "be the same as graph definition" in {
+    RandomGenerator.RNG.setSeed(1000)
+    val kseq = LeNet5.keras(classNum = 10)
+    RandomGenerator.RNG.setSeed(1000)
+    val kgraph = LeNet5.kerasGraph(classNum = 10)
     val input = Tensor[Float](Array(2, 28, 28, 1)).rand()
-    val output = lenet.forward(input)
-    val gradInput = lenet.backward(input, output)
-  }
-
-  "LeNet graph forward and backward" should "work properly" in {
-    val lenet = LeNet5.kerasGraph(classNum = 10)
-    val input = Tensor[Float](Array(2, 28, 28, 1)).rand()
-    val output = lenet.forward(input)
-    val gradInput = lenet.backward(input, output)
+    compareModels(kseq, kgraph, input)
   }
 
   "LeNet forward with incompatible input tensor" should "raise an exception" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/PTBSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/PTBSpec.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras
+
+import com.intel.analytics.bigdl.example.languagemodel.PTBModel
+import com.intel.analytics.bigdl.tensor.Tensor
+
+class PTBSpec extends KerasBaseSpec {
+
+  "PTB model" should "generate the correct outputShape" in {
+    val ptb = PTBModel.keras(10001, 650, 10001, 2)
+    ptb.getOutputShape().toSingle().toArray should be (Array(-1, 35, 10001))
+  }
+
+  "PTB Keras-Style definition" should "be the same as Torch-Style definition" in {
+    val kmodel = PTBModel.keras(10001, 650, 10001, 2)
+    val tmodel = PTBModel(10001, 650, 10001, 2)
+    val input = Tensor[Float](Array(10, 35)).fill(1f)
+    compareModels(kmodel, tmodel, input)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/SimpleRNNSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/SimpleRNNSpec.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras
+
+import com.intel.analytics.bigdl.models.rnn.SimpleRNN
+import com.intel.analytics.bigdl.tensor.Tensor
+
+class SimpleRNNSpec extends KerasBaseSpec {
+
+  "SimpleRNN Keras-Style definition" should "be the same as Torch-Style definition" in {
+    val kmodel = SimpleRNN.keras(4001, 40, 4001)
+    val tmodel = SimpleRNN(4001, 40, 4001)
+    val input = Tensor[Float](Array(3, 25, 4001)).rand()
+    compareKerasTorchModels(kmodel, tmodel, input)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/TextClassifierSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/TextClassifierSpec.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras
+
+import com.intel.analytics.bigdl.example.utils._
+import com.intel.analytics.bigdl.tensor.Tensor
+
+class TextClassifierSpec extends KerasBaseSpec {
+
+  "TextClassifier model" should "generate the correct outputShape" in {
+    val textclassifier = new TextClassifier(TextClassificationParams()).buildKerasModel(20)
+    textclassifier.getOutputShape().toSingle().toArray should be (Array(-1, 20))
+  }
+
+  "TextClassifier model forward and backward" should "work properly" in {
+    val input = Tensor[Float](Array(32, 500, 200)).rand()
+    val textclassifier = new TextClassifier(TextClassificationParams()).buildKerasModel(20)
+    val output = textclassifier.forward(input)
+    val gradInput = textclassifier.backward(input, output)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/VggForCifar10Spec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/VggForCifar10Spec.scala
@@ -22,23 +22,23 @@ import com.intel.analytics.bigdl.utils.RandomGenerator
 
 class VggForCifar10Spec extends KerasBaseSpec {
 
-  "VggForCifar10 Sequential Keras-Style definition" should
-    "be the same as Torch-Style definition" in {
-    RandomGenerator.RNG.setSeed(1000)
-    val kmodel = VggForCifar10.keras(classNum = 10, hasDropout = false)
-    RandomGenerator.RNG.setSeed(1000)
-    val tmodel = VggForCifar10(classNum = 10, hasDropout = false)
-    val input = Tensor[Float](Array(32, 3, 32, 32)).rand()
-    compareKerasTorchModels(kmodel, tmodel, input)
+  "VggForCifar10 sequential" should "generate the correct outputShape" in {
+    val vgg = VggForCifar10.keras(classNum = 10)
+    vgg.getOutputShape().toSingle().toArray should be (Array(-1, 10))
   }
 
-  "VggForCifar10 Graph Keras-Style definition" should
-    "be the same as Torch-Style definition" in {
-    RandomGenerator.RNG.setSeed(1000)
-    val kmodel = VggForCifar10.kerasGraph(classNum = 10, hasDropout = false)
-    RandomGenerator.RNG.setSeed(1000)
-    val tmodel = VggForCifar10.graph(classNum = 10, hasDropout = false)
-    val input = Tensor[Float](Array(32, 3, 32, 32)).rand()
-    compareKerasTorchModels(kmodel, tmodel, input)
+  "VggForCifar10 graph" should "generate the correct outputShape" in {
+    val vgg = VggForCifar10.kerasGraph(classNum = 10)
+    vgg.getOutputShape().toSingle().toArray should be (Array(-1, 10))
   }
+
+  "VggForCifar10 sequential definition" should "be the same as graph definition" in {
+    RandomGenerator.RNG.setSeed(1000)
+    val kseq = VggForCifar10.keras(classNum = 10, hasDropout = false)
+    RandomGenerator.RNG.setSeed(1000)
+    val kgraph = VggForCifar10.kerasGraph(classNum = 10, hasDropout = false)
+    val input = Tensor[Float](Array(32, 3, 32, 32)).rand()
+    compareModels(kseq, kgraph, input)
+  }
+
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/VggForCifar10Spec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/VggForCifar10Spec.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.keras
+
+import com.intel.analytics.bigdl.models.vgg.VggForCifar10
+import com.intel.analytics.bigdl.tensor.Tensor
+
+class VggForCifar10Spec extends KerasBaseSpec {
+
+  "VggForCifar10 Sequential Keras-Style definition" should
+    "be the same as Torch-Style definition" in {
+    val kmodel = VggForCifar10.keras(classNum = 10, hasDropout = false)
+    val tmodel = VggForCifar10(classNum = 10, hasDropout = false)
+    val input = Tensor[Float](Array(32, 3, 32, 32)).rand()
+    compareKerasTorchModels(kmodel, tmodel, input)
+  }
+
+  "VggForCifar10 Graph Keras-Style definition" should
+    "be the same as Torch-Style definition" in {
+    val kmodel = VggForCifar10.kerasGraph(classNum = 10, hasDropout = false)
+    val tmodel = VggForCifar10.graph(classNum = 10, hasDropout = false)
+    val input = Tensor[Float](Array(32, 3, 32, 32)).rand()
+    compareKerasTorchModels(kmodel, tmodel, input)
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/VggForCifar10Spec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/VggForCifar10Spec.scala
@@ -18,12 +18,15 @@ package com.intel.analytics.bigdl.keras
 
 import com.intel.analytics.bigdl.models.vgg.VggForCifar10
 import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.RandomGenerator
 
 class VggForCifar10Spec extends KerasBaseSpec {
 
   "VggForCifar10 Sequential Keras-Style definition" should
     "be the same as Torch-Style definition" in {
+    RandomGenerator.RNG.setSeed(1000)
     val kmodel = VggForCifar10.keras(classNum = 10, hasDropout = false)
+    RandomGenerator.RNG.setSeed(1000)
     val tmodel = VggForCifar10(classNum = 10, hasDropout = false)
     val input = Tensor[Float](Array(32, 3, 32, 32)).rand()
     compareKerasTorchModels(kmodel, tmodel, input)
@@ -31,7 +34,9 @@ class VggForCifar10Spec extends KerasBaseSpec {
 
   "VggForCifar10 Graph Keras-Style definition" should
     "be the same as Torch-Style definition" in {
+    RandomGenerator.RNG.setSeed(1000)
     val kmodel = VggForCifar10.kerasGraph(classNum = 10, hasDropout = false)
+    RandomGenerator.RNG.setSeed(1000)
     val tmodel = VggForCifar10.graph(classNum = 10, hasDropout = false)
     val input = Tensor[Float](Array(32, 3, 32, 32)).rand()
     compareKerasTorchModels(kmodel, tmodel, input)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Model definitions added:
- RNN
- AutoEncoder
- VGG for cifar 10
- Inception_v1_NoAuxClassifier
- TextClassifier
- PTB

Expose some arguments in torch but not in keras that are used in the above model definitions:
- padH, padW,  propagateBack in Convolution2D
- ceil in Pooling2D and corresponding change in computeOutputShape
- bias in SimpleRNN
- BatchNormalization for input other than 4D
- Use KerasLayerWrapper for SpatialCrossMapLRN

TODO: Update Python wrapper and doc for new parameters after these changed are confirmed.

## How was this patch tested?

Unit tests and training accuracy.
