### PR TITLE
fix: support int8 of jointable

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/DnnGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/DnnGraph.scala
@@ -327,8 +327,9 @@ class DnnGraph(
 
   private def getInputMemoryData(node: ModuleNode[Float], memoryData: Array[MemoryData])
     : Array[MemoryData] = {
-    if (inputs.length == 1) {
-      require(inputs(0).eq(node), "input node is not in the input list")
+    // the model may contains two inputs and all of them is Input.
+    if (inputs.length == 1 || memoryData.isEmpty) {
+      require(inputs.contains(node), "input node is not in the input list")
       memoryData
     } else {
       val i = inputs.indexOf(node)
@@ -392,13 +393,14 @@ class DnnGraph(
    */
   private def fusion(): Unit = {
     if (!this.train) {
-      for (j <- 0 to 2) {
+      for (j <- 0 to 3) {
         var i = forwardExecution.length - 1
         while (i >= 0) {
           if (j == 0) Fusion.fuseModule(forwardExecution(i))
           // we should do this before sum fusion, because it will change the structure of graph
           if (j == 1) Fusion.setNegativeInputOfConv(forwardExecution(i))
           if (j == 2) Fusion.fuseCAdd(forwardExecution(i))
+          if (j == 3) Fusion.setJoinTableSame(forwardExecution(i))
           i -= 1
         }
       }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/DnnGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/DnnGraph.scala
@@ -327,9 +327,9 @@ class DnnGraph(
 
   private def getInputMemoryData(node: ModuleNode[Float], memoryData: Array[MemoryData])
     : Array[MemoryData] = {
-    // the model may contains two inputs and all of them is Input.
+    // the model may contain two inputs and all of them is Input.
     if (inputs.length == 1 || memoryData.isEmpty) {
-      require(inputs.contains(node), "input node is not in the input list")
+      require(inputs.contains(node), "input node must be in the input list")
       memoryData
     } else {
       val i = inputs.indexOf(node)
@@ -400,7 +400,7 @@ class DnnGraph(
           // we should do this before sum fusion, because it will change the structure of graph
           if (j == 1) Fusion.setNegativeInputOfConv(forwardExecution(i))
           if (j == 2) Fusion.fuseCAdd(forwardExecution(i))
-          if (j == 3) Fusion.setJoinTableSame(forwardExecution(i))
+          if (j == 3) Fusion.setScalesPrevousJoinTable(forwardExecution(i))
           i -= 1
         }
       }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/JoinTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/JoinTable.scala
@@ -34,7 +34,6 @@ class JoinTable(val dimension: Int) extends MklDnnLayer {
     var i = 1
     while(i < inputs.length) {
       val curShape = inputs(i).shape
-      require(layout == inputs(i).layout, "layout not match")
       require(totalShape.length == curShape.length, "tensor dimension not match")
       // require(inputs(i).isInstanceOf[NativeData], "memory should be native")
       var j = 0
@@ -45,6 +44,10 @@ class JoinTable(val dimension: Int) extends MklDnnLayer {
           require(totalShape(j) == curShape(j), "tensor size not match")
         }
         j += 1
+      }
+
+      if (layout != inputs(i).layout || inputs(0).dataType != inputs(i).dataType) {
+        _inputFormats(i) = NativeData(inputs(i).shape, layout, inputs(0).dataType)
       }
       i += 1
     }
@@ -108,6 +111,11 @@ class JoinTable(val dimension: Int) extends MklDnnLayer {
     }
     gradInput
   }
+
+  private def isSameDataType(formats: Array[MemoryData]): Boolean = {
+    formats.map(_.dataType).toSet.size == 1
+  }
+
 }
 
 object JoinTable {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Output.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Output.scala
@@ -37,9 +37,6 @@ class Output(outputLayOut: Int = Memory.Format.nc,
       if (outLayout == Memory.Format.nhwc && inLayout != Memory.Format.nhwc) {
         // nchw*  -> nhwc
         Array(inShape(0), inShape(2), inShape(3), inShape(1))
-      } else if ((outLayout != Memory.Format.nhwc) && (inLayout == Memory.Format.nhwc)) {
-        // nhwc -> nchw*
-        Array(inShape(0), inShape(3), inShape(1), inShape(2))
       } else inShape
     outputShape
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

JoinTable need to specially care. If the previous nodes of `JoinTable` are convolutions, we should make the two conv's output scales to be the same, so JoinTable can do the computing on the same scale factor.

## How was this patch tested?

Unit tests.


