### PR TITLE
[Bug Fix] Fix const status not handled correct in loop

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Scheduler.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Scheduler.scala
@@ -86,9 +86,7 @@ private[bigdl] class Scheduler[T] (
   }
 
   private def skipExecution(node: ModuleNode[T]): Boolean = {
-    if (nodeStatus.isConst(node)) return true
-
-    if (node.element.isInstanceOf[ControlDependency[_]]) {
+    if (node.element.isInstanceOf[ControlDependency[_]] || nodeStatus.isConst(node)) {
       schedule(node)
       return true
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
When executing a Tensorflow graph, we will skip const-result node for the second time. But current implementation has a bug that if a loop has a const input, the loop cannot be executed correctly for the second time. This PR fix the issue.

## How was this patch tested?
new unit test and origin unit tests


