### PR TITLE
fix: bn nhwc error, the channel should be the last dim

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialBatchNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/SpatialBatchNormalization.scala
@@ -73,7 +73,11 @@ class SpatialBatchNormalization[T: ClassTag](
 
     _input.set(input)
     makeBatch(_input)
-    val nInput = _input.size(channelDim)
+    val nInput = if (dataFormat == DataFormat.NCHW) {
+      _input.size(2)
+    } else {
+      _input.size(4)
+    }
 
     if (runningMean.nElement == 0 || runningMean.nElement < nInput) {
       initializeBuffer(nInput)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialBatchNormalizationSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialBatchNormalizationSpec.scala
@@ -224,13 +224,20 @@ class SpatialBatchNormalizationSpec extends FlatSpec with Matchers with BeforeAn
     val bn1 = SpatialBatchNormalization[Float](16, dataFormat = DataFormat.NCHW)
     val bn2 = SpatialBatchNormalization[Float](16, dataFormat = DataFormat.NHWC)
 
-    val input1 = Tensor[Float](4, 16, 3, 3)
-    val input2 = Tensor[Float](4, 3, 3, 16)
+    bn2.parameters()._1.zip(bn1.parameters()._1).foreach {
+      case (bn2Para, bn1Para) => bn2Para.copy(bn1Para)
+    }
+
+    val input1 = Tensor[Float](4, 16, 3, 3).rand(-1, 1)
     bn1.forward(input1)
+
+    val input2 = input1.transpose(2, 4).contiguous()
     bn2.forward(input2)
 
     bn1.getExtraParameter().zip(bn2.getExtraParameter()).foreach {
-      case (p1, p2) => p1.size() should be (p2.size())
+      case (p1, p2) =>
+        p1.size() should be (p2.size())
+        p1 should be (p2)
     }
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialBatchNormalizationSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SpatialBatchNormalizationSpec.scala
@@ -219,6 +219,20 @@ class SpatialBatchNormalizationSpec extends FlatSpec with Matchers with BeforeAn
     bnNCHW.gradWeight.almostEqual(bnNHWC.gradWeight, 1e-5)
     bnNCHW.gradBias.almostEqual(bnNHWC.gradBias, 1e-5)
   }
+
+  "bn with NHWC" should "return correct extra parameters" in {
+    val bn1 = SpatialBatchNormalization[Float](16, dataFormat = DataFormat.NCHW)
+    val bn2 = SpatialBatchNormalization[Float](16, dataFormat = DataFormat.NHWC)
+
+    val input1 = Tensor[Float](4, 16, 3, 3)
+    val input2 = Tensor[Float](4, 3, 3, 16)
+    bn1.forward(input1)
+    bn2.forward(input2)
+
+    bn1.getExtraParameter().zip(bn2.getExtraParameter()).foreach {
+      case (p1, p2) => p1.size() should be (p2.size())
+    }
+  }
 }
 
 class SpatialBatchNormalizationSerialTest extends ModuleSerializationTest {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the input of `SpatialBatchNorm` is `NHWC`, the `runningMean` and `runningVariance` shape should be resized based on the last dimension of input, not the second dimension (1-base).

## How was this patch tested?

Add a unit tests and Jenkins.

## Related links or issues (optional)

fixed https://github.com/intel-analytics/BigDL/issues/2978
