### PR TITLE
Dilation in MKL-DNN Convolution

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/ColorJitter.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/dataset/image/ColorJitter.scala
@@ -34,7 +34,7 @@ object ColorJitter {
  * Process an image with brightness, contrast, saturation in a random order
  */
 class ColorJitter extends Transformer[LabeledBGRImage, LabeledBGRImage] {
-  // Todo: make the bcs parameter configurable
+  // TODO: make the bcs parameter configurable
   private val bcsParameters = Map("brightness" -> 0.4f, "contrast" -> 0.4f, "saturation" -> 0.4f)
   private var gs: Array[Float] = null
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ELU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ELU.scala
@@ -36,7 +36,7 @@ class ELU[T: ClassTag](
 
   val _alpha = ev.fromType[Double](alpha)
 
-  // Todo: Improve the performance of contiguous tensor
+  // TODO: Improve the performance of contiguous tensor
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
     if (inplace) {
       input.apply1(in => {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/HingeEmbeddingCriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/HingeEmbeddingCriterion.scala
@@ -84,7 +84,7 @@ class HingeEmbeddingCriterion[@specialized(Float, Double) T: ClassTag](
     output
   }
 
-  // Todo: Optimize performance to substitute apply3
+  // TODO: Optimize performance to substitute apply3
   override def updateGradInput(input: Tensor[T], target: Tensor[T]): Tensor[T] = {
     gradInput.resizeAs(input).copy(target)
     val func = new TensorFunc6[T] {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSigmoid.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LogSigmoid.scala
@@ -39,7 +39,7 @@ class LogSigmoid[T: ClassTag] (implicit ev: TensorNumeric[T])
     output.resizeAs(input)
     buffer.resizeAs(input)
 
-    // Todo: Replace apply to get a better performance
+    // TODO: Replace apply to get a better performance
     val func = new TensorFunc6[T] {
       override def apply(data1: Array[T], offset1: Int, data2: Array[T], offset2: Int,
         data3: Array[T], offset3: Int): Unit = {
@@ -59,7 +59,7 @@ class LogSigmoid[T: ClassTag] (implicit ev: TensorNumeric[T])
     gradInput
       .resizeAs(buffer)
 
-    // Todo: Replace apply to get a better performance
+    // TODO: Replace apply to get a better performance
     val func = new TensorFunc6[T] {
       override def apply(data1: Array[T], offset1: Int, data2: Array[T], offset2: Int,
         data3: Array[T], offset3: Int): Unit = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ResizeBilinear.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ResizeBilinear.scala
@@ -311,7 +311,7 @@ object ResizeBilinear {
     var _imageOffset = imageOffset
     var _outputOffset = outputOffset
 
-    // Todo: use multiple thread to speed up this
+    // TODO: use multiple thread to speed up this
     var b = 0
     while(b < batchSize) {
       var y = 0

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftMarginCriterion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SoftMarginCriterion.scala
@@ -42,7 +42,7 @@ class SoftMarginCriterion[@specialized(Float, Double) T: ClassTag](var sizeAvera
     this
   }
 
-  // Todo: replace apply for performance optimization
+  // TODO: replace apply for performance optimization
   override def updateOutput(input: Tensor[T], target: Tensor[T]): T = {
     require(input.isSameSizeAs(target), "The input should have the same size as target" +
       s"input size ${input.nElement()}, target size ${target.nElement()}")
@@ -63,7 +63,7 @@ class SoftMarginCriterion[@specialized(Float, Double) T: ClassTag](var sizeAvera
     output
   }
 
-  // Todo: replace apply for performance optimization
+  // TODO: replace apply for performance optimization
   override def updateGradInput(input: Tensor[T], target: Tensor[T]): Tensor[T] = {
     require(input.isSameSizeAs(target), "The input should have the same size as target" +
       s"input size ${input.nElement()}, target size ${target.nElement()}")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialConvolution.scala
@@ -25,7 +25,7 @@ import com.intel.analytics.bigdl.tensor.{DenseTensorMath, DnnTensor, Tensor}
 
 import scala.collection.mutable.ArrayBuffer
 
-/*
+/**
  * Applies a 2D convolution over an input image composed of several input planes.
  * The input tensor in forward(input) is expected to be
  * a 3D tensor (nInputPlane x height x width).
@@ -67,7 +67,9 @@ import scala.collection.mutable.ArrayBuffer
  *                    (eg. L1 or L2 regularization), applied to the input weights matrices.
  * @param bRegularizer: instance of [[Regularizer]]
  *                    applied to the bias.
-*/
+ * @param dilationW: dilation width, default to 1
+ * @param dilationH: dilation height, default to 1
+ */
 class SpatialConvolution(
   val nInputPlane: Int,
   val nOutputPlane: Int,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialConvolution.scala
@@ -645,7 +645,7 @@ class SpatialConvolution(
   }
 
   /**
-   * Todo:
+   * TODO:
    *   (1) add calculation logic for Full padding
    *   (2) abstract and design an object type for return value, insteaof returnning
    *       the result as an int array

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialConvolution.scala
@@ -169,7 +169,7 @@ class SpatialConvolution(
 
   /*
   Parameters for Dilated Convolution
-  In most of deep learning framework,
+  In most deep learning frameworks,
   the default value of dilation which defines regular convolution module is 1
   BigDL follows this convention
   However the default value used by mkl-dnn is 0;

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialConvolution.scala
@@ -165,12 +165,14 @@ class SpatialConvolution(
   // get padding type
   private val paddingType: PaddingType.Value = getPaddingType()
 
-  // Parameters for Dilated Convolution
-  // In most of deep learning framework,
-  // the default value of dilation which defines regular convolution module is 1
-  // BigDL follows this convention
-  // However the default value used by mkl-dnn is 0;
-  // in order to keep consistensy, we internally transform them with deducting by 1.
+  /*
+  Parameters for Dilated Convolution
+  In most of deep learning framework,
+  the default value of dilation which defines regular convolution module is 1
+  BigDL follows this convention
+  However the default value used by mkl-dnn is 0;
+  in order to keep consistensy, we internally transform them with deducting by 1.
+  */
   private val dilationW_mkldnn: Int = dilationW - 1
   private val dilationH_mkldnn: Int = dilationH - 1
 
@@ -641,17 +643,17 @@ class SpatialConvolution(
   }
 
   /**
-    * Todo:
-    *   (1) add calculation logic for Full padding
-    *   (2) abstract and design an object type for return value, insteaof returnning
-    *       the result as an int array
-    * Calculate padding size
-    * @param inputHeight height of input
-    * @param inputWidth width of input
-    * @param paddingType one of Same, Valid, Full
-    * @return an int array of length 4 representing padding sizes
-    *         (top, bottom, left, right)
-    */
+   * Todo:
+   *   (1) add calculation logic for Full padding
+   *   (2) abstract and design an object type for return value, insteaof returnning
+   *       the result as an int array
+   * Calculate padding size
+   * @param inputHeight height of input
+   * @param inputWidth width of input
+   * @param paddingType one of Same, Valid, Full
+   * @return an int array of length 4 representing padding sizes
+   *         (top, bottom, left, right)
+   */
   private def getConvPaddingShape(inputHeight: Int, inputWidth: Int,
                                   paddingType: PaddingType.Value): ConvPaddingShape = {
     paddingType match {
@@ -664,26 +666,26 @@ class SpatialConvolution(
   }
 
   /**
-    * Helper function to get convolution padding shape for Same Padding
-    * Steps:
-    *   1). calculate the dimension of dilated kernel
-    *       dilated kernel = kernel + (kernel - 1) * (dilation - 1)
-    *   2). calculate the number of stride it would make
-    *       number of stride = (input + stride - 1) / stride
-    *   3). calculate the number of pad needed to make
-    *       number of pad = start of last stride + dilated kernel - input
-    *       start of last stride = (number of stride - 1) * stride
-    *   4). assign the number of pad to left & right side
-    * @param inputHeight height of input
-    * @param inputWidth width of input
-    * @param kernelHeight height of kernel
-    * @param kernelWidth width of kernel
-    * @param strideHeight height of stride
-    * @param strideWidth width of stride
-    * @param dilationHeight height of dilation
-    * @param dilationWidth width of dilation
-    * @return ConvPaddingShape
-    */
+   * Helper function to get convolution padding shape for Same Padding
+   * Steps:
+   *   1). calculate the dimension of dilated kernel
+   *       dilated kernel = kernel + (kernel - 1) * (dilation - 1)
+   *   2). calculate the number of stride it would make
+   *       number of stride = (input + stride - 1) / stride
+   *   3). calculate the number of pad needed to make
+   *       number of pad = start of last stride + dilated kernel - input
+   *       start of last stride = (number of stride - 1) * stride
+   *   4). assign the number of pad to left & right side
+   * @param inputHeight height of input
+   * @param inputWidth width of input
+   * @param kernelHeight height of kernel
+   * @param kernelWidth width of kernel
+   * @param strideHeight height of stride
+   * @param strideWidth width of stride
+   * @param dilationHeight height of dilation
+   * @param dilationWidth width of dilation
+   * @return ConvPaddingShape
+   */
   private def getConvPaddingShape(inputHeight: Int, inputWidth: Int,
                                   kernelHeight: Int, kernelWidth: Int,
                                   strideHeight: Int, strideWidth: Int,
@@ -705,13 +707,13 @@ class SpatialConvolution(
 
 
   /**
-    * Calculate convolution output size
-    * Please try to keep the logic in consistent with MKL-DNN
-    * Reffernce: https://github.com/intel/mkl-dnn/blob/master/src/common/convolution.cpp#L117
-    * @param inputH height of input
-    * @param inputW width of input
-    * @return a ConvOutputShape object
-    */
+   * Calculate convolution output shape
+   * Please try to keep the logic in consistent with MKL-DNN
+   * Reffernce: https://github.com/intel/mkl-dnn/blob/master/src/common/convolution.cpp#L117
+   * @param inputH height of input
+   * @param inputW width of input
+   * @return a ConvOutputShape object
+   */
   private def getConvOutputShape(inputH: Int, inputW: Int,
                                  paddingShape: ConvPaddingShape): ConvOutputShape = {
     def getOutputLength(inputLength: Int, padLeft: Int, padRight: Int,
@@ -734,9 +736,9 @@ class SpatialConvolution(
 
 
   /**
-    *  Get padding type
-    * @return
-    */
+   * Get padding type
+   * @return PaddingType
+   */
   private def getPaddingType(): PaddingType.Value = {
     if (padH == -1 && padW == -1) {
       PaddingType.Same
@@ -784,10 +786,22 @@ object Scale {
 }
 
 
+/**
+ * Enum for padding type
+ * currently only support Same and Custom
+ */
 private[mkldnn] object PaddingType extends Enumeration {
   val Same, Custom = Value
 }
 
+
+/**
+ * object to store meta for convolution padding shape
+ * @param top
+ * @param bottom
+ * @param left
+ * @param right
+ */
 private[mkldnn] case class ConvPaddingShape (
   top: Int,
   bottom: Int,
@@ -795,6 +809,11 @@ private[mkldnn] case class ConvPaddingShape (
   right: Int
 )
 
+/**
+ * case class to store meta for convolution output shape
+ * @param height
+ * @param width
+ */
 private[mkldnn] case class ConvOutputShape (
   height: Int,
   width: Int

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
@@ -253,7 +253,7 @@ object Engine {
     val coreNum = Runtime.getRuntime().availableProcessors()
     require(coreNum > 0, "Get a non-positive core number")
     // We assume the HT is enabled
-    // Todo: check the Hyper threading
+    // TODO: check the Hyper threading
     if (coreNum > 1) coreNum / 2 else 1
   }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialConvolutionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialConvolutionSpec.scala
@@ -29,7 +29,79 @@ import org.scalatest.{FlatSpec, Matchers}
 import scala.util.Random
 
 class SpatialConvolutionSpec extends FlatSpec with Matchers {
-  
+
+  "MKL-DNN Dilated Convolution compared with BLAS Dilated Convolution" should "work correctly" in {
+    val nInputPlane = 2
+    val nOutputPlane = 4
+    val kW = 3
+    val kH = 3
+    val dW = 4
+    val dH = 4
+    val padW = 0
+    val padH = 0
+    var (dilationH, dilationW) = (1, 1)
+
+    var input = Tensor[Float](2, 2, 23, 23).apply1(e => Random.nextFloat())
+    var gradOutput = Tensor[Float](2, 4, 6, 6).apply1(e => Random.nextFloat())
+
+
+    def compareHelper(input: Tensor[Float], gradOutput: Tensor[Float],
+                      dilationHeight: Int, dilationWidth: Int): Unit = {
+      RNG.setSeed(100)
+      var mkldnnConv = SpatialConvolution(nInputPlane, nOutputPlane, kW, kH, dW, dH, padW, padH,
+        dilationH = dilationH, dilationW = dilationW)
+
+
+      RNG.setSeed(100)
+
+      val blasConv = nn.SpatialDilatedConvolution[Float](nInputPlane, nOutputPlane, kW, kH, dW, dH,
+        padW, padH, dilationH = dilationH, dilationW = dilationW)
+
+      val mkldnnSeq = Sequential()
+        .add(Input(input.size(), Memory.Format.nchw))
+        .add(mkldnnConv)
+        .add(ReorderMemory(HeapData(gradOutput.size(), Memory.Format.nchw)))
+
+      mkldnnSeq.compile(TrainingPhase)
+
+      val output = mkldnnSeq.forward(input)
+      val grad1 = mkldnnSeq.backward(input, gradOutput)
+
+      val weight1 = mkldnnConv.weight.dense
+      val gradweight1 = mkldnnConv.gradWeight.dense
+      val bias1 = mkldnnConv.bias.dense
+      val gradbias1 = mkldnnConv.gradBias.dense
+
+      val output2 = blasConv.forward(input)
+      val grad2 = blasConv.updateGradInput(input, gradOutput)
+      blasConv.accGradParameters(input, gradOutput)
+
+      val weight2 = blasConv.weight
+      val gradweight2 = blasConv.gradWeight
+      val bias2 = blasConv.bias
+      val gradbias2 = blasConv.gradBias
+
+      Equivalent.nearequals(weight1, weight2.resizeAs(weight1)) should be(true)
+      Equivalent.nearequals(gradweight1, gradweight2.resizeAs(gradweight1)) should be(true)
+      Equivalent.nearequals(bias1, bias2) should be(true)
+      Equivalent.nearequals(gradbias1, gradbias2) should be(true)
+      Equivalent.nearequals(output.toTensor, output2) should be(true)
+      Equivalent.nearequals(grad1.toTensor, grad2) should be(true)
+    }
+
+    compareHelper(input, gradOutput, dilationH, dilationW)
+
+
+
+    dilationH = 2
+    dilationW = 2
+    input = Tensor[Float](2, 2, 23, 23).apply1(e => Random.nextFloat())
+    gradOutput = Tensor[Float](2, 4, 5, 5).apply1(e => Random.nextFloat())
+
+    compareHelper(input, gradOutput, dilationH, dilationW)
+
+  }
+
   "ConvolutionDnn with format=nchw and ngroup=1" should "work correctly" in {
     val nInputPlane = 2
     val nOutputPlane = 4

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialConvolutionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialConvolutionSpec.scala
@@ -29,6 +29,7 @@ import org.scalatest.{FlatSpec, Matchers}
 import scala.util.Random
 
 class SpatialConvolutionSpec extends FlatSpec with Matchers {
+  
   "ConvolutionDnn with format=nchw and ngroup=1" should "work correctly" in {
     val nInputPlane = 2
     val nOutputPlane = 4


### PR DESCRIPTION
## What changes were proposed in this pull request?
Enable Dilation in MKL-DNN Convolution

## How was this patch tested?
1. Create convolution layers both in BLAS and MKLDNN with dilation of one, which is just the regular convolution, and compare their output and weight
2. Create convolution layers both in BLAS and MKLDNN with dilation of two, and compare their output and weight.

## Related links or issues (optional)

Jenkins Result:
http://mlt-bddl01.sh.intel.com:8080/job/BigDL-PRVN-lite/581/