### PR TITLE
[Enhancement] update  latest weight for validation

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -462,7 +462,8 @@ object DistriOptimizer extends AbstractOptimizer {
           models,
           driverState,
           validationSummary,
-          _header
+          _header,
+          parameters
         )
 
         trainSummary.foreach { summary =>


### PR DESCRIPTION
## What changes were proposed in this pull request?

For optimization validation, the validation does not apply latest iteration updated weights. this does not impact the final model accuracy, but the validation accuracy for last iteration will be different from evaluation result after model optimization. 

related user query : https://groups.google.com/forum/#!topic/bigdl-user-group/hjEjfgHyfbQ


## How was this patch tested?
Run lenet example, PR

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/2709

