### PR TITLE
change Reshape to InferReShape in reshapeLoadTF

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/tensorflow/loadandsave/README.md
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/tensorflow/loadandsave/README.md
@@ -5,7 +5,7 @@ Before you run this example, you need to install tensorflow on your machine. Thi
 by
 
 ```bash
-pip install tensorflow==1.2.0
+pip install tensorflow
 ```
 
 ## Load tensorflow model
@@ -16,7 +16,7 @@ python model.py
 
 2. Freeze tensorflow model
 ```bash
-wget https://raw.githubusercontent.com/tensorflow/tensorflow/v1.0.0/tensorflow/python/tools/freeze_graph.py
+wget https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/tools/freeze_graph.py
 python freeze_graph.py --input_graph model/model.pbtxt --input_checkpoint model/model.chkp --output_node_names="LeNet/fc4/BiasAdd" --output_graph "model.pb"
 ```
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Reshape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Reshape.scala
@@ -50,8 +50,8 @@ class ReshapeLoadTF[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends Adapte
       k += 1
       i += 1
     }
-    if (infer) ReshapeOps[T](size = arraySize, Some(batchMode))
-    else InferReshape[T](size = arraySize, batchMode)
+    if (infer) InferReshape[T](size = arraySize, batchMode)
+    else ReshapeOps[T](size = arraySize, Some(batchMode))
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Reshape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Reshape.scala
@@ -40,7 +40,7 @@ class ReshapeLoadTF[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends Adapte
     val sizes = tensorArrays(0).asInstanceOf[Tensor[Int]]
     val infer = sizes.toArray().contains(-1)
 
-    val batchMode = if (infer) false else true
+    val batchMode = false
 
     val arraySize = new Array[Int](if (batchMode) sizes.nElement() - 1 else sizes.nElement())
     var i = if (batchMode) 2 else 1

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Reshape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Reshape.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import java.nio.ByteOrder
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.nn.{Reshape => ReshapeOps}
+import com.intel.analytics.bigdl.nn.{InferReshape => ReshapeOps}
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
@@ -52,7 +52,7 @@ class ReshapeLoadTF[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends Adapte
       k += 1
       i += 1
     }
-    ReshapeOps[T](size = arraySize, Some(batchMode))
+    ReshapeOps[T](size = arraySize, batchMode)
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Reshape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Reshape.scala
@@ -40,18 +40,17 @@ class ReshapeLoadTF[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends Adapte
     val sizes = tensorArrays(0).asInstanceOf[Tensor[Int]]
     val infer = sizes.toArray().contains(-1)
 
-    val batchMode = false
+    // val batchMode = false
 
-    val arraySize = new Array[Int](if (batchMode) sizes.nElement() - 1 else sizes.nElement())
-    var i = if (batchMode) 2 else 1
+    val arraySize = new Array[Int](sizes.nElement())
+    var i = 1
     var k = 0
     while(i <= sizes.nElement()) {
       arraySize(k) = sizes.valueAt(i)
-      k += 1
       i += 1
     }
-    if (infer) InferReshape[T](size = arraySize, batchMode)
-    else ReshapeOps[T](size = arraySize, Some(batchMode))
+    if (infer) InferReshape[T](size = arraySize)
+    else ReshapeOps[T](size = arraySize, Some(true))
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Reshape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Reshape.scala
@@ -30,7 +30,7 @@ import scala.reflect.ClassTag
 
 class Reshape extends TensorflowOpsLoader {
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder,
-                                  context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
+    context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
     new ReshapeLoadTF[T]()
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/loaders/ReshapeLoadTFSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/loaders/ReshapeLoadTFSpec.scala
@@ -25,8 +25,8 @@ import scala.util.Random
 class ReshapeLoadTFSerialTest extends ModuleSerializationTest {
   override def test(): Unit = {
     val reshapeLoadTF = new ReshapeLoadTF[Float]().setName("reshapeLoadTF")
-    val input = T(Tensor[Float](5, 5, 5).apply1(_ => Random.nextFloat()),
-      Tensor[Int](T(1, 5, 25)))
+    val input = T(Tensor[Float](2, 3, 4).apply1(_ => Random.nextFloat()),
+      Tensor[Int](T(1, 6, -1)))
     runSerializationTest(reshapeLoadTF, input)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/loaders/ReshapeLoadTFSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/loaders/ReshapeLoadTFSpec.scala
@@ -25,8 +25,8 @@ import scala.util.Random
 class ReshapeLoadTFSerialTest extends ModuleSerializationTest {
   override def test(): Unit = {
     val reshapeLoadTF = new ReshapeLoadTF[Float]().setName("reshapeLoadTF")
-    val input = T(Tensor[Float](2, 3, 4).apply1(_ => Random.nextFloat()),
-      Tensor[Int](T(1, 6, -1)))
+    val input = T(Tensor[Float](5, 5, 5).apply1(_ => Random.nextFloat()),
+      Tensor[Int](T(1, 5, 25)))
     runSerializationTest(reshapeLoadTF, input)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/loaders/ReshapeSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/loaders/ReshapeSpec.scala
@@ -18,9 +18,40 @@ package com.intel.analytics.bigdl.utils.tf.loaders
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.T
 import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+import com.intel.analytics.bigdl.utils.tf.Tensorflow.typeAttr
+import com.intel.analytics.bigdl.utils.tf.TensorflowSpecHelper
+import org.tensorflow.framework.{DataType, NodeDef}
 
 import scala.util.Random
 
+class ReshapeSpec extends TensorflowSpecHelper {
+  "Reshape" should "be correct for Float" in {
+    val data = Tensor[Float](4, 32, 32, 3).rand()
+    val shape = Tensor[Int](T(1, 32, 12, 32))
+    compare[Float](
+      NodeDef.newBuilder()
+        .setName("Reshape test")
+        .putAttr("T", typeAttr(DataType.DT_FLOAT))
+        .putAttr("Tshape", typeAttr(DataType.DT_FLOAT))
+        .setOp("Reshape"),
+      Seq(data, shape),
+      0
+    )
+  }
+  "Reshape" should "be correct for Float with inference" in {
+    val data = Tensor[Float](4, 32, 32, 3).rand()
+    val shape = Tensor[Int](T(1, 32, -1, 32))
+    compare[Float](
+      NodeDef.newBuilder()
+        .setName("Reshape test")
+        .putAttr("T", typeAttr(DataType.DT_FLOAT))
+        .putAttr("Tshape", typeAttr(DataType.DT_FLOAT))
+        .setOp("Reshape"),
+      Seq(data, shape),
+      0
+    )
+  }
+}
 
 class ReshapeLoadTFSerialTest extends ModuleSerializationTest {
   override def test(): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. change Reshape to InferReShape in reshapeLoadTF to allow -1 in shape size
2. modified the docs for the loadandsave example in the tensorflow support
3. modified the unit test in the reshapeLoadTFSpec to test the case where the shape size contains a '-1'

## How was this patch tested?
1. Use modified old unit tests to run Jenkins build. No new unit tests need to be added.
2. Run the loadandsave example successfully to support both TF1.2 and TF1.11 which is the latest version during the test

## Related links or issues (optional)
fixed loadandsave in https://github.com/intel-analytics/BigDL/issues/2511 and in https://github.com/intel-analytics/BigDL/issues/2606

