### PR TITLE
[backport 0.5] Add Keras Website Documentation for Layers I

### DIFF
--- a/docs/docs/KerasStyleAPIGuide/Layers/advanced-activation.md
+++ b/docs/docs/KerasStyleAPIGuide/Layers/advanced-activation.md
@@ -1,0 +1,293 @@
+## **ELU**
+Exponential Linear Unit.
+
+It follows: f(x) =  alpha * (exp(x) - 1.) for x < 0, f(x) = x for x >= 0.
+
+**Scala:**
+```scala
+ELU(alpha = 1.0, inputShape = null)
+```
+**Python:**
+```python
+ELU(alpha=1.0, input_shape=None)
+```
+
+**Parameters:**
+
+* `alpha`: Double, scale for the negative factor.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, ELU}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(ELU(inputShape = Shape(3)))
+val input = Tensor[Float](2, 3).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+-0.13405465	0.05160992	-1.4711418
+1.5808829	-1.3145303	0.6709266
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+-0.1254577	0.05160992	-0.77033687
+1.5808829	-0.73139954	0.6709266
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import ELU
+
+model = Sequential()
+model.add(ELU(input_shape=(3, )))
+input = np.random.random([2, 3])
+output = model.forward(input)
+```
+Input is:
+```python
+[[0.90404922 0.23530925 0.49711093]
+ [0.43009161 0.22446032 0.90144771]]
+```
+Output is
+```python
+[[0.9040492  0.23530924 0.49711093]
+ [0.43009162 0.22446032 0.9014477 ]]
+```
+
+---
+## **LeakyReLU**
+Leaky version of a Rectified Linear Unit.
+
+It allows a small gradient when the unit is not active: f(x) = alpha * x for x < 0, f(x) = x for x >= 0.
+
+**Scala:**
+```scala
+LeakyReLU(alpha = 0.3, inputShape = null)
+```
+**Python:**
+```python
+LeakyReLU(alpha=0.3, input_shape=None)
+```
+
+**Parameters:**
+
+* `alpha`: Double >= 0. Negative slope coefficient.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, LeakyReLU}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(LeakyReLU(inputShape = Shape(3)))
+val input = Tensor[Float](2, 3).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+0.8846715	-0.5720033	-0.8220917
+-0.51755846	1.099684	2.6011446
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+0.8846715	    -0.005720033	-0.008220917
+-0.0051755845	1.099684	    2.6011446
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import LeakyReLU
+
+model = Sequential()
+model.add(LeakyReLU(input_shape=(3, )))
+input = np.random.random([2, 3])
+output = model.forward(input)
+```
+Input is:
+```python
+[[0.14422043 0.38066946 0.55092494]
+ [0.60075682 0.53505094 0.78330962]]
+```
+Output is
+```python
+[[0.14422044 0.38066944 0.55092496]
+ [0.6007568  0.5350509  0.78330964]]
+```
+
+---
+## **SReLU**
+S-shaped Rectified Linear Unit.
+
+It follows: f(x) = t^r + a^r(x - t^r) for x >= t^r, f(x) = x for t^r > x > t^l, f(x) = t^l + a^l(x - t^l) for x <= t^l.
+
+**Scala:**
+```scala
+SReLU(tLeftInit = "zero", aLeftInit = "glorot_uniform", tRightInit = "glorot_uniform", aRightInit = "one", sharedAxes = null, inputShape = null)
+```
+**Python:**
+```python
+SReLU(t_left_init="zero", a_left_init="glorot_uniform", t_right_init="glorot_uniform", a_right_init="one", shared_axes=None, input_shape=None)
+```
+
+**Parameters:**
+
+* `tLeftInit`: String representation of the initialization method for the left part intercept. Default is 'zero'.
+* `aLeftInit`: String representation of the initialization method for the left part slope. Default is 'glorot_uniform'.
+* `tRightInit`: String representation of ithe nitialization method for the right part intercept. Default is 'glorot_uniform'.
+* `aRightInit`: String representation of the initialization method for the right part slope. Default is 'one'.
+* `sharedAxes`: The axes along which to share learnable parameters for the activation function. Default is null.
+For example, if the incoming feature maps are from a 2D convolution with output shape (batch, height, width, channels), and you wish to share parameters across space so that each filter only has one set of parameters, set 'SharedAxes = Array(1,2)'.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, SReLU}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(SReLU(inputShape = Shape(2, 3)))
+val input = Tensor[Float](2, 2, 3).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,.,.) =
+0.5599429	0.22811626	-0.027771426
+-0.56582874	1.9261217	1.2686813
+
+(2,.,.) =
+0.7538568	0.8725621	0.19803657
+0.49057	    0.0537252	0.8684544
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,.,.) =
+0.5599429	0.22811626	-0.009864618
+0.07011698	1.9261217	1.2686813
+
+(2,.,.) =
+0.7538568	0.87256205	0.19803657
+0.49057	    0.0537252	0.8684544
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import SReLU
+
+model = Sequential()
+model.add(SReLU(input_shape=(2, 3)))
+input = np.random.random([2, 2, 3])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[0.42998132 0.47736492 0.9554154 ]
+  [0.93264942 0.56851545 0.39508313]]
+
+ [[0.5164102  0.22304862 0.44380779]
+  [0.69137804 0.26413953 0.60638032]]]
+```
+Output is
+```python
+[[[0.42998132 0.47736493 0.9554154 ]
+  [0.93264943 0.5685154  0.39508313]]
+
+ [[0.5164102  0.22304863 0.44380778]
+  [0.69137806 0.26413953 0.60638034]]]
+```
+
+---
+## **ThresholdedReLU**
+Thresholded Rectified Linear Unit.
+
+It follows: f(x) = x for x > theta, f(x) = 0 otherwise.
+
+**Scala:**
+```scala
+ThresholdedReLU(theta = 1.0, inputShape = null)
+```
+**Python:**
+```python
+ThresholdedReLU(theta=1.0, input_shape=None)
+```
+
+**Parameters:**
+
+* `theta`: Double >= 0. Threshold location of activation.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, ThresholdedReLU}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(ThresholdedReLU(inputShape = Shape(3)))
+val input = Tensor[Float](2, 3).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+2.220999	1.2022058	-1.0015608
+0.6532913	0.31831574	1.6747104
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+2.220999	1.2022058	0.0
+0.0	        0.0	        1.6747104
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import ThresholdedReLU
+
+model = Sequential()
+model.add(ThresholdedReLU(input_shape=(3, )))
+input = np.random.random([2, 3])
+output = model.forward(input)
+```
+Input is:
+```python
+[[0.91854565 0.58317415 0.33089385]
+ [0.82472184 0.70572913 0.32803604]]
+```
+Output is
+```python
+[[0.0   0.0   0.0]
+ [0.0   0.0   0.0]]
+```

