### PR TITLE
Missing Funtoo URL Link due to which `docker build` failed

### DIFF
--- a/docker/BigDL/Dockerfile
+++ b/docker/BigDL/Dockerfile
@@ -33,7 +33,7 @@ ENV PATH 			${JAVA_HOME}/bin:${PATH}
 RUN apt-get update && \
     apt-get install -y vim curl nano wget unzip maven git
 #java
-RUN wget http://ftp.osuosl.org/pub/funtoo/distfiles/oracle-java/jdk-8u152-linux-x64.tar.gz && \
+RUN wget https://build.funtoo.org/distfiles/oracle-java/jdk-8u152-linux-x64.tar.gz && \
     gunzip jdk-8u152-linux-x64.tar.gz && \
     tar -xf jdk-8u152-linux-x64.tar -C /opt && \
     rm jdk-8u152-linux-x64.tar && \


### PR DESCRIPTION
# Issue:

While building BigDL Docker Image, it fails due to incorrect JDK link under Dockerfile.


## What changes were proposed in this pull request?

The URL link for downloading JDK went missing due to which the docker build command was unsuccessful. I have added the official link from Funtoo that fixes the issue.

The correct link - ```https://build.funtoo.org/distfiles/oracle-java/jdk-8u152-linux-x64.tar.gz```

## How was this patch tested?

Manual Test was performed. I tested it on one of my Ubuntu 16.04 running on DellEMC Bare Metal System.


```
root@csetower:~# docker version
Client:
 Version:           18.06.1-ce
 API version:       1.38
 Go version:        go1.10.3
 Git commit:        e68fc7a
 Built:             Tue Aug 21 17:24:51 2018
 OS/Arch:           linux/amd64
 Experimental:      false

Server:
 Engine:
  Version:          18.06.1-ce
  API version:      1.38 (minimum version 1.12)
  Go version:       go1.10.3
  Git commit:       e68fc7a
  Built:            Tue Aug 21 17:23:15 2018
  OS/Arch:          linux/amd64
  Experimental:     false
```

## Cloning the Repository

```
cd ~  
git clone https://github.com/intel-analytics/BigDL.git  
cd BigDL/docker/BigDL  
sudo docker build --build-arg BIGDL_VERSION=0.5.0 -t bigdl/bigdl:default .  
```

The above command throws an error stating invalid URL link.