### PR TITLE
fix: inplace of input/output and weight dimension error

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/mkldnn/int8/GenerateInt8Scales.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/mkldnn/int8/GenerateInt8Scales.scala
@@ -52,6 +52,7 @@ object GenerateInt8Scales {
       .map(_.getInput().toTensor[Float])
 
     samples.foreach { sample =>
+      model.forward(sample)
       model.calcScales(sample)
     }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MklInt8Convertible.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MklInt8Convertible.scala
@@ -55,15 +55,17 @@ trait MklInt8Convertible {
 
     if (inputActvt != null) {
       val module = this.asInstanceOf[AbstractModule[_, _, Float]]
-      val outputActvt = mkldnn.Utils.getOutput(module, inputActvt)
+      // do not forward here, because the input maybe not the real input
+      // such as th ReLU(true) will do the computing inplace
+      val outputActvt = module.output.asInstanceOf[Activity]
 
       module match {
         case graph: Graph[Float] => calcGraphScales(inputActvt, outputActvt)
         // handlers for BLAS modules
         case linear: Linear[Float@unchecked] =>
-          calcModuleScales(inputActvt, outputActvt, linear.weight)
+          calcModuleScales(inputActvt, outputActvt, getWeight(linear))
         case spatialConv: SpatialConvolution[Float@unchecked] =>
-          calcModuleScales(inputActvt, outputActvt, spatialConv.weight)
+          calcModuleScales(inputActvt, outputActvt, getWeight(spatialConv))
         case relu: ReLU[Float@unchecked] =>
           calcModuleScales(inputActvt, outputActvt)
         case caddTable: CAddTable[Float@unchecked, Float@unchecked] =>
@@ -131,7 +133,6 @@ trait MklInt8Convertible {
     calcModuleScales(inActivity, outActivity)
     // calculate scales for weight
     appendWeightScales(calcTensorScale(weightTensor, weightDimMask))
-
   }
 
   /**
@@ -282,7 +283,14 @@ trait MklInt8Convertible {
   private def getWeight(module: AbstractModule[_, _, Float]): Tensor[Float] = {
     if (module != null) {
       // the getParameters will flatten the weight and bias, it's wrong
-      module.parameters()._1(0)
+      val weight = module.parameters()._1(0)
+      // if the weight is came from nn.SpatialConvolution and the nGroup is 1,
+      // we need to skip the first dimension
+      if (module.isInstanceOf[SpatialConvolution[Float]] && weight.size(1) == 1) {
+        weight.select(1, 1)
+      } else {
+        weight
+      }
     } else {
       null
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MklInt8Convertible.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/MklInt8Convertible.scala
@@ -284,8 +284,10 @@ trait MklInt8Convertible {
     if (module != null) {
       // the getParameters will flatten the weight and bias, it's wrong
       val weight = module.parameters()._1(0)
-      // if the weight is came from nn.SpatialConvolution and the nGroup is 1,
-      // we need to skip the first dimension
+      // If the weight is came from nn.SpatialConvolution and the nGroup is 1,
+      // we need to skip the first dimension. Because if the group is 1, mkldnn thinks
+      // it's 4-D tensor weight. But for original nn.SpatialConvolution, for convenience,
+      // it always use 5-D tensor weight although the nGroup is 1.
       if (module.isInstanceOf[SpatialConvolution[Float]] && weight.size(1) == 1) {
         weight.select(1, 1)
       } else {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Utils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Utils.scala
@@ -135,7 +135,7 @@ private[bigdl] object Utils {
   def getOutput(module: AbstractModule[_, _, _], input: Activity): Activity = {
     module match {
       case mklDnnModule: MklDnnModule => module.output.asInstanceOf[Activity]
-      case _ => module.forward(input)
+      case _ => module.output.asInstanceOf[Activity]
     }
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ScaleCalculatorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/ScaleCalculatorSpec.scala
@@ -53,6 +53,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     // Global mask, non-null input
     val linear1 = Linear[Float](inputSize, outputSize)
+    linear1.forward(inputTensor)
     linear1.calcScales(inputTensor)
     linear1.getInputScales() should be (Array(Array[Float](sampleMax)))
     linear1.getOutputScales().length should be (1)
@@ -67,6 +68,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     linear2.setInputDimMask(inputMask)
     linear2.setOutputDimMask(outputMask)
 
+    linear2.forward(inputTensor)
     linear2.calcScales(inputTensor)
     val output2 = linear2.output
     linear2.getInputScales() should be (Array(getScalesFromTensor(inputTensor, inputMask)))
@@ -163,6 +165,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     // Global mask, non-null input
     val spatialConv1 = SpatialConvolution[Float](inputSize, outputSize, 1, 1)
+    spatialConv1.forward(inputTensor)
     spatialConv1.calcScales(inputTensor)
     spatialConv1.getInputScales() should be (Array(Array[Float](12)))
     spatialConv1.getOutputScales().length should be (1)
@@ -174,6 +177,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     dimMaskIdx = 1
     val spatialConv2 = SpatialConvolution[Float](inputSize, outputSize, 1, 1)
     spatialConv2.setInputDimMask(Math.pow(2, dimMaskIdx - 1).toInt)
+    spatialConv2.forward(inputTensor)
     spatialConv2.calcScales(inputTensor)
     val inputScales2 = Array(Array(inputTensor.select(dimMaskIdx, 1).max()))
     spatialConv2.getInputScales() should be (inputScales2)
@@ -181,6 +185,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     dimMaskIdx = 2
     val spatialConv3 = SpatialConvolution[Float](inputSize, outputSize, 1, 1)
     spatialConv3.setInputDimMask(Math.pow(2, dimMaskIdx - 1).toInt)
+    spatialConv3.forward(inputTensor)
     spatialConv3.calcScales(inputTensor)
     val inputScales3 = Array((1 to inputTensor.size(dimMaskIdx)).map(
       idx => inputTensor.select(dimMaskIdx, idx).max()
@@ -190,6 +195,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     dimMaskIdx = 3
     val spatialConv4 = SpatialConvolution[Float](inputSize, outputSize, 1, 1)
     spatialConv4.setInputDimMask(Math.pow(2, dimMaskIdx - 1).toInt)
+    spatialConv4.forward(inputTensor)
     spatialConv4.calcScales(inputTensor)
     val inputScales4 = Array((1 to inputTensor.size(dimMaskIdx)).map(
       idx => inputTensor.select(dimMaskIdx, idx).max()
@@ -324,6 +330,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     // Global mask, non-null input
     val sequential1 = makeSequential()
+    sequential1.forward(inputTensor)
     sequential1.calcScales(inputTensor)
     sequential1.getInputScales().isEmpty should be (false)
     sequential1.getInputScales().length should be (1)
@@ -395,6 +402,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     // Global mask, non-null input
     val concatTable1 = makeConcatTable()
 
+    concatTable1.forward(inputTensor)
     concatTable1.calcScales(inputTensor)
     concatTable1.getInputScales() should be (Array(Array[Float](sampleMax)))
     concatTable1.getOutputScales() should be (
@@ -434,6 +442,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     // Global mask, non-null input
     val caddTable1 = CAddTable()
 
+    caddTable1.forward(inputTable)
     caddTable1.calcScales(inputTable)
     caddTable1.getOutputScales() should be (Array(Array[Float](4.0f)))
     caddTable1.getInputScales() should be (
@@ -470,6 +479,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     // Global mask, non-null input
     val relu1 = ReLU[Float]()
 
+    relu1.forward(inputTensor)
     relu1.calcScales(inputTensor)
     relu1.getInputScales() should be (Array(Array[Float](sampleMax)))
     relu1.getOutputScales() should be (Array(Array[Float](relu1.output.max())))
@@ -499,6 +509,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     // Global mask, non-null input
     val bn1 = SpatialBatchNormalization[Float](2)
 
+    bn1.forward(inputTensor)
     bn1.calcScales(inputTensor)
     bn1.getInputScales() should be (Array(Array[Float](inputTensor.abs().max())))
     bn1.getOutputScales() should be (Array(Array[Float](bn1.output.abs().max())))
@@ -544,6 +555,7 @@ class ScaleCalculatorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val graph1 = makeTestingGraph()
     graph1.setInputDimMask(0)
     graph1.setOutputDimMask(0)
+    graph1.forward(inputTensor)
     graph1.calcScales(inputTensor)
     val graphOutput1 = graph1.output
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
This patch fix the accuracy issue of non bn models after the refactor.

Some layer's input and output use the same memory. We can't do forward in the
calcScales. Because at that time, the input has been changed, its scales maybe
not right. Such as,

Seqeuntail().add(Conv).add(ReLU)

it will do two steps, seq.forward(input) first. and when go into the ReLU, it
will do another forward, so the input will be the output. And scales will be
wrong.

For convolution's weight, the dimension always is 5, although the group number
is 1. But for dnn convolution, if there's no group, the weight's dimension
should be 4.
## How was this patch tested?

Jenkins and example tests.

