### PR TITLE
add layer norm and expand size layers

### DIFF
--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -929,6 +929,39 @@ class FeedForwardNetwork(Layer):
     def __init__(self, hidden_size, filter_size, relu_dropout, bigdl_type="float"):
         super(FeedForwardNetwork, self).__init__(None, bigdl_type,
                                         hidden_size, filter_size, relu_dropout)
+class LayerNormalization(Layer):
+    '''
+    Applies layer normalization.
+
+    >>> norm = LayerNormalization(8)
+    creating: createLayerNormalization
+    '''
+
+    def __init__(self, hidden_size, bigdl_type="float"):
+        super(LayerNormalization, self).__init__(None, bigdl_type, hidden_size)
+
+class createTableOperationExpand(Layer):
+    '''
+    When two tensors have different size, firstly expand small size tensor to large size tensor,
+    and then do table operation.
+
+    >>> norm = TableOperationExpand(CMulTable)
+    creating: createTableOperationExpand
+    '''
+
+    def __init__(self, operation_layer, expand_pos=2, bigdl_type="float"):
+        super(TableOperationExpand, self).__init__(None, bigdl_type, operation_layer, expand_pos)
+
+class createExpandSize(Layer):
+    '''
+    Expand tensor to configured size
+
+    >>> expand = ExpandSize([2, 3, 4])
+    creating: createExpandSize
+    '''
+
+    def __init__(self, sizes, bigdl_type="float"):
+        super(ExpandSize, self).__init__(None, bigdl_type, sizes)
 
 class Linear(Layer):
 

--- a/pyspark/bigdl/nn/layer.py
+++ b/pyspark/bigdl/nn/layer.py
@@ -940,19 +940,20 @@ class LayerNormalization(Layer):
     def __init__(self, hidden_size, bigdl_type="float"):
         super(LayerNormalization, self).__init__(None, bigdl_type, hidden_size)
 
-class createTableOperationExpand(Layer):
+class TableOperation(Layer):
     '''
     When two tensors have different size, firstly expand small size tensor to large size tensor,
     and then do table operation.
 
-    >>> norm = TableOperationExpand(CMulTable)
-    creating: createTableOperationExpand
+    >>> norm = TableOperation(CMulTable())
+    creating: createCMulTable
+    creating: createTableOperation
     '''
 
-    def __init__(self, operation_layer, expand_pos=2, bigdl_type="float"):
-        super(TableOperationExpand, self).__init__(None, bigdl_type, operation_layer, expand_pos)
+    def __init__(self, operation_layer, bigdl_type="float"):
+        super(TableOperation, self).__init__(None, bigdl_type, operation_layer)
 
