### PR TITLE
fix: memory leak in `model.predictImageSet`.

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
@@ -203,6 +203,7 @@ object CachedModels {
 
   import scala.collection._
   import scala.collection.convert.decorateAsScala._
+  import scala.language.existentials
 
   type Modles = ArrayBuffer[Module[_]]
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
@@ -212,9 +212,10 @@ object CachedModels {
   def add[T: ClassTag](uuid: String, model: Module[T])( implicit ev: TensorNumeric[T]): Unit =
     CachedModels.synchronized {
       val models = cachedModels.get(uuid) match {
-        case Some(values) => values += model
-        case _ => ArrayBuffer(model)
+        case Some(values) => values += model.asInstanceOf[Module[_]]
+        case _ => ArrayBuffer(model.asInstanceOf[Module[_]])
       }
+      cachedModels.put(uuid, models.asInstanceOf[Modles])
     }
 
   def deleteAll[T: ClassTag](currentKey: String)(implicit ev: TensorNumeric[T]): Unit =

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Container.scala
@@ -227,4 +227,8 @@ abstract class Container[A <: Activity : ClassTag,
     super.checkDuplicate(record)
     if (!skipDuplicateCheck()) modules.foreach(_.checkDuplicate(record))
   }
+
+  override def release(): Unit = {
+    modules.foreach(_.release())
+  }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -665,8 +665,11 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag, 
         Predictor(this, featurePaddingParam, batchPerPartition)
           .predictImage(distributedImageFrame, outputLayer, shareBuffer, predictKey)
       case localImageFrame: LocalImageFrame =>
-        LocalPredictor(this, featurePaddingParam, batchPerPartition)
-          .predictImage(localImageFrame, outputLayer, shareBuffer, predictKey)
+        val predictor = LocalPredictor(this, featurePaddingParam, batchPerPartition)
+        val imageFrame = predictor.predictImage(localImageFrame, outputLayer, shareBuffer,
+          predictKey)
+        predictor.shutdown()
+        imageFrame
     }
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -1097,5 +1097,11 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag, 
    * @return
    */
   private[nn] def skipDuplicateCheck(): Boolean = false
+
+  /**
+   * if the model contains native resources such as aligned memory, we should release it by manual.
+   * JVM GC can't release them reliably.
+   */
+  def release(): Unit = {}
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/Desc.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/Desc.scala
@@ -181,9 +181,9 @@ object QuantParams {
   val THRESHOLD = 127.0f
 }
 
-case class StorageInfo(descType: DescType, isFreed: Boolean)
+private[bigdl] case class StorageInfo(descType: DescType, isFreed: Boolean)
 
-object StorageManager {
+private[bigdl] object StorageManager {
   import java.util.concurrent.ConcurrentHashMap
   private val nativeStorages: ConcurrentHashMap[Long, StorageInfo] = new ConcurrentHashMap()
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/Desc.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/Desc.scala
@@ -147,6 +147,9 @@ object Desc {
         desc
     }
 
+    // add every native memory allocation.
+    StorageManager.add(desc, params.getType)
+
     desc
   }
 
@@ -178,3 +181,28 @@ object QuantParams {
   val THRESHOLD = 127.0f
 }
 
+case class StorageInfo(descType: DescType, isFreed: Boolean)
+
+object StorageManager {
+  import java.util.concurrent.ConcurrentHashMap
+  private val nativeStorages: ConcurrentHashMap[Long, StorageInfo] = new ConcurrentHashMap()
+
+  def isFreed(nativeStorage: Long): Boolean = {
+    nativeStorages.get(nativeStorage).isFreed
+  }
+
+  // atomically set the value
+  def checkAndSet(nativeStorage: Long): Boolean = {
+    val descType = nativeStorages.get(nativeStorage).descType
+    nativeStorages.replace(nativeStorage, StorageInfo(descType, false), StorageInfo(descType, true))
+  }
+
+  def get(): Map[Long, StorageInfo] = {
+    import scala.collection.JavaConverters._
+    nativeStorages.asScala.toMap
+  }
+
+  def add(key: Long, descType: DescType): Unit = {
+    nativeStorages.put(key, StorageInfo(descType, false))
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/Linear.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/Linear.scala
@@ -141,8 +141,12 @@ private[bigdl] class Linear[T: ClassTag](
     s"quantized.${getPrintName()}($inputSize -> $outputSize)"
   }
 
-  def release(): Unit = {
+  override def release(): Unit = {
     weight.release()
+    data.release()
+  }
+
+  override def releaseExceptWeights(): Unit = {
     data.release()
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/Linear.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/Linear.scala
@@ -145,10 +145,6 @@ private[bigdl] class Linear[T: ClassTag](
     weight.release()
     data.release()
   }
-
-  override def releaseExceptWeights(): Unit = {
-    data.release()
-  }
 }
 
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/QuantizedModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/QuantizedModule.scala
@@ -26,5 +26,4 @@ abstract class QuantizedModule[T: ClassTag](length: Int)(
   val empty: Tensor[T] = Tensor[T](1)
 
   def release(): Unit
-  def releaseExceptWeights(): Unit
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/QuantizedModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/QuantizedModule.scala
@@ -24,4 +24,7 @@ import scala.reflect.ClassTag
 abstract class QuantizedModule[T: ClassTag](length: Int)(
   implicit ev: TensorNumeric[T]) extends TensorModule[T] {
   val empty: Tensor[T] = Tensor[T](1)
+
+  def release(): Unit
+  def releaseExceptWeights(): Unit
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/QuantizedModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/QuantizedModule.scala
@@ -24,6 +24,4 @@ import scala.reflect.ClassTag
 abstract class QuantizedModule[T: ClassTag](length: Int)(
   implicit ev: TensorNumeric[T]) extends TensorModule[T] {
   val empty: Tensor[T] = Tensor[T](1)
-
-  def release(): Unit
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/SpatialConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/SpatialConvolution.scala
@@ -270,8 +270,12 @@ private[bigdl] class SpatialConvolution[T: ClassTag](
       s" $kernelH, $strideW, $strideH, $padW, $padH, $nGroup)"
   }
 
-  def release(): Unit = {
+  override def release(): Unit = {
     weight.foreach(_.asInstanceOf[QuantizedTensor[T]].release())
+    data.release()
+  }
+
+  override def releaseExceptWeights(): Unit = {
     data.release()
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/SpatialConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/quantized/SpatialConvolution.scala
@@ -274,10 +274,6 @@ private[bigdl] class SpatialConvolution[T: ClassTag](
     weight.foreach(_.asInstanceOf[QuantizedTensor[T]].release())
     data.release()
   }
-
-  override def releaseExceptWeights(): Unit = {
-    data.release()
-  }
 }
 
 object SpatialConvolution extends QuantSerializer {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalPredictor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalPredictor.scala
@@ -184,23 +184,11 @@ class LocalPredictor[T: ClassTag] private[optim](model: Module[T],
   }
 
   /**
-   * if the model is a quantized model, we should release the native resources except the weights
+   * `shutdown` will release all native resources.
    */
   def shutdown(): Unit = {
-    def release(model: Module[T]): Unit = {
-      model match {
-        case container: Container[_, _, T] => container.modules.foreach(release)
-        case module if module.isInstanceOf[QuantizedModule[T]] =>
-          module.asInstanceOf[QuantizedModule[T]].release()
-        case _ =>
-      }
-    }
-
-    workingModels.foreach { model =>
-      release(model)
-    }
-
-    release(clonedModel)
+    workingModels.foreach(_.release())
+    clonedModel.release()
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
@@ -2204,6 +2204,8 @@ private[tensor] class DenseTensor[@specialized T: ClassTag](
     this.apply1(a => ev.digamma(a))
   }
 
+  override def toQuantizedTensor: QuantizedTensor[T] =
+    throw new IllegalArgumentException("DenseTensor cannot be cast to QuantizedTensor")
 }
 
 object DenseTensor {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DenseTensor.scala
@@ -2204,7 +2204,7 @@ private[tensor] class DenseTensor[@specialized T: ClassTag](
     this.apply1(a => ev.digamma(a))
   }
 
-  override def toQuantizedTensor: QuantizedTensor[T] =
+  override private[bigdl] def toQuantizedTensor: QuantizedTensor[T] =
     throw new IllegalArgumentException("DenseTensor cannot be cast to QuantizedTensor")
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/QuantizedTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/QuantizedTensor.scala
@@ -45,7 +45,7 @@ private[bigdl] class QuantizedTensor[T: ClassTag](
   }
 
   def release(): this.type = {
-    if (desc != 0) {
+    if (desc != 0 && StorageManager.checkAndSet(desc)) {
       BigQuant.FreeMemory(desc)
     }
     desc = 0L
@@ -269,6 +269,8 @@ private[bigdl] class QuantizedTensor[T: ClassTag](
   }
 
   override def getTensorNumeric(): TensorNumeric[T] = ev
+
+  override def toQuantizedTensor: QuantizedTensor[T] = this.asInstanceOf[QuantizedTensor[T]]
 
   @throws(classOf[IOException])
   private def readObject(in: ObjectInputStream): Unit = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/SparseTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/SparseTensor.scala
@@ -1126,6 +1126,9 @@ private[tensor] class SparseTensor[@specialized(Float, Double) T: ClassTag](
 
   override def sumSquare(): T =
     throw new UnsupportedOperationException(s"SparseTensor: Unimplemented method")
+
+  override def toQuantizedTensor: QuantizedTensor[T] =
+    throw new IllegalArgumentException("SparseTensor cannot be cast to QuantizedTensor")
 }
 
 object SparseTensor{

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/SparseTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/SparseTensor.scala
@@ -1127,7 +1127,7 @@ private[tensor] class SparseTensor[@specialized(Float, Double) T: ClassTag](
   override def sumSquare(): T =
     throw new UnsupportedOperationException(s"SparseTensor: Unimplemented method")
 
-  override def toQuantizedTensor: QuantizedTensor[T] =
+  override private[bigdl] def toQuantizedTensor: QuantizedTensor[T] =
     throw new IllegalArgumentException("SparseTensor cannot be cast to QuantizedTensor")
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
@@ -804,6 +804,8 @@ trait Tensor[T] extends Serializable with TensorMath[T] with Activity {
     }
     return false
   }
+
+  def toQuantizedTensor: QuantizedTensor[T]
 }
 
 /**

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
@@ -805,7 +805,7 @@ trait Tensor[T] extends Serializable with TensorMath[T] with Activity {
     return false
   }
 
-  def toQuantizedTensor: QuantizedTensor[T]
+  private[bigdl] def toQuantizedTensor: QuantizedTensor[T]
 }
 
 /**

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/LocalPredictorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/LocalPredictorSpec.scala
@@ -23,6 +23,7 @@ import com.intel.analytics.bigdl.dataset.{PaddingParam, Sample, SampleToMiniBatc
 import com.intel.analytics.bigdl.models.inception.Inception_v1_NoAuxClassifier
 import com.intel.analytics.bigdl.nn.abstractnn.Activity
 import com.intel.analytics.bigdl.nn._
+import com.intel.analytics.bigdl.nn.quantized.StorageManager
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.transform.vision.image._
 import com.intel.analytics.bigdl.transform.vision.image.augmentation.{CenterCrop, ChannelNormalize, Resize}
@@ -302,5 +303,36 @@ class LocalPredictorSpec extends FlatSpec with Matchers with BeforeAndAfter {
       assert(imageFeatures(x - 1).predict() != null)
       assert(imageFeatures(x - 1).predict().asInstanceOf[Table].length() == 2)
     })
+  }
+
+  "local predictor shutdown" should "work properly" in {
+    import com.intel.analytics.bigdl.numeric.NumericFloat
+    val input = Tensor[Float](4, 3, 224, 224).rand(-1, 1)
+
+    val samples = (1 to 20).map(i => {
+      Sample(Tensor[Float](3, 224, 224).randn())
+    }).toArray
+    val imageFrame = ImageFrame.array((0 until 20).map(x => {
+      val im = ImageFeature()
+      im(ImageFeature.sample) = samples(x)
+      im
+    }).toArray)
+
+    val model = Inception_v1_NoAuxClassifier(1000)
+    val quant = model.quantize().evaluate()
+    val initNativeSize = StorageManager.get().count(x => !x._2.isFreed)
+
+    // has no memory issues
+    (0 to 4).foreach { _ =>
+      quant.predictImage(imageFrame).toLocal().array.map(_.predict().asInstanceOf[Tensor[Float]])
+      StorageManager.get().count(x => !x._2.isFreed) should be (initNativeSize)
+    }
+
+    // check the model can work again
+    quant.forward(input)
+    val quant2 = model.quantize().evaluate()
+    quant2.forward(input)
+
+    quant.output.toTensor[Float] should be (quant2.output.toTensor[Float])
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
There're three reasons of memory leak.

1. repeat allocations in bigquant, which will be fixed in BigDL-core.
2. repeat clone module but no release. `model.predictImageSet` will new
   Predictor again and again.
3. share weights.

Because of multi models architecture, every `LocalPredictor` will clone models.
For efficiency all cloned models and origin model will share the same parameters.
If we iterate and release all cloned models, the parameters of origin model will
be released also. So we should clone a new model first in `LocalPredictor`.

This patch add a `StorageManager` which contains a concurrent hash map
to maintain all allocations of native memory/resources and prevent
duplicate release. It's also helpful for debug.

## How was this patch tested?

Add a new test case and run Jenkins.

## Related links or issues (optional)
fixed #2535

