### PR TITLE
fix: invokeAndWait2 should throw the exception in the tasks

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import org.apache.log4j.Logger
 import org.apache.spark._
 import com.intel.analytics.bigdl.mkl.MKL
-import com.intel.analytics.bigdl.mkl.hardware.CpuInfo
+import com.intel.analytics.bigdl.mkl.hardware.{Affinity, CpuInfo}
 import org.apache.spark.utils.SparkUtils
 import py4j.GatewayServer
 
@@ -556,7 +556,24 @@ object Engine {
   }
 
   private def setMklDnnEnvironments(): Unit = {
-    val default = Math.ceil(Runtime.getRuntime.availableProcessors().toFloat / 2).toInt
+    import com.intel.analytics.bigdl.mkl.hardware.CpuInfo
+    val affinityCores = Affinity.getAffinity
+    val physicalCoreNum = CpuInfo.getPhysicalProcessorCount
+    val affinityCoreNum = affinityCores.length
+
+    // 1. this library in docker/cgroup env, which sets cpu affinity fist. so we can't use
+    //    resources exceeding limits.
+    // 2. this library is in a hyper thread envs, which enables hyper threading of cpu. so
+    //    we should set the mkl num threads to physical core number for performance
+
+    val default = if (affinityCores.min > 0 && affinityCores.max >= physicalCoreNumber) {
+      affinityCoreNum
+    } else if (physicalCoreNum > affinityCoreNum ) {
+      affinityCoreNum
+    } else {
+      physicalCoreNum
+    }
+
     val threadsNumber = System.getProperty("bigdl.mklNumThreads", default.toString)
     System.setProperty("bigdl.mklNumThreads", s"$threadsNumber")
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
@@ -563,8 +563,8 @@ object Engine {
 
     // 1. this library in docker/cgroup env, which sets cpu affinity fist. so we can't use
     //    resources exceeding limits.
-    // 2. this library is in a hyper thread envs, which enables hyper threading of cpu. so
-    //    we should set the mkl num threads to physical core number for performance
+    // 2. this library is in a hyper threading envs, so we should set the mkl num threads
+    //    to physical core number for performance
 
     val default = if (affinityCores.min > 0 && affinityCores.max >= physicalCoreNumber) {
       affinityCoreNum

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/ThreadPool.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/ThreadPool.scala
@@ -16,20 +16,17 @@
 
 package com.intel.analytics.bigdl.utils
 
-import java.lang.Thread.UncaughtExceptionHandler
 import java.util.concurrent._
 
-import com.intel.analytics.bigdl.mkl.MKL
 import com.intel.analytics.bigdl.mkl.hardware.Affinity
-import com.intel.analytics.bigdl.mkl.{MklDnn => BackendMklDnn}
+import com.intel.analytics.bigdl.mkl.{MKL, MklDnn => BackendMklDnn}
 import org.apache.commons.lang.exception.ExceptionUtils
 import org.apache.log4j.Logger
-import org.glassfish.jersey.server.monitoring.RequestEvent.ExceptionCause
 
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, ExecutionContext, Future}
 
 /**
  * A thread pool wrapper, provide some helper functions for multi-threading

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/ThreadPool.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/ThreadPool.scala
@@ -16,6 +16,7 @@
 
 package com.intel.analytics.bigdl.utils
 
+import java.lang.Thread.UncaughtExceptionHandler
 import java.util.concurrent._
 
 import com.intel.analytics.bigdl.mkl.MKL
@@ -23,10 +24,12 @@ import com.intel.analytics.bigdl.mkl.hardware.Affinity
 import com.intel.analytics.bigdl.mkl.{MklDnn => BackendMklDnn}
 import org.apache.commons.lang.exception.ExceptionUtils
 import org.apache.log4j.Logger
+import org.glassfish.jersey.server.monitoring.RequestEvent.ExceptionCause
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 /**
  * A thread pool wrapper, provide some helper functions for multi-threading
@@ -135,24 +138,45 @@ class ThreadPool(private var poolSize: Int) {
     })
   }
 
+  private type JavaFuture[T] = java.util.concurrent.Future[T]
+
+  /**
+   * Use java future to execute the tasks. It will be blocking until tasks completed.
+   * If any task throws an exception, it will throw that exception in caller.
+   *
+   * @param tasks task sequence. each task's return type is T
+   * @param timeout the maximum time to wait
+   * @param timeUnit the time unit for the timeout
+   * @tparam T return type of tasks
+   * @return a sequence of Futures representing the tasks.
+   */
   def invokeAndWait2[T](tasks: Seq[() => T], timeout: Long = Long.MaxValue,
-    timeUnit: TimeUnit = TimeUnit.NANOSECONDS):
-  scala.collection.mutable.Buffer[java.util.concurrent.Future[T]] = {
+    timeUnit: TimeUnit = TimeUnit.NANOSECONDS): mutable.Buffer[JavaFuture[T]] = {
     val callables = tasks.map(task => new Callable[T] {
       override def call(): T = {
-        try {
-          task()
-        } catch {
-          case t : Throwable =>
-            logger.error("Error: " + ExceptionUtils.getStackTrace(t))
-            throw t
-        }
+        task()
       }
     })
-    threadPool.invokeAll(callables.asJava, timeout, timeUnit).asScala
+
+    val resultFutures = threadPool.invokeAll(callables.asJava, timeout, timeUnit)
+
+    // we should check all the future in the list, if any task has an exception,
+    // we should throw it.
+    var i = 0
+    while (i < resultFutures.size()) {
+      try {
+        resultFutures.get(i).get()
+      } catch {
+        case t: ExecutionException => throw t.getCause
+        case i: InterruptedException => throw i.getCause
+      }
+      i += 1
+    }
+
+    resultFutures.asScala
   }
 
-  def invoke2[T](tasks: Seq[() => T]): Seq[java.util.concurrent.Future[T]] = {
+  def invoke2[T](tasks: Seq[() => T]): Seq[JavaFuture[T]] = {
     tasks.map(task => new Callable[T] {
       override def call(): T = {
         try {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/ThreadPoolSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/ThreadPoolSpec.scala
@@ -26,7 +26,7 @@ class ThreadPoolSpec extends FlatSpec with Matchers {
   "mkldnn backend" should "create omp threads and bind correctly" in {
     com.intel.analytics.bigdl.mkl.MklDnn.isLoaded
     val poolSize = 1
-    val ompSize = 4
+    val ompSize = Runtime.getRuntime.availableProcessors() / 2
 
     val threadPool = new ThreadPool(poolSize)
     // backup the affinities
@@ -57,7 +57,7 @@ class ThreadPoolSpec extends FlatSpec with Matchers {
 
   "mkldnn thread affinity binding" should "not influence other threads" in {
     val poolSize = 1
-    val ompSize = 4
+    val ompSize = Runtime.getRuntime.availableProcessors() / 2
 
     val threadPool = new ThreadPool(poolSize)
     threadPool.setMKLThreadOfMklDnnBackend(ompSize)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/ThreadPoolSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/ThreadPoolSpec.scala
@@ -16,9 +16,10 @@
 
 package com.intel.analytics.bigdl.utils
 
-import com.intel.analytics.bigdl.mkl.MKL
 import com.intel.analytics.bigdl.mkl.hardware.Affinity
 import org.scalatest.{FlatSpec, Matchers}
+
+import scala.concurrent.ExecutionException
 
 class ThreadPoolSpec extends FlatSpec with Matchers {
 
@@ -72,5 +73,42 @@ class ThreadPoolSpec extends FlatSpec with Matchers {
       println(Affinity.getAffinity.mkString("\t"))
       Affinity.getAffinity.length should not be (1)
     }))
+  }
+
+  "invokeAndWait2" should "catch the unsupported exception" in {
+    val threadPool = new ThreadPool(1)
+    val task = () => { throw new UnsupportedOperationException(s"test invokeAndWait2") }
+
+    intercept[UnsupportedOperationException] {
+      threadPool.invokeAndWait2( (0 until 1).map( i => task ))
+    }
+  }
+
+  "invokeAndWait2" should "catch the interrupt exception" in {
+    val threadPool = new ThreadPool(1)
+    val task = () => { throw new InterruptedException(s"test invokeAndWait2")}
+
+    intercept[InterruptedException] {
+      threadPool.invokeAndWait2( (0 until 1).map( i => task ))
+    }
+  }
+
+  "invokeAndWait" should "catch the exception" in {
+    val threadPool = new ThreadPool(1)
+    val task = () => { throw new InterruptedException(s"test invokeAndWait")}
+
+    intercept[InterruptedException] {
+      threadPool.invokeAndWait( (0 until 1).map( i => task ))
+    }
+  }
+
+  "invoke" should "catch the exception" in {
+    val threadPool = new ThreadPool(1)
+    val task = () => { throw new UnsupportedOperationException(s"test invoke2") }
+
+    intercept[ExecutionException] {
+      val results = threadPool.invoke2( (0 until 1).map( i => task ))
+      results.foreach(_.get())
+    }
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/ThreadPoolSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/ThreadPoolSpec.scala
@@ -51,7 +51,7 @@ class ThreadPoolSpec extends FlatSpec with Matchers {
 
     threadPool.invokeAndWait2( (0 until poolSize).map( i =>
       () => {
-        Affinity.getAffinity.zipWithIndex.foreach(ai => ai._1 should be (ai._2))
+        Affinity.getAffinity.zip(affinities.head).foreach(ai => ai._1 should be (ai._2))
       }))
 
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `invokeAndWait2` will not throw exceptions in the tasks to caller thread.

## How was this patch tested?
test cases and Jenkins.


