### PR TITLE
Optimize backward graph generation and CAddTable

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DirectedGraph.scala
@@ -154,7 +154,14 @@ class DirectedGraph[T](val source : Node[T], val reverse : Boolean = false) exte
         node.nextNodesAndEdges.foreach(nextNodeAndEdge => {
           // Some next nodes may be not included in the graph
           if (oldToNew.containsKey(nextNodeAndEdge._1)) {
-            oldToNew.get(nextNodeAndEdge._1).add(oldToNew.get(node), nextNodeAndEdge._2)
+            oldToNew.get(node).addPrevious(
+              oldToNew.get(nextNodeAndEdge._1), nextNodeAndEdge._2)
+          }
+        })
+        node.prevNodesAndEdges.foreach(prevNodeAndEdge => {
+          if (oldToNew.containsKey(prevNodeAndEdge._1)) {
+            oldToNew.get(node).addNexts(
+              oldToNew.get(prevNodeAndEdge._1), prevNodeAndEdge._2)
           }
         })
       } else {
@@ -239,6 +246,14 @@ class Node[T](var element: T) extends Serializable {
     if (!node.prevs.contains((this, e))) node.prevs.append((this, e))
     if (!this.nexts.contains((node, e))) this.nexts.append((node, e))
     node
+  }
+
+  def addPrevious(node: Node[T], e: Edge = Edge()): Unit = {
+    if (!this.prevs.contains((node, e))) this.prevs.append((node, e))
+  }
+
+  def addNexts(node: Node[T], e: Edge = Edge()): Unit = {
+    if (!this.nexts.contains((node, e))) this.nexts.append((node, e))
   }
 
   def from(node: Node[T], e: Edge = Edge()): Node[T] = {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/CAddTableSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/CAddTableSpec.scala
@@ -43,6 +43,28 @@ class CAddTableSpec extends FlatSpec with Matchers {
     grads[Tensor[Float]](1) should be(Tensor[Float](T(1, 2, 3)))
     grads[Tensor[Float]](2).value() should be(6)
   }
+
+  "CAddTable with different size" should "be correct" in {
+    val input1 = Tensor[Float](T(T(-0.52817175, -1.07296862, 0.86540763, -2.3015387,
+      1.74481176, -0.7612069, 0.3190391, -0.24937038),
+      T( 1.46210794, -2.06014071, -0.3224172, -0.38405435, 1.13376944, -1.09989127,
+        -0.17242821, -0.87785842)))
+    val input2 = Tensor[Float](T(T(1.62434536), T(-0.61175641)))
+    val input3 = Tensor[Float](T(T(1.62434536, 1.62434536, 1.62434536, 1.62434536,
+      1.62434536, 1.62434536, 1.62434536, 1.62434536),
+      T(-0.61175641, -0.61175641, -0.61175641, -0.61175641, -0.61175641,
+        -0.61175641, -0.61175641, -0.61175641)))
+    val layer = CAddTable[Float]()
+    val output = layer.forward(T(input1, input2))
+    val output2 = layer.forward(T(input1, input3))
+    output should be(output2)
+
+    val gradInput = layer.backward(T(input1, input2), output)
+    val gradInput2 = layer.backward(T(input1, input3), output2)
+
+    gradInput[Tensor[Float]](1) should be(gradInput2[Tensor[Float]](1))
+    gradInput[Tensor[Float]](2) should be(gradInput2[Tensor[Float]](2))
+  }
 }
 
 class CAddTableSerialTest extends ModuleSerializationTest {


### PR DESCRIPTION
## What changes were proposed in this pull request?

. Optimize backward graph generation
. Enhance CAddTable to support tensors with different size

## How was this patch tested?

unit tests

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

