### PR TITLE
NHWC support when running with MKL-DNN

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Dropout.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/Dropout.scala
@@ -18,9 +18,10 @@ package com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.nn.abstractnn.{IdentityOutputShape, TensorModule}
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
-import com.intel.analytics.bigdl.utils.Engine
+import com.intel.analytics.bigdl.utils.{Engine, Shape}
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 
+import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.Future
 import scala.reflect.ClassTag
 
@@ -206,6 +207,10 @@ class Dropout[T: ClassTag](
 
   override def toString(): String = {
     s"${getPrintName}($p)"
+  }
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    inputShape
   }
 }
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/StaticGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/StaticGraph.scala
@@ -191,12 +191,6 @@ class StaticGraph[T: ClassTag](
 
     val allNodes = forwardExecution
     if (!BlasToIR[T].convertingCheck(allNodes)) return null
-    inFormats.foreach(in =>
-      if (in == Memory.Format.nhwc) {
-        logger.warn("Not support NHWC in IRGraph")
-        return null
-      }
-    )
 
     val nodeMap = BlasToIR[T].convert(allNodes)
     val inputNodes = inputs.toArray.map(n => nodeMap.get(n).get)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/AvgPooling.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/AvgPooling.scala
@@ -17,7 +17,7 @@ package com.intel.analytics.bigdl.nn.mkldnn
 
 import com.intel.analytics.bigdl.mkl._
 import com.intel.analytics.bigdl.nn.{Utils => NNUtils}
-import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.nn.abstractnn.{Activity, DataFormat}
 import com.intel.analytics.bigdl.nn.mkldnn.Phase.InferencePhase
 import com.intel.analytics.bigdl.tensor.Tensor
 
@@ -28,7 +28,8 @@ class AvgPooling(
   dH: Int = 1,
   padW: Int = 0,
   padH: Int = 0,
-  globalPooling: Boolean = false
+  globalPooling: Boolean = false,
+  val format: DataFormat = DataFormat.NCHW
 ) extends MklDnnLayer {
   @transient private var paddingTL: Array[Int] = _
   @transient private var paddingBR: Array[Int] = _
@@ -137,6 +138,7 @@ object AvgPooling {
     dH: Int = 1,
     padW: Int = 0,
     padH: Int = 0,
-    globalPooling: Boolean = false
-  ): AvgPooling = new AvgPooling(kW, kH, dW, dH, padW, padH, globalPooling)
+    globalPooling: Boolean = false,
+    format: DataFormat = DataFormat.NCHW
+  ): AvgPooling = new AvgPooling(kW, kH, dW, dH, padW, padH, globalPooling, format = format)
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/DnnBase.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/DnnBase.scala
@@ -247,12 +247,12 @@ trait MklDnnLayer extends AbstractModule[Activity, Activity, Float] with MklDnnM
   }
 
 
