### PR TITLE
fix: fuse bn scale and relu to bn.

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/DnnGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/DnnGraph.scala
@@ -394,14 +394,15 @@ class DnnGraph(
    */
   private def fusion(): Unit = {
     if (!this.train) {
-      for (j <- 0 to 3) {
+      for (j <- 0 to 4) {
         var i = forwardExecution.length - 1
         while (i >= 0) {
-          if (j == 0) Fusion.fuseModule(forwardExecution(i))
+          if (j == 0) Fusion.fuseScale(forwardExecution(i))
+          if (j == 1) Fusion.fuseModule(forwardExecution(i))
           // we should do this before sum fusion, because it will change the structure of graph
-          if (j == 1) Fusion.setNegativeInputOfConv(forwardExecution(i))
-          if (j == 2) Fusion.fuseCAdd(forwardExecution(i))
-          if (j == 3) Fusion.setScalesPrevousJoinTable(forwardExecution(i))
+          if (j == 2) Fusion.setNegativeInputOfConv(forwardExecution(i))
+          if (j == 3) Fusion.fuseCAdd(forwardExecution(i))
+          if (j == 4) Fusion.setScalesPrevousJoinTable(forwardExecution(i))
           i -= 1
         }
       }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Fusion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Fusion.scala
@@ -288,31 +288,35 @@ private[mkldnn] object Fusion {
   }
 
   def fuseScale(node: Node[AbstractModule[Activity, Activity, Float]]): Unit = {
-    // check all prevNodes are SpatialBatchNormalization
-    val isValid = node.prevNodes.forall(_.element.isInstanceOf[SpatialBatchNormalization])
-    if (!isValid) { return }
+    node.element match {
+      case wrapper: BlasWrapper if wrapper.module.isInstanceOf[ScaleLayer[Float]] =>
+        // check all prevNodes are SpatialBatchNormalization
+        val isValid = node.prevNodes.forall(_.element.isInstanceOf[SpatialBatchNormalization])
+        if (!isValid) { return }
 
-    node.prevNodes.foreach { prevNode =>
-      val bn = prevNode.element.asInstanceOf[SpatialBatchNormalization]
-      val weightAndBias = bn.weightAndBias.dense
-      val weight = weightAndBias.narrow(1, 1, bn.nOutput)
-      val bias = weightAndBias.narrow(1, bn.nOutput + 1, bn.nOutput)
+        node.prevNodes.foreach { prevNode =>
+          val bn = prevNode.element.asInstanceOf[SpatialBatchNormalization]
+          val weightAndBias = bn.weightAndBias.dense
+          val weight = weightAndBias.narrow(1, 1, bn.nOutput)
+          val bias = weightAndBias.narrow(1, bn.nOutput + 1, bn.nOutput)
 
-      val scale = node.element.asInstanceOf[BlasWrapper].module.asInstanceOf[ScaleLayer[Float]]
-      val scaleWeight = scale.parameters()._1(0)
-      val scaleBias = scale.parameters()._1(1)
+          val scale = node.element.asInstanceOf[BlasWrapper].module.asInstanceOf[ScaleLayer[Float]]
+          val scaleWeight = scale.parameters()._1(0)
+          val scaleBias = scale.parameters()._1(1)
 
-      weight.cmul(scaleWeight)
-      bias.cmul(scaleWeight)
-      bias.add(scaleBias)
+          weight.cmul(scaleWeight)
+          bias.cmul(scaleWeight)
+          bias.add(scaleBias)
 
 
-      // set the weight and bias to new tensor, we do not modify the original model's tensor.
-      // sometimes, the model need to be reused.
-      bn.weightAndBias.dense.set(weightAndBias)
+          // set the weight and bias to new tensor, we do not modify the original model's tensor.
+          // sometimes, the model need to be reused.
+          bn.weightAndBias.dense.set(weightAndBias)
+        }
+
+        node.element = Identity[Float]() // set the BlasWrapper to Identity, we need no scale now
+      case _ =>
     }
-
-    node.element = Identity[Float]() // set the BlasWrapper to Identity, we need no scale now
   }
 
   private def findAllNonIdentityPrevs(node: Node[AbstractModule[Activity, Activity, Float]])

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Fusion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Fusion.scala
@@ -38,8 +38,6 @@ private[mkldnn] object Fusion {
     node.element match {
       case relu: ReLU => fusionRelu(node)
       case bn: SpatialBatchNormalization => fusionBN(node)
-      case blasWrapper: BlasWrapper if blasWrapper.module.isInstanceOf[ScaleLayer[Float]] =>
-        fuseScale(node)
       case _ =>
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The original fusion only fuses the bn with scale and will skip the bn + identity + relu.

## How was this patch tested?

Unit tests. 