-class createExpandSize(Layer):
+class ExpandSize(Layer):
     '''
     Expand tensor to configured size
 

--- a/pyspark/test/dev/diff.py
+++ b/pyspark/test/dev/diff.py
@@ -31,7 +31,7 @@ def extract_scala_class(class_path):
     exclude_key_words = set(["*", "abstract", "Const", "Fill", "Shape",
                              "SplitAndSelect", "StrideSlice", "Scheduler",
                              "StaticGraph", "DynamicGraph", "DynamicContainer",
-                             "SplitHeads", "CombineHeads"])   # noqa
+                             "SplitHeads", "CombineHeads", "LayerLinear"])   # noqa
     include_key_words = set(["Module", "Criterion", "Container", "Cell", "TensorNumeric"])  # noqa
     content = "\n".join([line for line in open(class_path).readlines() if all([key not in line for key in exclude_key_words])])  # noqa
     match = re.search(r"class ([\w]+)[^{]+", content)

--- a/pyspark/test/dev/diff.py
+++ b/pyspark/test/dev/diff.py
@@ -31,7 +31,7 @@ def extract_scala_class(class_path):
     exclude_key_words = set(["*", "abstract", "Const", "Fill", "Shape",
                              "SplitAndSelect", "StrideSlice", "Scheduler",
                              "StaticGraph", "DynamicGraph", "DynamicContainer",
-                             "SplitHeads", "CombineHeads", "LayerLinear"])   # noqa
+                             "SplitHeads", "CombineHeads", "VectorProduct"])   # noqa
     include_key_words = set(["Module", "Criterion", "Container", "Cell", "TensorNumeric"])  # noqa
     content = "\n".join([line for line in open(class_path).readlines() if all([key not in line for key in exclude_key_words])])  # noqa
     match = re.search(r"class ([\w]+)[^{]+", content)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ExpandSize.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ExpandSize.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018 Analytics Zoo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn
+
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
+
+/**
+ * Expand tensor to configured size
+ * @param tgtSizes target tensor sizes, dim whose size is -1 will be ignored
+ * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now.
+ */
+class ExpandSize[T: ClassTag](tgtSizes: Array[Int])
+   (implicit ev: TensorNumeric[T]) extends AbstractModule[Tensor[T], Tensor[T], T] {
+
+  override def updateOutput(input: Tensor[T]): Tensor[T] = {
+    require(tgtSizes.length == input.dim(),
+      s"the number of dimensions provided must equal ${input.dim()}")
+    val tensorDim = input.dim()
+    val tensorStride = input.stride()
+    val tensorSize = input.size()
+
+    var i = 0
+    while (i < tensorDim) {
+      if (tgtSizes(i) != -1) {
+        if (tensorSize(i) == 1) {
+          tensorSize(i) = tgtSizes(i)
+          tensorStride(i) = 0
+        } else if (tensorSize(i) != tgtSizes(i)) {
+          throw new UnsupportedOperationException(
+            "incorrect size: only supporting singleton expansion (size=1)")
+        }
+      }
+      i += 1
+    }
+
+    output.set(input.storage(), input.storageOffset(), tensorSize, tensorStride)
+    output
+  }
+
+  override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
+    val tensorDim = input.dim()
+    val tensorSize = input.size()
+
+    gradInput = Tensor[T](tensorSize)
+    val expandDim = new ArrayBuffer[Int]()
+    var i = 0
+    while (i < tensorDim) {
+      if (tgtSizes(i) != -1) {
+        if (tensorSize(i) == 1 && tgtSizes(i) != 1) {
+          expandDim.append(i + 1)
+        }
+      }
+      i += 1
+    }
+
+    i = expandDim.size - 1
+    val sizes = gradOutput.size()
+    var _gradOutput = gradOutput
+    while (i >= 0) {
+      var start = 1
+      sizes(expandDim(i) - 1) = 1
+      val _gradInput = Tensor[T](sizes)
+      while (start <= gradOutput.size(expandDim(i))) {
+        val x = _gradOutput.narrow(expandDim(i), start, 1)
+        _gradInput.add(x)
+        start += 1
+      }
+      _gradOutput = _gradInput
+      i -= 1
+    }
+    gradInput = _gradOutput
+    gradInput
+  }
+
+  override def toString: String = s"InternalExpand()"
+}
+
+object ExpandSize {
+  def apply[@specialized(Float, Double) T: ClassTag](tgtSizes: Array[Int])
+     (implicit ev: TensorNumeric[T]) : ExpandSize[T] = {
+    new ExpandSize[T](tgtSizes)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ExpandSize.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/ExpandSize.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Analytics Zoo Authors.
+ * Copyright 2016 The BigDL Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,14 +25,14 @@ import scala.reflect.ClassTag
 
 /**
  * Expand tensor to configured size
- * @param tgtSizes target tensor sizes, dim whose size is -1 will be ignored
+ * @param targetSizes target tensor sizes, dim whose size is -1 will be ignored
  * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now.
  */
-class ExpandSize[T: ClassTag](tgtSizes: Array[Int])
+class ExpandSize[T: ClassTag](targetSizes: Array[Int])
    (implicit ev: TensorNumeric[T]) extends AbstractModule[Tensor[T], Tensor[T], T] {
 
   override def updateOutput(input: Tensor[T]): Tensor[T] = {
-    require(tgtSizes.length == input.dim(),
+    require(targetSizes.length == input.dim(),
       s"the number of dimensions provided must equal ${input.dim()}")
     val tensorDim = input.dim()
     val tensorStride = input.stride()
@@ -40,11 +40,11 @@ class ExpandSize[T: ClassTag](tgtSizes: Array[Int])
 
     var i = 0
     while (i < tensorDim) {
-      if (tgtSizes(i) != -1) {
+      if (targetSizes(i) != -1) {
         if (tensorSize(i) == 1) {
-          tensorSize(i) = tgtSizes(i)
+          tensorSize(i) = targetSizes(i)
           tensorStride(i) = 0
-        } else if (tensorSize(i) != tgtSizes(i)) {
+        } else if (tensorSize(i) != targetSizes(i)) {
           throw new UnsupportedOperationException(
             "incorrect size: only supporting singleton expansion (size=1)")
         }
@@ -64,8 +64,8 @@ class ExpandSize[T: ClassTag](tgtSizes: Array[Int])
     val expandDim = new ArrayBuffer[Int]()
     var i = 0
     while (i < tensorDim) {
-      if (tgtSizes(i) != -1) {
-        if (tensorSize(i) == 1 && tgtSizes(i) != 1) {
+      if (targetSizes(i) != -1) {
+        if (tensorSize(i) == 1 && targetSizes(i) != 1) {
           expandDim.append(i + 1)
         }
       }
@@ -91,12 +91,12 @@ class ExpandSize[T: ClassTag](tgtSizes: Array[Int])
     gradInput
   }
 
-  override def toString: String = s"InternalExpand()"
+  override def toString: String = s"ExpandSize"
 }
 
 object ExpandSize {
-  def apply[@specialized(Float, Double) T: ClassTag](tgtSizes: Array[Int])
+  def apply[@specialized(Float, Double) T: ClassTag](targetSizes: Array[Int])
      (implicit ev: TensorNumeric[T]) : ExpandSize[T] = {
-    new ExpandSize[T](tgtSizes)
+    new ExpandSize[T](targetSizes)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LayerNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LayerNormalization.scala
@@ -41,7 +41,7 @@ class LayerNormalization[T: ClassTag](hiddenSize: Int)
     val add = AddConstant(1e-6).inputs(mean2)
     val sqrt = Power(-0.5, 1, 0).inputs(add)
     val mul = CMulTableExpand().inputs(sub, sqrt)
-    val linear = new LayerLinear[T](hiddenSize).inputs(mul)
+    val linear = new VectorProduct[T](hiddenSize).inputs(mul)
     Graph(input, linear)
   }
   override def updateOutput(input: Activity): Activity = {
@@ -57,7 +57,7 @@ class LayerNormalization[T: ClassTag](hiddenSize: Int)
  * @param ev
  * @tparam T The numeric type in this module parameters
  */
-private[nn] class LayerLinear[T: ClassTag](hiddenSize: Int)
+private[nn] class VectorProduct[T: ClassTag](val hiddenSize: Int)
    (implicit ev: TensorNumeric[T]) extends TensorModule[T] {
 
   var weight = Tensor[T](hiddenSize).fill(ev.one)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LayerNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/LayerNormalization.scala
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn
+
+import com.intel.analytics.bigdl._
+import com.intel.analytics.bigdl.nn.abstractnn.{Activity, TensorModule}
+import com.intel.analytics.bigdl.nn.{Module => _}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+
+import scala.reflect.ClassTag
+
+/**
+ * Applies layer normalization.
+ * @param hiddenSize
+ * @param ev$1
+ * @param ev
+ * @tparam T
+ */
+class LayerNormalization[T: ClassTag](hiddenSize: Int)
+  (implicit ev: TensorNumeric[T]) extends BaseModule[T] {
+  override def buildModel(): Module[T] = {
+    val input = Input()
+    val mean = Mean(-1, squeeze = false).inputs(input)
+    val sub = CSubTableExpand().inputs(input, mean)
+    val square = Square().inputs(sub)
+    val mean2 = Mean(-1, squeeze = false).inputs(square)
+    val add = AddConstant(1e-6).inputs(mean2)
+    val sqrt = Power(-0.5, 1, 0).inputs(add)
+    val mul = CMulTableExpand().inputs(sub, sqrt)
+    val linear = new LayerLinear[T](hiddenSize).inputs(mul)
+    Graph(input, linear)
+  }
+  override def updateOutput(input: Activity): Activity = {
+    output = model.updateOutput(input)
+    output
+  }
+}
+
+/**
+ * Implement x * weight vector + bias vector
+ * @param hiddenSize
+ * @param ev$1
+ * @param ev
+ * @tparam T The numeric type in this module parameters
+ */
+private[nn] class LayerLinear[T: ClassTag](hiddenSize: Int)
+   (implicit ev: TensorNumeric[T]) extends TensorModule[T] {
+
+  var weight = Tensor[T](hiddenSize).fill(ev.one)
+  var bias = Tensor[T](hiddenSize).fill(ev.zero)
+  var gradWeight = Tensor[T](hiddenSize)
+  var gradBias = Tensor[T](hiddenSize)
+
+  private val buffer = Tensor[T]()
+  private var inputSize: Array[Int] = _
+  private var gradOutputSize: Array[Int] = _
+  private var outputSize: Array[Int] = _
+
+  private def combine(src: Array[Int], target: Array[Int]): Array[Int] = {
+    if (src.length <= 2) return src
+    val targetArr = if (target == null) new Array[Int](src.length - 1) else target
+    require(src.length == targetArr.length + 1,
+      "combine method requires src.length == target.length + 1" +
+        s" Current src.length = ${src.length}" +
+        s" Current target.length = ${targetArr.length}")
+    targetArr(0) = src(0) * src(1)
+    var j = 1
+    while (j < targetArr.length) {
+      targetArr(j) = src(j + 1)
+      j += 1
+    }
+    targetArr
+  }
+
+  private def split(src: Array[Int], target: Array[Int], srcInput: Array[Int]): Array[Int] = {
+    if (src.length == srcInput.length) return src
+    val dim1 = srcInput(0)
+    val dim2 = srcInput(1)
+    val targetArr = if (target == null) new Array[Int](srcInput.length) else target
+    require(src.length == targetArr.length - 1,
+      "split method requires src.length == target.length - 1" +
+        s" Current src.length = ${src.length}" +
+        s" Current target.length = ${targetArr.length}")
+    require(dim1 * dim2 == src(0),
+      "split method requires dim1 * dim2 == src(0), " +
+        s"Current dim1 = ${dim1}, dim2 = ${dim2}, src(0) = ${src(0)}")
+
+    targetArr(0) = dim1
+    targetArr(1) = dim2
+    var j = 1
+    while (j < src.length) {
+      targetArr(j + 1) = src(j)
+      j += 1
+    }
+    targetArr
+  }
+
+  override def updateOutput(input: Tensor[T]): Tensor[T] = {
+    val _inputSize = input.size
+    inputSize = combine(_inputSize, inputSize)
+
+    input.resize(inputSize)
+    output.resizeAs(input).copy(input)
+    val size = output.size(1)
+    var i = 1
+    while(i <= size) {
+      output.select(1, i).cmul(weight).add(bias)
+      i += 1
+    }
+
+    outputSize = split(output.size, outputSize, _inputSize)
+    input.resize(_inputSize)
+    output.resize(outputSize)
+
+    output
+  }
+
+  override def updateGradInput(input: Tensor[T], gradOutput: Tensor[T]): Tensor[T] = {
+    val _inputSize = input.size
+    val _gradOutputSize = gradOutput.size
+    gradOutputSize = combine(_gradOutputSize, gradOutputSize)
+    input.resize(inputSize)
+    gradOutput.resize(gradOutputSize)
+    gradInput.resizeAs(input).zero()
+
+    val size = gradInput.size(1)
+    var i = 1
+    while(i <= size) {
+      gradInput.select(1, i).addcmul(gradOutput.select(1, i), weight)
+      i += 1
+    }
+
+    gradInput.resize(_inputSize)
+    input.resize(_inputSize)
+    gradOutput.resize(_gradOutputSize)
+
+    gradInput
+  }
+
+  override def accGradParameters(input: Tensor[T], gradOutput: Tensor[T]): Unit = {
+    val _inputSize = input.size
+    val _gradOutputSize = gradOutput.size
+    input.resize(inputSize)
+    gradOutput.resize(gradOutputSize)
+
+    buffer.resizeAs(input).zero()
+    buffer.addcmul(input, gradOutput)
+    gradWeight = buffer.sum(1).squeeze()
+    gradBias = gradOutput.sum(1).squeeze()
+
+    input.resize(_inputSize)
+    gradOutput.resize(_gradOutputSize)
+  }
+
+  override def parameters(): (Array[Tensor[T]], Array[Tensor[T]]) = {
+    (Array(this.weight, this.bias), Array(this.gradWeight, this.gradBias))
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TableOperationExpand.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/TableOperationExpand.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 Analytics Zoo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn
+
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.transform.vision.image.augmentation.Expand
+import com.intel.analytics.bigdl.utils.{T, Table}
+
+import scala.reflect.ClassTag
+
+/**
+ * When two tensors have different size, firstly expand small size tensor to large size tensor,
+ * and then do table operation.
+ * @param operationLayer layer that can handle table operation, such as CSubTable, CMulTable, etc.
+ * @param expandPos small tensor position in input table
+ * @param ev$1
+ * @param ev
+ * @tparam T
+ */
+class TableOperationExpand[T: ClassTag](
+   operationLayer: AbstractModule[Table, Tensor[T], T], expandPos: Int = 2)
+   (implicit ev: TensorNumeric[T]) extends AbstractModule[Table, Tensor[T], T] {
+
+  require(expandPos == 1 || expandPos == 2, s"TableOperationExpand:" +
+    s"small tensor position in input table should be 1 or 2 , but get ${expandPos}")
+
+  @transient
+  private var expandLayer: AbstractModule[Tensor[T], Tensor[T], T] = null
+
+  override def updateOutput(input: Table): Tensor[T] = {
+    val inputSmall = input[Tensor[T]](expandPos)
+    val inputLarge = input[Tensor[T]](3 - expandPos)
+
+    if (expandLayer == null) expandLayer = ExpandSize(inputLarge.size())
+    val inputExpand = expandLayer.forward(inputSmall)
+
+    output = operationLayer.updateOutput(T(inputLarge, inputExpand))
+    return output
+  }
+
+  override def updateGradInput(input: Table, gradOutput: Tensor[T]): Table = {
+    val inputSmall = input[Tensor[T]](expandPos)
+    val inputLarge = input[Tensor[T]](3 - expandPos)
+
+    val inputExpand = expandLayer.output
+    gradInput = operationLayer.updateGradInput(T(inputLarge, inputExpand), gradOutput)
+    gradInput(2) = expandLayer.backward(inputSmall, gradInput[Tensor[T]](2))
+    gradInput
+  }
+
+  override def toString: String = s"TableOperationExpand"
+
+  override def clearState(): this.type = {
+    if (expandLayer != null) expandLayer.clearState()
+    operationLayer.clearState()
+    this
+  }
+}
+
+object CMulTableExpand {
+  def apply[@specialized(Float, Double) T: ClassTag](expandPos: Int = 2)
+    (implicit ev: TensorNumeric[T]) : TableOperationExpand[T] = {
+    new TableOperationExpand[T](CMulTable[T], expandPos)
+  }
+}
+
+object CSubTableExpand {
+  def apply[@specialized(Float, Double) T: ClassTag](expandPos: Int = 2)
+    (implicit ev: TensorNumeric[T]) : TableOperationExpand[T] = {
+    new TableOperationExpand[T](CSubTable[T]
+      .asInstanceOf[AbstractModule[Table, Tensor[T], T]], expandPos)
+  }
+}
+

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -279,6 +279,19 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
     FeedForwardNetwork(hiddenSize, filterSize, reluDropout)
   }
 
+  def createExpandSize(tgtSizes: JList[Int]): ExpandSize[T] = {
+    ExpandSize(tgtSizes.asScala.toArray)
+  }
+
+  def createTableOperationExpand(operationLayer: AbstractModule[Table, Tensor[T], T],
+                                 expandPos: Int = 2): TableOperationExpand[T] = {
+    new TableOperationExpand(operationLayer, expandPos)
+  }
+
+  def createLayerNormalization(hiddenSize: Int): LayerNormalization[T] = {
+    new LayerNormalization[T](hiddenSize)
+  }
+
   def createLinear(inputSize: Int, outputSize: Int,
     withBias: Boolean,
     wRegularizer: Regularizer[T] = null,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/python/api/PythonBigDL.scala
@@ -279,13 +279,13 @@ class PythonBigDL[T: ClassTag](implicit ev: TensorNumeric[T]) extends Serializab
     FeedForwardNetwork(hiddenSize, filterSize, reluDropout)
   }
 
-  def createExpandSize(tgtSizes: JList[Int]): ExpandSize[T] = {
-    ExpandSize(tgtSizes.asScala.toArray)
+  def createExpandSize(targetSizes: JList[Int]): ExpandSize[T] = {
+    ExpandSize(targetSizes.asScala.toArray)
   }
 
-  def createTableOperationExpand(operationLayer: AbstractModule[Table, Tensor[T], T],
-                                 expandPos: Int = 2): TableOperationExpand[T] = {
-    new TableOperationExpand(operationLayer, expandPos)
+  def createTableOperation(
+    operationLayer: AbstractModule[Table, Tensor[T], T]): TableOperation[T] = {
+    new TableOperation(operationLayer)
   }
 
   def createLayerNormalization(hiddenSize: Int): LayerNormalization[T] = {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LayerNormalizationSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LayerNormalizationSpec.scala
@@ -136,7 +136,7 @@ class LayerNormalizationSpec extends FlatSpec with Matchers {
     gradWeights should be(gradWeightExpected)
   }
 
-  "layer linear with 2 dims" should "work correct" in {
+  "vector linear with 2 dims" should "work correct" in {
     val weight = Tensor[Float](T(-0.14037117, -0.16902402, -0.06451887,
       -0.5642037, 0.24212438, 0.44951588, -0.4296978, 0.423163))
     val bias = Tensor[Float](T(0.44111532, -0.06523705, -0.3474969,
@@ -158,7 +158,7 @@ class LayerNormalizationSpec extends FlatSpec with Matchers {
       -2.7860408, 0.01291263, 2.9350655, -0.5385718, 1.4307464, 0.60943544,
       0.01507702, -0.75525033, 1.6029637, -0.5815844, -1.5703702, -0.31845763, -1.5114479))
 
-    val layer = new LayerLinear[Float](8)
+    val layer = new VectorProduct[Float](8)
     layer.setWeightsBias(Array(weight, bias))
 
     val output = layer.forward(input)
@@ -247,5 +247,22 @@ class ExpandSizeSerialTest extends ModuleSerializationTest {
     val model = ExpandSize[Float](Array(2, 8)).setName("ExpandSize")
     val input = Tensor[Float](2, 1).apply1(_ => Random.nextFloat())
     runSerializationTest(model, input)
+  }
+}
+
+class VectorProductSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val model = new VectorProduct[Float](8).setName("VectorProduct")
+    val input = Tensor[Float](2, 8).apply1(_ => Random.nextFloat())
+    runSerializationTest(model, input)
+  }
+}
+
+class TableOperationSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val model = new TableOperation[Float](CMulTable()).setName("TableOperation")
+    val input1 = Tensor[Float](2, 8).apply1(_ => Random.nextFloat())
+    val input2 = Tensor[Float](2, 1).apply1(_ => Random.nextFloat())
+    runSerializationTest(model, T(input1, input2))
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LayerNormalizationSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/LayerNormalizationSpec.scala
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn
+
+import com.intel.analytics.bigdl.nn.mkldnn.Equivalent
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.T
+import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.util.Random
+
+class LayerNormalizationSpec extends FlatSpec with Matchers {
+
+  val input = Tensor[Float](
+    T(T(1.62434536, -0.61175641, -0.52817175, -1.07296862, 0.86540763, -2.3015387,
+      1.74481176, -0.7612069),
+      T( 0.3190391, -0.24937038, 1.46210794, -2.06014071, -0.3224172, -0.38405435,
+        1.13376944, -1.09989127))
+  )
+  val weightsExpected = Tensor[Float](T(-0.14037117, -0.16902402, -0.06451887,
+    -0.5642037, 0.24212438, 0.44951588, -0.4296978, 0.423163))
+
+  val biasExpected = Tensor[Float](T(0.44111532, -0.06523705, -0.3474969, -0.08237404,
+    -0.3565278, -0.18157673, 0.4592312, -0.36194998))
+
+  val outputExpected = Tensor[Float](
+    T(T( 0.2547953, -0.00365025, -0.32806823, 0.32006884, -0.17416702, -0.92002285,
+      -0.15028489, -0.56398183),
+      T( 0.37940904, -0.04951846, -0.444961, 0.9273568, -0.39561632, -0.28010735,
+        -0.05768752, -0.73853105)))
+
+  val gradInputExpected = Tensor[Float](
+    T(T(-0.0655726, 0.11039984, 0.12039759, 0.00393196, -0.02003431, -0.09076728,
+      0.00234376, -0.06069893),
+      T(0.00566998, 0.14491531, -0.08142705, -0.09353723, 0.05779467, 0.03840649,
+        -0.03802159, -0.03380056)))
+
+  val gradWeightExpected = Tensor[Float](
+    T( 0.5049854, 0.00593506, -0.5733794, -1.8879533, -0.06730913, 1.5727731,
+      -0.28257257, 0.9264967, 0.6342044, -0.05316871, -0.7730292, 1.2474256,
+      -0.56978333, -1.2001302, -0.2079724, -1.3025129))
+
+  "LayerNormalization layer" should "work correct" in {
+    val layerNorm = new LayerNormalization[Float](8)
+    val params = layerNorm.parameters()
+    params._1.apply(0).copy(weightsExpected)
+    params._1.apply(1).copy(biasExpected)
+
+    val output = layerNorm.forward(input)
+    output should be(outputExpected)
+
+    val gradInput = layerNorm.backward(input, output)
+    Equivalent.nearequals(gradInput.toTensor[Float], gradInputExpected)
+
+    val gradWeights = layerNorm.getParameters()._2
+
+    gradWeights should be(gradWeightExpected)
+  }
+
+  "LayerNormalization layer for 3 dims" should "work correct" in {
+    val layerNorm = new LayerNormalization[Float](8)
+    val params = layerNorm.parameters()
+    params._1.apply(0).copy(weightsExpected)
+    params._1.apply(1).copy(biasExpected)
+
+    val input = Tensor[Float](T(T(
+      T( 1.62434536, -0.61175641, -0.52817175, -1.07296862, 0.86540763,
+        -2.3015387, 1.74481176, -0.7612069),
+      T( 0.3190391, -0.24937038, 1.46210794, -2.06014071, -0.3224172,
+        -0.38405435, 1.13376944, -1.09989127),
+      T(-0.17242821, -0.87785842, 0.04221375, 0.58281521, -1.10061918,
+        1.14472371, 0.90159072, 0.50249434)),
+      T(T( 0.90085595, -0.68372786, -0.12289023, -0.93576943, -0.26788808,
+        0.53035547, -0.69166075, -0.39675353),
+        T(-0.6871727, -0.84520564, -0.67124613, -0.0126646, -1.11731035,
+          0.2344157, 1.65980218, 0.74204416),
+        T(-0.19183555, -0.88762896, -0.74715829, 1.6924546, 0.05080775,
+          -0.63699565, 0.19091548, 2.10025514))))
+
+    val outputExpected = Tensor[Float](
+      T(T(T( 0.2547953, -0.00365025, -0.32806823, 0.32006884, -0.17416702,
+        -0.92002285, -0.15028489, -0.56398183),
+        T( 0.37940904, -0.04951846, -0.444961, 0.9273568, -0.39561632,
+          -0.28010735, -0.05768752, -0.73853105),
+        T( 0.49671584, 0.15898634, -0.34020767, -0.42094654, -0.74886715,
+          0.4213413, 0.02069786, -0.15284662)),
+        T(T( 0.17843285, 0.07028739, -0.3568077, 0.60989976, -0.3808119,
+          0.37866306, 0.80951583, -0.4963839),
+          T( 0.53689927, 0.08047631, -0.30464026, -0.13017833, -0.6401863,
+            -0.0171783, -0.3944744, 0.0371049),
+          T( 0.49308524, 0.1095071, -0.28943837, -0.8874372, -0.39013758,
+            -0.5388527, 0.46145913, 0.40644628))))
+
+    val gradInputExpected = Tensor[Float](
+      T(T(T(-0.0655726, 0.11039984, 0.12039759, .00393196, -0.02003431,
+        -0.09076728, 0.00234376, -0.06069893),
+        T( 0.00566998, 0.14491531, -0.08142705, -0.09353723, 0.05779467,
+          0.03840649, -0.03802159, -0.03380056),
+        T(-0.06164519, 0.10382065, 0.02612757, 0.22695568, -0.06549627,
+          0.07673246, -0.14727353, -0.15922137)),
+        T(T(-0.2443429, 0.31894156, 0.18631479, -0.15545437, 0.04144509,
+          0.21156964, -0.24511626, -0.11335772),
+          T(-0.03258525, 0.05264378, 0.07396686, 0.07267879, -0.08235938,
+            -0.04306597, 0.02329509, -0.06457391),
+          T(-0.01852474, 0.12962818, 0.14494516, 0.2547746, -0.07740442,
+            -0.11968417, -0.19652283, -0.11721179))))
+
+    val gradWeightExpected = Tensor[Float](
+      T( 0.09323123, -0.44392002, -0.12362102, -4.166217, 1.9885124, 3.0318348,
+        -1.7074748, 1.7816961, 2.3393373, 0.36608845, -2.0641232, 0.41876316,
+        -2.7297864, -0.95615685, 0.68922603, -1.5081923)
+    )
+
+    val output = layerNorm.forward(input)
+    output should be(outputExpected)
+
+    val gradInput = layerNorm.backward(input, output)
+    Equivalent.nearequals(gradInput.toTensor[Float], gradInputExpected)
+
+    val gradWeights = layerNorm.getParameters()._2
+
+    gradWeights should be(gradWeightExpected)
+  }
+
+  "layer linear with 2 dims" should "work correct" in {
+    val weight = Tensor[Float](T(-0.14037117, -0.16902402, -0.06451887,
+      -0.5642037, 0.24212438, 0.44951588, -0.4296978, 0.423163))
+    val bias = Tensor[Float](T(0.44111532, -0.06523705, -0.3474969,
+      -0.08237404, -0.3565278, -0.18157673, 0.4592312, -0.36194998))
+
+    val outputExpected = Tensor[Float](
+      T(T( 0.21310404, 0.03816448, -0.31341985, 0.5229988, -0.14699152, -1.2161549,
+        -0.2905106, -0.6840646),
+        T( 0.39633143, -0.02308746, -0.44183046, 1.0799649, -0.43459287, -0.35421526,
+          -0.02794704, -0.8273833)))
+
+    val gradInputExpected = Tensor[Float](
+      T(T(-0.02991366, -0.00645071, 0.02022149, -0.29507786, -0.03559023, -0.5466809,
+        0.12483177, -0.28947085),
+        T(-0.05563351, 0.00390234, 0.0285064, -0.60932016, -0.10522553, -0.15922539,
+          0.01200878, -0.35011798)))
+
+    val gradWeightExpected = Tensor[Float](T(0.4725998, -0.01759003, -0.48046428,
+      -2.7860408, 0.01291263, 2.9350655, -0.5385718, 1.4307464, 0.60943544,
+      0.01507702, -0.75525033, 1.6029637, -0.5815844, -1.5703702, -0.31845763, -1.5114479))
+
+    val layer = new LayerLinear[Float](8)
+    layer.setWeightsBias(Array(weight, bias))
+
+    val output = layer.forward(input)
+    output should be(outputExpected)
+
+    val gradInput = layer.backward(input, output)
+    gradInput should be(gradInputExpected)
+
+    val gradWeights = layer.getParameters()._2
+    gradWeights should be(gradWeightExpected)
+  }
+
+  "CMulTableExpand" should "work correctly" in {
+    val input1 = Tensor[Float](T(T(-0.52817175, -1.07296862, 0.86540763, -2.3015387,
+      1.74481176, -0.7612069, 0.3190391, -0.24937038),
+      T( 1.46210794, -2.06014071, -0.3224172, -0.38405435, 1.13376944, -1.09989127,
+        -0.17242821, -0.87785842)))
+    val input2 = Tensor[Float](T(T(1.62434536), T(-0.61175641)))
+    val input3 = Tensor[Float](T(T(1.62434536, 1.62434536, 1.62434536, 1.62434536,
+      1.62434536, 1.62434536, 1.62434536, 1.62434536),
+      T(-0.61175641, -0.61175641, -0.61175641, -0.61175641, -0.61175641,
+        -0.61175641, -0.61175641, -0.61175641)))
+    val layer = CMulTableExpand[Float]()
+    val output = layer.forward(T(input1, input2))
+    val output2 = layer.forward(T(input1, input3))
+    output should be(output2)
+
+    val gradInput = layer.backward(T(input1, input2), output)
+    val gradInput2 = layer.backward(T(input1, input3), output2)
+
+    gradInput[Tensor[Float]](1) should be(gradInput2[Tensor[Float]](1))
+    gradInput[Tensor[Float]](2) should be(gradInput2[Tensor[Float]](2))
+  }
+
+  "CSubTableExpand" should "work correctly" in {
+    val input1 = Tensor[Float](T(T(-0.52817175, -1.07296862, 0.86540763, -2.3015387,
+      1.74481176, -0.7612069, 0.3190391, -0.24937038),
+      T( 1.46210794, -2.06014071, -0.3224172, -0.38405435, 1.13376944, -1.09989127,
+        -0.17242821, -0.87785842)))
+    val input2 = Tensor[Float](T(T(1.62434536), T(-0.61175641)))
+    val input3 = Tensor[Float](T(T(1.62434536, 1.62434536, 1.62434536, 1.62434536,
+      1.62434536, 1.62434536, 1.62434536, 1.62434536),
+      T(-0.61175641, -0.61175641, -0.61175641, -0.61175641, -0.61175641,
+        -0.61175641, -0.61175641, -0.61175641)))
+    val layer = CSubTableExpand[Float]()
+    val output = layer.forward(T(input1, input2))
+    val output2 = layer.forward(T(input1, input3))
+    output should be(output2)
+
+    val gradInput = layer.backward(T(input1, input2), output)
+    val gradInput2 = layer.backward(T(input1, input3), output2)
+
+    gradInput[Tensor[Float]](1) should be(gradInput2[Tensor[Float]](1))
+    gradInput[Tensor[Float]](2) should be(gradInput2[Tensor[Float]](2))
+  }
+}
+
+class LayerNormalizationSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val model = new LayerNormalization[Float](8).setName("LayerNormalization")
+    val input = Tensor[Float](2, 3, 8).apply1(_ => Random.nextFloat())
+    runSerializationTest(model, input)
+  }
+}
+
+class CMulTableExpandSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val model = CMulTableExpand[Float]().setName("CMulTableExpand")
+    val input1 = Tensor[Float](2, 8).apply1(_ => Random.nextFloat())
+    val input2 = Tensor[Float](2, 1).apply1(_ => Random.nextFloat())
+    runSerializationTest(model, T(input1, input2))
+  }
+}
+
+class CSubTableExpandSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val model = CSubTableExpand[Float]().setName("CSubTableExpand")
+    val input1 = Tensor[Float](2, 8).apply1(_ => Random.nextFloat())
+    val input2 = Tensor[Float](2, 1).apply1(_ => Random.nextFloat())
+    runSerializationTest(model, T(input1, input2))
+  }
+}
+
+class ExpandSizeSerialTest extends ModuleSerializationTest {
+  override def test(): Unit = {
+    val model = ExpandSize[Float](Array(2, 8)).setName("ExpandSize")
+    val input = Tensor[Float](2, 1).apply1(_ => Random.nextFloat())
+    runSerializationTest(model, input)
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

. Implement Layer normalization
. Implement ExpandSize and TableOperationExpand that handling two tensors with different size
. Add corresponding python api

## How was this patch tested?

unit tests

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