-  override private[mkldnn] def inputFormats() = {
+  override private[bigdl] def inputFormats() = {
     require(_inputFormats != null, "You should call initFwdPrimitives first")
     _inputFormats
   }
 
-  override private[mkldnn] def gradInputFormats() = {
+  override private[bigdl] def gradInputFormats() = {
     require(_gradInputFormats != null, "You should call initBwdPrimitives first")
     _gradInputFormats
   }
@@ -262,7 +262,7 @@ trait MklDnnLayer extends AbstractModule[Activity, Activity, Float] with MklDnnM
     _outputFormats
   }
 
-  override private[mkldnn] def gradOutputFormats() = {
+  override private[bigdl] def gradOutputFormats() = {
     require(_gradOutputFormats != null, "You should call initBwdPrimitives first")
     _gradOutputFormats
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/LRN.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/LRN.scala
@@ -16,7 +16,7 @@
 package com.intel.analytics.bigdl.nn.mkldnn
 
 import com.intel.analytics.bigdl.mkl._
-import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.nn.abstractnn.{Activity, DataFormat}
 import com.intel.analytics.bigdl.nn.mkldnn.Phase.InferencePhase
 import com.intel.analytics.bigdl.tensor.Tensor
 
@@ -24,7 +24,8 @@ class LRN(
   size: Int = 5,
   alpha: Double = 1.0,
   beta: Double = 0.75,
-  k: Double = 1.0
+  k: Double = 1.0,
+  val format: DataFormat = DataFormat.NCHW
 ) extends MklDnnLayer {
   private val UNDEFINED = 0
 
@@ -108,6 +109,7 @@ class LRN(
 }
 
 object LRN {
-  def apply(size: Int = 5, alpha: Double = 1.0, beta: Double = 0.75, k: Double = 1.0): LRN =
-    new LRN(size, alpha, beta, k)
+  def apply(size: Int = 5, alpha: Double = 1.0, beta: Double = 0.75, k: Double = 1.0,
+            format: DataFormat = DataFormat.NCHW): LRN =
+    new LRN(size, alpha, beta, k, format)
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/MaxPooling.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/MaxPooling.scala
@@ -17,7 +17,7 @@ package com.intel.analytics.bigdl.nn.mkldnn
 
 import com.intel.analytics.bigdl.mkl._
 import com.intel.analytics.bigdl.nn.{Utils => NNUtils}
-import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.nn.abstractnn.{Activity, DataFormat}
 import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
 import com.intel.analytics.bigdl.tensor.Tensor
 
@@ -27,7 +27,8 @@ class MaxPooling(
   dW: Int = 1,
   dH: Int = 1,
   padW: Int = 0,
-  padH: Int = 0
+  padH: Int = 0,
+  val format: DataFormat = DataFormat.NCHW
 ) extends MklDnnLayer {
   @transient private var workSpaceFormat: MemoryData = _
   @transient private var workSpace: Tensor[Float] = _
@@ -162,6 +163,7 @@ object MaxPooling {
     dW: Int = 1,
     dH: Int = 1,
     padW: Int = 0,
-    padH: Int = 0
-  ): MaxPooling = new MaxPooling(kW, kH, dW, dH, padW, padH)
+    padH: Int = 0,
+    format: DataFormat = DataFormat.NCHW
+  ): MaxPooling = new MaxPooling(kW, kH, dW, dH, padW, padH, format)
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/MemoryData.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/MemoryData.scala
@@ -22,6 +22,7 @@ sealed trait MemoryData extends Serializable {
   def shape: Array[Int]
   def layout: Int
   def dataType: Int
+  var heapFormat : Int = -1
 
   private var _mask: Int = -1
   private var _scales: Array[Float] = Array.emptyFloatArray
@@ -30,6 +31,16 @@ sealed trait MemoryData extends Serializable {
   def setMask(s: Int): Unit = _mask = s
   def scales: Array[Float] = _scales
   def setScales(f: Array[Float]): Unit = _scales = f
+
+  def setHeapFormat(f: Int): this.type = {
+    heapFormat = f
+    this
+  }
+  def getHeapShape(): Array[Int] = {
+    if (layout == Memory.Format.nhwc) { // native shape is nchw
+      Array(shape(0), shape(2), shape(3), shape(1))
+    } else shape
+  }
 
   def cloneFormat(): MemoryData
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Output.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/Output.scala
@@ -34,10 +34,7 @@ class Output(outputLayOut: Int = Memory.Format.nc,
 
   private def getShape(inLayout: Int, inShape: Array[Int], outLayout: Int): Array[Int] = {
     val outputShape =
-      if (outLayout == Memory.Format.nhwc && inLayout != Memory.Format.nhwc) {
-        // nchw*  -> nhwc
-        Array(inShape(0), inShape(2), inShape(3), inShape(1))
-      } else if (outLayout == Memory.Format.tnc && inLayout == Memory.Format.ntc) {
+     if (outLayout == Memory.Format.tnc && inLayout == Memory.Format.ntc) {
         // ntc -> tnc
         Array(inShape(1), inShape(0), inShape(2))
       } else if (outLayout == Memory.Format.ntc && inLayout == Memory.Format.tnc) {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialBatchNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/mkldnn/SpatialBatchNormalization.scala
@@ -17,7 +17,7 @@
 package com.intel.analytics.bigdl.nn.mkldnn
 
 import com.intel.analytics.bigdl.mkl._
-import com.intel.analytics.bigdl.nn.abstractnn.{Activity, Initializable}
+import com.intel.analytics.bigdl.nn.abstractnn.{Activity, DataFormat, Initializable}
 import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
 import com.intel.analytics.bigdl.nn.{MklInt8Convertible, Ones, VariableFormat, Zeros}
 import com.intel.analytics.bigdl.tensor._
@@ -31,7 +31,8 @@ class SpatialBatchNormalization(
   private val initWeight: Tensor[Float] = null,
   private val initBias: Tensor[Float] = null,
   private val initGradWeight: Tensor[Float] = null,
-  private val initGradBias: Tensor[Float] = null
+  private val initGradBias: Tensor[Float] = null,
+  val format: DataFormat = DataFormat.NCHW
 ) extends MklDnnLayer with Initializable with MklInt8Convertible {
 
   @transient private var forwardDesc: Long = 0L
@@ -455,8 +456,9 @@ object SpatialBatchNormalization {
     initWeight: Tensor[Float] = null,
     initBias: Tensor[Float] = null,
     initGradWeight: Tensor[Float] = null,
-    initGradBias: Tensor[Float] = null): SpatialBatchNormalization = {
+    initGradBias: Tensor[Float] = null,
+    format: DataFormat = DataFormat.NCHW): SpatialBatchNormalization = {
     new SpatialBatchNormalization(nOutput, eps, momentum, initWeight, initBias, initGradWeight,
-      initGradBias)
+      initGradBias, format = format)
   }
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/intermediate/IRElement.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/intermediate/IRElement.scala
@@ -85,9 +85,6 @@ case class IRSpatialBatchNormalization[T: ClassTag](
 
 case class IRIdentity[T: ClassTag]() extends IROperator[T]
 
-case class IRDropout[T: ClassTag](initP: Double = 0.5, inplace: Boolean = false,
-                                  scale: Boolean = true) extends IROperator[T]
-
 case class IRReLU[T: ClassTag](ip: Boolean = false) extends IROperator[T]
 
 case class IRLinear[T: ClassTag](

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/intermediate/IRGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/intermediate/IRGraph.scala
@@ -151,6 +151,9 @@ private[bigdl] class IRGraph[T: ClassTag](
         val sizeNew = if (size.length == 3 && inputFormats(0) != Memory.Format.ntc
           && inputFormats(0) != Memory.Format.tnc) {
           Array(size(0), 1, size(1), size(2))
+        } else if (inputFormats(0) == Memory.Format.nhwc) {
+          // always use NCHW to create heap data
+          Array(size(0), size(3), size(1), size(2))
         } else size
         inputMemory(0) = HeapData(sizeNew, inputFormats(0))
       } else {
@@ -162,7 +165,12 @@ private[bigdl] class IRGraph[T: ClassTag](
             "Only support input with tensor type, table not supported")
           val t1 = t._1.asInstanceOf[Int] // starts from 1
           val t2 = t._2.asInstanceOf[Tensor[T]]
-          inputMemory(t1 - 1) = HeapData(t2.size(), inputFormats(t1 - 1))
+          if (inputFormats(t1 - 1 ) == Memory.Format.nhwc) {
+            val sizeNew = Array(t2.size(1), t2.size(4), t2.size(2), t2.size(3))
+            inputMemory(t1 - 1) = HeapData(sizeNew, inputFormats(t1 - 1))
+          } else {
+            inputMemory(t1 - 1) = HeapData(t2.size(), inputFormats(t1 - 1))
+          }
         })
       }
       val dnnGraph = graph.asInstanceOf[DnnGraph]

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/AvgPoolingSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/AvgPoolingSpec.scala
@@ -21,7 +21,7 @@ import com.intel.analytics.bigdl.nn.{SpatialAveragePooling, SpatialMaxPooling, S
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
 import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
 import com.intel.analytics.bigdl.tensor.{DnnTensor, Tensor}
-import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, Engine}
+import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, Engine, MklDnn}
 import com.intel.analytics.bigdl.utils.RandomGenerator.RNG
 import com.intel.analytics.bigdl.utils.intermediate.{BlasToIR, IRToDnn}
 import org.apache.commons.lang3.SerializationUtils
@@ -69,7 +69,8 @@ class AvgPoolingSpec extends BigDLSpecHelper {
   }
 
   "Avg Pooling with NHWC" should "be correct" in {
-    System.setProperty("bigdl.engineType", "mkldnn")
+    Engine.setEngineType(MklDnn)
+    RNG.setSeed(100)
     val batchSize = 2
     val input = Tensor[Float](batchSize, 28, 28, 480).apply1(e => Random.nextFloat())
     val gradOutput = Tensor[Float](batchSize, 14, 14, 480).apply1(e => Random.nextFloat())
@@ -106,8 +107,6 @@ class AvgPoolingSpec extends BigDLSpecHelper {
     val grad2 = layer.backward(input, output2).toTensor[Float]
     val grad1 = dnn.backward(input, output2)
     grad1 should be(grad2)
-
-    System.clearProperty("bigdl.engineType")
   }
 
   "Convert average pooling with ceilMode to dnn layer" should "be correct" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/AvgPoolingSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/AvgPoolingSpec.scala
@@ -15,8 +15,10 @@
  */
 package com.intel.analytics.bigdl.nn.mkldnn
 
+import breeze.numerics.ceil
 import com.intel.analytics.bigdl.mkl.{DataType, Memory}
-import com.intel.analytics.bigdl.nn.SpatialAveragePooling
+import com.intel.analytics.bigdl.nn.{SpatialAveragePooling, SpatialMaxPooling, StaticGraph}
+import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
 import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
 import com.intel.analytics.bigdl.tensor.{DnnTensor, Tensor}
 import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, Engine}
@@ -64,6 +66,48 @@ class AvgPoolingSpec extends BigDLSpecHelper {
     val grad2 = layer.backward(input, output2).toTensor[Float]
     val grad1 = seq.backward(input, output2)
     grad1 should be(grad2)
+  }
+
+  "Avg Pooling with NHWC" should "be correct" in {
+    System.setProperty("bigdl.engineType", "mkldnn")
+    val batchSize = 2
+    val input = Tensor[Float](batchSize, 28, 28, 480).apply1(e => Random.nextFloat())
+    val gradOutput = Tensor[Float](batchSize, 14, 14, 480).apply1(e => Random.nextFloat())
+
+    val pad = -1
+    RNG.setSeed(100)
+    val layer = SpatialAveragePooling[Float](3, 3, 2, 2,
+      padH = pad, padW = pad, format = DataFormat.NHWC).ceil()
+    RNG.setSeed(100)
+    val layer2 = SpatialAveragePooling[Float](3, 3, 2, 2,
+      padH = pad, padW = pad).ceil()
+
+    import com.intel.analytics.bigdl.nn
+    val static = nn.Sequential[Float]().add(layer2)
+      .toGraph().asInstanceOf[StaticGraph[Float]]
+    static.setInputFormats(Seq(Memory.Format.nhwc))
+    static.setOutputFormats(Seq(Memory.Format.nhwc))
+    val dnn = static.toIRgraph()
+
+    for (i <- 0 to 3) {
+      input.rand()
+      gradOutput.rand()
+
+      dnn.forward(input)
+      dnn.backward(input, gradOutput)
+
+      layer.forward(input)
+      layer.backward(input, gradOutput)
+    }
+    val output1 = dnn.forward(input)
+    val output2 = layer.forward(input).toTensor[Float]
+    output1 should be(output2)
+
+    val grad2 = layer.backward(input, output2).toTensor[Float]
+    val grad1 = dnn.backward(input, output2)
+    grad1 should be(grad2)
+
+    System.clearProperty("bigdl.engineType")
   }
 
   "Convert average pooling with ceilMode to dnn layer" should "be correct" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/LinearSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/LinearSpec.scala
@@ -18,15 +18,51 @@ package com.intel.analytics.bigdl.nn.mkldnn
 
 import com.intel.analytics.bigdl.mkl.Memory
 import com.intel.analytics.bigdl.nn
+import com.intel.analytics.bigdl.nn.StaticGraph
 import com.intel.analytics.bigdl.nn.mkldnn.Phase.TrainingPhase
 import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.optim.L2Regularizer
 import com.intel.analytics.bigdl.tensor.{DnnStorage, Tensor}
+import com.intel.analytics.bigdl.utils.RandomGenerator
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 import org.apache.commons.lang3.SerializationUtils
 import org.scalatest.{FlatSpec, Matchers}
 
 class LinearSpec extends FlatSpec with Matchers {
+
+  "Convert blas linear to mkldnn with NHWC" should "be correct" in {
+    System.setProperty("bigdl.engineType", "mkldnn")
+    RandomGenerator.RNG.setSeed(100)
+    val linear = nn.Linear(12, 3)
+    val linear2 = nn.Linear(12, 3)
+
+    linear2.weight.copy(linear.weight)
+    linear2.bias.copy(linear.bias)
+
+    val blas = nn.Sequential()
+    blas.add(nn.Reshape(Array(12)).setName("linear"))
+    blas.add(linear)
+
+    val blas2 = nn.Sequential().add(linear2).toGraph().
+      asInstanceOf[StaticGraph[Float]]
+    blas2.setInputFormats(Seq(Memory.Format.nhwc))
+    blas2.setOutputFormats(Seq(Memory.Format.nc))
+    val dnn = blas2.toIRgraph()
+
+    val input = Tensor[Float](4, 2, 2, 3).rand() // nhwc
+
+    val outBlas = blas.forward(input).toTensor[Float]
+    val outDnn = dnn.forward(input).toTensor[Float]
+    Equivalent.nearequals(outDnn.toTensor, outBlas.toTensor, 1e-5) should be (true)
+
+    val gradOutput = Tensor[Float]().resizeAs(outBlas).copy(outBlas)
+    val gradInputBlas = blas.backward(input, gradOutput)
+    val gradInputDnn = dnn.backward(input, gradOutput)
+    Equivalent.nearequals(gradInputBlas.toTensor, gradInputDnn.toTensor, 1e-5) should be (true)
+
+    System.clearProperty("bigdl.engineType")
+  }
+
   "linear updateOutput" should "work correctly" in {
     val inputSize = 2
     val outputSize = 2

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/LinearSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/LinearSpec.scala
@@ -23,7 +23,7 @@ import com.intel.analytics.bigdl.nn.mkldnn.Phase.TrainingPhase
 import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.optim.L2Regularizer
 import com.intel.analytics.bigdl.tensor.{DnnStorage, Tensor}
-import com.intel.analytics.bigdl.utils.RandomGenerator
+import com.intel.analytics.bigdl.utils.{Engine, MklDnn, RandomGenerator}
 import com.intel.analytics.bigdl.utils.RandomGenerator._
 import org.apache.commons.lang3.SerializationUtils
 import org.scalatest.{FlatSpec, Matchers}
@@ -31,7 +31,7 @@ import org.scalatest.{FlatSpec, Matchers}
 class LinearSpec extends FlatSpec with Matchers {
 
   "Convert blas linear to mkldnn with NHWC" should "be correct" in {
-    System.setProperty("bigdl.engineType", "mkldnn")
+    Engine.setEngineType(MklDnn)
     RandomGenerator.RNG.setSeed(100)
     val linear = nn.Linear(12, 3)
     val linear2 = nn.Linear(12, 3)
@@ -59,8 +59,6 @@ class LinearSpec extends FlatSpec with Matchers {
     val gradInputBlas = blas.backward(input, gradOutput)
     val gradInputDnn = dnn.backward(input, gradOutput)
     Equivalent.nearequals(gradInputBlas.toTensor, gradInputDnn.toTensor, 1e-5) should be (true)
-
-    System.clearProperty("bigdl.engineType")
   }
 
   "linear updateOutput" should "work correctly" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/MaxPoolingSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/MaxPoolingSpec.scala
@@ -20,7 +20,7 @@ import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
 import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
 import com.intel.analytics.bigdl.nn.{Graph, SpatialAveragePooling, SpatialMaxPooling, StaticGraph}
 import com.intel.analytics.bigdl.tensor.{DnnTensor, Tensor}
-import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, Engine}
+import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, Engine, MklDnn}
 import com.intel.analytics.bigdl.utils.RandomGenerator.RNG
 import com.intel.analytics.bigdl.utils.intermediate.{BlasToIR, IRToDnn}
 import org.apache.commons.lang3.SerializationUtils
@@ -70,7 +70,7 @@ class MaxPoolingSpec extends BigDLSpecHelper {
   }
 
   "Max Pooling with NHWC format" should "be correct" in {
-    System.setProperty("bigdl.engineType", "mkldnn")
+    Engine.setEngineType(MklDnn)
     val batchSize = 2
     val input = Tensor[Float](batchSize, 28, 28, 480).apply1(e => Random.nextFloat())
     val gradOutput = Tensor[Float](batchSize, 14, 14, 480).apply1(e => Random.nextFloat())
@@ -99,8 +99,6 @@ class MaxPoolingSpec extends BigDLSpecHelper {
     val grad2 = layer.backward(input, output2).toTensor[Float]
     val grad1 = dnn.backward(input, output2)
     grad1 should be(grad2)
-
-    System.clearProperty("bigdl.engineType")
   }
 
   "Convert max pooling with ceilMode to dnn layer" should "be correct" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/MaxPoolingSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/MaxPoolingSpec.scala
@@ -16,8 +16,9 @@
 package com.intel.analytics.bigdl.nn.mkldnn
 
 import com.intel.analytics.bigdl.mkl.{AlgKind, DataType, Memory}
+import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
 import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
-import com.intel.analytics.bigdl.nn.{SpatialAveragePooling, SpatialMaxPooling}
+import com.intel.analytics.bigdl.nn.{Graph, SpatialAveragePooling, SpatialMaxPooling, StaticGraph}
 import com.intel.analytics.bigdl.tensor.{DnnTensor, Tensor}
 import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, Engine}
 import com.intel.analytics.bigdl.utils.RandomGenerator.RNG
@@ -66,6 +67,40 @@ class MaxPoolingSpec extends BigDLSpecHelper {
     val grad2 = layer.backward(input, output2).toTensor[Float]
     val grad1 = seq.backward(input, output2)
     grad1 should be(grad2)
+  }
+
+  "Max Pooling with NHWC format" should "be correct" in {
+    System.setProperty("bigdl.engineType", "mkldnn")
+    val batchSize = 2
+    val input = Tensor[Float](batchSize, 28, 28, 480).apply1(e => Random.nextFloat())
+    val gradOutput = Tensor[Float](batchSize, 14, 14, 480).apply1(e => Random.nextFloat())
+
+    val pad = -1
+    RNG.setSeed(100)
+    val pool = MaxPooling(3, 3, 2, 2, padH = pad, padW = pad)
+    RNG.setSeed(100)
+    val layer = SpatialMaxPooling[Float](3, 3, 2, 2, padH = pad, padW = pad,
+      format = DataFormat.NHWC).ceil()
+    val layer2 = SpatialMaxPooling[Float](3, 3, 2, 2, padH = pad, padW = pad).ceil()
+
+    import com.intel.analytics.bigdl.nn
+    val static = nn.Sequential[Float]().add(layer2)
+      .toGraph().asInstanceOf[StaticGraph[Float]]
+    static.setInputFormats(Seq(Memory.Format.nhwc))
+    static.setOutputFormats(Seq(Memory.Format.nhwc))
+
+    val dnn = static.toIRgraph()
+
+    val output1 = dnn.forward(input)
+    val output2 = layer.forward(input).toTensor[Float]
+
+    output1 should be(output2)
+
+    val grad2 = layer.backward(input, output2).toTensor[Float]
+    val grad1 = dnn.backward(input, output2)
+    grad1 should be(grad2)
+
+    System.clearProperty("bigdl.engineType")
   }
 
   "Convert max pooling with ceilMode to dnn layer" should "be correct" in {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/SoftMaxSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/SoftMaxSpec.scala
@@ -21,6 +21,7 @@ import com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
 import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.T
 import org.apache.commons.lang3.SerializationUtils
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -253,5 +254,47 @@ class SoftMaxSpec extends FlatSpec with Matchers {
 
     Tools.dense(sm.gradInput) should be (Tools.dense(cloned.gradInput))
 
+  }
+
+  "SoftMax with 2dims input" should "be ok" in {
+    System.setProperty("bigdl.engineType", "mkldnn")
+
+    val input = Tensor[Float](T(
+      T(-0.33185136,	-0.36650753,	-0.18259251,	-0.28977787,	0.12433326,	-0.2162494,	0.10134846,	-0.3177442,	-0.1484699,	0.13634288),
+      T(-0.5104831,	-0.5519625,	-0.11421487,	-0.2595594,	0.16804607,	-0.23292251,	0.07044585,	-0.44675964,	0.12295306,	0.18260688),
+      T(-0.48692894,	-0.49688655,	-0.18367237,	-0.27386612,	0.16401377,	-0.18842852,	0.07758184,	-0.31743416,	-0.105054736,	0.16071126)
+    ))
+
+    val gradOutput = Tensor[Float](T(
+      T(0.9667894,	0.24395128,	0.76337516,	0.9502087,	0.23601186,	0.076125905,	0.62328607,	0.770936,	0.975731,	0.21108276),
+      T(0.34206265,	0.8998105,	0.73317754,	0.3519888,	0.6322726,	0.47116464,	0.67990524,	0.7170129,	0.41524208,	0.20622952),
+      T(0.3923543,	0.017130794,	0.20689869,	0.37415645,	0.62618166,	0.58558035,	0.87812847,	0.4298241,	0.01781603,	0.029151212)))
+
+    val gradInput = Tensor[Float](T(
+    T(0.033650335,	-0.02460857,	0.019749852,	0.033681773,	-0.041227575,	-0.044008553,	0.008562913,	0.017880393,	0.041301828,	-0.04498242),
+    T(-0.012584607,	0.024181157,	0.020681644,	-0.015309532,	0.013951356,	-0.0050649773,	0.018423514,	0.013663444,	-0.014368655,	-0.043573305),
+    T(0.0013979464,	-0.024840426,	-0.015835835,	1.402814E-4,	0.034327768,	0.020268412,	0.06276163,	0.0047896877,	-0.036685247,	-0.046324227)))
+
+
+    val (batchSize, channel) = (3, 10)
+    val sm = SoftMax()
+    sm.setRuntime(new MklDnnRuntime)
+    sm.initFwdPrimitives(Array(HeapData(Array(batchSize, channel),
+      Memory.Format.nc)), TrainingPhase)
+    sm.initBwdPrimitives(Array(HeapData(Array(batchSize, channel),
+      Memory.Format.nc)), TrainingPhase)
+
+    val nnSm = nn.SoftMax()
+
+    sm.forward(input)
+    nnSm.forward(input)
+
+    sm.backward(input, gradOutput)
+    nnSm.backward(input, gradOutput)
+
+    Equivalent.nearequals(Tools.dense(sm.output).toTensor, nnSm.output.toTensor,
+      epsilon = 1e-4) should be(true)
+    Equivalent.nearequals(Tools.dense(sm.gradInput).toTensor, nnSm.gradInput.toTensor,
+      epsilon = 1e-4) should be(true)
   }
 }

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/SoftMaxSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/mkldnn/SoftMaxSpec.scala
@@ -21,7 +21,6 @@ import com.intel.analytics.bigdl.nn
 import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
 import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.bigdl.utils.T
 import org.apache.commons.lang3.SerializationUtils
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -254,47 +253,5 @@ class SoftMaxSpec extends FlatSpec with Matchers {
 
     Tools.dense(sm.gradInput) should be (Tools.dense(cloned.gradInput))
 
-  }
-
-  "SoftMax with 2dims input" should "be ok" in {
-    System.setProperty("bigdl.engineType", "mkldnn")
-
-    val input = Tensor[Float](T(
-      T(-0.33185136,	-0.36650753,	-0.18259251,	-0.28977787,	0.12433326,	-0.2162494,	0.10134846,	-0.3177442,	-0.1484699,	0.13634288),
-      T(-0.5104831,	-0.5519625,	-0.11421487,	-0.2595594,	0.16804607,	-0.23292251,	0.07044585,	-0.44675964,	0.12295306,	0.18260688),
-      T(-0.48692894,	-0.49688655,	-0.18367237,	-0.27386612,	0.16401377,	-0.18842852,	0.07758184,	-0.31743416,	-0.105054736,	0.16071126)
-    ))
-
-    val gradOutput = Tensor[Float](T(
-      T(0.9667894,	0.24395128,	0.76337516,	0.9502087,	0.23601186,	0.076125905,	0.62328607,	0.770936,	0.975731,	0.21108276),
-      T(0.34206265,	0.8998105,	0.73317754,	0.3519888,	0.6322726,	0.47116464,	0.67990524,	0.7170129,	0.41524208,	0.20622952),
-      T(0.3923543,	0.017130794,	0.20689869,	0.37415645,	0.62618166,	0.58558035,	0.87812847,	0.4298241,	0.01781603,	0.029151212)))
-
-    val gradInput = Tensor[Float](T(
-    T(0.033650335,	-0.02460857,	0.019749852,	0.033681773,	-0.041227575,	-0.044008553,	0.008562913,	0.017880393,	0.041301828,	-0.04498242),
-    T(-0.012584607,	0.024181157,	0.020681644,	-0.015309532,	0.013951356,	-0.0050649773,	0.018423514,	0.013663444,	-0.014368655,	-0.043573305),
-    T(0.0013979464,	-0.024840426,	-0.015835835,	1.402814E-4,	0.034327768,	0.020268412,	0.06276163,	0.0047896877,	-0.036685247,	-0.046324227)))
-
-
-    val (batchSize, channel) = (3, 10)
-    val sm = SoftMax()
-    sm.setRuntime(new MklDnnRuntime)
-    sm.initFwdPrimitives(Array(HeapData(Array(batchSize, channel),
-      Memory.Format.nc)), TrainingPhase)
-    sm.initBwdPrimitives(Array(HeapData(Array(batchSize, channel),
-      Memory.Format.nc)), TrainingPhase)
-
-    val nnSm = nn.SoftMax()
-
-    sm.forward(input)
-    nnSm.forward(input)
-
-    sm.backward(input, gradOutput)
-    nnSm.backward(input, gradOutput)
-
-    Equivalent.nearequals(Tools.dense(sm.output).toTensor, nnSm.output.toTensor,
-      epsilon = 1e-4) should be(true)
-    Equivalent.nearequals(Tools.dense(sm.gradInput).toTensor, nnSm.gradInput.toTensor,
-      epsilon = 1e-4) should be(true)
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

mainly for NHWC support when running with MKL-DNN, summary changes:
(1) Add `heapFormat` (NHWC or NCHW) for models, so when one layer uses 4 dims, it can get its real format which may be not same with format from previous layer.

(2) Add `DataFormat` for DNN layers according to BLAS layers. E.g. Blas MaxPooling has DataFormat in its construct parameters, so add the same param for DNN MaxPooling.

(3) Refactor mkldnn.Linear to support NHWC input

(4) Deprecate  `DropOut` for MKLDNN, use `BlasWrapper(nn.DropOut)` if needed.

(5) Delete some constraints for NHWC, and now we can run models with NHWC input under MKLDNN backend


## How was this patch tested?

unit tests

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/XXX

