### PR TITLE
Add document for wrap preprocessor and model in one graph and add its python API

### DIFF
--- a/docs/docs/ProgrammingGuide/Model/Functional.md
+++ b/docs/docs/ProgrammingGuide/Model/Functional.md
@@ -144,3 +144,20 @@ model = Model([linear1, linear2], [add])
 In the above code, we define two input nodes linear1 and linear2 and put them
 into the first parameter when create the graph model.
 
+## **Define a model with data pre-processing**
+You can use a model as the data preprocessor for another model. In the training, the parameter of
+the preprocessor won't be updated. Here's how you can use it:
+
+**Scala:**
+```scala
+val preprocessor = Module.Load(...)
+val trainable = Module.Load(...)
+val model = Graph(preprocessor, trainable)
+```
+
+**Python:**
+```python
+preprocessor = Model.loadModel(...)
+trainable = Model.loadModel(...)
+model = Model(preprocessor, trainable)
+```

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -728,10 +728,14 @@ class Model(Container):
         if jvalue:
             self.value = jvalue
             self.bigdl_type = bigdl_type
-        elif model_type == "bigdl":
+        elif model_type == "bigdl" and isinstance(inputs, list):
             super(Model, self).__init__(None, bigdl_type,
                                         to_list(inputs),
                                         to_list(outputs))
+        elif model_type == "bigdl":
+            self.value = callBigDlFunc(
+                bigdl_type, "createModelPreprocessor", inputs, outputs)
+            self.bigdl_type = bigdl_type
         else:
             from bigdl.util.tf_utils import convert
             model = convert(to_list(inputs), to_list(outputs), byte_order, bigdl_type)

--- a/pyspark/test/bigdl/test_simple_integration.py
+++ b/pyspark/test/bigdl/test_simple_integration.py
@@ -230,6 +230,22 @@ class TestSimple():
         model = Model([fc1, fc2], [output1, output2])
         model.save_graph_topology(tempfile.mkdtemp())
 
+    def test_graph_preprocessor(self):
+        fc1 = Linear(4, 2)()
+        fc2 = Linear(4, 2)()
+        cadd = CAddTable()([fc1, fc2])
+        preprocessor = Model([fc1, fc2], [cadd])
+        relu = ReLU()()
+        fc3 = Linear(2, 1)(relu)
+        trainable = Model([relu], [fc3])
+        model = Model(preprocessor, trainable)
+        output = model.forward([np.array([0.1, 0.2, -0.3, -0.4]),
+                                np.array([0.5, 0.4, -0.2, -0.1])])
+        gradInput = model.backward([np.array([0.1, 0.2, -0.3, -0.4]),
+                                    np.array([0.5, 0.4, -0.2, -0.1])],
+                                   [np.array([1.0]),
+                                    np.array([3.0])])
+
     def test_load_zip_conf(self):
         from bigdl.util.common import get_bigdl_conf
         import sys

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -2358,6 +2358,11 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
     Graph(input.asScala.toArray, output.asScala.toArray)
   }
 
+  def createModelPreprocessor(preprocessor: AbstractModule[Activity, Activity, T],
+    trainable: AbstractModule[Activity, Activity, T]): Graph[T] = {
+    Graph(preprocessor, trainable)
+  }
+
   def createNode(module: AbstractModule[Activity, Activity, T],
     x: JList[ModuleNode[T]]): ModuleNode[T] = {
     if (null == x || x.isEmpty) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add document for wrap preprocessor and model in one graph and add its python API

## How was this patch tested?
unit tests

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/2496

