### PR TITLE
Add the flushing denormal values option on BigDL side

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/ThreadPool.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/ThreadPool.scala
@@ -102,6 +102,10 @@ class ThreadPool(private var poolSize: Int) {
 
 
     this.invokeAndWait2((0 until 1).map(_ => () => {
+      if (System.getProperty("bigdl.flushDenormalState", "true").toBoolean) {
+        BackendMklDnn.setFlushDenormalState()
+      }
+
       require(MKL.isMKLLoaded)
       require(BackendMklDnn.isLoaded)
 
@@ -109,10 +113,6 @@ class ThreadPool(private var poolSize: Int) {
       BackendMklDnn.setNumThreads(size)
       if (!System.getProperty("bigdl.disableOmpAffinity", "false").toBoolean) {
         Affinity.setOmpAffinity()
-      }
-
-      if (System.getProperty("bigdl.flushDenormalState", "true").toBoolean) {
-        BackendMklDnn.setFlushDenormalState()
       }
     }))
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/ThreadPool.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/ThreadPool.scala
@@ -110,6 +110,10 @@ class ThreadPool(private var poolSize: Int) {
       if (!System.getProperty("bigdl.disableOmpAffinity", "false").toBoolean) {
         Affinity.setOmpAffinity()
       }
+
+      if (System.getProperty("bigdl.flushDenormalState", "true").toBoolean) {
+        BackendMklDnn.setFlushDenormalState()
+      }
     }))
 
     this

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/ThreadPoolSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/ThreadPoolSpec.scala
@@ -138,7 +138,7 @@ class ThreadPoolSpec extends FlatSpec with Matchers {
       val denormal: Float = -1.234E-41F
       val floatOne: Float = 1.0F
 
-      var result: Float = denormal * floatOne
+      val result: Float = denormal * floatOne
       // The result should not be zero without setting
       (result == 0.0F) should be(false)
     }))
@@ -158,7 +158,7 @@ class ThreadPoolSpec extends FlatSpec with Matchers {
       (result == 0.0F) should be (true)
     }))
 
-    System.clearProperty("bigdl.engineType")
+    System.clearProperty("bigdl.flushDenormalState")
   }
 
   "setFlushDenormalState" should "not influence other threads" in {
@@ -191,6 +191,6 @@ class ThreadPoolSpec extends FlatSpec with Matchers {
       (result == 0.0F) should be (false)
     }))
 
-    System.clearProperty("bigdl.engineType")
+    System.clearProperty("bigdl.flushDenormalState")
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
To fix issue #2888 

Add property "bigdl.flushDenormalState" for providing an option to flush denormal values to zeros.

The corresponding operations would be done on BigDL core side by setting MXCSR values, to flush-to-zero (FTZ) and denormals-are-zeros (DAZ). 

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If it is possible, please attach a screenshot; otherwise, remove this)

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

