### PR TITLE
fix: move mkldnn computing to a single thread pool

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/MTLabeledBGRImgToBatch.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/MTLabeledBGRImgToBatch.scala
@@ -76,7 +76,7 @@ class MTLabeledBGRImgToBatch[A: ClassTag] private[bigdl](width: Int, height: Int
 
       override def next(): MiniBatch[Float] = {
         val count = new AtomicInteger(0)
-        val batch = Engine.io.invokeAndWait((0 until parallelism).map(tid => () => {
+        val batch = Engine.default.invokeAndWait((0 until parallelism).map(tid => () => {
           var position = 0
           var record = 0
           while (iterators(tid).hasNext && {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Perf.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Perf.scala
@@ -17,7 +17,7 @@
 package com.intel.analytics.bigdl.nn.mkldnn
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.mkl.{Memory, MklDnn}
+import com.intel.analytics.bigdl.mkl.{MKL, Memory, MklDnn}
 import com.intel.analytics.bigdl.nn.Graph._
 import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.nn.abstractnn.Activity
@@ -28,7 +28,7 @@ import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.RandomGenerator._
-import com.intel.analytics.bigdl.utils.{Engine, T, Table}
+import com.intel.analytics.bigdl.utils.{Engine, T, Table, ThreadPool}
 import org.apache.log4j.Logger
 import scopt.OptionParser
 
@@ -86,34 +86,39 @@ object Perf {
 
       val criterion = CrossEntropyCriterion()
 
-      if (training) {
-        if (model.isInstanceOf[MklDnnContainer]) {
-          model.asInstanceOf[MklDnnContainer]
-            .compile(TrainingPhase, Array(HeapData(inputShape, inputFormat)))
-        } else if (model.isInstanceOf[DnnGraph]) {
-          model.asInstanceOf[DnnGraph].compile(TrainingPhase)
+      Engine.computing.invokeAndWait2(Array(1).map(_ => () => {
+        if (training) {
+          if (model.isInstanceOf[MklDnnContainer]) {
+            model.asInstanceOf[MklDnnContainer]
+              .compile(TrainingPhase, Array(HeapData(inputShape, inputFormat)))
+          } else if (model.isInstanceOf[DnnGraph]) {
+            model.asInstanceOf[DnnGraph].compile(TrainingPhase)
+          }
+          model.training()
+        } else {
+          if (model.isInstanceOf[MklDnnContainer]) {
+            model.asInstanceOf[MklDnnContainer]
+              .compile(InferencePhase, Array(HeapData(inputShape, inputFormat)))
+          } else if (model.isInstanceOf[DnnGraph]) {
+            model.asInstanceOf[DnnGraph].compile(InferencePhase)
+          }
+          model.evaluate()
         }
-        model.training()
-      } else {
-        if (model.isInstanceOf[MklDnnContainer]) {
-          model.asInstanceOf[MklDnnContainer]
-            .compile(InferencePhase, Array(HeapData(inputShape, inputFormat)))
-        } else if (model.isInstanceOf[DnnGraph]) {
-          model.asInstanceOf[DnnGraph].compile(InferencePhase)
-        }
-        model.evaluate()
-      }
+      }))
 
       var iteration = 0
       while (iteration < iterations) {
         val start = System.nanoTime()
-        val output = model.forward(input)
 
-        if (training) {
-          val _loss = criterion.forward(output, label)
-          val errors = criterion.backward(output, label).toTensor
-          model.backward(input, errors)
-        }
+        Engine.computing.invokeAndWait2(Array(1).map(_ => () => {
+          val output = model.forward(input)
+
+          if (training) {
+            val _loss = criterion.forward(output, label)
+            val errors = criterion.backward(output, label).toTensor
+            model.backward(input, errors)
+          }
+        }))
 
         val takes = System.nanoTime() - start
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/transform/vision/image/MTImageFeatureToBatch.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/transform/vision/image/MTImageFeatureToBatch.scala
@@ -73,7 +73,7 @@ class MTImageFeatureToBatch private[bigdl](width: Int, height: Int,
 
       override def next(): MiniBatch[Float] = {
         val count = new AtomicInteger(0)
-        val batch = Engine.io.invokeAndWait((0 until parallelism).map(tid => () => {
+        val batch = Engine.default.invokeAndWait((0 until parallelism).map(tid => () => {
           var position = 0
           var record = 0
           while (iterators(tid).hasNext && {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
@@ -220,8 +220,20 @@ object Engine {
   // Thread pool for layer use
   @volatile private var _model: ThreadPool = new ThreadPool(1)
 
-  // Thread pool for read data
-  @volatile private var _io: ThreadPool = null
+  // This thread is mainly for mkldnn library.
+  // Because if we use the parent thread directly, there will be two bugs,
+  //   1. The child threads forked from parent thread will be bound to core 0
+  //      because of the affinity settings.
+  //   2. The native thread has some unknown thread local variables. So if
+  //      the parent thread exits and is recreated, such as the thread from
+  //      Executors.newFixedThreadPool. The whole app will be segment fault.
+  // The parent thread means the main thread (Local Mode) or worker thread of
+  // `mapPartition` (Distributed Mode).
+  // --------------------------------------------------------------------------
+  // We will only use the `threadPool` in ThreadPool, which is a ExecutorService.
+  // For `context` in ThreadPool, it is the called thread when poolSize is 1.
+  // So many usages of that thread, we will not change it for now.
+  val computing: ThreadPool = new ThreadPool(1)
 
   /**
    * If user undefine the property bigdl.coreNumber, it will return physical core number
@@ -321,24 +333,13 @@ object Engine {
     _default
   }
 
-  private[bigdl] def io: ThreadPool = {
-    if (_io == null) {
-      throw new IllegalStateException(s"Engine.init: Thread engine is not " +
-        s"initialized. $NOT_INIT_ERROR")
-    }
-    _io
-  }
-
   private def initThreadPool(core : Int) : Unit = {
     val defaultPoolSize: Int = System.getProperty("bigdl.utils.Engine.defaultPoolSize",
       (core * 50).toString).toInt
     if(_default == null || _default.getPoolSize != defaultPoolSize) {
       _default = new ThreadPool(defaultPoolSize)
     }
-
-    if (_io == null) {
-      _io = new ThreadPool(core * 50)
-    }
+    _default.setMKLThread(1)
 
     // for dnn model we should set the pool size to 1 also.
     // otherwise, it will downgrade the performance and
@@ -350,7 +351,13 @@ object Engine {
     }
     _model.setMKLThread(MKL.getMklNumThreads)
 
-    ThreadPool.setThreadsOfBackend(MKL.getMklNumThreads)
+    // do two things, set number of threads for omp thread pool and set the affinity
+    // only effects the `threadPool` and `computing.invoke/invokeAndWait` will not
+    // be effected. And affinity will not effect the other threads except
+    // this thread and the omp threads forked from computing.
+    computing.invokeAndWait2((0 until 1).map(_ => () => {
+      ThreadPool.setThreadsOfBackend(MKL.getMklNumThreads)
+    }))
   }
 
   /**
@@ -545,9 +552,7 @@ object Engine {
     val threadsNumber = System.getProperty("bigdl.mklNumThreads", default.toString)
     System.setProperty("bigdl.mklNumThreads", s"$threadsNumber")
 
-
     System.setProperty("bigdl.disable.mklBlockTime", "true")
     System.setProperty("bigdl.coreNumber", "1")
-    System.setProperty("bigdl.utils.Engine.defaultPoolSize", "1")
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/intermediate/IRGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/intermediate/IRGraph.scala
@@ -67,8 +67,10 @@ private[bigdl] class IRGraph[T: ClassTag](
     if (graph == null) {
       throw new UnsupportedOperationException("forward not supported, Please build graph first")
     }
-    initFwdPrimitives(input)
-    output = graph.updateOutput(input)
+    Engine.computing.invokeAndWait2(Array(0).map(_ => () => {
+      initFwdPrimitives(input)
+      output = graph.updateOutput(input)
+    }))
     output
   }
 
@@ -76,8 +78,10 @@ private[bigdl] class IRGraph[T: ClassTag](
     if (graph == null) {
       throw new UnsupportedOperationException("backward not supported, Please build graph first")
     }
-    initBwdPrimitives()
-    gradInput = graph.updateGradInput(input, gradOutput)
+    Engine.computing.invokeAndWait2(Array(0).map(_ => () => {
+      initBwdPrimitives()
+      gradInput = graph.updateGradInput(input, gradOutput)
+    }))
     gradInput
   }
 
@@ -85,8 +89,10 @@ private[bigdl] class IRGraph[T: ClassTag](
     if (graph == null) {
       throw new UnsupportedOperationException("backward not supported, Please build graph first")
     }
-    initGradWPrimitives()
-    graph.accGradParameters(input, gradOutput)
+    Engine.computing.invokeAndWait2(Array(0).map(_ => () => {
+      initGradWPrimitives()
+      graph.accGradParameters(input, gradOutput)
+    }))
   }
 
   def build(): this.type = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/visualization/tensorboard/FileWriter.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/visualization/tensorboard/FileWriter.scala
@@ -37,7 +37,7 @@ private[bigdl] class FileWriter(val logDirectory : String, flushMillis: Int = 10
   if (!fs.exists(logPath)) fs.mkdirs(logPath)
 
   private val eventWriter = new EventWriter(logDirectory, flushMillis, fs)
-  Engine.io.invoke(() => eventWriter.run())
+  Engine.default.invoke(() => eventWriter.run())
 
   /**
    * Adds a Summary protocol buffer to the event file.

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/ReorderMemorySpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/ReorderMemorySpec.scala
@@ -16,10 +16,76 @@
 package com.intel.analytics.bigdl.nn.mkldnn
 
 import com.intel.analytics.bigdl.mkl.Memory
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.bigdl.utils.BigDLSpecHelper
+import com.intel.analytics.bigdl.utils.Engine
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
-class ReorderMemorySpec extends BigDLSpecHelper {
+class ReorderMemorySpec extends FlatSpec with Matchers with BeforeAndAfter {
+  "lenet5 with reorder" should "works no segment fault" in {
+    // after upgrade to mkldnn v0.17, the thread local variables will cause spark to stop
+    // this test case tests the single pool
+    System.setProperty("bigdl.localMode", "true")
+    System.setProperty("bigdl.engineType", "mkldnn")
+    System.setProperty("bigdl.coreNumber", "1")
+    System.setProperty("bigdl.utils.Engine.defaultPoolSize", "1")
+    Engine.init
+
+    println(System.getProperty("bigdl.engineType"))
+
+    val inputShape = Array(100, 1, 28, 28)
+    val outputShape = Array(100, 10)
+
+    val model = Sequential()
+      .add(Input(inputShape, Memory.Format.nchw))
+      .add(SpatialConvolution(1, 20, 5, 5).setName("conv1"))
+      .add(SpatialBatchNormalization(20).setName("bn1"))
+      .add(MaxPooling(2, 2, 2, 2).setName("pool1"))
+      .add(SpatialConvolution(20, 50, 5, 5).setName("conv2"))
+      .add(MaxPooling(2, 2, 2, 2).setName("pool2"))
+      .add(Linear(50 * 4 * 4, 500).setName("ip1"))
+      .add(ReLU().setName("relu1"))
+      .add(Linear(500, 10).setName("ip2"))
+      .add(ReorderMemory(HeapData(outputShape, Memory.Format.nc)))
+
+    val input = Tensor[Float](inputShape).rand(-1, 1)
+    val gradOutput = Tensor[Float](outputShape).rand(-1, 1)
+
+    // we need to compile the model in the invokeAndWait2 threads.
+    Engine.default.invokeAndWait2((0 until 1).map(i =>
+      () => {
+        model.compile(TrainingPhase)
+      }))
+
+    Engine.default.invokeAndWait2((0 until 1).map(i =>
+      () => {
+        println(s"${Thread.currentThread().getId}")
+        model.training()
+        model.forward(input)
+        model.updateGradInput(input, gradOutput)
+        model.accGradParameters(input, gradOutput)
+        i
+      }
+    ), Long.MaxValue)
+
+    for (i <- 0 until 3) {
+      Engine.default.invokeAndWait2((0 until 1).map(i =>
+        () => {
+          println(s"${Thread.currentThread().getId}")
+          model.training()
+          model.forward(input)
+          model.updateGradInput(input, gradOutput)
+          i
+        }
+      ), Long.MaxValue)
+    }
+
+    System.clearProperty("bigdl.localMode")
+    System.clearProperty("bigdl.engineType")
+    System.clearProperty("bigdl.coreNumber")
+    System.clearProperty("bigdl.utils.Engine.defaultPoolSize")
+  }
+
   "From heap to native" should "be correct" in {
     val layer = ReorderMemory(new NativeData(Array(3, 4), Memory.Format.nc),
       HeapData(Array(3, 4), Memory.Format.nc))
@@ -102,5 +168,4 @@ class ReorderMemorySpec extends BigDLSpecHelper {
     inputNHWC should be(output)
     inputNHWC should be(grad)
   }
-
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/ThreadPoolSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/ThreadPoolSpec.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.utils
+
+import com.intel.analytics.bigdl.mkl.MKL
+import com.intel.analytics.bigdl.mkl.hardware.Affinity
+import org.scalatest.{FlatSpec, Matchers}
+
+class ThreadPoolSpec extends FlatSpec with Matchers {
+
+  "mkldnn backend" should "not bind all java threads to the first core" in {
+    com.intel.analytics.bigdl.mkl.MklDnn.isLoaded
+    System.setProperty("bigdl.engineType", "mkldnn")
+    val poolSize = 1
+    val ompSize = 4
+
+    val threadPool = new ThreadPool(poolSize)
+    // backup the affinities
+    val affinities = threadPool.invokeAndWait2( (0 until poolSize).map(i =>
+      () => {
+        Affinity.getAffinity()
+      })).map(_.get()).toArray
+
+    threadPool.invokeAndWait2((0 until poolSize).map(i =>
+      () => {
+        ThreadPool.setThreadsOfBackend(MKL.getNumThreads)
+      }))
+
+    threadPool.invokeAndWait2( (0 until poolSize).map( i =>
+      () => {
+        Affinity.getAffinity.length should be (1)
+        Affinity.getAffinity.head should be (0)
+      }))
+
+    // set back the affinities
+    threadPool.invokeAndWait2( (0 until poolSize).map( i => () => {
+      Affinity.setAffinity(affinities(i))
+    }))
+
+    System.clearProperty("bigdl.engineType")
+    threadPool.invokeAndWait2( (0 until poolSize).map( i =>
+      () => {
+        Affinity.getAffinity.zipWithIndex.foreach(ai => ai._1 should be (ai._2))
+      }))
+
+  }
+
+  "mkldnn thread" should "not influence other threads" in {
+    System.setProperty("bigdl.engineType", "mkldnn")
+    System.setProperty("bigdl.localMode", "true")
+    Engine.init
+
+    Engine.default.invokeAndWait( (0 until Engine.default.getPoolSize).map(i => () => {
+      Affinity.getAffinity.zipWithIndex.foreach(ai => ai._1 should be (ai._2))
+    }))
+
+    // backup the affinities
+    val affinities = Engine.default.invokeAndWait2( (0 until Engine.default.getPoolSize).map(i =>
+      () => {
+        println(Affinity.getAffinity.mkString("\t"))
+        Affinity.getAffinity()
+      })).map(_.get()).toArray
+
+    Engine.default.invokeAndWait2( (0 until Engine.default.getPoolSize).map(i => () => {
+      Affinity.getAffinity.length should be (Runtime.getRuntime.availableProcessors())
+      Affinity.getAffinity.zipWithIndex.foreach(ai => ai._1 should be (ai._2))
+    }))
+
+    Engine.default.invokeAndWait( (0 until Engine.default.getPoolSize).map(i => () => {
+      Affinity.getAffinity.zipWithIndex.foreach(ai => ai._1 should be (ai._2))
+    }))
+
+    // set back the affinities
+    Engine.default.invokeAndWait2( (0 until Engine.default.getPoolSize).map( i => () => {
+      Affinity.setAffinity(affinities(i))
+    }))
+
+    System.clearProperty("bigdl.engineType")
+    System.clearProperty("bigdl.localMode")
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Move the computing of mkldnn to a single thread.

  Because if we use the parent thread directly, there will be two bugs,
    1. The child threads forked from parent thread will be bound to core 0
       because of the affinity settings.
    2. The native thread has some unknown thread local variables. So if
       the parent thread exits and is recreated, such as the thread from
       Executors.newFixedThreadPool. The whole app will be segment fault.
  The parent thread means the main thread (Local Mode) or worker thread of
  `mapPartition` (Distributed Mode).


## How was this patch tested?
Jenkins.


