### PR TITLE
Reserve all state in OptimMethod when calling Optimizer.optimize() multiple times

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/AbstractOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/AbstractOptimizer.scala
@@ -113,6 +113,7 @@ abstract class AbstractOptimizer {
       case MklDnn => 1
       case _ => throw new IllegalArgumentException
     }
+    val start = System.nanoTime()
     val results = ZippedPartitionsWithLocalityRDD(models, validateRDD)((modelIter, dataIter) => {
       val cached = modelIter.next()
       val vMethodsArr = cached.localMethods
@@ -157,6 +158,12 @@ abstract class AbstractOptimizer {
         l + r
       }
     }).zip(vMethods)
+
+    val validateTime = (System.nanoTime() - start) / 1e9f
+    val count = results(0)._1.result()._2.toFloat
+    // print validation throughput
+    logger.info(s"$header validate model throughput is ${count / validateTime} records/second")
+
     results.foreach(r => {
       logger.info(s"$header ${r._2} is ${r._1}")
     })

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -707,6 +707,14 @@ class DistriOptimizer[T: ClassTag] (
    * If you want to reserve optimMethod for each worker, and reuse those methods in
    * next training task, you can call it.
    */
+
+  /**
+   * If you want to reserve optimMethod for each worker and reuse those methods in
+   * next training task, please set reserve = true
+   * Otherwise, if just using optimMethod you set in optimizer, please set reserve = false
+   * @param reserve whether to reserve optim method for each worker
+   * @return
+   */
   def reserveOptim(reserve: Boolean): this.type = {
     reserveOptimMethod = reserve
     this

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -707,8 +707,8 @@ class DistriOptimizer[T: ClassTag] (
    * If you want to reserve optimMethod for each worker, and reuse those methods in
    * next training task, you can call it.
    */
-  def reserveOptim(): this.type = {
-    reserveOptimMethod = true
+  def reserveOptim(reserve: Boolean): this.type = {
+    reserveOptimMethod = reserve
     this
   }
 
@@ -923,11 +923,12 @@ class DistriOptimizer[T: ClassTag] (
 
     // reserve optimMethod internal state for each worker if need
     if (reserveOptimMethod) {
-      previousOptim = models.map(m => m.optimMethods)
+      previousOptim = models.map(m => m.optimMethods).cache()
+      previousOptim.count()
     } else {
-      previousOptim = null
-      models.unpersist()
+      if (previousOptim != null) previousOptim.unpersist()
     }
+    models.unpersist()
 
     model
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -715,7 +715,7 @@ class DistriOptimizer[T: ClassTag] (
    * @param reserve whether to reserve optim method for each worker
    * @return
    */
-  def reserveOptim(reserve: Boolean): this.type = {
+  override def reserveOptim(reserve: Boolean): this.type = {
     reserveOptimMethod = reserve
     this
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Optimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Optimizer.scala
@@ -466,6 +466,11 @@ abstract class Optimizer[T: ClassTag, D](
    * shutdown the optimizer, which will release the native resources if exists.
    */
   private[optim] def shutdown(): Unit = {}
+
+  def reserveOptim(reserve: Boolean): this.type = {
+    throw new UnsupportedOperationException(
+      "Only support DistriOptimizer to reserve optim methods for each worker")
+  }
 }
 
 object Optimizer {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DistriOptimizerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DistriOptimizerSpec.scala
@@ -930,6 +930,10 @@ class DistriOptimizerSpec extends FlatSpec with Matchers with BeforeAndAfter {
       t1.learningRate should be(t2.learningRate)
       t1.learningRateDecay should be(t2.learningRateDecay)
       t1.Epsilon should be(t2.Epsilon)
+
+      t2.state.contains("s") should be(true)
+      t2.state.contains("r") should be(true)
+
       t1.state should be(t2.state)
 
       i += 1

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DistriOptimizerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DistriOptimizerSpec.scala
@@ -911,7 +911,7 @@ class DistriOptimizerSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     optimizer
         .setOptimMethod(optimMethod)
-        .reserveOptim()
+        .reserveOptim(true)
         .setEndWhen(Trigger.maxIteration(3))
     val model = optimizer.optimize()
     val optim1 = optimizer.previousOptim.collect()


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Print validation throughput when doing distribute training
2. Support user to reserve optimMethod on each worker and reuse in next training task

## How was this patch tested?

unit tests

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/2640
fixed https://github.com/intel-analytics/BigDL/issues/2636

