### PR TITLE
[Branch-0.8]fix softmax with narrowed input

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftMax.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftMax.scala
@@ -94,12 +94,13 @@ object SoftMax{
     } else {
       input.contiguous().storage().array()
     }
+    val storageOffset = input.storageOffset() - 1
 
     var t = 0
     while (t < stride * nFrame) {
       val _t = t
       results(_t) = Engine.model.invoke(() => {
-        val inputOffset = (_t / stride) * dim * stride + _t % stride
+        val inputOffset = (_t / stride) * dim * stride + _t % stride + storageOffset
         val outputOffset = (_t / stride) * dim * stride + _t % stride
 
         var inputMax = ev.fromType[Float](Float.MinValue)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/SoftMaxSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/torch/SoftMaxSpec.scala
@@ -138,4 +138,20 @@ class SoftMaxSpec extends TorchSpec {
 
     println("Test case : SoftMax, Torch : " + luaTime + " s, Scala : " + scalaTime / 1e9 + " s")
   }
+
+  "A SoftMax with narrowed input" should "generate correct output" in {
+    val layer = new SoftMax[Double]()
+    val input = Tensor[Double](4, 6).apply1(_ => Random.nextDouble())
+
+    val in1 = input.narrow(1, 1, 2)
+    val in2 = input.narrow(1, 3, 2)
+
+    val output = layer.forward(input).clone()
+    val output1 = layer.forward(in1).clone()
+    val output2 = layer.forward(in2).clone()
+
+    output.narrow(1, 1, 2) should be(output1)
+    output.narrow(1, 3, 2) should be(output2)
+    println("done")
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

softmax will use input array storage directly without considering its storage offset.

## How was this patch tested?

unit test

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

