### PR TITLE
feature: add byte supports for DnnTensor

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Convertable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Convertable.scala
@@ -156,6 +156,8 @@ trait ConvertableFrom[@spec A] {
 
   implicit def toChar(a: A): Char
 
+  implicit def toByte(a: A): Byte
+
   implicit def toBoolean(a: A): Boolean
 }
 
@@ -173,6 +175,8 @@ trait ConvertableFromFloat extends ConvertableFrom[Float] {
   implicit def toString(a: Float): String = a.toString
 
   implicit def toChar(a: Float): Char = a.toChar
+
+  implicit def toByte(a: Float): Byte = a.toByte
 
   implicit def toBoolean(a: Float): Boolean =
     throw new UnsupportedOperationException("Float cannot be cast to Boolean type")
@@ -193,6 +197,8 @@ trait ConvertableFromDouble extends ConvertableFrom[Double] {
 
   implicit def toChar(a: Double): Char = a.toChar
 
+  implicit def toByte(a: Double): Byte = a.toByte
+
   implicit def toBoolean(a: Double): Boolean =
     throw new UnsupportedOperationException("Float cannot be cast to Boolean type")
 }
@@ -211,6 +217,8 @@ trait ConvertableFromInt extends ConvertableFrom[Int] {
   implicit def toString(a: Int): String = a.toString
 
   implicit def toChar(a: Int): Char = a.toChar
+
+  implicit def toByte(a: Int): Byte = a.toByte
 
   implicit def toBoolean(a: Int): Boolean =
     throw new UnsupportedOperationException("Float cannot be cast to Boolean type")
@@ -231,6 +239,8 @@ trait ConvertableFromShort extends ConvertableFrom[Short] {
 
   implicit def toChar(a: Short): Char = a.toChar
 
+  implicit def toByte(a: Short): Byte = a.toByte
+
   implicit def toBoolean(a: Short): Boolean =
     throw new UnsupportedOperationException("Float cannot be cast to Boolean type")
 }
@@ -249,6 +259,8 @@ trait ConvertableFromLong extends ConvertableFrom[Long] {
   implicit def toString(a: Long): String = a.toString
 
   implicit def toChar(a: Long): Char = a.toChar
+
+  implicit def toByte(a: Long): Byte = a.toByte
 
   implicit def toBoolean(a: Long): Boolean =
     throw new UnsupportedOperationException("Float cannot be cast to Boolean type")
@@ -275,6 +287,9 @@ trait ConvertableFromBoolean extends ConvertableFrom[Boolean] {
   implicit def toChar(a: Boolean): Char =
     throw new UnsupportedOperationException("Float cannot be cast to Boolean")
 
+  implicit def toByte(a: Boolean): Byte =
+    throw new UnsupportedOperationException("Boolean cannot be cast to Byte")
+
   implicit def toBoolean(a: Boolean): Boolean = a
 }
 
@@ -300,6 +315,9 @@ trait ConvertableFromString extends ConvertableFrom[String] {
   implicit def toBoolean(a: String): Boolean =
     throw new UnsupportedOperationException("Boolean cannot be cast to String")
 
+  implicit def toByte(a: String): Byte =
+    throw new UnsupportedOperationException("String cannot be cast to Byte type")
+
   implicit def toString(a: String): String = a
 }
 
@@ -320,6 +338,30 @@ trait ConvertableFromChar extends ConvertableFrom[Char] {
   implicit def toString(a: Char): String = a.toString
 
   implicit def toChar(a: Char): Char = a
+
+  implicit def toByte(a: Char): Byte = a.toByte
+
+}
+
+trait ConvertableFromByte extends ConvertableFrom[Byte] {
+  implicit def toFloat(a: Byte): Float = a.toFloat
+
+  implicit def toDouble(a: Byte): Double = a.toDouble
+
+  implicit def toInt(a: Byte): Int = a.toInt
+
+  implicit def toShort(a: Byte): Short = a.toShort
+
+  implicit def toLong(a: Byte): Long = a.toLong
+
+  implicit def toBoolean(a: Byte): Boolean =
+    throw new UnsupportedOperationException("Byte cannot be cast to boolean type")
+
+  implicit def toString(a: Byte): String = a.toString
+
+  implicit def toByte(a: Byte): Byte = a
+
+  implicit def toChar(a: Byte): Char = a.toChar
 }
 
 object ConvertableFrom {
@@ -339,5 +381,7 @@ object ConvertableFrom {
   implicit object ConvertableFromString extends ConvertableFromString
 
   implicit object ConvertableFromBoolean extends ConvertableFromBoolean
+
+  implicit object ConvertableFromByte extends ConvertableFromByte
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DnnTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DnnTensor.scala
@@ -134,6 +134,10 @@ class DnnTensor[T: ClassTag](
     true
   }
 
+  override def getType(): TensorDataType = {
+    ev.getType()
+  }
+
   override def hashCode(): Int = {
     val seed = 37
     var hash = 1
@@ -149,8 +153,35 @@ class DnnTensor[T: ClassTag](
     hash
   }
 
-  override def toString(): String = {
-    Tensor[Float]().resize(this.size()).copy(this.asInstanceOf[Tensor[Float]]).toString
+  override def set(): Tensor[T] = {
+    // TODO we will do nothing. the behavior is not the same with DenseTensor
+    this
+  }
+
+  override def toString: String = {
+    ev.getType() match {
+      case FloatType =>
+        if (size().product != this.nElement()) {
+          val dense = Tensor[Float](Array(this.nElement()))
+          Memory.CopyPtr2Array(this.storageAddress(), 0, dense.storage().array(),
+            0, nElement(), 4)
+          dense.toString
+        } else {
+          val dense = Tensor[Float](size())
+          dense.copy(this.asInstanceOf[DnnTensor[Float]])
+          dense.toString
+        }
+      case ByteType =>
+        val array = new Array[Byte](nElement())
+        Memory.CopyPtr2ByteArray(this.asInstanceOf[DnnTensor[Byte]].storageAddress(), 0,
+          array, 0, nElement(), 1)
+        array.mkString("\t")
+      case IntType =>
+        val array = new Array[Int](nElement())
+        Memory.CopyPtr2IntArray(this.storageAddress(), 0, array, 0, nElement(), 4)
+        array.mkString("\t")
+      case _ => "unknown string"
+    }
   }
 }
 
@@ -174,6 +205,12 @@ object DnnTensor {
 
   def apply[T: ClassTag](sizes: Array[Int])(implicit ev: TensorNumeric[T]): DnnTensor[T] = {
     val storage = new DnnStorage[T](sizes.product)
+    new DnnTensor[T](storage, sizes)
+  }
+
+  def apply[T: ClassTag](sizes: Array[Int], realSize: Long)(
+    implicit ev: TensorNumeric[T]): DnnTensor[T] = {
+    val storage = new DnnStorage[T](realSize.toInt) // FIXME if size more than int ?
     new DnnTensor[T](storage, sizes)
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DnnTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DnnTensor.scala
@@ -180,7 +180,7 @@ class DnnTensor[T: ClassTag](
         val array = new Array[Int](nElement())
         Memory.CopyPtr2IntArray(this.storageAddress(), 0, array, 0, nElement(), 4)
         array.mkString("\t")
-      case _ => "unknown string"
+      case _ => "unknown type"
     }
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/Tensor.scala
@@ -817,6 +817,8 @@ object BooleanType extends TensorDataType
 
 object CharType extends TensorDataType
 
+object ByteType extends TensorDataType
+
 object StringType extends TensorDataType
 
 object IntType extends TensorDataType

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/TensorNumeric.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/TensorNumeric.scala
@@ -1451,5 +1451,31 @@ object TensorNumericMath {
         a == b
       }
     }
+
+    implicit object NumericByte extends UndefinedTensorNumeric[Byte]("Byte") {
+      override def getType(): TensorDataType = ByteType
+
+      override def plus(x: Byte, y: Byte): Byte = (x + y).toByte
+
+      override def minus(x: Byte, y: Byte): Byte = (x - y).toByte
+
+      override def fromType[K](k: K)(
+        implicit c: ConvertableFrom[K]): Byte =
+        c.toByte(k)
+
+      override def axpy(n: Int, da: Byte, dx: Array[Byte], _dx_offset: Int,
+        incx: Int, dy: Array[Byte],
+        _dy_offset: Int, incy: Int): Unit = {
+        var i = 0
+        while (i < n) {
+          dy(i + _dy_offset) = (dx(_dx_offset + i) + dy(_dy_offset + i)).toByte
+          i += 1
+        }
+      }
+
+      override def nearlyEqual(a: Byte, b: Byte, epsilon: Double): Boolean = {
+        a == b
+      }
+    }
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DnnTensorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DnnTensorSpec.scala
@@ -25,8 +25,8 @@ class DnnTensorSpec extends BigDLSpecHelper {
     tensor.nElement() should be(3 * 4 * 5)
   }
 
-  "DnnTensor" should "only support float" in {
-    intercept[IllegalArgumentException] {
+  "DnnTensor" should "does not support double" in {
+    intercept[UnsupportedOperationException] {
       val t = DnnTensor[Double](3, 4, 5)
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch add Byte support for `DnnTensor` which will be used in int8 implementation.

## How was this patch tested?

Test on Jenkins and model training, inference.

