### PR TITLE
fix: uuid() will return a new uuid every call

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/utils/ModelBroadcast.scala
@@ -35,6 +35,8 @@ import scala.reflect.ClassTag
  * ModelBroadcast is used to broadcast model
  */
 trait ModelBroadcast[T] extends Serializable {
+  private val _uuid = UUID.randomUUID().toString
+
   /**
    * Broadcast the model
    * @param sc    SparkContext
@@ -52,7 +54,7 @@ trait ModelBroadcast[T] extends Serializable {
    */
   def value(initGradient: Boolean = false, shareWeight: Boolean = true): Module[T]
 
-  def uuid(): String = UUID.randomUUID().toString
+  def uuid(): String = _uuid
 }
 
 object ModelBroadcast {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/PredictorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/PredictorSpec.scala
@@ -279,8 +279,11 @@ class PredictorSpec extends FlatSpec with Matchers with BeforeAndAfter{
     var second: Map[Long, StorageInfo] = null
     (0 until 20).foreach { i =>
       val detection = quant.predictImage(imageFrame, batchPerPartition = 16).toDistributed()
-      detection.rdd.first()
-      detection.rdd.collect()
+
+      // adding a transformer to handle multi trans of detection will be right
+      val transformer = ImageFrameToSample()
+      transformer(detection).toDistributed().rdd.collect()
+
       println("=" * 80)
       println(StorageManager.get().count(!_._2.isFreed))
       println("-" * 80)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch fix a bug of `ModelBroadcast`. ModelBroadcast will generate a new uuid when call uuid(). So value() will delete all models because their uuid are different with the new uuid.

## How was this patch tested?

Jenkins and manual.



