### PR TITLE
[new feature]new optimMethod ftrl

### DIFF
--- a/docs/docs/APIGuide/Optimizers/Optim-Methods.md
+++ b/docs/docs/APIGuide/Optimizers/Optim-Methods.md
@@ -344,15 +344,16 @@ Support L1 penalty, L2 penalty and shrinkage-type L2 penalty.
 
 **Scala example:**
 ```scala
-val optimMethod = new LBFGS(learningRate = 5e-3, learningRatePower = -0.5,
+val optimMethod = new Ftrl(learningRate = 5e-3, learningRatePower = -0.5,
   initialAccumulatorValue = 0.01)
 optimizer.setOptimMethod(optimMethod)
 ```
 
 **Python example:**
 ```python
-optim_method = LBFGS(learningrate = 5e-3, learningrate_power = -0.5,
-                 initial_accumulator_value = 0.01)
+optim_method = Ftrl(learningrate = 5e-3, \
+    learningrate_power = -0.5, \
+    initial_accumulator_value = 0.01)
                   
 optimizer = Optimizer(
     model=mlp_model,

--- a/docs/docs/APIGuide/Optimizers/Optim-Methods.md
+++ b/docs/docs/APIGuide/Optimizers/Optim-Methods.md
@@ -322,7 +322,7 @@ val optimMethod = new Ftrl(
 
 **Python:**
 ```python
