### PR TITLE
fix: softmax dnn backend wrong order of primitive

### DIFF
--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SparseLinearSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/SparseLinearSpec.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.nn
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.tensor.{SparseTensor, Tensor}
 import com.intel.analytics.bigdl.utils.{RandomGenerator, T}
@@ -24,7 +24,12 @@ import com.intel.analytics.bigdl.utils.serializer.ModuleSerializationTest
 
 import scala.util.Random
 
-class SparseLinearSpec extends FlatSpec with Matchers {
+class SparseLinearSpec extends FlatSpec with Matchers with BeforeAndAfter {
+
+  before {
+    RandomGenerator.RNG.setSeed(100)
+  }
+
   "Sparse Linear" should "return the same result with Linear" in {
     val weight = Tensor.range(1, 8, 1).resize(2, 4)
     val bias = Tensor(2)

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/SoftMaxSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/SoftMaxSpec.scala
@@ -44,8 +44,9 @@ class SoftMaxSpec extends FlatSpec with Matchers {
 
       Tools.dense(output) should be (nnOutput)
 
-      sm.backward(input, nnOutput)
-      nnSm.backward(input, nnOutput)
+      val gradOutput = Tensor[Float]().resizeAs(nnOutput).rand(-10, 10)
+      sm.backward(input, gradOutput)
+      nnSm.backward(input, gradOutput)
 
       Tools.dense(sm.gradInput) should be (nnSm.gradInput)
     }
@@ -75,8 +76,9 @@ class SoftMaxSpec extends FlatSpec with Matchers {
 
       Tools.dense(output) shouldEqual nnOutput
 
-      sm.backward(input, nnOutput)
-      nnSm.backward(input, nnOutput)
+      val gradOutput = Tensor[Float]().resizeAs(nnOutput).rand(-10, 10)
+      sm.backward(input, gradOutput)
+      nnSm.backward(input, gradOutput)
 
       Tools.dense(sm.gradInput) should be (nnSm.gradInput)
     }
@@ -110,11 +112,12 @@ class SoftMaxSpec extends FlatSpec with Matchers {
 
       Tools.dense(output) should be (nnOutput)
 
-      sm.backward(input, nnOutput)
-      nnSm.backward(input, nnOutput)
+      val gradOutput = Tensor[Float]().resizeAs(nnOutput).rand(-10, 10)
+      sm.backward(input, gradOutput)
+      nnSm.backward(input, gradOutput)
 
       Equivalent.nearequals(Tools.dense(sm.gradInput).toTensor, nnSm.gradInput.toTensor,
-        epsilon = 10-5)
+        epsilon = 1e-5) should be (true)
     }
   }
 
@@ -143,11 +146,13 @@ class SoftMaxSpec extends FlatSpec with Matchers {
       val nnOutput = nnSm.forward(input)
 
       Tools.dense(output) should be (nnOutput)
-      sm.backward(input, nnOutput)
-      nnSm.backward(input, nnOutput)
+
+      val gradOutput = Tensor[Float]().resizeAs(nnOutput).rand(-10, 10)
+      sm.backward(input, gradOutput)
+      nnSm.backward(input, gradOutput)
 
       Equivalent.nearequals(Tools.dense(sm.gradInput).toTensor, nnSm.gradInput.toTensor,
-        epsilon = 10-5)
+        epsilon = 1e-5) should be (true)
     }
   }
 
@@ -172,9 +177,9 @@ class SoftMaxSpec extends FlatSpec with Matchers {
     nnSm.backward(input, gradOutput)
 
     Equivalent.nearequals(Tools.dense(sm.output).toTensor, nnSm.output.toTensor,
-      epsilon = 10-4)
+      epsilon = 1e-5) should be (true)
     Equivalent.nearequals(Tools.dense(sm.gradInput).toTensor, nnSm.gradInput.toTensor,
-      epsilon = 10-4)
+      epsilon = 1e-5) should be (true)
   }
 
   "SoftMax multi times forward" should "work correctly" in {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Based on the mkldnn.hpp, the memory order of softmax backward is wrong.

## How was this patch tested?

Jenkins.