--- a/docs/docs/KerasStyleAPIGuide/Layers/convolutional.md
+++ b/docs/docs/KerasStyleAPIGuide/Layers/convolutional.md
@@ -1,0 +1,884 @@
+## **Convolution1D**
+Applies convolution operator for filtering neighborhoods of 1-D inputs.
+
+You can also use Conv1D as an alias of this layer.
+
+The input of this layer should be 3D.
+
+**Scala:**
+```scala
+Convolution1D(nbFilter, filterLength, init = "glorot_uniform", activation = null, borderMode = "valid", subsampleLength = 1, wRegularizer = null, bRegularizer = null, bias = true, inputShape = null)
+```
+**Python:**
+```python
+Convolution1D(nb_filter, filter_length, init="glorot_uniform", activation=None, border_mode="valid", subsample_length=1, W_regularizer=None, b_regularizer=None, bias=True, input_shape=None)
+```
+
+**Parameters:**
+
+* `nbFilter`: Number of convolution filters to use.
+* `filterLength`: The extension (spatial or temporal) of each filter.
+* `init`: String representation of the initialization method for the weights of the layer. See [here](initialization/#available-initialization-methods) for available initialization strings. Default is "glorot_uniform".
+* `activation`: String representation of the activation function to use. See [here](activation/#available-activations) for available activation strings. Default is null.
+* `borderMode`: Either 'valid' or 'same'. Default is 'valid'.
+* `subsampleLength`: Factor by which to subsample output. Integer. Default is 1.
+* `wRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), (eg. L1 or L2 regularization), applied to the input weights matrices. Default is null.
+* `bRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), applied to the bias. Default is null.
+* `bias`: Whether to include a bias (i.e. make the layer affine rather than linear). Default is true.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, Convolution1D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(Convolution1D(8, 3, inputShape = Shape(3, 4)))
+val input = Tensor[Float](2, 3, 4).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,.,.) =
+-1.4253887	-0.044403594	-1.1169672	-0.19499049
+0.85463065	0.6665206	0.21340805	0.56255895
+1.1126599	-0.3423326	0.09643264	-0.34345046
+
+(2,.,.) =
+-0.04046587	-0.2710401	0.10183265	1.4503858
+1.0639644	1.5317003	-0.18313104	-0.7098296
+0.612399	1.7357533	0.4641411	0.13530721
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3x4]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,.,.) =
+0.22175728	0.76192796	1.7907748	1.1534728	-1.5304534	0.07466106	-0.18292685	0.6038852
+
+(2,.,.) =
+0.85337734	0.43939286	-0.16770163	-0.8380078	0.7825804	-0.3485601	0.3017909	0.5823619
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x1x8]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import Convolution1D
+
+model = Sequential()
+model.add(Convolution1D(8, 3, input_shape=(3, 4)))
+input = np.random.random([2, 3, 4])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[0.06092268 0.0508438  0.47256153 0.80004565]
+  [0.48706905 0.65704781 0.04297214 0.42288264]
+  [0.92286158 0.85394381 0.46423248 0.87896669]]
+
+ [[0.216527   0.13880484 0.93482372 0.44812419]
+  [0.95553331 0.27084259 0.58913626 0.01879454]
+  [0.6656435  0.1985877  0.94133745 0.57504128]]]
+```
+Output is
+```python
+[[[ 0.7461933  -2.3189526  -1.454972   -0.7323345   1.5272427  -0.87963724  0.6278059  -0.23403725]]
+
+ [[ 1.2397771  -0.9249111  -1.1432207  -0.92868984  0.53766745 -1.0271561  -0.9593589  -0.4768026 ]]]
+```
+
+---
+## **Convolution2D**
+Applies a 2D convolution over an input image composed of several input planes.
+
+You can also use Conv2D as an alias of this layer.
+
+The input of this layer should be 4D.
+
+**Scala:**
+```scala
+Convolution2D(nbFilter, nbRow, nbCol, init = "glorot_uniform", activation = null, borderMode = "valid", subsample = Array(1, 1), dimOrdering = "th", wRegularizer = null, bRegularizer = null, bias = true, inputShape = null)
+```
+**Python:**
+```python
+Convolution2D(nb_filter, nb_row, nb_col, init="glorot_uniform", activation=None, border_mode="valid", subsample=(1, 1), dim_ordering="th", W_regularizer=None, b_regularizer=None, bias=True, input_shape=None)
+```
+
+**Parameters:**
+
+* `nbFilter`: Number of convolution filters to use.
+* `nbRow`: Number of rows in the convolution kernel.
+* `nbCol`: Number of columns in the convolution kernel.
+* `init`: String representation of the initialization method for the weights of the layer. See [here](initialization/#available-initialization-methods) for available initialization strings. Default is "glorot_uniform".
+* `activation`: String representation of the activation function to use. See [here](activation/#available-activations) for available activation strings. Default is null.
+* `borderMode`: Either 'valid' or 'same'. Default is 'valid'.
+* `subsample`: Length 2 corresponding to the step of the convolution in the height and width dimension. Also called strides elsewhere. Default is (1, 1).
+* `dimOrdering`: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
+* `wRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), (eg. L1 or L2 regularization), applied to the input weights matrices. Default is null.
+* `bRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), applied to the bias. Default is null.
+* `bias`: Whether to include a bias (i.e. make the layer affine rather than linear). Default is true.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, Convolution2D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(Convolution2D(4, 2, 2, activation = "relu", inputShape = Shape(2, 3, 4)))
+val input = Tensor[Float](2, 2, 3, 4).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,1,.,.) =
+-1.6687597	1.3452173	-1.9608531	-0.30892205
+1.7459077	-0.443617	0.25789636	0.44496542
+-1.5395774	-0.37713575	-0.9973955	0.16208267
+
+(1,2,.,.) =
+0.593965	1.0544858	-1.0765858	0.22257836
+0.69452614	1.3700147	-0.886259	0.013910895
+-1.9819669	0.32151425	1.8303248	0.24231844
+
+(2,1,.,.) =
+-2.150859	-1.5894475	0.7543173	0.7713991
+-0.17536041	0.89053404	0.50489277	-0.098128
+0.11551995	1.3663125	0.76734704	0.28318745
+
+(2,2,.,.) =
+-0.9801306	0.39797616	-0.6403248	1.0090133
+-0.16866015	-1.426308	-2.4097774	0.26011375
+-2.5700948	1.0486397	-0.4585798	-0.94231766
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3x4]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,1,.,.) =
+0.0	        0.6800046	0.0
+1.0366663	0.235024	0.0
+
+(1,2,.,.) =
+0.0	        0.84696645	0.0
+0.9099177	0.0	        0.0
+
+(1,3,.,.) =
+0.122891426	0.0	        0.86579126
+0.0	        0.0	        0.0
+
+(1,4,.,.) =
+0.0	        0.7185988	0.0
+1.0967548	0.48376864	0.0
+
+(2,1,.,.) =
+0.0	        0.0	        0.29164955
+0.06815311	0.0	        0.0
+
+(2,2,.,.) =
+0.36370438	0.42393038	0.26948324
+1.1676859	0.5698308	0.44842285
+
+(2,3,.,.) =
+1.0797265	1.2410768	0.18289843
+0.0	        0.0	        0.18757495
+
+(2,4,.,.) =
+0.0	        0.35713753	0.0
+0.0	        0.0	        0.0
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x4x2x3]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import Convolution2D
+
+model = Sequential()
+model.add(Convolution2D(4, 2, 2, input_shape=(2, 3, 4)))
+input = np.random.random([2, 2, 3, 4])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[[0.05182015 0.91971256 0.81030852 0.64093699]
+   [0.60282957 0.16269049 0.79136121 0.05202386]
+   [0.62560999 0.00174107 0.75762976 0.93589574]]
+
+  [[0.13728558 0.85812609 0.39695457 0.81678788]
+   [0.7569393  0.61161632 0.60750583 0.6222684 ]
+   [0.53094821 0.38715199 0.0087283  0.05758945]]]
+
+
+ [[[0.50030948 0.40179766 0.54900785 0.60950401]
+   [0.17464329 0.01506322 0.55273153 0.21567461]
+   [0.09037649 0.58831638 0.818708   0.96642448]]
+
+  [[0.77126628 0.58039509 0.91612417 0.12578268]
+   [0.6095838  0.15802154 0.78099004 0.63619778]
+   [0.70632951 0.91378968 0.84851605 0.7242516 ]]]]
+```
+Output is
+```python
+[[[[-0.45239753  0.2432243  -0.02717562]
+   [ 0.2698849  -0.09664132  0.92311716]]
+
+  [[ 0.9092748   0.7945191   0.8834159 ]
+   [ 0.4853364   0.6511425   0.52513427]]
+
+  [[ 0.5550465   0.8177169   0.43213058]
+   [ 0.4209347   0.7514105   0.27255327]]
+
+  [[-0.22105691  0.02853963  0.01092601]
+   [ 0.1258291  -0.41649136 -0.18953061]]]
+
+
+ [[[-0.12111888  0.06418754  0.26331317]
+   [ 0.41674113  0.04221775  0.7313505 ]]
+
+  [[ 0.49442202  0.6964868   0.558412  ]
+   [ 0.25196168  0.8145504   0.69307953]]
+
+  [[ 0.5885831   0.59289575  0.71726865]
+   [ 0.46759683  0.520353    0.59305453]]
+
+  [[ 0.00594708  0.09721318  0.07852311]
+   [ 0.49868047  0.02704304  0.14635414]]]]
+```
+
+---
+## **Convolution3D**
+Applies convolution operator for filtering windows of three-dimensional inputs.
+
+You can also use Conv3D as an alias of this layer.
+
+Data format currently supported for this layer is 'CHANNEL_FIRST' (dimOrdering='th').
+
+The input of this layer should be 5D.
+
+**Scala:**
+```scala
+Convolution3D(nbFilter, kernelDim1, kernelDim2, kernelDim3, init = "glorot_uniform", activation = null, borderMode = "valid", subsample = Array(1, 1, 1), dimOrdering = "th", wRegularizer = null, bRegularizer = null, bias = true, inputShape = null)
+```
+**Python:**
+```python
+Convolution3D(nb_filter, kernel_dim1, kernel_dim2, kernel_dim3, init="glorot_uniform", activation=None, border_mode="valid", subsample=(1, 1, 1), dim_ordering="th", W_regularizer=None, b_regularizer=None, bias=True, input_shape=None)
+```
+
+**Parameters:**
+
+* `nbFilter`: Number of convolution filters to use.
+* `kernelDim1`: Length of the first dimension in the convolution kernel.
+* `kernelDim2`: Length of the second dimension in the convolution kernel.
+* `kernelDim3`: Length of the third dimension in the convolution kernel.
+* `init`: String representation of the initialization method for the weights of the layer. See [here](initialization/#available-initialization-methods) for available initialization strings. Default is "glorot_uniform".
+* `activation`: String representation of the activation function to use. See [here](activation/#available-activations) for available activation strings. Default is null.
+* `borderMode`: Either 'valid' or 'same'. Default is 'valid'.
+* `subsample`: Length 3. Factor by which to subsample output. Also called strides elsewhere. Default is (1, 1, 1).
+* `dimOrdering`: Format of input data. Only 'th' (Channel First) is supported for now.
+* `wRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), (eg. L1 or L2 regularization), applied to the input weights matrices. Default is null.
+* `bRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), applied to the bias. Default is null.
+* `bias`: Whether to include a bias (i.e. make the layer affine rather than linear). Default is true.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, Convolution3D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(Convolution3D(4, 2, 2, 2, inputShape = Shape(2, 2, 2, 3)))
+val input = Tensor[Float](2, 2, 2, 2, 3).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,1,1,.,.) =
+0.64140224	-1.4049392	0.4935015
+0.33096266	1.2768826	-0.57567996
+
+(1,1,2,.,.) =
+0.49570087	-2.0367618	-0.0032108661
+-0.24242361	-0.092683665	1.1579652
+
+(1,2,1,.,.) =
+-0.6730608	0.9149566	-1.7478822
+-0.1763675	-0.90117735	0.38452747
+
+(1,2,2,.,.) =
+0.5314353	1.4802488	-1.196325
+0.43506134	-0.56575996	-1.5489199
+
+(2,1,1,.,.) =
+0.074545994	-1.4092928	-0.57647055
+1.9998664	-0.19424418	-0.9296713
+
+(2,1,2,.,.) =
+-0.42966184	0.9247804	-0.21713361
+0.2723336	-1.3024703	1.278154
+
+(2,2,1,.,.) =
+1.1240695	1.1061385	-2.4662287
+-0.36022148	0.1620907	-1.1525819
+
+(2,2,2,.,.) =
+0.9885768	-0.526637	-0.40684605
+0.37813842	0.53998697	1.0001947
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x2x2x3]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,1,1,.,.) =
+0.36078936	-0.6334647
+
+(1,2,1,.,.) =
+-0.19685572	0.4559337
+
+(1,3,1,.,.) =
+1.3750207	-2.4377227
+
+(1,4,1,.,.) =
+-0.82853335	-0.74145436
+
+(2,1,1,.,.) =
+-0.17973013	1.2930126
+
+(2,2,1,.,.) =
+0.69144577	0.44385013
+
+(2,3,1,.,.) =
+-0.5597819	0.5965629
+
+(2,4,1,.,.) =
+0.89755684	-0.6737796
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x4x1x1x2]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import Convolution3D
+
+model = Sequential()
+model.add(Convolution3D(4, 2, 2, 2, input_shape=(2, 2, 2, 3)))
+input = np.random.random([2, 2, 2, 2, 3])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[[[0.36798873 0.92635561 0.31834968]
+    [0.09001392 0.66762381 0.64477164]]
+
+   [[0.09760993 0.38067132 0.15069965]
+    [0.39052699 0.0223722  0.04786307]]]
+
+
+  [[[0.2867726  0.3674255  0.11852931]
+    [0.96436629 0.8012903  0.3211012 ]]
+
+   [[0.81738622 0.80606827 0.4060485 ]
+    [0.68010177 0.0934071  0.98479026]]]]
+
+
+
+ [[[[0.71624597 0.37754442 0.07367964]
+    [0.60742428 0.38549046 0.78880978]]
+
+   [[0.97844361 0.11426373 0.55479659]
+    [0.06395313 0.86007246 0.34004405]]]
+
+
+  [[[0.94149643 0.8027673  0.19478027]
+    [0.17437108 0.754479   0.51055297]]
+
+   [[0.81933677 0.09040694 0.33775061]
+    [0.02582059 0.40027544 0.91809986]]]]]
+
+```
+Output is
+```python
+[[[[[ 1.6276866  -4.4106215]]]
+
+  [[[ 6.6988254  1.1409638]]]
+
+  [[[-5.7734865  -5.2575850]]]
+
+  [[[-1.8073934  -4.4056013]]]]
+
+
+ [[[[-4.8580116  9.4352424]]]
+
+  [[[ 7.8890514  6.6063654]]]
+
+  [[[-7.3165756  -1.0116580]]]
+
+  [[[-1.3100024  1.0475740]]]]]
+```
+
+---
+## **Cropping1D**
+Cropping layer for 1D input (e.g. temporal sequence).
+
+The input of this layer should be 3D.
+
+**Scala:**
+```scala
+Cropping1D(cropping = Array(1, 1), inputShape = null)
+```
+**Python:**
+```python
+Cropping1D(cropping=(1, 1), input_shape=None)
+```
+
+**Parameters:**
+
+* `cropping`: Length 2. How many units should be trimmed off at the beginning and end of the cropping dimension. Default is (1, 1).
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, Cropping1D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(Cropping1D(inputShape = Shape(3, 4)))
+val input = Tensor[Float](2, 3, 4).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,.,.) =
+-1.0038188	-0.75265634	0.7417358	1.0674809
+-1.4702164	0.64112693	0.17750219	-0.21439286
+-0.93766433	-1.0809567	0.7706962	0.16380796
+
+(2,.,.) =
+0.45019576	-0.36689326	0.08852628	-0.21602148
+0.66039973	0.11638404	0.062985964	-1.0420738
+0.46727908	-0.85894865	1.9853845	0.059447426
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3x4]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,.,.) =
+-1.4702164	0.64112693	0.17750219	-0.21439286
+
+(2,.,.) =
+0.66039973	0.11638404	0.062985964	-1.0420738
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x1x4]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import Cropping1D
+
+model = Sequential()
+model.add(Cropping1D(input_shape=(3, 4)))
+input = np.random.random([2, 3, 4])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[0.01030651 0.77603525 0.97263208 0.15933375]
+  [0.05135971 0.01139832 0.28809891 0.57260363]
+  [0.28128354 0.55290954 0.77011153 0.09879061]]
+
+ [[0.75765909 0.55102462 0.42426818 0.14383546]
+  [0.85198966 0.3990277  0.13061313 0.10349525]
+  [0.69892804 0.30310119 0.2241441  0.05978997]]]
+```
+Output is
+```python
+[[[0.05135971 0.01139832 0.2880989  0.57260364]]
+
+ [[0.8519896  0.3990277  0.13061313 0.10349525]]]
+```
+
+---
+## **Cropping2D**
+Cropping layer for 2D input (e.g. picture).
+
+The input of this layer should be 4D.
+
+**Scala:**
+```scala
+Cropping2D(heightCrop = Array(0, 0), widthCrop = Array(0, 0), dimOrdering = "th", inputShape = null)
+```
+**Python:**
+```python
+Cropping2D(cropping=((0, 0), (0, 0)), dim_ordering="th", input_shape=None)
+```
+
+**Parameters:**
+
+* `heightCrop`: Length 2. Height of the 2 cropping dimension. Default is (0, 0).
+* `widthCrop`: Length 2. Width of the 2 cropping dimension. Default is (0, 0).
+* `dimOrdering`: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, Cropping2D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(Cropping2D(inputShape = Shape(2, 3, 4)))
+val input = Tensor[Float](2, 2, 3, 4).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,1,.,.) =
+3.0181491	    0.39339828	0.4084114	-0.7549943
+2.2580957	    -2.0485866	1.7900336	-0.2639151
+0.2533084	    1.3308302	-0.57494026	0.08826585
+
+(1,2,.,.) =
+-0.82792234	    0.13290255	-0.30093324	-0.24207604
+-0.055458296	-0.8811668	0.8884301	0.5545515
+2.379106	    0.8125195	0.6664347	0.7499066
+
+(2,1,.,.) =
+-0.3470294	    -0.41142288	0.3438717	1.2533135
+-0.33849892	    0.9443926	0.8818804	-1.1636207
+-0.68680257	    0.94270635	-0.7203154	0.2628462
+
+(2,2,.,.) =
+0.04728707	    1.8275687	0.5546023	0.6797352
+-0.35856625	    -1.1059879	-0.06116452	-0.7903911
+0.13801727	    -0.14702533	1.2484895	1.4973202
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3x4]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,1,.,.) =
+3.0181491	    0.39339828	0.4084114	-0.7549943
+2.2580957	    -2.0485866	1.7900336	-0.2639151
+0.2533084	    1.3308302	-0.57494026	0.08826585
+
+(1,2,.,.) =
+-0.82792234	    0.13290255	-0.30093324	-0.24207604
+-0.055458296	-0.8811668	0.8884301	0.5545515
+2.379106	    0.8125195	0.6664347	0.7499066
+
+(2,1,.,.) =
+-0.3470294	    -0.41142288	0.3438717	1.2533135
+-0.33849892	    0.9443926	0.8818804	-1.1636207
+-0.68680257	    0.94270635	-0.7203154	0.2628462
+
+(2,2,.,.) =
+0.04728707	    1.8275687	0.5546023	0.6797352
+-0.35856625	    -1.1059879	-0.06116452	-0.7903911
+0.13801727	    -0.14702533	1.2484895	1.4973202
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3x4]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import Cropping2D
+
+model = Sequential()
+model.add(Cropping2D(input_shape=(2, 3, 4)))
+input = np.random.random([2, 2, 3, 4])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[[0.03691489 0.60233732 0.96327319 0.99561146]
+   [0.85728883 0.77923287 0.41328434 0.87490199]
+   [0.3389653  0.94804499 0.72922732 0.21191413]]
+
+  [[0.28962322 0.30133445 0.58516862 0.22476588]
+   [0.95386045 0.72488497 0.12056255 0.01265548]
+   [0.48645173 0.34426033 0.09410422 0.86815053]]]
+
+
+ [[[0.57444115 0.79141167 0.20755353 0.38616465]
+   [0.95793123 0.22366943 0.5080078  0.27193368]
+   [0.65402317 0.1023231  0.67207896 0.2229965 ]]
+
+  [[0.04160647 0.55577895 0.30907277 0.42227706]
+   [0.54489229 0.90423796 0.50782414 0.51441165]
+   [0.87544565 0.47791071 0.0341273  0.14728084]]]]
+```
+Output is
+```python
+[[[[0.03691489 0.6023373  0.96327317 0.9956115 ]
+   [0.85728884 0.77923286 0.41328433 0.874902  ]
+   [0.3389653  0.948045   0.7292273  0.21191412]]
+
+  [[0.28962323 0.30133444 0.5851686  0.22476588]
+   [0.95386046 0.724885   0.12056255 0.01265548]
+   [0.48645175 0.34426033 0.09410422 0.86815053]]]
+
+
+ [[[0.57444113 0.7914117  0.20755354 0.38616467]
+   [0.9579312  0.22366942 0.5080078  0.27193367]
+   [0.6540232  0.10232309 0.67207897 0.2229965 ]]
+
+  [[0.04160647 0.555779   0.30907276 0.42227706]
+   [0.5448923  0.904238   0.5078241  0.5144116 ]
+   [0.87544566 0.47791073 0.0341273  0.14728084]]]]
+```
+
+---
+## **Cropping3D**
+Cropping layer for 3D data (e.g. spatial or spatio-temporal).
+
+The input of this layer should be 5D.
+
+**Scala:**
+```scala
+Cropping3D(dim1Crop = Array(1, 1), dim2Crop = Array(1, 1), dim3Crop = Array(1, 1), dimOrdering = "th", inputShape = null)
+```
+**Python:**
+```python
+Cropping3D(cropping=((1, 1), (1, 1), (1, 1)), dim_ordering="th", input_shape=None)
+```
+
+**Parameters:**
+
+* `dim1Crop`: Length 2. Kernel dim1 of the three cropping dimensions. Default is (1, 1).
+* `dim2Crop`: Length 2. Kernel dim2 of the three cropping dimensions. Default is (1, 1).
+* `dim3Crop`: Length 2. Kernel dim3 of the three cropping dimensions. Default is (1, 1).
+* `dimOrdering`: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, Cropping3D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(Cropping3D(inputShape = Shape(2, 3, 4, 5)))
+val input = Tensor[Float](2, 2, 3, 4, 5).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,1,1,.,.) =
+-0.12339484	    0.25661087	    0.04387503	    -1.1047344	    -1.1413815
+1.1830065	    -0.07189157	    -0.5418846	    0.5576781	    -0.5460917
+-0.5679186	    -0.30854696	    1.2614665	    -0.6774269	    -0.63295823
+0.5269464	    -2.7981617	    -0.056265026	-1.0814936	    -1.0848739
+
+(1,1,2,.,.) =
+-1.9100302	    0.461067	    0.4014941	    0.60723174	    -0.40414023
+0.34300476	    0.7107094	    1.3142885	    1.5696589	    0.97591686
+0.38320687	    0.07036536	    -0.43628898	    0.58050656	    -0.57882625
+-0.43699506	    -0.0094956765	0.15171598	    0.038076796	    -1.2433665
+
+(1,1,3,.,.) =
+0.39671394	    0.880047	    0.30971292	    -0.3369089	    0.13062176
+-0.27803114 	-0.62177086	    0.16659822	    0.89428085	    0.23684736
+1.6151237	    -1.1479733	    -0.2229254	    1.1361892	    0.79478127
+-1.8207864	    1.6544164	    0.07977915	    -1.1316417	    -0.25483203
+
+(1,2,1,.,.) =
+1.3165517	    -0.9479057	    -1.4662051	    -0.3343554	    -0.4522552
+-1.5829691	    0.6378519	    -0.16399206	    1.4724066	    1.2387054
+-1.1467208	    -0.6325814	    -1.2106491	    -0.035734158	0.19871919
+2.285004	    1.0482147	    -2.0056705  	-0.80917794	    2.523167
+
+(1,2,2,.,.) =
+-0.57108706	    -0.23606259	    -0.45569882	    -0.034214735    -1.9130942
+-0.2743481	    1.61177	        -0.7052599	    0.17889105	    -0.31241596
+0.22377247	    1.5860337	    -0.3226252	    -0.1341058	    0.9239994
+0.03615294	    0.6233593	    0.757827	    -0.72271305	    0.9429943
+
+(1,2,3,.,.) =
+-0.4409662	    0.8867786	    2.0036085	    0.16242673	    -0.3332395
+0.09082064	    0.04958198	    -0.27834833	    1.8025815	    -0.04848101
+0.2690667	    -1.1263227	    -0.95486647	    0.09473259	    0.98166656
+-0.9509363	    -0.10084029	    -0.35410827	    0.29626986	    0.97203517
+
+(2,1,1,.,.) =
+0.42096403	    0.14016314	    0.20216857	    -0.678293	    -1.0970931
+-0.4981112	    0.12429344	    1.7156922	    -0.24384527 	-0.010780937
+0.03672217	    2.3021698	    1.568247	    -0.43173146	    -0.5550057
+0.30469602	    1.4772439	    -0.21195345 	0.04221814	    -1.6883365
+
+(2,1,2,.,.) =
+0.22468264	    0.72787744	    -0.9597003	    -0.28472963	    -1.4575284
+1.0487963	    0.4982454	    -1.0186157	    -1.9877508	    -1.133779
+0.17539643	    -0.35151628	    -1.8955303	    2.1854792	    0.59556997
+0.6893949	    -0.19556235	    0.25862908	    0.24450152	    0.17786922
+
+(2,1,3,.,.) =
+1.147159	    -0.8849993	    0.9826487	    0.95360875	    -0.9210176
+1.3439047	    0.6739913	    0.06558858	    0.91963255  	-1.1758618
+1.747105	    -0.7225308	    -1.0160877	    0.67554474	    -0.7762811
+0.21184689	    -0.43668815	    -1.0738864	    0.04661594	    0.9613895
+
+(2,2,1,.,.) =
+-0.377159	    -0.28094378	    0.1081715	    1.3683178       1.2572801
+0.47781375	    0.4545212	    0.55356956	    1.0366637	    -0.1962683
+-1.820227	    -0.111765414	1.9194998	    -1.6089902	    -1.6960226
+0.14896627	    0.9360371	    0.49156702	    0.08601956	    -0.08815153
+
+(2,2,2,.,.) =
+0.056315728	    -0.13061485	    -0.49018836	    -0.59103477     -1.6910721
+-0.023719765	-0.44977355	    0.11218439	    0.224829	    1.400084
+0.31496882	    -1.6386473	    -0.6715097	    0.14816228	    0.3240011
+-0.80607724	    -0.37951842	    -0.2187672	    1.1087769	    0.43044603
+
+(2,2,3,.,.) =
+-1.6647842	    -0.5720825	    -1.5150099	    0.42346838	    1.495052
+-0.3567161	    -1.4341534	    -0.19422509	    -1.2871891	    -1.2758921
+-0.47077888	    -0.42217267	    0.67764246	    1.2170314	    0.8420698
+-0.4263702	    1.2792329	    0.38645822	    -2.4653213	    -1.512707
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3x4x5]
+
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,1,1,.,.) =
+0.7107094	1.3142885	1.5696589
+0.07036536	-0.43628898	0.58050656
+
+(1,2,1,.,.) =
+1.61177	    -0.7052599	0.17889105
+1.5860337	-0.3226252	-0.1341058
+
+(2,1,1,.,.) =
+0.4982454	-1.0186157	-1.9877508
+-0.35151628	-1.8955303	2.1854792
+
+(2,2,1,.,.) =
+-0.44977355	0.11218439	0.224829
+-1.6386473	-0.6715097	0.14816228
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x1x2x3]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import Cropping3D
+
+model = Sequential()
+model.add(Cropping3D(input_shape=(2, 3, 4, 5)))
+input = np.random.random([2, 2, 3, 4, 5])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[[[0.17398425 0.68189365 0.77769123 0.53108205 0.64715435]
+    [0.14553671 0.56312657 0.68612354 0.69176945 0.30109699]
+    [0.09732807 0.37460879 0.19945361 0.86471357 0.66225896]
+    [0.23071766 0.7940814  0.20828491 0.05256511 0.39059369]]
+
+   [[0.61604377 0.08752888 0.0373393  0.2074062  0.60620641]
+    [0.72873275 0.86871873 0.89248703 0.9407502  0.71830713]
+    [0.23277175 0.75968678 0.2160847  0.76278034 0.27796526]
+    [0.45593022 0.31406512 0.83030059 0.17528758 0.56134316]]
+
+   [[0.65576189 0.41055457 0.90979203 0.76003643 0.26369912]
+    [0.20767533 0.60489496 0.44996379 0.20016757 0.39282226]
+    [0.14055952 0.15767185 0.70149107 0.88403803 0.77345544]
+    [0.34344548 0.03721154 0.86204782 0.45349481 0.69348787]]]
+
+
+  [[[0.55441874 0.59949813 0.4450893  0.2103161  0.6300366 ]
+    [0.71573331 0.32423206 0.06302588 0.91902299 0.30852669]
+    [0.73540519 0.20697542 0.20543135 0.44461869 0.89286638]
+    [0.41614996 0.48155318 0.51663767 0.23681825 0.34780746]]
+
+   [[0.34529962 0.81156897 0.77911935 0.65392321 0.45178564]
+    [0.39702465 0.36180668 0.37867952 0.24818676 0.84365902]
+    [0.67836434 0.24043224 0.59870659 0.81976809 0.95442206]
+    [0.15342281 0.48607751 0.11420129 0.68621285 0.09892679]]
+
+   [[0.61122758 0.40359022 0.99805441 0.76764677 0.6281926 ]
+    [0.44867213 0.81206033 0.40117858 0.98967612 0.76897064]
+    [0.90603977 0.17299288 0.68803644 0.75164168 0.4161878 ]
+    [0.18996933 0.93317759 0.77711184 0.50760022 0.77439241]]]]
+
+
+
+ [[[[0.49974828 0.74486599 0.12447392 0.15415173 0.36715309]
+    [0.49334423 0.66699219 0.22202136 0.52689596 0.15497081]
+    [0.4117844  0.21886979 0.13096058 0.82589121 0.00621519]
+    [0.38257617 0.60924058 0.53549974 0.64299846 0.66315369]]
+
+   [[0.78048895 0.20350694 0.16485496 0.71243727 0.4581091 ]
+    [0.554526   0.66891789 0.90082079 0.76729771 0.40647459]
+    [0.72809646 0.68164733 0.83008334 0.90941546 0.1441997 ]
+    [0.44580521 0.78015871 0.63982938 0.26813225 0.15588673]]
+
+   [[0.85294056 0.0928758  0.37056251 0.82930655 0.27178195]
+    [0.95953427 0.60170629 0.69156911 0.27902576 0.55613879]
+    [0.97101437 0.49876892 0.36313494 0.11233855 0.24221145]
+    [0.28739626 0.2990425  0.68940864 0.95621615 0.6922569 ]]]
+
+
+  [[[0.90283303 0.51320503 0.78356741 0.79301195 0.17681709]
+    [0.61624755 0.95418399 0.68118889 0.69241549 0.17943311]
+    [0.71129437 0.55478761 0.34121912 0.86018439 0.03652437]
+    [0.39098173 0.87916544 0.39647239 0.00104663 0.01377085]]
+
+   [[0.28875017 0.03733266 0.47260498 0.2896268  0.55976704]
+    [0.08723092 0.45523634 0.98463086 0.56950302 0.98261442]
+    [0.20716971 0.52744283 0.39455719 0.57384754 0.76698272]
+    [0.3079253  0.88143353 0.85897125 0.0969679  0.43760548]]
+
+   [[0.44239165 0.56141652 0.30344311 0.05425044 0.34003295]
+    [0.31417344 0.39485584 0.47300811 0.38006721 0.23185974]
+    [0.06158527 0.95330693 0.63043506 0.9480669  0.93758737]
+    [0.05340179 0.2064604  0.97254971 0.60841205 0.89738937]]]]]
+```
+Output is
+```python
+[[[[[0.86871874 0.89248705 0.9407502 ]
+    [0.75968677 0.2160847  0.7627803 ]]]
+
+
+  [[[0.3618067  0.3786795  0.24818675]
+    [0.24043223 0.5987066  0.8197681 ]]]]
+
+
+
+ [[[[0.6689179  0.9008208  0.7672977 ]
+    [0.68164736 0.8300834  0.9094155 ]]]
+
+
+  [[[0.45523635 0.9846309  0.569503  ]
+    [0.5274428  0.39455718 0.57384753]]]]]
+```

