### PR TITLE
[Enhancement] - Speed up BlasWrapper performance under MKL-DNN

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/BlasWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/BlasWrapper.scala
@@ -55,7 +55,7 @@ private[bigdl] class BlasWrapper(val module: AbstractModule[Activity, Activity, 
   }
 
   private[mkldnn] var needOutputFormats: Boolean = true
-  private val logger = Logger.getLogger(getClass)
+  @transient private val logger = Logger.getLogger(getClass)
 
   @transient private var subModels: Array[Module[Float]] = _
   @transient private var subModelNumber : Int = 1

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Fusion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Fusion.scala
@@ -122,7 +122,7 @@ private[mkldnn] object Fusion {
       if (conv != null) {
         node.element = conv.element
         val element = node.element.asInstanceOf[SpatialConvolution]
-        element.setSumOp(previousNodes(otherNumber - 1).element, otherNumber)
+        element.setSumOp(previousNodes(otherNumber).element, otherNumber + 1)
         conv.element = Identity[Float]().asInstanceOf[AbstractModule[Activity, Activity, Float]]
 
         val nexts = node.nextNodes(0)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
@@ -220,7 +220,7 @@ object Engine {
   // Thread pool for layer use
   @volatile private var _model: ThreadPool = new ThreadPool(1)
 
-  // Thread pool for blaw wrapper layer
+  // Thread pool for blas wrapper layer
   private[bigdl] var wrapperComputing: ThreadPool = null
 
   // This thread is mainly for mkldnn library.

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
@@ -220,6 +220,9 @@ object Engine {
   // Thread pool for layer use
   @volatile private var _model: ThreadPool = new ThreadPool(1)
 
+  // Thread pool for blaw wrapper layer
+  private[bigdl] var wrapperComputing: ThreadPool = null
+
   // This thread is mainly for mkldnn library.
   // Because if we use the parent thread directly, there will be two bugs,
   //   1. The child threads forked from parent thread will be bound to core 0
@@ -339,6 +342,9 @@ object Engine {
     if(_default == null || _default.getPoolSize != defaultPoolSize) {
       _default = new ThreadPool(defaultPoolSize)
     }
+    if (wrapperComputing == null || wrapperComputing.getPoolSize != defaultPoolSize) {
+      wrapperComputing = new ThreadPool(defaultPoolSize)
+    }
 
     // for dnn model we should set the pool size to 1 also.
     // otherwise, it will downgrade the performance and
@@ -356,6 +362,9 @@ object Engine {
     // this thread and the omp threads forked from computing.
     if (engineType == MklDnn) {
       dnnComputing.setMKLThreadOfMklDnnBackend(MKL.getMklNumThreads)
+    }
+    if (System.getProperty("multiThread", "false").toBoolean) {
+      wrapperComputing.setMKLThread(1)
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
 Current mkl-dnn implementation is that we only run single model on top of multi-thread enabled mkl-dnn, so if we switch to blas model , we will lack the ability to leverage multi threading. In order to solve the performance drop, we check the layer type and do parallel computing for blas wrapper. 

the underlying layer must be computed in batch (both input and output have same batch size)

## How was this patch tested?

unit tests and performance tests by hand

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/2744

