### PR TITLE
fix: wrong affinity settings

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/ThreadPool.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/ThreadPool.scala
@@ -107,7 +107,7 @@ class ThreadPool(private var poolSize: Int) {
 
       MKL.setNumThreads(size)
       BackendMklDnn.setNumThreads(size)
-      if (System.getProperty("bigdl.disableOmpAffinity", "false").toBoolean) {
+      if (!System.getProperty("bigdl.disableOmpAffinity", "false").toBoolean) {
         Affinity.setOmpAffinity()
       }
     }))


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `getProperty` will return false by default, so it will not set affnity.

## How was this patch tested?
Jenkins.


