### PR TITLE
Fix ut failed due to duplicated spark context

### DIFF
--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/BatchNormalizationSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/BatchNormalizationSpec.scala
@@ -20,20 +20,24 @@ import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import com.intel.analytics.bigdl.utils.{Engine, T}
 import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
 import org.apache.spark.SparkContext
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
 @com.intel.analytics.bigdl.tags.Parallel
-class BatchNormalizationSpec extends FlatSpec with Matchers {
+class BatchNormalizationSpec extends FlatSpec with Matchers with BeforeAndAfter{
+  before {
+    System.setProperty("bigdl.localMode", "true")
+    System.setProperty("spark.master", "local[2]")
+    Engine.init
+  }
+
+  after {
+    System.clearProperty("bigdl.localMode")
+    System.clearProperty("spark.master")
+  }
 
   "BacthNormalization parameter sync" should "work properly" in {
-    val conf = Engine.createSparkConf().setAppName("Test sync")
-      .set("spark.rpc.message.maxSize", "200").setMaster("local[*]")
-    val sc = SparkContext.getOrCreate(conf)
-
-    Engine.init
-
     val bn = BatchNormalization[Float](2)
 
     bn.setParallism(1)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialBatchNormalizationSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialBatchNormalizationSpec.scala
@@ -21,18 +21,23 @@ import com.intel.analytics.bigdl.utils.Engine
 import com.intel.analytics.bigdl.utils.RandomGenerator.RNG
 import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
 import org.apache.spark.SparkContext
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.util.Random
 
-class SpatialBatchNormalizationSpec extends FlatSpec with Matchers {
+class SpatialBatchNormalizationSpec extends FlatSpec with Matchers with BeforeAndAfter {
+  before {
+    System.setProperty("bigdl.localMode", "true")
+    System.setProperty("spark.master", "local[2]")
+    Engine.init
+  }
+
+  after {
+    System.clearProperty("bigdl.localMode")
+    System.clearProperty("spark.master")
+  }
 
   "SpatialBacthNormalization parameter sync" should "work properly" in {
-
-    val conf = Engine.createSparkConf().setAppName("Test sync")
-      .set("spark.rpc.message.maxSize", "200").setMaster("local[*]")
-    val sc = SparkContext.getOrCreate(conf)
-
     Engine.init
 
     val bn = SpatialBatchNormalization[Float](2)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/SparkContextLifeCycle.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/SparkContextLifeCycle.scala
@@ -39,8 +39,8 @@ trait SparkContextLifeCycle extends FlatSpec with BeforeAndAfter {
 
   before {
     Engine.init(nodeNumber, coreNumber, true)
-    val conf = new SparkConf().setMaster(s"local[$coreNumber]").setAppName(appName)
-    sc = new SparkContext(conf)
+    val conf = Engine.createSparkConf().setMaster(s"local[$coreNumber]").setAppName(appName)
+    sc = SparkContext.getOrCreate(conf)
     beforeTest
   }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoaderSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/tf/TensorflowLoaderSpec.scala
@@ -78,7 +78,9 @@ class TensorflowLoaderSpec extends TensorflowSpecHelper{
   var dataSet: DistributedDataSet[MiniBatch[Float]] = null
 
   override def doBefore(): Unit = {
-    sc = new SparkContext("local[1]", "RDDOptimizerSpec")
+    val conf = Engine.createSparkConf().setAppName("RDDOptimizerSpec")
+      .setMaster("local[1]")
+    sc = SparkContext.getOrCreate(conf)
 
     val rdd = sc.parallelize(1 to (256 * 4), 4).map(prepareData)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

fix ut failed due to duplicate spark context on jeninks
```
[31m  org.apache.spark.SparkException: Only one SparkContext may be running in this JVM (see SPARK-2243). To ignore this error, set spark.driver.allowMultipleContexts = true. The currently running SparkContext was created at:[0m
[31morg.apache.spark.SparkContext$.getOrCreate(SparkContext.scala:2493)[0m
[31mcom.intel.analytics.bigdl.nn.BatchNormalizationSpec$$anonfun$1.apply$mcV$sp(BatchNormalizationSpec.scala:33)[0m
[31mcom.intel.analytics.bigdl.nn.BatchNormalizationSpec$$anonfun$1.apply(BatchNormalizationSpec.scala:30)[0m
[31mcom.intel.analytics.bigdl.nn.BatchNormalizationSpec$$anonfun$1.apply(BatchNormalizationSpec.scala:30)[0m
[31morg.scalatest.Transformer$$anonfun$apply$1.apply$mcV$sp(Transformer.scala:22)[0m
[31morg.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)[0m
[31morg.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)[0m
[31morg.scalatest.Transformer.apply(Transformer.scala:22)[0m
[31morg.scalatest.Transformer.apply(Transformer.scala:20)[0m
[31morg.scalatest.FlatSpecLike$$anon$1.apply(FlatSpecLike.scala:1647)[0m
[31morg.scalatest.Suite$class.withFixture(Suite.scala:1122)[0m
[31morg.scalatest.FlatSpec.withFixture(FlatSpec.scala:1683)[0m
[31morg.scalatest.FlatSpecLike$class.invokeWithFixture$1(FlatSpecLike.scala:1644)[0m
[31morg.scalatest.FlatSpecLike$$anonfun$runTest$1.apply(FlatSpecLike.scala:1656)[0m
[31morg.scalatest.FlatSpecLike$$anonfun$runTest$1.apply(FlatSpecLike.scala:1656)[0m
[31morg.scalatest.SuperEngine.runTestImpl(Engine.scala:306)[0m
[31morg.scalatest.FlatSpecLike$class.runTest(FlatSpecLike.scala:1656)[0m
[31morg.scalatest.FlatSpec.runTest(FlatSpec.scala:1683)[0m
[31morg.scalatest.FlatSpecLike$$anonfun$runTests$1.apply(FlatSpecLike.scala:1714)[0m
[31morg.scalatest.FlatSpecLike$$anonfun$runTests$1.apply(FlatSpecLike.scala:1714)[0m
[31m  at org.apache.spark.SparkContext$$anonfun$assertNoOtherContextIsRunning$2.apply(SparkContext.scala:2456)[0m
[31m  at org.apache.spark.SparkContext$$anonfun$assertNoOtherContextIsRunning$2.apply(SparkContext.scala:2452)[0m
[31m  at scala.Option.foreach(Option.scala:257)[0m
[31m  at org.apache.spark.SparkContext$.assertNoOtherContextIsRunning(SparkContext.scala:2452)[0m
[31m  at org.apache.spark.SparkContext$.markPartiallyConstructed(SparkContext.scala:2541)[0m
[31m  at org.apache.spark.SparkContext.<init>(SparkContext.scala:84)[0m
[31m  at com.intel.analytics.bigdl.utils.SparkContextLifeCycle$$anonfun$1.apply(SparkContextLifeCycle.scala:43)[0m
[31m  at org.scalatest.BeforeAndAfter$class.runTest(BeforeAndAfter.scala:195)[0m
[31m  at com.intel.analytics.bigdl.dataset.text.TextToLabeledSentenceSpec.runTest(TextToLabeledSentenceSpec.scala:29)[0m
[31m  at org.scalatest.FlatSpecLike$$anonfun$runTests$1.apply(FlatSpecLike.scala:1714)[0m
[31m  ...[0m
```


## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If it is possible, please attach a screenshot; otherwise, remove this)

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

