### PR TITLE
Allow Python DLEstimator/DLClassifier to use non-default columns

### DIFF
--- a/pyspark/bigdl/dlframes/dl_classifier.py
+++ b/pyspark/bigdl/dlframes/dl_classifier.py
@@ -1,5 +1,6 @@
 from pyspark.ml.pipeline import Estimator, Model
 from pyspark.ml.param.shared import *
+from pyspark.ml.wrapper import JavaModel, JavaEstimator, JavaTransformer
 from bigdl.util.common import *
 
 
@@ -57,23 +58,6 @@ class HasMaxEpoch(Params):
         """
         return self.getOrDefault(self.maxEpoch)
 
-class HasFeatureSize(Params):
-    featureSize = Param(Params._dummy(), "featureSize", "size of the feature")
-
-    def __init__(self):
-        super(HasFeatureSize, self).__init__()
-        self.featureSize = Param(self, "featureSize", "featureSize")
-        self._setDefault(featureSize=None)
-
-    def setFeatureSize(self, val):
-        self._paramMap[self.featureSize] = val
-        pythonBigDL_mehtod_name = "setFeatureSize" + self.__class__.__name__
-        callBigDlFunc(self.bigdl_type, pythonBigDL_mehtod_name, self.value, val)
-        return self
-
-    def getFeatureSize(self):
-        return self.getOrDefault(self.featureSize)
-
 class HasLearningRate(Params):
     learningRate = Param(Params._dummy(), "learningRate", "learning rate")
 
@@ -94,37 +78,45 @@ class HasLearningRate(Params):
         """
         return self.getOrDefault(self.learningRate)
 
-class DLEstimator(Estimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, HasBatchSize, HasMaxEpoch, HasLearningRate, JavaValue):
+class DLEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, HasBatchSize, HasMaxEpoch, HasLearningRate, JavaValue):
 
     def __init__(self,  model, criterion, feature_size, label_size, jvalue=None, bigdl_type="float"):
         super(DLEstimator, self).__init__()
         self.value = jvalue if jvalue else callBigDlFunc(
             bigdl_type, self.jvm_class_constructor(), model, criterion, feature_size, label_size)
         self.bigdl_type = bigdl_type
+        self._java_obj = self.value
         self.featureSize = feature_size
 
-    def _fit(self, dataset):
-        #self._transfer_params_to_java()
-        jmodel = callBigDlFunc(self.bigdl_type, "fitEstimator", self.value, dataset)
-        model = DLModel.of(jmodel, self.featureSize, self.bigdl_type)
-        return model
+    def _create_model(self, java_model):
+        return DLModel.of(java_model, self.featureSize, self.bigdl_type).setFeaturesCol(self.getFeaturesCol())
 
-
-class DLModel(Model, HasFeaturesCol, HasPredictionCol, HasBatchSize, HasFeatureSize, JavaValue):
+class DLModel(JavaTransformer, HasFeaturesCol, HasPredictionCol, HasBatchSize, JavaValue):
     def __init__(self,  model, featureSize, jvalue=None, bigdl_type="float"):
         super(DLModel, self).__init__()
         self.value = jvalue if jvalue else callBigDlFunc(
             bigdl_type, self.jvm_class_constructor(), model, featureSize)
+        self._java_obj = self.value
         self.bigdl_type = bigdl_type
         self.setFeatureSize(featureSize)
 
-    def _transform(self, dataset):
+    def transform(self, dataset):
+        self._transfer_params_to_java()
         return callBigDlFunc(self.bigdl_type, "dlModelTransform", self.value, dataset)
 
     @classmethod
     def of(self, jvalue, feature_size=None, bigdl_type="float"):
         model = DLModel(model=None, featureSize=feature_size, jvalue=jvalue, bigdl_type=bigdl_type)
         return model
+
+    def setFeatureSize(self, val):
+        pythonBigDL_mehtod_name = "setFeatureSize" + self.__class__.__name__
+        self.__featuresize = val
+        callBigDlFunc(self.bigdl_type, pythonBigDL_mehtod_name, self.value, val)
+        return self
+
+    def getFeatureSize(self):
+        return self.__featuresize
 
 
 class DLClassifier(DLEstimator):


### PR DESCRIPTION
## What changes were proposed in this pull request?

fix the issue that DLEstimator/DLModel cannot support non-default columns, and made some code refactor along the way

## How was this patch tested?
existing and new unit tests

