### PR TITLE
[BugFix] - Fix parameter syn that parameter not starting with 1 offset

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DistriParameterSynchronizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DistriParameterSynchronizer.scala
@@ -274,7 +274,7 @@ class BlockManagerParameterSynchronizer[T: ClassTag](partitionID: Int,
         new Callable[Int] {
           override def call(): Int = {
             try {
-              val offset = parameter.storageOffset() + pid * taskSize + math.min(pid, extraSize)
+              val offset = 1 + pid * taskSize + math.min(pid, extraSize)
               val length = taskSize + (if (pid < extraSize) 1 else 0)
               val partitionParam = parameter.narrow(1, offset, length)
               syncMeta.aggregatedStateOfWorld.put(pid, partitionParam)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/DistributedSynchronizerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/DistributedSynchronizerSpec.scala
@@ -75,7 +75,7 @@ class DistributedSynchronizerSpec  extends FlatSpec with Matchers with BeforeAnd
     res(3) should be (Tensor[Float](2).fill(2.5f))
   }
 
-  "DistributedSynchronizer with parameter offset > 1" should "worl properly" in {
+  "DistributedSynchronizer with parameter offset > 1" should "work properly" in {
     val partition = 4
     val cores = 4
     val res = sc.parallelize((0 until partition), partition).mapPartitions(p => {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/DistributedSynchronizerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/DistributedSynchronizerSpec.scala
@@ -30,6 +30,7 @@ class DistributedSynchronizerSpec  extends FlatSpec with Matchers with BeforeAnd
     sc = new SparkContext(conf)
     Engine.init
   }
+
   "DistributedSynchronizer" should "work properly" in {
     val partition = 4
     val cores = 4
@@ -72,6 +73,29 @@ class DistributedSynchronizerSpec  extends FlatSpec with Matchers with BeforeAnd
     res(1) should be (Tensor[Float](2).fill(2.5f))
     res(2) should be (Tensor[Float](2).fill(2.5f))
     res(3) should be (Tensor[Float](2).fill(2.5f))
+  }
+
+  "DistributedSynchronizer with parameter offset > 1" should "worl properly" in {
+    val partition = 4
+    val cores = 4
+    val res = sc.parallelize((0 until partition), partition).mapPartitions(p => {
+      Engine.setNodeAndCore(partition, cores)
+      val partitionID = TaskContext.getPartitionId
+      val sync = new BlockManagerParameterSynchronizer[Float](partitionID, partition)
+      val tensor = Tensor[Float](20)
+      val parameter = tensor.narrow(1, 10, 10).fill(partitionID.toFloat + 1.0f)
+      sync.init(s"testPara", 10)
+      var res : Iterator[_] = null
+      sync.put(s"testPara", parameter)
+      res = Iterator.single(sync.get(s"testPara"))
+      sync.clear
+      res
+    }).collect
+    res.length should be  (4)
+    res(0) should be (Tensor[Float](10).fill(2.5f))
+    res(1) should be (Tensor[Float](10).fill(2.5f))
+    res(2) should be (Tensor[Float](10).fill(2.5f))
+    res(3) should be (Tensor[Float](10).fill(2.5f))
   }
 
   after {


### PR DESCRIPTION
## What changes were proposed in this pull request?

if the parameter storage offset is not 1, the synchronizer will cause incorrect result, this PR is to fix it

## How was this patch tested?
unit test
## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

