### PR TITLE
fix: Don't crash NLL classifier if all targets are unlabeled

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ClassNLLCriterion.scala
@@ -153,6 +153,9 @@ class ClassNLLCriterion[@specialized(Float, Double) T: ClassTag]
         total_weight = ev.plus(total_weight, w)
         i += 1
       }
+      if (total_weight == 0) {
+        total_weight = ev.fromType[Int](1)
+      }
       target.resize(targetSize)
     }
     if (sizeAverage && total_weight != 0) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
If all the targets are unlabeled (or all target classes have a weight of zero), changes total_weight from 0 to 1, so it doesn't crash in backwards() when it asserts the total weight is > 0. This doesn't change the output of forward or backwards to anything unexpected.

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/2617

