### PR TITLE
refactor model.evaluate parameter

### DIFF
--- a/docs/docs/APIGuide/Module.md
+++ b/docs/docs/APIGuide/Module.md
@@ -170,7 +170,7 @@ val testSet = sc.parallelize(Seq(testSample))
 
 //train a new model or load an existing model
 //val model=...
-val evaluateResult = model.evaluate(testSet, Array(new Top1Accuracy), None)
+val evaluateResult = model.evaluate(testSet, Array(new Top1Accuracy))
 ```
 
 **Python example**

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -827,10 +827,10 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag, 
    */
   final def evaluate(
     dataset: RDD[Sample[T]],
-    vMethods: Array[ValidationMethod[T]],
+    vMethods: Array[_ <:ValidationMethod[T]],
     batchSize: Option[Int] = None
   ): Array[(ValidationResult, ValidationMethod[T])] = {
-    Evaluator(this).test(dataset, vMethods, batchSize)
+    Evaluator(this).test(dataset, vMethods.map(v => v), batchSize)
   }
 
   /**
@@ -841,9 +841,9 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag, 
    */
   final def evaluate(
     dataSet: LocalDataSet[MiniBatch[T]],
-    vMethods: Array[ValidationMethod[T]]
+    vMethods: Array[_ <:ValidationMethod[T]]
   ): Array[(ValidationResult, ValidationMethod[T])] = {
-    Validator(this, dataSet).test(vMethods)
+    Validator(this, dataSet).test(vMethods.map(v => v))
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refactor  parameter vMethods of model.evaluate api  from Array[ValidationMethod[T]] to Array[_ <:ValidationMethod[T]], then there will be no type mismatch compile error when using  "model.evaluate(testSet, Array(new Top1Accuracy))". 

## How was this patch tested?

unit tests & manual tests

## Related links or issues (optional)

fix https://github.com/intel-analytics/BigDL/issues/1836

