### PR TITLE
fix: the influence of default value of fusion

### DIFF
--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ScaleCalculatorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ScaleCalculatorSpec.scala
@@ -563,6 +563,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
   "Calculating scales" should "work correct for DNN Graph Module" in {
     import com.intel.analytics.bigdl.mkl.Memory
+    System.setProperty("bigdl.mkldnn.fusion", "false")
 
     def dnnGraph(batchSize: Int, classNum: Int): mkldnn.DnnGraph = {
       val inputShape = Array(batchSize, 1, 28, 28)
@@ -630,6 +631,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
       .exists(_ == false) should be (false)
 
     graph1.release()
+    System.clearProperty("bigdl.mkldnn.fusion")
   }
 
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/TopologySpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/TopologySpec.scala
@@ -983,6 +983,7 @@ class TopologySpec extends FlatSpec with Matchers {
   }
 
   "resnet-50 block graph" should "work correctly" in {
+    System.setProperty("bigdl.mkldnn.fusion", "false")
     RandomGenerator.RNG.setSeed(1)
     val inputShape = Array(4, 3, 224, 224)
     val outputShape = Array(4, 256, 56, 56)


### PR DESCRIPTION
## What changes were proposed in this pull request?

When writing these test cases, the default value of fusion is `false`. But now the default value is `true`. But the test case should use the `false`.

## How was this patch tested?
Jenkins and NB.