--- a/docs/docs/KerasStyleAPIGuide/Layers/core.md
+++ b/docs/docs/KerasStyleAPIGuide/Layers/core.md
@@ -33,7 +33,7 @@ Dense(output_dim, init="glorot_uniform", activation=None, W_regularizer=None, b_
 **Parameters:**
 
 * `outputDim`: The size of the output dimension.
-* `init`: String representation of the initialization method for the weights of the layer. See [here](initialization/#available-initialization-methods) for available initialization strings. Default is "glorot_uniform".
+* `init`: String representation of the initialization method for the weights of the layer. See [here](initialization/#available-initialization-methods) for available initialization strings. Default is 'glorot_uniform'.
 * `activation`: String representation of the activation function to use. See [here](activation/#available-activations) for available activation strings. Default is null.
 * `wRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), applied to the input weights matrices. Default is null.
 * `bRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), applied to the bias. Default is null.
@@ -55,7 +55,7 @@ Input is:
 ```scala
 input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
  1.8646977	-0.059090078  0.091468036   0.6387431
--0.4485392	   1.5150243  -0.60176533  -0.6811443
+-0.4485392	1.5150243     -0.60176533   -0.6811443
 [com.intel.analytics.bigdl.tensor.DenseTensor of size 2x4]
 ```
 Output is:
@@ -84,6 +84,575 @@ Input is:
 ```
 Output is
 ```python
-[[ 0.  0.  0.  0.02094215  0.38839486]
- [ 0.  0.  0.  0.24498197  0.38024583]]
+[[ 0.0   0.0     0.0     0.02094215  0.38839486]
+ [ 0.0   0.0     0.0     0.24498197  0.38024583]]
+```
+
+---
+## **Flatten**
+Flattens the input without affecting the batch size.
+
+**Scala:**
+```scala
+Flatten(inputShape = null)
+```
+**Python:**
+```python
+Flatten(input_shape=None)
+```
+
+**Parameters:**
+
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, Flatten}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(Flatten(inputShape = Shape(2, 2, 3)))
+val input = Tensor[Float](2, 2, 2, 3).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,1,.,.) =
+1.2196734	-0.37271047	-0.31215316
+-0.68951845	-0.20356052	-0.85899264
+
+(1,2,.,.) =
+-1.7452804	-0.1138052	-0.9124519
+-0.94204897	0.28943604	-0.71905166
+
+(2,1,.,.) =
+0.7228912	-0.51781553	-0.5869045
+-0.82529205	0.26846665	-0.6199292
+
+(2,2,.,.) =
+-0.4529333	-0.57688874	0.9097755
+0.7112487	-0.6711465	1.3074298
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x2x3]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+1.2196734	-0.37271047	-0.31215316	-0.68951845	-0.20356052	-0.85899264	-1.7452804	-0.1138052	-0.9124519	-0.94204897	0.28943604	-0.71905166
+0.7228912	-0.51781553	-0.5869045	-0.82529205	0.26846665	-0.6199292	-0.4529333	-0.57688874	0.9097755	0.7112487	-0.6711465	1.3074298
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x12]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import Flatten
+
+model = Sequential()
+model.add(Flatten(input_shape=(2, 2, 3)))
+input = np.random.random([2, 2, 2, 3])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[[0.86901694 0.18961039 0.40317114]
+   [0.03546013 0.44338256 0.14267447]]
+
+  [[0.08971508 0.04943281 0.47568212]
+   [0.21874466 0.54040762 0.19513549]]]
+
+
+ [[[0.89994454 0.10154699 0.19762439]
+   [0.90341835 0.44006613 0.08758557]]
+
+  [[0.51165122 0.15523108 0.47434121]
+   [0.24526962 0.79663289 0.52078471]]]]
+```
+Output is
+```python
+[[0.86901695 0.18961039 0.40317115 0.03546013 0.44338256 0.14267448
+  0.08971508 0.04943281 0.4756821  0.21874467 0.5404076  0.19513549]
+ [0.89994454 0.10154699 0.1976244  0.90341836 0.44006613 0.08758558
+  0.5116512  0.15523107 0.4743412  0.24526963 0.7966329  0.52078474]]
+```
+
+---
+## **Reshape**
+Reshapes an output to a certain shape.
+
+Supports shape inference by allowing one -1 in the target shape. For example, if inputShape is (2, 3, 4), targetShape is (3, -1), then outputShape will be (3, 8).
+
+**Scala:**
+```scala
+Reshape(targetShape, inputShape = null)
+```
+**Python:**
+```python
+Reshape(target_shape, input_shape=None)
+```
+
+**Parameters:**
+
+* `targetShape`: Array of int. The target shape that you desire to have. Batch dimension should be excluded.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, Reshape}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(Reshape(Array(3, 8), inputShape = Shape(2, 3, 4)))
+val input = Tensor[Float](2, 2, 3, 4).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,1,.,.) =
+-1.7092276	-1.3941092	-0.6348466	0.71309644
+0.3605411	0.025597548	0.4287048	-0.548675
+0.4623341	-2.3912702	0.22030865	-0.058272455
+
+(1,2,.,.) =
+-1.5049093	-1.8828062	0.8230564	-0.020209199
+-0.3415721	1.1219939	1.1089007	-0.74697906
+-1.503861	-1.616539	0.048006497	1.1613717
+
+(2,1,.,.) =
+0.21216023	1.0107462	0.8586909	-0.05644316
+-0.31436008	1.6892323	-0.9961186	-0.08169463
+0.3559391	0.010261055	-0.70408463	-1.2480727
+
+(2,2,.,.) =
+1.7663039	0.07122444	0.073556066	-0.7847014
+0.17604464	-0.99110585	-1.0302067	-0.39024687
+-0.0260166	-0.43142694	0.28443158	0.72679126
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3x4]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,.,.) =
+-1.7092276	-1.3941092	-0.6348466	0.71309644	    0.3605411	0.025597548	0.4287048	-0.548675
+0.4623341	-2.3912702	0.22030865	-0.058272455	-1.5049093	-1.8828062	0.8230564	-0.020209199
+-0.3415721	1.1219939	1.1089007	-0.74697906	    -1.503861	-1.616539	0.048006497	1.1613717
+
+(2,.,.) =
+0.21216023	1.0107462	0.8586909	-0.05644316	    -0.31436008	1.6892323	-0.9961186	-0.08169463
+0.3559391	0.010261055	-0.70408463	-1.2480727	    1.7663039	0.07122444	0.073556066	-0.7847014
+0.17604464	-0.99110585	-1.0302067	-0.39024687	    -0.0260166	-0.43142694	0.28443158	0.72679126
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3x8]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import Reshape
+
+model = Sequential()
+model.add(Reshape(target_shape=(3, 8), input_shape=(2, 3, 4)))
+input = np.random.random([2, 2, 3, 4])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[[0.39260304 0.10383185 0.87490319 0.89167328]
+   [0.61649117 0.43285247 0.86851582 0.97743004]
+   [0.90018969 0.04303951 0.74263493 0.14208656]]
+
+  [[0.66193405 0.93432157 0.76160537 0.70437459]
+   [0.99953431 0.23016734 0.42293405 0.66078049]
+   [0.03357645 0.9695145  0.30111138 0.67109948]]]
+
+
+ [[[0.39640201 0.92930203 0.86027666 0.13958544]
+   [0.34584767 0.14743425 0.93804016 0.38053062]
+   [0.55068792 0.77375329 0.84161166 0.48131356]]
+
+  [[0.90116368 0.53253689 0.03332962 0.58278686]
+   [0.34935685 0.32599554 0.97641892 0.57696434]
+   [0.53974677 0.90682861 0.20027319 0.05962118]]]]
+```
+Output is
+```python
+[[[0.39260304 0.10383185 0.8749032  0.89167327 0.6164912  0.43285248 0.86851585 0.97743005]
+  [0.9001897  0.04303951 0.74263495 0.14208655 0.661934   0.9343216  0.7616054  0.7043746 ]
+  [0.9995343  0.23016734 0.42293406 0.6607805  0.03357645 0.9695145  0.30111137 0.6710995 ]]
+
+ [[0.396402   0.92930204 0.86027664 0.13958544 0.34584767 0.14743425 0.93804014 0.38053063]
+  [0.5506879  0.7737533  0.8416117  0.48131356 0.9011637  0.53253686 0.03332962 0.58278686]
+  [0.34935686 0.32599553 0.9764189  0.5769643  0.53974676 0.9068286  0.20027319 0.05962119]]]
+```
+
+---
+## **Permute**
+Permutes the dimensions of the input according to a given pattern.
+
+Useful for connecting RNNs and convnets together.
+
+**Scala:**
+```scala
+Permute(dims, inputShape = null)
+```
+**Python:**
+```python
+Permute(dims, input_shape=None)
+```
+
+**Parameters:**
+
+* `dims`: Permutation pattern, does not include the samples dimension. Indexing starts at 1.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, Permute}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(Permute(Array(2, 3, 1), inputShape = Shape(2, 3, 4)))
+val input = Tensor[Float](2, 2, 3, 4).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,1,.,.) =
+-1.1030567	-1.4624393	0.6139582	0.21287616
+-2.2278674	-2.5211496	1.9219213	0.85134244
+0.32953477	-2.1209111	-0.82459116	-0.82447577
+
+(1,2,.,.) =
+1.0540756	2.2638302	0.19139263	-0.9037997
+-0.20562297	-0.07835103	0.3883783	0.20750551
+-0.56583923	0.9617757	-0.5792387	0.9008493
+
+(2,1,.,.) =
+-0.54270995	-1.9089237	0.9289245	0.27833897
+-1.4734148	-0.9408616	-0.40362656	-1.1730295
+0.9813707	-0.0040280274	-1.5321463	-1.4322052
+
+(2,2,.,.) =
+-0.056844145	2.2309854	2.1172705	0.10043324
+1.121064	0.16069101	-0.51750094	-1.9682871
+0.9011646	0.47903928	-0.54172426	-0.6604068
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3x4]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,1,.,.) =
+-1.1030567	1.0540756
+-1.4624393	2.2638302
+0.6139582	0.19139263
+0.21287616	-0.9037997
+
+(1,2,.,.) =
+-2.2278674	-0.20562297
+-2.5211496	-0.07835103
+1.9219213	0.3883783
+0.85134244	0.20750551
+
+(1,3,.,.) =
+0.32953477	-0.56583923
+-2.1209111	0.9617757
+-0.82459116	-0.5792387
+-0.82447577	0.9008493
+
+(2,1,.,.) =
+-0.54270995	-0.056844145
+-1.9089237	2.2309854
+0.9289245	2.1172705
+0.27833897	0.10043324
+
+(2,2,.,.) =
+-1.4734148	1.121064
+-0.9408616	0.16069101
+-0.40362656	-0.51750094
+-1.1730295	-1.9682871
+
+(2,3,.,.) =
+0.9813707	0.9011646
+-0.0040280274	0.47903928
+-1.5321463	-0.54172426
+-1.4322052	-0.6604068
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3x4x2]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import Permute
+
+model = Sequential()
+model.add(Permute(dims=(2, 3, 1), input_shape=(2, 3, 4)))
+input = np.random.random([2, 2, 3, 4])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[[0.47372355 0.18103412 0.07076151 0.51208742]
+   [0.3830121  0.2036672  0.24978515 0.3458438 ]
+   [0.34180976 0.54635229 0.90048856 0.89178666]]
+
+  [[0.15893009 0.62223068 0.1060953  0.26898095]
+   [0.97659789 0.72022333 0.12613522 0.66538681]
+   [0.79589927 0.32906473 0.27806256 0.99698214]]]
+
+
+ [[[0.14608597 0.96667223 0.17876087 0.37672275]
+   [0.89726934 0.09588159 0.19987136 0.99728596]
+   [0.592439   0.40126537 0.18349086 0.88102044]]
+
+  [[0.29313258 0.94066727 0.57244849 0.79352687]
+   [0.31302252 0.65390325 0.54829736 0.63749209]
+   [0.76679177 0.43937809 0.06966902 0.27204878]]]]
+```
+Output is
+```python
+[[[[0.47372353 0.1589301 ]
+   [0.18103412 0.6222307 ]
+   [0.07076152 0.1060953 ]
+   [0.5120874  0.26898095]]
+
+  [[0.38301212 0.9765979 ]
+   [0.2036672  0.7202233 ]
+   [0.24978516 0.12613523]
+   [0.3458438  0.6653868 ]]
+
+  [[0.34180975 0.7958993 ]
+   [0.54635227 0.32906473]
+   [0.90048856 0.27806255]
+   [0.89178663 0.99698216]]]
+
+
+ [[[0.14608598 0.29313257]
+   [0.96667224 0.9406673 ]
+   [0.17876087 0.5724485 ]
+   [0.37672275 0.7935269 ]]
+
+  [[0.8972693  0.31302252]
+   [0.09588159 0.65390325]
+   [0.19987136 0.54829735]
+   [0.99728596 0.63749206]]
+
+  [[0.592439   0.76679176]
+   [0.40126538 0.43937808]
+   [0.18349086 0.06966902]
+   [0.8810204  0.27204877]]]]
+```
+
+---
+## **RepeatVector**
+Repeats the input n times.
+
+The input of this layer should be 2D.
+
+**Scala:**
+```scala
+RepeatVector(n, inputShape = null)
+```
+**Python:**
+```python
+RepeatVector(n, input_shape=None)
+```
+
+**Parameters:**
+
+* `n`: Repetition factor. Integer.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, RepeatVector}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(RepeatVector(4, inputShape = Shape(3)))
+val input = Tensor[Float](2, 3).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+1.4182444	2.858577	1.3975657
+-0.19606766	0.8585809	0.3027246
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,.,.) =
+1.4182444	2.858577	1.3975657
+1.4182444	2.858577	1.3975657
+1.4182444	2.858577	1.3975657
+1.4182444	2.858577	1.3975657
+
+(2,.,.) =
+-0.19606766	0.8585809	0.3027246
+-0.19606766	0.8585809	0.3027246
+-0.19606766	0.8585809	0.3027246
+-0.19606766	0.8585809	0.3027246
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x4x3]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import RepeatVector
+
+model = Sequential()
+model.add(RepeatVector(4, input_shape=(3, )))
+input = np.random.random([2, 3])
+output = model.forward(input)
+```
+Input is:
+```python
+[[0.51416513 0.87768557 0.48015041]
+ [0.66598164 0.58916225 0.03983186]]
+```
+Output is
+```python
+[[[0.5141651  0.87768555 0.4801504 ]
+  [0.5141651  0.87768555 0.4801504 ]
+  [0.5141651  0.87768555 0.4801504 ]
+  [0.5141651  0.87768555 0.4801504 ]]
+
+ [[0.66598165 0.58916223 0.03983186]
+  [0.66598165 0.58916223 0.03983186]
+  [0.66598165 0.58916223 0.03983186]
+  [0.66598165 0.58916223 0.03983186]]]
+```
+
+---
+## **Merge**
+Used to merge a list of inputs into a single output, following some merge mode.
+
+Merge must have at least two input layers.
+
+**Scala:**
+```scala
+Merge(layers = null, mode = "sum", concatAxis = -1, inputShape = null)
+```
+**Python:**
+```python
+Merge(layers=None, mode="sum", concat_axis=-1, input_shape=None)
+```
+
+**Parameters:**
+
+* `layers`: A list of layer instances. Must be more than one layer.
+* `mode`: Merge mode. String, must be one of: 'sum', 'mul', 'concat', 'ave', 'cos', 'dot', 'max'. Default is 'sum'.
+* `concatAxis`: Integer, axis to use when concatenating layers. Only specify this when merge mode is 'concat'. Default is -1, meaning the last axis of the input.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, Merge, InputLayer}
+import com.intel.analytics.bigdl.utils.{Shape, T}
+import com.intel.analytics.bigdl.tensor._
+
+val input1 = Tensor[Float](2, 2, 3).rand(0, 1)
+val input2 = Tensor[Float](2, 2, 3).rand(0, 1)
+val input = T(1 -> input1, 2 -> input2)
+val model = Sequential[Float]()
+val l1 = InputLayer[Float](inputShape = Shape(2, 3))
+val l2 = InputLayer[Float](inputShape = Shape(2, 3))
+val layer = Merge[Float](layers = List(l1, l2), mode = "sum")
+model.add(layer)
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.utils.Table =
+ {
+	2: (1,.,.) =
+	   0.87815475	0.15025006	0.34412447
+	   0.07909282	0.008027249	0.111715704
+
+	   (2,.,.) =
+	   0.52245367	0.2547527	0.35857987
+	   0.7718501	0.26783863	0.8642062
+
+	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3]
+	1: (1,.,.) =
+	   0.5377018	0.28364193	0.3424284
+	   0.0075349305	0.9018168	0.9435114
+
+	   (2,.,.) =
+	   0.09112563	0.88585275	0.3100201
+	   0.7910178	0.57497376	0.39764535
+
+	   [com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3]
+ }
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,.,.) =
+1.4158566	0.433892	0.6865529
+0.08662775	0.90984404	1.0552272
+
+(2,.,.) =
+0.6135793	1.1406054	0.66859996
+1.5628679	0.8428124	1.2618515
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import Merge, InputLayer
+
+model = Sequential()
+l1 = InputLayer(input_shape=(3, 4))
+l2 = InputLayer(input_shape=(3, 4))
+model.add(Merge(layers=[l1, l2], mode='sum'))
+input = [np.random.random([2, 3, 4]), np.random.random([2, 3, 4])]
+output = model.forward(input)
+```
+Input is:
+```python
+[array([[[0.28764351, 0.0236015 , 0.78927442, 0.52646492],
+        [0.63922826, 0.45101604, 0.4555552 , 0.70105653],
+        [0.75790798, 0.78551523, 0.00686686, 0.61290369]],
+
+       [[0.00430865, 0.3303661 , 0.59915782, 0.90362298],
+        [0.26230717, 0.99383052, 0.50630521, 0.99119486],
+        [0.56138318, 0.68165639, 0.10644523, 0.51860127]]]),
+
+ array([[[0.84365767, 0.8854741 , 0.84183673, 0.96322321],
+        [0.49354248, 0.97936826, 0.2266097 , 0.88083622],
+        [0.11011776, 0.65762034, 0.17446099, 0.76658969]],
+
+       [[0.58266689, 0.86322199, 0.87122999, 0.19031255],
+        [0.42275118, 0.76379413, 0.21355413, 0.81132937],
+        [0.97294728, 0.68601731, 0.39871792, 0.63172344]]])]
+```
+Output is
+```python
+[[[1.1313012  0.90907556 1.6311111  1.4896882 ]
+  [1.1327708  1.4303843  0.6821649  1.5818927 ]
+  [0.8680257  1.4431355  0.18132785 1.3794935 ]]
+
+ [[0.5869755  1.1935881  1.4703878  1.0939355 ]
+  [0.68505836 1.7576246  0.71985936 1.8025242 ]
+  [1.5343305  1.3676738  0.50516313 1.1503248 ]]]
 ```

