### PR TITLE
fix: should load dnn relevant library if enabled dnn engine.

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/ThreadPool.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/ThreadPool.scala
@@ -217,9 +217,9 @@ object ThreadPool {
 
   def setThreadsOfBackend(size: Int): Unit = {
     require(MKL.isMKLLoaded)
-    require(BackendMklDnn.isLoaded)
     MKL.setNumThreads(size)
     if (System.getProperty("bigdl.engineType") == "mkldnn") {
+      require(BackendMklDnn.isLoaded)
       BackendMklDnn.setNumThreads(size)
       Affinity.setOmpAffinity()
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

It should load the dnn relevant library when enable dnn engine. Because currently we has not supported windows so should not do if disabled dnn engine.

## How was this patch tested?
Jenkins and manual on windows.

