### PR TITLE
fix: takeSample only works for dnn backend and get one batch

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Evaluator.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Evaluator.scala
@@ -19,7 +19,6 @@ package com.intel.analytics.bigdl.optim
 import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.dataset.{MiniBatch, Sample, SampleToMiniBatch}
 import com.intel.analytics.bigdl.models.utils.ModelBroadcast
-import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.{Engine, MklDnn}
 import com.intel.analytics.bigdl.utils.intermediate.ConversionUtils
@@ -88,6 +87,7 @@ class Evaluator[T: ClassTag] private[optim](model: Module[T])(implicit ev: Tenso
   private[bigdl] def testMiniBatch(dataset: RDD[MiniBatch[T]],
            vMethods: Array[ValidationMethod[T]]
           ): Array[(ValidationResult, ValidationMethod[T])] = {
+
     val rdd = ConversionUtils.coalesce(dataset)
     val modelBroad = ModelBroadcast[T]().broadcast(rdd.sparkContext,
       ConversionUtils.convert(model.evaluate()))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Evaluator.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Evaluator.scala
@@ -88,12 +88,6 @@ class Evaluator[T: ClassTag] private[optim](model: Module[T])(implicit ev: Tenso
   private[bigdl] def testMiniBatch(dataset: RDD[MiniBatch[T]],
            vMethods: Array[ValidationMethod[T]]
           ): Array[(ValidationResult, ValidationMethod[T])] = {
-
-    val dummyInput = if (Engine.getEngineType() == MklDnn) {
-      dataset.takeSample(withReplacement = false, num = 1).head.getInput()
-    } else {
-      Tensor[T]()
-    }
     val rdd = ConversionUtils.coalesce(dataset)
     val modelBroad = ModelBroadcast[T]().broadcast(rdd.sparkContext,
       ConversionUtils.convert(model.evaluate()))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Evaluator.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Evaluator.scala
@@ -89,7 +89,6 @@ class Evaluator[T: ClassTag] private[optim](model: Module[T])(implicit ev: Tenso
            vMethods: Array[ValidationMethod[T]]
           ): Array[(ValidationResult, ValidationMethod[T])] = {
 
-    // TODO this should be fixed next release because of some objects can't be serialized
     val dummyInput = if (Engine.getEngineType() == MklDnn) {
       dataset.takeSample(withReplacement = false, num = 1).head.getInput()
     } else {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Predictor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Predictor.scala
@@ -197,7 +197,6 @@ object Predictor {
   // because Evaluator will use it too, we extend the scope out of Predictor
   private[optim] def getDummyData[T: ClassTag, R](dataSet: RDD[R],
     batchSize: Int)(implicit ev: TensorNumeric[T]): Activity = {
-    // TODO this should be fixed next release because of some objects can't be serialized
     if (Engine.getEngineType() == MklDnn) {
       // here has an assumption, batchSizePerPar is not very large.
       val samples = dataSet.takeSample(withReplacement = false, num = batchSize)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Predictor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Predictor.scala
@@ -197,14 +197,20 @@ object Predictor {
   // because Evaluator will use it too, we extend the scope out of Predictor
   private[optim] def getDummyData[T: ClassTag, R](dataSet: RDD[R],
     batchSize: Int)(implicit ev: TensorNumeric[T]): Activity = {
-    // here has an assumption, batchSizePerPar is not very large.
-    val samples = dataSet.takeSample(withReplacement = false, num = batchSize)
-      .map {
-        case feature: ImageFeature => feature[Sample[T]](ImageFeature.sample)
-        case sample => sample.asInstanceOf[Sample[T]]
-      }
-    val sampleToMiniBatch = SampleToMiniBatch(batchSize)
-    sampleToMiniBatch(samples.toIterator).toSeq.head.getInput()
+    // TODO this should be fixed next release because of some objects can't be serialized
+    if (Engine.getEngineType() == MklDnn) {
+      // here has an assumption, batchSizePerPar is not very large.
+      val samples = dataSet.takeSample(withReplacement = false, num = batchSize)
+        .map {
+          case feature: ImageFeature => feature[Sample[T]](ImageFeature.sample)
+          case sample => sample.asInstanceOf[Sample[T]]
+        }
+      val sampleToMiniBatch = SampleToMiniBatch(batchSize, partitionNum = Some(1))
+      val miniBatch = sampleToMiniBatch(samples.toIterator).toSeq
+      miniBatch.head.getInput()
+    } else {
+      Tensor()
+    }
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Predictor.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/Predictor.scala
@@ -197,7 +197,7 @@ object Predictor {
   // because Evaluator will use it too, we extend the scope out of Predictor
   private[optim] def getDummyData[T: ClassTag, R](dataSet: RDD[R],
     batchSize: Int)(implicit ev: TensorNumeric[T]): Activity = {
-    if (Engine.getEngineType() == MklDnn) {
+    if (Engine.getEngineType() == MklDnn && Engine.isMultiModels) {
       // here has an assumption, batchSizePerPar is not very large.
       val samples = dataSet.takeSample(withReplacement = false, num = batchSize)
         .map {


### PR DESCRIPTION
## What changes were proposed in this pull request?

For multi models of MKL-DNN backend, we should take a batch back to driver first for get the input size, where exists serialization. But for some objects output of transformer can not be serialized. Add this patch to narrow the influence.

## How was this patch tested?

Manual tests and Jenkins.