--- a/docs/docs/KerasStyleAPIGuide/Layers/dropout.md
+++ b/docs/docs/KerasStyleAPIGuide/Layers/dropout.md
@@ -1,0 +1,694 @@
+## **Dropout**
+Applies Dropout to the input by randomly setting a fraction 'p' of input units to 0 at each update during training time in order to prevent overfitting.
+
+**Scala:**
+```scala
+Dropout(p, inputShape = null)
+```
+**Python:**
+```python
+Dropout(p, input_shape=None)
+```
+
+**Parameters:**
+
+* `p`: Fraction of the input units to drop. Double between 0 and 1.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, Dropout}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(Dropout(0.3, inputShape = Shape(3, 4)))
+val input = Tensor[Float](2, 3, 4).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,.,.) =
+-1.1256621	2.5402398	-1.1346831	0.50337905
+-1.3835752	0.9513693	-0.24547328	-0.28897092
+-0.0302343	-0.4106753	0.46467322	-0.7328933
+
+(2,.,.) =
+1.2569109	0.16947697	-0.5000246	2.0856402
+-0.04246076	1.5827807	-1.0235463	1.7278075
+-0.0035352164	-1.2579697	0.206815	-0.053890422
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3x4]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,.,.) =
+0.0	          0.0	     -1.620976	0.0
+-1.976536	  1.359099	 0.0	    -0.4128156
+-0.043191858  -0.586679	 0.6638189	-1.0469904
+
+(2,.,.) =
+0.0	           0.0	       -0.7143209  2.979486
+-0.060658228   2.2611153   0.0	       0.0
+-0.0050503095  -1.7970997  0.0	       0.0
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3x4]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import Dropout
+
+model = Sequential()
+model.add(Dropout(0.3, input_shape=(3, 4)))
+input = np.random.random([2, 3, 4])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[0.61976372 0.36074095 0.59003926 0.75373888]
+  [0.2390103  0.93491731 0.89078166 0.93083315]
+  [0.62360382 0.73646417 0.32886041 0.25372008]]
+
+ [[0.10235195 0.7782206  0.54940485 0.41757437]
+  [0.94804637 0.04642807 0.17194449 0.2675274 ]
+  [0.89322413 0.3301816  0.49910094 0.00819342]]]
+```
+Output is
+```python
+[[[0.88537675 0.51534426 0.0        0.0       ]
+  [0.0        1.3355962  1.2725452  1.3297616 ]
+  [0.89086264 1.0520917  0.4698006  0.0       ]]
+
+ [[0.14621708 1.1117437  0.7848641  0.59653485]
+  [1.354352   0.06632582 0.24563499 0.382182  ]
+  [1.2760345  0.471688   0.7130013  0.01170488]]]
+```
+
+---
+## **GaussianDropout**
+Apply multiplicative 1-centered Gaussian noise.
+
+As it is a regularization layer, it is only active at training time.
+
+**Scala:**
+```scala
+GaussianDropout(p, inputShape = null)
+```
+**Python:**
+```python
+GaussianDropout(p, input_shape=None)
+```
+
+**Parameters:**
+
+* `p`: Double, drop probability (as with 'Dropout'). The multiplicative noise will have standard deviation 'sqrt(p/(1-p))'.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, GaussianDropout}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(GaussianDropout(0.45, inputShape = Shape(3, 4)))
+val input = Tensor[Float](2, 3, 4).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,.,.) =
+-0.14522108	0.27993536	-0.38809696	0.26372102
+-0.5572615	0.091684595	0.27881327	-1.6235427
+-0.32884964	-0.46456075	1.6169231	0.31943536
+
+(2,.,.) =
+-1.813811	1.1577623	-0.8995344	-1.0607182
+-0.3952898	-2.3437335	-0.6608733	1.1752778
+-1.3373735	-1.7404749	0.82832927	0.3053458
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3x4]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,.,.) =
+-0.27553135	0.15290284	-0.23144199	0.619676
+-0.6648747	0.053253293	-0.08241931	-0.47651786
+-0.46381548	-1.0048811	1.5911313	0.39929882
+
+(2,.,.) =
+-0.43828326	0.4397059	-0.7071283	-1.440457
+-0.27415445	-1.6525689	-0.14050363	0.8728552
+-2.0516112	-2.1537325	1.4714862	0.29218474
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3x4]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import GaussianDropout
+
+model = Sequential()
+model.add(GaussianDropout(0.45, input_shape=(3, 4)))
+input = np.random.random([2, 3, 4])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[0.87208899 0.1353189  0.325058   0.63174633]
+  [0.20479221 0.29774652 0.42038452 0.23819006]
+  [0.07608872 0.91696766 0.245824   0.84324374]]
+
+ [[0.26268714 0.76275494 0.63620997 0.15049668]
+  [0.54144135 0.70412821 0.05555471 0.72317157]
+  [0.32796076 0.26804862 0.80775221 0.46948471]]]
+```
+Output is
+```python
+[[[ 2.1392     -0.16185573 -0.18517245 -0.36539674]
+  [ 0.15324984  0.17320508  0.82520926  0.21734479]
+  [ 0.17601383  0.24906069  0.15664667  0.12675671]]
+
+ [[ 0.49689308  1.8231225   1.0023257   0.37604305]
+  [ 1.2827866  -0.08726044  0.01333602  0.8518126 ]
+  [ 0.20021693  0.31828243  1.0940336   0.00866747]]]
+```
+
+---
+## **GaussianNoise**
+Apply additive zero-centered Gaussian noise.
+
+This is useful to mitigate overfitting (you could see it as a form of random data augmentation).
+
+Gaussian Noise is a natural choice as corruption process for real valued inputs.
+
+As it is a regularization layer, it is only active at training time.
+
+**Scala:**
+```scala
+GaussianNoise(sigma, inputShape = null)
+```
+**Python:**
+```python
+GaussianNoise(sigma, input_shape=None)
+```
+
+**Parameters:**
+
+* `sigma`: Double, standard deviation of the noise distribution.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, GaussianNoise}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(GaussianNoise(0.6, inputShape = Shape(3, 4)))
+val input = Tensor[Float](2, 3, 4).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,.,.) =
+0.4226985	-0.010519333	-0.49748304	-0.3176052
+0.52444375	0.31100306	1.0308859	2.0337727
+0.21513703	-0.396619	-0.055275716	-0.40603992
+
+(2,.,.) =
+-1.2393064	-0.536477	-0.35633054	-0.09068655
+-1.7297741	-0.5812992	-1.2833812	-0.7185058
+0.13474904	0.06468039	-0.6630115	1.2471422
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3x4]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,.,.) =
+-0.72299504	0.7733576	-0.13965577	0.72079915
+0.20137814	0.6300731	2.5559645	2.3056328
+-0.19732013	-0.482926	-0.22114205	-0.88772345
+
+(2,.,.) =
+-1.4293398	-1.0870209	-0.5509953	-0.31268832
+-2.244024	-0.23773572	-3.022697	-0.65151817
+-0.035656676	-0.7470889	-0.8566216	1.1347939
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3x4]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import GaussianNoise
+
+model = Sequential()
+model.add(GaussianNoise(0.6, input_shape=(3, 4)))
+input = np.random.random([2, 3, 4])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[0.61699657 0.9759922  0.62898391 0.57265605]
+  [0.88815108 0.9484446  0.0300381  0.54114527]
+  [0.94046216 0.05998474 0.24860526 0.82020617]]
+
+ [[0.87308242 0.24780141 0.73385444 0.40836049]
+  [0.33166358 0.74540915 0.28333526 0.08263288]
+  [0.17527315 0.79798327 0.49351559 0.13895365]]]
+```
+Output is
+```python
+[[[ 1.5833025   1.1431103   0.14338043  1.634818  ]
+  [ 0.01713479  1.1608562   0.222246    0.40559798]
+  [ 0.9930201   0.1187391   -0.35643864 -0.7164774 ]]
+
+ [[ 1.0105296   1.423961    0.90040827  1.3460591 ]
+  [ 0.943779    -0.48430538 0.20670155  -0.50143087]
+  [ -0.29849088 0.12774569  -0.16126743 -0.011041  ]]]
+```
+
+---
+## **SpatialDropout1D**
+Spatial 1D version of Dropout.
+
+This version performs the same function as Dropout, however it drops entire 1D feature maps instead of individual elements. If adjacent frames within feature maps are strongly correlated (as is normally the case in early convolution layers) then regular dropout will not regularize the activations and will otherwise just result in an effective learning rate decrease. In this case, SpatialDropout1D will help promote independence between feature maps and should be used instead.
+
+The input of this layer should be 3D.
+
+**Scala:**
+```scala
+SpatialDropout1D(p = 0.5, inputShape = null)
+```
+**Python:**
+```python
+SpatialDropout1D(p=0.5, input_shape=None)
+```
+
+**Parameters:**
+
+* `p`: Fraction of the input units to drop. Double between 0 and 1.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, SpatialDropout1D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(SpatialDropout1D(inputShape = Shape(3, 4)))
+val input = Tensor[Float](2, 3, 4).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,.,.) =
+-0.41961443	-0.3900255	-0.11937201	1.2904007
+-1.7623849	-1.6778483	-0.30053464	0.33295104
+-0.29824665	-0.25474855	-2.1878588	1.2741995
+
+(2,.,.) =
+0.24517925	2.0451863	-0.4281332	-1.2022524
+-0.7767442	0.24794191	-0.5614063	0.14720131
+-1.4832486	0.59478635	-0.13351384	-0.8799204
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3x4]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,.,.) =
+-0.41961443	-0.0	-0.11937201	1.2904007
+-1.7623849	-0.0	-0.30053464	0.33295104
+-0.29824665	-0.0	-2.1878588	1.2741995
+
+(2,.,.) =
+0.24517925	0.0	    -0.4281332	-0.0
+-0.7767442	0.0	    -0.5614063	0.0
+-1.4832486	0.0	    -0.13351384	-0.0
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3x4]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import SpatialDropout1D
+
+model = Sequential()
+model.add(SpatialDropout1D(input_shape=(3, 4)))
+input = np.random.random([2, 3, 4])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[0.67162434 0.91104925 0.66869854 0.17295748]
+  [0.78326617 0.27447329 0.18051406 0.24230118]
+  [0.7098933  0.32496974 0.00517668 0.21293476]]
+
+ [[0.26932307 0.33496273 0.71258256 0.15464896]
+  [0.75286915 0.210486   0.91826256 0.81379954]
+  [0.11960744 0.37420041 0.03886506 0.22882457]]]
+```
+Output is
+```python
+[[[0.0        0.0        0.0        0.0       ]
+  [0.0        0.0        0.0        0.0       ]
+  [0.0        0.0        0.0        0.0       ]]
+
+ [[0.0        0.33496273 0.0        0.15464896]
+  [0.0        0.210486   0.0        0.81379956]
+  [0.0        0.3742004  0.0        0.22882457]]]
+```
+
+---
+## **SpatialDropout2D**
+Spatial 2D version of Dropout.
+
+This version performs the same function as Dropout, however it drops entire 2D feature maps instead of individual elements. If adjacent pixels within feature maps are strongly correlated (as is normally the case in early convolution layers) then regular dropout will not regularize the activations and will otherwise just result in an effective learning rate decrease. In this case, SpatialDropout2D will help promote independence between feature maps and should be used instead.
+
+The input of this layer should be 4D.
+
+**Scala:**
+```scala
+SpatialDropout2D(p = 0.5, dimOrdering = "th", inputShape = null)
+```
+**Python:**
+```python
+SpatialDropout2D(p=0.5, dim_ordering="th", input_shape=None)
+```
+
+**Parameters:**
+
+* `p`: Fraction of the input units to drop. Double between 0 and 1.
+* `dimOrdering`: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, SpatialDropout2D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(SpatialDropout2D(inputShape = Shape(2, 3, 4)))
+val input = Tensor[Float](2, 2, 3, 4).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,1,.,.) =
+1.1651757	1.0867785	-0.56122786	-0.542156
+-0.79321486	0.64733976	-0.7040698	-0.8619171
+-0.61122066	-1.9640825	-1.0078672	-0.12195914
+
+(1,2,.,.) =
+-0.24738677	-0.9351172	-0.11694977	0.8657273
+-0.4773825	-1.6853696	-1.4906564	-0.06981948
+-0.8184341	-1.3537912	1.2442955	-0.0071462104
+
+(2,1,.,.) =
+1.8801081	0.44946647	0.47776535	0.036228795
+-1.2122079	0.41413695	-0.691067	2.6273472
+1.4293005	-1.2627622	-1.8263477	0.015581204
+
+(2,2,.,.) =
+2.0050068	-0.32893315	0.19670151	0.8031714
+0.16645809	-0.68172836	0.5169275	-0.83938134
+0.1789333	2.1845143	1.3843338	-0.8283524
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3x4]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,1,.,.) =
+0.0	        0.0	        -0.0	    -0.0
+-0.0	    0.0	        -0.0	    -0.0
+-0.0	    -0.0	    -0.0	    -0.0
+
+(1,2,.,.) =
+-0.0	    -0.0	    -0.0	    0.0
+-0.0	    -0.0	    -0.0	    -0.0
+-0.0	    -0.0	    0.0	        -0.0
+
+(2,1,.,.) =
+1.8801081	0.44946647	0.47776535	0.036228795
+-1.2122079	0.41413695	-0.691067	2.6273472
+1.4293005	-1.2627622	-1.8263477	0.015581204
+
+(2,2,.,.) =
+2.0050068	-0.32893315	0.19670151	0.8031714
+0.16645809	-0.68172836	0.5169275	-0.83938134
+0.1789333	2.1845143	1.3843338	-0.8283524
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3x4]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import SpatialDropout2D
+
+model = Sequential()
+model.add(SpatialDropout2D(input_shape=(2, 3, 4)))
+input = np.random.random([2, 2, 3, 4])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[[0.21864846 0.43531162 0.23078088 0.81122115]
+   [0.19442596 0.11110444 0.533805   0.68291312]
+   [0.40738259 0.05448269 0.04647733 0.41683944]]
+
+  [[0.23354645 0.46005503 0.87695602 0.13318982]
+   [0.2596346  0.67654484 0.79389709 0.50408343]
+   [0.50043622 0.28028835 0.81897585 0.01629935]]]
+
+
+ [[[0.32173241 0.38367311 0.10315543 0.22691558]
+   [0.41640003 0.45932496 0.70795718 0.67185326]
+   [0.11911477 0.90231481 0.49881045 0.74297438]]
+
+  [[0.48873758 0.53475116 0.06801025 0.50640297]
+   [0.95740488 0.14928652 0.10466387 0.29040436]
+   [0.44062539 0.36983024 0.35326756 0.60592402]]]]
+```
+Output is
+```python
+[[[[0.21864846 0.43531162 0.23078088 0.8112211 ]
+   [0.19442596 0.11110444 0.533805   0.6829131 ]
+   [0.4073826  0.05448269 0.04647733 0.41683942]]
+
+  [[0.23354645 0.46005502 0.87695605 0.13318983]
+   [0.2596346  0.67654485 0.7938971  0.50408345]
+   [0.50043625 0.28028834 0.81897587 0.01629935]]]
+
+
+ [[[0.0        0.0        0.0        0.0       ]
+   [0.0        0.0        0.0        0.0       ]
+   [0.0        0.0        0.0        0.0       ]]
+
+  [[0.48873758 0.5347512  0.06801025 0.50640297]
+   [0.95740485 0.14928652 0.10466387 0.29040435]
+   [0.4406254  0.36983025 0.35326755 0.605924  ]]]]
+```
+
+---
+## **SpatialDropout3D**
+Spatial 3D version of Dropout.
+
+This version performs the same function as Dropout, however it drops entire 3D feature maps instead of individual elements. If adjacent voxels within feature maps are strongly correlated (as is normally the case in early convolution layers) then regular dropout will not regularize the activations and will otherwise just result in an effective learning rate decrease. In this case, SpatialDropout3D will help promote independence between feature maps and should be used instead.
+
+The input of this layer should be 5D.
+
+**Scala:**
+```scala
+SpatialDropout3D(p = 0.5, dimOrdering = "th", inputShape = null)
+```
+**Python:**
+```python
+SpatialDropout3D(p=0.5, dim_ordering="th", input_shape=None)
+```
+
+**Parameters:**
+
+* `p`: Fraction of the input units to drop. Double between 0 and 1.
+* `dimOrdering`: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, SpatialDropout3D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(SpatialDropout3D(inputShape = Shape(2, 2, 2, 3)))
+val input = Tensor[Float](2, 2, 2, 2, 3).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,1,1,.,.) =
+0.28834015	    -0.74598366	0.16951436
+0.17009573	    0.3626017	-0.24652131
+
+(1,1,2,.,.) =
+1.3008109	    0.37243804	0.073205866
+1.0715603	    0.02033514	-1.7862324
+
+(1,2,1,.,.) =
+-0.5285066	    -1.3859391	-1.0543352
+0.7904896	    0.7473174	-0.5941196
+
+(1,2,2,.,.) =
+-0.060706574	-2.4405587	1.5963978
+-0.33285397	    -0.48576602	0.8121179
+
+(2,1,1,.,.) =
+-0.7060156	    0.31667668	-0.28765643
+-1.3115436	    -1.7266335	1.0080509
+
+(2,1,2,.,.) =
+1.2365453	    -0.13272893	-1.2130978
+0.26921487	    -0.66259027	0.5537464
+
+(2,2,1,.,.) =
+1.6578121	    -0.09890133	0.4794677
+1.5102282	    0.067802615	0.76998603
+
+(2,2,2,.,.) =
+-0.47348467	    0.19535838	0.62601316
+-2.4771519	    -0.40744382	0.04029308
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x2x2x3]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,1,1,.,.) =
+0.0	            -0.0	    0.0
+0.0	            0.0	        -0.0
+
+(1,1,2,.,.) =
+0.0	            0.0	        0.0
+0.0	            0.0	        -0.0
+
+(1,2,1,.,.) =
+-0.5285066	    -1.3859391	-1.0543352
+0.7904896	    0.7473174	-0.5941196
+
+(1,2,2,.,.) =
+-0.060706574	-2.4405587	1.5963978
+-0.33285397	    -0.48576602	0.8121179
+
+(2,1,1,.,.) =
+-0.0	        0.0	        -0.0
+-0.0	        -0.0	    0.0
+
+(2,1,2,.,.) =
+0.0	            -0.0	    -0.0
+0.0	            -0.0	    0.0
+
+(2,2,1,.,.) =
+0.0	            -0.0	    0.0
+0.0	            0.0	        0.0
+
+(2,2,2,.,.) =
+-0.0	        0.0	        0.0
+-0.0	        -0.0	    0.0
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x2x2x3]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import SpatialDropout3D
+
+model = Sequential()
+model.add(SpatialDropout3D(input_shape=(2, 2, 2, 2)))
+input = np.random.random([2, 2, 2, 2, 2])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[[[0.68128454 0.57379206]
+    [0.19533742 0.19906853]]
+
+   [[0.21527836 0.79586573]
+    [0.51065215 0.94422278]]]
+
+
+  [[[0.95178211 0.50359204]
+    [0.0306965  0.92563536]]
+
+   [[0.33744311 0.58750719]
+    [0.45437398 0.7081438 ]]]]
+
+
+
+ [[[[0.00235233 0.8092749 ]
+    [0.65525661 0.01079958]]
+
+   [[0.29877429 0.42090468]
+    [0.28265598 0.81520172]]]
+
+
+  [[[0.91811333 0.3275563 ]
+    [0.66125455 0.15555596]]
+
+   [[0.53651033 0.66013486]
+    [0.45874838 0.7613676 ]]]]]
+```
+Output is
+```python
+[[[[[0.68128455 0.57379204]
+    [0.19533743 0.19906853]]
+
+   [[0.21527836 0.7958657 ]
+    [0.5106521  0.94422275]]]
+
+
+  [[[0.0        0.0       ]
+    [0.0        0.0       ]]
+
+   [[0.0        0.0       ]
+    [0.0        0.0       ]]]]
+
+
+
+ [[[[0.0        0.0       ]
+    [0.0        0.0       ]]
+
+   [[0.0        0.0       ]
+    [0.0        0.0       ]]]
+
+
+  [[[0.91811335 0.3275563 ]
+    [0.6612545  0.15555596]]
+
+   [[0.53651035 0.66013485]
+    [0.45874837 0.7613676 ]]]]]
+```

