### PR TITLE
feat: enable global average pooling

### DIFF
--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/AvgPoolingSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/AvgPoolingSpec.scala
@@ -236,4 +236,33 @@ class AvgPoolingSpec extends BigDLSpecHelper {
 
     Equivalent.nearequals(seq.output.toTensor, seq2.output.toTensor, 1e-2) should be (true)
   }
+
+  "global average pooling" should "work correctly" in {
+    val gap = AvgPooling(2, 2, globalPooling = true)
+    val ap = AvgPooling(3, 3)
+
+    val inputShape = Array(4, 2, 3, 3)
+    val input = Tensor[Float](inputShape).rand(-1, 1)
+
+    val seq1 = Sequential()
+      .add(Input(inputShape, Memory.Format.nchw))
+      .add(ap)
+      .add(Output(Memory.Format.nchw))
+
+    val seq2 = Sequential()
+      .add(Input(inputShape, Memory.Format.nchw))
+      .add(gap)
+      .add(Output(Memory.Format.nchw))
+
+    seq1.evaluate()
+    seq2.evaluate()
+
+    seq1.compile(InferencePhase)
+    seq2.compile(InferencePhase)
+
+    seq1.forward(input)
+    seq2.forward(input)
+
+    seq1.output should be (seq2.output)
+  }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/AvgPoolingSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/AvgPoolingSpec.scala
@@ -265,4 +265,25 @@ class AvgPoolingSpec extends BigDLSpecHelper {
 
     seq1.output should be (seq2.output)
   }
+
+  "global average pooling" should "has same behavior with nn" in {
+    val gap = AvgPooling(2, 2, globalPooling = true)
+
+    val inputShape = Array(4, 2, 3, 3)
+    val input = Tensor[Float](inputShape).rand(-1, 1)
+
+    val seq1 = Sequential()
+      .add(Input(inputShape, Memory.Format.nchw))
+      .add(gap)
+      .add(Output(Memory.Format.nchw))
+
+    seq1.evaluate()
+    seq1.compile(InferencePhase)
+    seq1.forward(input)
+
+    val nngap = SpatialAveragePooling[Float](2, 2, globalPooling = true)
+    nngap.forward(input)
+
+    seq1.output should be (nngap.output)
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
This patch enable the global pooling. As the implementation in `SpatialAveragePooling`, use the same parameter style, which means use `var` to handle `kH` and `kW` in the argument list.

## How was this patch tested?
Jenkins and unit tests.

