### PR TITLE
[Backport] update "can't find locality partition for partition ..." to warning message

### DIFF
--- a/spark/spark-version/1.5-plus/src/main/scala/org/apache/spark/rdd/ZippedPartitionsWithLocalityRDD.scala
+++ b/spark/spark-version/1.5-plus/src/main/scala/org/apache/spark/rdd/ZippedPartitionsWithLocalityRDD.scala
@@ -18,6 +18,7 @@ package org.apache.spark.rdd
 
 import java.io.{IOException, ObjectOutputStream}
 
+import org.apache.log4j.Logger
 import org.apache.spark.{Partition, SparkContext}
 
 import scala.collection.mutable.ArrayBuffer
@@ -32,6 +33,8 @@ object ZippedPartitionsWithLocalityRDD {
     new ZippedPartitionsWithLocalityRDD(
       sc, sc.clean(f), rdd1, rdd2, preservesPartitioning)
   }
+
+  val logger: Logger = Logger.getLogger(getClass)
 }
 
 /**
@@ -91,9 +94,9 @@ class ZippedPartitionsWithLocalityRDD[A: ClassTag, B: ClassTag, V: ClassTag](
         parts(i) =
           new ZippedPartitionsLocalityPartition(i, Array(i, matchPartition._1), rdds, locs)
       } else {
-        println(s"can't find locality partition for partition $i " +
-          s"Partition locations are (${curPrefs}) Candidate partition locations are\n" +
-          s"${candidateLocs.mkString("\n")}.")
+        ZippedPartitionsWithLocalityRDD.logger.warn(s"can't find locality partition for" +
+          s" partition $i Partition locations are (${curPrefs}) Candidate partition" +
+          s" locations are\n" + s"${candidateLocs.mkString("\n")}.")
         nonmatchPartitionId.append(i)
       }
     }

--- a/spark/spark-version/2.0/src/main/scala/org/apache/spark/rdd/ZippedPartitionsWithLocalityRDD.scala
+++ b/spark/spark-version/2.0/src/main/scala/org/apache/spark/rdd/ZippedPartitionsWithLocalityRDD.scala
@@ -18,6 +18,7 @@ package org.apache.spark.rdd
 
 import java.io.{IOException, ObjectOutputStream}
 
+import org.apache.log4j.Logger
 import org.apache.spark.util.Utils
 import org.apache.spark.{Partition, SparkContext}
 
@@ -32,6 +33,8 @@ object ZippedPartitionsWithLocalityRDD {
     new ZippedPartitionsWithLocalityRDD(
       sc, sc.clean(f), rdd1, rdd2, preservesPartitioning)
   }
+
+  val logger: Logger = Logger.getLogger(getClass)
 }
 
 /**
@@ -91,9 +94,9 @@ class ZippedPartitionsWithLocalityRDD[A: ClassTag, B: ClassTag, V: ClassTag](
         parts(i) =
           new ZippedPartitionsLocalityPartition(i, Array(i, matchPartition._1), rdds, locs)
       } else {
-        println(s"can't find locality partition for partition $i " +
-          s"Partition locations are (${curPrefs}) Candidate partition locations are\n" +
-          s"${candidateLocs.mkString("\n")}.")
+        ZippedPartitionsWithLocalityRDD.logger.warn(s"can't find locality partition" +
+          s"for partition $i Partition locations are (${curPrefs}) Candidate partition" +
+          s" locations are\n" + s"${candidateLocs.mkString("\n")}.")
         nonmatchPartitionId.append(i)
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
change println("can't find locality partition for partition ...") to logger.warn in ZippedPartitionsWithLocalityRDD to make less confusion.

## How was this patch tested?
manual test and ut

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/2361

