### PR TITLE
fix: fusion for multi-group of convolution

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Fusion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Fusion.scala
@@ -189,7 +189,10 @@ private[mkldnn] object Fusion {
       val weight = if (conv.nGroup == 1) {
         convWeight.select(1, j + 1)
       } else {
-        convWeight.select(2, j + 1)
+        val channelPerGroup = conv.nOutputPlane / conv.nGroup
+        val group = j  / channelPerGroup + 1
+        val channel = j % channelPerGroup + 1
+        convWeight.select(1, group).select(2, channel)
       }
       weight.div(base)
       weight.mul(alpha)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialConvolution.scala
@@ -45,6 +45,16 @@ class SpatialConvolution(
   val withBias: Boolean = true,
   val format: DataFormat = DataFormat.NCHW
 ) extends MklDnnLayer with Initializable with Serializable with MklInt8Convertible {
+  require(nInputPlane % nGroup == 0, s"Number of input channels " +
+    s"should be multiples of group " +
+    s"number of input channels ${nInputPlane}, " +
+    s"group ${nGroup}.")
+  require(nOutputPlane % nGroup == 0,
+    "Number of output channels " +
+      "should be multiples of group " +
+      s"(number of output channels ${nOutputPlane}, " +
+      s"group ${nGroup}).")
+
   private val weightShape = if (nGroup == 1) {
     Array(nOutputPlane, nInputPlane, kernelH, kernelW)
   } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

For fusion between multi-group convolution and batch norm, we should select the right channel computed with batch norm.

## How was this patch tested?
Jenkins.

