### PR TITLE
fix: set the encoding of input and output files is UTF-8

### DIFF
--- a/spark/dl/pom.xml
+++ b/spark/dl/pom.xml
@@ -273,6 +273,7 @@
                     <testSourceDirectory>${basedir}/src/test/scala</testSourceDirectory>
                     <configLocation>${project.parent.parent.basedir}/scalastyle_config.xml</configLocation>
                     <outputFile>${project.build.directory}/stylecheck/scalastyle-output.xml</outputFile>
+                    <inputEncoding>UTF-8</inputEncoding>
                     <outputEncoding>UTF-8</outputEncoding>
                 </configuration>
                 <executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

On windows the scala style check will failed. Need the input encoding to UTF-8.

## How was this patch tested?

Manual test on Windows 10.


