### PR TITLE
[BugFix]include edge case to cover all the data types

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/tf/ImageOps.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/tf/ImageOps.scala
@@ -182,6 +182,7 @@ private[bigdl] class DecodeRaw[T: ClassTag](val outType: DataType,
       case DataType.DT_INT64 => decodeInt64(input, buffer.asLongBuffer().capacity())
       case DataType.DT_FLOAT => decodeFloat(input, buffer.asFloatBuffer().capacity())
       case DataType.DT_DOUBLE => decodeDouble(input, buffer.asDoubleBuffer().capacity())
+      case _ => throw new IllegalArgumentException(s"$outType are not supported")
     }
     output
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add edge case to handle data types which are not supported yet

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If it is possible, please attach a screenshot; otherwise, remove this)

## Related links or issues (optional)

Error:(177, 5) match may not be exhaustive.
It would fail on the following inputs: DT_BFLOAT16, DT_BFLOAT16_REF, DT_COMPLEX128, DT_COMPLEX64_REF, DT_DOUBLE_REF, DT_FLOAT_REF, DT_HALF, DT_HALF_REF, DT_INT16_REF, DT_INVALID, DT_QINT16, DT_QINT16_REF, DT_QINT32, DT_QINT8, DT_QUINT16, DT_QUINT16_REF, DT_STRING, DT_STRING_REF, DT_UINT16_REF, UNRECOGNIZED
    outType match {