### PR TITLE
fix: the inference performance regression of mkldnn

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Linear.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Linear.scala
@@ -136,8 +136,10 @@ class Linear(
 
     updateWithNewTensor(updateOutputTensors, 0, input)
 
-    weight.syncToNative()
-    bias.syncToNative()
+    if (isTraining()) {
+      weight.syncToNative()
+      bias.syncToNative()
+    }
 
     MklDnnOps.streamSubmit(runtime.stream, 1, updateOutputPrimitives, updateOutputPrimitives.length,
       updateOutputMemoryPrimitives, updateOutputTensors)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialBatchNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialBatchNormalization.scala
@@ -193,7 +193,9 @@ class SpatialBatchNormalization(
       }
     }
 
-    weightAndBias.syncToNative()
+    if (isTraining()) {
+      weightAndBias.syncToNative()
+    }
 
     updateWithNewTensor(updateOutputTensors, 0, input)
 
@@ -206,10 +208,9 @@ class SpatialBatchNormalization(
 
       mean.axpby(1, momentum.toFloat, runningMean.native)
       variance.axpby(biasFactor, momentum.toFloat, runningVariance.native)
+      runningMean.syncToHeap()
+      runningVariance.syncToHeap()
     }
-
-    runningMean.syncToHeap()
-    runningVariance.syncToHeap()
 
     output
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialConvolution.scala
@@ -223,8 +223,10 @@ class SpatialConvolution(
 
     updateWithNewTensor(updateOutputTensors, 0, input)
 
-    weight.syncToNative()
-    bias.syncToNative()
+    if (isTraining()) {
+      weight.syncToNative()
+      bias.syncToNative()
+    }
 
     MklDnnOps.streamSubmit(runtime.stream, 1, updateOutputPrimitives, updateOutputPrimitives.length,
       updateOutputMemoryPrimitives, updateOutputTensors)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
@@ -542,10 +542,12 @@ object Engine {
   }
 
   private def setMklDnnEnvironments(): Unit = {
-    val threadsNumber = Math.ceil(Runtime.getRuntime.availableProcessors().toFloat / 2).toInt
+    val default = Math.ceil(Runtime.getRuntime.availableProcessors().toFloat / 2).toInt
+    val threadsNumber= System.getProperty("bigdl.mklNumThreads", default.toString)
+    System.setProperty("bigdl.mklNumThreads", s"$threadsNumber")
+
 
     System.setProperty("bigdl.disable.mklBlockTime", "true")
-    System.setProperty("bigdl.mklNumThreads", s"$threadsNumber")
     System.setProperty("bigdl.coreNumber", "1")
     System.setProperty("bigdl.utils.Engine.defaultPoolSize", "1")
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should copy weights when `updateOutput` at training. The weights are loaded before and will not be changed when do inference.

## How was this patch tested?

Manual tests.


