### PR TITLE
Use a separated java gateway on local mode

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
@@ -115,7 +115,6 @@ object Engine {
 
   @volatile
   private var gatewayServer: py4j.GatewayServer = null
-  private val driverPortFileCreated = new AtomicBoolean()
 
   private def createGatewayPortFile(port: Int): Unit = {
     val file = new java.io.File(SparkFiles.getRootDirectory(), "gateway_port")
@@ -135,17 +134,6 @@ object Engine {
   }
 
   private[bigdl] def createJavaGateway(driverPort: Int): Unit = {
-    if (SparkUtils.isDriver) {
-      if (driverPortFileCreated.compareAndSet(false, true)) {
-        try {
-          createGatewayPortFile(driverPort)
-        } catch {
-          case NonFatal(e) =>
-            throw new Exception("Could not create java gateway port file", e)
-        }
-      }
-      return
-    }
     if (gatewayServer != null) return
     this.synchronized {
       if (gatewayServer != null) return


### PR DESCRIPTION
## What changes were proposed in this pull request?
In Spark 2.3, the py4j is upgraded. The gateway server authentication is enabled, which is not supported in the old py4j gateway server.

To keep the compatibility with Spark 2.0/2.1/2.2, we still use the old way to create py4j gateway server. It works fine in most cases. As on distributed mode, we'll create our own gateway server on worker JVM. In driver python process, we'll use the gateway client created by Spark.

However, in local mode, the worker python process will create its own gateway client, which connect to the gateway server created by Spark. This PR fixes this. It will create a separated gateway server for usage.

## How was this patch tested?
unit test



