### PR TITLE
Fix Add operation error when type is Double importing Tensorflow graph

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Add.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/tf/loaders/Add.scala
@@ -29,12 +29,13 @@ import scala.reflect.ClassTag
 class Add extends TensorflowOpsLoader {
   override def build[T: ClassTag](nodeDef: NodeDef, byteOrder: ByteOrder
     , context: Context[T])(implicit ev: TensorNumeric[T]): Module[T] = {
-
     val t = getType(nodeDef.getAttrMap, "T")
     if (t == DataType.DT_FLOAT) {
       new CAddTable[T, Float]()
     } else if (t == DataType.DT_INT32) {
       new CAddTable[T, Int]()
+    } else if (t == DataType.DT_DOUBLE) {
+      new CAddTable[T, Double]()
     } else {
       throw new UnsupportedOperationException(s"Not support numeric type $t")
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Loading wan Tensor flow graph with and Add operation gives the following result:

"Cannot convert the given tensorflow operation graph to BigDL model. The convert fails
 at node Linear33c12dce/add. Operation type is Add". 

 I had to add the "else if" clause to support the Double Type in this kind of operation importing graph to Bigdl format.

## How was this patch tested?

As the change is so minimal I don´t include a specific unit test. 

## Related links or issues (optional)
I didn´t open issue

