### PR TITLE
[Bug Fix] Empty tensor call size() and stride() not throw null exception

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
@@ -68,7 +68,9 @@ private[tensor] class DenseTensor[@specialized T: ClassTag](
     result.squeeze()
   }
 
-  override def size(): Array[Int] = _size.slice(0, this.nDimension)
+  override def size(): Array[Int] = {
+    if (_size == null) null else _size.slice(0, this.nDimension)
+  }
 
   override def size(dim: Int): Int = {
     require(dim > 0 && dim <= this.nDimension,
@@ -76,7 +78,9 @@ private[tensor] class DenseTensor[@specialized T: ClassTag](
     _size(dim - 1)
   }
 
-  override def stride(): Array[Int] = _stride.slice(0, this.nDimension)
+  override def stride(): Array[Int] = {
+    if (_stride == null) null else _stride.slice(0, this.nDimension)
+  }
 
   override def stride(dim: Int): Int = {
     require(dim > 0 && dim <= this.nDimension,

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DenseTensorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DenseTensorSpec.scala
@@ -1082,4 +1082,14 @@ class DenseTensorSpec extends FlatSpec with Matchers {
 
     scalar2.value() should be(1)
   }
+
+  "size" should "work on empty tensor" in {
+    val t = Tensor[Float]()
+    t.size() should be (null)
+  }
+
+  "stride" should "work on empty tensor" in {
+    val t = Tensor[Float]()
+    t.stride() should be (null)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Empty tensor call size() and stride() not throw null exception

## How was this patch tested?
new unit test and jenkins

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/1947

