### PR TITLE
fix: distribute predictor will send model twice when do `mapPartition`.

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Predictor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Predictor.scala
@@ -16,18 +16,15 @@
 
 package com.intel.analytics.bigdl.optim
 
-import java.util.UUID
-
 import com.intel.analytics.bigdl._
-import com.intel.analytics.bigdl.dataset.{MiniBatch, PaddingParam, Sample, SampleToMiniBatch, Transformer, Utils, DataSet => _}
-import com.intel.analytics.bigdl.models.utils.{CachedModels, ModelBroadcast, ModelInfo}
+import com.intel.analytics.bigdl.dataset.{MiniBatch, PaddingParam, Sample, SampleToMiniBatch, Transformer, DataSet => _}
+import com.intel.analytics.bigdl.models.utils.ModelBroadcast
 import com.intel.analytics.bigdl.nn.abstractnn.Activity
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.transform.vision.image.{DistributedImageFrame, ImageFeature, ImageFrame}
 import com.intel.analytics.bigdl.utils.{T, Table}
 import org.apache.spark.rdd.RDD
-import Predictor._
 
 import scala.reflect.ClassTag
 
@@ -121,34 +118,40 @@ object Predictor {
     }
     out.asInstanceOf[Array[Activity]]
   }
-}
 
-/**
- * Predictor for distributed data
- * @param model BigDL model
- * @param featurePaddingParam featurePaddingParam if the inputs have variant size
- * @param batchPerPartition batch size per partition, default is 4
- */
-class Predictor[T: ClassTag] private[optim](
-   model: Module[T],
-   featurePaddingParam: Option[PaddingParam[T]] = None,
-   batchPerPartition: Int = 4)
-  (implicit ev: TensorNumeric[T]) extends Serializable {
+  def predictImage[T: ClassTag](imageFrame: DistributedImageFrame,
+    outputLayer: String = null,
+    shareBuffer: Boolean = false,
+    predictKey: String = ImageFeature.predict,
+    batchPerPartition: Int,
+    model: Module[T],
+    featurePaddingParam: Option[PaddingParam[T]])(
+    implicit ev: TensorNumeric[T]): DistributedImageFrame = {
+    val localBatchPerPartition = batchPerPartition
 
-  def predictClass(dataSet: RDD[Sample[T]], batchSize: Int = -1): RDD[Int] = {
-    val result = predict(dataSet, batchSize, true)
-    result.mapPartitions { partition =>
-      partition.map(output => {
-        val _output = output.toTensor[T]
-        require(_output.dim() == 1, s"Predictor.predictClass:" +
-          s"Only support one sample has one label, but got ${_output.dim()} label")
-        ev.toType[Int](_output.max(1)._2.valueAt(1))
+    val rdd = imageFrame.asInstanceOf[DistributedImageFrame].rdd
+    val modelBroad = ModelBroadcast[T]().broadcast(rdd.sparkContext, model.evaluate())
+    val partitionNum = rdd.partitions.length
+    val toBatchBroad = rdd.sparkContext.broadcast(SampleToMiniBatch(
+      batchSize = partitionNum * batchPerPartition,
+      partitionNum = Some(partitionNum),
+      featurePaddingParam = featurePaddingParam), shareBuffer)
+    val result = rdd.mapPartitions(partition => {
+      val localModel = modelBroad.value()
+      val localToBatch = toBatchBroad.value._1.cloneTransformer()
+
+      partition.grouped(localBatchPerPartition).flatMap(imageFeatures => {
+        Predictor.predictImageBatch[T](localModel, imageFeatures, outputLayer, predictKey,
+          localToBatch, shareBuffer)
+        imageFeatures
       })
-    }
+    })
+    ImageFrame.rdd(result)
   }
 
-  def predict(dataSet: RDD[Sample[T]], batchSize: Int = -1,
-              shareBuffer: Boolean = false): RDD[Activity] = {
+  def predict[T: ClassTag](dataSet: RDD[Sample[T]], batchSize: Int = -1,
+    shareBuffer: Boolean = false, model: Module[T], batchPerPartition: Int,
+    featurePaddingParam: Option[PaddingParam[T]])(implicit ev: TensorNumeric[T]): RDD[Activity] = {
     val modelBroad = ModelBroadcast[T]().broadcast(dataSet.sparkContext, model.evaluate())
     val partitionNum = dataSet.partitions.length
     val totalBatch = if (batchSize > 0) {
@@ -163,16 +166,60 @@ class Predictor[T: ClassTag] private[optim](
       partitionNum = Some(partitionNum),
       featurePaddingParam = featurePaddingParam))
     dataSet.mapPartitions { partition =>
-      CachedModels.add(modelBroad.uuid, model)
-
       val localModel = modelBroad.value()
       val localTransformer = otherBroad.value.cloneTransformer()
       val miniBatch = localTransformer(partition)
-      miniBatch.flatMap( batch => {
+      miniBatch.flatMap(batch => {
         val output = localModel.forward(batch.getInput)
         splitBatch(output, shareBuffer, batch.size())
       })
     }
+  }
+
+  def predictClass[T: ClassTag](dataSet: RDD[Sample[T]], batchSize: Int = -1, model: Module[T],
+    batchPerPartition: Int, featurePaddingParam: Option[PaddingParam[T]])(
+    implicit ev: TensorNumeric[T]): RDD[Int] = {
+    val result = Predictor.predict(dataSet, batchSize, true, model,
+      batchPerPartition, featurePaddingParam)
+    result.mapPartitions { partition =>
+      partition.map(output => {
+        val _output = output.toTensor[T]
+        require(_output.dim() == 1, s"Predictor.predictClass:" +
+          s"Only support one sample has one label, but got ${_output.dim()} label")
+        ev.toType[Int](_output.max(1)._2.valueAt(1))
+      })
+    }
+  }
+}
+
+/**
+ * Predictor for distributed data
+ *
+ * NOTE: The `predictClass`, `predict` and `predictImage` will call the relevant methods of
+ * object `Predictor`. Why we do this? Because every these methods uses the ClassTag `T`. If we do
+ * these jobs in the methods of class`Predictor`, when we do `mapPartition`, Spark will find all
+ * used values and do serialization. The `T` is the argument of constructor, the serialization will
+ * package the whole `Predictor` class, which contains the`model`. It will send a duplicate model
+ * to the workers. So we should move these methods to object `Predictor`.
+ *
+ * @param model BigDL model
+ * @param featurePaddingParam featurePaddingParam if the inputs have variant size
+ * @param batchPerPartition batch size per partition, default is 4
+ */
+class Predictor[T: ClassTag] private[optim](
+   model: Module[T],
+   featurePaddingParam: Option[PaddingParam[T]] = None,
+   batchPerPartition: Int = 4)
+  (implicit ev: TensorNumeric[T]) extends Serializable {
+
+  def predictClass(dataSet: RDD[Sample[T]], batchSize: Int = -1): RDD[Int] = {
+    Predictor.predictClass(dataSet, batchSize, model, batchPerPartition, featurePaddingParam)
+  }
+
+  def predict(dataSet: RDD[Sample[T]], batchSize: Int = -1,
+    shareBuffer: Boolean = false): RDD[Activity] = {
+    Predictor.predict(dataSet, batchSize, shareBuffer, model, batchPerPartition,
+      featurePaddingParam)
   }
 
 
@@ -188,25 +235,7 @@ class Predictor[T: ClassTag] private[optim](
     outputLayer: String = null,
     shareBuffer: Boolean = false,
     predictKey: String = ImageFeature.predict): DistributedImageFrame = {
-    val rdd = imageFrame.asInstanceOf[DistributedImageFrame].rdd
-    val modelBroad = ModelBroadcast[T]().broadcast(rdd.sparkContext, model.evaluate())
-    val partitionNum = rdd.partitions.length
-    val toBatchBroad = rdd.sparkContext.broadcast(SampleToMiniBatch(
-      batchSize = partitionNum * batchPerPartition,
-      partitionNum = Some(partitionNum),
-      featurePaddingParam = featurePaddingParam), shareBuffer)
-    val result = rdd.mapPartitions(partition => {
-      // By default, the `model` will be deserialized on worker, which will create new resources.
-      CachedModels.add(modelBroad.uuid, model)
-
-      val localModel = modelBroad.value()
-      val localToBatch = toBatchBroad.value._1.cloneTransformer()
-
-      partition.grouped(batchPerPartition).flatMap(imageFeatures => {
-        Predictor.predictImageBatch[T](localModel, imageFeatures, outputLayer, predictKey,
-          localToBatch, shareBuffer)
-      })
-    })
-    ImageFrame.rdd(result)
+    Predictor.predictImage(imageFrame, outputLayer, shareBuffer, predictKey, batchPerPartition,
+      model, featurePaddingParam)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/PredictorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/PredictorSpec.scala
@@ -239,6 +239,9 @@ class PredictorSpec extends FlatSpec with Matchers with BeforeAndAfter{
       println("-" * 80)
     }
     CachedModels.deleteAll("")
+    // NOTE: if this case failed, please check,
+    // 1. mapPartition, does it used the variable out side of the method scope.
+    // 2. ModelBroadcast, does it add the ref correctly
     StorageManager.get().count(!_._2.isFreed) should be (init.count(!_._2.isFreed))
   }
 }


### PR DESCRIPTION
The `predictClass`, `predict` and `predictImage` will call the relevant methods
of object `Predictor`. Why we do this? Because every these methods uses the
ClassTag `T`. If we do these jobs in the methods of class`Predictor`, when we do
`mapPartition`, Spark will find all used values and do serialization. The `T` is
the argument of constructor, the serialization will package the whole
`Predictor` class, which contains the`model`.  Then it will send a duplicate model
to the workers. So we should move these methods to object `Predictor`.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this patch)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If it is possible, please attach a screenshot; otherwise, remove this)

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

