### PR TITLE
test: should compare the right grad input

### DIFF
--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/ReflectionUtilsSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/ReflectionUtilsSpec.scala
@@ -71,7 +71,7 @@ class ReflectionUtilsSpec extends BigDLSpecHelper {
     Equivalent.nearequals(weight1, weight2) should be (true)
     Equivalent.nearequals(gradWeight1, gradWeight2) should be (true)
 
-    Equivalent.nearequals(Tools.dense(modelDnn.gradInput).toTensor,
+    Equivalent.nearequals(Tools.dense(seq.gradInput).toTensor,
       modelBlas.gradInput.toTensor[Float]) should be (true)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This test case error is found when do mkldnn update. Because the grad input of convolution sometimes will be paded, so we should compare the nchw format gradinput.

## How was this patch tested?
Jenkins with v0.18 mkldnn library.


