### PR TITLE
fix: uuid() will return a new uuid every call

### DIFF
--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/PredictorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/PredictorSpec.scala
@@ -268,8 +268,11 @@ class PredictorSpec extends SparkContextLifeCycle with Matchers {
     var second: Map[Long, StorageInfo] = null
     (0 until 20).foreach { i =>
       val detection = quant.predictImage(imageFrame, batchPerPartition = 16).toDistributed()
-      detection.rdd.first()
-      detection.rdd.collect()
+
+      // adding a transformer to handle multi trans of detection will be right
+      val transformer = ImageFrameToSample()
+      transformer(detection).toDistributed().rdd.collect()
+
       println("=" * 80)
       println(StorageManager.get().count(!_._2.isFreed))
       println("-" * 80)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch fix two bugs.

1. ModelBroadcast will generate a new uuid when call `uuid()`. So `value()` will delete all models because their `uuid` are different with the new `uuid`.
2. If multiple partitions are mapped to the same worker, it will delete the previous cached model.

## How was this patch tested?

Manual and Jenkins.

