### PR TITLE
fix: Input and ParallelTable connection in Graph for backward

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Graph.scala
@@ -329,9 +329,11 @@ abstract class Graph[T: ClassTag](
       .foreach(n => {
         val otherActivity = if (n._1.element.gradInput.isTensor || n._1.nextEdges.length == 1) {
           n._1.element.gradInput
-        } else {
+        } else if (curNode.element.output.isTensor) {
           val index = n._1.nextEdges.indexOf(n._2) + 1
           n._1.element.gradInput.toTable.apply[Activity](index)
+        } else {
+          n._1.element.gradInput
         }
 
         n._2.fromIndex match {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix error which is reported when doing backward of a Graph with a connection between Input and ParallelTable

## How was this patch tested?
Unit test

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