--- a/docs/docs/KerasStyleAPIGuide/Layers/embedding.md
+++ b/docs/docs/KerasStyleAPIGuide/Layers/embedding.md
@@ -1,0 +1,94 @@
+## **Embedding**
+Turn positive integers (indexes) into dense vectors of fixed size.
+
+The input of this layer should be 2D.
+
+**Scala:**
+```scala
+Embedding(inputDim, outputDim, init = "uniform", wRegularizer = null, inputShape = null)
+```
+**Python:**
+```python
+Embedding(input_dim, output_dim, init="uniform", W_regularizer=None, input_shape=None)
+```
+
+**Parameters:**
+
+* `inputDim`: Int > 0. Size of the vocabulary.
+* `outputDim`: Int >= 0. Dimension of the dense embedding.
+* `init`: String representation of the initialization method for the weights of the layer. See [here](initialization/#available-initialization-methods) for available initialization strings. Default is "uniform".
+* `wRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), (eg. L1 or L2 regularization), applied to the input weights matrices. Default is null.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, Embedding}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(Embedding(8, 2, inputShape = Shape(4)))
+val input = Tensor[Float](2, 4)
+input(Array(1, 1)) = 1
+input(Array(1, 2)) = 2
+input(Array(1, 3)) = 4
+input(Array(1, 4)) = 5
+input(Array(2, 1)) = 4
+input(Array(2, 2)) = 3
+input(Array(2, 3)) = 2
+input(Array(2, 4)) = 6
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+1.0	2.0	4.0	5.0
+4.0	3.0	2.0	6.0
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x4]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,.,.) =
+0.03256504	    -0.043232664
+-0.044753443	0.026075097
+0.045668535	    0.02456015
+0.021222712	    -0.04373116
+
+(2,.,.) =
+0.045668535	    0.02456015
+0.03761902	    -0.0014174521
+-0.044753443	0.026075097
+-0.030343587	-0.0015718295
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x4x2]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import Embedding
+
+model = Sequential()
+model.add(Embedding(8, 2, input_shape=(4,)))
+input = np.random.randint(4, size=(2, 4))
+output = model.forward(input)
+```
+Input is:
+```python
+[[0 2 2 2]
+ [2 1 1 0]]
+```
+Output is
+```python
+[[[ 0.0094721  -0.01927968]
+  [-0.00483634 -0.03992473]
+  [-0.00483634 -0.03992473]
+  [-0.00483634 -0.03992473]]
+
+ [[-0.00483634 -0.03992473]
+  [-0.03603687 -0.03708585]
+  [-0.03603687 -0.03708585]
+  [ 0.0094721  -0.01927968]]]
+```

--- a/docs/docs/KerasStyleAPIGuide/Layers/normalization.md
+++ b/docs/docs/KerasStyleAPIGuide/Layers/normalization.md
@@ -1,0 +1,138 @@
+## **BatchNormalization**
+Batch normalization layer.
+
+Normalize the activations of the previous layer at each batch, i.e. applies a transformation that maintains the mean activation close to 0 and the activation standard deviation close to 1.
+
+It is a feature-wise normalization, each feature map in the input will be normalized separately.
+
+The input of this layer should be 4D.
+
+**Scala:**
+```scala
+BatchNormalization(epsilon = 0.001, momentum = 0.99, betaInit = "zero", gammaInit = "one", dimOrdering = "th", inputShape = null)
+```
+**Python:**
+```python
+BatchNormalization(epsilon=0.001, momentum=0.99, beta_init="zero", gamma_init="one", dim_ordering="th", input_shape=None)
+```
+
+**Parameters:**
+
+* `epsilon`: Small Double > 0. Fuzz parameter. Default is 0.001.
+* `momentum`: Double. Momentum in the computation of the exponential average of the mean and standard deviation of the data, for feature-wise normalization. Default is 0.99.
+* `betaInit`: Name of initialization function for shift parameter. Default is 'zero'.
+* `gammaInit`: Name of initialization function for scale parameter. Default is 'one'.
+* `dimOrdering`: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'. For 'th', axis along which to normalize is 1. For 'tf', axis is 3.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, BatchNormalization}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(BatchNormalization(inputShape = Shape(2, 3, 4)))
+val input = Tensor[Float](2, 2, 3, 4).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,1,.,.) =
+0.77107763	    0.2937704	0.5191167	1.7458088
+0.6895759	    1.1034386	0.076277375	0.73515415
+0.8190946	    0.63958114	0.5226141	-0.42864776
+
+(1,2,.,.) =
+-0.121818945	0.34588146	0.055290654	-0.07994603
+0.6463561	    0.13930246	1.5822772	0.5089318
+-0.21778189	    -1.4048384	0.47113693	0.7929269
+
+(2,1,.,.) =
+0.6308846	    -0.3855579	1.1685323	1.5646453
+0.06638282	    -1.7852567	2.5698936	0.54044205
+1.020025	    0.9537036	-0.95600724	2.0834947
+
+(2,2,.,.) =
+-0.5315871	    -1.5204562	-0.19082998	-1.5210537
+0.35849532	    0.15615761	-0.55561566	1.1889576
+-0.16226959	    -2.1243215	1.1446979	-1.1057223
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3x4]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,1,.,.) =
+0.16141568	    -0.3597713	-0.1137085	1.2257558
+0.07242136	    0.5243313	-0.5972589	0.12218969
+0.21384695	    0.017830472	-0.10988956	-1.1486028
+
+(1,2,.,.) =
+-0.03555677	    0.4775637	0.15875259	0.010382571
+0.80721855	    0.25092307	1.8340303	0.6564485
+-0.14083901	    -1.4431748	0.6149832	0.96802336
+
+(2,1,.,.) =
+0.008334424	    -1.1015517	0.5954091	1.0279375
+-0.6080631	    -2.6299274	2.1256003	-0.090422675
+0.4332493	    0.36083078	-1.7244436	1.5944856
+
+(2,2,.,.) =
+-0.48511901	    -1.5700207	-0.11126971	-1.5706762
+0.49140254	    0.26941508	-0.51148105	1.402514
+-0.07993572	    -2.2325294	1.3539561	-1.1150105
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3x4]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import BatchNormalization
+
+model = Sequential()
+model.add(BatchNormalization(input_shape=(2, 3, 4)))
+input = np.random.random([2, 2, 3, 4])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[[0.01633039 0.08359466 0.31828698 0.31132638]
+   [0.82236941 0.34455877 0.40301781 0.09545177]
+   [0.32995004 0.21716768 0.40654485 0.0607145 ]]
+
+  [[0.04502162 0.90428985 0.54087212 0.78525733]
+   [0.02355475 0.86309013 0.25354746 0.88168388]
+   [0.77375427 0.74295181 0.43970331 0.07890251]]]
+
+
+ [[[0.87290131 0.15790927 0.25248005 0.56290773]
+   [0.47154244 0.98287739 0.59877866 0.3287331 ]
+   [0.0048165  0.47392756 0.32070177 0.51298559]]
+
+  [[0.89172586 0.68240756 0.86829594 0.79287212]
+   [0.13308157 0.04279427 0.59920687 0.26807939]
+   [0.42409288 0.54029318 0.65308363 0.90739643]]]]
+```
+Output is
+```python
+[[[[-1.3824786   -1.1216924   -0.21178117  -0.2387677 ]
+   [ 1.7425659   -0.10992443  0.11672354   -1.075722  ]
+   [-0.16656308  -0.6038247   0.13039804   -1.2103996 ]]
+
+  [[-1.6169451   1.149055     -0.02079336  0.7658872 ]
+   [-1.6860473   1.0164324    -0.9456966   1.076286  ]
+   [ 0.7288585   0.6297049    -0.3464575   -1.5078819 ]]]
+
+
+ [[[ 1.93848     -0.8335718   -0.4669172   0.73662305]
+   [ 0.3823962   2.3648615    0.87569594   -0.17128123]
+   [-1.4271184   0.39164335   -0.20241894  0.5430728 ]]
+
+  [[ 1.1086112   0.43481186   1.0331899    0.7903993 ]
+   [-1.3334786   -1.6241149   0.16698733   -0.89891803]
+   [-0.39670774  -0.02265698  0.3404176    1.1590551 ]]]]
+```

--- a/docs/docs/KerasStyleAPIGuide/Layers/pooling.md
+++ b/docs/docs/KerasStyleAPIGuide/Layers/pooling.md
@@ -1,0 +1,1349 @@
+## **MaxPooling1D**
+Max pooling operation for temporal data.
+
+The input of this layer should be 3D.
+
+**Scala:**
+```scala
+MaxPooling1D(poolLength = 2, stride = -1, borderMode = "valid", inputShape = null)
+```
+**Python:**
+```python
+MaxPooling1D(pool_length=2, stride=None, border_mode="valid", input_shape=None)
+```
+
+Parameters:
+
+* `poolLength`: Size of the region to which max pooling is applied.
+* `stride`: Factor by which to downscale. 2 will halve the input. If not specified, it will default to poolLength.
+* `borderMode`: Either 'valid' or 'same'. Default is 'valid'.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, MaxPooling1D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(MaxPooling1D(poolLength = 3, inputShape = Shape(4, 5)))
+val input = Tensor[Float](3, 4, 5).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,.,.) =
+0.32697344	 -1.901702	  0.9338836	   0.4988416	-1.4769285
+0.82112324	 -1.749153	  -1.2225364   0.17479241	-0.1569928
+-1.9349245	 -0.7208759	  -2.6186085   0.7094514	0.02309827
+0.06299127	 -0.28094748  -1.679667	   -0.19593267	-0.6486389
+
+(2,.,.) =
+0.5059762	 -0.27661985  1.3978469	   -0.13661754	0.9121702
+1.20289	     -1.2779995	  -1.221474	   1.6933655	0.06884759
+-0.8358409	 -1.5242177	  0.38067985   0.1758138	-2.0869224
+-0.052700672 -1.2065598	  0.65831304   -2.7004414	-1.5840155
+
+(3,.,.) =
+-1.5877407	 -0.23685509  -1.1487285   0.6082965	0.5463596
+-0.6323151	 1.6099663	  0.16473362   -0.6759079	-0.22952202
+0.07198518	 1.0313594	  1.4555247	   0.7538992	-1.2048378
+1.2034347	 0.11312642	  -0.14845283  -1.3795642	1.1672769
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 3x4x5]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,.,.) =
+0.82112324	-0.7208759	0.9338836	0.7094514	0.02309827
+
+(2,.,.) =
+1.20289	    -0.27661985	1.3978469	1.6933655	0.9121702
+
+(3,.,.) =
+0.07198518	1.6099663	1.4555247	0.7538992	0.5463596
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 3x1x5]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import MaxPooling1D
+
+model = Sequential()
+model.add(MaxPooling1D(pool_length = 3, input_shape = (4, 5)))
+input = np.random.random([3, 4, 5])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[0.40580359 0.91869648 0.52699134 0.96507862 0.45316868]
+  [0.55665601 0.91599093 0.68640946 0.55788983 0.79788871]
+  [0.63706076 0.86559853 0.2157637  0.56051023 0.48453306]
+  [0.68673896 0.35445905 0.98369363 0.05747027 0.54176785]]
+
+ [[0.00154654 0.02109022 0.69103023 0.08356977 0.51230376]
+  [0.01498106 0.32251403 0.98859889 0.6393191  0.59248678]
+  [0.43467219 0.97269656 0.82172126 0.62731276 0.19477236]
+  [0.44162847 0.50752131 0.43099026 0.07546448 0.97122237]]
+
+ [[0.9526254  0.82221173 0.13355431 0.19929353 0.95937559]
+  [0.53449677 0.8041899  0.45077759 0.40048272 0.31712774]
+  [0.83603459 0.72547619 0.61066729 0.09561956 0.32530191]
+  [0.10199395 0.77512743 0.69522612 0.7456257  0.73544269]]]
+```
+Output is:
+```python
+[[[0.63706076 0.91869646 0.6864095  0.9650786  0.7978887 ]]
+
+ [[0.43467218 0.97269654 0.9885989  0.6393191  0.5924868 ]]
+
+ [[0.9526254  0.82221174 0.6106673  0.4004827  0.95937556]]]
+```
+
+---
+## **MaxPooling2D**
+Max pooling operation for spatial data.
+
+The input of this layer should be 4D.
+
+**Scala:**
+```scala
+MaxPooling2D(poolSize = Array(2, 2), strides = null, borderMode = "valid", dimOrdering = "th", inputShape = null)
+```
+**Python:**
+```python
+MaxPooling2D(pool_size=(2, 2), strides=None, border_mode="valid", dim_ordering="th", input_shape=None)
+```
+
+Parameters:
+
+* `poolSize`: Length 2 corresponding to the downscale vertically and horizontally. Default is (2, 2), which will halve the image in each dimension.
+* `strides`: Length 2. Stride values. Default is null, and in this case it will be equal to poolSize.
+* `borderMode`: Either 'valid' or 'same'. Default is 'valid'.
+* `dimOrdering`: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, MaxPooling2D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(MaxPooling2D(inputShape = Shape(2, 3, 4)))
+val input = Tensor[Float](2, 2, 3, 4).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,1,.,.) =
+2.5301383	0.10926374	0.6072471	0.658932
+-0.3569041	0.32731345	-1.4209954	-0.4969882
+0.70455354	-2.7349844	0.66514283	-1.0055662
+
+(1,2,.,.) =
+-0.29669985	0.054489832	-1.1771511	-0.37510478
+1.2857671	-1.1703448	0.39755398	-1.6102049
+-0.42201662	1.2561954	1.1706035	0.20676066
+
+(2,1,.,.) =
+2.2395058	0.36936793	-1.0407287	0.46479732
+0.08024679	-1.3457166	-0.7048267	-0.017787607
+-0.66454273	-1.5704913	-1.7375602	-2.417642
+
+(2,2,.,.) =
+-1.5279706	-1.0108438	1.0017345	-0.5810244
+-1.5944351	0.11111861	0.4439802	-0.48056543
+-2.4090567	-1.459287	0.67291117	0.24757418
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3x4]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,1,.,.) =
+2.5301383	0.658932
+
+(1,2,.,.) =
+1.2857671	0.39755398
+
+(2,1,.,.) =
+2.2395058	0.46479732
+
+(2,2,.,.) =
+0.11111861	1.0017345
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x1x2]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import MaxPooling2D
+
+model = Sequential()
+model.add(MaxPooling2D(input_shape = (2, 3, 4)))
+input = np.random.random([2, 2, 3, 4])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[[0.82279705 0.62487892 0.37391352 0.22834848]
+   [0.68709158 0.40902972 0.73191486 0.40095294]
+   [0.651977   0.93330601 0.45785981 0.45939351]]
+
+  [[0.372833   0.39871945 0.13426243 0.83083849]
+   [0.24290548 0.04446027 0.58070741 0.37752852]
+   [0.13116942 0.59339663 0.94669915 0.02460278]]]
+
+
+ [[[0.46505904 0.96103464 0.75846419 0.77357123]
+   [0.37835688 0.88438048 0.5679742  0.74607276]
+   [0.41415466 0.73945737 0.39188398 0.52736799]]
+
+  [[0.51772064 0.19857965 0.15476197 0.64569767]
+   [0.21794751 0.74455093 0.48423447 0.15482331]
+   [0.38363071 0.78733222 0.2542284  0.88671892]]]]
+```
+Output is:
+```python
+[[[[0.82279706 0.7319149 ]]
+
+  [[0.39871946 0.8308385 ]]]
+
+
+ [[[0.96103466 0.77357125]]
+
+  [[0.74455094 0.64569765]]]]
+```
+
+---
+## **MaxPooling3D**
+Applies max pooling operation for 3D data (spatial or spatio-temporal).
+
+Data format currently supported for this layer is 'CHANNEL_FIRST' (dimOrdering='th').
+
+Border mode currently supported for this layer is 'valid'.
+
+The input of this layer should be 5D.
+
+**Scala:**
+```scala
+MaxPooling3D(poolSize = Array(2, 2, 2), strides = null, dimOrdering = "th", inputShape = null)
+```
+**Python:**
+```python
+MaxPooling3D(pool_size=(2, 2, 2), strides=None, border_mode="valid", dim_ordering="th", input_shape=None)
+```
+
+Parameters:
+
+* `poolSize`: Length 3. Factors by which to downscale (dim1, dim2, dim3). Default is (2, 2, 2), which will halve the image in each dimension.
+* `strides`: Length 3. Stride values. Default is null, and in this case it will be equal to poolSize.
+* `dimOrdering`: Format of input data. Only 'th' (Channel First) is supported for now.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, MaxPooling3D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(MaxPooling3D(inputShape = Shape(2, 2, 2, 3)))
+val input = Tensor[Float](2, 2, 2, 2, 3).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,1,1,.,.) =
+-0.5052603	0.8938585	0.44785392
+-0.48919395	0.35026026	0.541859
+
+(1,1,2,.,.) =
+1.5306468	0.24512683	1.71524
+-0.49025944	2.1886358	0.15880944
+
+(1,2,1,.,.) =
+-0.5133986	-0.16549884	-0.2971134
+1.5887301	1.8269571	1.3843931
+
+(1,2,2,.,.) =
+0.07515256	1.6993935	-0.3392596
+1.2611006	0.20215735	1.3105171
+
+(2,1,1,.,.) =
+-2.0070438	0.35554957	0.21326075
+-0.4078646	-1.5748956	-1.1007504
+
+(2,1,2,.,.) =
+1.0571382	-1.6031493	1.4638771
+-0.25891435	1.4923956	-0.24045596
+
+(2,2,1,.,.) =
+-0.57790893	0.14577095	1.3165486
+0.81937057	-0.3797079	1.2544848
+
+(2,2,2,.,.) =
+-0.42183575	-0.63774794	-2.0576336
+0.43662143	1.9010457	-0.061519064
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x2x2x3]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,1,1,.,.) =
+2.1886358
+
+(1,2,1,.,.) =
+1.8269571
+
+(2,1,1,.,.) =
+1.4923956
+
+(2,2,1,.,.) =
+1.9010457
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x1x1x1]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import MaxPooling3D
+
+model = Sequential()
+model.add(MaxPooling3D(input_shape = (2, 2, 2, 3)))
+input = np.random.random([2, 2, 2, 2, 3])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[[[0.73349746 0.9811588  0.86071417]
+    [0.33287621 0.37991739 0.87029317]]
+
+   [[0.62537904 0.48099174 0.06194759]
+    [0.38747972 0.05175308 0.36096032]]]
+
+
+  [[[0.63260385 0.69990236 0.63353249]
+    [0.19081261 0.56210617 0.75985185]]
+
+   [[0.8624058  0.47224318 0.26524027]
+    [0.75317792 0.39251436 0.98938982]]]]
+
+
+
+ [[[[0.00556086 0.18833728 0.80340438]
+    [0.9317538  0.88142596 0.90724509]]
+
+   [[0.90243612 0.04594116 0.43662143]
+    [0.24205094 0.58687822 0.57977055]]]
+
+
+  [[[0.17240398 0.18346483 0.02520754]
+    [0.06968248 0.02442692 0.56078895]]
+
+   [[0.69503427 0.09528588 0.46104647]
+    [0.16752596 0.88175901 0.71032998]]]]]
+```
+Output is:
+```python
+[[[[[0.9811588]]]
+
+  [[[0.8624058]]]]
+
+
+ [[[[0.9317538]]]
+
+  [[[0.881759 ]]]]]
+```
+
+---
+## **AveragePooling1D**
+Average pooling for temporal data.
+
+The input of this layer should be 3D.
+
+**Scala:**
+```scala
+AveragePooling1D(poolLength = 2, stride = -1, borderMode = "valid", inputShape = null)
+```
+**Python:**
+```python
+AveragePooling1D(pool_length=2, stride=None, border_mode="valid", input_shape=None)
+```
+
+Parameters:
+
+* `poolLength`: Size of the region to which average pooling is applied. Integer. Default is 2.
+* `stride`: Factor by which to downscale. 2 will halve the input. If not specified, it will default to poolLength.
+* `borderMode`: Either 'valid' or 'same'. Default is 'valid'.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, AveragePooling1D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(AveragePooling1D(poolLength = 3, inputShape = Shape(4, 5)))
+val input = Tensor[Float](3, 4, 5).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,.,.) =
+-1.1377933	 0.21371832	  1.7306958	   -1.9029621	-1.4344455
+0.30368176	 1.4264593	  -2.1044374   1.9331307	0.064429775
+-0.20389123	 1.0778805	  -0.6283651   1.3097609	-0.13545972
+0.2993623	 0.6173592	  0.36244655   0.79175955	0.79752296
+
+(2,.,.) =
+-0.2151101	 -0.016314683 0.42787352   0.8266788	1.3463322
+-0.5822824	 -0.80566406  1.8474609	   1.0040557	0.058591228
+1.1027422	 -1.3031522	  -0.17601672  1.0220417	-0.26774135
+0.5274945	 0.33779684	  -0.85662115  0.057247106	-0.26438802
+
+(3,.,.) =
+-0.069942534 0.9225811	  -0.46108767  2.4335458	0.101546675
+-0.12930758	 0.7706995	  -0.1920893   -0.23971881	0.72432745
+0.55851805	 -0.5315623	  0.7103099    -0.5954772	1.1504582
+0.6810412	 2.08239	  0.5578813    -0.21148366	0.6381254
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 3x4x5]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,.,.) =
+-0.34600094	0.9060194	-0.33403555	0.4466432	-0.50182515
+
+(2,.,.) =
+0.10178324	-0.70837694	0.69977254	0.95092535	0.37906072
+
+(3,.,.) =
+0.11975598	0.38723943	0.01904432	0.5327832	0.6587774
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 3x1x5]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import AveragePooling1D
+
+model = Sequential()
+model.add(AveragePooling1D(pool_length = 3, input_shape = (4, 5)))
+input = np.random.random([3, 4, 5])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[0.70712635 0.03582033 0.06284402 0.32036469 0.81474437]
+  [0.79836044 0.90868531 0.28817162 0.82013972 0.31323463]
+  [0.22585456 0.36409411 0.22224669 0.93922795 0.19095179]
+  [0.39250119 0.64782355 0.85172164 0.28749378 0.1088145 ]]
+
+ [[0.04373644 0.29722078 0.3117768  0.64487829 0.4810562 ]
+  [0.3168246  0.08202731 0.58480522 0.72992227 0.64433289]
+  [0.49511033 0.09427843 0.80680702 0.23613413 0.70898751]
+  [0.50461138 0.26695611 0.34203601 0.09773049 0.19039967]]
+
+ [[0.75294793 0.55036481 0.26584527 0.98080601 0.43339867]
+  [0.50389323 0.07068883 0.78938881 0.96551069 0.15544646]
+  [0.12795345 0.23093578 0.22171131 0.54183322 0.39152313]
+  [0.53546306 0.66279754 0.52490436 0.14028357 0.40409458]]]
+```
+Output is:
+```python
+[[[0.57711375 0.4361999  0.19108744 0.69324416 0.43964362]]
+
+ [[0.2852238  0.15784217 0.56779635 0.53697824 0.61145884]]
+
+ [[0.4615982  0.28399646 0.42564845 0.8293833  0.3267894 ]]]
+```
+
+---
+## **AveragePooling2D**
+Average pooling operation for spatial data.
+
+The input of this layer should be 4D.
+
+**Scala:**
+```scala
+AveragePooling2D(poolSize = Array(2, 2), strides = null, borderMode = "valid", dimOrdering = "th", inputShape = null)
+```
+**Python:**
+```python
+AveragePooling2D(pool_size=(2, 2), strides=None, border_mode="valid", dim_ordering="th", input_shape=None)
+```
+
+Parameters:
+
+* `poolSize`: Length 2 corresponding to the downscale vertically and horizontally. Default is (2, 2), which will halve the image in each dimension.
+* `strides`: Length 2. Stride values. Default is null, and in this case it will be equal to poolSize.
+* `borderMode`: Either 'valid' or 'same'. Default is 'valid'.
+* `dimOrdering`: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, AveragePooling2D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(AveragePooling2D(inputShape = Shape(2, 3, 4)))
+val input = Tensor[Float](2, 2, 3, 4).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,1,.,.) =
+0.9929163	0.73885435	-0.34893242	1.1493853
+-0.45246652	-0.32470804	1.2192643	0.30351913
+1.3251832	0.52051955	-1.1398637	-2.427732
+
+(1,2,.,.) =
+-0.5123787	-0.5055035	0.3858232	0.71986055
+0.9580216	0.36081943	1.4867425	0.9852266
+-0.6051215	-0.15555465	-1.4472512	0.51882136
+
+(2,1,.,.) =
+-1.5209191	0.006158142	1.5162845	-0.06919313
+0.56743985	-0.499725	-0.44013703	-0.12666322
+0.78009427	1.9432178	1.4082893	-0.6143322
+
+(2,2,.,.) =
+-1.387891	0.023748515	-0.8295103	-0.9282333
+1.1375008	-1.4631946	-0.67415875	-0.7773346
+-2.297338	1.0384767	1.7125391	-1.7680352
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3x4]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,1,.,.) =
+0.23864903	0.5808091
+
+(1,2,.,.) =
+0.075239725	0.89441323
+
+(2,1,.,.) =
+-0.36176154	0.22007278
+
+(2,2,.,.) =
+-0.4224591	-0.8023093
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x1x2]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import AveragePooling2D
+
+model = Sequential()
+model.add(AveragePooling2D(input_shape = (2, 3, 4)))
+input = np.random.random([2, 2, 3, 4])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[[0.23128514 0.69922098 0.52158685 0.43063779]
+   [0.89149649 0.33910949 0.4402748  0.08933058]
+   [0.71712488 0.21574851 0.76768248 0.57027882]]
+
+  [[0.08349921 0.85318742 0.49922456 0.6256355 ]
+   [0.22331336 0.78402155 0.91424506 0.18895412]
+   [0.89722286 0.31067545 0.82655572 0.37775551]]]
+
+
+ [[[0.9706926  0.28398186 0.36623623 0.23701637]
+   [0.49936358 0.50951663 0.48116156 0.89941571]
+   [0.06519683 0.34624179 0.2462403  0.48512833]]
+
+  [[0.58408752 0.68318898 0.67886418 0.43403476]
+   [0.87328453 0.8412756  0.59168164 0.49972216]
+   [0.82188585 0.63685579 0.50966912 0.51439279]]]]
+```
+Output is:
+```python
+[[[[0.540278   0.3704575 ]]
+
+  [[0.48600537 0.5570148 ]]]
+
+
+ [[[0.56588864 0.49595746]]
+
+  [[0.7454592  0.5510757 ]]]]
+```
+
+---
+## **AveragePooling3D**
+Applies average pooling operation for 3D data (spatial or spatio-temporal).
+
+Data format currently supported for this layer is 'CHANNEL_FIRST' (dimOrdering='th').
+
+Border mode currently supported for this layer is 'valid'.
+
+The input of this layer should be 5D.
+
+**Scala:**
+```scala
+AveragePooling3D(poolSize = Array(2, 2, 2), strides = null, dimOrdering = "th", inputShape = null)
+```
+**Python:**
+```python
+AveragePooling3D(pool_size=(2, 2, 2), strides=None, border_mode="valid", dim_ordering="th", input_shape=None)
+```
+
+Parameters:
+
+* `poolSize`: Length 3. Factors by which to downscale (dim1, dim2, dim3). Default is (2, 2, 2), which will halve the image in each dimension.
+* `strides`: Length 3. Stride values. Default is null, and in this case it will be equal to poolSize.
+* `dimOrdering`: Format of input data. Only 'th' (Channel First) is supported for now.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, AveragePooling3D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(AveragePooling3D(inputShape = Shape(2, 2, 2, 3)))
+val input = Tensor[Float](2, 2, 2, 2, 3).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,1,1,.,.) =
+-1.2491689	-0.72333497	0.076971635
+-1.2854124	-0.026098572	2.1735003
+
+(1,1,2,.,.) =
+1.4519714	1.1690209	2.3558137
+0.53576165	0.544173	1.1044264
+
+(1,2,1,.,.) =
+-1.2603238	-0.5580594	-0.91401285
+-0.18393324	-0.34946147	-0.5833402
+
+(1,2,2,.,.) =
+-0.2528762	0.5091298	0.2399745
+1.4895978	-1.3734508	-1.0218369
+
+(2,1,1,.,.) =
+-1.7266496	-0.04624697	0.47165343
+0.16339892	0.9384256	1.0018257
+
+(2,1,2,.,.) =
+-0.45763373	0.41072395	0.3123065
+-1.1914686	0.90784425	-2.8544335
+
+(2,2,1,.,.) =
+0.81638193	-1.2425674	1.9570643
+1.444956	0.37828556	-1.7336447
+
+(2,2,2,.,.) =
+-0.43858975	0.91795254	0.3359727
+0.20638026	-0.07622202	-2.1452882
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x2x2x3]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,1,1,.,.) =
+0.052114002
+
+(1,2,1,.,.) =
+-0.24742219
+
+(2,1,1,.,.) =
+-0.12520081
+
+(2,2,1,.,.) =
+0.25082216
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x1x1x1]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import AveragePooling3D
+
+model = Sequential()
+model.add(AveragePooling3D(input_shape = (2, 2, 2, 3)))
+input = np.random.random([2, 2, 2, 2, 3])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[[[0.97536696 0.01017816 0.77256405]
+    [0.53928594 0.80710453 0.71903394]]
+
+   [[0.67067647 0.38680811 0.05431165]
+    [0.98320357 0.8602754  0.12535218]]]
+
+
+  [[[0.32317928 0.17129988 0.51584225]
+    [0.70060648 0.36568169 0.36353108]]
+
+   [[0.90675921 0.68967216 0.29854921]
+    [0.72568459 0.34304905 0.9501725 ]]]]
+
+
+
+ [[[[0.96295459 0.51457555 0.15752579]
+    [0.29569757 0.73166152 0.24217882]]
+
+   [[0.69938844 0.98315048 0.36022304]
+    [0.97079866 0.03950786 0.18505114]]]
+
+
+  [[[0.10255992 0.87988966 0.13163776]
+    [0.286857   0.56472867 0.73914834]]
+
+   [[0.51970598 0.19869426 0.47845175]
+    [0.86776147 0.60381965 0.88064078]]]]]
+```
+Output is:
+```python
+[[[[[0.6541124 ]]]
+
+  [[[0.5282415 ]]]]
+
+
+ [[[[0.64971685]]]
+
+  [[[0.5030021 ]]]]]
+
+```
+
+---
+## **GlobalMaxPooling1D**
+Global max pooling operation for temporal data.
+
+The input of this layer should be 3D.
+
+**Scala:**
+```scala
+GlobalMaxPooling1D(inputShape = null)
+```
+**Python:**
+```python
+GlobalMaxPooling1D(input_shape=None)
+```
+
+Parameters:
+
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, GlobalMaxPooling1D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(GlobalMaxPooling1D(inputShape = Shape(2, 3)))
+val input = Tensor[Float](2, 2, 3).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,.,.) =
+-1.0603509	2.0034506	-1.9884554
+-1.187076	-1.3023934	-0.8058352
+
+(2,.,.) =
+-0.9960039	-2.5800185	-0.01848254
+-0.66063184	-1.451372	1.3490999
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+-1.0603509	2.0034506	-0.8058352
+-0.66063184	-1.451372	1.3490999
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import GlobalMaxPooling1D
+
+model = Sequential()
+model.add(GlobalMaxPooling1D(input_shape = (2, 3)))
+input = np.random.random([2, 2, 3])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[0.70782546 0.2064717  0.45753652]
+  [0.41262607 0.72777349 0.21662695]]
+
+ [[0.0937254  0.16749913 0.65395922]
+  [0.51027108 0.67591602 0.41025529]]]
+```
+Output is:
+```python
+[[0.7078255  0.7277735  0.45753652]
+ [0.5102711  0.675916   0.6539592 ]]
+```
+
+---
+## **GlobalMaxPooling2D**
+Global max pooling operation for spatial data.
+
+The input of this layer should be 4D.
+
+**Scala:**
+```scala
+GlobalMaxPooling2D(dimOrdering = "th", inputShape = null)
+```
+**Python:**
+```python
+GlobalMaxPooling2D(dim_ordering="th", input_shape=None)
+```
+
+Parameters:
+
+* `dimOrdering`: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, GlobalMaxPooling2D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(GlobalMaxPooling2D(inputShape = Shape(2, 3, 4)))
+val input = Tensor[Float](2, 2, 3, 4).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,1,.,.) =
+-0.33040258	-0.94677037	0.14672963	 0.1252591
+-0.3141728	0.68040586	1.3511285	 -0.29235613
+0.03947779	-1.1260709	0.16128083	 -1.1656744
+
+(1,2,.,.) =
+1.0182372	-0.6030568	-1.5335841	 0.37804475
+0.26944965	-1.6720067	0.2405665	 -0.95661074
+-0.31286374	0.109459646	-1.6644431	 -1.9295278
+
+(2,1,.,.) =
+1.0210015	-0.69647574	-0.629564	 1.6719679
+-0.7825565	-0.48921636	0.1892077	 0.17827414
+0.76913565	0.17354056	-0.5749589	 -1.736962
+
+(2,2,.,.) =
+0.82071537	-0.22566034	0.12415939	 0.02941268
+0.34600595	0.86877316	0.9797952	 -1.7793267
+0.025843443	-1.6373945	-0.093925744 -0.22479358
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3x4]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+1.3511285	1.0182372
+1.6719679	0.9797952
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import GlobalMaxPooling2D
+
+model = Sequential()
+model.add(GlobalMaxPooling2D(input_shape = (2, 3, 4)))
+input = np.random.random([2, 2, 3, 4])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[[0.4037502  0.02214535 0.83987632 0.63656679]
+   [0.57757778 0.41884406 0.94446159 0.55776242]
+   [0.40213234 0.4463349  0.04457756 0.99123233]]
+
+  [[0.71114675 0.88609155 0.40299526 0.01648121]
+   [0.23102758 0.89673552 0.07030409 0.79674961]
+   [0.84665248 0.18257089 0.87211872 0.22697933]]]
+
+
+ [[[0.08033122 0.26298654 0.10863184 0.57894922]
+   [0.03999134 0.90867755 0.80473921 0.79913378]
+   [0.60443084 0.92055786 0.17994007 0.87414516]]
+
+  [[0.50193442 0.52639178 0.72124789 0.41776979]
+   [0.09495006 0.91797563 0.48755794 0.50458372]
+   [0.47387433 0.93445126 0.83216554 0.67275364]]]]
+```
+Output is:
+```python
+[[0.99123234 0.8967355 ]
+ [0.92055786 0.9344513 ]]
+```
+
+---
+## **GlobalMaxPooling3D**
+Applies global max pooling operation for 3D data.
+
+Data format currently supported for this layer is 'CHANNEL_FIRST' (dimOrdering='th').
+
+Border mode currently supported for this layer is 'valid'.
+
+The input of this layer should be 5D.
+
+**Scala:**
+```scala
+GlobalMaxPooling3D(dimOrdering = "th", inputShape = null)
+```
+**Python:**
+```python
+GlobalMaxPooling3D(dim_ordering="th", input_shape=None)
+```
+
+Parameters:
+
+* `dimOrdering`: Format of input data. Only 'th' (Channel First) is supported for now.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, GlobalMaxPooling3D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(GlobalMaxPooling3D(inputShape = Shape(2, 2, 2, 3)))
+val input = Tensor[Float](2, 2, 2, 2, 3).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,1,1,.,.) =
+0.5882856	0.6403546	-0.42084476
+-0.097307995	-0.52530056	-0.36757985
+
+(1,1,2,.,.) =
+0.60983604	-0.24730012	-0.07744695
+0.36276138	0.34722528	0.19874145
+
+(1,2,1,.,.) =
+-0.912143	0.14050196	2.1116483
+-0.67692965	-0.5708391	-2.1040971
+
+(1,2,2,.,.) =
+2.1500692	1.1697202	1.364164
+1.2241726	-0.12069768	1.2471954
+
+(2,1,1,.,.) =
+0.39550102	-0.7435119	0.47669584
+-0.17335615	0.2690476	-0.8462402
+
+(2,1,2,.,.) =
+-1.0553921	-0.35153934	0.8036665
+-1.029019	-0.64534503	0.94537926
+
+(2,2,1,.,.) =
+0.5388452	-0.27233714	1.5837694
+1.0976856	-0.20959699	1.6285672
+
+(2,2,2,.,.) =
+-0.7736055	0.58593166	-1.2158531
+1.2194971	1.4081163	1.2056179
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x2x2x3]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+0.6403546	2.1500692
+0.94537926	1.6285672
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import GlobalMaxPooling3D
+
+model = Sequential()
+model.add(GlobalMaxPooling3D(input_shape = (2, 2, 2, 3)))
+input = np.random.random([2, 2, 2, 2, 3])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[[[0.35670186 0.12860978 0.99958102]
+    [0.17345679 0.19473725 0.41235665]]
+
+   [[0.98948429 0.26686797 0.4632353 ]
+    [0.15791828 0.07452679 0.73215605]]]
+
+
+  [[[0.80305568 0.73208753 0.31179214]
+    [0.43452576 0.563038   0.65955869]]
+
+   [[0.31947806 0.00899334 0.55208827]
+    [0.57471665 0.10157217 0.42698318]]]]
+
+
+
+ [[[[0.59277903 0.35379325 0.5311834 ]
+    [0.91781414 0.10407255 0.58049721]]
+
+   [[0.14371521 0.24279466 0.26071055]
+    [0.89431752 0.66817043 0.61662462]]]
+
+
+  [[[0.6672706  0.38855847 0.88462881]
+    [0.38859986 0.80439572 0.27661295]]
+
+   [[0.41453042 0.11527795 0.75953012]
+    [0.77940987 0.26283438 0.97745039]]]]]
+```
+Output is:
+```python
+[[0.99958104 0.8030557 ]
+ [0.91781414 0.9774504 ]]
+```
+
+---
+## **GlobalAveragePooling1D**
+Global average pooling operation for temporal data.
+
+The input of this layer should be 3D.
+
+**Scala:**
+```scala
+GlobalAveragePooling1D(inputShape = null)
+```
+**Python:**
+```python
+GlobalAveragePooling1D(input_shape=None)
+```
+
+Parameters:
+
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, GlobalAveragePooling1D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(GlobalAveragePooling1D(inputShape = Shape(2, 3)))
+val input = Tensor[Float](2, 2, 3).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,.,.) =
+0.52390736	-0.2733816	0.124149635
+-1.351596	-1.1435038	-1.5176618
+
+(2,.,.) =
+1.0428048	-0.65227276	-0.44158915
+-0.23790422	0.4179904	-0.12358317
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+-0.41384432	-0.7084427	-0.69675606
+0.40245032	-0.11714119	-0.28258616
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import GlobalAveragePooling1D
+
+model = Sequential()
+model.add(GlobalAveragePooling1D(input_shape = (2, 3)))
+input = np.random.random([2, 2, 3])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[0.93869359 0.22245741 0.9744004 ]
+  [0.89151128 0.8211663  0.73579694]]
+
+ [[0.37929716 0.509159   0.21713254]
+  [0.81838451 0.72323228 0.0370643 ]]]
+```
+Output is:
+```python
+[[0.9151024   0.52181184 0.85509866]
+ [0.59884083  0.6161956  0.12709841]]
+```
+
+---
+## **GlobalAveragePooling2D**
+Global average pooling operation for spatial data.
+
+The input of this layer should be 4D.
+
+**Scala:**
+```scala
+GlobalAveragePooling2D(dimOrdering = "th", inputShape = null)
+```
+**Python:**
+```python
+GlobalAveragePooling2D(dim_ordering="th", input_shape=None)
+```
+
+Parameters:
+
+* `dimOrdering`: Format of input data. Either 'th' (Channel First) or 'tf' (Channel Last). Default is 'th'.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, GlobalAveragePooling2D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(GlobalAveragePooling2D(inputShape = Shape(2, 3, 4)))
+val input = Tensor[Float](2, 2, 3, 4).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,1,.,.) =
+0.110688895	    -0.95155084	1.8221924	-2.0326483
+-0.013243215	-1.2766567	-0.16704278	-0.97121066
+-2.4606674	    -0.24223651	-0.5687073	0.69842345
+
+(1,2,.,.) =
+0.14165956	    0.17032783	2.5329256	0.011501087
+-0.3236992	    1.1332442	0.18139894	-2.3126595
+0.1546373	    0.35264283	-0.04404357	-0.70906943
+
+(2,1,.,.) =
+-0.08527824	    0.29270124	-0.7355773	-0.6026267
+-0.71629876	    0.83938205	0.5129336	0.118145116
+0.17555784	    -0.8842884	0.12628363	-0.5556226
+
+(2,2,.,.) =
+0.6230317	    0.64954233	-1.3002442	-0.44802713
+-0.7294096	    0.29014868	-0.55649257	2.1427174
+0.0146621745	0.67039204	0.12979278	1.8543824
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3x4]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+-0.5043883	0.10740545
+-0.12622404	0.27837467
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import GlobalAveragePooling2D
+
+model = Sequential()
+model.add(GlobalAveragePooling2D(input_shape = (2, 3, 4)))
+input = np.random.random([2, 2, 3, 4])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[[0.44851152 0.94140516 0.45500829 0.07239139]
+   [0.58724461 0.7386701  0.69641719 0.70497337]
+   [0.15950558 0.56006247 0.82534941 0.59303245]]
+
+  [[0.94628326 0.75747177 0.92495215 0.16233194]
+   [0.21553426 0.65968036 0.72130258 0.8929379 ]
+   [0.91295078 0.36362834 0.04734189 0.32399088]]]
+
+
+ [[[0.74069289 0.8804913  0.38783329 0.82279268]
+   [0.29561186 0.86405938 0.21608269 0.618583  ]
+   [0.16823803 0.65690701 0.85394726 0.94541932]]
+
+  [[0.33876558 0.47517543 0.25908204 0.81933296]
+   [0.16176792 0.57166    0.28295922 0.95254489]
+   [0.10532106 0.98495855 0.41048516 0.86755462]]]]
+```
+Output is:
+```python
+[[0.5652142 0.5773672]
+ [0.6208883 0.519134 ]]
+```
+
+---
+## **GlobalAveragePooling3D**
+Applies global average pooling operation for 3D data.
+
+Data format currently supported for this layer is 'CHANNEL_FIRST' (dimOrdering='th').
+
+Border mode currently supported for this layer is 'valid'.
+
+The input of this layer should be 5D.
+
+**Scala:**
+```scala
+GlobalAveragePooling3D(dimOrdering = "th", inputShape = null)
+```
+**Python:**
+```python
+GlobalAveragePooling3D(dim_ordering="th", input_shape=None)
+```
+
+Parameters:
+
+* `dimOrdering`: Format of input data. Only 'th' (Channel First) is supported for now.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, GlobalAveragePooling3D}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(GlobalAveragePooling3D(inputShape = Shape(2, 2, 2, 3)))
+val input = Tensor[Float](2, 2, 2, 2, 3).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,1,1,.,.) =
+1.8996966	 -0.20018125	-0.3271749
+0.27594963	 -1.0520669	0.86003053
+
+(1,1,2,.,.) =
+-0.7652662	 0.72945994	 0.9008456
+0.8692407	 -1.1327444	 2.0664887
+
+(1,2,1,.,.) =
+0.10636215	 -0.812925   -0.3757974
+0.48761207	 0.017417012 -2.395701
+
+(1,2,2,.,.) =
+-1.3122851	 -0.5942121	 -0.6180062
+-0.032230377 -0.27521232 -0.3567782
+
+(2,1,1,.,.) =
+1.8668615	 -0.4244298	 1.0701258
+0.63794065	 -1.023562	 0.16939393
+
+(2,1,2,.,.) =
+0.20582832	 0.5321886	 -1.5412451
+-0.38068503	 1.4506307	 -0.47838798
+
+(2,2,1,.,.) =
+-0.7344984	 -0.28647164 2.410416
+-1.8175911	 -1.1973995	 1.001777
+
+(2,2,2,.,.) =
+-0.09646813	 0.11988298	 1.4687495
+1.493955	 0.16738588	 1.133337
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x2x2x3]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+0.34368983	-0.51347965
+0.17372166	0.30525622
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import GlobalAveragePooling3D
+
+model = Sequential()
+model.add(GlobalAveragePooling3D(input_shape = (2, 2, 2, 3)))
+input = np.random.random([2, 2, 2, 2, 3])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[[[0.38403874 0.30696173 0.25682854]
+    [0.53124253 0.62668969 0.21927777]]
+
+   [[0.33040063 0.37388563 0.75210039]
+    [0.08358634 0.80063745 0.13251887]]]
+
+
+  [[[0.41724617 0.2241106  0.55527267]
+    [0.69493785 0.71098284 0.54058444]]
+
+   [[0.4773658  0.92236993 0.76933649]
+    [0.45217032 0.61153948 0.01976393]]]]
+
+
+
+ [[[[0.27256789 0.56008397 0.19898919]
+    [0.44973465 0.66605998 0.77117999]]
+
+   [[0.07868799 0.94786045 0.2240451 ]
+    [0.92261946 0.4053334  0.2572511 ]]]
+
+
+  [[[0.33754374 0.28838802 0.79900278]
+    [0.26374789 0.25610211 0.9320699 ]]
+
+   [[0.19518511 0.80707822 0.29660536]
+    [0.56917623 0.07653736 0.77836375]]]]]
+```
+Output is:
+```python
+[[0.3998474  0.53297335]
+ [0.47953442 0.46665   ]]
+```

--- a/docs/docs/KerasStyleAPIGuide/Layers/recurrent.md
+++ b/docs/docs/KerasStyleAPIGuide/Layers/recurrent.md
@@ -1,0 +1,332 @@
+## **SimpleRNN**
+A fully-connected recurrent neural network cell. The output is to be fed back to input.
+
+The input of this layer should be 3D, i.e. (batch, time steps, input dim).
+
+**Scala:**
+```scala
+SimpleRNN(outputDim, activation = "tanh", returnSequences = false, goBackwards = false, wRegularizer = null, uRegularizer = null, bRegularizer = null, inputShape = null)
+```
+**Python:**
+```python
+SimpleRNN(output_dim, activation="tanh", return_sequences=False, go_backwards=False, W_regularizer=None, U_regularizer=None, b_regularizer=None, input_shape=None)
+```
+
+Parameters:
+
+* `outputDim`: Hidden unit size. Dimension of internal projections and final output.
+* `activation`: String representation of the activation function to use. See [here](activation/#available-activations) for available activation strings. Default is 'tanh'.
+* `returnSequences`: Whether to return the full sequence or only return the last output in the output sequence. Default is false.
+* `goBackwards`: Whether the input sequence will be processed backwards. Default is false.
+* `wRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), (eg. L1 or L2 regularization), applied to the input weights matrices. Default is null.
+* `uRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), applied the recurrent weights matrices. Default is null.
+* `bRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), applied to the bias. Default is null.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, SimpleRNN}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(SimpleRNN(8, activation = "relu", inputShape = Shape(4, 5)))
+val input = Tensor[Float](2, 4, 5).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,.,.) =
+0.71328646	0.24269831	-0.75013286	-1.6663225	0.35494477
+0.073439054	-1.1181073	-0.6577777	1.3154761	0.15396282
+0.41183218	-1.2667576	-0.11167632	0.946616	0.06427766
+0.013886308	-0.20620999	1.1173447	1.9083043	1.7680032
+
+(2,.,.) =
+-2.3510098	-0.8492037	0.042268332	-0.43801674	-0.010638754
+1.298793	-0.24814601	0.31325665	-0.19119295	-2.072075
+-0.11629801	0.27296612	0.94443846	0.37293285	-0.82289046
+0.6044998	0.93386084	-1.3502276	-1.7753356	1.6173482
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x4x5]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+0.0	 0.020557694  0.0	0.39700085	0.622244  0.0	0.36524248	0.88961613
+0.0	 1.4797685	  0.0	0.0	        0.0	      0.0	0.0	        0.0
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x8]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import SimpleRNN
+
+model = Sequential()
+model.add(SimpleRNN(8, activation = "relu", input_shape = (4, 5)))
+input = np.random.random([2, 4, 5])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[0.43400622 0.65452575 0.94952774 0.96210478 0.05286231]
+  [0.2162183  0.33225502 0.09725628 0.80813221 0.29556109]
+  [0.19720487 0.35077585 0.80904872 0.80576513 0.82035253]
+  [0.36175687 0.63291153 0.08437936 0.71581099 0.790709  ]]
+
+ [[0.35387003 0.36532078 0.9834315  0.07562338 0.05600369]
+  [0.65927201 0.14652252 0.10848068 0.88225065 0.88871385]
+  [0.23627135 0.72620104 0.60391828 0.51571874 0.73550574]
+  [0.80773506 0.35121494 0.66889362 0.530684   0.52066982]]]
+```
+Output is:
+```python
+[[0.77534926 0.23742369 0.14946866 0.0        0.16289112 0.0  0.71689016 0.24594748]
+ [0.8987881  0.06123672 0.3312829  0.29757586 0.0        0.0  1.0179179  0.23447856]]
+```
+
+---
+## **LSTM**
+Long Short Term Memory unit architecture.
+
+The input of this layer should be 3D, i.e. (batch, time steps, input dim).
+
+**Scala:**
+```scala
+LSTM(outputDim, activation = "tanh", innerActivation = "hard_sigmoid", returnSequences = false, goBackwards = false, wRegularizer = null, uRegularizer = null, bRegularizer = null, inputShape = null)
+```
+**Python:**
+```python
+LSTM(output_dim, activation="tanh", inner_activation="hard_sigmoid", return_sequences=False, go_backwards=False, W_regularizer=None, U_regularizer=None, b_regularizer=None, input_shape=None, input_shape=None)
+```
+
+Parameters:
+
+* `outputDim`: Hidden unit size. Dimension of internal projections and final output.
+* `activation`: String representation of the activation function to use. See [here](activation/#available-activations) for available activation strings. Default is 'tanh'.
+* `innerActivation`: String representation of the activation function for inner cells. See [here](activation/#available-activations) for available activation strings. Default is 'hard_sigmoid'.
+* `returnSequences`: Whether to return the full sequence or only return the last output in the output sequence. Default is false.
+* `goBackwards`: Whether the input sequence will be processed backwards. Default is false.
+* `wRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), (eg. L1 or L2 regularization), applied to the input weights matrices. Default is null.
+* `uRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), applied the recurrent weights matrices. Default is null.
+* `bRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), applied to the bias. Default is null.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, LSTM}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(LSTM(8, inputShape = Shape(2, 3)))
+val input = Tensor[Float](2, 2, 3).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,.,.) =
+1.3485646	0.38385049	0.676986
+0.13189854	0.30926105	0.4539456
+
+(2,.,.) =
+-1.7166822	-0.71257055	-0.477679
+-0.36572325	-0.5534503	-0.018431915
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+-0.20168768	-0.20359062	-0.11801678	-0.08987579	0.20480658	-0.05170132	-0.048530716	0.08447949
+-0.07134238	-0.11233686	0.073534355	0.047955263	0.13415548	0.12862797	-0.07839044	    0.28296617
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x8]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import LSTM
+
+model = Sequential()
+model.add(LSTM(8, input_shape = (2, 3)))
+input = np.random.random([2, 2, 3])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[0.84004043 0.2081865  0.76093342]
+  [0.06878797 0.13804673 0.23251666]]
+
+ [[0.24651173 0.5650254  0.41424478]
+  [0.49338729 0.40505622 0.01497762]]]
+```
+Output is:
+```python
+[[ 0.01089199  0.02563154 -0.04335827  0.03037791  0.11265078 -0.17756112
+   0.14166507  0.01017009]
+ [ 0.0144811   0.03360332  0.00676281 -0.01473055  0.09639315 -0.16620669
+   0.07391933  0.01746811]]
+```
+
+---
+## **GRU**
+Gated Recurrent Unit architecture.
+
+The input of this layer should be 3D, i.e. (batch, time steps, input dim).
+
+**Scala:**
+```scala
+GRU(outputDim, activation = "tanh", innerActivation = "hard_sigmoid", returnSequences = false, goBackwards = false, wRegularizer = null, uRegularizer = null, bRegularizer = null, inputShape = null)
+```
+**Python:**
+```python
+GRU(output_dim, activation="tanh", inner_activation="hard_sigmoid", return_sequences=False, go_backwards=False, W_regularizer=None, U_regularizer=None, b_regularizer=None, input_shape=None)
+```
+
+Parameters:
+
+* `outputDim`: Hidden unit size. Dimension of internal projections and final output.
+* `activation`: String representation of the activation function to use. See [here](activation/#available-activations) for available activation strings. Default is 'tanh'.
+* `innerActivation`: String representation of the activation function for inner cells. See [here](activation/#available-activations) for available activation strings. Default is 'hard_sigmoid'.
+* `returnSequences`: Whether to return the full sequence or only return the last output in the output sequence. Default is false.
+* `goBackwards`: Whether the input sequence will be processed backwards. Default is false.
+* `wRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), (eg. L1 or L2 regularization), applied to the input weights matrices. Default is null.
+* `uRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), applied the recurrent weights matrices. Default is null.
+* `bRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), applied to the bias. Default is null.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, GRU}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(GRU(8, inputShape = Shape(2, 3)))
+val input = Tensor[Float](2, 2, 3).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,.,.) =
+-0.010477358 -1.1201298  -0.86472356
+0.12688802   -0.6696582  0.08027417
+
+(2,.,.) =
+0.1724209    -0.52319324 -0.8808063
+0.17918338   -0.552886	 -0.11891741
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+-0.12018716	 -0.31560755	0.2867627	0.6728765	0.13287778	0.2112865	0.13381396	-0.4267934
+-0.18521798	 -0.30512968	0.14875418	0.63962734	0.1841841	0.25272882	0.016909363	-0.38463163
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x8]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import GRU
+
+model = Sequential()
+model.add(GRU(8, input_shape = (2, 3)))
+input = np.random.random([2, 2, 3])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[0.25026651 0.35433442 0.01417391]
+  [0.77236921 0.97315472 0.66090386]]
+
+ [[0.76037554 0.41029034 0.68725938]
+  [0.17888889 0.67670088 0.70580547]]]
+```
+Output is:
+```python
+[[-0.03584666  0.07984452 -0.06159414 -0.13331707  0.34015405 -0.07107028  0.12444386 -0.06606203]
+ [ 0.02881907  0.04856917 -0.15306929 -0.24991018  0.23814955  0.0303434   0.06634206 -0.15335503]]
+```
+
+---
+## **Highway**
+Densely connected highway network.
+
+Highway layers are a natural extension of LSTMs to feedforward networks.
+
+The input of this layer should be 2D, i.e. (batch, input dim).
+
+**Scala:**
+```scala
+Highway(activation = null, wRegularizer = null, bRegularizer = null, bias = true, inputShape = null)
+```
+**Python:**
+```python
+Highway(activation=None, W_regularizer=None, b_regularizer=None, bias=True, input_shape=None)
+```
+
+Parameters:
+
+* `activation`: String representation of the activation function to use. See [here](activation/#available-activations) for available activation strings. Default is null.
+* `wRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), (eg. L1 or L2 regularization), applied to the input weights matrices. Default is null.
+* `bRegularizer`: An instance of [Regularizer](../../../APIGuide/Regularizers/), applied to the bias. Default is null.
+* `bias`: Whether to include a bias (i.e. make the layer affine rather than linear). Default is true.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, Highway}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(Highway(inputShape = Shape(3)))
+val input = Tensor[Float](2, 3).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+-0.26041138	0.4286919	1.723103
+1.4516269	0.5557163	-0.1149741
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+-0.006746907	-0.109112576	1.3375516
+0.6065166	0.41575465	-0.06849813
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x3]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import Highway
+
+model = Sequential()
+model.add(Highway(input_shape = (3)))
+input = np.random.random([2, 3])
+output = model.forward(input)
+```
+Input is:
+```python
+[[0.5762107  0.45679288 0.00370956]
+ [0.24133312 0.38104653 0.05249192]]
+```
+Output is:
+```python
+[[0.5762107  0.4567929  0.00370956]
+ [0.24133313 0.38104653 0.05249191]]
+```

--- a/docs/docs/KerasStyleAPIGuide/Layers/wrappers.md
+++ b/docs/docs/KerasStyleAPIGuide/Layers/wrappers.md
@@ -1,0 +1,175 @@
+## **TimeDistributed**
+TimeDistributed wrapper. Apply a layer to every temporal slice of an input.
+
+The input should be at least 3D, and the dimension of index one will be considered to be the temporal dimension.
+
+**Scala:**
+```scala
+TimeDistributed(layer, inputShape = null)
+```
+**Python:**
+```python
+TimeDistributed(layer, input_shape=None)
+```
+
+Parameters:
+
+* `layer`: A layer instance.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, TimeDistributed, Dense}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(TimeDistributed(Dense(8, activation = "relu"), inputShape = Shape(2, 3)))
+val input = Tensor[Float](2, 2, 3).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,.,.) =
+-0.15650798	-0.60011286	-0.0883946
+-0.8020574	-2.0070791	0.58417106
+
+(2,.,.) =
+1.1210757	0.061217457	0.37585327
+0.11572507	0.045938224	-1.1890792
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,.,.) =
+0.35345355	0.019948795 0.0	        0.22901565	 0.0  0.035260748  0.0	        0.40403664
+1.4793522	0.803728	0.0	        0.93547887	 0.0  0.097175285  0.0	        1.2386305
+
+(2,.,.) =
+0.06176605	0.0	        0.051847294 0.76588714   0.0  0.67298067   0.10942559   0.0
+0.0	        0.0	        0.0	        0.0	         0.0  0.0	       0.4285032    0.3072814
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x8]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import TimeDistributed, Dense
+
+model = Sequential()
+model.add(TimeDistributed(Dense(8, activation = "relu"), input_shape = (2, 3)))
+input = np.random.random([2, 2, 3])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[0.37107995 0.16777911 0.07691505]
+  [0.42678424 0.53602176 0.01580607]]
+
+ [[0.31664302 0.03947526 0.1556008 ]
+  [0.2834384  0.68845104 0.23020768]]]
+```
+Output is:
+```python
+[[[0.09678233 0.21351711 0.0   0.07420383 0.09885262 0.0 0.13514107 0.0 ]
+  [0.06882857 0.18277436 0.0   0.1371126  0.00853634 0.0 0.1224944  0.0 ]]
+
+ [[0.11387025 0.20642482 0.0   0.04896355 0.11478973 0.0 0.12610494 0.0 ]
+  [0.08322716 0.08292685 0.0   0.14674747 0.0        0.0 0.05299555 0.0 ]]]
+```
+
+---
+## **Bidirectional**
+Bidirectional wrapper for RNNs.
+
+Bidirectional currently requires RNNs to return the full sequence, i.e. returnSequences = true.
+
+**Scala:**
+```scala
+Bidirectional(layer, mergeMode = "concat", inputShape = null)
+```
+**Python:**
+```python
+Bidirectional(layer, merge_mode="concat", input_shape=None)
+```
+
+Parameters:
+
+* `layer`: An instance of a recurrent layer.
+* `mergeMode`: Mode by which outputs of the forward and backward RNNs will be combined. Must be one of: 'sum', 'mul', 'concat', 'ave'. Default is 'concat'.
+* `inputShape`: Only need to specify this argument when you use this layer as the first layer of a model. For Scala API, it should be a [`Shape`](../keras-api-scala/#shape) object. For Python API, it should be a shape tuple. Batch dimension should be excluded.
+
+**Scala example:**
+```scala
+import com.intel.analytics.bigdl.nn.keras.{Sequential, Bidirectional, SimpleRNN}
+import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.bigdl.tensor._
+
+val model = Sequential[Float]()
+model.add(Bidirectional(SimpleRNN(4, returnSequences = true), inputShape = Shape(2, 3)))
+val input = Tensor[Float](2, 2, 3).randn()
+val output = model.forward(input)
+```
+Input is:
+```scala
+input: com.intel.analytics.bigdl.tensor.Tensor[Float] =
+(1,.,.) =
+0.6564635	1.525706	-0.54619956
+0.67109746	-0.45657027	-0.5378798
+
+(2,.,.) =
+0.19413045	-0.08337678	-0.0016114949
+0.6112209	0.7706432	1.3831
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x3]
+```
+Output is:
+```scala
+output: com.intel.analytics.bigdl.nn.abstractnn.Activity =
+(1,.,.) =
+0.7013748	0.4841168	  0.10397806 0.3799655   0.6934304	0.27561978	0.44025457	0.44310626
+0.4784317	-0.040266205  0.6599038	 -0.29032442 0.55478245	0.061714854	0.5239438	-0.2890968
+
+(2,.,.) =
+0.32227796	0.23023699	0.34051302	-0.18683606	0.38275728	0.49924713	0.3152017	-0.14768216
+0.1766845	0.39446256	-0.12303881	0.08089487	0.08701726	0.46380803	-0.3540904	-0.0030886582
+
+[com.intel.analytics.bigdl.tensor.DenseTensor of size 2x2x8]
+```
+
+**Python example:**
+```python
+import numpy as np
+from bigdl.nn.keras.topology import Sequential
+from bigdl.nn.keras.layer import Bidirectional, LSTM
+
+model = Sequential()
+model.add(Bidirectional(LSTM(4, return_sequences = True), merge_mode = "sum", input_shape = (3, 3)))
+input = np.random.random([2, 3, 3])
+output = model.forward(input)
+```
+Input is:
+```python
+[[[0.95180543 0.87111702 0.08901385]
+  [0.77432517 0.27843224 0.83308397]
+  [0.9140173  0.28253884 0.01381966]]
+
+ [[0.12674146 0.74173106 0.86059416]
+  [0.40666387 0.85293504 0.9403338 ]
+  [0.42748364 0.14310765 0.98098256]]]
+```
+Output is:
+```python
+[[[ 0.11651072  0.07040063  0.53200144 -0.37872505]
+  [ 0.03238479  0.15081021  0.55530167 -0.3390156 ]
+  [ 0.18388109  0.02891854  0.5591757  -0.28601688]]
+
+ [[-0.17779878 -0.02685877  0.244566   -0.34734237]
+  [-0.17816684  0.077871    0.3195565  -0.40989208]
+  [-0.13442594  0.08941883  0.3418655  -0.29824993]]]
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -98,6 +98,14 @@ pages:
     - Activation: KerasStyleAPIGuide/Layers/activation.md
     - Initialization: KerasStyleAPIGuide/Layers/initialization.md
     - Core Layers: KerasStyleAPIGuide/Layers/core.md
+    - Convolutional Layers: KerasStyleAPIGuide/Layers/convolutional.md
+    - Pooling Layers: KerasStyleAPIGuide/Layers/pooling.md
+    - Recurrent Layers: KerasStyleAPIGuide/Layers/recurrent.md
+    - Normalization Layers: KerasStyleAPIGuide/Layers/normalization.md
+    - Embedding Layers: KerasStyleAPIGuide/Layers/embedding.md
+    - Dropout Layers: KerasStyleAPIGuide/Layers/dropout.md
+    - Advanced Activations Layers: KerasStyleAPIGuide/Layers/advanced-activation.md
+    - Wrappers Layers: KerasStyleAPIGuide/Layers/wrappers.md
 - Powered by: powered-by.md
 - Known Issues: known-issues.md
 - Presentations: presentations.md

--- a/pyspark/bigdl/nn/keras/layer.py
+++ b/pyspark/bigdl/nn/keras/layer.py
@@ -1223,7 +1223,7 @@ class MaxPooling2D(KerasLayer):
     creating: createKerasMaxPooling2D
     """
     def __init__(self, pool_size=(2, 2), strides=None,
-                 border_mode='valid', dim_ordering='th',
+                 border_mode="valid", dim_ordering="th",
                  input_shape=None, **kwargs):
         super(MaxPooling2D, self).__init__(None,
                                            pool_size,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/LeakyReLU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/LeakyReLU.scala
@@ -36,7 +36,7 @@ import scala.reflect.ClassTag
  * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now.
  */
 class LeakyReLU[T: ClassTag](
-   private val alpha: Double = 0.01,
+   private val alpha: Double = 0.3,
    val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
   extends KerasLayer[Tensor[T], Tensor[T], T](KerasLayer.addBatch(inputShape))
     with IdentityOutputShape {
@@ -51,7 +51,7 @@ class LeakyReLU[T: ClassTag](
 
 object LeakyReLU {
   def apply[@specialized(Float, Double) T: ClassTag](
-    alpha: Double = 0.01,
+    alpha: Double = 0.3,
     inputShape: Shape = null)(implicit ev: TensorNumeric[T]): LeakyReLU[T] = {
     new LeakyReLU[T](alpha, inputShape)
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add keras website documentation for dropout, core, pooling, recurrent, convolutional, embedding, normalization and advancedActivations layers.

## How was this patch tested?

Jenkins

