### PR TITLE
[Bug Fix] Fix duplicate check sometimes should be suspend

### DIFF
--- a/pyspark/test/bigdl/keras/test_keras_api.py
+++ b/pyspark/test/bigdl/keras/test_keras_api.py
@@ -30,7 +30,7 @@ from keras.models import Sequential as KSequential
 np.random.seed(1337)  # for reproducibility
 
 
-class TestNewAPI(BigDLTestCase):
+class TestKerasAPI(BigDLTestCase):
 
     def test_embedding(self):
         input_data = np.random.randint(1000, size=(32, 10))
@@ -200,13 +200,12 @@ class TestNewAPI(BigDLTestCase):
 
     def test_merge_method_model_concat(self):
         bx1 = BLayer.Input(shape=(4, ))
-        bx1_1 = BLayer.Input(shape=(4, ))
         bx2 = BLayer.Input(shape=(5, ))
         by1 = BLayer.Dense(6, activation="sigmoid")(bx1)
-        bbranch1 = BModel(bx1, by1)(bx1_1)
+        bbranch1 = BModel(bx1, by1)(bx1)
         bbranch2 = BLayer.Dense(8)(bx2)
         bz = BLayer.merge([bbranch1, bbranch2], mode="concat")
-        bmodel = BModel([bx1_1, bx2], bz)
+        bmodel = BModel([bx1, bx2], bz)
 
         kx1 = KLayer.Input(shape=(4, ))
         kx2 = KLayer.Input(shape=(5, ))
@@ -221,15 +220,14 @@ class TestNewAPI(BigDLTestCase):
 
     def test_merge_method_seq_concat(self):
         bx1 = BLayer.Input(shape=(10, ))
-        bx1_1 = BLayer.Input(shape=(10, ))
         bx2 = BLayer.Input(shape=(10, ))
         by1 = BLayer.Dense(12, activation="sigmoid")(bx1)
-        bbranch1_node = BModel(bx1, by1)(bx1_1)
+        bbranch1_node = BModel(bx1, by1)(bx1)
         bbranch2 = BSequential()
         bbranch2.add(BLayer.Dense(12, input_dim=10))
         bbranch2_node = bbranch2(bx2)
         bz = BLayer.merge([bbranch1_node, bbranch2_node], mode="concat")
-        bmodel = BModel([bx1_1, bx2], bz)
+        bmodel = BModel([bx1, bx2], bz)
 
         kx1 = KLayer.Input(shape=(10, ))
         kx2 = KLayer.Input(shape=(10, ))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
