### PR TITLE
fix: require consistent between shape and layout of mkldnn

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/MemoryData.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/MemoryData.scala
@@ -104,7 +104,8 @@ sealed trait MemoryData extends Serializable {
   private def checkConsistency(shape: Array[Int], layout: Int): Unit = {
     val isConsistency = Memory.Format.any == layout || (shape.length match {
       case 1 => layout == Memory.Format.x
-      case 2 => layout == Memory.Format.nc
+      case 2 => layout == Memory.Format.nc || layout == Memory.Format.io ||
+        layout == Memory.Format.oi
       case 3 | 4 | 5 => layout != Memory.Format.nc || layout != Memory.Format.x
       case _ => false
     })

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/MemoryData.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/MemoryData.scala
@@ -102,10 +102,11 @@ sealed trait MemoryData extends Serializable {
   }
 
   private def checkConsistency(shape: Array[Int], layout: Int): Unit = {
-    // TODO current only handle the 4-D and 2-D shape
-    val isConsistency = if (shape.length == 4) layout != Memory.Format.nc
-    else {
-      true
+    val isConsistency = shape.length match {
+      case 1 => layout == Memory.Format.x
+      case 2 => layout == Memory.Format.nc
+      case 3 | 4 | 5 => layout != Memory.Format.nc || layout != Memory.Format.x
+      case _ => false
     }
 
     require(isConsistency,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/MemoryData.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/MemoryData.scala
@@ -102,12 +102,12 @@ sealed trait MemoryData extends Serializable {
   }
 
   private def checkConsistency(shape: Array[Int], layout: Int): Unit = {
-    val isConsistency = shape.length match {
+    val isConsistency = Memory.Format.any == layout || (shape.length match {
       case 1 => layout == Memory.Format.x
       case 2 => layout == Memory.Format.nc
       case 3 | 4 | 5 => layout != Memory.Format.nc || layout != Memory.Format.x
       case _ => false
-    }
+    })
 
     require(isConsistency,
       s"the shape([${shape.mkString(",")}]) of tensor is different from layout(${layout})")

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/MemoryData.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/MemoryData.scala
@@ -49,6 +49,7 @@ sealed trait MemoryData extends Serializable {
 
   def getMemoryDescription(): Long = {
     if (description == UNDEFINED || description == ERROR) {
+      checkConsistency(shape, layout)
       description = MklDnn.MemoryDescInit(shape.length, shape, dataType, layout)
     }
     description
@@ -98,6 +99,17 @@ sealed trait MemoryData extends Serializable {
       case DataType.U8 => DnnStorage.INT8_BYTES
       case _ => throw new UnsupportedOperationException(s"unsupported data type")
     }
+  }
+
+  private def checkConsistency(shape: Array[Int], layout: Int): Unit = {
+    // TODO current only handle the 4-D and 2-D shape
+    val isConsistency = if (shape.length == 4) layout != Memory.Format.nc
+    else {
+      true
+    }
+
+    require(isConsistency,
+      s"the shape([${shape.mkString(",")}]) of tensor is different from layout(${layout})")
   }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The exception information is not clear when the reorder can't work. For example,
a graph with a maxpooling, which will output 4-D tensor. If we convert the 4-D tensor with
a `Memory.Format.nc` format. It will be segment fault.

## How was this patch tested?
Jenkins.

