### PR TITLE
[BRANCH-0.8] fix: allocate too much memory of mkldnn models

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/MemoryData.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/MemoryData.scala
@@ -16,6 +16,7 @@
 package com.intel.analytics.bigdl.nn.mkldnn
 
 import com.intel.analytics.bigdl.mkl._
+import com.intel.analytics.bigdl.tensor.DnnStorage
 
 sealed trait MemoryData extends Serializable {
   def shape: Array[Int]
@@ -81,12 +82,22 @@ sealed trait MemoryData extends Serializable {
 
   def getRealSize: Long = {
     require(primitiveDesc != UNDEFINED && primitiveDesc != ERROR)
-    MklDnn.PrimitiveDescGetSize(primitiveDesc)
+    MklDnn.PrimitiveDescGetSize(primitiveDesc) / getDataTypeBytes
   }
 
   def getPaddingShape: Array[Int] = {
     require(description != UNDEFINED && description != ERROR)
     Memory.GetPaddingShape(description)
+  }
+
+  private def getDataTypeBytes: Int = {
+    dataType match {
+      case DataType.F32 => DnnStorage.FLOAT_BYTES
+      case DataType.S32 => DnnStorage.INT_BYTES
+      case DataType.S8 => DnnStorage.INT8_BYTES
+      case DataType.U8 => DnnStorage.INT8_BYTES
+      case _ => throw new UnsupportedOperationException(s"unsupported data type")
+    }
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DnnStorage.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/DnnStorage.scala
@@ -144,9 +144,9 @@ private[bigdl] class Pointer(val address: Long)
 
 object DnnStorage {
   private[tensor] val CACHE_LINE_SIZE = System.getProperty("bigdl.cache.line", "64").toInt
-  private[tensor] val FLOAT_BYTES: Int = 4
-  private[tensor] val INT8_BYTES: Int = 1
-  private[tensor] val INT_BYTES: Int = 4
+  private[bigdl] val FLOAT_BYTES: Int = 4
+  private[bigdl] val INT8_BYTES: Int = 1
+  private[bigdl] val INT_BYTES: Int = 4
 
   import java.util.concurrent.ConcurrentHashMap
   private val nativeStorages: ConcurrentHashMap[Long, Boolean] = new ConcurrentHashMap()


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `realSize` of DnnTensor means the element number of this tensor. But mkldnn will return the bytes of memory, we should make it to the elements number.

## How was this patch tested?
Jenkins and model training.


