### PR TITLE
Optimizers: use member variable in parent class

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -807,7 +807,7 @@ class DistriOptimizer[T: ClassTag] (
     state("warmupIterationNum") = warmupIterationNum
     state("computeThresholdbatchSize") = computeThresholdbatchSize
     state("maxDropPercentage") = maxDropPercentage
-    state("isLayerwiseScaled") = Utils.isLayerwiseScaled(_model)
+    state("isLayerwiseScaled") = Utils.isLayerwiseScaled(model)
 
     val nodeNumber = Engine.nodeNumber()
     val coresPerNode = Engine.coreNumber()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalOptimizer.scala
@@ -38,17 +38,17 @@ object LocalOptimizer {
 /**
  * Optimize a model on a single machine
  *
- * @param model model to be optimized
- * @param dataset data set
- * @param criterion criterion to be used
+ * @param _model model to be optimized
+ * @param _dataset data set
+ * @param _criterion criterion to be used
  */
 class LocalOptimizer[T: ClassTag] (
-  model: Module[T],
-  dataset: LocalDataSet[MiniBatch[T]],
-  criterion: Criterion[T]
+  _model: Module[T],
+  _dataset: LocalDataSet[MiniBatch[T]],
+  _criterion: Criterion[T]
 )(implicit ev: TensorNumeric[T])
   extends Optimizer[T, MiniBatch[T]](
-    model, dataset, criterion) {
+    _model, _dataset, _criterion) {
 
   import LocalOptimizer._
   import Optimizer.{header, saveModel, saveState, checkSubModules, getHyperParameterLog}
@@ -114,8 +114,9 @@ class LocalOptimizer[T: ClassTag] (
     state("isLayerwiseScaled") = Utils.isLayerwiseScaled(model)
 
     dataset.shuffle()
-    val numSamples = dataset.data(train = false).map(_.size()).reduce(_ + _)
-    var iter = dataset.data(train = true)
+    val _dataset = dataset.asInstanceOf[LocalDataSet[MiniBatch[T]]]
+    val numSamples = _dataset.data(train = false).map(_.size()).reduce(_ + _)
+    var iter = _dataset.data(train = true)
     logger.info("model thread pool size is " + Engine.model.getPoolSize)
     while (!endWhen(state)) {
       val start = System.nanoTime()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/ParallelOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/ParallelOptimizer.scala
@@ -646,7 +646,7 @@ class ParallelOptimizer[T: ClassTag] (
         asInstanceOf[Container[_, _, T]].modules,
         optimMethodMap(this.model.getName), optimMethodMap)
     } else {
-      require(optimMethodMap.contains(this._model.getName),
+      require(optimMethodMap.contains(this.model.getName),
         "single layer model should have optim method set")
     }
 
@@ -675,7 +675,7 @@ class ParallelOptimizer[T: ClassTag] (
 
   private def defaultPrioritize(): mutable.HashMap[String, Int] = {
     val priorities = new mutable.HashMap[String, Int]
-    val orders = ParallelOptimizer.getExecutionOrder(this._model)
+    val orders = ParallelOptimizer.getExecutionOrder(this.model)
     val len = orders.size
     orders.zipWithIndex.foreach(order => {
       priorities.put(order._1.getName, len - order._2)
@@ -709,7 +709,7 @@ class ParallelOptimizer[T: ClassTag] (
     state("warmupIterationNum") = warmupIterationNum
     state("computeThresholdbatchSize") = computeThresholdbatchSize
     state("maxDropPercentage") = maxDropPercentage
-    state("isLayerwiseScaled") = Utils.isLayerwiseScaled(_model)
+    state("isLayerwiseScaled") = Utils.isLayerwiseScaled(model)
 
     val nodeNumber = Engine.nodeNumber()
     val coresPerNode = Engine.coreNumber()


### PR DESCRIPTION
## What changes were proposed in this pull request?

The subclasses of `Optimizer` uses their own variables/values. They are not updated when the super class `Opimizer` updates these variables. This PR changes the subclasses to use the parent's data.

## How was this patch tested?

UT

## Related links or issues (optional)


