### PR TITLE
fix: memory data hash code should contain data type

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/MemoryData.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/MemoryData.scala
@@ -126,6 +126,8 @@ case class HeapData(private var _shape: Array[Int], private var _layout: Int,
       d += 1
     }
 
+    hash = hash * seed + this.dataType
+
     hash
   }
 
@@ -190,6 +192,8 @@ case class NativeData(private var _shape: Array[Int], private var _layout: Int,
       hash = hash * seed + this.shape(d)
       d += 1
     }
+
+    hash = hash * seed + this.dataType
 
     hash
   }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/MemoryDataSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/MemoryDataSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.mkl.{DataType, Memory}
+import org.scalatest.{FlatSpec, Matchers}
+
+class MemoryDataSpec extends FlatSpec with Matchers {
+  "memory data hashCode comparison data" should "work correctly" in {
+    val fp32 = HeapData(Array(4, 3), Memory.Format.nc, DataType.F32)
+    val int8 = HeapData(Array(4, 3), Memory.Format.nc, DataType.S8)
+
+    fp32.hashCode() == int8.hashCode() should not be (true)
+  }
+
+  "memory data hashCode comparison native" should "work correctly" in {
+    val fp32 = NativeData(Array(3, 3), Memory.Format.nc, DataType.F32)
+    val int8 = NativeData(Array(3, 3), Memory.Format.nc, DataType.S8)
+
+    fp32.hashCode() == int8.hashCode() should not be (true)
+  }
+
+  "memory data hashCode comparison heap and native" should "work correctly" in {
+    val heap = HeapData(Array(3, 3), Memory.Format.nc, DataType.F32)
+    val native = NativeData(Array(3, 3), Memory.Format.nc, DataType.F32)
+
+    heap.hashCode() == native.hashCode() should not be (true)
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

After enable int8, the memory data / description should contain data type in hash code.

## How was this patch tested?

Jenkins and unit tests.

