### PR TITLE
[Bug Fix]clear preTopology's output while cloneCells

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -174,7 +174,11 @@ class Recurrent[T : ClassTag](
       cloneCell.parameters()._1.map(_.set())
       cloneCell.parameters()._2.map(_.set())
       // preTopology's output is useless here, clear it.
-      cloneCell.preTopology.output.set()
+      // Notice: preTopology is a merge output of all i2h,
+      // it's a bigdl tensor, and shouldn't be cloned.
+      if (cloneCell.preTopology != null) {
+        cloneCell.preTopology.output.set()
+      }
       while (t < times) {
         cells += cloneCell.cloneModule()
           .asInstanceOf[Cell[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Recurrent.scala
@@ -173,6 +173,8 @@ class Recurrent[T : ClassTag](
       val cloneCell = cells.head.cloneModule()
       cloneCell.parameters()._1.map(_.set())
       cloneCell.parameters()._2.map(_.set())
+      // preTopology's output is useless here, clear it.
+      cloneCell.preTopology.output.set()
       while (t < times) {
         cells += cloneCell.cloneModule()
           .asInstanceOf[Cell[T]]

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -467,7 +467,7 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag, 
    * Clone the model
    * @return
    */
-  final def cloneModule(): AbstractModule[A, B, T] = {
+  final def cloneModule(): this.type = {
     SerializationUtils.clone(this)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Recurrent cost too many memories, find it's caused by cloneCells. 
clear preTopology's output while cloneCells.

With this fix, 9-depth deepspeech2 model forward a input tensor of size  (1, 1, 13, 3000) cost only 1GB memory.
Without this fix, the model will cost about 80GB memory.

## How was this patch tested?

unit tests, manual tests

