### PR TITLE
Docs update for spark 2.3, build 0.7 and deps exclude fix

### DIFF
--- a/docs/docs/ScalaUserGuide/install-pre-built.md
+++ b/docs/docs/ScalaUserGuide/install-pre-built.md
@@ -9,7 +9,7 @@ Currently, BigDL releases are hosted on maven central; here's an example to add 
 ```xml
 <dependency>
     <groupId>com.intel.analytics.bigdl</groupId>
-    <artifactId>bigdl-[SPARK_1.5|SPARK_1.6|SPARK_2.1|SPARK_2.2]</artifactId>
+    <artifactId>bigdl-[SPARK_1.5|SPARK_1.6|SPARK_2.1|SPARK_2.2|SPARK_2.3]</artifactId>
     <version>${BIGDL_VERSION}</version>
 </dependency>
 ```
@@ -17,7 +17,7 @@ Please choose the suffix according to your Spark platform.
 
 SBT developers can use
 ```sbt
-libraryDependencies += "com.intel.analytics.bigdl" % "bigdl-[SPARK_1.5|SPARK_1.6|SPARK_2.1|SPARK_2.2]" % "${BIGDL_VERSION}"
+libraryDependencies += "com.intel.analytics.bigdl" % "bigdl-[SPARK_1.5|SPARK_1.6|SPARK_2.1|SPARK_2.2|SPARK_2.3]" % "${BIGDL_VERSION}"
 ```
 You can find the optional `${BIGDL_VERSION}` from the [Release Page](../release-download.md).
 
@@ -46,7 +46,7 @@ SBT developers can use
 ```sbt
 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 ```
-Note: if you use sbt on branch 0.3 and before, you should add this configuration to `build.sbt` like below.
+Note: if you use sbt on branch 0.7 and before, you should add this configuration to `build.sbt` like below.
 
 ```scala
 val repo = "http://repo1.maven.org/maven2"
@@ -59,11 +59,13 @@ def bigquant_native(os: String): String = {
 
 }
 
-libraryDependencies += "com.intel.analytics.bigdl" % "bigdl-SPARK_2.1" % "0.3.0" exclude("com.intel.analytics.bigdl", "bigdl-core")
+libraryDependencies += "com.intel.analytics.bigdl" % "bigdl-SPARK_2.3" % "0.7.0" exclude("com.intel.analytics.bigdl", "bigdl-core") exclude("com.intel.analytics.bigdl.core.dist", "all")
+
+// Mac
 libraryDependencies += "com.intel.analytics.bigdl.native" % "mkl-java-mac" % "0.3.0" from mkl_native("mac")
 libraryDependencies += "com.intel.analytics.bigdl.bigquant" % "bigquant-java-mac" % "0.3.0" from bigquant_native("mac")
-```
 
+```
 If you want to run it on other platforms too, append below,
 
 ```scala


### PR DESCRIPTION
## What changes were proposed in this pull request?

Documentation updates for Spark 2.3, a new build and excluding additional dep for correct building and assembling packages for Spark.

## How was this patch tested?

Manual tests
