### PR TITLE
Remove JBoss repo out from pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,17 +51,6 @@
             </snapshots>
         </repository>
         <repository>
-            <id>jboss-repo</id>
-            <name>JBoss Repository</name>
-            <url>https://repository.jboss.org/nexus/content/repositories/releases</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
             <id>sonatype</id>
             <name>sonatype repository</name>
             <url>https://oss.sonatype.org/content/groups/public/</url>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Remove JBoss repository out from pom.xml, since no dependency is relaying on it.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If it is possible, please attach a screenshot; otherwise, remove this)

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

