### PR TITLE
[Feature] Allow user to customized how model is broadcast in distributed training

### DIFF
--- a/docs/docs/ScalaUserGuide/configuration.md
+++ b/docs/docs/ScalaUserGuide/configuration.md
@@ -34,7 +34,7 @@ java -cp xxx.jar -DFOO=BAR your.main.class.name
 **Mode**
 
 - `bigdl.localMode`: Whether BigDL is running as a local Java/Scala program. Default is false.
-- `bigdl.engineType`: Default is **mkldnn**. When you run model contains mkl dnn layers, you should set it to **mkldnn** to get better performance.
+- `bigdl.engineType`: Default is **mklblas**. When you run model contains mkl dnn layers, you should set it to **mkldnn** to get better performance.
 
 **Multi-threading**
 

--- a/docs/docs/ScalaUserGuide/configuration.md
+++ b/docs/docs/ScalaUserGuide/configuration.md
@@ -34,6 +34,7 @@ java -cp xxx.jar -DFOO=BAR your.main.class.name
 **Mode**
 
 - `bigdl.localMode`: Whether BigDL is running as a local Java/Scala program. Default is false.
+- `bigdl.engineType`: Default is **mkldnn**. When you run model contains mkl dnn layers, you should set it to **mkldnn** to get better performance.
 
 **Multi-threading**
 

--- a/docs/docs/ScalaUserGuide/configuration.md
+++ b/docs/docs/ScalaUserGuide/configuration.md
@@ -46,6 +46,7 @@ java -cp xxx.jar -DFOO=BAR your.main.class.name
 - `bigdl.failure.retryTimes`: To set how many times to retry when there's failure in distributed training. Default is 5.
 - `bigdl.failure.retryTimeInterval`: To set how long to recount the retry times. Time unit here is second. Default is 120.
 - `bigdl.check.singleton`: To check whether multiple partitions run on the same executor, which is bad for performance. Default is false.
+- `bigdl.ModelBroadcastFactory`: Specify a ModelBroadcastFactory which creates a ModelBroadcast to control how to broadcast the model in the distributed training.
 
 **Tensor**
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
@@ -55,7 +55,7 @@ trait ModelBroadcast[T] extends Serializable {
   def uuid(): String = UUID.randomUUID().toString
 }
 
-private[bigdl] object ModelBroadcast {
+object ModelBroadcast {
   def apply[T: ClassTag]()(implicit ev: TensorNumeric[T]): ModelBroadcast[T] = {
     if (System.getProperty("bigdl.ModelBroadcastFactory") != null) {
       val cls = Class.forName(System.getProperty("bigdl.ModelBroadcastFactory"))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcastFactory.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcastFactory.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.models.utils
+
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+
+import scala.reflect.ClassTag
+
+/**
+ * Create a ModelBroadcast. User can override how model is broadcast by extending this class to
+ * create a customized ModelBroadcast. To enable customized broadcast factory, user need to specify
+ * its full class name via system property bigdl.ModelBroadcastFactory.
+ */
+trait ModelBroadcastFactory {
+  def create[T: ClassTag]()(implicit ev: TensorNumeric[T]) : ModelBroadcast[T]
+}
+
+private[bigdl] class DefaultModelBroadcastFactory extends ModelBroadcastFactory {
+  override def create[T: ClassTag]()(implicit ev: TensorNumeric[T]): ModelBroadcast[T] = {
+    new ModelBroadcastImp[T]()
+  }
+}
+
+private[bigdl] class ProtoBufferModelBroadcastFactory extends ModelBroadcastFactory {
+  override def create[T: ClassTag]()(implicit ev: TensorNumeric[T]): ModelBroadcast[T] = {
+    new ModelBroadcastImp[T](true)
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcastSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcastSpec.scala
@@ -49,7 +49,9 @@ class ModelBroadcastSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val input2 = Const[Float, Float](Tensor[Float].range(1, 6, 1)).setName("const").inputs()
     val output = CAddTable[Float]().inputs(input1, input2)
     val model = Graph(input1, output)
-    val modelBroadCast = ModelBroadcast[Float](true).broadcast(sc, model)
+    System.setProperty("bigdl.ModelBroadcastFactory",
+      "com.intel.analytics.bigdl.models.utils.ProtoBufferModelBroadcastFactory")
+    val modelBroadCast = ModelBroadcast[Float]().broadcast(sc, model)
 
     val testModel = modelBroadCast.value()
     val testInput = Tensor[Float].range(2, 7, 1)
@@ -90,7 +92,9 @@ class ModelBroadcastSpec extends FlatSpec with Matchers with BeforeAndAfter {
   "model broadcast with applyProtoBuffer" should "work properly" in {
     val model = LeNet5(10)
 
-    val modelBroadCast = ModelBroadcast[Float](true).broadcast(sc, model)
+    System.setProperty("bigdl.ModelBroadcastFactory",
+      "com.intel.analytics.bigdl.models.utils.ProtoBufferModelBroadcastFactory")
+    val modelBroadCast = ModelBroadcast[Float]().broadcast(sc, model)
     modelBroadCast.value().toString should be(model.toString)
     modelBroadCast.value().parameters()._1 should be(model.parameters()._1)
   }
@@ -108,7 +112,10 @@ class ModelBroadcastSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val model = LeNet5(10)
     model.getParameters()
 
-    val modelBroadCast = ModelBroadcast[Float](true).broadcast(sc, model)
+
+    System.setProperty("bigdl.ModelBroadcastFactory",
+      "com.intel.analytics.bigdl.models.utils.ProtoBufferModelBroadcastFactory")
+    val modelBroadCast = ModelBroadcast[Float]().broadcast(sc, model)
     modelBroadCast.value().toString should be(model.toString)
     modelBroadCast.value().parameters()._1 should be(model.parameters()._1)
   }
@@ -124,7 +131,9 @@ class ModelBroadcastSpec extends FlatSpec with Matchers with BeforeAndAfter {
   "quantized model broadcast with applyProtoBuffer" should "work properly" in {
     val model = LeNet5(10).quantize()
 
-    val modelBroadCast = ModelBroadcast[Float](true).broadcast(sc, model)
+    System.setProperty("bigdl.ModelBroadcastFactory",
+      "com.intel.analytics.bigdl.models.utils.ProtoBufferModelBroadcastFactory")
+    val modelBroadCast = ModelBroadcast[Float]().broadcast(sc, model)
     modelBroadCast.value().toString should be(model.toString)
     modelBroadCast.value().parameters()._1 should be(model.parameters()._1)
   }
@@ -152,6 +161,7 @@ class ModelBroadcastSpec extends FlatSpec with Matchers with BeforeAndAfter {
   }
 
   after {
+    System.clearProperty("bigdl.ModelBroadcastFactory")
     if (sc != null) {
       sc.stop()
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
In this PR, we define a ModelBroadcast factory. It will create a ModelBroadcast class to control how model is broadcasted in training. The user can extend the ModelBroadcast factory to change it. 

## How was this patch tested?
unit tests

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/2604

