### PR TITLE
add computshape for some layers and add skip primitives in DnnGraph

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CAdd.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CAdd.scala
@@ -21,7 +21,7 @@ import com.intel.analytics.bigdl.optim.Regularizer
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.RandomGenerator._
-import com.intel.analytics.bigdl.utils.{T, Table}
+import com.intel.analytics.bigdl.utils.{Shape, T, Table}
 
 import scala.reflect.ClassTag
 
@@ -179,6 +179,10 @@ class CAdd[T: ClassTag](
 
   override def toString(): String = {
     s"${getPrintName}(${java.util.Arrays.toString(size)})"
+  }
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    inputShape
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CMul.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/CMul.scala
@@ -21,7 +21,7 @@ import com.intel.analytics.bigdl.optim.Regularizer
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.RandomGenerator._
-import com.intel.analytics.bigdl.utils.{T, Table}
+import com.intel.analytics.bigdl.utils.{Shape, T, Table}
 
 import scala.reflect.ClassTag
 
@@ -204,6 +204,10 @@ class CMul[T: ClassTag](
 
   override def toString(): String = {
     s"${getPrintName}(${java.util.Arrays.toString(size)})"
+  }
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    inputShape
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/DetectionOutputSSD.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/DetectionOutputSSD.scala
@@ -23,7 +23,7 @@ import com.intel.analytics.bigdl.nn.{Module => _, _}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.transform.vision.image.util.BboxUtil
-import com.intel.analytics.bigdl.utils.Table
+import com.intel.analytics.bigdl.utils.{Shape, Table}
 import org.apache.log4j.Logger
 import DetectionOutputSSD.logger
 
@@ -274,6 +274,14 @@ class DetectionOutputSSD[T: ClassTag](val nClasses: Int = 21,
     allIndicesNum = null
     if (null != confPost) confPost.clearState()
     this
+  }
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    if (isTraining()) {
+      return inputShape
+    }
+    throw new RuntimeException("Haven't been " +
+      "implemented computeOutputShape for DetectionOutputSSD Inference")
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/DetectionOutputSSD.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/DetectionOutputSSD.scala
@@ -280,8 +280,7 @@ class DetectionOutputSSD[T: ClassTag](val nClasses: Int = 21,
     if (isTraining()) {
       return inputShape
     }
-    throw new RuntimeException("Haven't been " +
-      "implemented computeOutputShape for DetectionOutputSSD Inference")
+    throw new RuntimeException("Not support computeOutputShape for DetectionOutputSSD Inference")
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/InferReshape.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/InferReshape.scala
@@ -19,7 +19,9 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.nn.abstractnn.TensorModule
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
 
+import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 
 /**
@@ -163,6 +165,28 @@ class InferReshape[T: ClassTag](
       super.clearState()
     }
     this
+  }
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val inputSize = inputShape.toSingle().toArray
+    val outputSize = new ArrayBuffer[Int]()
+    inferedSizes.foreach(outputSize.append(_))
+
+    var total = subTotal
+    var i = 0
+    while (i < size.length) {
+      if (size(i) == 0) { // use the same dim value as input
+        outputSize(i + startIndex) = inputSize(i)
+        total *= inputSize(i)
+      }
+      i += 1
+    }
+    if (inferIndex != -1) {
+      outputSize(inferIndex) = inputSize.product / total
+      if (batchMode) outputSize(inferIndex) = outputSize(inferIndex) / inputSize(0)
+    }
+    if (batchMode) outputSize(0) = inputSize(0)
+    Shape(outputSize.toArray)
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Normalize.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Normalize.scala
@@ -18,6 +18,7 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.nn.abstractnn.TensorModule
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
 
 import scala.reflect.ClassTag
 
@@ -175,6 +176,10 @@ class Normalize[T: ClassTag](val p: Double, val eps: Double = 1e-10
     def getHashCode(a: Any): Int = if (a == null) 0 else a.hashCode()
     val state = Seq(super.hashCode(), p, eps)
     state.map(getHashCode).foldLeft(0)((a, b) => 31 * a + b)
+  }
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    inputShape
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/NormalizeScale.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/NormalizeScale.scala
@@ -20,7 +20,7 @@ import com.intel.analytics.bigdl.nn.abstractnn.TensorModule
 import com.intel.analytics.bigdl.optim.Regularizer
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
-import com.intel.analytics.bigdl.utils.{T, Table}
+import com.intel.analytics.bigdl.utils.{Shape, T, Table}
 
 import scala.reflect.ClassTag
 
@@ -64,6 +64,11 @@ class NormalizeScale[T: ClassTag](val p: Double, val eps: Double = 1e-10,
 
   override def parameters(): (Array[Tensor[T]], Array[Tensor[T]]) = {
     (Array(cmul.weight), Array(cmul.gradWeight))
+  }
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val outShape = normalize.computeOutputShape(inputShape)
+    cmul.computeOutputShape(outShape)
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Power.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Power.scala
@@ -19,6 +19,7 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, TensorModule}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.Shape
 
 import scala.reflect.ClassTag
 
@@ -101,6 +102,10 @@ class Power[T: ClassTag](
 
   override def toString(): String = {
     s"${getPrintName}($power, $scale, $shift)"
+  }
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    inputShape
   }
 
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Scale.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Scale.scala
@@ -21,7 +21,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.serializer._
 import com.intel.analytics.bigdl.utils.serializer.converters.DataConverter
-import com.intel.analytics.bigdl.utils.{T, Table}
+import com.intel.analytics.bigdl.utils.{Shape, T, Table}
 import com.intel.analytics.bigdl.serialization.Bigdl.{AttrValue, BigDLModule}
 
 import scala.reflect.ClassTag
@@ -74,6 +74,11 @@ class Scale[T: ClassTag](val size: Array[Int])
   }
 
   override def toString: String = "nn.Scale"
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val outputShape = cmul.computeOutputShape(inputShape)
+    cadd.computeOutputShape(outputShape)
+  }
 }
 
 object Scale extends ModuleSerializable {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftMax.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftMax.scala
@@ -19,7 +19,7 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.nn.abstractnn.TensorModule
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
-import com.intel.analytics.bigdl.utils.Engine
+import com.intel.analytics.bigdl.utils.{Engine, Shape}
 
 import scala.concurrent.Future
 import scala.reflect.ClassTag
@@ -61,6 +61,10 @@ class SoftMax[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends TensorModule
     gradInput.resizeAs(output)
     SoftMax.updateGradInput[T](input, gradOutput, gradInput, output, results)
     gradInput
+  }
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    inputShape
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributed.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TimeDistributed.scala
@@ -20,7 +20,7 @@ import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, TensorModule}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
-import com.intel.analytics.bigdl.utils.Table
+import com.intel.analytics.bigdl.utils.{Shape, Table}
 import com.intel.analytics.bigdl.utils.serializer.{DeserializeContext, ModuleSerializable}
 import com.intel.analytics.bigdl.utils.serializer.converters.DataConverter
 
@@ -247,6 +247,17 @@ class TimeDistributed[T : ClassTag] (
 
   override def getExtraParameter(): Array[Tensor[T]] = {
     layer.getExtraParameter()
+  }
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val _inputSize = inputShape.toSingle().toArray
+    val inputSize = new Array[Int](_inputSize.length - 1)
+    val outputSize = new Array[Int](_inputSize.length)
+
+    combine(_inputSize, inputSize)
+    val _outputSize = layer.computeOutputShape(Shape(inputSize)).toSingle().toArray
+    split(_outputSize, outputSize, _inputSize(0), _inputSize(1))
+    Shape(outputSize)
   }
 
   override def clearState(): TimeDistributed.this.type = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Transpose.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Transpose.scala
@@ -22,6 +22,7 @@ import com.intel.analytics.bigdl.tensor.TensorNumericMath.{NumericWildcard, Tens
 import com.intel.analytics.bigdl.utils.serializer._
 import com.intel.analytics.bigdl.utils.serializer.converters.DataConverter
 import com.intel.analytics.bigdl.serialization.Bigdl.{AttrValue, BigDLModule}
+import com.intel.analytics.bigdl.utils.Shape
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe
@@ -65,6 +66,18 @@ class Transpose[T: ClassTag](
     gradInput.resizeAs(buffer).asInstanceOf[Tensor[NumericWildcard]]
       .copy(buffer.asInstanceOf[Tensor[NumericWildcard]])
     gradInput
+  }
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    val inputSize = inputShape.toSingle().toArray
+    var i = 0
+    while (i < permutations.length) {
+      val tmp = inputSize(permutations(i)._1 - 1)
+      inputSize(permutations(i)._1 - 1) = inputSize(permutations(i)._2 - 1)
+      inputSize(permutations(i)._2 - 1) = tmp
+      i += 1
+    }
+    Shape(inputSize)
   }
 
   override def toString(): String = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/BlasWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/BlasWrapper.scala
@@ -44,7 +44,7 @@ private[bigdl] class BlasWrapper(val module: AbstractModule[Activity, Activity, 
       case 3 => Memory.Format.ntc
       case 2 => Memory.Format.nc
       case 1 => Memory.Format.x
-      case _ => throw new UnsupportedOperationException(s"UnSupport dims ${dims}")
+      case _ => throw new UnsupportedOperationException(s"UnSupported dims ${dims}")
     }
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/intermediate/IRConverter.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/intermediate/IRConverter.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.intermediate
 
 import com.intel.analytics.bigdl.nn.Graph
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
-import com.intel.analytics.bigdl.nn.mkldnn.{DnnGraph, InputWrapper, Output}
+import com.intel.analytics.bigdl.nn.mkldnn._
 import com.intel.analytics.bigdl.tensor.{FloatType, Tensor}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.{Module, utils}
@@ -91,8 +91,11 @@ private[bigdl] class IRConverter[T: ClassTag](IRgraph: IRGraph[T])(implicit ev: 
     // add output node for graph
     val realOutputs = outputs.zipWithIndex.map {
       case (model: Node[Module[Float]], index: Int) =>
-        val node = new Node[Module[Float]](Output(IRgraph.outputFormats(index)))
-        model.add(node)
+        val node = if (model.element.isInstanceOf[BlasWrapper]) {
+          model
+        } else {
+          model.add(new Node[Module[Float]](Output(IRgraph.outputFormats(index))))
+        }
         node
     }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/BlasToDnnSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/BlasToDnnSpec.scala
@@ -34,8 +34,14 @@ import com.intel.analytics.bigdl.utils._
 import scala.util.Random
 
 class BlasToDnnSpec extends BigDLSpecHelper {
-  "vgg16 blas to dnn" should "work properly" in {
+  override def doBefore(): Unit = {
     System.setProperty("bigdl.engineType", "mkldnn")
+  }
+
+  override def doAfter(): Unit = {
+    System.setProperty("bigdl.engineType", "mklblas")
+  }
+  "vgg16 blas to dnn" should "work properly" in {
     val batchSize = 2
     val classNum = 1000
     RandomGenerator.RNG.setSeed(1000)
@@ -60,7 +66,6 @@ class BlasToDnnSpec extends BigDLSpecHelper {
   }
 
   "lenet5 blas to dnn" should "work properly" in {
-    System.setProperty("bigdl.engineType", "mkldnn")
     val batchSize = 2
     val seed = 1
     val inputFormat = Memory.Format.nchw
@@ -85,7 +90,6 @@ class BlasToDnnSpec extends BigDLSpecHelper {
   }
 
   "resnet50 blas to dnn" should "work properly" in {
-    System.setProperty("bigdl.engineType", "mkldnn")
     val batchSize = 2
     val classNum = 1000
     RandomGenerator.RNG.setSeed(1000)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/BlasToDnnSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/BlasToDnnSpec.scala
@@ -23,12 +23,13 @@ import com.intel.analytics.bigdl.models.lenet.LeNet5
 import com.intel.analytics.bigdl.models.resnet.ResNet
 import com.intel.analytics.bigdl.models.resnet.ResNet.{DatasetType, ShortcutType}
 import com.intel.analytics.bigdl.models.vgg.Vgg_16
-import com.intel.analytics.bigdl.nn.StaticGraph
+import com.intel.analytics.bigdl.nn.{Module, StaticGraph}
 import com.intel.analytics.bigdl.nn
-import com.intel.analytics.bigdl.nn.mkldnn.Equivalent
+import com.intel.analytics.bigdl.nn.mkldnn.{DnnGraph, Equivalent}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.numeric.NumericFloat
-import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, RandomGenerator, T}
+import com.intel.analytics.bigdl.utils.RandomGenerator._
+import com.intel.analytics.bigdl.utils._
 
 import scala.util.Random
 
@@ -81,5 +82,36 @@ class BlasToDnnSpec extends BigDLSpecHelper {
 
     Equivalent.nearequals(outDnn, outBlas, 1e-6) should be(true)
     Equivalent.nearequals(gradInputDnn, gradInputBlas, 1e-6) should be(true)
+  }
+
+  "resnet50 blas to dnn" should "work properly" in {
+    System.setProperty("bigdl.engineType", "mkldnn")
+    val batchSize = 2
+    val classNum = 1000
+    RandomGenerator.RNG.setSeed(1000)
+    val input = Tensor[Float](Array(batchSize, 3, 224, 224)).apply1(_ =>
+      RandomGenerator.RNG.uniform(0.1, 1.0).toFloat)
+    var gradOutput = Tensor[Float](batchSize, classNum).apply1(_ =>
+      RandomGenerator.RNG.uniform(1.0, 1000.0).toFloat)
+
+    val blas = ResNet.graph(classNum,
+      T("shortcutType" -> ShortcutType.B, "depth" -> 50,
+        "optnet" -> false, "dataset" -> DatasetType.ImageNet)).asInstanceOf[StaticGraph[Float]]
+    val irBlas = blas.toIRgraph()
+
+    irBlas.build()
+    val outBlas = blas.forward(input).toTensor[Float]
+    val outDnn = irBlas.forward(input).toTensor[Float]
+
+
+    gradOutput.resizeAs(outBlas).apply1(_ =>
+      RandomGenerator.RNG.uniform(1.0, 1000.0).toFloat)
+
+    val gradInputBlas = blas.backward(input, gradOutput).toTensor[Float]
+
+    val gradInputDnn = irBlas.backward(input, gradOutput).toTensor[Float]
+    val gradInputTensor = Tensor[Float]().resize(gradInputDnn.size()).copy(gradInputDnn)
+
+    Equivalent.nearequals(outDnn, outBlas, 1e-6) should be(true)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. add computshape for some layers, mainly for ssd model
2.  add skip primitives in DnnGraph
as output shape for some blas layers can not be computed, so in some case, we can skip such nodes

## How was this patch tested?

unit tests

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

