### PR TITLE
fix join table will throw exception during backward if batchsize is changed

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/JoinTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/JoinTable.scala
@@ -130,8 +130,12 @@ class JoinTable[T: ClassTag] (
         val narrowedTensor = gradOutput.narrow(dimension, _offset, currentOutput.size(dimension))
           .asInstanceOf[Tensor[NumericWildcard]]
         val inputTensor = input[Tensor[_]](_i + 1)
-        if (!gradInput.contains(_i + 1)) gradInput(_i + 1) =
-          inputTensor.emptyInstance().resize(inputTensor.size())
+        if (!gradInput.contains(_i + 1)) {
+          gradInput(_i + 1) =
+            inputTensor.emptyInstance().resize(inputTensor.size())
+        } else {
+          gradInput[Tensor[T]](_i + 1).resize(inputTensor.size())
+        }
         if(narrowedTensor.isContiguous() || dimension > 2) {
           gradInput[Tensor[NumericWildcard]](_i + 1).copy(narrowedTensor)
         } else {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/JoinTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/JoinTable.scala
@@ -132,9 +132,9 @@ class JoinTable[T: ClassTag] (
         val inputTensor = input[Tensor[_]](_i + 1)
         if (!gradInput.contains(_i + 1)) {
           gradInput(_i + 1) =
-            inputTensor.emptyInstance().resize(inputTensor.size())
+            inputTensor.emptyInstance().resizeAs(inputTensor)
         } else {
-          gradInput[Tensor[T]](_i + 1).resize(inputTensor.size())
+          gradInput[Tensor[T]](_i + 1).resizeAs(inputTensor)
         }
         if(narrowedTensor.isContiguous() || dimension > 2) {
           gradInput[Tensor[NumericWildcard]](_i + 1).copy(narrowedTensor)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/JoinTableSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/JoinTableSpec.scala
@@ -38,6 +38,26 @@ class JoinTableSpec extends FlatSpec with Matchers {
     gradInput[Tensor[Int]](2) should be (Tensor[Int](T(3, 4)))
   }
 
+  "Join Table " should "works if batchsize changed" in {
+    val input1 = Tensor[Int](T(1, 2, 3, 4)).resize(2, 2)
+    val input2 = Tensor[Int](T(5, 6, 7, 8)).resize(2, 2)
+    val layer = JoinTable[Float](2, 2)
+    val gradOuput = Tensor[Int](T(9, 10, 11, 12, 13, 14, 15, 16)).resize(2, 4)
+    layer.forward(T(input1, input2))
+    layer.backward(T(input1, input2), gradOuput)
+
+    val input3 = Tensor[Int](T(1, 2)).resize(1, 2)
+    val input4 = Tensor[Int](T(3, 4)).resize(1, 2)
+    val expectedOutput2 = Tensor[Int](T(1, 2, 3, 4)).resize(1, 4)
+    val output2 = layer.forward(T(input3, input4))
+    output2 should be (expectedOutput2)
+    val gradOuput2 = Tensor[Int](T(5, 6, 7, 8)).resize(1, 4)
+    val gradInput = layer.backward(T(input3, input4), gradOuput2)
+
+    gradInput[Tensor[Int]](1) should be (Tensor[Int](T(5, 6)).resize(1, 2))
+    gradInput[Tensor[Int]](2) should be (Tensor[Int](T(7, 8)).resize(1, 2))
+  }
+
 }
 
 class JoinTableSerialTest extends ModuleSerializationTest {


### PR DESCRIPTION
## What changes were proposed in this pull request?

fix join table will throw exception during backward if batchsize is changed
Will throw exception
```
 2018-09-29 10:16:04 ERROR ThreadPool$:172 - Error: java.lang.IllegalArgumentException: requirement failed: self element number(4) is not equal to source element number(2)
	at scala.Predef$.require(Predef.scala:224)
	at com.intel.analytics.bigdl.tensor.DenseTensor$.copy(DenseTensor.scala:2587)
	at com.intel.analytics.bigdl.tensor.DenseTensor.copy(DenseTensor.scala:432)
	at com.intel.analytics.bigdl.nn.JoinTable$$anonfun$updateGradInput$1.apply$mcV$sp(JoinTable.scala:136)
	at com.intel.analytics.bigdl.nn.JoinTable$$anonfun$updateGradInput$1.apply(JoinTable.scala:129)
	at com.intel.analytics.bigdl.nn.JoinTable$$anonfun$updateGradInput$1.apply(JoinTable.scala:129)
	at com.intel.analytics.bigdl.utils.ThreadPool$$anonfun$invoke$2.apply(ThreadPool.scala:169)
	at scala.concurrent.impl.Future$PromiseCompletingRunnable.liftedTree1$1(Future.scala:24)
	at scala.concurrent.impl.Future$PromiseCompletingRunnable.run(Future.scala:24)
	at com.intel.analytics.bigdl.utils.ThreadPool$$anon$1.execute(ThreadPool.scala:210)
	at scala.concurrent.impl.Future$.apply(Future.scala:31)
	at scala.concurrent.Future$.apply(Future.scala:494)
	at com.intel.analytics.bigdl.utils.ThreadPool.invoke(ThreadPool.scala:175)
	at com.intel.analytics.bigdl.nn.JoinTable.updateGradInput(JoinTable.scala:129)
	at com.intel.analytics.bigdl.nn.JoinTable.updateGradInput(JoinTable.scala:44)
	at com.intel.analytics.bigdl.nn.abstractnn.AbstractModule.backward(AbstractModule.scala:282)
	at com.intel.analytics.bigdl.nn.JoinTableSpec$$anonfun$2.apply$mcV$sp(JoinTableSpec.scala:55)
	at com.intel.analytics.bigdl.nn.JoinTableSpec$$anonfun$2.apply(JoinTableSpec.scala:41)
	at com.intel.analytics.bigdl.nn.JoinTableSpec$$anonfun$2.apply(JoinTableSpec.scala:41)
	at org.scalatest.Transformer$$anonfun$apply$1.apply$mcV$sp(Transformer.scala:22)
	at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)
	at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
	at org.scalatest.Transformer.apply(Transformer.scala:22)
	at org.scalatest.Transformer.apply(Transformer.scala:20)
	at org.scalatest.FlatSpecLike$$anon$1.apply(FlatSpecLike.scala:1647)
	at org.scalatest.Suite$class.withFixture(Suite.scala:1122)
	at org.scalatest.FlatSpec.withFixture(FlatSpec.scala:1683)
	at org.scalatest.FlatSpecLike$class.invokeWithFixture$1(FlatSpecLike.scala:1644)
	at org.scalatest.FlatSpecLike$$anonfun$runTest$1.apply(FlatSpecLike.scala:1656)
	at org.scalatest.FlatSpecLike$$anonfun$runTest$1.apply(FlatSpecLike.scala:1656)
	at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
	at org.scalatest.FlatSpecLike$class.runTest(FlatSpecLike.scala:1656)
	at org.scalatest.FlatSpec.runTest(FlatSpec.scala:1683)
	at org.scalatest.FlatSpecLike$$anonfun$runTests$1.apply(FlatSpecLike.scala:1714)
	at org.scalatest.FlatSpecLike$$anonfun$runTests$1.apply(FlatSpecLike.scala:1714)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:413)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:401)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
	at org.scalatest.SuperEngine.org$scalatest$SuperEngine$$runTestsInBranch(Engine.scala:390)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:427)
	at org.scalatest.SuperEngine$$anonfun$traverseSubNodes$1$1.apply(Engine.scala:401)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
	at org.scalatest.SuperEngine.org$scalatest$SuperEngine$$runTestsInBranch(Engine.scala:396)
	at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:483)
	at org.scalatest.FlatSpecLike$class.runTests(FlatSpecLike.scala:1714)
	at org.scalatest.FlatSpec.runTests(FlatSpec.scala:1683)
	at org.scalatest.Suite$class.run(Suite.scala:1424)
	at org.scalatest.FlatSpec.org$scalatest$FlatSpecLike$$super$run(FlatSpec.scala:1683)
	at org.scalatest.FlatSpecLike$$anonfun$run$1.apply(FlatSpecLike.scala:1760)
	at org.scalatest.FlatSpecLike$$anonfun$run$1.apply(FlatSpecLike.scala:1760)
	at org.scalatest.SuperEngine.runImpl(Engine.scala:545)
	at org.scalatest.FlatSpecLike$class.run(FlatSpecLike.scala:1760)
	at org.scalatest.FlatSpec.run(FlatSpec.scala:1683)
	at org.scalatest.tools.SuiteRunner.run(SuiteRunner.scala:55)
	at org.scalatest.tools.Runner$$anonfun$doRunRunRunDaDoRunRun$3.apply(Runner.scala:2563)
	at org.scalatest.tools.Runner$$anonfun$doRunRunRunDaDoRunRun$3.apply(Runner.scala:2557)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at org.scalatest.tools.Runner$.doRunRunRunDaDoRunRun(Runner.scala:2557)
	at org.scalatest.tools.Runner$$anonfun$runOptionallyWithPassFailReporter$2.apply(Runner.scala:1044)
	at org.scalatest.tools.Runner$$anonfun$runOptionallyWithPassFailReporter$2.apply(Runner.scala:1043)
	at org.scalatest.tools.Runner$.withClassLoaderAndDispatchReporter(Runner.scala:2722)
	at org.scalatest.tools.Runner$.runOptionallyWithPassFailReporter(Runner.scala:1043)
	at org.scalatest.tools.Runner$.run(Runner.scala:883)
	at org.scalatest.tools.Runner.run(Runner.scala)
	at org.jetbrains.plugins.scala.testingSupport.scalaTest.ScalaTestRunner.runScalaTest2(ScalaTestRunner.java:131)
	at org.jetbrains.plugins.scala.testingSupport.scalaTest.ScalaTestRunner.main(ScalaTestRunner.java:28)
```

## How was this patch tested?

unit tests