-optim_method = Ftrl(learningrate = 1e-3, learningrate_power = 0.0, \
+optim_method = Ftrl(learningrate = 1e-3, learningrate_power = -0.5, \
                  initial_accumulator_value = 0.1, l1_regularization_strength = 0.0, \
                  l2_regularization_strength = 0.0, l2_shrinkage_regularization_strength = 0.0)
 ```

--- a/docs/docs/APIGuide/Optimizers/Optim-Methods.md
+++ b/docs/docs/APIGuide/Optimizers/Optim-Methods.md
@@ -334,13 +334,10 @@ Support L1 penalty, L2 penalty and shrinkage-type L2 penalty.
 
 * learningRate: learning rate
 * learningRatePower: double, must be less or equal to zero. Default is -0.5.
-* initialAccumulatorValue: double, the starting value for accumulators,
-*     require zero or positive values. Default is 0.1.
+* initialAccumulatorValue: double, the starting value for accumulators, require zero or positive values. Default is 0.1.
 * l1RegularizationStrength: double, must be greater or equal to zero. Default is zero.
 * l2RegularizationStrength: double, must be greater or equal to zero. Default is zero.
-* l2ShrinkageRegularizationStrength: double, must be greater or equal to zero.
-*     Default is zero. This differs from l2RegularizationStrength above. L2 above is a
-*     stabilization penalty, whereas this one is a magnitude penalty.
+* l2ShrinkageRegularizationStrength: double, must be greater or equal to zero. Default is zero. This differs from l2RegularizationStrength above. L2 above is a stabilization penalty, whereas this one is a magnitude penalty.
 
 **Scala example:**
 ```scala

--- a/docs/docs/APIGuide/Optimizers/Optim-Methods.md
+++ b/docs/docs/APIGuide/Optimizers/Optim-Methods.md
@@ -322,9 +322,9 @@ val optimMethod = new Ftrl(
 
 **Python:**
 ```python
-optim_method = LBFGS(learningrate = 1e-3, learningrate_power = 0.0, \
+optim_method = Ftrl(learningrate = 1e-3, learningrate_power = 0.0, \
                  initial_accumulator_value = 0.1, l1_regularization_strength = 0.0, \
-                 l2_regularization_strength = 0.0, l2_shrinkage_regularization_strength = 0.0,)
+                 l2_regularization_strength = 0.0, l2_shrinkage_regularization_strength = 0.0)
 ```
 
 An implementation of (Ftrl)[https://www.eecs.tufts.edu/~dsculley/papers/ad-click-prediction.pdf.]

--- a/docs/docs/APIGuide/Optimizers/Optim-Methods.md
+++ b/docs/docs/APIGuide/Optimizers/Optim-Methods.md
@@ -252,6 +252,7 @@ x after optimize: 0.27779138
 [com.intel.analytics.bigdl.tensor.DenseTensor$mcF$sp of size 2]
 ```
 
+## LBFGS ##
 
 **Scala:**
 ```scala
@@ -309,4 +310,55 @@ optimizer = Optimizer(
     batch_size=32)
 ```
 
+## Ftrl ##
 
+**Scala:**
+```scala
+val optimMethod = new Ftrl(
+  learningRate = 1e-3, learningRatePower = -0.5,
+  initialAccumulatorValue = 0.1, l1RegularizationStrength = 0.0,
+  l2RegularizationStrength = 0.0, l2ShrinkageRegularizationStrength = 0.0)
+```
+
+**Python:**
+```python
+optim_method = LBFGS(learningrate = 1e-3, learningrate_power = 0.0, \
+                 initial_accumulator_value = 0.1, l1_regularization_strength = 0.0, \
+                 l2_regularization_strength = 0.0, l2_shrinkage_regularization_strength = 0.0,)
+```
+
+An implementation of (Ftrl)[https://www.eecs.tufts.edu/~dsculley/papers/ad-click-prediction.pdf.]
+Support L1 penalty, L2 penalty and shrinkage-type L2 penalty.
+
+**Parameters:**
+
+* learningRate: learning rate
+* learningRatePower: double, must be less or equal to zero. Default is -0.5.
+* initialAccumulatorValue: double, the starting value for accumulators,
+*     require zero or positive values. Default is 0.1.
+* l1RegularizationStrength: double, must be greater or equal to zero. Default is zero.
+* l2RegularizationStrength: double, must be greater or equal to zero. Default is zero.
+* l2ShrinkageRegularizationStrength: double, must be greater or equal to zero.
+*     Default is zero. This differs from l2RegularizationStrength above. L2 above is a
+*     stabilization penalty, whereas this one is a magnitude penalty.
+
+**Scala example:**
+```scala
+val optimMethod = new LBFGS(learningRate = 5e-3, learningRatePower = -0.5,
+  initialAccumulatorValue = 0.01)
+optimizer.setOptimMethod(optimMethod)
+```
+
+**Python example:**
+```python
+optim_method = LBFGS(learningrate = 5e-3, learningrate_power = -0.5,
+                 initial_accumulator_value = 0.01)
+                  
+optimizer = Optimizer(
+    model=mlp_model,
+    training_rdd=train_data,
+    criterion=ClassNLLCriterion(),
+    optim_method=optim_method,
+    end_trigger=MaxEpoch(20),
+    batch_size=32)
+```

--- a/pyspark/bigdl/optim/optimizer.py
+++ b/pyspark/bigdl/optim/optimizer.py
@@ -511,6 +511,34 @@ class Adam(OptimMethod):
         super(Adam, self).__init__(None, bigdl_type, learningrate, learningrate_decay,
                            beta1, beta2, epsilon)
 
+class Ftrl(OptimMethod):
+    """
+    An implementation of Ftrl https://www.eecs.tufts.edu/~dsculley/papers/ad-click-prediction.pdf.
+    Support L1 penalty, L2 penalty and shrinkage-type L2 penalty.
+
+    :param learningRate learning rate
+    :param learningRatePower double, must be less or equal to zero.
+    :param initialAccumulatorValue double, the starting value for accumulators,
+        require zero or positive values.
+    :param l1RegularizationStrength double, must be greater or equal to zero.
+    :param l2RegularizationStrength double, must be greater or equal to zero.
+    :param l2ShrinkageRegularizationStrength double, must be greater or equal to zero.
+        This differs from l2RegularizationStrength above. L2 above is a stabilization
+        penalty, whereas this one is a magnitude penalty.
+    >>> adagrad = Ftrl()
+    creating: createFtrl
+    """
+    def __init__(self,
+                 learningrate = 1e-3,
+                 learningrate_power = 0.0,
+
+                 l1_regu = 0.9,
+                 beta2 = 0.999,
+                 epsilon = 1e-8,
+                 bigdl_type="float"):
+        super(Adam, self).__init__(None, bigdl_type, learningrate, learningrate_decay,
+                                   beta1, beta2, epsilon)
+
 class Adamax(OptimMethod):
     """
     An implementation of Adamax http://arxiv.org/pdf/1412.6980.pdf

--- a/pyspark/bigdl/optim/optimizer.py
+++ b/pyspark/bigdl/optim/optimizer.py
@@ -516,13 +516,13 @@ class Ftrl(OptimMethod):
     An implementation of Ftrl https://www.eecs.tufts.edu/~dsculley/papers/ad-click-prediction.pdf.
     Support L1 penalty, L2 penalty and shrinkage-type L2 penalty.
 
-    :param learningRate learning rate
-    :param learningRatePower double, must be less or equal to zero.
-    :param initialAccumulatorValue double, the starting value for accumulators,
+    :param learningrate learning rate
+    :param learningrate_power double, must be less or equal to zero.
+    :param initial_accumulator_value double, the starting value for accumulators,
         require zero or positive values.
-    :param l1RegularizationStrength double, must be greater or equal to zero.
-    :param l2RegularizationStrength double, must be greater or equal to zero.
-    :param l2ShrinkageRegularizationStrength double, must be greater or equal to zero.
+    :param l1_regularization_strength double, must be greater or equal to zero.
+    :param l2_regularization_strength double, must be greater or equal to zero.
+    :param l2_shrinkage_regularization_strength double, must be greater or equal to zero.
         This differs from l2RegularizationStrength above. L2 above is a stabilization
         penalty, whereas this one is a magnitude penalty.
     >>> adagrad = Ftrl()
@@ -531,13 +531,16 @@ class Ftrl(OptimMethod):
     def __init__(self,
                  learningrate = 1e-3,
                  learningrate_power = 0.0,
-
-                 l1_regu = 0.9,
-                 beta2 = 0.999,
-                 epsilon = 1e-8,
+                 initial_accumulator_value = 0.1,
+                 l1_regularization_strength = 0.0,
+                 l2_regularization_strength = 0.0,
+                 l2_shrinkage_regularization_strength = 0.0,
                  bigdl_type="float"):
-        super(Adam, self).__init__(None, bigdl_type, learningrate, learningrate_decay,
-                                   beta1, beta2, epsilon)
+        super(Ftrl, self).__init__(None, bigdl_type, learningrate, learningrate_power,
+                                   initial_accumulator_value,
+                                   l1_regularization_strength,
+                                   l2_regularization_strength,
+                                   l2_shrinkage_regularization_strength)
 
 class Adamax(OptimMethod):
     """

--- a/pyspark/bigdl/optim/optimizer.py
+++ b/pyspark/bigdl/optim/optimizer.py
@@ -517,15 +517,17 @@ class Ftrl(OptimMethod):
     Support L1 penalty, L2 penalty and shrinkage-type L2 penalty.
 
     :param learningrate learning rate
-    :param learningrate_power double, must be less or equal to zero.
+    :param learningrate_power double, must be less or equal to zero. Default is zero.
     :param initial_accumulator_value double, the starting value for accumulators,
         require zero or positive values.
-    :param l1_regularization_strength double, must be greater or equal to zero.
-    :param l2_regularization_strength double, must be greater or equal to zero.
+    :param l1_regularization_strength double, must be greater or equal to zero. Default is zero.
+    :param l2_regularization_strength double, must be greater or equal to zero. Default is zero.
     :param l2_shrinkage_regularization_strength double, must be greater or equal to zero.
-        This differs from l2RegularizationStrength above. L2 above is a stabilization
-        penalty, whereas this one is a magnitude penalty.
-    >>> adagrad = Ftrl()
+        Default is zero. This differs from l2RegularizationStrength above. L2 above is a
+        stabilization penalty, whereas this one is a magnitude penalty.
+    >>> ftrl = Ftrl()
+    creating: createFtrl
+    >>> ftrl2 = Ftrl(1e-2, 0.1, 0.2, 0.3, 0.4, 0.5)
     creating: createFtrl
     """
     def __init__(self,

--- a/pyspark/bigdl/optim/optimizer.py
+++ b/pyspark/bigdl/optim/optimizer.py
@@ -517,7 +517,7 @@ class Ftrl(OptimMethod):
     Support L1 penalty, L2 penalty and shrinkage-type L2 penalty.
 
     :param learningrate learning rate
-    :param learningrate_power double, must be less or equal to zero. Default is zero.
+    :param learningrate_power double, must be less or equal to zero. Default is -0.5.
     :param initial_accumulator_value double, the starting value for accumulators,
         require zero or positive values.
     :param l1_regularization_strength double, must be greater or equal to zero. Default is zero.
@@ -527,12 +527,12 @@ class Ftrl(OptimMethod):
         stabilization penalty, whereas this one is a magnitude penalty.
     >>> ftrl = Ftrl()
     creating: createFtrl
-    >>> ftrl2 = Ftrl(1e-2, 0.1, 0.2, 0.3, 0.4, 0.5)
+    >>> ftrl2 = Ftrl(1e-2, -0.1, 0.2, 0.3, 0.4, 0.5)
     creating: createFtrl
     """
     def __init__(self,
                  learningrate = 1e-3,
-                 learningrate_power = 0.0,
+                 learningrate_power = -0.5,
                  initial_accumulator_value = 0.1,
                  l1_regularization_strength = 0.0,
                  l2_regularization_strength = 0.0,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Ftrl.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Ftrl.scala
@@ -27,7 +27,7 @@ import scala.reflect.ClassTag
  * Support L1 penalty, L2 penalty and shrinkage-type L2 penalty.
  *
  * @param learningRate learning rate
- * @param learningRatePower double, must be less or equal to zero. Default is zero.
+ * @param learningRatePower double, must be less or equal to zero. Default is -0.5.
  * @param initialAccumulatorValue double, the starting value for accumulators,
  *     require zero or positive values. Default is 0.1.
  * @param l1RegularizationStrength double, must be greater or equal to zero. Default is zero.

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Ftrl.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Ftrl.scala
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.optim
+
+import com.intel.analytics.bigdl.tensor.{DenseTensorApply, Tensor, TensorFunc6}
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Table
+
+import scala.reflect.ClassTag
+
+/**
+ * An implementation of Ftrl https://www.eecs.tufts.edu/~dsculley/papers/ad-click-prediction.pdf.
+ * Support L1 penalty, L2 penalty and shrinkage-type L2 penalty.
+ *
+ * @param learningRate learning rate
+ * @param learningRatePower double, must be less or equal to zero.
+ * @param initialAccumulatorValue double, the starting value for accumulators,
+ *     require zero or positive values.
+ * @param l1RegularizationStrength double, must be greater or equal to zero.
+ * @param l2RegularizationStrength double, must be greater or equal to zero.
+ * @param l2ShrinkageRegularizationStrength double, must be greater or equal to zero.
+ *     This differs from l2RegularizationStrength above. L2 above is a stabilization
+ *     penalty, whereas this one is a magnitude penalty.
+ */
+class Ftrl[@specialized(Float, Double) T: ClassTag](
+  var learningRate: Double = 1e-3,
+  var learningRatePower: Double = -0.5,
+  var initialAccumulatorValue: Double = 0.1,
+  var l1RegularizationStrength: Double = 0.0,
+  var l2RegularizationStrength: Double = 0.0,
+  var l2ShrinkageRegularizationStrength: Double = 0.0
+  )(implicit ev: TensorNumeric[T]) extends OptimMethod[T] {
+
+  @transient var accumNew: Tensor[T] = _
+  @transient var buffer: Tensor[T] = _
+  @transient var quadratic: Tensor[T] = _
+
+  def checkParam(learningRate: Double,
+  learningRatePower: Double,
+  initialAccumulatorValue: Double,
+  l1RegularizationStrength: Double,
+  l2RegularizationStrength: Double,
+  l2ShrinkageRegularizationStrength: Double): Unit = {
+    require(learningRate >= 0.0, s"Ftrl: learning rate should be greater or equal to zero." +
+      s" but got $learningRate")
+    require(learningRatePower <= 0.0,
+      s"Ftrl: learning rate power should be smaller or equal to zero." +
+        s" but got $learningRatePower")
+    require(initialAccumulatorValue >= 0.0,
+      s"Ftrl: initial value of accumulator should be greater or equal to zero." +
+        s" but got $initialAccumulatorValue")
+    require(l1RegularizationStrength >= 0.0,
+      s"Ftrl: L1 regularization strength should be greater or equal to zero." +
+        s" but got $l1RegularizationStrength")
+    require(l2RegularizationStrength >= 0.0,
+      s"Ftrl: L2 regularization strength should be greater or equal to zero." +
+        s" but got $l2RegularizationStrength")
+    require(l2ShrinkageRegularizationStrength >= 0.0,
+      s"Ftrl: L2 shrinkage regularization strength should be greater or equal to zero." +
+        s" but got $l2ShrinkageRegularizationStrength")
+  }
+
+  override def optimize(feval: (Tensor[T]) => (T, Tensor[T]),
+               parameter: Tensor[T]): (Tensor[T], Array[T]) = {
+    checkParam(learningRate, learningRatePower, initialAccumulatorValue, l1RegularizationStrength,
+      l2RegularizationStrength, l2ShrinkageRegularizationStrength)
+    val lr = this.learningRate
+    val lrp = this.learningRatePower
+    val iav = ev.fromType(this.initialAccumulatorValue)
+    val l1rs = ev.fromType(this.l1RegularizationStrength)
+    val l2rs = ev.fromType(this.l2RegularizationStrength)
+    val l2srs = ev.fromType(this.l2ShrinkageRegularizationStrength)
+
+    val (fx, dfdx) = feval(parameter)
+
+    val (accum, linear) = if (state.get[Tensor[T]]("accum").isDefined) {
+      (state.get[Tensor[T]]("accum").get, state.get[Tensor[T]]("linear").get)
+    } else {
+      // fill accum with initialAccumulatorValue
+      (Tensor[T]().resizeAs(dfdx).fill(iav), Tensor[T]().resizeAs(dfdx))
+    }
+
+    if (accumNew == null || !accumNew.isSameSizeAs(dfdx)) {
+      accumNew = Tensor[T]().resizeAs(dfdx).copy(accum)
+    }
+
+    if (buffer == null || !buffer.isSameSizeAs(dfdx)) buffer = Tensor[T]().resizeAs(dfdx)
+
+    if (quadratic == null || !quadratic.isSameSizeAs(dfdx)) quadratic = Tensor[T]().resizeAs(dfdx)
+
+    val computeParameter = new TensorFunc6[T]() {
+      // parameter = (sign(linear) * l1rs - linear) / quadratic if |linear| > l1rs else 0.0
+      override def apply(data1: Array[T], offset1: Int, data2: Array[T], offset2: Int,
+                         data3: Array[T], offset3: Int): Unit = {
+        data1(offset1) = if (ev.isGreater(ev.abs(data2(offset2)), l1rs)) {
+          val l1 = if (ev.isGreater(data2(offset2), ev.zero)) {
+            l1rs
+          } else if (ev.isGreater(ev.zero, data2(offset2))) {
+            ev.negative(l1rs)
+          } else {
+            ev.zero
+          }
+          ev.divide(ev.minus(l1, data2(offset2)), data3(offset3))
+        } else {
+          ev.zero
+        }
+      }
+    }
+
+    if (ev.isGreaterEq(ev.zero, l2srs)) {
+      // accumNew = accum + dfdx * dfdx
+      accumNew.addcmul(dfdx, dfdx)
+      // linear += dfdx + accum^(-lrp) / lr * parameter - accumNew^(-lrp) / lr * parameter
+      linear.add(dfdx)
+      buffer.pow(accum, ev.fromType(-lrp))
+      linear.addcmul(ev.fromType(1 / lr), buffer, parameter)
+      buffer.pow(accumNew, ev.fromType(-lrp))
+      linear.addcmul(ev.fromType(-1 / lr), buffer, parameter)
+      // quadratic = 1.0 / lr * accumNew^(- lrp) + 2 * l2
+      quadratic.fill(ev.times(ev.fromType(2), l2rs))
+      quadratic.add(ev.fromType(1 / lr), buffer)
+      // parameter = (sign(linear) * l1 - linear) / quadratic if |linear| > l1 else 0.0
+      DenseTensorApply.apply3(parameter, linear, quadratic, computeParameter)
+    } else {
+      // TODO: result is different compared with tensorflow, waitting for
+      // https://github.com/tensorflow/tensorflow/issues/18317
+      val gradWithStrinkage = if (state.get[Tensor[T]]("gradWithStrinkage").isDefined) {
+        state.get[Tensor[T]]("gradWithStrinkage").get
+      } else {
+        Tensor[T]().resizeAs(dfdx)
+      }
+      // gradWithShrinkage = dfdx + 2 * l2srs * parameter
+      gradWithStrinkage.copy(dfdx)
+      gradWithStrinkage.add(ev.times(ev.fromType(2), l2srs), parameter)
+      // accumNew = accum + gradWithShrinkage * gradWithShrinkage
+      accumNew.addcmul(gradWithStrinkage, gradWithStrinkage)
+      // linear += gradWithStrinkage + accum^(-lrp) / lr * parameter
+      // - accumNew^(-lrp) / lr * parameter
+      linear.add(gradWithStrinkage)
+      buffer.pow(accum, ev.fromType(-lrp))
+      linear.addcmul(ev.fromType(1.0 / lr), buffer, parameter)
+      buffer.pow(accumNew, ev.fromType(-lrp))
+      linear.addcmul(ev.fromType(-1.0 / lr), buffer, parameter)
+      // quadratic = 1.0 / lr * accumNew^(- lrp) + 2 * l2
+      quadratic.fill(ev.times(ev.fromType(2), l2rs))
+      quadratic.add(ev.fromType(1 / lr), buffer)
+      // parameter = (sign(linear) * l1 - linear) / quadratic if |linear| > l1 else 0.0
+      DenseTensorApply.apply3(parameter, linear, quadratic, computeParameter)
+    }
+    // accum = accum_new
+    accum.copy(accumNew)
+
+    state("accum") = accum
+    state("linear") = linear
+
+    (parameter, Array(fx))
+  }
+
+  override def loadFromTable(config: Table): this.type = {
+    this.learningRate = config.get[Double]("learningRate").getOrElse(this.learningRate)
+    this.learningRatePower = config.get[Double]("learningRatePower")
+      .getOrElse(this.learningRatePower)
+    this.initialAccumulatorValue = config.get[Double]("initialAccumulatorValue")
+      .getOrElse(this.initialAccumulatorValue)
+    this.l1RegularizationStrength = config.get[Double]("l1RegularizationStrength")
+      .getOrElse(this.l1RegularizationStrength)
+    this.l2RegularizationStrength = config.get[Double]("l2RegularizationStrength")
+      .getOrElse(this.l2RegularizationStrength)
+    this.l2ShrinkageRegularizationStrength = config.get[Double]("l2ShrinkageRegularizationStrength")
+      .getOrElse(this.l2ShrinkageRegularizationStrength)
+    this
+  }
+
+  override def clearHistory(): Unit = {
+    state.delete("accum")
+    state.delete("linear")
+    accumNew = null
+    buffer = null
+    quadratic = null
+  }
+
+  override def getLearningRate(): Double = this.learningRate
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -2130,6 +2130,21 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
     new Adam[T](learningRate, learningRateDecay, beta1, beta2, Epsilon)
   }
 
+  def createFtrl(
+      learningRate: Double = 1e-3,
+      learningRatePower: Double = -0.5,
+      initialAccumulatorValue: Double = 0.1,
+      l1RegularizationStrength: Double = 0.0,
+      l2RegularizationStrength: Double = 0.0,
+      l2ShrinkageRegularizationStrength: Double = 0.0): Ftrl[T] = {
+    new Ftrl[T](learningRate,
+      learningRatePower,
+      initialAccumulatorValue,
+      l1RegularizationStrength,
+      l2RegularizationStrength,
+      l2ShrinkageRegularizationStrength)
+  }
+
   def createAdamax(
     learningRate: Double = 0.002,
     beta1: Double = 0.9,

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/FtrlSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/FtrlSpec.scala
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.optim
+
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.{RandomGenerator, T, TestUtils}
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.mutable.ArrayBuffer
+
+@com.intel.analytics.bigdl.tags.Parallel
+class FtrlSpec extends FlatSpec with Matchers {
+  val start = System.currentTimeMillis()
+  "Ftrl" should "perform well on rosenbrock function" in {
+    val x = Tensor[Double](2).fill(0)
+    val config = T("learningRate" -> 0.1)
+    val optm = new Ftrl[Double]
+    var fx = new ArrayBuffer[Double]
+    for (i <- 1 to 10001) {
+      val result = optm.optimize(TestUtils.rosenBrock, x, config)
+      if ((i - 1) % 1000 == 0) {
+        fx += result._2(0)
+      }
+    }
+
+    println(s"x is \n$x")
+    println("fx is")
+    for (i <- 1 to fx.length) {
+      println(s"${(i - 1) * 1000 + 1}, ${fx(i - 1)}")
+    }
+
+    val spend = System.currentTimeMillis() - start
+    println("Time Cost: " + spend + "ms")
+
+    (fx.last < 1e-4) should be(true)
+    x(Array(1)) should be(1.0 +- 0.01)
+    x(Array(2)) should be(1.0 +- 0.01)
+  }
+
+  "Ftrl" should "works fine" in {
+    val weights = Tensor[Float](2).zero()
+    val grads = Tensor[Float](T(0.1f, 0.2f))
+    val ftrl = new Ftrl[Float](3.0)
+    (1 to 3).foreach{_ =>
+      ftrl.optimize(_ => (0.0f, grads), weights)
+    }
+
+    weights.valueAt(1) should be (-2.602609f +- 0.000001f)
+    weights.valueAt(2) should be (-4.296985f +- 0.000001f)
+  }
+
+  "Ftrl" should "works fine 2" in {
+    val weights = Tensor[Float](2).zero()
+    val grads = Tensor[Float](T(0.01f, 0.02f))
+    val ftrl = new Ftrl[Float](3.0)
+    (1 to 3).foreach{_ =>
+      ftrl.optimize(_ => (0.0f, grads), weights)
+    }
+
+    weights.valueAt(1) should be (-0.284321f +- 0.000001f)
+    weights.valueAt(2) should be (-0.566949f +- 0.000001f)
+  }
+
+  "Ftrl" should "works fine 3" in {
+    val weights = Tensor[Float](T(1.0f, 2.0f))
+    val grads = Tensor[Float](T(0.1f, 0.2f))
+    val ftrl = new Ftrl[Float](3.0)
+    (1 to 3).foreach{_ =>
+      ftrl.optimize(_ => (0.0f, grads), weights)
+    }
+
+    weights.valueAt(1) should be (-2.556072f +- 0.000001f)
+    weights.valueAt(2) should be (-3.987293f +- 0.000001f)
+  }
+
+  "Ftrl with L1" should "works fine 3" in {
+    val weights = Tensor[Float](T(1.0f, 2.0f))
+    val grads = Tensor[Float](T(0.1f, 0.2f))
+    val ftrl = new Ftrl[Float](3.0, l1RegularizationStrength = 0.001)
+    (1 to 10).foreach{_ =>
+      ftrl.optimize(_ => (0.0f, grads), weights)
+    }
+
+    weights.valueAt(1) should be (-7.667187f +- 0.000001f)
+    weights.valueAt(2) should be (-10.912737f +- 0.000001f)
+  }
+
+  "Ftrl with L1, L2" should "works fine 3" in {
+    val weights = Tensor[Float](T(1.0f, 2.0f))
+    val grads = Tensor[Float](T(0.1f, 0.2f))
+    val ftrl = new Ftrl[Float](3.0, l1RegularizationStrength = 0.001,
+      l2RegularizationStrength = 2.0)
+    (1 to 10).foreach{_ =>
+      ftrl.optimize(_ => (0.0f, grads), weights)
+    }
+
+    weights.valueAt(1) should be (-0.240599f +- 0.000001f)
+    weights.valueAt(2) should be (-0.468293f +- 0.000001f)
+  }
+
+  "Ftrl with L1, L2, L2Shrinkage" should "works fine 3" in {
+    val weights = Tensor[Float](T(1.0f, 2.0f))
+    val grads = Tensor[Float](T(0.1f, 0.2f))
+    val ftrl = new Ftrl[Float](3.0, initialAccumulatorValue = 0.1, l1RegularizationStrength = 0.001,
+      l2RegularizationStrength = 2.0, l2ShrinkageRegularizationStrength = 0.1f)
+    (1 to 10).foreach{_ =>
+      ftrl.optimize(_ => (0.0f, grads), weights)
+    }
+
+    weights.valueAt(1) should be (-0.219319f +- 0.000001f)
+    weights.valueAt(2) should be (-0.406429f +- 0.000001f)
+
+    // TODO: this result is different from tensorflow's result. It seems a bug of tensorflow.
+    // Waiting for their reply: https://github.com/tensorflow/tensorflow/issues/18317
+//    weights.valueAt(1) should be (-0.220788f +- 0.000001f)
+//    weights.valueAt(2) should be (-0.413781f +- 0.000001f)
+  }
+}
+

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/FtrlSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/FtrlSpec.scala
@@ -123,11 +123,24 @@ class FtrlSpec extends FlatSpec with Matchers {
 
     weights.valueAt(1) should be (-0.219319f +- 0.000001f)
     weights.valueAt(2) should be (-0.406429f +- 0.000001f)
+  }
 
-    // TODO: this result is different from tensorflow's result. It seems a bug of tensorflow.
-    // Waiting for their reply: https://github.com/tensorflow/tensorflow/issues/18317
-//    weights.valueAt(1) should be (-0.220788f +- 0.000001f)
-//    weights.valueAt(2) should be (-0.413781f +- 0.000001f)
+  "Ftrl save/load" should "works fine" in {
+    val weights = Tensor[Float](T(1.0f, 2.0f))
+    val grads = Tensor[Float](T(0.1f, 0.2f))
+    val ftrl = new Ftrl[Float](3.0, initialAccumulatorValue = 0.1, l1RegularizationStrength = 0.001,
+      l2RegularizationStrength = 2.0, l2ShrinkageRegularizationStrength = 0.1f)
+    val tmpFile = java.io.File.createTempFile("ftrl", ".optim")
+    ftrl.save(tmpFile.getAbsolutePath, true)
+    val loaded = OptimMethod.load[Float](tmpFile.getAbsolutePath)
+
+    (1 to 10).foreach{_ =>
+      loaded.optimize(_ => (0.0f, grads), weights)
+    }
+
+    weights.valueAt(1) should be (-0.219319f +- 0.000001f)
+    weights.valueAt(2) should be (-0.406429f +- 0.000001f)
+
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add an implementation of Ftrl https://www.eecs.tufts.edu/~dsculley/papers/ad-click-prediction.pdf.
    Support L1 penalty, L2 penalty and shrinkage-type L2 penalty.

Ftrl is the default optimMethod of Wide&Deep's wide model.

Tensorflow's implement is https://github.com/tensorflow/tensorflow/blob/r1.7/tensorflow/python/training/ftrl.py

## How was this patch tested?

unit tests, 
manual tests this Ftrl in the training of Lenet5 on Mnist. The lenet5 is converged with optimMethod `Ftrl(learningRate=0.1)` and `Ftrl(learningRate=0.1, l2ShrinkageRegularizationStrength = 0.0001)`.

## Related links or issues (optional)
fixed #2481 