@@ -215,18 +215,7 @@ abstract class Container[A <: Activity : ClassTag,
   private[bigdl] override final def checkDuplicate(
     record: mutable.HashSet[Int] = mutable.HashSet()
   ): Unit = {
-    val errMsg = "Some module is duplicate in the current model: "
-    val curId = System.identityHashCode(this)
-    require(!record.contains(curId), errMsg + this.getName())
-    record.add(curId)
-    modules.foreach(m => {
-      if (m.isInstanceOf[Container[_, _, _]]) {
-        m.asInstanceOf[Container[_, _, _]].checkDuplicate(record)
-      } else {
-        val mId = System.identityHashCode(m)
-        require(!record.contains(mId), errMsg + m.getName())
-        record.add(mId)
-      }
-    })
+    super.checkDuplicate(record)
+    if (!skipDuplicateCheck()) modules.foreach(_.checkDuplicate(record))
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -1044,6 +1044,17 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag, 
    */
   private[bigdl] def checkDuplicate(
     record: mutable.HashSet[Int] = mutable.HashSet()
-  ): Unit = {}
+  ): Unit = {
+    val errMsg = "Some module is duplicate in the current model: "
+    val curId = System.identityHashCode(this)
+    require(this.skipDuplicateCheck() || !record.contains(curId), errMsg + this.getName())
+    record.add(curId)
+  }
+
+  /**
+   * Sometimes, some layer need skip the duplicate check process, e.g. Keras-like input layer
+   * @return
+   */
+  private[nn] def skipDuplicateCheck(): Boolean = false
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Input.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Input.scala
@@ -27,20 +27,27 @@ import scala.reflect.ClassTag
 class Input[T: ClassTag](val inputShape: Shape)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Activity, Activity, T](KerasLayer.addBatch(inputShape)) {
 
+  private var skipDuplicate = false
+
+  private[Input] def setSkipDuplicate(): this.type = {
+    this.skipDuplicate = true
+    this
+  }
+
   override def computeOutputShape(inputShape: Shape): Shape = inputShape
 
   override def doBuild(inputShape: Shape): TInput[T] = new TInput[T]()
 
   override def allowRebuilt(): Boolean = true
 
-  override def skipDuplicateCheck(): Boolean = true
+  override def skipDuplicateCheck(): Boolean = skipDuplicate
 }
 
 object Input {
   def apply[T: ClassTag](
     inputShape: Shape = null,
     name : String = null)(implicit ev: TensorNumeric[T]): ModuleNode[T] = {
-    val module = new Input(inputShape)
+    val module = new Input(inputShape).setSkipDuplicate()
     module.build(KerasLayer.addBatch(inputShape))
     if (name != null) {
       module.setName(name)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Input.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Input.scala
@@ -32,6 +32,8 @@ class Input[T: ClassTag](val inputShape: Shape)(implicit ev: TensorNumeric[T])
   override def doBuild(inputShape: Shape): TInput[T] = new TInput[T]()
 
   override def allowRebuilt(): Boolean = true
+
+  override def skipDuplicateCheck(): Boolean = true
 }
 
 object Input {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Input.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Input.scala
@@ -47,6 +47,10 @@ object Input {
   def apply[T: ClassTag](
     inputShape: Shape = null,
     name : String = null)(implicit ev: TensorNumeric[T]): ModuleNode[T] = {
+    // As this method return a node, so it cannot be added to a container or connect from other
+    // nodes multiple times. So we can skip the duplicate checking.
+    // Even it is repeated appears multiple time in a nested container, it's okay as it will always
+    // be the first layer.
     val module = new Input(inputShape).setSkipDuplicate()
     module.build(KerasLayer.addBatch(inputShape))
     if (name != null) {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Topology.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/Topology.scala
@@ -302,6 +302,7 @@ class Sequential[T: ClassTag]()
 
     labor.asInstanceOf[TSequential[T]].modules +=
       module.asInstanceOf[AbstractModule[Activity, Activity, T]]
+    checkDuplicate()
     this
   }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/InputSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/InputSpec.scala
@@ -16,12 +16,28 @@
 
 package com.intel.analytics.bigdl.keras.nn
 
-import com.intel.analytics.bigdl.nn.keras.{InputLayer, Sequential}
+import com.intel.analytics.bigdl.nn.keras.Merge.merge
+import com.intel.analytics.bigdl.nn.keras._
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, Shape}
 import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+import com.intel.analytics.bigdl.numeric.NumericFloat
 
 import scala.util.Random
+
+class InputSpec extends BigDLSpecHelper {
+  "Duplicate container" should "not throw exception" in {
+    val bx1 = Input(Shape(4))
+    val bx2 = Input(Shape(5))
+    val by1 = Dense(6, activation = "sigmoid").inputs(bx1)
+    val bbranch1 = Model(bx1, by1).inputs(bx1)
+    val bbranch2 = Dense(8).inputs(bx2)
+    val bz = merge(List(bbranch1, bbranch2), mode = "concat")
+    val bmodel = Model(Array(bx1, bx2), bz)
+
+    // No exception should be threw in the above code
+  }
+}
 
 class InputSerialTest extends ModuleSerializationTest {
   override def test(): Unit = {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/InputSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/keras/nn/InputSpec.scala
@@ -37,6 +37,16 @@ class InputSpec extends BigDLSpecHelper {
 
     // No exception should be threw in the above code
   }
+
+  "Duplicate input layer" should "throw exception" in {
+    val i = InputLayer(Shape(4))
+    val seq = Sequential()
+    seq.add(i)
+
+    intercept[IllegalArgumentException] {
+      seq.add(i)
+    }
+  }
 }
 
 class InputSerialTest extends ModuleSerializationTest {


### PR DESCRIPTION
## What changes were proposed in this pull request?
We find that sometimes duplicate check should be suspended. Here's an example
```scala
    val bx1 = Input(Shape(4))
    val bx2 = Input(Shape(5))
    val by1 = Dense(6, activation = "sigmoid").inputs(bx1)
    val bbranch1 = Model(bx1, by1).inputs(bx1)
    val bbranch2 = Dense(8).inputs(bx2)
    val bz = merge(List(bbranch1, bbranch2), mode = "concat")
    val bmodel = Model(Array(bx1, bx2), bz)
```
This kind of code will be allowed in keras but will thrown exception in BigDL. The root cause is that the ```bx1``` is added to ```bbranch1``` and ```bmodel```. So bmodel will throw exeption when do the duplicate check.

However, this kind of usage should be allowed as
1. Keras can do it
2. The ```bx1``` is the first node in both ```bbranch1``` and ```bmode```, which won't cause any error

The PR fix this by adding a flag to the module API. So when the user uses an input node, the duplicate check will be suspended.

This PR also fix a bug that the duplicate check is missed in Keras Seq topology.

## How was this patch tested?
unit tests

