### PR TITLE
[Enhancement] - Enhance unig test to avoid dynamic resource allocation issue by docker

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalPredictor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalPredictor.scala
@@ -24,7 +24,7 @@ import com.intel.analytics.bigdl.nn.quantized.QuantizedModule
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.transform.vision.image.{ImageFeature, ImageFrame, LocalImageFrame}
 import com.intel.analytics.bigdl.utils.Util._
-import com.intel.analytics.bigdl.utils.{Engine, MklBlas, Util}
+import com.intel.analytics.bigdl.utils.{Engine, MklBlas, MklDnn, Util}
 import org.apache.log4j.Logger
 
 import scala.reflect.ClassTag
@@ -56,7 +56,7 @@ class LocalPredictor[T: ClassTag] private[optim](model: Module[T],
 
   private val subModelNumber = Engine.getEngineType match {
     case MklBlas => coreNumber
-    case _ => throw new IllegalArgumentException
+    case MklDnn => 1
   }
 
   // we should clone a new model which has no impact to origin model

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/LocalPredictorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/LocalPredictorSpec.scala
@@ -27,7 +27,7 @@ import com.intel.analytics.bigdl.nn.quantized.StorageManager
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.transform.vision.image._
 import com.intel.analytics.bigdl.transform.vision.image.augmentation.{CenterCrop, ChannelNormalize, Resize}
-import com.intel.analytics.bigdl.utils.{Engine, MklBlas, Table, Util}
+import com.intel.analytics.bigdl.utils._
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 import org.apache.commons.io.FileUtils
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
@@ -44,8 +44,9 @@ class LocalPredictorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     Engine.init(nodeNumber, coreNumber, false)
     subModelNumber = Engine.getEngineType match {
       case MklBlas => coreNumber
-      case _ => throw new IllegalArgumentException
+      case MklDnn => 1
     }
+
   }
 
   after {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/DistributedSynchronizerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/DistributedSynchronizerSpec.scala
@@ -25,7 +25,7 @@ class DistributedSynchronizerSpec extends FlatSpec with Matchers with BeforeAndA
   var sc: SparkContext = null
 
   before {
-    val conf = Engine.createSparkConf().setAppName("test synchronizer").setMaster("local[*]")
+    val conf = Engine.createSparkConf().setAppName("test synchronizer").setMaster("local[4]")
       .set("spark.rpc.message.maxSize", "200")
     sc = new SparkContext(conf)
     Engine.init


### PR DESCRIPTION
## What changes were proposed in this pull request?

Java runtime will get available processors to set the executor cores in Spark, but it will not match the one specified in command line of ran from docker. this enhancement is to set fixed number for spark to avoid the inconsistency 

## How was this patch tested?

unit test

## Related links or issues (optional)


