### PR TITLE
[Branch-0.8] fix: performance regression on resnet50

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/ReorderManager.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/ReorderManager.scala
@@ -107,7 +107,8 @@ private[mkldnn] class ReorderManager() {
             // we will skip the S8 to U8 reorder
             val doNotReorderIt = n.layout == nn.layout && (
               n.dataType == nn.dataType || // the same data type
-                (n.dataType == DataType.S8 && nn.dataType == DataType.U8)) // skip the s8->u8
+                (n.dataType == DataType.S8 && nn.dataType == DataType.U8) || // skip the u8 -> s8
+                (n.dataType == DataType.U8 && nn.dataType == DataType.S8)) // skip the s8->u8
 
             !doNotReorderIt
           case _ => throw new UnsupportedOperationException("Not support such memory format")


### PR DESCRIPTION
## What changes were proposed in this pull request?
This patch fix the performance regression issue of ResNet-50 after refactor.
The u8 to s8 or s8 to u8 needs no reorder on this case.

## How was this patch tested?
Jenkins and example with manual tests.

