### PR TITLE
Add a method to merge nested StaticGraphs

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/StaticGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/StaticGraph.scala
@@ -211,51 +211,70 @@ class StaticGraph[T: ClassTag](
 
   // Merge a nested StaticGraph into a non-nested one
   def toSingleGraph(): StaticGraph[T] = {
-    val graph = this.cloneModule()
-    val fwdExecution = graph.getSortedForwardExecutions()
-    val dmOutput = fwdExecution(fwdExecution.length - 1).nextNodes(0)
+    if (this.isNestedGraph()) {
+      val graph = this.cloneModule()
+      val fwdExecution = graph.getSortedForwardExecutions()
+      val dmOutput = fwdExecution(fwdExecution.length - 1).nextNodes(0)
 
-    var i = 0
-    while (i < fwdExecution.length) {
-      if (fwdExecution(i).element.isInstanceOf[StaticGraph[T]]) {
-        var g = fwdExecution(i).element.asInstanceOf[StaticGraph[T]]
-        require(g.outputs.length == 1 && g.inputs.length == 1,
-          s"In order to avoid possible ambiguities in node connection. " +
-            s"This StaticGraph cannot be merged into a non-nested one. " +
-            s"Its inner graph ${g.getName()} has more than one input or output. ")
-        g = g.toSingleGraph().asInstanceOf[StaticGraph[T]]
-        fwdExecution(i).element = g
+      var i = 0
+      while (i < fwdExecution.length) {
+        if (fwdExecution(i).element.isInstanceOf[StaticGraph[T]]) {
+          var g = fwdExecution(i).element.asInstanceOf[StaticGraph[T]]
+          require(g.outputs.length == 1 && g.inputs.length == 1,
+            s"In order to avoid possible ambiguities in node connection. " +
+              s"This StaticGraph cannot be merged into a non-nested one. " +
+              s"Its inner graph ${g.getName()} has more than one input or output. ")
+          g = g.toSingleGraph().asInstanceOf[StaticGraph[T]]
+          fwdExecution(i).element = g
 
-        if (fwdExecution(i).prevNodes.length == 1) {
-          val inputNode = g.inputs(0).nextNodes(0)
-          g.inputs(0).delete(inputNode)
-          val preNode = fwdExecution(i).prevNodes(0)
-          preNode.delete(fwdExecution(i))
-          preNode.add(inputNode)
-        } else {
-          g.inputs(0).element = Identity()
-          val inputNode = g.inputs(0)
-          while (fwdExecution(i).prevNodes.length != 0) {
+          if (fwdExecution(i).prevNodes.length == 1) {
+            val inputNode = g.inputs(0).nextNodes(0)
+            g.inputs(0).delete(inputNode)
             val preNode = fwdExecution(i).prevNodes(0)
             preNode.delete(fwdExecution(i))
             preNode.add(inputNode)
+          } else {
+            g.inputs(0).element = Identity()
+            val inputNode = g.inputs(0)
+            while (fwdExecution(i).prevNodes.length != 0) {
+              val preNode = fwdExecution(i).prevNodes(0)
+              preNode.delete(fwdExecution(i))
+              preNode.add(inputNode)
+            }
+          }
+
+          val outputNode = g.outputs(0)
+          outputNode.removeNextEdges()
+          while (fwdExecution(i).nextNodes.length != 0) {
+            val nextNode = fwdExecution(i).nextNodes(0)
+            fwdExecution(i).delete(nextNode)
+            outputNode.add(nextNode)
           }
         }
-
-        val outputNode = g.outputs(0)
-        outputNode.removeNextEdges()
-        while (fwdExecution(i).nextNodes.length != 0) {
-          val nextNode = fwdExecution(i).nextNodes(0)
-          fwdExecution(i).delete(nextNode)
-          outputNode.add(nextNode)
-        }
+        i += 1
       }
-      i += 1
+
+      val resultOutputNodes = dmOutput.prevNodes
+      resultOutputNodes.foreach(_.delete(dmOutput))
+      new StaticGraph[T](Array(graph.inputs(0)), resultOutputNodes,
+        enableExcludeChecking = this.enableExcludeChecking)
+    } else {
+      this
+    }
+  }
+
+  def isNestedGraph(): Boolean = {
+    var count = 0
+    for (i <- 0 until forwardExecution.length) {
+      if (forwardExecution(i).element.isInstanceOf[StaticGraph[T]]) {
+        count += 1
+      }
     }
 
-    val resultOutputNodes = dmOutput.prevNodes
-    resultOutputNodes.foreach(_.delete(dmOutput))
-    new StaticGraph[T](Array(graph.inputs(0)), resultOutputNodes,
-      enableExcludeChecking = this.enableExcludeChecking)
+    if (count > 0) {
+      true
+    } else {
+      false
+    }
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/StaticGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/StaticGraph.scala
@@ -210,7 +210,7 @@ class StaticGraph[T: ClassTag](
   }
 
   // Merge a nested StaticGraph into a non-nested one
-  def toSingleGraph(): StaticGraph[T] = {
+  private[bigdl] def toSingleGraph(): StaticGraph[T] = {
     if (this.isNestedGraph()) {
       val graph = this.cloneModule()
       val fwdExecution = graph.getSortedForwardExecutions()
@@ -219,23 +219,13 @@ class StaticGraph[T: ClassTag](
       var i = 0
       while (i < fwdExecution.length) {
         if (fwdExecution(i).element.isInstanceOf[StaticGraph[T]]) {
-          var g = fwdExecution(i).element.asInstanceOf[StaticGraph[T]]
-          require(g.outputs.length == 1 && g.inputs.length == 1,
-            s"In order to avoid possible ambiguities in node connection. " +
-              s"This StaticGraph cannot be merged into a non-nested one. " +
-              s"Its inner graph ${g.getName()} has more than one input or output. ")
-          g = g.toSingleGraph().asInstanceOf[StaticGraph[T]]
+          var g = fwdExecution(i).element.asInstanceOf[StaticGraph[T]].toSingleGraph()
           fwdExecution(i).element = g
 
-          if (fwdExecution(i).prevNodes.length == 1) {
-            val inputNode = g.inputs(0).nextNodes(0)
-            g.inputs(0).delete(inputNode)
-            val preNode = fwdExecution(i).prevNodes(0)
-            preNode.delete(fwdExecution(i))
-            preNode.add(inputNode)
-          } else {
-            g.inputs(0).element = Identity()
-            val inputNode = g.inputs(0)
+          for (inputIndex <- 0 until fwdExecution(i).prevNodes.length) {
+            val inputNode = g.inputs(inputIndex)
+            inputNode.element = Identity()
+
             while (fwdExecution(i).prevNodes.length != 0) {
               val preNode = fwdExecution(i).prevNodes(0)
               preNode.delete(fwdExecution(i))
@@ -243,12 +233,14 @@ class StaticGraph[T: ClassTag](
             }
           }
 
-          val outputNode = g.outputs(0)
-          outputNode.removeNextEdges()
-          while (fwdExecution(i).nextNodes.length != 0) {
-            val nextNode = fwdExecution(i).nextNodes(0)
-            fwdExecution(i).delete(nextNode)
-            outputNode.add(nextNode)
+          for (outputIndex <- 0 until g.outputs.length) {
+            val outputNode = g.outputs(outputIndex)
+            outputNode.removeNextEdges()
+            while (fwdExecution(i).nextNodes.length != 0) {
+              val nextNode = fwdExecution(i).nextNodes(0)
+              fwdExecution(i).delete(nextNode)
+              outputNode.add(nextNode)
+            }
           }
         }
         i += 1
@@ -263,18 +255,13 @@ class StaticGraph[T: ClassTag](
     }
   }
 
-  def isNestedGraph(): Boolean = {
-    var count = 0
+  private def isNestedGraph(): Boolean = {
     for (i <- 0 until forwardExecution.length) {
       if (forwardExecution(i).element.isInstanceOf[StaticGraph[T]]) {
-        count += 1
+        return true
       }
     }
 
-    if (count > 0) {
-      true
-    } else {
-      false
-    }
+    false
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/StaticGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/StaticGraph.scala
@@ -210,7 +210,7 @@ class StaticGraph[T: ClassTag](
   }
 
   // Merge a nested StaticGraph into a non-nested one
-  def toSingleGraph(): Graph[T] = {
+  def toSingleGraph(): StaticGraph[T] = {
     val graph = this.cloneModule()
     val fwdExecution = graph.getSortedForwardExecutions()
     val dmOutput = fwdExecution(fwdExecution.length - 1).nextNodes(0)
@@ -255,6 +255,7 @@ class StaticGraph[T: ClassTag](
 
     val resultOutputNodes = dmOutput.prevNodes
     resultOutputNodes.foreach(_.delete(dmOutput))
-    Graph(graph.inputs(0), resultOutputNodes.toArray)
+    new StaticGraph[T](Array(graph.inputs(0)), resultOutputNodes,
+      enableExcludeChecking = this.enableExcludeChecking)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/StaticGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/StaticGraph.scala
@@ -219,8 +219,10 @@ class StaticGraph[T: ClassTag](
     while (i < fwdExecution.length) {
       if (fwdExecution(i).element.isInstanceOf[StaticGraph[T]]) {
         var g = fwdExecution(i).element.asInstanceOf[StaticGraph[T]]
-        require(toSingleGraphCheck(g),
-          "This graph cannot be converted into a non-nested StaticGraph")
+        require(g.outputs.length == 1 && g.inputs.length == 1,
+          s"In order to avoid possible ambiguities in node connection. " +
+            s"This StaticGraph cannot be merged into a non-nested one. " +
+            s"Its inner graph ${g.getName()} has more than one input or output. ")
         g = g.toSingleGraph().asInstanceOf[StaticGraph[T]]
         fwdExecution(i).element = g
 
@@ -254,12 +256,5 @@ class StaticGraph[T: ClassTag](
     val resultOutputNodes = dmOutput.prevNodes
     resultOutputNodes.foreach(_.delete(dmOutput))
     Graph(graph.inputs(0), resultOutputNodes.toArray)
-  }
-
-  private def toSingleGraphCheck(graph: StaticGraph[T]): Boolean = {
-    if (graph.asInstanceOf[StaticGraph[T]].outputs.length == 1
-      && graph.asInstanceOf[StaticGraph[T]].inputs.length == 1) {
-      true
-    } else false
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -830,6 +830,7 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag, 
     val endNodes = this.getEndNodes(starts)
     val graph = Graph(starts, endNodes)
     if (graph.isInstanceOf[StaticGraph[T]]) {
+      // Merge nested graphs inside to make the whole graph non-nested
       graph.asInstanceOf[StaticGraph[T]].toSingleGraph()
     } else {
       graph

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/abstractnn/AbstractModule.scala
@@ -828,7 +828,12 @@ abstract class AbstractModule[A <: Activity: ClassTag, B <: Activity: ClassTag, 
   def toGraph(startNodes: ModuleNode[T]*): Graph[T] = {
     val starts = if (startNodes.isEmpty) Array(Input[T]()) else startNodes.toArray
     val endNodes = this.getEndNodes(starts)
-    Graph(starts, endNodes)
+    val graph = Graph(starts, endNodes)
+    if (graph.isInstanceOf[StaticGraph[T]]) {
+      graph.asInstanceOf[StaticGraph[T]].toSingleGraph()
+    } else {
+      graph
+    }
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a method toSingleGraph() which merges nested StaticGraphs into a non-nested one. The method returns the merged result without effects on the original one.

## How was this patch tested?
Unit tests. Compared the results. Examined if the conversion result is non-nested.

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

