### PR TITLE
[Bug Fix] Use "NHWC" as the default value when "data_format" of DepthwiseConv2dNative is missing

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/DepthwiseConv2dNative.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/DepthwiseConv2dNative.scala
@@ -42,7 +42,12 @@ class DepthwiseConv2dNative extends TensorflowOpsLoader {
     val strideList = getIntList(attributes, "strides")
     require(strideList.head == 1, s"not support strides on batch")
 
-    val format = getString(attributes, "data_format")
+    val format = if (attributes.containsKey("data_format")) {
+      getString(attributes, "data_format")
+    } else {
+      "NHWC"
+    }
+
     val conv = format match {
       case "NHWC" =>
         require(strideList(3) == 1, s"not support strides on depth")

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/loaders/DepthwiseConv2DNativeSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/loaders/DepthwiseConv2DNativeSpec.scala
@@ -54,4 +54,19 @@ class DepthwiseConv2DNativeSpec extends TensorflowSpecHelper {
       0
     )
   }
+
+  "DepthwiseConv2DNative forward" should "be correct when use default data_format" in {
+    RNG.setSeed(100)
+    val filter = Tensor[Float](2, 2, 3, 2).rand()
+    compare[Float](
+      NodeDef.newBuilder()
+        .setName("depthwise_conv2d_test")
+        .putAttr("T", typeAttr(DataType.DT_FLOAT))
+        .putAttr("padding", PaddingType.PADDING_VALID.value)
+        .putAttr("strides", listIntAttr(Seq(1, 1, 1, 1)))
+        .setOp("DepthwiseConv2dNative"),
+      Seq(Tensor[Float](4, 24, 24, 3).rand(), filter),
+      0
+    )
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Sometimes "data_format" field of DepthwiseConv2dNative is missing. Follow tensorflow, use "NHWC" as the default value when "data_format" of DepthwiseConv2dNative is missing

## How was this patch tested?
unit tests

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/2280

