### PR TITLE
Fix weights changed for model fusion

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Fusion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Fusion.scala
@@ -199,8 +199,11 @@ private[mkldnn] object Fusion {
       convBias.storage().array()(j) = alpha / base * bias + beta - (alpha * mean) / base
     }
 
-    conv.weight.copy(convWeight)
-    conv.bias.copy(convBias)
+    // We will change model structure and weights when doing conv and bn fusion
+    // In order to not influence broadcast model and weights,
+    // we set new storage to weight and bias.
+    conv.weight.dense.set(convWeight)
+    conv.bias.dense.set(convBias)
 
     // regenerate the weight scales and output scales
     conv.flushWeightScales(conv.weight.dense)


### PR DESCRIPTION
## What changes were proposed in this pull request?
    
We will change model structure and weights when doing conv and bn fusion.
 In order to not influence broadcast model and weights, we have to set new storage to weight and bias.

## How was this patch tested?

unit tests

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/2838
