### PR TITLE
[Doc] Fix incorrect package names in tf examples

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/tensorflow/loadandsave/README.md
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/tensorflow/loadandsave/README.md
@@ -5,7 +5,7 @@ Before you run this example, you need to install tensorflow on your machine. Thi
 by
 
 ```bash
-pip install tensorflow
+pip install tensorflow==1.2.0
 ```
 
 ## Load tensorflow model
@@ -22,13 +22,13 @@ python freeze_graph.py --input_graph model/model.pbtxt --input_checkpoint model/
 
 3. Run BigDL
 ```bash
-spark-submit --master local[1] --class com.intel.analytics.bigdl.example.tensorflow.Load BigDL_jar_file ./model.pb
+spark-submit --master local[1] --class com.intel.analytics.bigdl.example.tensorflow.loadandsave.Load BigDL_jar_file ./model.pb
 ```
 
 ## Save BigDL model as tensorflow model
 1. Run BigDL
 ```bash
-spark-submit --master local[1] --class com.intel.analytics.bigdl.example.tensorflow.Save BigDL_jar_file
+spark-submit --master local[1] --class com.intel.analytics.bigdl.example.tensorflow.loadandsave.Save BigDL_jar_file
 ```
 
 2. Generate summary file, you can find the dump_tf_graph.py in the bin folder of the dist package, or script folder of

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/tensorflow/transferlearning/README.md
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/tensorflow/transferlearning/README.md
@@ -19,6 +19,10 @@ Please refer to [BigDL](https://bigdl-project.github.io/master/), [Tensorflow](h
 
 We currently support Tensorflow r1.2.
 
+```shell
+pip install tensorflow==1.2.0
+```
+
 ## Install the TF-slim image models library
 
 Please checkout this [page](https://github.com/tensorflow/models/tree/master/research/slim#installing-the-tf-slim-image-models-library)
@@ -142,7 +146,7 @@ $SPARK_HOME/bin/spark-submit \
 --executor-cores cores_per_executor \
 --total-executor-cores total_cores_for_the_job \
 --driver-class-path $BIGDL_HOME/lib/bigdl-$BIGDL_VERSION-jar-with-dependencies.jar \
---class com.intel.analytics.bigdl.example.tensorflow.transferLearning.TransferLearning  \
+--class com.intel.analytics.bigdl.example.tensorflow.transferlearning.TransferLearning  \
 $BIGDL_HOME/lib/bigdl-$BIGDL_VERSION-jar-with-dependencies.jar \
 -t /tmp/tf_model_train/ -v /tmp/tf_model_validation/ \
 -b batch_size -e nEpochs


### PR DESCRIPTION
## What changes were proposed in this pull request?
The package names in tf examples are not correct and this PR fix it. And also add a stronger hint that these examples currently run under tensorflow 1.2.0

## How was this patch tested?
Doc change, Manual tests

## Related links or issues (optional)
https://github.com/intel-analytics/BigDL/issues/2511

