### PR TITLE
[Backport to master]fix softmax with narrowed input

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/mkldnn/int8/GenerateInt8Scales.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/mkldnn/int8/GenerateInt8Scales.scala
@@ -52,6 +52,7 @@ object GenerateInt8Scales {
       .map(_.getInput().toTensor[Float])
 
     samples.foreach { sample =>
+      model.forward(sample)
       model.calcScales(sample)
     }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftMax.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftMax.scala
@@ -94,12 +94,13 @@ object SoftMax{
     } else {
       input.contiguous().storage().array()
     }
+    val storageOffset = input.storageOffset() - 1
 
     var t = 0
     while (t < stride * nFrame) {
       val _t = t
       results(_t) = Engine.model.invoke(() => {
-        val inputOffset = (_t / stride) * dim * stride + _t % stride
+        val inputOffset = (_t / stride) * dim * stride + _t % stride + storageOffset
         val outputOffset = (_t / stride) * dim * stride + _t % stride
 
         var inputMax = ev.fromType[Float](Float.MinValue)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Utils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Utils.scala
@@ -25,13 +25,19 @@ import com.intel.analytics.bigdl.utils.T
 
 private[bigdl] object Utils {
   def copyMaskAndScales(from: MemoryData, to: MemoryData): Unit = {
-    if (to.scales.isEmpty) {
+    // here we check the from and to, they should not be null ideally
+    // but if the model is mixin with blas layer, it may be null
+    if (from != null && to != null && to.scales.isEmpty) {
       to.setScales(from.scales.clone())
       to.setMask(from.mask)
     }
   }
 
   def copyMaskAndScales(from: Array[MemoryData], to: Array[MemoryData]): Unit = {
+    // here we check the from and to, they should not be null ideally
+    // but if the model is mixin with blas layer, it may be null
+    if (from == null || to == null) return
+
     val valid = (from.length == 1 || to.length == 1) || // the ConcatTable or JoinTable
       (from.length == to.length) // the same length of from and to.
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Utils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Utils.scala
@@ -135,7 +135,7 @@ private[bigdl] object Utils {
   def getOutput(module: AbstractModule[_, _, _], input: Activity): Activity = {
     module match {
       case mklDnnModule: MklDnnModule => module.output.asInstanceOf[Activity]
-      case _ => module.forward(input)
+      case _ => module.output.asInstanceOf[Activity]
     }
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ScaleCalculatorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ScaleCalculatorSpec.scala
@@ -53,6 +53,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     // Global mask, non-null input
     val linear1 = Linear[Float](inputSize, outputSize)
+    linear1.forward(inputTensor)
     linear1.calcScales(inputTensor)
     linear1.getInputScales() should be (Array(Array[Float](sampleMax)))
     linear1.getOutputScales().length should be (1)
@@ -67,6 +68,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     linear2.setInputDimMask(inputMask)
     linear2.setOutputDimMask(outputMask)
 
+    linear2.forward(inputTensor)
     linear2.calcScales(inputTensor)
     val output2 = linear2.output
     linear2.getInputScales() should be (Array(getScalesFromTensor(inputTensor, inputMask)))
@@ -163,6 +165,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     // Global mask, non-null input
     val spatialConv1 = SpatialConvolution[Float](inputSize, outputSize, 1, 1)
+    spatialConv1.forward(inputTensor)
     spatialConv1.calcScales(inputTensor)
     spatialConv1.getInputScales() should be (Array(Array[Float](12)))
     spatialConv1.getOutputScales().length should be (1)
@@ -174,6 +177,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     dimMaskIdx = 1
     val spatialConv2 = SpatialConvolution[Float](inputSize, outputSize, 1, 1)
     spatialConv2.setInputDimMask(Math.pow(2, dimMaskIdx - 1).toInt)
+    spatialConv2.forward(inputTensor)
     spatialConv2.calcScales(inputTensor)
     val inputScales2 = Array(Array(inputTensor.select(dimMaskIdx, 1).max()))
     spatialConv2.getInputScales() should be (inputScales2)
@@ -181,6 +185,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     dimMaskIdx = 2
     val spatialConv3 = SpatialConvolution[Float](inputSize, outputSize, 1, 1)
     spatialConv3.setInputDimMask(Math.pow(2, dimMaskIdx - 1).toInt)
+    spatialConv3.forward(inputTensor)
     spatialConv3.calcScales(inputTensor)
     val inputScales3 = Array((1 to inputTensor.size(dimMaskIdx)).map(
       idx => inputTensor.select(dimMaskIdx, idx).max()
@@ -190,6 +195,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     dimMaskIdx = 3
     val spatialConv4 = SpatialConvolution[Float](inputSize, outputSize, 1, 1)
     spatialConv4.setInputDimMask(Math.pow(2, dimMaskIdx - 1).toInt)
+    spatialConv4.forward(inputTensor)
     spatialConv4.calcScales(inputTensor)
     val inputScales4 = Array((1 to inputTensor.size(dimMaskIdx)).map(
       idx => inputTensor.select(dimMaskIdx, idx).max()
@@ -324,6 +330,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     // Global mask, non-null input
     val sequential1 = makeSequential()
+    sequential1.forward(inputTensor)
     sequential1.calcScales(inputTensor)
     sequential1.getInputScales().isEmpty should be (false)
     sequential1.getInputScales().length should be (1)
@@ -395,6 +402,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     // Global mask, non-null input
     val concatTable1 = makeConcatTable()
 
+    concatTable1.forward(inputTensor)
     concatTable1.calcScales(inputTensor)
     concatTable1.getInputScales() should be (Array(Array[Float](sampleMax)))
     concatTable1.getOutputScales() should be (
@@ -434,6 +442,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     // Global mask, non-null input
     val caddTable1 = CAddTable()
 
+    caddTable1.forward(inputTable)
     caddTable1.calcScales(inputTable)
     caddTable1.getOutputScales() should be (Array(Array[Float](4.0f)))
     caddTable1.getInputScales() should be (
@@ -470,6 +479,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     // Global mask, non-null input
     val relu1 = ReLU[Float]()
 
+    relu1.forward(inputTensor)
     relu1.calcScales(inputTensor)
     relu1.getInputScales() should be (Array(Array[Float](sampleMax)))
     relu1.getOutputScales() should be (Array(Array[Float](relu1.output.max())))
@@ -499,6 +509,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     // Global mask, non-null input
     val bn1 = SpatialBatchNormalization[Float](2)
 
+    bn1.forward(inputTensor)
     bn1.calcScales(inputTensor)
     bn1.getInputScales() should be (Array(Array[Float](inputTensor.abs().max())))
     bn1.getOutputScales() should be (Array(Array[Float](bn1.output.abs().max())))
@@ -544,6 +555,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val graph1 = makeTestingGraph()
     graph1.setInputDimMask(0)
     graph1.setOutputDimMask(0)
+    graph1.forward(inputTensor)
     graph1.calcScales(inputTensor)
     val graphOutput1 = graph1.output
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ScaleCalculatorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ScaleCalculatorSpec.scala
@@ -563,6 +563,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
   "Calculating scales" should "work correct for DNN Graph Module" in {
     import com.intel.analytics.bigdl.mkl.Memory
+    System.setProperty("bigdl.mkldnn.fusion", "false")
 
     def dnnGraph(batchSize: Int, classNum: Int): mkldnn.DnnGraph = {
       val inputShape = Array(batchSize, 1, 28, 28)
@@ -630,6 +631,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
       .exists(_ == false) should be (false)
 
     graph1.release()
+    System.clearProperty("bigdl.mkldnn.fusion")
   }
 
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/TopologySpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/TopologySpec.scala
@@ -983,6 +983,7 @@ class TopologySpec extends FlatSpec with Matchers {
   }
 
   "resnet-50 block graph" should "work correctly" in {
+    System.setProperty("bigdl.mkldnn.fusion", "false")
     RandomGenerator.RNG.setSeed(1)
     val inputShape = Array(4, 3, 224, 224)
     val outputShape = Array(4, 256, 56, 56)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/SoftMaxSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/SoftMaxSpec.scala
@@ -138,4 +138,21 @@ class SoftMaxSpec extends TorchSpec {
 
     println("Test case : SoftMax, Torch : " + luaTime + " s, Scala : " + scalaTime / 1e9 + " s")
   }
+
+  "A SoftMax with narrowed input" should "generate correct output" in {
+    torchCheck()
+    val layer = new SoftMax[Double]()
+    val input = Tensor[Double](4, 6).apply1(_ => Random.nextDouble())
+
+    val in1 = input.narrow(1, 1, 2)
+    val in2 = input.narrow(1, 3, 2)
+
+    val output = layer.forward(input).clone()
+    val output1 = layer.forward(in1).clone()
+    val output2 = layer.forward(in2).clone()
+
+    output.narrow(1, 1, 2) should be(output1)
+    output.narrow(1, 3, 2) should be(output2)
+    println("done")
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

softmax will use input array storage directly without considering its storage offset.

## How was this patch tested?

unit test

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

