### PR TITLE
[bug fix]max support one-element tensor indices

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ops/Max.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ops/Max.scala
@@ -43,7 +43,8 @@ class Max[T: ClassTag, D: ClassTag](
     val x = input[Tensor[D]](1)
     val y = input[Tensor[Int]](2)
 
-    require(y.isScalar, s"reduction indices should be a scalar")
+    require(y.isScalar || (y.nElement() == 1 && y.dim() == 1),
+      s"reduction indices should be a scalar or one-element tensor")
     val reductionIndices = if (startFromZero) {
       y.value() + 1
     } else {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ops/MaxSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ops/MaxSpec.scala
@@ -36,6 +36,21 @@ class MaxSpec extends FlatSpec with Matchers {
     output should be(expectOutput)
   }
 
+  "Max operation forward one-element tensor index" should "works correctly" in {
+    import com.intel.analytics.bigdl.numeric.NumericFloat
+    RandomGenerator.RNG.setSeed(10)
+    val input =
+      T(
+        Tensor.range(1, 10).resize(2, 5),
+        Tensor[Int](1).fill(1)
+      )
+
+    val expectOutput = Tensor(T(5f, 10f))
+
+    val output = Max(startFromZero = true).forward(input)
+    output should be(expectOutput)
+  }
+
   "Max keepDims" should "works correctly" in {
     import com.intel.analytics.bigdl.numeric.NumericFloat
     RandomGenerator.RNG.setSeed(10)


### PR DESCRIPTION
## What changes were proposed in this pull request?

max support one-element tensor indices

or Max may throw exception:
```
java.lang.IllegalArgumentException: requirement failed: reduction indices should be a scalar
	at scala.Predef$.require(Predef.scala:224)
	at com.intel.analytics.bigdl.nn.ops.Max.updateOutput(Max.scala:46)
	at com.intel.analytics.bigdl.nn.ops.Max.updateOutput(Max.scala:32)
	at com.intel.analytics.bigdl.nn.abstractnn.AbstractModule.forward(AbstractModule.scala:257)
	at com.intel.analytics.bigdl.nn.DynamicGraph.updateOutput(DynamicGraph.scala:51)
	at com.intel.analytics.bigdl.nn.abstractnn.AbstractModule.forward(AbstractModule.scala:257)
	at com.intel.analytics.bigdl.optim.Predictor$$anonfun$predict$1$$anonfun$apply$3.apply(Predictor.scala:168)
	at com.intel.analytics.bigdl.optim.Predictor$$anonfun$predict$1$$anonfun$apply$3.apply(Predictor.scala:167)
	at scala.collection.Iterator$$anon$12.nextCur(Iterator.scala:434)
	at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:440)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:408)
	at org.apache.spark.api.python.SerDeUtil$AutoBatchedPickler.hasNext(SerDeUtil.scala:117)
	at scala.collection.Iterator$class.foreach(Iterator.scala:893)
	at org.apache.spark.api.python.SerDeUtil$AutoBatchedPickler.foreach(SerDeUtil.scala:112)
	at org.apache.spark.api.python.PythonRDD$.writeIteratorToStream(PythonRDD.scala:504)
	at org.apache.spark.api.python.PythonRunner$WriterThread$$anonfun$run$3.apply(PythonRDD.scala:328)
	at org.apache.spark.util.Utils$.logUncaughtExceptions(Utils.scala:1951)
	at org.apache.spark.api.python.PythonRunner$WriterThread.run(PythonRDD.scala:269)

	at com.intel.analytics.bigdl.nn.abstractnn.AbstractModule.forward(AbstractModule.scala:263)
	at com.intel.analytics.bigdl.nn.DynamicGraph.updateOutput(DynamicGraph.scala:51)
	at com.intel.analytics.bigdl.nn.abstractnn.AbstractModule.forward(AbstractModule.scala:257)
	at com.intel.analytics.bigdl.optim.Predictor$$anonfun$predict$1$$anonfun$apply$3.apply(Predictor.scala:168)
	at com.intel.analytics.bigdl.optim.Predictor$$anonfun$predict$1$$anonfun$apply$3.apply(Predictor.scala:167)
	at scala.collection.Iterator$$anon$12.nextCur(Iterator.scala:434)
	at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:440)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:408)
	at org.apache.spark.api.python.SerDeUtil$AutoBatchedPickler.hasNext(SerDeUtil.scala:117)
	at scala.collection.Iterator$class.foreach(Iterator.scala:893)
	at org.apache.spark.api.python.SerDeUtil$AutoBatchedPickler.foreach(SerDeUtil.scala:112)
	at org.apache.spark.api.python.PythonRDD$.writeIteratorToStream(PythonRDD.scala:504)
	at org.apache.spark.api.python.PythonRunner$WriterThread$$anonfun$run$3.apply(PythonRDD.scala:328)
	at org.apache.spark.util.Utils$.logUncaughtExceptions(Utils.scala:1951)
	at org.apache.spark.api.python.PythonRunner$WriterThread.run(PythonRDD.scala:269)
```

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If it is possible, please attach a screenshot; otherwise, remove this)

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

