### PR TITLE
[Bug Fix] - Fix module version comparison 

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/serializer/ModuleSerializable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/serializer/ModuleSerializable.scala
@@ -52,11 +52,18 @@ trait ModuleSerializable extends Loadable with Savable{
   // Separate this two methods for reuse in sub-classes
   protected def checkVersion[T: ClassTag](module : BigDLModule)
                                          (implicit ev: TensorNumeric[T]) : Unit = {
-    val version = module.getVersion
-    require(version <= bigDLVersion, s"bigDL version mismatch," +
-      s"module version $version," +
-      s"bigdl version $bigDLVersion, you cannot use low version bigdl" +
-      s" to load a higher version module")
+    val moduleVersion = module.getVersion
+    val modelVersionSplits = moduleVersion.split(".")
+    val bigdlVersinSplits = bigDLVersion.split(".")
+    require(modelVersionSplits.length == bigdlVersinSplits.length,
+      s"model version ${moduleVersion} has different format as BigDL version ${bigDLVersion}")
+    (0 until modelVersionSplits.length).foreach(idx => {
+      require(modelVersionSplits(idx).toInt <= bigdlVersinSplits(idx).toInt,
+        s"bigDL version mismatch," +
+          s"module version $moduleVersion," +
+          s"bigdl version $bigDLVersion, you cannot use low version bigdl" +
+          s" to load a higher version module")
+    })
   }
 
   protected def setVersion[T: ClassTag](modelBuilder : BigDLModule.Builder)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/serializer/ModuleSerializable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/serializer/ModuleSerializable.scala
@@ -54,11 +54,11 @@ trait ModuleSerializable extends Loadable with Savable{
                                          (implicit ev: TensorNumeric[T]) : Unit = {
     val moduleVersion = module.getVersion
     val modelVersionSplits = moduleVersion.split(".")
-    val bigdlVersinSplits = bigDLVersion.split(".")
-    require(modelVersionSplits.length == bigdlVersinSplits.length,
+    val bigdlVersionSplits = bigDLVersion.split(".")
+    require(modelVersionSplits.length == bigdlVersionSplits.length,
       s"model version ${moduleVersion} has different format as BigDL version ${bigDLVersion}")
     (0 until modelVersionSplits.length).foreach(idx => {
-      require(modelVersionSplits(idx).toInt <= bigdlVersinSplits(idx).toInt,
+      require(modelVersionSplits(idx).toInt <= bigdlVersionSplits(idx).toInt,
         s"bigDL version mismatch," +
           s"module version $moduleVersion," +
           s"bigdl version $bigDLVersion, you cannot use low version bigdl" +


### PR DESCRIPTION
## What changes were proposed in this pull request?

when loading pre-trained model into BigDl, We would check if the model version is higher than current BigDL version. A higher versioned model will not be loaded into BigDL. Currently we only compare the string representation of version which may cause some issue. e.g., if we have a model with version `0.9.0` and currently BigDL version is '0.10.0', BigDL would think model version is higher than BigDL version.

the change is to fix this issue by comparing int value of each version segment instead of comparing string value.

## How was this patch tested?
UT
## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

