### PR TITLE
feat: reorder for int8 supports

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/AvgPooling.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/AvgPooling.scala
@@ -102,7 +102,7 @@ class AvgPooling(
       strides, kernel, paddingTL, paddingBR, MklDnn.PaddingKind.mkldnnPaddingZero)
 
     val pd = MklDnn.PrimitiveDescCreate(description, runtime.engine, fwdPD)
-    _gradInputFormats = Array(MemoryData.primitiveGradInput(pd))
+    _gradInputFormats = Array(MemoryData.operationWant(pd, Query.DiffSrcPd))
     updateGradInputPrimitives = Array(MklDnn.PrimitiveCreate2(pd,
       _gradOutputFormats.map(_.getPrimitive(runtime)),
       Array(0, 0), 2, _gradInputFormats.map(_.getPrimitive(runtime)), 1))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/BlasWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/BlasWrapper.scala
@@ -162,7 +162,9 @@ private[bigdl] class BlasWrapper(val module: AbstractModule[Activity, Activity, 
   override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
     _inputFormats = inferInputFormats(inputs)
     _outputFormats = if (needOutputFormats) inferOutputFormats(inputs) else null
-    _outputFormats.map(_.getPrimitive(runtime))
+    if (_outputFormats != null) {
+      _outputFormats.map(_.getPrimitive(runtime))
+    }
     (_inputFormats, _outputFormats)
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/BlasWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/BlasWrapper.scala
@@ -162,6 +162,7 @@ private[bigdl] class BlasWrapper(val module: AbstractModule[Activity, Activity, 
   override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
     _inputFormats = inferInputFormats(inputs)
     _outputFormats = if (needOutputFormats) inferOutputFormats(inputs) else null
+    _outputFormats.map(_.getPrimitive(runtime))
     (_inputFormats, _outputFormats)
   }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/DnnBase.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/DnnBase.scala
@@ -15,7 +15,7 @@
  */
 package com.intel.analytics.bigdl.nn.mkldnn
 
-import com.intel.analytics.bigdl.mkl.{Memory, MklDnn}
+import com.intel.analytics.bigdl.mkl.DataType
 import com.intel.analytics.bigdl.nn.DynamicContainer
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.tensor.{DenseType, DnnTensor, MklDnnType, Tensor}
@@ -80,12 +80,20 @@ trait MklDnnModuleHelper {
     }
   }
 
-  protected def initTensor(format: MemoryData): Tensor[Float] = {
+  protected def initTensor(format: MemoryData): Tensor[_] = {
+    val paddingShape = format.getPaddingShape
+    val realSize = format.getRealSize
+
     format match {
       case d: NativeData =>
-        DnnTensor[Float](Memory.GetPaddingShape(format.getMemoryDescription()))
+        d.dataType match {
+          case DataType.S8 => DnnTensor[Byte](paddingShape, realSize)
+          case DataType.U8 => DnnTensor[Byte](paddingShape, realSize)
+          case DataType.S32 => DnnTensor[Int](paddingShape, realSize)
+          case DataType.F32 => DnnTensor[Float](paddingShape, realSize)
+        }
       case d: HeapData =>
-        Tensor[Float](Memory.GetPaddingShape(format.getMemoryDescription()))
+        Tensor[Float](paddingShape)
       case _ => throw new UnsupportedOperationException("memory format is not supported")
     }
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Dropout.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Dropout.scala
@@ -39,6 +39,7 @@ class Dropout(
   override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
     _inputFormats = inputs.map(x => HeapData(x.shape, format(x.shape)))
     _outputFormats = inputs.map(x => HeapData(x.shape, format(x.shape)))
+    // we should genereate the primitives here, otherwise the initTensor can't get the padding shape
     _outputFormats.map(_.getPrimitive(runtime))
     output = initTensor(_outputFormats.head)
     (_inputFormats, _outputFormats)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Dropout.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Dropout.scala
@@ -39,6 +39,7 @@ class Dropout(
   override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
     _inputFormats = inputs.map(x => HeapData(x.shape, format(x.shape)))
     _outputFormats = inputs.map(x => HeapData(x.shape, format(x.shape)))
+    _outputFormats.map(_.getPrimitive(runtime))
     output = initTensor(_outputFormats.head)
     (_inputFormats, _outputFormats)
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Linear.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Linear.scala
@@ -272,8 +272,9 @@ class Linear(
       updateGradWTensors = buffer.toArray
     }
 
-    updateWithNewTensor(updateGradInputTensors, 0, input)
-    updateWithNewTensor(updateGradInputTensors, 1, gradOutput)
+    // do not use the updateGradInputTensors for acc
+    updateWithNewTensor(updateGradWTensors, 0, input)
+    updateWithNewTensor(updateGradWTensors, 1, gradOutput)
 
     MklDnnOps.streamSubmit(runtime.stream, 1, accGradientPrimitives,
       accGradientPrimitives.length, updateGradWMemoryPrimitives, updateGradWTensors)
@@ -300,7 +301,6 @@ class Linear(
     super.release()
     List(weight, bias, gradWeight, gradBias).foreach(_.release())
   }
-
 }
 
 object Linear {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/MaxPooling.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/MaxPooling.scala
@@ -84,8 +84,8 @@ class MaxPooling(
     fwdPD = MklDnn.PrimitiveDescCreate(description, runtime.engine, 0L)
     _outputFormats = Array(MemoryData.primitiveOutput(fwdPD))
     output = initTensor(_outputFormats(0))
-    workSpaceFormat = MemoryData.primitiveWorkSpace(fwdPD)
-    workSpace = initTensor(workSpaceFormat)
+    workSpaceFormat = MemoryData.operationWant(fwdPD, Query.WorkspacePd)
+    workSpace = initTensor(workSpaceFormat).asInstanceOf[Tensor[Float]]
     updateOutputPrimitives = Array(MklDnn.PrimitiveCreate2(fwdPD,
       _inputFormats.map(_.getPrimitive(runtime)), Array(0), 1,
       Array(_outputFormats(0), workSpaceFormat).map(_.getPrimitive(runtime)), 2))
@@ -105,7 +105,7 @@ class MaxPooling(
       strides, kernel, paddingTL, paddingBR, MklDnn.PaddingKind.mkldnnPaddingZero)
 
     val pd = MklDnn.PrimitiveDescCreate(description, runtime.engine, fwdPD)
-    _gradInputFormats = Array(MemoryData.primitiveGradInput(pd))
+    _gradInputFormats = Array(MemoryData.operationWant(pd, Query.DiffSrcPd))
     updateGradInputPrimitives = Array(MklDnn.PrimitiveCreate2(pd,
       Array(_gradOutputFormats(0), workSpaceFormat).map(_.getPrimitive(runtime)),
       Array(0, 0), 2, _gradInputFormats.map(_.getPrimitive(runtime)), 1))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/ReLU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/ReLU.scala
@@ -45,7 +45,7 @@ class ReLU(value: Float = 0.0f) extends MklDnnLayer {
       value, 0)
     require(fwdPrimDesc != UNDEFINED, "You should call initFwdPrimitives first")
     val primDesc = MklDnn.PrimitiveDescCreate(description, runtime.engine, fwdPrimDesc)
-    _gradInputFormats = Array(MemoryData.primitiveGradInput(primDesc))
+    _gradInputFormats = Array(MemoryData.operationWant(primDesc, Query.DiffSrcPd))
     updateGradInputPrimitives = Array(
       MklDnn.PrimitiveCreate2(primDesc, Array(_inputFormats(0),
         _gradOutputFormats(0)).map(_.getPrimitive(runtime)), Array(0), 2,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/ReorderManager.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/ReorderManager.scala
@@ -15,6 +15,7 @@
  */
 package com.intel.analytics.bigdl.nn.mkldnn
 
+import com.intel.analytics.bigdl.mkl.DataType
 import com.intel.analytics.bigdl.nn.abstractnn.Activity
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.T
@@ -103,7 +104,12 @@ private[mkldnn] class ReorderManager() {
         to match {
           case hh: HeapData => true
           case nn: NativeData =>
-            nn.layout != n.layout
+            // we will skip the S8 to U8 reorder
+            val doNotReorderIt = n.layout == nn.layout && (
+              n.dataType == nn.dataType || // the same data type
+                (n.dataType == DataType.S8 && nn.dataType == DataType.U8)) // skip the s8->u8
+
+            !doNotReorderIt
           case _ => throw new UnsupportedOperationException("Not support such memory format")
         }
       case _ => throw new UnsupportedOperationException("Not support such memory format")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/ReorderMemory.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/ReorderMemory.scala
@@ -128,7 +128,7 @@ class ReorderMemory(inputFormat: MemoryData, outputFormat: MemoryData,
     updateOutputPrimitives = Array(fwdReorderPrim)
 
     // recover to original data
-    output = initActivity(realOutput)
+    output = initTensor(realOutput(0))
 
     reshapeOutputIfNeeded(_outputFormats(0), output.toTensor[Float])
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DnnStorage.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DnnStorage.scala
@@ -47,7 +47,7 @@ private[tensor] class DnnStorage[T: ClassTag](size: Int) extends Storage[T] {
   // Hold the address of the native array
   @transient var ptr: Pointer = new Pointer(allocate(size))
 
-  override def length(): Int = size / bytes
+  override def length(): Int = size
 
   override def apply(index: Int): T =
     throw new UnsupportedOperationException("Not support this operation in DnnStorage")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DnnStorage.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DnnStorage.scala
@@ -47,7 +47,7 @@ private[tensor] class DnnStorage[T: ClassTag](size: Int) extends Storage[T] {
   // Hold the address of the native array
   @transient var ptr: Pointer = new Pointer(allocate(size))
 
-  override def length(): Int = size
+  override def length(): Int = size / bytes
 
   override def apply(index: Int): T =
     throw new UnsupportedOperationException("Not support this operation in DnnStorage")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DnnTensor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DnnTensor.scala
@@ -31,7 +31,7 @@ class DnnTensor[T: ClassTag](
 ) (implicit ev: TensorNumeric[T])
   extends DnnTensorUnsupportOperations[T]{
 
-  override def nElement(): Int = storage.length()
+  override def nElement(): Int = sizes.product
 
   override def copy(other: Tensor[T]): Tensor[T] = {
     other match {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/DropoutSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/DropoutSpec.scala
@@ -27,6 +27,7 @@ class DropoutSpec extends FlatSpec with Matchers {
     val zeros = Tensor[Float](Array(2, 3, 4, 4)).fill(0)
 
     val dropout = Dropout()
+    dropout.setRuntime(new MklDnnRuntime)
     dropout.initFwdPrimitives(Array(HeapData(Array(2, 3, 4, 4), Memory.Format.nchw)), TrainingPhase)
 
     {
@@ -54,6 +55,7 @@ class DropoutSpec extends FlatSpec with Matchers {
     val zeros = Tensor[Float](Array(2, 3, 4, 4)).fill(0)
 
     val dropout = Dropout()
+    dropout.setRuntime(new MklDnnRuntime)
     dropout.initFwdPrimitives(Array(HeapData(Array(2, 3, 4, 4), Memory.Format.nchw)),
       InferencePhase)
     dropout.evaluate()

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/ReorderMemorySpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/ReorderMemorySpec.scala
@@ -15,6 +15,10 @@
  */
 package com.intel.analytics.bigdl.nn.mkldnn
 
+import com.intel.analytics.bigdl.mkl.{DataType, Memory}
+import com.intel.analytics.bigdl.models.lenet.LeNet5
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.tensor.{DnnTensor, Storage, Tensor}
 import com.intel.analytics.bigdl.mkl.Memory
 import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
 import com.intel.analytics.bigdl.tensor.{DnnTensor, Tensor}
@@ -115,6 +119,24 @@ class ReorderMemorySpec extends FlatSpec with Matchers with BeforeAndAfter {
     grad should be(input)
   }
 
+  "conv1" should "work correctly" in {
+    val conv = SpatialConvolution(1, 20, 5, 5)
+
+    val inputShape = Array(4, 1, 28, 28)
+    val outputShape = Array(4, 20, 24, 24)
+    val nativeData1 = NativeData(inputShape, Memory.Format.nChw8c)
+    val nativeData2 = NativeData(outputShape, Memory.Format.nChw8c)
+
+    conv.setRuntime(new MklDnnRuntime)
+    conv.initFwdPrimitives(Array(nativeData1), TrainingPhase)
+    conv.initBwdPrimitives(Array(nativeData2), TrainingPhase)
+    conv.initGradWPrimitives(Array(nativeData2), TrainingPhase)
+
+    val input = DnnTensor[Float](Array(4, 24, 28, 28))
+    val output = DnnTensor[Float](Array(4, 24, 24, 24))
+
+    conv.accGradParameters(input, output)
+  }
   "Reorder from nhwc to nchw" should "be correct" in {
     val shapeNCHW = Array(4, 3, 7, 7)
     val shapeNHWC = Array(4, 7, 7, 3)
@@ -252,5 +274,146 @@ class ReorderMemorySpec extends FlatSpec with Matchers with BeforeAndAfter {
     reorder2.forward(reorder.output)
 
     reorder2.output.toTensor[Float] should be (t1)
+  }
+
+  "F32 to S8" should "work correctly" in {
+    val shape = Array[Int](2, 2)
+    val input = Tensor[Float](Array[Float](15, 14, 8, 10), shape).rand(0, 1)
+    val nativeData = NativeData(shape, Memory.Format.nc, DataType.S8)
+    val heapData = HeapData(shape, Memory.Format.nc)
+    heapData.setMask(0)
+    heapData.setScales(Array(128.0f / input.max()))
+    val f32ToS2 = ReorderMemory(nativeData)
+
+    f32ToS2.setRuntime(new MklDnnRuntime)
+    f32ToS2.initFwdPrimitives(Array(heapData), Phase.InferencePhase)
+
+    f32ToS2.forward(input)
+
+    val srcAddress = f32ToS2.output.asInstanceOf[DnnTensor[Byte]].storageAddress()
+
+    val len = shape.product
+    val output = new Array[Byte](len)
+    Memory.CopyPtr2ByteArray(srcAddress, 0, output, 0, len, 1)
+
+    output.foreach(println)
+
+    println(input)
+
+    val S8ToF32 = ReorderMemory(HeapData(shape, Memory.Format.nc))
+    S8ToF32.setRuntime(new MklDnnRuntime)
+    S8ToF32.initFwdPrimitives(Array(nativeData), Phase.InferencePhase)
+
+    S8ToF32.forward(f32ToS2.output)
+
+    // the int part should be the same
+    S8ToF32.output.toTensor[Float].storage().array().map(_.toInt) should be (
+      input.storage().array().map(_.toInt))
+  }
+
+  "F32 to S8 NCHW" should "work correctly" in {
+    val shape = Array[Int](4, 3, 2, 2)
+    val input = Tensor[Float](shape).rand(0, 1)
+    val inputScales = input.max(1)._1.max(3)._1.max(4)._1.storage().array()
+    val nativeData = NativeData(shape, Memory.Format.nhwc, DataType.U8)
+    val heapData = HeapData(shape, Memory.Format.nchw, DataType.F32)
+    heapData.setMask(2)
+    heapData.setScales(inputScales.map(x => 255f / x))
+    val f32ToS2 = ReorderMemory(nativeData)
+    println(Memory.Format.nchw)
+
+    f32ToS2.setRuntime(new MklDnnRuntime)
+    f32ToS2.initFwdPrimitives(Array(heapData), Phase.InferencePhase)
+
+    f32ToS2.forward(input)
+
+    val srcAddress = f32ToS2.output.asInstanceOf[DnnTensor[Byte]].storageAddress()
+
+    val len = shape.product
+    val output = new Array[Byte](len)
+    Memory.CopyPtr2ByteArray(srcAddress, 0, output, 0, len, 1)
+
+    output.foreach(println)
+
+    println(input)
+
+    val S8ToF32 = ReorderMemory(HeapData(shape, Memory.Format.nchw, DataType.F32))
+    S8ToF32.setRuntime(new MklDnnRuntime)
+    S8ToF32.initFwdPrimitives(Array(f32ToS2.outputFormats()(0)), Phase.InferencePhase)
+
+    S8ToF32.forward(f32ToS2.output)
+    println(S8ToF32.output)
+
+    // the int part should be the same
+    S8ToF32.output.toTensor[Float].storage().array().map(_.toInt) should be (
+      input.storage().array().map(_.toInt))
+  }
+
+  "F32 to S32 Memory.Format.x" should "work correctly" in {
+    val shape = Array[Int](2)
+    val inputData = Array[Float](10, 12)
+    val input = Tensor[Float](inputData, shape).rand(0, 1)
+    val nativeData = NativeData(shape, Memory.Format.x, DataType.S32)
+    val heapData = HeapData(shape, Memory.Format.x)
+    heapData.setMask(1)
+    heapData.setScales(inputData.map(x => 100 / inputData.max))
+
+    println(Integer.MAX_VALUE)
+
+    val f32ToS32 = ReorderMemory(nativeData)
+
+    f32ToS32.setRuntime(new MklDnnRuntime)
+    f32ToS32.initFwdPrimitives(Array(heapData), Phase.InferencePhase)
+
+    f32ToS32.forward(input)
+
+    println(input)
+    println(f32ToS32.output)
+
+    nativeData.setMask(1)
+    nativeData.setScales(inputData.map(x => 100 / inputData.max))
+    val S32ToF32 = ReorderMemory(HeapData(shape, Memory.Format.x))
+    S32ToF32.setRuntime(new MklDnnRuntime)
+    S32ToF32.initFwdPrimitives(Array(nativeData), Phase.InferencePhase)
+
+    S32ToF32.forward(f32ToS32.output)
+
+    println(S32ToF32.output)
+
+    // the int part should be the same
+    S32ToF32.output.toTensor[Float].storage().array().map(_.toInt) should be (
+      input.storage().array().map(_.toInt))
+  }
+
+  "oihw" should "work correctly" in {
+    // this test case is used to test oihw -> hwio_s8s8 reordering.
+    // the hwio_s8s8 will need more space than padding shape, which is called additional space
+    // called by mkldnn
+    val shape = Array(50, 24, 5, 5)
+    val from = Tensor[Float](shape).rand(-1, 1)
+
+    val heap = HeapData(shape, Memory.Format.oihw, DataType.F32)
+    val native = NativeData(shape, Memory.Format.hwio_s8s8, DataType.S8)
+
+    val mask = 0
+    val scales = Array(from.abs().max()) // (1 to 50).map(i => from.select(1, i).max()).toArray
+
+    heap.setMask(mask)
+    heap.setScales(scales)
+    native.setMask(mask)
+    native.setScales(scales)
+
+    val runtime = new MklDnnRuntime
+    val reorder = ReorderMemory(native)
+    reorder.setRuntime(runtime)
+    reorder.initFwdPrimitives(Array(heap), InferencePhase)
+
+    (0 to 10).foreach ( i => {
+      println(s"do forward ${i}")
+      reorder.forward(from)
+    })
+
+    println(from)
+    println(reorder.output)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

   Supports the reorder between int8 and fp32 format.
   
   1. Because the new data type, we should add a new attribute called dataType
      to the `MemoryData`.
   2. Because we should transfer the scales between FP32->int8 and Int8->FP32.
      we should add two new attributes called `mask` and `scales`.


## How was this patch tested?

Unit tests and the full model tests by manual.

