### PR TITLE
Upgrade mkldnn v0.19 to dnnl v1.1

### DIFF
--- a/make-dist.sh
+++ b/make-dist.sh
@@ -57,19 +57,13 @@ fi
 backend_exclude=dnnl
 for arg in "$@" 
 do 
-	echo $arg
   	case $arg in 
 		-d|--dnnl)
-		echo "hello"
 		backend_exclude=mkldnn
        	shift # Remove --initialize from processing
        	;;
     esac
 done
-# git checkout dnnl-update 
-###############################################
-
-
 
 mvn clean package -DskipTests $* "-Dbigdl.backend.exclude=${backend_exclude}"
 

--- a/make-dist.sh
+++ b/make-dist.sh
@@ -53,7 +53,25 @@ if [ $MVN_INSTALL -eq 0 ]; then
   exit 1
 fi
 
-mvn clean package -DskipTests $*
+
+backend_exclude=dnnl
+for arg in "$@" 
+do 
+	echo $arg
+  	case $arg in 
+		-d|--dnnl)
+		echo "hello"
+		backend_exclude=mkldnn
+       	shift # Remove --initialize from processing
+       	;;
+    esac
+done
+# git checkout dnnl-update 
+###############################################
+
+
+
+mvn clean package -DskipTests $* "-Dbigdl.backend.exclude=${backend_exclude}"
 
 BASEDIR=$(dirname "$0")
 DIST_DIR=$BASEDIR/dist

--- a/pom.xml
+++ b/pom.xml
@@ -464,6 +464,9 @@
                             <version>${scala.macros.version}</version>
                         </compilerPlugin>
                     </compilerPlugins>
+                    <excludes>
+                      <exclude>**/${bigdl.backend.exclude}/**</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
             <plugin>
@@ -584,7 +587,6 @@
                                 <goals>
                                     <goal>doc-jar</goal>
                                 </goals>
-
                                 <configuration>
                                     <args>
                                         <!-- Do not change the arg orders. It is a weird way to pass in
@@ -593,7 +595,6 @@
                                         <arg>caffe:org.tensorflow:netty:org.apache.spark.sparkExtension:org.apache.spark.rdd:org.apache.spark.storage:org.apache.spark.bigdl</arg>
                                     </args>
                                 </configuration>
-
                             </execution>
 
                         </executions>
@@ -618,9 +619,8 @@
                                 </compilerPlugin>
                             </compilerPlugins>
                             <excludes>
-                                <exclude>**/bigdl/nn/${bigdl.backend.exclude}/**</exclude>
+                                <exclude>**/${bigdl.backend.exclude}/**</exclude>
                             </excludes>
-
                         </configuration>
 
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
     </licenses>
 
     <properties>
+        <bigdl.backend.exclude>mkldnn</bigdl.backend.exclude>
         <failIfNoTests>false</failIfNoTests>
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 
@@ -583,6 +584,7 @@
                                 <goals>
                                     <goal>doc-jar</goal>
                                 </goals>
+
                                 <configuration>
                                     <args>
                                         <!-- Do not change the arg orders. It is a weird way to pass in
@@ -591,7 +593,9 @@
                                         <arg>caffe:org.tensorflow:netty:org.apache.spark.sparkExtension:org.apache.spark.rdd:org.apache.spark.storage:org.apache.spark.bigdl</arg>
                                     </args>
                                 </configuration>
+
                             </execution>
+
                         </executions>
                         <configuration>
                             <scalaVersion>${scala.version}</scalaVersion>
@@ -613,9 +617,16 @@
                                     <version>${scala.macros.version}</version>
                                 </compilerPlugin>
                             </compilerPlugins>
+                            <excludes>
+                                <exclude>**/bigdl/nn/${bigdl.backend.exclude}/**</exclude>
+                            </excludes>
+
                         </configuration>
+
                     </plugin>
+
                 </plugins>
+
             </build>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     </licenses>
 
     <properties>
-        <bigdl.backend.exclude>mkldnn</bigdl.backend.exclude>
+        <bigdl.backend.exclude>dnnl</bigdl.backend.exclude>
         <failIfNoTests>false</failIfNoTests>
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/languagemodel/PTBModel.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/languagemodel/PTBModel.scala
@@ -59,8 +59,8 @@ object PTBModel {
     val output = TimeDistributed[Float](linear).inputs(lstm)
 
     val model = Graph(input, output)
-    model.asInstanceOf[StaticGraph[Float]].setInputFormats(Seq(Memory.Format.nc))
-    model.asInstanceOf[StaticGraph[Float]].setOutputFormats(Seq(Memory.Format.ntc))
+    model.asInstanceOf[StaticGraph[Float]].setInputFormats(Seq(Memory.FormatTag.nc))
+    model.asInstanceOf[StaticGraph[Float]].setOutputFormats(Seq(Memory.FormatTag.ntc))
     if (Engine.getEngineType() == MklDnn) model.asInstanceOf[StaticGraph[Float]].toIRgraph()
     else model
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/languagemodel/PTBModel.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/languagemodel/PTBModel.scala
@@ -17,7 +17,7 @@
 package com.intel.analytics.bigdl.example.languagemodel
 
 import com.intel.analytics.bigdl.Module
-import com.intel.analytics.bigdl.mkl.Memory
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{MemoryWrapper => Memory}
 import com.intel.analytics.bigdl.nn.Graph._
 import com.intel.analytics.bigdl.nn.{TimeDistributed, _}
 import com.intel.analytics.bigdl.utils.{Engine, MklDnn}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/lenet/LeNet5.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/lenet/LeNet5.scala
@@ -17,7 +17,8 @@
 package com.intel.analytics.bigdl.models.lenet
 
 import com.intel.analytics.bigdl._
-import com.intel.analytics.bigdl.mkl.Memory
+import com.intel.analytics.bigdl.nn.mkldnn
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{MemoryWrapper => Memory}
 import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.nn.mkldnn.DnnGraph

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/lenet/LeNet5.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/lenet/LeNet5.scala
@@ -93,7 +93,7 @@ object LeNet5 {
     val outputShape = Array(batchSize, 10)
 
     val model = mkldnn.Sequential()
-      .add(mkldnn.Input(inputShape, Memory.Format.nchw))
+      .add(mkldnn.Input(inputShape, Memory.FormatTag.nchw))
       .add(mkldnn.SpatialConvolution(1, 20, 5, 5).setName("conv1"))
       .add(mkldnn.SpatialBatchNormalization(20).setName("bn1"))
       .add(mkldnn.MaxPooling(2, 2, 2, 2).setName("pool1"))
@@ -102,7 +102,7 @@ object LeNet5 {
       .add(mkldnn.Linear(50 * 4 * 4, 500).setName("ip1"))
       .add(mkldnn.ReLU().setName("relu1"))
       .add(mkldnn.Linear(500, 10).setName("ip2"))
-      .add(mkldnn.ReorderMemory(mkldnn.HeapData(outputShape, Memory.Format.nc)))
+      .add(mkldnn.ReorderMemory(mkldnn.HeapData(outputShape, Memory.FormatTag.nc)))
     model
   }
 
@@ -110,7 +110,7 @@ object LeNet5 {
     val inputShape = Array(batchSize, 1, 28, 28)
     val outputShape = Array(batchSize, 10)
 
-    val input = mkldnn.Input(inputShape, Memory.Format.nchw).inputs()
+    val input = mkldnn.Input(inputShape, Memory.FormatTag.nchw).inputs()
     val conv1 = mkldnn.SpatialConvolution(1, 20, 5, 5).setName("conv1").inputs(input)
     val bn1 = mkldnn.SpatialBatchNormalization(20).setName("bn1").inputs(conv1)
     val pool1 = mkldnn.MaxPooling(2, 2, 2, 2).setName("pool1").inputs(bn1)
@@ -119,7 +119,7 @@ object LeNet5 {
     val ip1 = mkldnn.Linear(50 * 4 * 4, 500).setName("ip1").inputs(pool2)
     val relu1 = mkldnn.ReLU().setName("relu1").inputs(ip1)
     val ip2 = mkldnn.Linear(500, 10).setName("ip2").inputs(relu1)
-    val output = mkldnn.ReorderMemory(mkldnn.HeapData(outputShape, Memory.Format.nc)).inputs(ip2)
+    val output = mkldnn.ReorderMemory(mkldnn.HeapData(outputShape, Memory.FormatTag.nc)).inputs(ip2)
 
     DnnGraph(Array(input), Array(output))
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/StaticGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/StaticGraph.scala
@@ -158,12 +158,12 @@ class StaticGraph[T: ClassTag](
   def toIRgraph() : IRGraph[T] = {
     val inFormats = if (inputsFormats == null) {
       logger.warn("Input formats NCHW by default, Please set explicitly if needed")
-      Seq(Memory.Format.nchw)
+      Seq(Memory.FormatTag.nchw)
     } else inputsFormats
 
     val outFormats = if (outputsFormats == null) {
       logger.warn("Output formats NC by default, Please set explicitly if needed")
-      Seq(Memory.Format.nc)
+      Seq(Memory.FormatTag.nc)
     } else outputsFormats
 
     val allNodes = forwardExecution

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/StaticGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/StaticGraph.scala
@@ -15,7 +15,7 @@
  */
 package com.intel.analytics.bigdl.nn
 
-import com.intel.analytics.bigdl.mkl.Memory
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{MemoryWrapper => Memory}
 import com.intel.analytics.bigdl.nn.Graph.ModuleNode
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.nn.tf.ControlDependency

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/AvgPooling.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/AvgPooling.scala
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl._
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.nn.{Utils => NNUtils}
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.tensor.Tensor
+
+import scala.collection.mutable
+
+
+class AvgPooling(
+  var kW: Int,
+  var kH: Int,
+  dW: Int = 1,
+  dH: Int = 1,
+  padW: Int = 0,
+  padH: Int = 0,
+  globalPooling: Boolean = false
+) extends MklDnnLayer {
+
+  @transient private var workSpaceFormat: MemoryData = _
+  @transient private var workSpace: Tensor[Float] = _
+  @transient private var paddingTL: Array[Int] = _
+  @transient private var paddingBR: Array[Int] = _
+  @transient private var fwdPD: Long = _
+
+  // reminder: ceilMode default value is true,
+  // but in blas SpatialMaxPooling, default ceilMode is false
+  private var ceilMode = true
+
+  /**
+   * set ceil mode
+   * @return this
+   */
+  def ceil(): AvgPooling = {
+    ceilMode = true
+    this
+  }
+
+  /**
+   * set floor mode
+   * @return this
+   */
+  def floor(): AvgPooling = {
+    ceilMode = false
+    this
+  }
+
+  private val algKind = if (padH == -1 && padW == -1) {
+    AlgKind.PoolingAvgIncludePadding
+  } else {
+    AlgKind.PoolingAvgExcludePadding
+  }
+
+  override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+    _inputFormats = singleNativeData(inputs)
+    val inShape = _inputFormats(0).shape
+    val (n, c, h, w) = (inShape(0), inShape(1), inShape(2), inShape(3))
+
+    // global average pooling reduce each feature map to a single average value
+    if (globalPooling) {
+      kH = h
+      kW = w
+    }
+
+    val strides = Array(dW, dH)
+    val kernel = Array(kH, kW)
+
+    val (pt, pb, pl, pr, oh, ow) = if (padH == -1 && padW == -1) {
+      val sizes = NNUtils.getSAMEOutSizeAndPadding(h, w, dH, dW, kH, kW)
+      (sizes(0), sizes(1), sizes(2), sizes(3), sizes(4), sizes(5))
+    } else {
+      NNUtils.getPaddingAndOutputSize(h, w, dH, dW, kH, kW, padH, padW, ceilMode)
+    }
+
+    paddingTL = Array(pt, pl)
+    paddingBR = Array(pb, pr)
+
+    val inputMd = inputFormats()(0).getMemoryDescriptor()
+    val outputMD = DnnlMemory.MemoryDescInit(4, Array(n, c, oh, ow), inputs(0).dataType,
+      Memory.FormatTag.any)
+
+    val kind = if (phase == InferencePhase) {
+      PropKind.ForwardScoring
+    } else {
+      PropKind.ForwardTraining
+    }
+
+    val description = DnnlMemory.PoolingForwardDescInit(
+      kind, algKind,
+      inputMd, outputMD,
+      strides, kernel, paddingTL, paddingBR,
+      DNNL.PaddingKind.mkldnnPaddingZero)
+
+    fwdPD = DnnlMemory.PrimitiveDescCreate(description, runtime.engine, 0L)
+
+    _outputFormats = Array(MemoryData.primitiveOutput(fwdPD))
+
+    fwdExecArgs = mutable.Map[Int, Long](
+      ArgType.DNNL_ARG_SRC -> _inputFormats(0).getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DST -> _outputFormats(0).getMemoryObject(runtime)
+    )
+
+    if (phase == TrainingPhase) {
+      workSpaceFormat = MemoryData.operationWant(fwdPD, Query.WorkspaceMd)
+      workSpaceFormat.getMemoryObject(runtime)
+    }
+
+    output = initTensor(_outputFormats(0))
+
+    updateOutputPrimitives = Array(DnnlMemory.PrimitiveCreate(fwdPD))
+
+    (_inputFormats, _outputFormats)
+  }
+
+  override private[mkldnn] def initBwdPrimitives(grad: Array[MemoryData], phase: Phase) = {
+    _gradOutputFormats = singleNativeData(grad)
+    _gradOutputFormatsForWeight = _gradOutputFormats
+
+    val strides = Array(dW, dH)
+    val kernel = Array(kH, kW)
+
+    val description = DnnlMemory.PoolingBackwardDescInit(algKind,
+      _inputFormats(0).getMemoryDescriptor(),
+      _gradOutputFormats(0).getMemoryDescriptor(),
+      strides, kernel, paddingTL, paddingBR, DNNL.PaddingKind.mkldnnPaddingZero)
+
+    val pd = DnnlMemory.PrimitiveDescCreate(description, runtime.engine, fwdPD)
+
+    _gradInputFormats = Array(MemoryData.operationWant(pd, Query.DiffSrcMd))
+
+    updateGradInputPrimitives = Array(DnnlMemory.PrimitiveCreate(pd))
+
+    gradInput = initTensor(_gradInputFormats(0))
+
+    bwdExecArgs = mutable.Map(
+      ArgType.DNNL_ARG_SRC -> _inputFormats(0).getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DIFF_DST -> _gradOutputFormats(0).getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DIFF_SRC -> _gradInputFormats(0).getMemoryObject(runtime)
+    )
+
+    updateGradInputPrimitives = Array(DnnlMemory.PrimitiveCreate(pd))
+
+    (_gradOutputFormats, _gradInputFormats)
+  }
+
+  override def updateOutput(input: Activity): Activity = {
+    updateOutputTensors = mutable.Map(
+      ArgType.DNNL_ARG_SRC -> input.asInstanceOf[Tensor[Float]],
+      ArgType.DNNL_ARG_DST -> output.asInstanceOf[Tensor[Float]]
+    )
+
+    MklDnnOps.streamSubmit(updateOutputPrimitives, runtime.stream,
+      fwdExecArgs, updateOutputTensors)
+
+    output
+  }
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    updateGradInputTensors = mutable.Map(
+      ArgType.DNNL_ARG_SRC -> input.asInstanceOf[Tensor[Float]],
+      ArgType.DNNL_ARG_DIFF_DST -> gradOutput.asInstanceOf[Tensor[Float]],
+      ArgType.DNNL_ARG_DIFF_SRC -> gradInput.asInstanceOf[Tensor[Float]]
+    )
+
+    MklDnnOps.streamSubmit(updateGradInputPrimitives,
+      runtime.stream,
+      bwdExecArgs,
+      updateGradInputTensors)
+
+    gradInput
+  }
+
+}
+
+object AvgPooling {
+  def apply(
+    kW: Int,
+    kH: Int,
+    dW: Int = 1,
+    dH: Int = 1,
+    padW: Int = 0,
+    padH: Int = 0,
+    globalPooling: Boolean = false
+  ): AvgPooling = new AvgPooling(kW, kH, dW, dH, padW, padH, globalPooling)
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/AvgPooling.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/AvgPooling.scala
@@ -119,7 +119,10 @@ class AvgPooling(
 
     if (phase == TrainingPhase) {
       workSpaceFormat = MemoryData.operationWant(fwdPD, Query.WorkspaceMd)
-      workSpaceFormat.getMemoryObject(runtime)
+      if (workSpaceFormat != null) {
+        workSpace = initTensor(workSpaceFormat).asInstanceOf[Tensor[Float]]
+        fwdExecArgs.put(ArgType.DNNL_ARG_WORKSPACE, workSpaceFormat.getMemoryObject(runtime))
+      }
     }
 
     output = initTensor(_outputFormats(0))
@@ -155,6 +158,10 @@ class AvgPooling(
       ArgType.DNNL_ARG_DIFF_SRC -> _gradInputFormats(0).getMemoryObject(runtime)
     )
 
+    if (workSpaceFormat != null) {
+      bwdExecArgs.put(ArgType.DNNL_ARG_WORKSPACE, workSpaceFormat.getMemoryObject(runtime))
+    }
+
     updateGradInputPrimitives = Array(DnnlMemory.PrimitiveCreate(pd))
 
     (_gradOutputFormats, _gradInputFormats)
@@ -165,6 +172,10 @@ class AvgPooling(
       ArgType.DNNL_ARG_SRC -> input.asInstanceOf[Tensor[Float]],
       ArgType.DNNL_ARG_DST -> output.asInstanceOf[Tensor[Float]]
     )
+
+    if (workSpace != null) {
+      updateOutputTensors.put(ArgType.DNNL_ARG_WORKSPACE, workSpace)
+    }
 
     MklDnnOps.streamSubmit(updateOutputPrimitives, runtime.stream,
       fwdExecArgs, updateOutputTensors)
@@ -178,6 +189,10 @@ class AvgPooling(
       ArgType.DNNL_ARG_DIFF_DST -> gradOutput.asInstanceOf[Tensor[Float]],
       ArgType.DNNL_ARG_DIFF_SRC -> gradInput.asInstanceOf[Tensor[Float]]
     )
+
+    if (workSpace != null) {
+      updateGradInputTensors.put(ArgType.DNNL_ARG_WORKSPACE, workSpace)
+    }
 
     MklDnnOps.streamSubmit(updateGradInputPrimitives,
       runtime.stream,

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/BlasWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/BlasWrapper.scala
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import breeze.linalg.Axis._1
+import breeze.linalg.dim
+import com.intel.analytics.bigdl.Module
+// import com.intel.analytics.bigdl.dataset.MiniBatch
+import com.intel.analytics.bigdl.dnnl.{Memory}
+import com.intel.analytics.bigdl.nn.{DetectionOutputSSD, PriorBox}
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.{Util => NNUtils, _}
+import org.apache.log4j.Logger
+
+/**
+ * wrap blas module to dnn module,
+ * and the module should have implemented "computeOutputShape" func.
+ * @param module
+ */
+private[bigdl] class BlasWrapper(val module: AbstractModule[Activity, Activity, Float])
+  extends MklDnnLayer {
+
+  require(!module.isInstanceOf[MklDnnModule], "Only support wrapper blas layer to dnn layer")
+
+  output = module.output
+  gradInput = module.gradInput
+
+  // reminder: for dim 3, there may be ntc or tnc, now we just support ntc
+  private def getFormats(dims: Int): Int = {
+    dims match {
+      case 4 => Memory.FormatTag.nchw
+      case 3 => Memory.FormatTag.ntc
+      case 2 => Memory.FormatTag.nc
+      case 1 => Memory.FormatTag.x
+      case _ => throw new UnsupportedOperationException(s"Unsupported dims ${dims}")
+    }
+  }
+
+  private[mkldnn] var needOutputFormats: Boolean = true
+
+  @transient private lazy val logger = Logger.getLogger(getClass)
+
+  @transient private var subModels: Array[Module[Float]] = _
+  @transient private var subModelNumber : Int = 1
+  @transient private var withMultiThread: Boolean = false
+  @transient private var inputBuffer : Array[Activity] = _
+  @transient private var tensorBuffer : Array[Tensor[Float]] = _
+  @transient private var batchSize : Int = _
+  @transient private var initEnv: Boolean = false
+
+  private def inferInputFormats(inputs: Array[MemoryData]): Array[MemoryData] = {
+    inputs.map(in => {
+      if (in.layout == Memory.FormatTag.tnc) {
+        val size = in.shape
+        HeapData(Array(size(1), size(0), size(2)), Memory.FormatTag.ntc)
+      } else HeapData(in.shape, getFormats(in.shape.length))
+    })
+  }
+
+  private def inferOutputFormats(inputs: Array[MemoryData]): Array[MemoryData] = {
+    val inputShape = inputs.map(in => Shape(in.shape))
+    val outputShape = if (inputShape.length == 1) {
+      List(module.computeOutputShape(inputShape(0)))
+    } else {
+      // multi shape
+      val out = module.computeOutputShape(MultiShape(inputShape.toList))
+      if (out.isInstanceOf[MultiShape]) out.toMulti() else List(out)
+    }
+    outputShape.map(in => {
+      val size = in.toSingle().toArray
+      HeapData(size, getFormats(size.length))
+    }).toArray
+  }
+
+  /**
+   * Blas layers normally do not have competitive performance when running under mkldnn.
+   * So we can leverage multi-threading to resolve bottleneck introduced by one model only
+   * for mkl-dnn backend. The parallelism is determined by both bath size and core number,
+   * with restrictions that both input and output format must be batched.
+   */
+  private def setMultiThreadEnv(input: Activity): Unit = {
+    initEnv = true
+    val multiThread = System.getProperty("multiThread", "false").toBoolean
+    if (this.train && multiThread) {
+      throw new IllegalArgumentException("Please not set multiThread to true for model training")
+    }
+    if (this.train
+      || !multiThread
+      || (_outputFormats != null && _outputFormats.length != 1)
+      || (_outputFormats != null && _inputFormats != null
+      && _inputFormats(0).shape(0) != _outputFormats(0).shape(0))
+      || !flattenInput(input)
+    ) {
+      return
+    }
+    batchSize = tensorBuffer(0).size(1)
+    val residue = batchSize % Engine.coreNumber()
+    if (residue != 0 || batchSize < 2 || Engine.coreNumber() < 2) {
+      logger.warn("If you want to use multiThread property to speed up, " +
+        "please attention core number should be greater than 1, " +
+        s"batch size should be greater than 1 and divided by core number, " +
+        s"but now get core number ${Engine.coreNumber()} batch size ${batchSize}")
+      return
+    }
+    subModelNumber = Engine.coreNumber()
+    initModules()
+    withMultiThread = true
+  }
+  private def flattenInput(input: Activity): Boolean = {
+    val inputDepth = if (input.isTensor) 1 else input.toTable.length()
+    if (tensorBuffer == null) tensorBuffer = new Array[Tensor[Float]](inputDepth)
+    var batch : Int = 0
+    if (inputDepth == 1) {
+      tensorBuffer(0) = input.toTensor[Float]
+    } else {
+      val in = input.toTable
+      for (i <- 1 to in.length()) {
+        if (in.get(i).get.isInstanceOf[Table]) return false
+        tensorBuffer(i - 1) = in.get[Tensor[Float]](i).get
+        if (i == 1) batch = tensorBuffer(i - 1).size(1)
+        // reminder: inputs for DetectionOutputSSD are not all in batch,
+        // but the non-batched input can be shared in all batch. So this layer can be paralleled.
+        if (batch != tensorBuffer(i - 1).size(1)
+          && !module.isInstanceOf[DetectionOutputSSD[Float]]) {
+          return false
+        }
+      }
+    }
+    true
+  }
+  private def initModules(): Unit = {
+    subModels = if (module.parameters() != null) {
+        val wb = NNUtils.getAndClearWeightBias(module.parameters())
+        val models = (1 to subModelNumber).map(i => {
+          val m = module.cloneModule()
+          NNUtils.putWeightBias(wb, m)
+          m.asInstanceOf[Module[Float]]
+        }).toArray
+        NNUtils.putWeightBias(wb, module)
+        models
+      } else {
+        val models = (1 to subModelNumber).map(i => {
+          val m = module.cloneModule()
+          m.asInstanceOf[Module[Float]]
+        }).toArray
+        models
+      }
+  }
+
+  override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+    _inputFormats = inferInputFormats(inputs)
+    _outputFormats = if (needOutputFormats) inferOutputFormats(inputs) else null
+    if (_outputFormats != null) {
+      _outputFormats.map(_.getMemoryObject(runtime))
+    }
+    (_inputFormats, _outputFormats)
+  }
+
+  override private[mkldnn] def initBwdPrimitives(grad: Array[MemoryData], phase: Phase) = {
+    _gradOutputFormats = _outputFormats
+    _gradInputFormats = _inputFormats
+    (_gradOutputFormats, _gradInputFormats)
+  }
+
+  override private[mkldnn] def initGradWPrimitives(grad: Array[MemoryData], phase: Phase) = {
+    _gradOutputFormatsForWeight = _outputFormats
+    _gradOutputFormatsForWeight
+  }
+
+  private def getInput(dim: Int, index: Int, size: Int): Activity = {
+    if (tensorBuffer.length == 1) {
+      tensorBuffer(0).narrow(dim, index, size)
+    } else {
+      // the third tensor of inputs for DetectionOutputSSD is not in batch,
+      // but it can be shared with all batch.
+      if (module.isInstanceOf[DetectionOutputSSD[Float]]) {
+        T(tensorBuffer(0).narrow(dim, index, size),
+          tensorBuffer(1).narrow(dim, index, size), tensorBuffer(2))
+      } else {
+        T.array(tensorBuffer.map(_.narrow(dim, index, size)))
+      }
+    }
+  }
+  private def forwardInParallel(input: Activity): Activity = {
+    if (inputBuffer == null) inputBuffer = new Array[Activity](subModelNumber)
+    val stackSize = batchSize / subModelNumber
+
+    val tasks = Engine.wrapperComputing.invoke((0 until subModelNumber).map(i =>
+      () => inputBuffer(i) = getInput(1, i * stackSize + 1, stackSize)))
+    Engine.wrapperComputing.sync(tasks)
+
+    val forwardThreads = Engine.wrapperComputing.invoke((0 until subModelNumber).map(i =>
+      () => subModels(i).forward(inputBuffer(i)).toTensor[Float]))
+    Engine.wrapperComputing.sync(forwardThreads)
+
+    if (subModels(0).output.isTable) {
+      withMultiThread = false
+      module.forward(input)
+    } else {
+      val subOutSize = subModels(0).output.toTensor[Float].size()
+      if (subOutSize(0) != stackSize) {
+        withMultiThread = false
+        module.forward(input)
+      } else {
+        subOutSize(0) = batchSize
+        if (output == null || output.toTensor[Float].isEmpty) {
+          output = Tensor[Float]().resize(subOutSize)
+        }
+        val copyThreads = Engine.wrapperComputing.invoke((0 until subModelNumber).map(i =>
+          () => {
+            output.toTensor[Float].narrow(1, i * stackSize + 1, stackSize)
+              .copy(subModels(i).output.toTensor[Float])
+          }))
+        Engine.wrapperComputing.sync(copyThreads)
+
+        output
+      }
+    }
+  }
+
+  override def updateOutput(input: Activity): Activity = {
+    if (!initEnv) setMultiThreadEnv(input)
+    output = if (withMultiThread) {
+      forwardInParallel(input)
+    } else {
+      module.forward(input)
+    }
+    output
+  }
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    gradInput = module.updateGradInput(input, gradOutput)
+    gradInput
+  }
+
+  override def accGradParameters(input: Activity, gradOutput: Activity): Unit = {
+    module.accGradParameters(input, gradOutput)
+  }
+
+  override def clearState() : this.type = {
+    super.clearState()
+    module.clearState()
+    this
+  }
+
+  override def parameters(): (Array[Tensor[Float]], Array[Tensor[Float]]) = {
+    module.parameters()
+  }
+
+  override def equals(obj: Any): Boolean = {
+    if (!super.equals(obj) || !obj.isInstanceOf[BlasWrapper]) {
+      return false
+    }
+    val other = obj.asInstanceOf[BlasWrapper]
+    if (this.eq(other)) {
+      return true
+    }
+    if (module != other) return false
+    true
+  }
+
+  override def hashCode() : Int = {
+    val seed = 37
+    var hash = super.hashCode()
+    hash = hash * seed + module.hashCode()
+    hash
+  }
+
+  override def training(): this.type = {
+    train = true
+    module.training()
+    this
+  }
+
+  /**
+   * Set the module to evaluate mode
+   * @return
+   */
+  override def evaluate(): this.type = {
+    train = false
+    module.evaluate()
+    this
+  }
+
+  override def release(): Unit = module.release()
+
+}
+
+
+private[bigdl] object BlasWrapper {
+  def apply(module: AbstractModule[Activity, Activity, Float]): BlasWrapper =
+    new BlasWrapper(module)
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/CAddTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/CAddTable.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.{AlgKind, ArgType, DNNL, DataType, Memory}
+import com.intel.analytics.bigdl.nn.MklInt8Convertible
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.T
+
+import scala.collection.mutable
+
+
+class CAddTable extends MklDnnLayer with MklInt8Convertible {
+
+  // TODO: should CAddTable be defined as a MklDnnContainer?
+  protected var subModuleFwdPrimitives: Array[Array[Long]] = _
+
+  override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+    subModuleFwdPrimitives = new Array[Array[Long]](inputs.length)
+    val headInputsFormats = inputs.head
+    _inputFormats = nativeData(inputs)
+    _outputFormats = Array(MemoryData.cloneFormatWithDesc(inputFormats().head))
+
+    for(i <- 0 until inputs.length) {
+      require(headInputsFormats.shape.length == inputs(i).shape.length, "dimension not match")
+      for(j <- 0 until headInputsFormats.shape.length) {
+        require(headInputsFormats.shape(j) == inputs(i).shape(j), "size not match")
+      }
+      val currInputFormat = inputs(i)
+      val binaryDescInit = DNNL.BinaryDescInit(AlgKind.BinaryAdd,
+        outputFormats().head.getMemoryDescriptor(),
+        currInputFormat.getMemoryDescriptor(),
+        outputFormats().head.getMemoryDescriptor()
+      )
+      val binaryPd = DnnlMemory.PrimitiveDescCreate(binaryDescInit, runtime.engine, 0)
+      subModuleFwdPrimitives(i) = Array(DNNL.PrimitiveCreate(binaryPd))
+    }
+
+    _outputFormats.head.getMemoryObject(runtime)
+    output = initTensor(_outputFormats.head)
+
+    (_inputFormats, _outputFormats)
+  }
+
+  override private[mkldnn] def initBwdPrimitives(grad: Array[MemoryData], phase: Phase) = {
+    _gradOutputFormats = grad
+    _gradOutputFormatsForWeight = grad
+    _gradInputFormats = new Array[MemoryData](_inputFormats.length).map(a => grad(0))
+    gradInput = T()
+    (_gradOutputFormats, _gradInputFormats)
+  }
+
+
+  override def updateOutput(input: Activity): Activity = {
+    output.toTensor[Float].zero()
+
+    for (i <- 0 until input.toTable.length()) {
+      fwdExecArgs = mutable.Map(
+        ArgType.DNNL_ARG_SRC_0 -> outputFormats().head.getMemoryObject(runtime),
+        ArgType.DNNL_ARG_SRC_1 -> inputFormats()(i).getMemoryObject(runtime),
+        ArgType.DNNL_ARG_DST -> outputFormats().head.getMemoryObject(runtime)
+      )
+      updateOutputTensors = mutable.Map(
+        ArgType.DNNL_ARG_SRC_0 -> output.toTensor[Float],
+        ArgType.DNNL_ARG_SRC_1 -> input.toTable(i + 1).asInstanceOf[Tensor[Float]],
+        ArgType.DNNL_ARG_DST -> output.toTensor[Float]
+      )
+      MklDnnOps.streamSubmit(subModuleFwdPrimitives(i), runtime.stream,
+        fwdExecArgs, updateOutputTensors)
+    }
+    output
+  }
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    require(gradOutput.isTensor, "gradOutput should be a tensor")
+    val _gradInput = gradInput.toTable
+    var i = 1
+    while(i <= _inputFormats.length) {
+      _gradInput(i) = gradOutput
+      i += 1
+    }
+    gradInput
+  }
+}
+
+object CAddTable {
+  def apply(): CAddTable = new CAddTable()
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/ConcatTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/ConcatTable.scala
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+import com.intel.analytics.bigdl.dnnl.{AlgKind, ArgType, DNNL, Memory}
+import com.intel.analytics.bigdl.nn.MklInt8Convertible
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.T
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+
+class ConcatTable extends MklDnnContainer with MklInt8Convertible {
+
+  output = T()
+
+  override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+    require(mklDnnModules != null, "You should call compile first")
+    require(inputs.length == 1, "Concat only accept one tensor")
+    val buffer = new ArrayBuffer[MemoryData]()
+    var prevSubModule: MklDnnModule = null
+
+    for(i <- 0 until mklDnnModules.length) {
+      val currSubModule: MklDnnModule = mklDnnModules(i)
+      currSubModule.initFwdPrimitives(inputs, phase)
+      val subModuleInFormat = currSubModule.inputFormats()
+      val subModuleOutFormat = currSubModule.outputFormats()
+      require(subModuleOutFormat.length == 1, "output should be one tensor")
+      inputs.zip(subModuleInFormat).map {case(f, t) => reorderManager.register(f, t)}
+      buffer.append(subModuleOutFormat(0))
+      if(prevSubModule != null) {
+        require(prevSubModule.inputFormats().head.shape sameElements
+          currSubModule.inputFormats().head.shape)
+      }
+      prevSubModule = currSubModule
+    }
+    _outputFormats = buffer.toArray
+    _inputFormats = inputs
+
+    (_inputFormats, _outputFormats)
+  }
+
+  override private[mkldnn] def initBwdPrimitives(grads: Array[MemoryData], phase: Phase) = {
+    require(grads.length == mklDnnModules.length, "grad tensor number is not correct")
+    _gradOutputFormats = new Array[MemoryData](grads.length)
+    _gradInputFormats = new Array[MemoryData](inputFormats().length)
+    subModuleBwdPrimitives = new Array[Array[Long]](grads.length)
+
+    for(i <- 0 until grads.length) {
+      val subModule = mklDnnModules(i)
+      subModule.initBwdPrimitives(Array(grads(i)), phase)
+      val subGradOutFormats = subModule.gradOutputFormats()
+      val subGradInFormats = subModule.gradInputFormats()
+      require(subGradOutFormats.length == 1, "real grad length should be 1")
+      require(subGradInFormats.length == 1, "real grad length should be 1")
+      _gradOutputFormats(i) = subGradOutFormats.head
+      if (i == 0) {
+        _gradInputFormats(0) = NativeData(
+          subGradInFormats.head.shape,
+          subGradInFormats.head.layout,
+          subGradInFormats.head.dataType
+        )
+        _gradInputFormats = Array(MemoryData.cloneFormatWithDesc(
+          mklDnnModules.head.gradInputFormats().head))
+        _gradInputFormats.map(_.getMemoryObject(runtime))
+        gradInput = initTensor(_gradInputFormats.head)
+      }
+      val binaryDescInit = DNNL.BinaryDescInit(
+        AlgKind.BinaryAdd,
+        gradInputFormats().head.getMemoryDescriptor(),
+        subModule.gradInputFormats().head.getMemoryDescriptor(),
+        gradInputFormats().head.getMemoryDescriptor()
+      )
+      val fwdPd = DnnlMemory.PrimitiveDescCreate(binaryDescInit, runtime.engine, 0)
+      subModuleBwdPrimitives(i) = Array(DNNL.PrimitiveCreate(fwdPd))
+    }
+
+    (_gradOutputFormats, _gradInputFormats)
+  }
+
+
+  override private[mkldnn] def initGradWPrimitives(grads: Array[MemoryData], phase: Phase) = {
+    val realGradsBuffer = new ArrayBuffer[MemoryData]()
+    for(i <- 0 until grads.length) {
+      val m = mklDnnModules(i)
+      val realGradOutput = m.initGradWPrimitives(Array(grads(i)), phase)
+      realGradsBuffer.append(realGradOutput(0))
+    }
+    _gradOutputWeightFormats = realGradsBuffer.toArray
+    _gradOutputWeightFormats
+  }
+
+  override def updateOutput(input: Activity): Activity = {
+    require(modules.length > 0, "empty modules of concat table")
+    var i = 0
+    while (i < modules.length) {
+      val currentOutput = modules(i).forward(
+        reorderManager.infer(_inputFormats, mklDnnModules(i).inputFormats(), input))
+      output.toTable(i + 1) = currentOutput
+      i += 1
+    }
+    output
+  }
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    gradInput.toTensor[Float].zero()
+    require(modules.length > 0, "empty modules of concat table")
+    modules.zipWithIndex.map {
+      case (m, i) =>
+        val subGradInTensor = m.updateGradInput(input, gradOutput.toTable(i + 1))
+        bwdExecArgs = mutable.Map(
+          ArgType.DNNL_ARG_SRC_0 -> gradInputFormats().head.getMemoryObject(runtime),
+          ArgType.DNNL_ARG_SRC_1 -> mklDnnModules(i).gradInputFormats().head
+            .getMemoryObject(runtime),
+          ArgType.DNNL_ARG_DST -> gradInputFormats().head.getMemoryObject(runtime)
+        )
+        updateGradInputTensors = mutable.Map(
+          ArgType.DNNL_ARG_SRC_0 -> gradInput.toTensor[Float],
+          ArgType.DNNL_ARG_SRC_1 -> subGradInTensor.asInstanceOf[Tensor[Float]],
+          ArgType.DNNL_ARG_DST -> gradInput.toTensor[Float]
+        )
+        MklDnnOps.streamSubmit(subModuleBwdPrimitives(i), runtime.stream,
+          bwdExecArgs, updateGradInputTensors)
+    }
+    gradInput
+  }
+
+  override def accGradParameters(input: Activity, gradOutput: Activity): Unit = {
+    var i = 0
+    while (i < modules.length) {
+      modules(i).accGradParameters(input, gradOutput.toTable(i + 1))
+      modules(i).asyncGradient
+      i += 1
+    }
+  }
+
+  private[mkldnn] def reconstruct(): Unit = {
+    mklDnnModules = modules.map(_.asInstanceOf[MklDnnModule]).toArray
+  }
+
+  override private[mkldnn] def inputFormats() = {
+    require(_inputFormats != null, "You should call initFwdPrimitives first")
+    _inputFormats
+  }
+
+  override private[mkldnn] def gradInputFormats() = {
+    require(_gradInputFormats != null, "You should call initBwdPrimitives first")
+    _gradInputFormats
+  }
+
+  override private[mkldnn] def outputFormats() = {
+    require(_outputFormats != null, "You should call initFwdPrimitives first")
+    _outputFormats
+  }
+
+  override private[mkldnn] def gradOutputFormats() = {
+    require(_gradOutputFormats != null, "You should call initBwdPrimitives first")
+    _gradOutputFormats
+  }
+
+  private var _gradOutputWeightFormats: Array[MemoryData] = _
+
+  override private[mkldnn] def gradOutputWeightFormats() = _gradOutputWeightFormats
+
+  override def toString(): String = {
+    val tab = "\t"
+    val line = "\n"
+    val next = "  |`-> "
+    val lastNext = "   `-> "
+    val ext = "  |    "
+    val extlast = "       "
+    val last = "   ... -> "
+    var str = s"${getPrintName}"
+    str = str + " {" + line + tab + "input"
+    var i = 1
+    while (i <= modules.length) {
+      if (i == modules.length) {
+        str = str + line + tab + lastNext + "(" + i + "): " +
+          modules(i-1).toString.replace(line, line + tab + extlast)
+      } else {
+        str = str + line + tab + next + "(" + i + "): " +
+          modules(i-1).toString.replace(line, line + tab + ext)
+      }
+      i += 1
+    }
+    str = str + line + tab + last + "output"
+    str = str + line + "}"
+    str
+  }
+}
+
+object ConcatTable {
+  def apply(): ConcatTable = new ConcatTable()
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/DnnBase.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/DnnBase.scala
@@ -1,0 +1,365 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.{DataType, ArgType}
+import com.intel.analytics.bigdl.nn.DynamicContainer
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
+import com.intel.analytics.bigdl.tensor.{DenseType, DnnTensor, Tensor}
+import com.intel.analytics.bigdl.utils.T
+
+import scala.collection.mutable
+
+/**
+ * Helper utilities when integrating Module with MKL-DNN
+ */
+trait MklDnnModule extends MemoryOwner {
+
+  protected var _inputFormats: Array[MemoryData] = _
+  protected var _gradInputFormats: Array[MemoryData] = _
+  protected var _outputFormats: Array[MemoryData] = _
+  protected var _gradOutputFormats: Array[MemoryData] = _
+  protected var _gradOutputFormatsForWeight: Array[MemoryData] = _
+
+  @transient
+  protected var updateOutputTensors: mutable.Map[Int, Tensor[Float]] = _
+  @transient
+  protected var updateGradInputTensors: mutable.Map[Int, Tensor[Float]] = _
+  @transient
+  protected var updateGradInputPrimitives: Array[Long] = _
+
+  @transient
+  protected var fwdExecArgs: mutable.Map[Int, Long] = _
+  @transient
+  protected var bwdExecArgs: mutable.Map[Int, Long] = _
+  @transient
+  protected var weightUpdateExecArgs: mutable.Map[Int, Long] = _
+
+  @transient protected implicit lazy val _this : MemoryOwner = this
+
+  /**
+   * MklDnn runtime, which includes a MKL-DNN engine and a MKL-DNN stream.
+   * Note that this instance will be erased when send to remote worker, so you
+   * should recreate a MklDnnRuntime.
+   */
+  @transient protected var runtime: MklDnnRuntime = _
+
+  def setRuntime(runtime: MklDnnRuntime): Unit = {
+    this.runtime = runtime
+  }
+
+  private[bigdl] def getRuntime: MklDnnRuntime = {
+    require(runtime != null, s"you should init the mkldnn runtime first")
+    runtime
+  }
+
+  /**
+   * Init the MKL-DNN primitives for the layer. Note that these primitives will be erased when
+   * sent to a remote worker.
+   */
+  private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase = null)
+  : (Array[MemoryData], Array[MemoryData])
+
+  private[mkldnn] def initBwdPrimitives(grad: Array[MemoryData], phase: Phase = null)
+  : (Array[MemoryData], Array[MemoryData])
+
+  private[mkldnn] def initGradWPrimitives(grad: Array[MemoryData], phase: Phase = null)
+  : Array[MemoryData]
+  = grad
+
+  private[mkldnn] def inputFormats(): Array[MemoryData]
+
+  private[mkldnn] def gradInputFormats(): Array[MemoryData]
+
+  private[mkldnn] def outputFormats(): Array[MemoryData]
+
+  private[mkldnn] def gradOutputFormats(): Array[MemoryData]
+
+  private[mkldnn] def gradOutputWeightFormats(): Array[MemoryData]
+
+  def setQuantize(value: Boolean): this.type
+
+  // Merge from helper
+  protected def initActivity(formats: Array[MemoryData]): Activity = {
+    if (formats.length == 1) {
+      initTensor(formats(0))
+    } else {
+      T.array(formats.map(initTensor(_)))
+    }
+  }
+
+  protected def initTensor(format: MemoryData): Tensor[_] = {
+    val paddingShape = format.getPaddingShape
+    val realSize = format.getRealSize
+    format match {
+      case d: NativeData =>
+        d.dataType match {
+          case DataType.S8 => DnnTensor[Byte](paddingShape, realSize)
+          case DataType.U8 => DnnTensor[Byte](paddingShape, realSize)
+          case DataType.S32 => DnnTensor[Int](paddingShape, realSize)
+          case DataType.F32 => DnnTensor[Float](paddingShape, realSize)
+        }
+      case d: HeapData =>
+        Tensor[Float](paddingShape)
+      case _ => throw new UnsupportedOperationException("memory format is not supported")
+    }
+  }
+
+  protected def singleNativeData(formats: Array[MemoryData]): Array[MemoryData] = {
+    require(formats.length == 1, "Only accept one tensor as input")
+    nativeData(formats)
+  }
+
+  protected def nativeData(formats: Array[MemoryData]): Array[MemoryData] = {
+    formats.map(
+      f => {
+        f match {
+          case i: NativeData => i
+          case i: HeapData => i.toNative()
+          case _ => throw new UnsupportedOperationException("Not support memory format")
+        }
+      }
+    )
+  }
+
+}
+
+
+trait MklDnnLayer extends AbstractModule[Activity, Activity, Float] with MklDnnModule {
+  /**
+   * MKL-DNN primitives of the module. Note you should only initialize this field by calling
+   * initPrimitives method. This field will be erased when sending model to remote worker. So you
+   * need to reinitialize it after sending the model.
+   */
+
+  @transient
+  protected var updateOutputPrimitives: Array[Long] = _
+  @transient
+  protected var accGradientPrimitives: Array[Long] = _
+  @transient
+  private var cachedInput: Activity = _
+  @transient
+  private var cachedGradOutput: Activity = _
+
+
+  override private[mkldnn] def initGradWPrimitives(grad: Array[MemoryData],
+                                                 phase: Phase): Array[MemoryData] = {
+    _gradOutputFormatsForWeight = grad
+    grad
+  }
+
+
+  // TODO: rename
+  def initFwdExecArgs(): Unit = {
+    fwdExecArgs = mutable.Map(
+      ArgType.DNNL_ARG_SRC ->
+        inputFormats().map(_.getMemoryObject(runtime)).head,
+      ArgType.DNNL_ARG_DST ->
+        outputFormats().map(_.getMemoryObject(runtime)).head
+    )
+  }
+
+  // TODO: rename
+  def initBwdExecArgs(): Unit = {
+    bwdExecArgs = mutable.Map(
+      ArgType.DNNL_ARG_DIFF_SRC ->
+        gradInputFormats().map(_.getMemoryObject(runtime)).head,
+      ArgType.DNNL_ARG_DIFF_DST ->
+        gradOutputFormats().map(_.getMemoryObject(runtime)).head
+    )
+  }
+
+  // TODO:
+  override def updateOutput(input: Activity): Activity = {
+    if (updateOutputTensors == null || cachedInput == null || !cachedInput.eq(input)) {
+      updateOutputTensors = mutable.Map(
+        ArgType.DNNL_ARG_SRC -> input.asInstanceOf[Tensor[Float]],
+        ArgType.DNNL_ARG_DST -> output.asInstanceOf[Tensor[Float]]
+      )
+      cachedInput = input
+    }
+    MklDnnOps.streamSubmit(updateOutputPrimitives,
+      runtime.stream, fwdExecArgs,
+      updateOutputTensors
+    )
+    output
+  }
+
+  // TODO:
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    if (updateGradInputTensors == null || cachedInput == null || !cachedInput.eq(input) ||
+      cachedGradOutput == null || !cachedGradOutput.eq(gradOutput)) {
+      updateGradInputTensors = mutable.Map(
+        ArgType.DNNL_ARG_DIFF_DST -> gradOutput.asInstanceOf[Tensor[Float]],
+        ArgType.DNNL_ARG_DIFF_SRC -> gradInput.asInstanceOf[Tensor[Float]]
+      )
+      cachedInput = input
+      cachedGradOutput = gradOutput
+    }
+
+    // TODO:
+    MklDnnOps.streamSubmit(updateGradInputPrimitives,
+      runtime.stream, bwdExecArgs,
+      updateGradInputTensors
+    )
+    gradInput
+  }
+
+  override private[mkldnn] def inputFormats() = {
+    require(_inputFormats != null, "You should call initFwdPrimitives first")
+    _inputFormats
+  }
+
+  override private[mkldnn] def gradInputFormats() = {
+    require(_gradInputFormats != null, "You should call initBwdPrimitives first")
+    _gradInputFormats
+  }
+
+  override private[bigdl] def outputFormats() = {
+    require(_outputFormats != null, "You should call initFwdPrimitives first")
+    _outputFormats
+  }
+
+  override private[mkldnn] def gradOutputFormats() = {
+    require(_gradOutputFormats != null, "You should call initBwdPrimitives first")
+    _gradOutputFormats
+  }
+
+  override private[mkldnn] def gradOutputWeightFormats() = {
+    _gradOutputFormatsForWeight
+  }
+
+  def updateWithNewTensor(from: mutable.Map[Int, Tensor[Float]], index: Int,
+    value: Activity): Unit = {
+    from(index).getTensorType match {
+      case DenseType => from(index) = value.toTensor[Float]
+      case _ =>
+    }
+  }
+
+  override def release(): Unit = {
+    this.releaseResources()
+  }
+
+  override def setQuantize(value: Boolean): MklDnnLayer.this.type = this
+
+  def paramsMMap(): (Array[TensorMMap], Array[TensorMMap]) = {
+    // return null for weight and gradWeight by default
+    (Array.empty[TensorMMap], Array.empty[TensorMMap])
+  }
+}
+
+/**
+ * Helper utilities when integrating containers with MKL-DNN
+ */
+trait MklDnnContainer extends DynamicContainer[Activity, Activity, Float] with MklDnnModule {
+  @transient protected lazy val reorderManager = new ReorderManager()
+  protected var mklDnnModules : Array[MklDnnModule] = _
+  // protected var subModuleFwdPrimitives: Array[Array[Long]] = _
+  protected var subModuleBwdPrimitives: Array[Array[Long]] = _
+
+  override def add(module: AbstractModule[_ <: Activity, _ <: Activity, Float]): this.type = {
+    require(mklDnnModules == null, "You should not call add after compilation")
+    require(module.isInstanceOf[MklDnnModule], "layer should be MklDnnModule")
+    super.add(module)
+  }
+
+  private def checkInputs: Boolean = {
+    def getAllInputs(
+      module: AbstractModule[_ <: Activity, _ <: Activity, Float]): Boolean = {
+      module match {
+        case seq: Sequential => getAllInputs(seq.modules.head)
+        case concat: ConcatTable => concat.modules.map(x => getAllInputs(x)).reduce(_ && _)
+        case _: Input => true
+        case _ => false
+      }
+    }
+
+    getAllInputs(this)
+  }
+
+  final def compile(phase: Phase): Unit = {
+    require(checkInputs, s"You should add Input for the container.")
+    compile(phase, new MklDnnRuntime, Array[MemoryData]())
+  }
+
+  /**
+   * Create MklDnnRuntime and compile the model
+   * @param phase
+   */
+  private[mkldnn] final def compile(phase: Phase, formats: Array[MemoryData]): Unit = {
+    compile(phase, new MklDnnRuntime(), formats)
+  }
+
+  /**
+   * Compile the model, which includes infer memory shapes, allocate memory, optimize computing
+   * path and create MKL-DNN primitives
+   * @param phase
+   * @param runtime
+   */
+  private[mkldnn] final def compile(phase: Phase, runtime: MklDnnRuntime,
+                                  formats: Array[MemoryData]): Unit = {
+    freeze()
+    fusion(phase)
+    initPrimitives(phase, runtime, formats)
+  }
+
+  final def initPrimitives(phase: Phase, runtime: MklDnnRuntime, formats: Array[MemoryData])
+  : Unit = {
+    setRuntime(runtime)
+    initFwdPrimitives(formats, phase)
+    val outFormats = outputFormats()
+    if (phase == Phase.TrainingPhase) {
+      initBwdPrimitives(outFormats, phase)
+      initGradWPrimitives(outFormats, phase)
+    }
+  }
+
+  override def setRuntime(runtime: MklDnnRuntime): Unit = {
+    super.setRuntime(runtime)
+    reorderManager.setRuntime(runtime)
+    modules.foreach { case m: MklDnnModule => m.setRuntime(runtime) }
+  }
+
+  /**
+   * Modify the computing path by fuse some layers into one to improve the performance
+   */
+  private[mkldnn] def fusion(phase: Phase): Unit = {
+    modules.filter(_.isInstanceOf[MklDnnContainer])
+      .map { case mc: MklDnnContainer => mc.fusion(phase) }
+  }
+
+  private def freeze(): Unit = {
+    if (mklDnnModules == null) {
+      mklDnnModules = modules.map(_.asInstanceOf[MklDnnModule]).toArray
+    }
+    modules.filter(_.isInstanceOf[MklDnnContainer])
+      .map { case mc: MklDnnContainer => mc.freeze() }
+  }
+
+  override def release(): Unit = {
+    super.release()
+    this.releaseResources()
+  }
+
+  override def setQuantize(value: Boolean): this.type = {
+    this.modules.foreach {
+      case mkldnnModule: MklDnnModule => mkldnnModule.setQuantize(value)
+      case _ =>
+    }
+    this
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/DnnGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/DnnGraph.scala
@@ -1,0 +1,537 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import java.util
+
+import com.intel.analytics.bigdl.nn
+import com.intel.analytics.bigdl.nn.Graph.ModuleNode
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
+import com.intel.analytics.bigdl.nn.tf.{ControlDependency, WithoutInput}
+import com.intel.analytics.bigdl.nn.{Graph, mkldnn, MklInt8Convertible}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.{Node, T}
+
+import scala.collection.mutable
+
+
+class DnnGraph(
+  private val _inputs : Seq[ModuleNode[Float]],
+  private val _outputs : Seq[ModuleNode[Float]],
+  private val _variables: Option[(Array[Tensor[Float]], Array[Tensor[Float]])] = None,
+  private val enableExcludeChecking: Boolean = true)
+  extends Graph[Float](_inputs, _outputs, _variables)
+  with MklDnnLayer with MklInt8Convertible {
+  private val forwardExecution = forwardGraph.topologySort.reverse
+  private var backwardExecution: Array[Node[AbstractModule[Activity, Activity, Float]]] = _
+  private var inputCache: Array[Activity] = _
+  private var backId2ForwardId: Array[Int] = _
+  private var skipPrimitiveId = new Array[Boolean](forwardExecution.length)
+
+  /**
+   * Batch size may change when model prediction, but output size of dnn layers will not be changed.
+   * So we have to compare batchSize for input and output, and do some change if not the same.
+   * @param input
+   * @param output
+   * @return
+   */
+  private def getRealOutput(input: Activity, output: Activity): Activity = {
+    if (input.isTensor && output.isTensor) {
+      val in = input.toTensor[Float]
+      val out = output.toTensor[Float]
+      // for grey image, input should be 3 dims and the first dim should be batch size
+      // for non grey image, input should be 4 dims and the first dim should be batch size
+      // for rnn model, input should be 2 dims and the first dim should be batch size
+      require(in.nDimension() == 4 || in.nDimension() == 3 || in.nDimension() == 2,
+        s"only support input with 4 dimension or 3 dimension, but get ${in.nDimension()}")
+      if (in.size(1) != out.size(1)) out.narrow(1, 1, in.size(1)) else output
+    } else output
+  }
+
+  @transient protected lazy val reorderManager = new ReorderManager()
+
+  if (enableExcludeChecking) {
+    excludeInvalidLayers(forwardExecution.map {_.element})
+  }
+
+  buildBackwardGraph()
+
+  override def updateOutput(input: Activity): Activity = {
+    var i = 0
+    while(i < forwardExecution.length) {
+      val node = forwardExecution(i)
+      val nodeInput = if (skipPrimitiveId(i)) {
+        findInput(node, input)
+      } else {
+        findDnnInput(node, input)
+      }
+      inputCache(i) = nodeInput
+      node.element.forward(nodeInput)
+      i += 1
+    }
+    output = getRealOutput(input, dummyOutput.element.output)
+    output
+  }
+
+  override def backward(input: Activity, gradOutput: Activity): Activity = {
+    val before = System.nanoTime()
+    val gradients = updateGradInput(input, gradOutput)
+    accGradParameters(input, gradOutput)
+    backwardTime += System.nanoTime() - before
+    gradients
+  }
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    dummyOutputGrad.element.gradInput = gradOutput
+    var i = 0
+    while (i < backwardExecution.length - 1) { // do not execute the dummy backward end
+      val curNode = backwardExecution(i)
+      val curGradOutput = findDnnGradOutput(curNode, gradOutput)
+      // use input from forward
+      val curInput = inputCache(backId2ForwardId(i))
+      if (!isStopGradient(curNode.element)) {
+        curNode.element.updateGradInput(curInput, curGradOutput)
+      }
+      i += 1
+    }
+    gradInput = getRealOutput(input, fetchModelGradInput())
+    gradInput
+  }
+
+  override def accGradParameters(input: Activity, gradOutput: Activity): Unit = {
+    var i = 0
+    while (i < backwardExecution.length - 1) {
+      val curNode = backwardExecution(i)
+      // use input from forward
+      val curInput = inputCache(backId2ForwardId(i))
+      val curGradOutput = findDnnGradOutput(curNode, gradOutput, true)
+      curNode.element.accGradParameters(curInput, curGradOutput)
+      curNode.element.asyncGradient()
+      i += 1
+    }
+  }
+
+  override def buildBackwardGraph(): this.type = {
+    super.buildBackwardGraph()
+    inputCache = new Array[Activity](forwardExecution.length)
+    backwardExecution = backwardGraph.topologySort.reverse
+    backId2ForwardId = new Array[Int](backwardExecution.length)
+
+    var i = 0
+    // do not execute the dummy backward end
+    while(i < backwardExecution.length - 1) {
+      var j = 0
+      var find = false
+      while(j < forwardExecution.length) {
+        if (forwardExecution(j).element.getName() == backwardExecution(i).element.getName()) {
+          val e = forwardExecution(j).element
+          // when creating graph, there may add nn.Identity node,
+          // here we have to change it to mkldnn node
+          if (e.isInstanceOf[nn.Identity[Float]]) {
+            forwardExecution(j).element = toDnnIdentity(e.asInstanceOf[nn.Identity[Float]])
+            backwardExecution(i).element = forwardExecution(j).element
+          } else {
+            require(e.isInstanceOf[MklDnnModule], s"DnnGraph should only contain dnn layers," +
+                s"but find ${forwardExecution(j).element.getName()} is not a mkldnn layer")
+          }
+          backId2ForwardId(i) = j
+          find = true
+        }
+        j += 1
+      }
+      require(find, "Cannot find backward layer in forward executions")
+      i += 1
+    }
+    this
+  }
+
+  /**
+   * When doing inference, we may not have to compute forward primitives for some blas layers
+   */
+  private def skipInitFwdPrimitives() : Unit = {
+    val skipNodesMap = new mutable.HashMap[String, Boolean]()
+    util.Arrays.fill(skipPrimitiveId, 0, skipPrimitiveId.length, false)
+    if (!this.train) {
+      var i = forwardExecution.length - 1
+      while (i >= 0) {
+        val node = forwardExecution(i)
+        skipPrimitiveId(i) = skip(node, skipNodesMap)
+        skipNodesMap(node.element.getName()) = skipPrimitiveId(i)
+        i -= 1
+      }
+    }
+  }
+
+  /**
+   * to determine whether to skip computing primitives for current node
+   * Now, if current node is blaswrapper node and meets one of following cases,
+   * then we will skip computing primitives for this node
+   * case 1: it has no next nodes
+   * case 2: all next nodes are identity node, and those next nodes has no next nodes
+   * case 3: all next nodes are also skip nodes
+   * In some special case, if previous nodes are not blas node, we can not skip this node,
+   * but don't have to compute its output shape.
+   * @param node current node
+   * @return
+   */
+  private def skip(node: ModuleNode[Float],
+                   skipNodesMap: mutable.HashMap[String, Boolean]) : Boolean = {
+    if (node.element.isInstanceOf[BlasWrapper] || node.element.isInstanceOf[Identity]) {
+      if (node.nextNodes.length == 0) return true
+      var isSkip : Boolean = true
+      node.nextNodes.map(n => {
+        if ((skipNodesMap.getOrElse(n.element.getName(), false))
+          || (n.element.isInstanceOf[mkldnn.Identity] && n.nextNodes.length == 0)) {
+        } else isSkip = false
+      })
+      node.prevNodes.map(n =>
+        if (!n.element.isInstanceOf[BlasWrapper]
+          && node.element.isInstanceOf[BlasWrapper] && isSkip) {
+          node.element.asInstanceOf[BlasWrapper].needOutputFormats = false
+         isSkip = false
+        }
+      )
+      isSkip
+    } else false
+  }
+
+  // change nn identity to mkldnn identity
+  private def toDnnIdentity(model: nn.Identity[Float])
+  : AbstractModule[Activity, Activity, Float] = {
+    mkldnn.Identity[Float]().setName(model.getName())
+      .asInstanceOf[AbstractModule[Activity, Activity, Float]]
+  }
+
+  // if node has no previous node, then it will just use graph input as real module input
+  private def findDnnInput(node: ModuleNode[Float], input: Activity): Activity = {
+    if (node.element.isInstanceOf[WithoutInput]) return null
+
+    val realInputFormats = node.element.asInstanceOf[MklDnnModule].inputFormats()
+
+    val nodeInput = if (node.prevNodes.isEmpty) {
+      getInput(node, input)
+    } else {
+      val prevActivitiesAndFormats = node.prevNodesAndEdges
+        .filterNot(n => n._1.element.isInstanceOf[ControlDependency[Float]])
+        .map(n => {
+          val format = n._1.element.asInstanceOf[MklDnnModule].outputFormats()
+          n._2.fromIndex match {
+            case Some(i) =>
+              if (n._1.element.output == null || (i == 1 && n._1.element.output.isTensor)) {
+                (n._1.element.output, format)
+              } else {
+                (n._1.element.output.toTable.apply[Activity](i), Array(format(i - 1)))
+              }
+            case None => (n._1.element.output, format)
+          }
+        })
+
+      val inputAndFormat = if (prevActivitiesAndFormats.length == 1) {
+        prevActivitiesAndFormats.head
+      } else {
+        (T.seq(prevActivitiesAndFormats.map(m => m._1)),
+          prevActivitiesAndFormats.map(m => m._2).toArray.flatMap(_.toSeq))
+      }
+      reorderManager.infer(inputAndFormat._2, realInputFormats, inputAndFormat._1)
+    }
+    nodeInput
+  }
+
+  private def findDnnGradOutput(curNode: ModuleNode[Float], gradOutput: Activity,
+    isAcc: Boolean = false): Activity = {
+    var curGradOutput : Activity = if (curNode.eq(dummyOutputGrad)) gradOutput else null
+
+    val realGradOutputFormats = if (isAcc) {
+      curNode.element.asInstanceOf[MklDnnModule].gradOutputWeightFormats()
+    } else {
+      curNode.element.asInstanceOf[MklDnnModule].gradOutputFormats()
+    }
+
+    curNode.prevNodesAndEdges.filterNot(n => n._1.element.isInstanceOf[ControlDependency[Float]])
+      .foreach(n => {
+        val (otherActivity, format) =
+          if (n._1.element.gradInput.isTensor || n._1.nextEdges.length == 1) {
+            (n._1.element.gradInput, n._1.element.asInstanceOf[MklDnnModule].gradInputFormats())
+          } else {
+            val index = n._1.nextEdges.indexOf(n._2) + 1
+            (n._1.element.gradInput.toTable.apply[Activity](index),
+              Array(n._1.element.asInstanceOf[MklDnnModule].gradInputFormats().apply(index - 1)))
+          }
+
+        n._2.fromIndex match {
+          case Some(i) =>
+            if (i == 1 && curNode.element.output.isTensor) {
+              curGradOutput = addActivity(curGradOutput, realGradOutputFormats,
+                otherActivity, format)
+            } else {
+              if (curNode.element.output.isTable && curGradOutput == null) {
+                curGradOutput = T()
+              }
+              val curActivity = curGradOutput.toTable.getOrElse[Activity](i, null)
+              curGradOutput.toTable(i) = addActivity(curActivity, realGradOutputFormats,
+                otherActivity, format)
+            }
+          case None =>
+            curGradOutput = addActivity(curGradOutput, realGradOutputFormats,
+              otherActivity, format)
+        }
+      })
+
+    if (curNode.element.output.isTable) {
+      addZeroTensorToMissingGradOutput(curNode.element.output.toTable, curGradOutput.toTable)
+    }
+    curGradOutput
+  }
+
+  private def addActivity(activity: Activity, realFormats: Array[MemoryData],
+    other: Activity, otherFormats: Array[MemoryData]): Activity = {
+    val realOthers = if (otherFormats.length > 0) {
+      reorderManager.infer(otherFormats, realFormats, other)
+    } else {
+      other
+    }
+    super.accActivity(activity, realOthers)
+  }
+
+  final def compile(phase: Phase) : Unit = {
+    setRuntime(new MklDnnRuntime())
+    initPrimitives(phase, Array[MemoryData]())
+  }
+
+  override def setRuntime(runtime: MklDnnRuntime): Unit = {
+    this.runtime = runtime
+    reorderManager.setRuntime(runtime)
+    forwardExecution.foreach(m => m.element.asInstanceOf[MklDnnModule].setRuntime(runtime))
+  }
+
+  private def initPrimitives(phase: Phase, inputFormats: Array[MemoryData]): Unit = {
+    _outputFormats = initFwdPrimitives(inputFormats, phase)._2
+    if (phase == Phase.TrainingPhase) {
+      _gradOutputFormats = initBwdPrimitives(_outputFormats, phase)._1
+      _gradOutputFormatsForWeight = initGradWPrimitives(_outputFormats, phase)
+    }
+  }
+
+  private def getInputMemoryData(node: ModuleNode[Float], memoryData: Array[MemoryData])
+    : Array[MemoryData] = {
+    // the model may contain two inputs and all of them is Input.
+    if (inputs.length == 1 || memoryData.isEmpty) {
+      require(inputs.contains(node), "input node must be in the input list")
+      memoryData
+    } else {
+      val i = inputs.indexOf(node)
+      require(i != -1, "input node is not in the input list")
+      Array(memoryData(i))
+    }
+  }
+
+  private def findInputFormats(node: ModuleNode[Float], inputs: Array[MemoryData])
+    : Array[MemoryData] = {
+    if (node.prevNodes.isEmpty) {
+      getInputMemoryData(node, inputs)
+    } else {
+      val prevFormats = node.prevNodesAndEdges
+        .filterNot(n => n._1.element.isInstanceOf[ControlDependency[Float]])
+        .map(n => {
+          val outputFormats = n._1.element.asInstanceOf[MklDnnModule].outputFormats()
+          // if outputFormats length is 1, output is a tensor
+          n._2.fromIndex match {
+            case Some(i) =>
+              if (n._1.element.output == null || (i == 1 && outputFormats.length == 1)) {
+                outputFormats
+              } else {
+                val index = n._2.fromIndex.get
+                Array(outputFormats(index))
+              }
+            case None => outputFormats
+          }
+        }).toArray
+      prevFormats.flatMap(n => n.toSeq)
+    }
+  }
+
+  private def findGradOutputFormats(node: ModuleNode[Float], inputs: Array[MemoryData])
+    : Array[MemoryData] = {
+    if (node.prevNodes.isEmpty) {
+      inputs
+    } else {
+      val prevFormats = node.prevNodesAndEdges
+        .filterNot(n => n._1.element.isInstanceOf[ControlDependency[Float]])
+        .map(n => {
+          // gradInput is tensor or nextEdges number is 1
+          if (n._1.element.asInstanceOf[MklDnnModule].gradInputFormats().length == 1 ||
+            n._1.nextEdges.length == 1) {
+            n._1.element.asInstanceOf[MklDnnModule].gradInputFormats()
+          } else {
+            val index = n._1.nextEdges.indexOf(n._2)
+            val f = n._1.element.asInstanceOf[MklDnnModule].gradInputFormats()
+            Array(f(index))
+          }
+        }).toArray
+      // reminder: if node has more than one previous node, use the first one as gradoutput format
+      prevFormats(0)
+    }
+  }
+
+  /**
+   * fuse some layers when doing inference
+   * first fuse layers in sequence, mainly relu with bn/conv, conv with bn.
+   * after that, fuse sum operation.
+   */
+  private def fusion(): Unit = {
+    if (!this.train) {
+      for (j <- 0 to 3) {
+        var i = forwardExecution.length - 1
+        while (i >= 0) {
+          if (j == 0) Fusion.fuseModule(forwardExecution(i))
+          // we should do this before sum fusion, because it will change the structure of graph
+          if (j == 1) Fusion.setNegativeInputOfConv(forwardExecution(i))
+          if (j == 2) Fusion.fuseCAdd(forwardExecution(i))
+          if (j == 3) Fusion.setScalesPrevousJoinTable(forwardExecution(i))
+          i -= 1
+        }
+      }
+    }
+  }
+
+  // init forward primitives
+  override private[bigdl] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase)
+    : (Array[MemoryData], Array[MemoryData]) = {
+    skipInitFwdPrimitives()
+    fusion()
+    var lastOutputFormats = inputs
+    var firstRealInputFormats: Array[MemoryData] = null
+    for (i <- 0 until forwardExecution.length) {
+      if (!skipPrimitiveId(i)) {
+        val m = forwardExecution(i)
+        lastOutputFormats = findInputFormats(m, inputs)
+        val realInputAndOutputFormats =
+          m.element.asInstanceOf[MklDnnModule].initFwdPrimitives(lastOutputFormats, phase)
+        lastOutputFormats.zip(realInputAndOutputFormats._1).foreach {
+          case (o, i) =>
+            Utils.copyMaskAndScales(o, i)
+            reorderManager.register(o, i)
+        }
+
+        // copy the scales from the input formats to output formats, for some layers,
+        // it will not copy the mask and scales automatically or generate the scales themselves
+        Utils.copyMaskAndScales(realInputAndOutputFormats._1, realInputAndOutputFormats._2)
+
+        if (i == 0) firstRealInputFormats = realInputAndOutputFormats._1
+      }
+    }
+    _inputFormats = firstRealInputFormats
+    _outputFormats = lastOutputFormats
+    (firstRealInputFormats, lastOutputFormats)
+  }
+
+  // init updateGradInput primitives
+  override private[bigdl] def initBwdPrimitives(grads: Array[MemoryData], phase: Phase)
+    : (Array[MemoryData], Array[MemoryData]) = {
+    var lastGradInputFormats = grads
+    var firstRealGradOutputFormats: Array[MemoryData] = null
+    for (i <- 0 until backwardExecution.length - 1) {
+      val m = backwardExecution(i)
+      lastGradInputFormats = findGradOutputFormats(m, grads)
+      val realGradOutputAndInputFomrats =
+        m.element.asInstanceOf[MklDnnModule].initBwdPrimitives(lastGradInputFormats, phase)
+      lastGradInputFormats.zip(realGradOutputAndInputFomrats._1).foreach {
+        case (gi, go) => reorderManager.register(gi, go)
+      }
+      if (i == 0) firstRealGradOutputFormats = realGradOutputAndInputFomrats._1
+    }
+    _gradOutputFormats = firstRealGradOutputFormats
+    _gradInputFormats = lastGradInputFormats
+    (firstRealGradOutputFormats, lastGradInputFormats)
+  }
+
+  // init acc primitives
+  override private[bigdl] def initGradWPrimitives(grads: Array[MemoryData], phase: Phase)
+    : Array[MemoryData] = {
+    var lastGradInputFormats = grads
+    var firstRealGradOutputFormats: Array[MemoryData] = null
+    for (i <- 0 until backwardExecution.length - 1) {
+      val m = backwardExecution(i)
+      lastGradInputFormats = findGradOutputFormats(m, grads)
+      val realGradOutput =
+        m.element.asInstanceOf[MklDnnModule].initGradWPrimitives(lastGradInputFormats, phase)
+      lastGradInputFormats.zip(realGradOutput).foreach {
+        case (gi, go2) => reorderManager.register(gi, go2)
+      }
+      if (i == 0) firstRealGradOutputFormats = realGradOutput
+    }
+    _gradOutputFormatsForWeight = firstRealGradOutputFormats
+    firstRealGradOutputFormats
+  }
+
+  override def populateModules(): Unit = {
+    modules.appendAll(
+      forwardGraph.topologySort
+        // todo: convert control dep node to edge
+        .filterNot(_.element.isInstanceOf[ControlDependency[Float]])
+        .filter(n => !n.eq(dummyOutput)).map(_.element)
+        .reverse
+    )
+    checkDuplicate()
+  }
+
+  override def release(): Unit = {
+    // do not call super.release, it will call MklDnnLayer.release()
+    modules.foreach(_.release())
+    // we need to call releaseResources here because super.release will never be called
+    this.releaseResources()
+  }
+
+  override def calcScales(input: Activity): Unit = {
+    if (input == null) return
+
+    var i = 0
+    while(i < forwardExecution.length) {
+      val node = forwardExecution(i)
+      val nodeInput = if (skipPrimitiveId(i)) {
+        findInput(node, input)
+      } else {
+        findDnnInput(node, input)
+      }
+
+      node.element match {
+        case convertible: MklInt8Convertible =>
+          convertible.calcScales(nodeInput)
+        case _ =>
+      }
+      i += 1
+    }
+  }
+
+  override def setQuantize(value: Boolean): DnnGraph.this.type = {
+    this.forwardExecution.foreach { node =>
+      if (node.element.isInstanceOf[MklDnnModule]) {
+        node.element.asInstanceOf[MklDnnModule].setQuantize(value)
+      }
+    }
+    this
+  }
+}
+
+object DnnGraph {
+  def apply(
+    inputs : Seq[ModuleNode[Float]],
+    outputs : Seq[ModuleNode[Float]],
+    variables: Option[(Array[Tensor[Float]], Array[Tensor[Float]])] = None,
+    enableExcludeChecking: Boolean = true): DnnGraph =
+    new DnnGraph(inputs, outputs, variables, enableExcludeChecking)
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/DnnlMemory.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/DnnlMemory.scala
@@ -1,0 +1,342 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.DNNL
+
+
+
+// TODO: rename to DNNL
+abstract class MklDnnNativeMemory(protected var __ptr: Long)(implicit owner: MemoryOwner)
+extends Releasable {
+  private val UNDEFINED: Long = -1
+  private val ERROR: Long = 0
+
+  owner.registerResource(this)
+
+  def isUndefOrError : Boolean = __ptr == UNDEFINED || __ptr == ERROR
+  def release(): Unit = {
+    if (!isUndefOrError) {
+      doRelease()
+      reset()
+    }
+  }
+
+  def doRelease(): Unit
+  def ptr: Long = __ptr
+  def reset(): Unit = {
+    __ptr = ERROR
+  }
+
+}
+class MklMemoryPrimitiveDesc(_ptr: Long)(implicit owner: MemoryOwner)
+  extends MklDnnNativeMemory(_ptr) {
+  def doRelease(): Unit = DNNL.PrimitiveDescDestroy(ptr)
+}
+
+class MklMemoryAttr(_ptr: Long)(implicit owner: MemoryOwner)
+  extends MklDnnNativeMemory(_ptr) {
+  def doRelease(): Unit = DNNL.DestroyAttr(ptr)
+}
+
+class MklMemoryPostOps(_ptr: Long)(implicit owner: MemoryOwner)
+  extends MklDnnNativeMemory(_ptr) {
+  def doRelease(): Unit = DNNL.DestroyPostOps(ptr)
+}
+
+// All *DescInit memory objects share the same dealloactor
+class MklMemoryDescInit(_ptr: Long)(implicit owner: MemoryOwner)
+  extends MklDnnNativeMemory(_ptr) {
+  def doRelease(): Unit = DNNL.FreeMemoryDescInit(ptr)
+}
+
+class MklMemoryPrimitive(_ptr: Long)(implicit owner: MemoryOwner)
+  extends MklDnnNativeMemory(_ptr) {
+  def doRelease(): Unit = DNNL.PrimitiveDestroy(ptr)
+}
+
+
+object DnnlMemory {
+
+  // scalastyle:off
+  def MemoryDescInit(ndims: Int, dims: Array[Int], dataType: Int, dataFormat: Int)
+    (implicit owner: MemoryOwner): Long = {
+    new MklMemoryDescInit(
+      DNNL.MemoryDescInit(ndims, dims.map(_.toLong), dataType, dataFormat)).ptr
+  }
+
+  def MemoryDescInitByStrides(ndims: Int, dims: Array[Int], dataType: Int)
+    (implicit owner: MemoryOwner): Long = {
+    new MklMemoryDescInit(
+      DNNL.MemoryDescInitByStrides(ndims, dims.map(_.toLong), dataType)).ptr
+  }
+
+  def EltwiseForwardDescInit(propKind: Int, algKind: Int, srcDesc: Long, alpha: Float,
+    beta: Float)(implicit owner: MemoryOwner): Long = {
+    new MklMemoryDescInit(
+      DNNL.EltwiseForwardDescInit(propKind, algKind, srcDesc, alpha, beta)).ptr
+  }
+
+  def EltwiseBackwardDescInit(algKind: Int, diffDataDesc: Long, dataDesc: Long, alpha: Float,
+    beta: Float)(implicit owner: MemoryOwner): Long = {
+    new MklMemoryDescInit(
+      DNNL.EltwiseBackwardDescInit(algKind, diffDataDesc, dataDesc, alpha, beta)).ptr
+  }
+
+  def LinearForwardDescInit(propKind: Int, srcMemDesc: Long, weightMemDesc: Long,
+    biasMemDesc: Long, dstMemDesc: Long)(implicit owner: MemoryOwner): Long = {
+    new MklMemoryDescInit(
+      DNNL.LinearForwardDescInit(propKind, srcMemDesc, weightMemDesc, biasMemDesc, dstMemDesc)).ptr
+  }
+
+  def LinearBackwardDataDescInit(diffSrcMemDesc: Long, weightMemDesc: Long, diffDstMemDesc: Long)
+    (implicit owner: MemoryOwner): Long = {
+    new MklMemoryDescInit(
+      DNNL.LinearBackwardDataDescInit(diffSrcMemDesc, weightMemDesc, diffDstMemDesc)).ptr
+  }
+
+  def LinearBackwardWeightsDescInit(srcMemDesc: Long, diffWeightMemDesc: Long,
+    diffBiasMemDesc: Long, diffDstMemDesc: Long)
+    (implicit owner: MemoryOwner): Long = {
+    new MklMemoryDescInit(
+      DNNL.LinearBackwardWeightsDescInit(srcMemDesc,
+        diffWeightMemDesc, diffBiasMemDesc, diffDstMemDesc)).ptr
+  }
+
+  def BatchNormForwardDescInit(propKind: Int, srcMemDesc: Long, epsilon: Float, flags: Long)
+  (implicit owner: MemoryOwner): Long = {
+    new MklMemoryDescInit(
+      DNNL.BatchNormForwardDescInit(propKind, srcMemDesc, epsilon, flags)).ptr
+  }
+
+  def BatchNormBackwardDescInit(prop_kind: Int, diffDstMemDesc: Long, srcMemDesc: Long,
+    epsilon: Float, flags: Long)(implicit owner: MemoryOwner): Long = {
+    new MklMemoryDescInit(
+      DNNL.BatchNormBackwardDescInit(prop_kind, diffDstMemDesc, srcMemDesc, epsilon, flags)).ptr
+  }
+
+  def SoftMaxForwardDescInit(prop_kind: Int, dataDesc: Long, axis: Int)
+    (implicit owner: MemoryOwner): Long = {
+    new MklMemoryDescInit(
+      DNNL.SoftMaxForwardDescInit(prop_kind, dataDesc, axis)).ptr
+  }
+
+//  def ConvForwardDescInit(prop_kind: Int, alg_kind: Int, src_desc: Long, weights_desc: Long,
+//    bias_desc: Long, dst_desc: Long, strides: Array[Int], padding_l: Array[Int],
+//    padding_r: Array[Int], padding_kind: Int)(implicit owner: MemoryOwner): Long = {
+//
+////    public native static long ConvForwardDescInit(int prop_kind, int alg_kind,
+////      long src_desc, long weights_desc,
+////      long bias_desc, long dst_desc,
+////      long[] strides, long[] padding_l,
+////      long[] padding_r);
+//    new MklMemoryDescInit(
+//      DNNL.ConvForwardDescInit(prop_kind, alg_kind, src_desc, weights_desc,
+//        bias_desc, dst_desc, strides.map(_.toLong), padding_l.map(_.toLong),
+//        padding_r.map(_.toLong))).ptr
+//
+//    0L
+//  }
+
+  def DilatedConvForwardDescInit(prop_kind: Int, alg_kind: Int, src_desc: Long,
+    weights_desc: Long, bias_desc: Long, dst_desc: Long, strides: Array[Int],
+    dilates: Array[Int], padding_l: Array[Int], padding_r: Array[Int], padding_kind: Int)
+    (implicit owner: MemoryOwner): Long = {
+    new MklMemoryDescInit(
+      DNNL.DilatedConvForwardDescInit(prop_kind, alg_kind, src_desc,
+        weights_desc, bias_desc, dst_desc, strides.map(_.toLong),
+        dilates.map(_.toLong), padding_l.map(_.toLong), padding_r.map(_.toLong))).ptr
+  }
+
+//  def ConvBackwardWeightsDescInit(alg_kind: Int, src_desc: Long, diff_weights_desc: Long,
+//    diff_bias_desc: Long, diff_dst_desc: Long, strides: Array[Int], padding_l: Array[Int],
+//    padding_r: Array[Int], padding_kind: Int)(implicit owner: MemoryOwner): Long = {
+//    new MklMemoryDescInit(
+//      DNNL.ConvBackwardWeightsDescInit(alg_kind, src_desc, diff_weights_desc,
+//        diff_bias_desc, diff_dst_desc, strides.map(_.toLong), padding_l.map(_.toLong),
+//        padding_r.map(_.toLong))).ptr
+//  }
+
+  def DilatedConvBackwardWeightsDescInit(alg_kind: Int, src_desc: Long, diff_weights_desc: Long,
+    diff_bias_desc: Long, diff_dst_desc: Long, strides: Array[Int], dilates: Array[Int],
+    padding_l: Array[Int], padding_r: Array[Int], padding_kind: Int)
+    (implicit owner: MemoryOwner): Long = {
+    new MklMemoryDescInit(
+      DNNL.DilatedConvBackwardWeightsDescInit(alg_kind, src_desc,
+        diff_weights_desc,
+        diff_bias_desc, diff_dst_desc, strides.map(_.toLong), dilates.map(_.toLong),
+        padding_l.map(_.toLong), padding_r.map(_.toLong))).ptr
+  }
+
+//  def ConvBackwardDataDescInit(alg_kind: Int, diff_src_desc: Long, weights_desc: Long,
+//    diff_dst_desc: Long, strides: Array[Int], padding_l: Array[Int], padding_r: Array[Int],
+//    padding_kind: Int)(implicit owner: MemoryOwner): Long = {
+//    new MklMemoryDescInit(
+//      DNNL.ConvBackwardDataDescInit(alg_kind, diff_src_desc, weights_desc, diff_dst_desc,
+//        strides.map(_.toLong), padding_l.map(_.toLong), padding_r.map(_.toLong))).ptr
+//  }
+
+  def DilatedConvBackwardDataDescInit(alg_kind: Int, diff_src_desc: Long, weights_desc: Long,
+    diff_dst_desc: Long, strides: Array[Int], padding_l: Array[Int], dilates: Array[Int],
+    padding_r: Array[Int], padding_kind: Int)(implicit owner: MemoryOwner): Long = {
+    new MklMemoryDescInit(
+      DNNL.DilatedConvBackwardDataDescInit(alg_kind, diff_src_desc, weights_desc, diff_dst_desc,
+        strides.map(_.toLong), padding_l.map(_.toLong), dilates.map(_.toLong), padding_r.map(_.toLong))).ptr
+  }
+
+  def PoolingForwardDescInit(prop_kind: Int, alg_kind: Int, src_desc: Long, dst_desc: Long,
+    strides: Array[Int], kernel: Array[Int], padding_l: Array[Int], padding_r: Array[Int],
+    padding_kind: Int)(implicit owner: MemoryOwner): Long = {
+    new MklMemoryDescInit(
+      DNNL.PoolingForwardDescInit(prop_kind, alg_kind, src_desc, dst_desc,
+        strides.map(_.toLong), kernel.map(_.toLong), padding_l.map(_.toLong), padding_r.map(_.toLong))).ptr
+  }
+
+  def PoolingBackwardDescInit(alg_kind: Int, diff_src_desc: Long, diff_dst_desc: Long,
+    strides: Array[Int], kernel: Array[Int], padding_l: Array[Int], padding_r: Array[Int],
+    padding_kind: Int)(implicit owner: MemoryOwner): Long = {
+    new MklMemoryDescInit(
+      DNNL.PoolingBackwardDescInit(alg_kind, diff_src_desc, diff_dst_desc,
+        strides.map(_.toLong), kernel.map(_.toLong), padding_l.map(_.toLong), padding_r.map(_.toLong))).ptr
+  }
+
+  def LRNForwardDescInit(prop_kind: Int, alg_kind: Int, data_desc: Long, local_size: Int,
+    alpha: Float, beta: Float, k: Float)(implicit owner: MemoryOwner): Long = {
+    new MklMemoryDescInit(
+      DNNL.LRNForwardDescInit(prop_kind, alg_kind, data_desc, local_size,
+        alpha, beta, k)).ptr
+  }
+
+  def LRNBackwardDescInit(alg_kind: Int, diff_data_desc: Long, data_desc: Long, local_size: Int,
+    alpha: Float, beta: Float, k: Float)(implicit owner: MemoryOwner): Long = {
+    new MklMemoryDescInit(
+      DNNL.LRNBackwardDescInit(alg_kind: Int, diff_data_desc: Long, data_desc: Long,
+        local_size: Int, alpha: Float, beta: Float, k: Float)).ptr
+  }
+
+  def RNNCellDescInit(kind: Int, f: Int, flags: Int, alpha: Float, clipping: Float)
+    (implicit owner: MemoryOwner): Long = {
+    // TODO
+//    new MklMemoryDescInit(
+//      DNNL.RNNCellDescInit(kind: Int, f: Int, flags: Int, alpha: Float, clipping: Float)).ptr
+    0L
+  }
+
+  def RNNForwardDescInit(prop_kind: Int, rnn_cell_desc: Long, direction: Int,
+    src_layer_desc: Long, src_iter_desc: Long, weights_layer_desc: Long, weights_iter_desc: Long,
+    bias_desc: Long, dst_layer_desc: Long, dst_iter_desc: Long)
+    (implicit owner: MemoryOwner): Long = {
+    // TODO
+
+//    JNIEXPORT long JNICALL Java_com_intel_analytics_bigdl_dnnl_DNNL_VanillaRNNForwardDescInit(
+//      JNIEnv *env, jclass cls,
+//      int prop_kind, int activation_kind,
+//      int direction, long src_layer_desc,
+//      long src_iter_desc, long weights_layer_desc,
+//      long weights_iter_desc, long bias_desc,
+//      long dst_layer_desc, long dst_iter_desc, unsigned int flags,
+//      float alpha, float beta)
+    0L
+  }
+
+  def RNNBackwardDescInit(prop_kind: Int, rnn_cell_desc: Long, direction: Int,
+    src_layer_desc: Long, src_iter_desc: Long, weights_layer_desc: Long, weights_iter_desc: Long,
+    bias_desc: Long, dst_layer_desc: Long, dst_iter_desc: Long, diff_src_layer_desc: Long,
+    diff_src_iter_desc: Long, diff_weights_layer_desc: Long, diff_weights_iter_desc: Long,
+    diff_bias_desc: Long, diff_dst_layer_desc: Long, diff_dst_iter_desc: Long)
+    (implicit owner: MemoryOwner): Long = {
+    // TODO
+//    new MklMemoryDescInit(
+//      DNNL.RNNBackwardDescInit(prop_kind: Int, rnn_cell_desc: Long, direction: Int,
+//        src_layer_desc: Long, src_iter_desc: Long, weights_layer_desc: Long, weights_iter_desc: Long,
+//        bias_desc: Long, dst_layer_desc: Long, dst_iter_desc: Long, diff_src_layer_desc: Long,
+//        diff_src_iter_desc: Long, diff_weights_layer_desc: Long, diff_weights_iter_desc: Long,
+//        diff_bias_desc: Long, diff_dst_layer_desc: Long, diff_dst_iter_desc: Long)).ptr
+    0L
+  }
+
+  def ReorderPrimitiveDescCreate(input: Long, output: Long, engine: Long, attr: Long)
+    (implicit owner: MemoryOwner): Long = {
+    // TODO:
+    new MklMemoryPrimitiveDesc(
+      DNNL.ReorderPrimitiveDescCreate(input, engine, output, engine, attr)).ptr
+  }
+
+//  def ReorderPrimitiveDescCreateV2(input: Long, output: Long, attr: Long)
+//    (implicit owner: MemoryOwner): Long = {
+//    // TODO
+////    new MklMemoryPrimitiveDesc(
+////      DNNL.ReorderPrimitiveDescCreateV2(input, output, attr)).ptr
+//    0L
+//  }
+
+  def PrimitiveCreate(desc: Long)(implicit owner: MemoryOwner): Long = {
+    new MklMemoryPrimitive(DNNL.PrimitiveCreate(desc)).ptr
+  }
+
+  def PrimitiveDescCreate(opDesc: Long, engine: Long, hingForwardPrimitiveDesc: Long)
+    (implicit owner: MemoryOwner): Long = {
+    new MklMemoryPrimitiveDesc(DNNL.PrimitiveDescCreate(opDesc, engine, hingForwardPrimitiveDesc)).ptr
+  }
+
+  def PrimitiveDescCreateV2(opDesc: Long, attr: Long, engine: Long,
+    hingForwardPrimitiveDesc: Long)(implicit owner: MemoryOwner): Long = {
+    new MklMemoryPrimitiveDesc(
+      DNNL.PrimitiveDescCreateV2(opDesc: Long, attr: Long, engine: Long,
+        hingForwardPrimitiveDesc: Long)).ptr
+  }
+
+  def MemoryPrimitiveDescCreate(desc: Long, engine: Long)
+    (implicit owner: MemoryOwner): Long = {
+    // TODO
+//    new MklMemoryPrimitiveDesc(
+//      DNNL.MemoryPrimitiveDescCreate(desc, engine)).ptr
+    0L
+  }
+
+  def ConcatPrimitiveDescCreate(output_desc: Long, n: Int, concat_dimension: Int,
+                                input_pds: Array[Long], engine: Long)(implicit owner: MemoryOwner): Long = {
+    new MklMemoryPrimitiveDesc(
+      DNNL.ConcatPrimitiveDescCreate(output_desc: Long, n: Int, concat_dimension: Int,
+        input_pds: Array[Long], 0L, engine)).ptr
+  }
+
+  def ViewPrimitiveDescCreate(memory_primitive_desc: Long, dims: Array[Int], offsets: Array[Int])
+    (implicit owner: MemoryOwner): Long = {
+    // TODO
+//    new MklMemoryPrimitiveDesc(
+//      DNNL.ViewPrimitiveDescCreate(memory_primitive_desc: Long, dims: Array[Int], offsets: Array[Int])).ptr
+    0L
+  }
+
+  def SumPrimitiveDescCreate(output_mem_desc: Long, n: Int, scales: Array[Float],
+    input_mds: Array[Long], attr: Long, engine: Long)(implicit owner: MemoryOwner): Long = {
+    new MklMemoryPrimitiveDesc(
+      DNNL.SumPrimitiveDescCreate(output_mem_desc, n, scales,
+        input_mds, attr, engine)).ptr
+  }
+
+  def CreateAttr()(implicit owner: MemoryOwner): Long = {
+    new MklMemoryAttr(
+      DNNL.CreateAttr()).ptr
+  }
+  def CreatePostOps()(implicit owner: MemoryOwner): Long = {
+    new MklMemoryPostOps(
+      DNNL.CreatePostOps()).ptr
+  }
+// scalastyle:on
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Dropout.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Dropout.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.{Memory}
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.nn.{Dropout => NNDropout}
+import com.intel.analytics.bigdl.tensor.DnnTensor
+
+class Dropout(
+  val initP: Double = 0.5,
+  val inplace: Boolean = false,
+  var scale: Boolean = true) extends MklDnnLayer {
+
+  private val dropout = NNDropout[Float](initP, inplace, scale)
+
+  private var mask: DnnTensor[Float] = _
+
+  private def format(shape: Array[Int], layout: Int): Int = {
+    shape.length match {
+      case 2 => Memory.FormatTag.nc
+      // reminder: for 3 dimension, we should keep original layout (ntc or tnc)
+      case 3 => layout
+      case 4 => Memory.FormatTag.nchw
+      case _ => throw new UnsupportedOperationException(s"${getName()} unsupported input shape")
+    }
+  }
+
+  override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+    _inputFormats = inputs.map(x => HeapData(x.shape, format(x.shape, x.layout)))
+    _outputFormats = inputs.map(x => HeapData(x.shape, format(x.shape, x.layout)))
+    // we should genereate the primitives here, otherwise the initTensor can't get the padding shape
+    _outputFormats.map(_.getMemoryObject(runtime))
+    output = initTensor(_outputFormats.head)
+    (_inputFormats, _outputFormats)
+  }
+
+  override private[mkldnn] def initBwdPrimitives(grad: Array[MemoryData], phase: Phase) = {
+    _gradOutputFormats = grad.map(x => HeapData(x.shape, format(x.shape, x.layout)))
+    _gradOutputFormatsForWeight = grad.map(x => HeapData(x.shape, format(x.shape, x.layout)))
+    _gradInputFormats = grad.map(x => HeapData(x.shape, format(x.shape, x.layout)))
+    _gradInputFormats.map(_.getMemoryObject(runtime))
+    gradInput = initTensor(_gradInputFormats.head)
+
+    (_gradOutputFormats, _gradInputFormats)
+  }
+
+  override def updateOutput(input: Activity): Activity = {
+    if (isTraining()) {
+      output = dropout.updateOutput(input)
+    } else {
+      output.toTensor[Float].copy(input.toTensor[Float])
+    }
+    output
+  }
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    gradInput = dropout.updateGradInput(input, gradOutput)
+    gradInput
+  }
+
+  override def clearState(): this.type = {
+    dropout.clearState()
+    this
+  }
+
+  override def toString(): String = {
+    s"mkldnn.Dropout"
+  }
+}
+
+object Dropout {
+  def apply(
+    initP: Double = 0.5,
+    inplace: Boolean = false,
+    scale: Boolean = true) : Dropout = {
+    new Dropout(initP, inplace, scale)
+  }
+}
+

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Fusion.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Fusion.scala
@@ -1,0 +1,332 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.Module
+import com.intel.analytics.bigdl.nn.{MklInt8Convertible, Scale => ScaleLayer}
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Node
+
+/**
+ * Add fusion operation for dnn graph node, there are three cases about fusion:
+ * case 1: fuse relu with conv(SpatialConvolution) or bn(SpatialBatchNormalization)
+ * case 2: fuse conv with bn
+ * case 3: sum conv output with another layer output
+ * If you want to use fusion for inference, please set property "bigdl.mkldnn.fusion" to true
+ */
+private[mkldnn] object Fusion {
+
+  private def fuse = System.getProperty("bigdl.mkldnn.fusion", "true").toBoolean
+
+  def fuseModule(node: Node[AbstractModule[Activity, Activity, Float]]): Unit = {
+    if (!fuse) return;
+    node.element match {
+      case relu: ReLU => fusionRelu(node)
+      case bn: SpatialBatchNormalization => fusionBN(node)
+      case blasWrapper: BlasWrapper if blasWrapper.module.isInstanceOf[ScaleLayer[Float]] =>
+        fuseScale(node)
+      case _ =>
+    }
+  }
+
+  def fuseCAdd(node: Node[AbstractModule[Activity, Activity, Float]]): Unit = {
+    if (!fuse) return;
+    node.element match {
+      case cadd: CAddTable => fusionCAddTable(node)
+      case _ =>
+    }
+  }
+
+  /**
+   * fuse conv(without relu or bn fusion) with bn
+   * if bn has fused with relu, then fuse relu and bn with conv
+   * @param node
+   */
+  private def fusionBN(node: Node[AbstractModule[Activity, Activity, Float]]): Unit = {
+    val bn = node.element.asInstanceOf[SpatialBatchNormalization]
+    node.prevNodes.foreach(n => {
+      n.element match {
+        case conv : SpatialConvolution =>
+          // reminder: may be conv can fuse with two bn
+          if (!conv.relu && !conv.batchNorm) {
+            if (bn.relu) conv.setReLU(true)
+            fusionConvBn(conv, bn)
+            node.element = Identity[Float]().asInstanceOf[AbstractModule[Activity, Activity, Float]]
+          }
+        case _ => null
+      }})
+  }
+
+  /**
+   * fuse relu with conv or bn
+   * @param node
+   */
+  private def fusionRelu(node: Node[AbstractModule[Activity, Activity, Float]]): Unit = {
+    node.prevNodes.foreach(n => {
+      val notIdentity = findPrevious(n)
+      notIdentity.element match {
+        case conv: SpatialConvolution =>
+          if (!conv.relu) {
+            conv.setReLU(true)
+            conv.setOutputScales(node.element.asInstanceOf[ReLU].getOutputScales())
+            node.element = Identity[Float]().asInstanceOf[AbstractModule[Activity, Activity, Float]]
+          }
+        case bn: SpatialBatchNormalization =>
+          if (!bn.relu) {
+            bn.setReLU(true)
+            bn.setOutputScales(node.element.asInstanceOf[ReLU].getOutputScales())
+            node.element = Identity[Float]().asInstanceOf[AbstractModule[Activity, Activity, Float]]
+          }
+        case _ => null
+      }})
+  }
+
+  private def findPrevious(node: Node[AbstractModule[Activity, Activity, Float]])
+  : Node[AbstractModule[Activity, Activity, Float]] = {
+    if (node.element.isInstanceOf[Identity] && node.prevNodes.length == 1) {
+      findPrevious(node.prevNodes(0))
+    } else node
+  }
+
+  private def findNext(node: Node[AbstractModule[Activity, Activity, Float]])
+  : Seq[Node[AbstractModule[Activity, Activity, Float]]] = {
+    if (node.element.isInstanceOf[Identity]) {
+      node.nextNodes.flatMap(n => findNext(n))
+    } else {
+      Seq(node)
+    }
+  }
+
+  /**
+   * If previous layers number of CAddTable is two, and one of it is conv layer.
+   * then fuse output of the other layer in conv layer.
+   * @param node
+   */
+  private def fusionCAddTable(node: Node[AbstractModule[Activity, Activity, Float]]): Unit = {
+    if (node.element.isInstanceOf[CAddTable] && node.prevNodes.length == 2) {
+      val previousNodes = node.prevNodes.toArray
+      val node1 = findPrevious(previousNodes(0))
+      val node2 = findPrevious(previousNodes(1))
+
+      var conv : Node[Module[Float]] = null
+      var otherNumber: Int = 0
+
+      if (node1.element.isInstanceOf[SpatialConvolution]) {
+        if (requirements(node1)) conv = node1
+        otherNumber = 1
+      } else if (node2.element.isInstanceOf[SpatialConvolution]) {
+        if (requirements(node2)) conv = node2
+        otherNumber = 0
+      }
+      // meet fuse requirements
+      if (conv != null) {
+        node.element = conv.element
+        val element = node.element.asInstanceOf[SpatialConvolution]
+        element.setSumOp(previousNodes(otherNumber).element, otherNumber + 1)
+        conv.element = Identity[Float]().asInstanceOf[AbstractModule[Activity, Activity, Float]]
+
+        val nexts = node.nextNodes(0)
+        if (nexts.element.isInstanceOf[ReLU] && !element.relu) {
+          node.element.asInstanceOf[SpatialConvolution].setReLU(true)
+          node.element.asInstanceOf[SpatialConvolution].setOutputScales(
+            nexts.element.asInstanceOf[ReLU].getOutputScales())
+          nexts.element = new Identity()
+        }
+
+        val prevIsNotIdentity = findPrevious(previousNodes(otherNumber))
+
+        prevIsNotIdentity.element match {
+          case conv: SpatialConvolution =>
+            conv.setOutputScales(node.element.asInstanceOf[SpatialConvolution].getOutputScales())
+          case relu: ReLU =>
+            relu.setOutputScales(node.element.asInstanceOf[SpatialConvolution].getOutputScales())
+            prevIsNotIdentity.nextNodes.flatMap(x => findNext(x))
+              .filter(x => x != node && x.element.isInstanceOf[MklInt8Convertible])
+              .foreach(_.element.asInstanceOf[MklInt8Convertible].setInputScales(
+                node.element.asInstanceOf[SpatialConvolution].getOutputScales()))
+          case _ =>
+        }
+      }
+    }
+  }
+
+  private def requirements(node: Node[AbstractModule[Activity, Activity, Float]]): Boolean = {
+    val conv = node.element.asInstanceOf[SpatialConvolution]
+    if (conv.sum) false else true
+  }
+
+  private def fusionConvBn(conv: SpatialConvolution,
+                           bn: SpatialBatchNormalization): Unit = {
+    conv.setBatchNorm(true)
+    val originVar = Tensor[Float].resize(bn.runningVariance.size()).copy(bn.runningVariance.dense)
+    val originMean = Tensor[Float].resize(bn.runningMean.size()).copy(bn.runningMean.dense)
+
+    val convWeight = Tensor[Float].resize(conv.weight.size()).copy(conv.weight.dense)
+    val convBias = Tensor[Float].resize(conv.bias.size()).copy(conv.bias.dense)
+
+    val bnWeight = Tensor[Float].resizeAs(bn.weightAndBias.dense).copy(bn.weightAndBias.dense)
+
+    (0 until bn.nOutput).foreach { j =>
+      val variance = originVar.storage().array()(j + originVar.storageOffset() - 1)
+      val base = Math.sqrt(variance.asInstanceOf[Float] + bn.eps).toFloat
+      require(base != 0.0, s"the eps of ${bn.getName()} should be more than 0")
+
+      val alpha = bnWeight.storage().array()(bnWeight.storageOffset() - 1 + j)
+      val beta = bnWeight.storage().array()(bnWeight.storageOffset() - 1 + bn.nOutput + j)
+
+      val weight = if (conv.nGroup == 1) {
+        convWeight.select(1, j + 1)
+      } else {
+        val channelPerGroup = conv.nOutputPlane / conv.nGroup
+        val group = j  / channelPerGroup + 1
+        val channel = j % channelPerGroup + 1
+        convWeight.select(1, group).select(2, channel)
+      }
+      weight.div(base)
+      weight.mul(alpha)
+
+      val bias = convBias.storage().array()(j)
+      val mean = originMean.storage().array()(j)
+      convBias.storage().array()(j) = alpha / base * bias + beta - (alpha * mean) / base
+    }
+
+    // We will change model structure and weights when doing conv and bn fusion
+    // In order to not influence broadcast model and weights,
+    // we set new storage to weight and bias.
+    conv.weight.dense.set(convWeight)
+    conv.bias.dense.set(convBias)
+
+    // regenerate the weight scales and output scales
+    conv.flushWeightScales(conv.weight.dense)
+    conv.setOutputScales(bn.getOutputScales())
+  }
+
+  def setNegativeInputOfConv(node: Node[AbstractModule[Activity, Activity, Float]]): Unit = {
+
+    if (!fuse || !node.element.isInstanceOf[SpatialConvolution]) return
+
+    val successFromReLU = node.prevNodes.flatMap(x => findAllNonIdentityPrevs(x))
+      .map { x =>
+        x.element match {
+          case _: SpatialConvolution =>
+            x.element.asInstanceOf[SpatialConvolution].relu
+          case _: ReLU =>
+            true
+          case _ =>
+            false
+        }
+      }.forall(_ == true)
+
+
+    if (successFromReLU) {
+      node.element.asInstanceOf[SpatialConvolution].negativeInput = false
+    }
+  }
+
+  /**
+   * set the layers' scales which is previous nodes of JoinTable.
+   *
+   * For a graph structure like below,
+   *
+   * conv1 --+
+   *         |--> JoinTable --> conv3
+   * conv2 --+
+   *
+   * we should set the conv1's and conv2's output scales to the conv3's input scales.
+   *
+   * If the operation next JoinTable has no input scales like below. We should set
+   * the scales to the max values of input scales of conv1 and conv2.
+   *
+   * conv1 --+
+   *         |--> JoinTable --> [Layer/Op has no input scales]
+   * conv2 --+
+   *
+   * @param node current node
+   */
+  def setScalesPrevousJoinTable(node: Node[AbstractModule[Activity, Activity, Float]]): Unit = {
+    // case 1, need not do fusion
+    if (!fuse || !node.element.isInstanceOf[JoinTable]) return
+
+    val preConvs = node.prevNodes.flatMap(x => findAllNonIdentityPrevs(x))
+      .filter(_.element.isInstanceOf[SpatialConvolution])
+      .map(_.element.asInstanceOf[SpatialConvolution])
+
+    // case 2, there's one node need not quantize
+    if (!preConvs.exists(_.needQuantize)) return
+
+    // case 3, the output dimension mask should be the same
+    val masks = preConvs.map(_.getOutputDimMask()).toSet
+    require(masks.size == 1, s"all preceding convolutions must have the same mask")
+
+    val nextConvs = node.nextNodes.flatMap(findNext)
+      .filter(_.element.isInstanceOf[SpatialConvolution])
+
+    val scales = if (nextConvs.isEmpty) {
+      Array(preConvs.map(_.getOutputScales().flatten).transpose.map(_.max).toArray)
+    } else {
+      nextConvs.map(_.element.asInstanceOf[SpatialConvolution]).head.getInputScales()
+    }
+
+    preConvs.foreach { conv =>
+      conv.setOutputScales(scales)
+    }
+  }
+
+  def fuseScale(node: Node[AbstractModule[Activity, Activity, Float]]): Unit = {
+    // check all prevNodes are SpatialBatchNormalization
+    val isValid = node.prevNodes.forall(_.element.isInstanceOf[SpatialBatchNormalization])
+    if (!isValid) { return }
+
+    node.prevNodes.foreach { prevNode =>
+      val bn = prevNode.element.asInstanceOf[SpatialBatchNormalization]
+      val weightAndBias = bn.weightAndBias.dense
+      val weight = weightAndBias.narrow(1, 1, bn.nOutput)
+      val bias = weightAndBias.narrow(1, bn.nOutput + 1, bn.nOutput)
+
+      val scale = node.element.asInstanceOf[BlasWrapper].module.asInstanceOf[ScaleLayer[Float]]
+      val scaleWeight = scale.parameters()._1(0)
+      val scaleBias = scale.parameters()._1(1)
+
+      weight.cmul(scaleWeight)
+      bias.cmul(scaleWeight)
+      bias.add(scaleBias)
+
+
+      // set the weight and bias to new tensor, we do not modify the original model's tensor.
+      // sometimes, the model need to be reused.
+      bn.weightAndBias.dense.set(weightAndBias)
+    }
+
+    node.element = Identity[Float]() // set the BlasWrapper to Identity, we need no scale now
+  }
+
+  private def findAllNonIdentityPrevs(node: Node[AbstractModule[Activity, Activity, Float]])
+  : Seq[Node[AbstractModule[Activity, Activity, Float]]] = {
+    // TODO currently, it will only skip the Identity, MaxPooling, AvgPooling, JoinTable
+    // becase if the output of layer/op previous of the four, they will output
+    // nonnegative too. it's not an elegant impl.
+    if (node.element.isInstanceOf[Identity] ||
+      node.element.isInstanceOf[MaxPooling] ||
+      node.element.isInstanceOf[AvgPooling] ||
+      node.element.isInstanceOf[JoinTable]) {
+      node.prevNodes.flatMap(findAllNonIdentityPrevs)
+    } else {
+      Seq(node)
+    }
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Identity.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Identity.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.nn.abstractnn.{Activity, AbstractModule}
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+
+import scala.reflect.ClassTag
+
+/**
+ * Identity just return the input to output.
+ * It's useful in same parallel container to get an origin input.
+ */
+class Identity() extends MklDnnLayer {
+
+  override def updateOutput(input: Activity): Activity = {
+    output = input
+    output
+  }
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+
+    gradInput = gradOutput
+    gradInput
+  }
+
+  override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+    _inputFormats = inputs
+    _outputFormats = inputs
+    (inputs, inputs)
+  }
+
+  override private[mkldnn] def initBwdPrimitives(grad: Array[MemoryData], phase: Phase) = {
+    _gradOutputFormats = grad
+    _gradOutputFormatsForWeight = grad
+    _gradInputFormats = grad
+    (grad, grad)
+  }
+}
+
+object Identity {
+  def apply[@specialized(Float, Double) T: ClassTag]()
+    (implicit ev: TensorNumeric[T]) : Identity = {
+    new Identity()
+  }
+}
+

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Input.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Input.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+class Input(shape: Array[Int], layout: Int) extends
+  ReorderMemory(HeapData(shape, layout), NativeData(shape, layout),
+    HeapData(shape, layout), NativeData(shape, layout)) {
+
+  override def toString(): String = {
+    s"nn.mkldnn.Input(${shape.mkString(",")}, $layout)"
+  }
+}
+
+object Input {
+  def apply(shape: Array[Int], layout: Int): Input = new Input(shape, layout)
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/InputWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/InputWrapper.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+
+private[bigdl] class InputWrapper extends MklDnnLayer {
+
+  private var inputLayer : Input = null
+
+  override private[bigdl] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+    require(inputs.length == 1, "Only accept one tensor as input")
+    inputLayer = Input(inputs(0).shape, inputs(0).layout)
+    inputLayer.setRuntime(this.runtime)
+    inputLayer.initFwdPrimitives(inputs, phase)
+    _inputFormats = inputLayer.inputFormats()
+    _outputFormats = inputLayer.outputFormats()
+    (_inputFormats, _outputFormats)
+  }
+
+  override def updateOutput(input: Activity): Activity = {
+    output = inputLayer.forward(input)
+    output
+  }
+
+  override private[bigdl] def initBwdPrimitives(grads: Array[MemoryData], phase: Phase) = {
+    require(grads.length == 1, "Only accept one tensor as input")
+    inputLayer.initBwdPrimitives(grads, phase)
+    _gradInputFormats = inputLayer.gradInputFormats()
+    _gradOutputFormats = inputLayer.gradOutputFormats()
+    (_gradOutputFormats, _gradInputFormats)
+  }
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    gradInput = inputLayer.backward(input, gradOutput)
+    gradInput
+  }
+
+  override def toString(): String = {
+    s"nn.mkl.InputWrapper"
+  }
+
+  override def release(): Unit = {
+    super.release()
+    if(inputLayer != null) {
+      inputLayer.release()
+    }
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/JoinTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/JoinTable.scala
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.{DNNL, Memory, ArgType}
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.tensor.Tensor
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+
+class JoinTable(val dimension: Int) extends MklDnnLayer {
+
+  @transient
+  private var bwdSrcMds: Array[Long] = null
+  @transient
+  private var bwdDstMds: Array[Long] = null
+
+  override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+    require(inputs.length > 0, s"at least one tensor, but is ${inputs.length}")
+    _inputFormats = nativeData(inputs)
+
+    val totalShape = inputs(0).shape.clone()
+    val layout = inputs(0).layout
+    var i = 1
+    while(i < inputs.length) {
+      val curShape = inputs(i).shape
+      require(totalShape.length == curShape.length, "tensor dimension not match")
+      // require(inputs(i).isInstanceOf[NativeData], "memory should be native")
+      var j = 0
+      while(j < curShape.length) {
+        if (j == dimension - 1) {
+          totalShape(j) += curShape(j)
+        } else {
+          require(totalShape(j) == curShape(j), "tensor size not match")
+        }
+        j += 1
+      }
+
+      if (layout != inputs(i).layout || inputs(0).dataType != inputs(i).dataType) {
+        _inputFormats(i) = NativeData(inputs(i).shape, layout, inputs(0).dataType)
+      }
+      i += 1
+    }
+
+    val dstMd = DnnlMemory.MemoryDescInit(totalShape.length,
+      totalShape, inputs(0).dataType, Memory.FormatTag.any)
+
+    val primDesc = DnnlMemory.ConcatPrimitiveDescCreate(
+      dstMd,
+      inputs.length,
+      dimension - 1,
+      _inputFormats.map(_.getMemoryDescriptor()),
+      runtime.engine
+    )
+
+    _outputFormats = Array(MemoryData.primitiveOutput(primDesc))
+    _outputFormats.head.getMemoryObject(runtime)
+    updateOutputPrimitives = Array(DnnlMemory.PrimitiveCreate(primDesc))
+    output = initTensor(_outputFormats(0))
+
+    fwdExecArgs = mutable.Map(
+      ArgType.DNNL_ARG_DST -> outputFormats().head.getMemoryObject(runtime)
+    )
+
+    var idx = 0
+    while (idx < inputs.length) {
+      fwdExecArgs(ArgType.DNNL_ARG_MULTIPLE_SRC + idx) =
+        inputs(idx).getMemoryObject(runtime)
+      idx += 1
+    }
+
+    (_inputFormats, _outputFormats)
+  }
+
+  override private[mkldnn] def initBwdPrimitives(grads: Array[MemoryData], phase: Phase) = {
+    _gradOutputFormats = singleNativeData(grads)
+    _gradOutputFormatsForWeight = _gradOutputFormats
+    _gradInputFormats = _inputFormats.map(f => {
+      NativeData(f.shape, f.layout)
+    })
+    val prims = new ArrayBuffer[Long]()
+    val srcMds = new ArrayBuffer[Long]()
+    val dstMds = new ArrayBuffer[Long]()
+
+    val offset = new Array[Int](_gradOutputFormats(0).shape.length)
+
+    for(i <- 0 until _gradInputFormats.length) {
+      val currSrcMd = DNNL.InitSubmemory(
+        _gradOutputFormats(0).getMemoryDescriptor(),
+        _gradInputFormats(i).shape.map(_.toLong), offset.map(_.toLong))
+
+      val currDstMd = gradInputFormats()(i).getMemoryDescriptor()
+
+      val reorderPd = DnnlMemory.ReorderPrimitiveDescCreate(
+        currSrcMd,
+        currDstMd,
+        runtime.engine,
+        0L)
+
+      val reorderPrim = DnnlMemory.PrimitiveCreate(reorderPd)
+      prims.append(reorderPrim)
+      srcMds.append(currSrcMd)
+      dstMds.append(currDstMd)
+
+      offset(dimension - 1) += _gradInputFormats(i).shape(dimension - 1)
+    }
+    updateGradInputPrimitives = prims.toArray
+    bwdSrcMds = srcMds.toArray
+    bwdDstMds = dstMds.toArray
+    gradInput = initActivity(_gradInputFormats)
+
+    (_gradOutputFormats, _gradInputFormats)
+  }
+
+
+  override def updateOutput(input: Activity): Activity = {
+    assert(input.isTable && output.isTensor)
+    val inputSrcs = input.toTable
+
+    updateOutputTensors = mutable.Map(
+      ArgType.DNNL_ARG_DST -> output.asInstanceOf[Tensor[Float]]
+    )
+
+    var idx = 0
+    while (idx < inputSrcs.length()) {
+      updateOutputTensors(ArgType.DNNL_ARG_MULTIPLE_SRC + idx) =
+        inputSrcs(idx + 1).asInstanceOf[Tensor[Float]]
+      idx += 1
+    }
+
+    MklDnnOps.streamSubmit(updateOutputPrimitives,
+      runtime.stream, fwdExecArgs,
+      updateOutputTensors
+    )
+
+    output
+  }
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    require(gradOutput.isTensor, "gradOutput should be tensor")
+    require(gradInput.isTable, "gradInput should be table")
+    val _gradOutput = gradOutput.asInstanceOf[Tensor[Float]]
+    val _gradInput = gradInput.toTable
+    val length = _gradInput.length()
+    require(length == updateGradInputPrimitives.length, "gradOutput number not match")
+    var i = 0
+    while(i < length) {
+      bwdExecArgs = mutable.Map(
+        ArgType.DNNL_ARG_FROM -> DNNL.MemoryCreate(bwdSrcMds(i), runtime.engine),
+        ArgType.DNNL_ARG_TO -> DNNL.MemoryCreate(bwdDstMds(i), runtime.engine)
+      )
+      updateGradInputTensors = mutable.Map(
+        ArgType.DNNL_ARG_FROM -> gradOutput.asInstanceOf[Tensor[Float]],
+        ArgType.DNNL_ARG_TO ->  _gradInput[Tensor[Float]](i + 1)
+      )
+      MklDnnOps.streamSubmit(Array(updateGradInputPrimitives(i)), runtime.stream,
+        bwdExecArgs, updateGradInputTensors)
+      i += 1
+    }
+
+    gradInput
+  }
+
+}
+
+object JoinTable {
+  def apply(dimension: Int): JoinTable = new JoinTable(dimension)
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/JoinTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/JoinTable.scala
@@ -35,7 +35,6 @@ class JoinTable(val dimension: Int) extends MklDnnLayer {
     _inputFormats = nativeData(inputs)
 
     val totalShape = inputs(0).shape.clone()
-    val layout = inputs(0).layout
     var i = 1
     while(i < inputs.length) {
       val curShape = inputs(i).shape
@@ -51,9 +50,7 @@ class JoinTable(val dimension: Int) extends MklDnnLayer {
         j += 1
       }
 
-      if (layout != inputs(i).layout || inputs(0).dataType != inputs(i).dataType) {
-        _inputFormats(i) = NativeData(inputs(i).shape, layout, inputs(0).dataType)
-      }
+      _inputFormats(i) = MemoryData.cloneFormatWithDesc(inputs(i))
       i += 1
     }
 
@@ -91,7 +88,7 @@ class JoinTable(val dimension: Int) extends MklDnnLayer {
     _gradOutputFormats = singleNativeData(grads)
     _gradOutputFormatsForWeight = _gradOutputFormats
     _gradInputFormats = _inputFormats.map(f => {
-      NativeData(f.shape, f.layout)
+      MemoryData.cloneFormatWithDesc(f)
     })
     val prims = new ArrayBuffer[Long]()
     val srcMds = new ArrayBuffer[Long]()

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/LRN.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/LRN.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl._
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.InferencePhase
+import com.intel.analytics.bigdl.tensor.Tensor
+
+import scala.collection.mutable
+
+class LRN(
+  size: Int = 5,
+  alpha: Double = 1.0,
+  beta: Double = 0.75,
+  k: Double = 1.0
+) extends MklDnnLayer {
+  private val UNDEFINED = 0
+
+  @transient private var workSpaceFormat: MemoryData = _
+  @transient private var fwdPrimDesc: Long = UNDEFINED
+  @transient private var fwdMemPrims: Array[Long] = _
+  @transient private var bwdMemPrims: Array[Long] = _
+
+  override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+    // the lrn only support f32
+    _inputFormats = Array(NativeData(inputs(0).shape, inputs(0).layout, DataType.F32))
+
+    val kind = if (phase == InferencePhase) {
+      PropKind.ForwardScoring
+    } else {
+      PropKind.ForwardTraining
+    }
+
+    val description = DnnlMemory.LRNForwardDescInit(
+      kind, AlgKind.LrnAcrossChannels,
+      _inputFormats(0).getMemoryDescriptor(),
+      size, alpha.toFloat, beta.toFloat, k.toFloat)
+
+    fwdPrimDesc = DnnlMemory.PrimitiveDescCreate(description, runtime.engine, 0L)
+    _outputFormats = Array(MemoryData.primitiveOutput(fwdPrimDesc))
+    output = initTensor(_outputFormats(0))
+
+    fwdMemPrims = if (phase == InferencePhase) {
+      Array(_inputFormats(0), _outputFormats(0)).map(_.getMemoryObject(runtime))
+    } else {
+      // we only create the workspace when the phase is training
+      workSpaceFormat = MemoryData.operationWant(fwdPrimDesc, Query.WorkspaceMd, 0)
+      Array(_inputFormats(0), _outputFormats(0)).map(_.getMemoryObject(runtime))
+    }
+
+    fwdExecArgs = mutable.Map (
+      ArgType.DNNL_ARG_SRC -> inputFormats().head.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DST -> _outputFormats.head.getMemoryObject(runtime)
+    )
+    updateOutputPrimitives = Array(DnnlMemory.PrimitiveCreate(fwdPrimDesc))
+
+    (_inputFormats, _outputFormats)
+  }
+
+  override private[mkldnn] def initBwdPrimitives(grad: Array[MemoryData], phase: Phase) = {
+    _gradOutputFormats = singleNativeData(grad)
+    _gradOutputFormatsForWeight = _gradOutputFormats
+    val description = DnnlMemory.LRNBackwardDescInit(AlgKind.LrnAcrossChannels,
+      _inputFormats(0).getMemoryDescriptor(),
+      _gradOutputFormats(0).getMemoryDescriptor(), size, alpha.toFloat, beta.toFloat, k.toFloat)
+    require(fwdPrimDesc != UNDEFINED, "You should call initFwdPrimitives first")
+    val primDesc = DnnlMemory.PrimitiveDescCreate(description, runtime.engine, fwdPrimDesc)
+    _gradInputFormats = Array(MemoryData.operationWant(primDesc, Query.DiffSrcMd))
+    updateGradInputPrimitives = Array(DnnlMemory.PrimitiveCreate(primDesc))
+    gradInput = initTensor(_gradInputFormats(0))
+    bwdExecArgs = mutable.Map(
+      ArgType.DNNL_ARG_SRC -> inputFormats().head.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DIFF_DST -> gradOutputFormats().head.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DIFF_SRC -> gradInputFormats().head.getMemoryObject(runtime)
+    )
+    (_gradOutputFormats, _gradInputFormats)
+  }
+
+  override def updateOutput(input: Activity): Activity = {
+    if (updateOutputTensors == null) {
+      updateOutputTensors = mutable.Map(
+        ArgType.DNNL_ARG_SRC -> input.asInstanceOf[Tensor[Float]],
+        ArgType.DNNL_ARG_DST -> output.asInstanceOf[Tensor[Float]]
+      )
+    }
+    updateWithNewTensor(updateOutputTensors, ArgType.DNNL_ARG_SRC, input)
+    MklDnnOps.streamSubmit(updateOutputPrimitives, runtime.stream,
+      fwdExecArgs, updateOutputTensors)
+    output
+  }
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    updateGradInputTensors = mutable.Map(
+      ArgType.DNNL_ARG_SRC -> input.asInstanceOf[Tensor[Float]],
+      ArgType.DNNL_ARG_DIFF_DST -> gradOutput.asInstanceOf[Tensor[Float]],
+      ArgType.DNNL_ARG_DIFF_SRC -> gradInput.asInstanceOf[Tensor[Float]]
+    )
+    MklDnnOps.streamSubmit(updateGradInputPrimitives, runtime.stream,
+      bwdExecArgs, updateGradInputTensors)
+    gradInput
+  }
+}
+
+object LRN {
+  def apply(size: Int = 5, alpha: Double = 1.0, beta: Double = 0.75, k: Double = 1.0): LRN =
+    new LRN(size, alpha, beta, k)
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Linear.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Linear.scala
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl._
+import com.intel.analytics.bigdl.nn.abstractnn.{Activity, Initializable}
+import com.intel.analytics.bigdl.nn.{InitializationMethod, MklInt8Convertible, RandomUniform, VariableFormat}
+import com.intel.analytics.bigdl.optim.Regularizer
+import com.intel.analytics.bigdl.tensor._
+
+import scala.collection.mutable
+
+class Linear(
+  val inputSize: Int,
+  val outputSize: Int,
+  var wRegularizer: Regularizer[Float] = null,
+  var bRegularizer: Regularizer[Float] = null,
+  private val initWeight: Tensor[Float] = null,
+  private val initBias: Tensor[Float] = null,
+  private val initGradWeight: Tensor[Float] = null,
+  private val initGradBias: Tensor[Float] = null)
+  extends MklDnnLayer with Initializable with MklInt8Convertible {
+
+  private[mkldnn] val weight: TensorMMap = new TensorMMap(Array(outputSize, inputSize))
+  private[mkldnn] val bias: TensorMMap = new TensorMMap(Array(outputSize))
+  private[mkldnn] val gradWeight: TensorMMap = new TensorMMap(Array(outputSize, inputSize))
+  private[mkldnn] val gradBias: TensorMMap = new TensorMMap(Array(outputSize))
+
+  @transient private var forwardPrimDesc: Long = 0L
+  @transient private var updateGradWMemoryPrimitives: Array[Long] = _
+//  @transient private var updateGradWTensors: Array[Tensor[Float]] = _
+  @transient private var updateGradWTensors: mutable.Map[Int, Tensor[Float]] = _
+
+  {
+    val stdv = 1.0 / math.sqrt(weight.size(2))
+    val wInit: InitializationMethod = RandomUniform(-stdv, stdv)
+    val bInit: InitializationMethod = RandomUniform(-stdv, stdv)
+    setInitMethod(wInit, bInit)
+  }
+
+  override def reset(): Unit = {
+    if (initWeight == null) {
+      weightInitMethod.init(weight.dense, VariableFormat.OUT_IN)
+    } else {
+      weight.dense.copy(initWeight)
+    }
+
+    if (initBias == null) {
+      biasInitMethod.init(bias.dense, VariableFormat.ONE_D)
+    } else {
+      bias.dense.copy(initBias)
+    }
+  }
+
+
+  override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+    require(inputs(0).shape.length > 1, s"mkldnn linear unspported input dimension")
+
+    val (weightShape, weightLayout) = inputs(0).shape.length match {
+      case 4 =>
+        (Array(weight.size(1)) ++ inputs(0).shape.slice(1, 4),
+          Memory.FormatTag.oihw)
+      case 2 => (weight.size(), Memory.FormatTag.nc)
+      case 1 => (weight.size(), Memory.FormatTag.x)
+    }
+
+    val inputShape = inputs(0).shape
+    val outputShape = Array(inputs(0).shape(0), outputSize)
+
+    val src = NativeData(inputShape, Memory.FormatTag.any)
+    val wei = NativeData(weightShape, Memory.FormatTag.any)
+    val bis = NativeData(bias.size(), Memory.FormatTag.x)
+    val dst = NativeData(outputShape, Memory.FormatTag.any)
+
+    val desc = DnnlMemory.LinearForwardDescInit(
+      PropKind.Forward,
+      src.getMemoryDescriptor(),
+      wei.getMemoryDescriptor(),
+      bis.getMemoryDescriptor(),
+      dst.getMemoryDescriptor())
+
+    forwardPrimDesc = DnnlMemory.PrimitiveDescCreate(desc, runtime.engine, 0)
+
+    val List(realSrc, realWei, realDst) = List(Query.SrcMd, Query.WeightsMd, Query.DstMd).map {x =>
+      MemoryData.operationWant(forwardPrimDesc, x)
+    }
+
+    require(weight.size().product == realWei.shape.product,
+      s"${getName} weight shape is not correct." + weight.size().mkString(" ") + "   " +
+    realWei.shape.mkString(" "))
+
+    weight.setMemoryData(HeapData(weightShape, weightLayout), realWei, runtime)
+    bias.setMemoryData(HeapData(bis.shape, Memory.FormatTag.x), bis, runtime)
+    weight.sync()
+    bias.sync()
+
+    val primitive = DnnlMemory.PrimitiveCreate(forwardPrimDesc)
+
+    updateOutputPrimitives = Array(primitive)
+    output = initTensor(realDst)
+    _inputFormats = Array(realSrc)
+    _outputFormats = Array(realDst)
+
+    fwdExecArgs = mutable.Map(
+      ArgType.DNNL_ARG_SRC -> realSrc.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_WEIGHTS -> realWei.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_BIAS -> bis.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DST -> realDst.getMemoryObject(runtime)
+    )
+
+    (_inputFormats, _outputFormats)
+  }
+
+  override def updateOutput(input: Activity): Activity = {
+    if (updateOutputTensors == null) {
+      updateOutputTensors = mutable.Map(
+        ArgType.DNNL_ARG_SRC -> input.asInstanceOf[Tensor[Float]],
+        ArgType.DNNL_ARG_WEIGHTS -> weight.native,
+        ArgType.DNNL_ARG_BIAS -> bias.native,
+        ArgType.DNNL_ARG_DST -> output.asInstanceOf[Tensor[Float]]
+      )
+    }
+    updateWithNewTensor(updateOutputTensors, ArgType.DNNL_ARG_SRC, input)
+
+    if (isTraining()) {
+      weight.sync()
+      bias.sync()
+    }
+
+    MklDnnOps.streamSubmit(updateOutputPrimitives,
+      runtime.stream,
+      fwdExecArgs,
+      updateOutputTensors)
+
+    output
+  }
+
+  override private[mkldnn] def initBwdPrimitives(grad: Array[MemoryData], phase: Phase) = {
+    val weightShape = inputFormats()(0).shape.length match {
+      case 4 => Array(weight.size(1)) ++ inputFormats()(0).shape.slice(1, 4)
+      case _ => weight.size()
+    }
+
+    val inputShape = inputFormats()(0).shape
+    val src = NativeData(inputShape, Memory.FormatTag.any)
+    val wei = NativeData(weightShape, Memory.FormatTag.any)
+
+    val desc = DnnlMemory.LinearBackwardDataDescInit(
+      src.getMemoryDescriptor(),
+      wei.getMemoryDescriptor(),
+      grad(0).getMemoryDescriptor())
+
+    val backwardPrimDesc = DnnlMemory.PrimitiveDescCreate(desc, runtime.engine, forwardPrimDesc)
+
+    val List(realDiffSrc, realWei, realDiffDst) =
+      List(Query.DiffSrcMd, Query.WeightsMd, Query.DiffDstMd).map { x =>
+        MemoryData.operationWant(backwardPrimDesc, x)
+      }
+
+    val primitive = DnnlMemory.PrimitiveCreate(backwardPrimDesc)
+
+    updateGradInputPrimitives = Array(primitive)
+
+    gradInput = initTensor(realDiffSrc)
+
+    _gradInputFormats = Array(realDiffSrc)
+    _gradOutputFormats = Array(realDiffDst)
+
+    bwdExecArgs = mutable.Map(
+      ArgType.DNNL_ARG_DIFF_SRC -> realDiffSrc.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DIFF_DST -> realDiffDst.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_WEIGHTS -> realWei.getMemoryObject(runtime)
+    )
+
+    (_gradOutputFormats, _gradInputFormats)
+  }
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    if (updateGradInputTensors == null) {
+      updateGradInputTensors = mutable.Map(
+        ArgType.DNNL_ARG_DIFF_SRC -> gradInput.asInstanceOf[Tensor[Float]],
+        ArgType.DNNL_ARG_DIFF_DST -> gradOutput.asInstanceOf[Tensor[Float]],
+        ArgType.DNNL_ARG_WEIGHTS -> weight.dense
+      )
+    }
+
+    updateWithNewTensor(updateGradInputTensors, ArgType.DNNL_ARG_DIFF_DST, gradOutput)
+
+    MklDnnOps.streamSubmit(updateGradInputPrimitives,
+      runtime.stream, bwdExecArgs, updateGradInputTensors)
+
+    gradInput
+  }
+
+  override private[mkldnn] def initGradWPrimitives(grad: Array[MemoryData],
+                                                 phase: Phase): Array[MemoryData] = {
+    val (weightShape, weightLayout) = inputFormats()(0).shape.length match {
+      case 4 =>
+        (Array(weight.size(1)) ++ inputFormats()(0).shape.slice(1, 4),
+          Memory.FormatTag.oihw)
+      case 2 => (weight.size(), Memory.FormatTag.nc)
+      case 1 => (weight.size(), Memory.FormatTag.x)
+    }
+
+    val inputShape = inputFormats()(0).shape
+    val outputShape = Array(inputFormats()(0).shape(0), outputSize)
+
+    val src = NativeData(inputShape, Memory.FormatTag.any)
+    val wei = NativeData(weightShape, Memory.FormatTag.any)
+    val bis = NativeData(bias.size(), Memory.FormatTag.x)
+    val dst = NativeData(outputShape, Memory.FormatTag.any)
+
+    val desc = DnnlMemory.LinearBackwardWeightsDescInit(
+      src.getMemoryDescriptor(),
+      wei.getMemoryDescriptor(),
+      bis.getMemoryDescriptor(),
+      dst.getMemoryDescriptor()
+    )
+
+    val gradWeightPrimDesc = DnnlMemory.PrimitiveDescCreate(desc, runtime.engine, forwardPrimDesc)
+
+    val List(realWei, realDiffDst) = List(Query.DiffWeightsMd, Query.DiffDstMd).map { x =>
+      MemoryData.operationWant(gradWeightPrimDesc, x)
+    }
+
+    gradWeight.setMemoryData(realWei, HeapData(weightShape, weightLayout), runtime)
+    gradBias.setMemoryData(bis, HeapData(bis.shape, Memory.FormatTag.x), runtime)
+    gradWeight.zero()
+    gradBias.zero()
+
+    val primitive = DnnlMemory.PrimitiveCreate(gradWeightPrimDesc)
+
+    weightUpdateExecArgs = mutable.Map(
+      ArgType.DNNL_ARG_SRC -> inputFormats()(0).getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DIFF_DST -> realDiffDst.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DIFF_WEIGHTS -> realWei.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DIFF_BIAS -> bis.getMemoryObject(runtime)
+    )
+
+    accGradientPrimitives = Array(primitive)
+
+    _gradOutputFormatsForWeight = Array(realDiffDst)
+
+    (_gradOutputFormatsForWeight)
+  }
+
+  override def accGradParameters(input: Activity, gradOutput: Activity): Unit = {
+    if (updateGradWTensors == null) {
+      updateGradWTensors = mutable.Map(
+        ArgType.DNNL_ARG_SRC -> input.asInstanceOf[Tensor[Float]],
+        ArgType.DNNL_ARG_DIFF_DST -> gradOutput.asInstanceOf[Tensor[Float]],
+        ArgType.DNNL_ARG_DIFF_WEIGHTS -> gradWeight.native,
+        ArgType.DNNL_ARG_DIFF_BIAS -> gradBias.native
+      )
+    }
+
+    updateWithNewTensor(updateGradWTensors, ArgType.DNNL_ARG_SRC, input)
+    updateWithNewTensor(updateGradWTensors, ArgType.DNNL_ARG_DIFF_DST, gradOutput)
+
+    MklDnnOps.streamSubmit(accGradientPrimitives,
+      runtime.stream, weightUpdateExecArgs, updateGradWTensors)
+
+    gradWeight.sync()
+    gradBias.sync()
+
+    if (null != wRegularizer && scaleW != 0) {
+      wRegularizer.accRegularization(weight.dense, gradWeight.dense, scaleW)
+    }
+    if (null != bRegularizer && scaleB != 0) {
+      bRegularizer.accRegularization(bias.dense, gradBias.dense, scaleB)
+    }
+  }
+
+  override def parameters(): (Array[Tensor[Float]], Array[Tensor[Float]]) = {
+    (Array(weight.dense, bias.dense), Array(gradWeight.dense, gradBias.dense))
+  }
+
+  override def paramsMMap(): (Array[TensorMMap], Array[TensorMMap]) = {
+    (Array(weight, bias), Array(gradWeight, gradBias))
+  }
+
+  override def zeroGradParameters(): Unit = {
+  }
+
+}
+
+object Linear {
+  def apply(
+    inputSize: Int,
+    outputSize: Int,
+    withBias: Boolean = true,
+    wRegularizer: Regularizer[Float] = null,
+    bRegularizer: Regularizer[Float] = null,
+    initWeight: Tensor[Float] = null,
+    initBias: Tensor[Float] = null,
+    initGradWeight: Tensor[Float] = null,
+    initGradBias: Tensor[Float] = null): Linear = {
+    new Linear(inputSize, outputSize, wRegularizer,
+      bRegularizer, initWeight, initBias, initGradWeight, initGradBias)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/MaxPooling.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/MaxPooling.scala
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.Memory.FormatTag
+import com.intel.analytics.bigdl.dnnl.{AlgKind, ArgType, DNNL, Memory, PropKind, Query}
+import com.intel.analytics.bigdl.nn.{Utils => NNUtils}
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.tensor.Tensor
+
+import scala.collection.mutable
+
+class MaxPooling(
+  kW: Int,
+  kH: Int,
+  dW: Int = 1,
+  dH: Int = 1,
+  padW: Int = 0,
+  padH: Int = 0
+) extends MklDnnLayer {
+  @transient private var workSpaceFormat: MemoryData = _
+  @transient private var workSpace: Tensor[Float] = _
+  @transient private var paddingTL: Array[Int] = _
+  @transient private var paddingBR: Array[Int] = _
+  @transient private var fwdPD: Long = _
+
+  // reminder: ceilMode default value is true,
+  // but in blas SpatialMaxPooling, default ceilMode is false
+  private var ceilMode = true
+  private val strides = Array(dW, dH)
+  private val kernel = Array(kH, kW)
+  private var _phase: Phase = Phase.InferencePhase
+
+
+  /**
+   * set ceil mode
+   * @return this
+   */
+  def ceil(): MaxPooling = {
+    ceilMode = true
+    this
+  }
+
+  /**
+   * set floor mode
+   * @return this
+   */
+  def floor(): MaxPooling = {
+    ceilMode = false
+    this
+  }
+
+
+  /**
+   * 1. Get input's MemoryData
+   * 2. Get input's shape, layout and data type from its MemoryData
+   * 3. Calculate output's shape, layout and data type according to input and layer type
+   * 4. Initialize input & output memory descriptor
+   * 5. Initialize layer operation descriptor
+   * 6. Create layer operation primitive descriptor
+   * 7. Create layer operation primitive
+   * 8. Get output's MemoryData by querying with operation primitive descriptor
+   * 9. Allocate memory for layer's output according to its MemoryData
+   *
+   * @param inputs
+   * @param phase
+   * @return
+   */
+  override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+    _phase = phase
+    _inputFormats = singleNativeData(inputs)
+
+    val shape = _inputFormats(0).shape
+    val (n, c, h, w) = (shape(0), shape(1), shape(2), shape(3))
+
+    val (pt, pb, pl, pr, oh, ow) = if (padH == -1 && padW == -1) {
+      val sizes = NNUtils.getSAMEOutSizeAndPadding(h, w, dH, dW, kH, kW)
+      (sizes(0), sizes(1), sizes(2), sizes(3), sizes(4), sizes(5))
+    } else {
+      NNUtils.getPaddingAndOutputSize(h, w, dH, dW, kH, kW, padH, padW, ceilMode)
+    }
+
+    paddingTL = Array(pt, pl)
+    paddingBR = Array(pb, pr)
+
+    val propKind = if (InferencePhase == phase) {
+      PropKind.ForwardScoring
+    } else {
+      PropKind.ForwardTraining
+    }
+
+    val inputMd = _inputFormats(0).getMemoryDescriptor()
+
+    val outputMd = DnnlMemory.MemoryDescInit(
+      4,
+      Array(n, c, oh, ow),
+      _inputFormats(0).dataType,
+      Memory.FormatTag.any
+    )
+
+    val poolingForwardDescriptor = DnnlMemory.PoolingForwardDescInit(
+      propKind,
+      AlgKind.PoolingMax,
+      inputMd, outputMd,
+      strides, kernel,
+      paddingTL, paddingBR, 0)
+
+    fwdPD = DNNL.PrimitiveDescCreate(poolingForwardDescriptor, runtime.engine, 0L)
+
+    _outputFormats = Array(MemoryData.primitiveOutput(fwdPD))
+
+    val realDst = MemoryData.primitiveOutput(fwdPD)
+    _outputFormats = Array(realDst)
+
+    fwdExecArgs = mutable.Map(
+      ArgType.DNNL_ARG_SRC -> _inputFormats(0).getMemoryObject(runtime),
+//      ArgType.DNNL_ARG_DST -> _outputFormats(0).getMemoryObject(runtime)
+      ArgType.DNNL_ARG_DST -> realDst.getMemoryObject(runtime)
+    )
+
+    if (phase == TrainingPhase) {
+      workSpaceFormat = MemoryData.operationWant(fwdPD, Query.WorkspaceMd)
+      workSpaceFormat.getMemoryObject(runtime)
+      workSpace = initTensor(workSpaceFormat).asInstanceOf[Tensor[Float]]
+      fwdExecArgs.put(ArgType.DNNL_ARG_WORKSPACE, workSpaceFormat.getMemoryObject(runtime))
+    }
+
+    updateOutputPrimitives = Array(DnnlMemory.PrimitiveCreate(fwdPD))
+    // if it's training, should have output and workspace primitive memory
+    // otherwise, only need the output memory
+
+//    output = initTensor(_outputFormats(0))
+    output = initTensor(realDst)
+
+    (_inputFormats, _outputFormats)
+  }
+
+  override private[mkldnn] def initBwdPrimitives(grad: Array[MemoryData], phase: Phase) = {
+    val shape = _inputFormats(0).shape
+    val (n, c, h, w) = (shape(0), shape(1), shape(2), shape(3))
+
+    val (pt, pb, pl, pr, oh, ow) = if (padH == -1 && padW == -1) {
+      val sizes = NNUtils.getSAMEOutSizeAndPadding(h, w, dH, dW, kH, kW)
+      (sizes(0), sizes(1), sizes(2), sizes(3), sizes(4), sizes(5))
+    } else {
+      NNUtils.getPaddingAndOutputSize(h, w, dH, dW, kH, kW, padH, padW, ceilMode)
+    }
+
+    val gradientOutputMd = DnnlMemory.MemoryDescInit(
+      4,
+      Array(n, c, oh, ow),
+      _inputFormats(0).dataType,
+      Memory.FormatTag.any
+    )
+
+    val inputMd = DnnlMemory.MemoryDescInit(
+      4,
+      Array(n, c, h, w),
+      _inputFormats(0).dataType,
+      Memory.FormatTag.any
+    )
+
+    // Pooling backward descriptor
+    val backwardDescriptor = DnnlMemory.PoolingBackwardDescInit(
+      AlgKind.PoolingMax,
+      inputMd,
+      gradientOutputMd,
+      strides, kernel, paddingTL, paddingBR,
+      0
+    )
+
+    // Pooling backward primitive descriptor
+    val backwardPd = DnnlMemory.PrimitiveDescCreate(backwardDescriptor, runtime.engine, fwdPD)
+    _gradInputFormats = Array(MemoryData.operationWant(backwardPd, Query.DiffSrcMd))
+    _gradOutputFormats = Array(MemoryData.operationWant(backwardPd, Query.DiffDstMd))
+    _gradOutputFormatsForWeight = _gradOutputFormats
+    gradInput = initTensor(_gradInputFormats(0))
+    bwdExecArgs = mutable.Map(
+      ArgType.DNNL_ARG_DIFF_DST -> _gradOutputFormats(0).getMemoryObject(runtime),
+      ArgType.DNNL_ARG_WORKSPACE -> workSpaceFormat.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DIFF_SRC -> _gradInputFormats(0).getMemoryObject(runtime)
+    )
+
+    updateGradInputPrimitives = Array(DnnlMemory.PrimitiveCreate(backwardPd))
+
+    (_gradOutputFormats, _gradInputFormats)
+  }
+
+  override def updateOutput(input: Activity): Activity = {
+    if (updateOutputTensors == null) {
+      updateOutputTensors = mutable.Map(
+        ArgType.DNNL_ARG_DST -> output.asInstanceOf[Tensor[Float]]
+      )
+      if (isTraining()) { // only for training.
+        updateOutputTensors.put(ArgType.DNNL_ARG_WORKSPACE, workSpace)
+      }
+    }
+    updateOutputTensors.put(ArgType.DNNL_ARG_SRC, input.asInstanceOf[Tensor[Float]])
+    MklDnnOps.streamSubmit(updateOutputPrimitives, runtime.stream,
+      fwdExecArgs, updateOutputTensors)
+    output
+  }
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    if (updateGradInputTensors == null) {
+      updateGradInputTensors = mutable.Map(
+        ArgType.DNNL_ARG_WORKSPACE -> workSpace,
+        ArgType.DNNL_ARG_DIFF_SRC -> gradInput.asInstanceOf[Tensor[Float]]
+      )
+    }
+    updateGradInputTensors.put(ArgType.DNNL_ARG_DIFF_DST, gradOutput.asInstanceOf[Tensor[Float]])
+    MklDnnOps.streamSubmit(updateGradInputPrimitives,
+      runtime.stream,
+      bwdExecArgs,
+      updateGradInputTensors)
+
+    gradInput
+  }
+}
+
+object MaxPooling {
+  def apply(
+    kW: Int,
+    kH: Int,
+    dW: Int = 1,
+    dH: Int = 1,
+    padW: Int = 0,
+    padH: Int = 0
+  ): MaxPooling = new MaxPooling(kW, kH, dW, dH, padW, padH)
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/MemoryData.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/MemoryData.scala
@@ -285,17 +285,20 @@ private[mkldnn] object MemoryData {
   }
 
   def operationWant(pd: Long, queryType: Int, index: Int = 0): NativeData = {
-      val memoryDescriptor = DNNL.PrimitiveDescQueryMd(pd, queryType, index)
-      if (memoryDescriptor == 0L) {
-        return null
-      }
-      val shape = Memory.GetShape(memoryDescriptor).map(_.toInt)
-      val paddingShape = Memory.GetPaddingShape(memoryDescriptor)
-      val layout = Memory.GetLayout(memoryDescriptor)
-      val dataType = Memory.GetDataType(memoryDescriptor)
-      val memory = NativeData(shape, layout, dataType)
-      memory.setMemoryDescriptor(memoryDescriptor)
-      memory
+    val memoryDescriptor = DNNL.PrimitiveDescQueryMd(pd, queryType, index)
+    if (memoryDescriptor == 0L) {
+      return null
+    }
+    var shape = Memory.GetShape(memoryDescriptor).map(_.toInt)
+    // the shape maybe empty, which means a zero md in native
+    if (shape.length == 0) {
+      return null
+    }
+    val layout = Memory.GetLayout(memoryDescriptor)
+    val dataType = Memory.GetDataType(memoryDescriptor)
+    val memory = NativeData(shape, layout, dataType)
+    memory.setMemoryDescriptor(memoryDescriptor)
+    memory
   }
 
   def cloneFormatWithDesc(data: MemoryData)(implicit owner: MemoryOwner): MemoryData = {

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/MemoryData.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/MemoryData.scala
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl._
+import com.intel.analytics.bigdl.dnnl.DataType
+import com.intel.analytics.bigdl.tensor.DnnStorage
+
+
+sealed trait MemoryData extends Serializable {
+
+  protected val UNDEFINED: Long = -1
+  protected val ERROR: Long = 0
+
+  private var _mask: Int = -1
+  private var _scales: Array[Float] = Array.emptyFloatArray
+
+//  @transient private var primitive: Long = UNDEFINED
+//  @transient private var primitiveDesc: Long = UNDEFINED
+//  @transient private var description: Long = UNDEFINED
+
+  // TODO: would like to make it to val
+  @transient protected var memoryDescriptor: Long = UNDEFINED
+  @transient protected var memoryObject: Long = UNDEFINED
+
+  def shape: Array[Int]
+  def layout: Int
+  def dataType: Int
+  def mask: Int = _mask
+  def scales: Array[Float] = _scales
+  def setMask(s: Int): Unit = _mask = s
+  def setScales(f: Array[Float]): Unit = _scales = f
+  def cloneFormat(): MemoryData
+
+  // refactored getMemoryDescriptor to getMemoryDescriptor
+  def getMemoryDescriptor()(implicit owner: MemoryOwner): Long = {
+    if (memoryDescriptor == UNDEFINED || memoryDescriptor == ERROR) {
+      if (layout == Memory.FormatTag.undef) {
+        memoryDescriptor = DnnlMemory.MemoryDescInitByStrides(shape.length, shape, dataType)
+      } else {
+        checkConsistency(shape, layout)
+        memoryDescriptor = DnnlMemory.MemoryDescInit(shape.length, shape, dataType, layout)
+      }
+    }
+    memoryDescriptor
+  }
+
+
+  // replace getMemoryObject to getMemoryObject
+  def getMemoryObject(runtime: MklDnnRuntime)(implicit owner: MemoryOwner): Long = {
+    require(runtime != null, s"Have you initialized the MklDnnRuntime?")
+    if (memoryObject == UNDEFINED || memoryObject == ERROR) {
+      memoryObject = DNNL.MemoryCreate(getMemoryDescriptor(), runtime.engine)
+    }
+    memoryObject
+  }
+
+  def setMemoryDescriptor(md: Long): Unit = {
+    memoryDescriptor = md
+  }
+
+  def setMemoryObject(memory: Long): Unit = {
+    memoryObject = memory
+  }
+
+
+  def toNative(): NativeData = {
+    this match {
+      case native: NativeData => native
+      case heap: HeapData => heap.toNative()
+      case _ => throw new UnsupportedOperationException("Unsupported memory format")
+    }
+  }
+
+  /**
+   * Returns the size (in bytes) that is required for given @p memory_desc
+   * size_t DNNL_API dnnl_memory_desc_get_size(
+   * const dnnl_memory_desc_t *memory_desc);
+   *
+   * @return
+   */
+  def getRealSize: Long = {
+    require(memoryDescriptor != UNDEFINED && memoryDescriptor != ERROR)
+    require(getDataTypeBytes != 0)
+    DNNL.getSize(memoryDescriptor) / getDataTypeBytes
+  }
+
+
+  def getPaddingShape: Array[Int] = {
+    require(memoryDescriptor != UNDEFINED && memoryDescriptor != ERROR)
+//    Memory.GetPaddingShape(memoryDescriptor)
+    Memory.GetPaddingShape(memoryDescriptor).map(_.toInt)
+  }
+
+  private def getDataTypeBytes: Int = {
+    dataType match {
+      case DataType.F32 => DnnStorage.FLOAT_BYTES
+      case DataType.S32 => DnnStorage.INT_BYTES
+      case DataType.S8 => DnnStorage.INT8_BYTES
+      case DataType.U8 => DnnStorage.INT8_BYTES
+      case _ => throw new UnsupportedOperationException(s"unsupported data type: " + dataType)
+    }
+  }
+
+  private def checkConsistency(shape: Array[Int], layout: Int): Unit = {
+    val isConsistency = Memory.FormatTag.any == layout || (shape.length match {
+      case 1 => layout == Memory.FormatTag.x
+      case 2 => layout == Memory.FormatTag.nc || layout == Memory.FormatTag.io ||
+        layout == Memory.FormatTag.oi
+      case 3 | 4 | 5 => layout != Memory.FormatTag.nc || layout != Memory.FormatTag.x
+      case _ => false
+    })
+
+    require(isConsistency,
+      s"the shape([${shape.mkString(",")}]) of tensor is different from layout(${layout})")
+  }
+}
+
+
+
+case class HeapData(
+  private var _shape: Array[Int],
+  private var _layout: Int,
+  private var _dataType: Int = DataType.F32) extends MemoryData {
+
+  override def dataType: Int = _dataType
+
+  override def shape: Array[Int] = _shape.clone()
+
+  override def layout: Int = _layout
+
+  override def hashCode(): Int = {
+    val seed = 37
+    var hash = 1
+    hash = hash * seed + this.layout
+    var d = 0
+    while (d < this.shape.length) {
+      hash = hash * seed + this.shape(d)
+      d += 1
+    }
+
+    hash = hash * seed + this.dataType
+    if (memoryDescriptor != UNDEFINED && memoryDescriptor != ERROR) {
+      hash = hash * seed + getRealSize.toInt
+      hash = hash * seed + getPaddingShape.product
+    }
+
+    hash
+  }
+
+  override def equals(obj: Any): Boolean = {
+    if (obj == null) {
+      return false
+    }
+    if (!obj.isInstanceOf[HeapData]) {
+      return false
+    }
+    val other = obj.asInstanceOf[HeapData]
+    if (this.eq(other)) {
+      return true
+    }
+    if (this.layout != other.layout) {
+      return false
+    }
+    if (this.shape == null && other.shape == null) {
+      return true
+    }
+    if (this.shape != null && other.shape != null) {
+      if (this.shape.length != other.shape.length) return false
+      var i = 0
+      while(i < this.shape.length) {
+        if (this.shape(i) != other.shape(i)) return false
+        i += 1
+      }
+      return true
+    } else {
+      return false
+    }
+  }
+
+  override def toString: String = {
+    s"HeapData([${shape.mkString("x")}], ${layout})"
+  }
+
+  override def cloneFormat(): MemoryData = new HeapData(_shape, _layout, _dataType)
+
+  override def toNative(): NativeData = {
+    NativeData(shape, layout)
+  }
+}
+
+case class NativeData(
+  private var _shape: Array[Int],
+  private var _layout: Int,
+  private var _dataType: Int = DataType.F32
+) extends MemoryData {
+
+  override def shape: Array[Int] = _shape.clone()
+
+  override def layout: Int = _layout
+
+  override def hashCode(): Int = {
+    val seed = 41
+    var hash = 1
+    hash = hash * seed + this.layout
+    var d = 0
+    while (d < this.shape.length) {
+      hash = hash * seed + this.shape(d)
+      d += 1
+    }
+
+    hash = hash * seed + this.dataType
+    if (memoryDescriptor != UNDEFINED && memoryDescriptor != ERROR) {
+      hash = hash * seed + getRealSize.toInt
+      hash = hash * seed + getPaddingShape.product
+    }
+
+    hash
+  }
+
+  override def equals(obj: Any): Boolean = {
+    if (obj == null) {
+      return false
+    }
+    if (!obj.isInstanceOf[NativeData]) {
+      return false
+    }
+    val other = obj.asInstanceOf[NativeData]
+    if (this.eq(other)) {
+      return true
+    }
+    if (this.layout != other.layout) {
+      return false
+    }
+    if (this.shape == null && other.shape == null) {
+      return true
+    }
+    if (this.shape != null && other.shape != null) {
+      if (this.shape.length != other.shape.length) return false
+      var i = 0
+      while(i < this.shape.length) {
+        if (this.shape(i) != other.shape(i)) return false
+        i += 1
+      }
+    }
+    // hotfix: because the layout not working now.
+    val owner = new MemoryOwner {}
+
+    val descIsEqual = DNNL.MemoryPrimitiveDescEqual(this.getMemoryDescriptor()(owner),
+      other.getMemoryDescriptor()(owner))
+
+    if (descIsEqual == 1) {
+      return true
+    } else {
+      return false
+    }
+  }
+
+  override def toString: String = {
+    s"NativeData([${shape.mkString("x")}], ${layout}, ${dataType}, ${mask}, ${scales})"
+  }
+
+  override def cloneFormat(): MemoryData = new NativeData(_shape, _layout, _dataType)
+
+  override def dataType: Int = _dataType
+}
+
+private[mkldnn] object MemoryData {
+
+  def primitiveOutput(pd: Long): NativeData = {
+    operationWant(pd, Query.DstMd, 0)
+  }
+
+  def operationWant(pd: Long, queryType: Int, index: Int = 0): NativeData = {
+      val memoryDescriptor = DNNL.PrimitiveDescQueryMd(pd, queryType, index)
+      if (memoryDescriptor == 0L) {
+        return null
+      }
+      val shape = Memory.GetShape(memoryDescriptor).map(_.toInt)
+      val paddingShape = Memory.GetPaddingShape(memoryDescriptor)
+      val layout = Memory.GetLayout(memoryDescriptor)
+      val dataType = Memory.GetDataType(memoryDescriptor)
+      val memory = NativeData(shape, layout, dataType)
+      memory.setMemoryDescriptor(memoryDescriptor)
+      memory
+  }
+
+  def cloneFormatWithDesc(data: MemoryData)(implicit owner: MemoryOwner): MemoryData = {
+    val format = data.cloneFormat()
+    val desc = DNNL.MemoryDescClone(data.getMemoryDescriptor())
+    format.setMemoryDescriptor(desc)
+    format
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/MemoryOwner.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/MemoryOwner.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import scala.collection.mutable.ArrayBuffer
+
+
+/**
+ * The trait for resources that need to be released
+ */
+private[bigdl] trait Releasable {
+  def release(): Unit
+}
+
+/**
+ * This trait is a owner of the resources that need to be released.
+ * It will track all Releasable resources (Primitives, tensor, ReorderMemory).
+ * You can call releaseResources to release all the
+ * resources at once. These resources will require an implicit MemoryOwner at
+ * the constructors. The constructors of the resources will register themselves to the MemoryOwner.
+ * For DNN Layer classes, they extends MemoryOwner and have a implicit value of "this" as a
+ * MemoryOwner. ReorderMemory is a kind of special resource. They can be a normal layer or a
+ * resource of another layer.
+ */
+private[bigdl] trait MemoryOwner {
+  @transient
+  private lazy val _resources: ArrayBuffer[Releasable] =
+    new ArrayBuffer[Releasable]()
+
+  def registerResource(m: Releasable): Unit = {
+    _resources.append(m)
+  }
+
+  def releaseResources(): Unit = {
+    _resources.foreach(_.release())
+    _resources.clear()
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/MklDnnOps.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/MklDnnOps.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.{DNNL, Memory, Engine => DnnEngine, Stream => DnnStream}
+import com.intel.analytics.bigdl.tensor.{DnnTensor, Tensor}
+
+import scala.collection.mutable
+
+private[mkldnn] object MklDnnOps {
+
+  def memorySetDataHandle(memory: Long, data: Tensor[Float], offset: Int): Long = {
+    require(DNNL.isLoaded, "mkldnn isn't loaded")
+    val ret = DNNL.MemorySetDataHandle(memory, data.storage().array(), offset)
+    ret
+  }
+
+  def memoryReleaseDataHandle(data: Tensor[Float], ptr: Long): Unit = {
+    require(DNNL.isLoaded, "mkldnn isn't loaded")
+    DNNL.MemoryReleaseDataHandle(data.storage().array(), ptr)
+  }
+
+  def streamSubmit(primitives: Array[Long], stream: Long,
+                   execArgs: mutable.Map[Int, Long],
+                   execTensors: mutable.Map[Int, Tensor[Float@unchecked]]): Unit = {
+    // the tensor maybe Tensor[Byte]. so use the unchecked to handle this
+    require(DNNL.isLoaded, "mkldnn isn't loaded")
+    require(execArgs.size == execTensors.size, execArgs.size + " " + execTensors.size)
+
+    val indexes = new Array[Int](execArgs.size)
+    val memories = new Array[Long](execArgs.size)
+    val handle = new Array[Long](execArgs.size)
+
+    // TODO: would like to set data h
+    execArgs.zipWithIndex.foreach {
+      case ((argIdx, argMemory), i) =>
+        if (execTensors.get(argIdx).get.isInstanceOf[DnnTensor[_]]) {
+          Memory.SetDataHandle(argMemory,
+            execTensors.get(argIdx).get.asInstanceOf[DnnTensor[Float]].storageAddress(),
+            0)
+        } else {
+          handle(i) = MklDnnOps.memorySetDataHandle(
+            argMemory, execTensors.get(argIdx).get,
+            execTensors.get(argIdx).get.storageOffset() - 1)
+        }
+        indexes(i) = argIdx
+        memories(i) = argMemory
+    }
+    DnnStream.Submit(primitives(0), stream, execArgs.size, indexes, memories)
+
+    handle.indices.foreach(i => {
+      if (handle(i) != 0L) {
+        MklDnnOps.memoryReleaseDataHandle(execTensors.get(indexes(i)).get, handle(i))
+      }
+    })
+
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/MklDnnRuntime.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/MklDnnRuntime.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.{Engine, DNNL, Stream}
+
+class MklDnnRuntime {
+  DNNL.isLoaded
+  @transient lazy val engine : Long = Engine.Create(Engine.Kind.Cpu, 0)
+  @transient lazy val stream : Long = Stream.Create(engine, Stream.Flags.DefaultFlags)
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Output.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Output.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.{Memory, DNNL}
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.tensor.{DnnTensor, Tensor}
+
+/**
+ * Convert output to user defined layout and appoint gradOutput layout
+ * @param outputLayOut output memory layout
+ * @param gradOutputLayout gradoutput memory layout, if it is -1,
+ *                         that means gradOutput memory layout is same with output memory layout
+ */
+class Output(outputLayOut: Int = Memory.FormatTag.nc,
+             gradOutputLayout: Int = -1) extends MklDnnLayer {
+
+  private val _outputLayOut = outputLayOut
+  private val _gradOutputLayout = if (gradOutputLayout == -1) outputLayOut else gradOutputLayout
+
+
+  private def getShape(inLayout: Int, inShape: Array[Int], outLayout: Int): Array[Int] = {
+    val outputShape =
+      if (outLayout == Memory.FormatTag.nhwc && inLayout != Memory.FormatTag.nhwc) {
+        // nchw*  -> nhwc
+        Array(inShape(0), inShape(2), inShape(3), inShape(1))
+      } else if (outLayout == Memory.FormatTag.tnc && inLayout == Memory.FormatTag.ntc) {
+        // ntc -> tnc
+        Array(inShape(1), inShape(0), inShape(2))
+      } else if (outLayout == Memory.FormatTag.ntc && inLayout == Memory.FormatTag.tnc) {
+        // tnc -> ntc
+        Array(inShape(1), inShape(0), inShape(2))
+      } else inShape
+    outputShape
+  }
+
+  override private[bigdl] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+    require(inputs.length == 1, "Only accept one tensor as input")
+    require(inputs(0).shape.length == 4 || inputs(0).shape.length == 2
+      || inputs(0).shape.length == 3,
+      s"Only support input with 2 or 3 or 4 dimentions, but get ${inputs(0).shape.length}")
+
+    val outputShape = getShape(inputs(0).layout, inputs(0).shape, _outputLayOut)
+    // remind: output memory storage should be heapData
+    _outputFormats = Array(HeapData(outputShape, outputLayOut))
+    _inputFormats = _outputFormats
+
+    (_inputFormats, _outputFormats)
+  }
+
+  override def updateOutput(input: Activity): Activity = {
+    output = input
+    output
+  }
+
+  override private[bigdl] def initBwdPrimitives(grads: Array[MemoryData], phase: Phase) = {
+    require(grads.length == 1, "Only accept one tensor as input")
+    require(grads(0).shape.length == 4 || grads(0).shape.length == 2
+      || grads(0).shape.length == 3,
+      s"Only support gradOutput with 2 or 3 or 4 dimentions, but get ${grads(0).shape.length}")
+
+    val outputShape = getShape(grads(0).layout, grads(0).shape, _gradOutputLayout)
+
+    _gradInputFormats = Array(HeapData(outputShape, _gradOutputLayout))
+    _gradOutputFormats = _gradInputFormats
+    _gradOutputFormatsForWeight = _gradOutputFormats
+
+    (_gradInputFormats, _gradOutputFormats)
+  }
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    gradInput = gradOutput
+    gradInput
+  }
+
+  override def toString(): String = {
+    s"nn.mkl.Output(${outputLayOut}, ${gradOutputLayout})"
+  }
+}
+
+object Output {
+  def apply(outputLayOut: Int = Memory.FormatTag.nc,
+            gradOutputLayout: Int = -1): Output =
+    new Output(outputLayOut, gradOutputLayout)
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Perf.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Perf.scala
@@ -1,0 +1,475 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.Module
+import com.intel.analytics.bigdl.dnnl.Memory
+import com.intel.analytics.bigdl.nn.Graph._
+import com.intel.analytics.bigdl.nn._
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.nn.mkldnn.ResNet.DatasetType.ImageNet
+import com.intel.analytics.bigdl.nn.mkldnn.models.Vgg_16
+import com.intel.analytics.bigdl.numeric.NumericFloat
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.RandomGenerator._
+import com.intel.analytics.bigdl.utils.{Engine, T, Table, ThreadPool}
+import org.apache.log4j.Logger
+import scopt.OptionParser
+
+import scala.reflect.ClassTag
+
+object Perf {
+
+  val logger = Logger.getLogger(getClass)
+
+  val parser = new OptionParser[ResNet50PerfParams]("BigDL w/ Dnn Local Model Performance Test") {
+    opt[String]('m', "model")
+      .text("model you want, vgg16 | resnet50 | vgg16_graph | resnet50_graph")
+      .action((v, p) => p.copy(model = v))
+    opt[Int]('b', "batchSize")
+      .text("Batch size of input data")
+      .action((v, p) => p.copy(batchSize = v))
+    opt[Int]('i', "iteration")
+      .text("Iteration of perf test. The result will be average of each iteration time cost")
+      .action((v, p) => p.copy(iteration = v))
+    opt[Boolean]('t', "training")
+      .text(s"Perf test training or testing")
+      .action((v, p) => p.copy(training = v))
+  }
+
+  def main(argv: Array[String]): Unit = {
+    System.setProperty("bigdl.mkldnn.fusion.convbn", "true")
+    System.setProperty("bigdl.mkldnn.fusion.bnrelu", "true")
+    System.setProperty("bigdl.mkldnn.fusion.convrelu", "true")
+    System.setProperty("bigdl.mkldnn.fusion.convsum", "true")
+
+    System.setProperty("bigdl.localMode", "true")
+    System.setProperty("bigdl.engineType", "mkldnn")
+    Engine.init
+
+    parser.parse(argv, new ResNet50PerfParams()).foreach { params =>
+      val batchSize = params.batchSize
+      val training = params.training
+      val iterations = params.iteration
+
+      val classNum = 1000
+
+      val inputFormat = Memory.FormatTag.nchw
+      val inputShape = Array(batchSize, 3, 224, 224)
+      val input = Tensor(inputShape).rand()
+      val label = Tensor(batchSize).apply1(_ => Math.ceil(RNG.uniform(0, 1) * 1000).toFloat)
+
+      val model = params.model match {
+        case "vgg16" => Vgg_16(batchSize, classNum, true)
+        case "resnet50" => ResNet(batchSize, classNum, T("depth" -> 50, "dataSet" -> ImageNet))
+        case "vgg16_graph" => Vgg_16.graph(batchSize, classNum, true)
+        case "resnet50_graph" =>
+          ResNet.graph(batchSize, classNum, T("depth" -> 50, "dataSet" -> ImageNet))
+        case _ => throw new UnsupportedOperationException(s"Unkown model ${params.model}")
+      }
+
+      val criterion = CrossEntropyCriterion()
+
+      Engine.dnnComputing.invokeAndWait2(Array(1).map(_ => () => {
+        if (training) {
+          model.training()
+          if (model.isInstanceOf[MklDnnContainer]) {
+            model.asInstanceOf[MklDnnContainer]
+              .compile(TrainingPhase, Array(HeapData(inputShape, inputFormat)))
+          } else if (model.isInstanceOf[DnnGraph]) {
+            model.asInstanceOf[DnnGraph].compile(TrainingPhase)
+          }
+        } else {
+          model.evaluate()
+          if (model.isInstanceOf[MklDnnContainer]) {
+            model.asInstanceOf[MklDnnContainer]
+              .compile(InferencePhase, Array(HeapData(inputShape, inputFormat)))
+          } else if (model.isInstanceOf[DnnGraph]) {
+            model.asInstanceOf[DnnGraph].compile(InferencePhase)
+          }
+        }
+      }))
+
+      var iteration = 0
+      while (iteration < iterations) {
+        val start = System.nanoTime()
+
+        Engine.dnnComputing.invokeAndWait2(Array(1).map(_ => () => {
+          val output = model.forward(input)
+
+          if (training) {
+            val _loss = criterion.forward(output, label)
+            val errors = criterion.backward(output, label).toTensor
+            model.backward(input, errors)
+          }
+        }))
+
+        val takes = System.nanoTime() - start
+
+        val throughput = "%.2f".format(batchSize.toFloat / (takes / 1e9))
+        logger.info(s"Iteration $iteration, takes $takes s, throughput is $throughput imgs/sec")
+
+        iteration += 1
+      }
+    }
+  }
+}
+
+case class ResNet50PerfParams (
+  batchSize: Int = 16,
+  iteration: Int = 50,
+  training: Boolean = true,
+  model: String = "vgg16"
+)
+
+object ResNet {
+  def modelInit(model: Module[Float]): Unit = {
+    def initModules(model: Module[Float]): Unit = {
+      model match {
+        case container: Container[Activity, Activity, Float] =>
+          container.modules.foreach(m => initModules(m))
+
+        case conv: SpatialConvolution =>
+          val n: Float = conv.kernelW * conv.kernelW * conv.nOutputPlane
+          val weight = Tensor[Float].resize(conv.weight.size()).apply1 { _ =>
+            RNG.normal(0, Math.sqrt(2.0f / n)).toFloat
+          }
+          val bias = Tensor[Float].resize(conv.bias.size()).apply1(_ => 0.0f)
+          conv.weight.copy(weight)
+          conv.bias.copy(bias)
+
+        case bn: SpatialBatchNormalization =>
+          val weightAndBias = Tensor[Float]().resize(Array(2, bn.nOutput))
+          weightAndBias.select(1, 1).fill(1)
+          weightAndBias.select(1, 2).fill(0)
+          bn.weightAndBias.copy(weightAndBias.view(Array(bn.nOutput * 2)))
+
+        case linear: Linear =>
+          val bias = Tensor[Float](linear.bias.size()).apply1(_ => 0.0f)
+          linear.bias.copy(bias)
+
+        case _ =>
+      }
+    }
+
+    initModules(model)
+  }
+
+  var iChannels = 0
+  def apply(batchSize: Int, classNum: Int, opt: Table): Sequential = {
+
+    val depth = opt.get("depth").getOrElse(18)
+    val shortCutType = opt.get("shortcutType")
+    val shortcutType = shortCutType.getOrElse(ShortcutType.B).asInstanceOf[ShortcutType]
+    val dataSet = opt.getOrElse[DatasetType]("dataSet", DatasetType.CIFAR10)
+    val optnet = opt.get("optnet").getOrElse(true)
+
+    def shortcut(nInputPlane: Int, nOutputPlane: Int, stride: Int, name: String): Module[Float] = {
+      val useConv = shortcutType == ShortcutType.C ||
+        (shortcutType == ShortcutType.B && nInputPlane != nOutputPlane)
+
+      if (useConv) {
+        Sequential()
+          .add(Convolution(nInputPlane, nOutputPlane, 1, 1, stride, stride, optnet = optnet)
+            .setName(s"res${name}_branch1"))
+          .add(SbnDnn(nOutputPlane).setName(s"bn${name}_branch1"))
+      } else if (nInputPlane != nOutputPlane) {
+        throw new IllegalArgumentException(s"useConv false")
+      } else {
+        Identity()
+      }
+    }
+
+    def bottleneck(n: Int, stride: Int, name: String = ""): Module[Float] = {
+      val nInputPlane = iChannels
+      iChannels = n * 4
+
+      val s = Sequential()
+      s.add(Convolution(nInputPlane, n, 1, 1, 1, 1, 0, 0, optnet = optnet).setName(
+          s"res${name}_branch2a"))
+        .add(SbnDnn(n).setName(s"bn${name}_branch2a"))
+        .add(ReLU().setName(s"res${name}_branch2a_relu"))
+        .add(Convolution(n, n, 3, 3, stride, stride, 1, 1, optnet = optnet).setName(
+          s"res${name}_branch2b"))
+        .add(SbnDnn(n).setName(s"bn${name}_branch2b"))
+        .add(ReLU().setName(s"res${name}_branch2b_relu"))
+        .add(Convolution(n, n*4, 1, 1, 1, 1, 0, 0, optnet = optnet).setName(
+          s"res${name}_branch2c"))
+        .add(SbnDnn(n * 4).setInitMethod(Zeros, Zeros).setName(s"bn${name}_branch2c"))
+
+      val model = Sequential()
+        .add(ConcatTable().
+          add(s).
+          add(shortcut(nInputPlane, n*4, stride, name)).setName(s"$name/concatTable"))
+        .add(CAddTable().setName(s"res$name"))
+        .add(ReLU().setName(s"res${name}_relu"))
+      model
+    }
+
+    def getName(i: Int, name: String): String = {
+      val name1 = i match {
+        case 1 => name + "a"
+        case 2 => name + "b"
+        case 3 => name + "c"
+        case 4 => name + "d"
+        case 5 => name + "e"
+        case 6 => name + "f"
+      }
+      return name1
+    }
+
+    def layer(block: (Int, Int, String) => Module[Float], features: Int,
+      count: Int, stride: Int = 1, name : String): Module[Float] = {
+      val s = Sequential()
+      for (i <- 1 to count) {
+        s.add(block(features, if (i == 1) stride else 1, getName(i, name)))
+      }
+      s
+    }
+
+    val model = Sequential()
+    if (dataSet == DatasetType.ImageNet) {
+      val cfg = Map(
+        50 -> ((3, 4, 6, 3), 2048, bottleneck: (Int, Int, String) => Module[Float])
+      )
+
+      require(cfg.keySet.contains(depth), s"Invalid depth ${depth}")
+
+      val (loopConfig, nFeatures, block) = cfg.get(depth).get
+      iChannels = 64
+
+      model.add(Input(Array(batchSize, 3, 224, 224), Memory.FormatTag.nchw))
+        .add(SpatialConvolution(3, 64, 7, 7, 2, 2, 3, 3, propagateBack = false).setName("conv1"))
+        .add(SbnDnn(64).setName("bn_conv1"))
+        .add(ReLU().setName("conv1_relu"))
+        .add(MaxPooling(3, 3, 2, 2).setName("pool1"))
+        .add(layer(block, 64, loopConfig._1, name = "2"))
+        .add(layer(block, 128, loopConfig._2, 2, name = "3"))
+        .add(layer(block, 256, loopConfig._3, 2, name = "4"))
+        .add(layer(block, 512, loopConfig._4, 2, name = "5"))
+        .add(AvgPooling(7, 7, 1, 1).setName("pool5"))
+        .add(Linear(nFeatures, classNum).setInitMethod(RandomNormal(0.0, 0.01), Zeros).setName(
+          "fc1000"))
+        .add(ReorderMemory(HeapData(Array(batchSize, classNum), Memory.FormatTag.nc)))
+    } else {
+      throw new IllegalArgumentException(s"Invalid dataset ${dataSet}")
+    }
+
+    modelInit(model)
+    model
+  }
+
+  def graph(batchSize: Int, classNum: Int, opt: Table): DnnGraph = {
+
+    def modelInit(graph: DnnGraph): Unit = {
+      graph.getSortedForwardExecutions.foreach(n => {
+        n.element match {
+          case conv: SpatialConvolution =>
+            val n: Float = conv.kernelW * conv.kernelW * conv.nOutputPlane
+            val weight = Tensor[Float].resize(conv.weight.size()).apply1 { _ =>
+              RNG.normal(0, Math.sqrt(2.0f / n)).toFloat
+            }
+            val bias = Tensor[Float].resize(conv.bias.size()).apply1(_ => 0.0f)
+            conv.weight.copy(weight)
+            conv.bias.copy(bias)
+
+          case bn: SpatialBatchNormalization =>
+            val weightAndBias = Tensor[Float]().resize(Array(2, bn.nOutput))
+            weightAndBias.select(1, 1).fill(1)
+            weightAndBias.select(1, 2).fill(0)
+            bn.weightAndBias.copy(weightAndBias.view(Array(bn.nOutput * 2)))
+
+          case linear: Linear =>
+            val bias = Tensor[Float](linear.bias.size()).apply1(_ => 0.0f)
+            linear.bias.copy(bias)
+
+          case _ =>
+        }
+      })
+    }
+
+    val depth = opt.get("depth").getOrElse(18)
+    val shortCutType = opt.get("shortcutType")
+    val shortcutType = shortCutType.getOrElse(ShortcutType.B).asInstanceOf[ShortcutType]
+    val dataSet = opt.getOrElse[DatasetType]("dataSet", DatasetType.CIFAR10)
+    val optnet = opt.get("optnet").getOrElse(true)
+
+    def shortcut(input: ModuleNode[Float], nInputPlane: Int, nOutputPlane: Int,
+                 stride: Int, name: String): ModuleNode[Float] = {
+      val useConv = shortcutType == ShortcutType.C ||
+        (shortcutType == ShortcutType.B && nInputPlane != nOutputPlane)
+
+      if (useConv) {
+        val conv = Convolution(nInputPlane, nOutputPlane, 1, 1, stride, stride, optnet = optnet)
+            .setName(s"res${name}_branch1").inputs(input)
+        SbnDnn(nOutputPlane).setName(s"bn${name}_branch1").inputs(conv)
+      } else if (nInputPlane != nOutputPlane) {
+        throw new IllegalArgumentException(s"useConv false")
+      } else {
+        Identity().inputs(input)
+      }
+    }
+
+    def bottleneck(input: ModuleNode[Float], n: Int, stride: Int, name: String = "")
+      : ModuleNode[Float] = {
+      val nInputPlane = iChannels
+      iChannels = n * 4
+
+      val conv1 = Convolution(nInputPlane, n, 1, 1, 1, 1, 0, 0, optnet = optnet)
+          .setName(s"res${name}_branch2a").inputs(input)
+      val bn1 = SbnDnn(n).setName(s"bn${name}_branch2a").inputs(conv1)
+      val relu1 = ReLU().setName(s"res${name}_branch2a_relu").inputs(bn1)
+      val conv2 = Convolution(n, n, 3, 3, stride, stride, 1, 1, optnet = optnet).setName(
+          s"res${name}_branch2b").inputs(relu1)
+      val bn2 = SbnDnn(n).setName(s"bn${name}_branch2b").inputs(conv2)
+      val relu3 = ReLU().setName(s"res${name}_branch2b_relu").inputs(bn2)
+      val conv3 = Convolution(n, n*4, 1, 1, 1, 1, 0, 0, optnet = optnet).setName(
+          s"res${name}_branch2c").inputs(relu3)
+      val bn3 = SbnDnn(n * 4).setInitMethod(Zeros, Zeros).setName(
+          s"bn${name}_branch2c").inputs(conv3)
+
+      val short = shortcut(input, nInputPlane, n*4, stride, name)
+      val cadd = CAddTable().setName(s"res$name").
+          inputs(Array(bn3.asInstanceOf[ModuleNode[Float]], short))
+      val relu = ReLU().setName(s"res${name}_relu").inputs(cadd)
+      relu
+    }
+
+    def getName(i: Int, name: String): String = {
+      val name1 = i match {
+        case 1 => name + "a"
+        case 2 => name + "b"
+        case 3 => name + "c"
+        case 4 => name + "d"
+        case 5 => name + "e"
+        case 6 => name + "f"
+      }
+      return name1
+    }
+
+    def layer(input: ModuleNode[Float],
+              block: (ModuleNode[Float], Int, Int, String) => ModuleNode[Float],
+              features: Int,
+              count: Int, stride: Int = 1, name : String): ModuleNode[Float] = {
+      var in = input
+      for (i <- 1 to count) {
+        val res = block(in, features, if (i == 1) stride else 1, getName(i, name))
+        in = res
+      }
+      in
+    }
+
+    if (dataSet == DatasetType.ImageNet) {
+      val cfg = Map(
+        50 -> ((3, 4, 6, 3), 2048,
+          bottleneck: (ModuleNode[Float], Int, Int, String) => ModuleNode[Float])
+      )
+
+      require(cfg.keySet.contains(depth), s"Invalid depth ${depth}")
+
+      val (loopConfig, nFeatures, block) = cfg.get(depth).get
+      iChannels = 64
+
+      val input = Input(Array(batchSize, 3, 224, 224), Memory.FormatTag.nchw).inputs()
+      val conv1 = SpatialConvolution(3, 64, 7, 7, 2, 2, 3, 3, propagateBack = false)
+        .setName("conv1").inputs(input)
+      val bn1 = SbnDnn(64).setName("bn_conv1").inputs(conv1)
+      val relu1 = ReLU().setName("conv1_relu").inputs(bn1)
+      val pool1 = MaxPooling(3, 3, 2, 2).setName("pool1").inputs(relu1)
+      val layer1 = layer(pool1, block, 64, loopConfig._1, name = "2")
+      val layer2 = layer(layer1, block, 128, loopConfig._2, 2, name = "3")
+      val layer3 = layer(layer2, block, 256, loopConfig._3, 2, name = "4")
+      val layer4 = layer(layer3, block, 512, loopConfig._4, 2, name = "5")
+      val pool2 = AvgPooling(7, 7, 1, 1).setName("pool5").inputs(layer4)
+      val fc = Linear(nFeatures, classNum).setInitMethod(RandomNormal(0.0, 0.01), Zeros).setName(
+          "fc1000").inputs(pool2)
+      val output = ReorderMemory(HeapData(Array(batchSize, classNum),
+        Memory.FormatTag.nc)).inputs(fc)
+
+      val model = DnnGraph(Array(input), Array(output))
+      modelInit(model)
+      model
+    } else {
+      throw new IllegalArgumentException(s"Invalid dataset ${dataSet}")
+    }
+  }
+
+  /**
+   * dataset type
+   * @param typeId type id
+   */
+  sealed abstract class DatasetType(typeId: Int)
+    extends Serializable
+
+  /**
+   *  define some dataset type
+   */
+  object DatasetType {
+    case object CIFAR10 extends DatasetType(0)
+    case object ImageNet extends DatasetType(1)
+  }
+
+  /**
+   * ShortcutType
+   * @param typeId type id
+   */
+  sealed abstract class ShortcutType(typeId: Int)
+    extends Serializable
+
+  /**
+   * ShortcutType-A is used for Cifar-10, ShortcutType-B is used for ImageNet.
+   * ShortcutType-C is used for others.
+   */
+  object ShortcutType{
+    case object A extends ShortcutType(0)
+    case object B extends ShortcutType(1)
+    case object C extends ShortcutType(2)
+  }
+}
+
+object Convolution {
+  def apply(
+    nInputPlane: Int,
+    nOutputPlane: Int,
+    kernelW: Int,
+    kernelH: Int,
+    strideW: Int = 1,
+    strideH: Int = 1,
+    padW: Int = 0,
+    padH: Int = 0,
+    nGroup: Int = 1,
+    propagateBack: Boolean = true,
+    optnet: Boolean = true,
+    weightDecay: Double = 1e-4): SpatialConvolution = {
+    val conv = SpatialConvolution(nInputPlane, nOutputPlane, kernelW, kernelH,
+      strideW, strideH, padW, padH, nGroup, propagateBack)
+    conv.setInitMethod(MsraFiller(false), Zeros)
+    conv
+  }
+}
+
+object SbnDnn {
+  def apply[@specialized(Float, Double) T: ClassTag](
+    nOutput: Int,
+    eps: Double = 1e-3,
+    momentum: Double = 0.9)
+    (implicit ev: TensorNumeric[T]): SpatialBatchNormalization = {
+    SpatialBatchNormalization(nOutput, eps, momentum).setInitMethod(Ones, Zeros)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Phase.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Phase.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+sealed class Phase
+
+object Phase {
+  case object TrainingPhase extends Phase
+
+  case object InferencePhase extends Phase
+
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/RNN.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/RNN.scala
@@ -1,0 +1,519 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl._
+import com.intel.analytics.bigdl.nn.{InitializationMethod, RandomUniform, VariableFormat, Zeros}
+import com.intel.analytics.bigdl.nn.abstractnn.{Activity, Initializable}
+import com.intel.analytics.bigdl.tensor.{DnnTensor, Tensor}
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+/**
+ * @param mode       : the type of RNN cell (LSTM / GRU)
+ * @param inputSize  : the size of input vector
+ * @param hiddenSize : the size of hidden state
+ * @param f          : the type of output activation function
+ *                   (AlgKind.EltwiseTanh or AlgKind.EltwiseRelu)
+ * @param direction  : the direction to run RNN
+ *                   (e.g. Direction.UnidirectionalLeft2Right or Direction.BidirectionalConcat)
+ * @param layers     : the number of RNN layers
+ */
+
+class RNN(
+  val mode: Int,
+  val inputSize: Int,
+  val hiddenSize: Int,
+  val f: Int,
+  val direction: Int,
+  val layers: Int = 1,
+  val flags: Int = 0, // TODO: RNNCellFlags.RNNCellWithRelu,
+  val alpha: Float = 0F,
+  val clipping: Float = 0F,
+  private val initWeight: Tensor[Float] = null,
+  private val initWeightIter: Tensor[Float] = null,
+  private val initBias: Tensor[Float] = null
+) extends MklDnnLayer with Initializable {
+//  private var updateOutputMemoryPrimitives: Array[Long] = _
+//  private var updateOutputTensors: Array[Tensor[Float]] = _
+//  private var updateGradInputMemoryPrimitives: Array[Long] = _
+//  private var updateGradInputTensors: Array[Tensor[Float]] = _
+  private var fwdPD: Long = _
+  private var rnnCellDesc : Long = 0L
+
+  private[mkldnn] var weight: TensorMMap = _
+  private[mkldnn] var weight_i: TensorMMap = _
+  private[mkldnn] var bias: TensorMMap = _
+  private[mkldnn] var gradWeight: TensorMMap = _
+  private[mkldnn] var gradWeight_i: TensorMMap = _
+  private[mkldnn] var gradBias: TensorMMap = _
+
+  private var workSpaceFormat: MemoryData = _
+  private var workSpace : Tensor[Float] = _
+
+  @transient private lazy val reorderManager = new ReorderManager
+  private var weightForBackward: DnnTensor[Float] = _
+  private var weightForBackwardMemoryData: MemoryData = _
+  private var weightIterForBackward: DnnTensor[Float] = _
+  private var weightIterForBackwardMemoryData: MemoryData = _
+
+  private var batchSize: Int = _
+  private var stepSize: Int = _
+  private var inputShape: Array[Int] = _
+  private var outputShape: Array[Int] = _
+  private var weightShape: Array[Int] = _
+  private var weightIterShape: Array[Int] = _
+  private var biasShape: Array[Int] = _
+  private var commonIterShape: Array[Int] = _
+
+  private var src_i: DnnTensor[Float] = _
+  private var dst_i: DnnTensor[Float] = _
+  private var gradsrc_i: DnnTensor[Float] = _
+  private var graddst_i: DnnTensor[Float] = _
+
+  if(layers > 1) {
+    require(inputSize == hiddenSize,
+      "If layer number of RNN is more than 1, the input size and the hidden size should equal.\n"
+      + "inputSize: " + inputSize + '\n'
+      + "hiddenSize: " + hiddenSize)
+  }
+
+  var (ngates, nstates) = mode match {
+    case AlgKind.VanillaLstm => (4, 2)
+    case AlgKind.VanillaGru => (3, 1)
+    case _ =>
+      throw new UnsupportedOperationException("Not support such RNN Cell. Cell type: " + mode)
+  }
+
+  /** TODO: Multi-layer Bidirectional Sum RNN is available in MKLDNN,
+   *  TODO: but the current version of BigDL BLAS does not support it.
+   */
+
+  val (numOfDirections, outputSizeFactor) = direction match {
+    case Direction.UnidirectionalLeft2Right
+         | Direction.UnidirectionalRight2Left => (1, 1)
+    case Direction.BidirectionalConcat =>
+      require(layers == 1, "Bidirectional Concat RNN does not support multiple layers. " +
+        "layers = " + layers)
+      (2, 2)
+    case Direction.BidirectionalSum => (2, 1)
+    case _ => throw new UnsupportedOperationException("Not support such direction")
+  }
+
+  /**
+   * Gate order matching between MKLDNN LSTM and nn/LSTM:
+   * MKLDNN Gate 1 -> nn/LSTM Gate 1 (input gate)
+   * MKLDNN Gate 2 -> nn/LSTM Gate 3 (forget gate)
+   * MKLDNN Gate 3 -> nn/LSTM Gate 2 (hidden)
+   * MKLDNN Gate 4 -> nn/LSTM Gate 4 (output gate)
+   *
+   * Gate order matching between MKLDNN GRU and nn/GRU:
+   * MKLDNN Gate 1 -> nn/GRU Gate 2
+   * MKLDNN Gate 2 -> nn/GRU Gate 1
+   * MKLDNN Gate 3 -> nn/GRU Gate 3
+   */
+
+  weightShape = Array(layers, numOfDirections, inputSize, ngates, hiddenSize)
+  weightIterShape = Array(layers, numOfDirections, hiddenSize, ngates, hiddenSize)
+  biasShape = Array(layers, numOfDirections, ngates, hiddenSize)
+
+  weight = new TensorMMap(weightShape)
+  weight_i = new TensorMMap(weightIterShape)
+  bias = new TensorMMap(biasShape)
+  gradWeight = new TensorMMap(weightShape)
+  gradWeight_i = new TensorMMap(weightIterShape)
+  gradBias = new TensorMMap(biasShape)
+
+  {
+    val stdv = 1.0 / math.sqrt(hiddenSize)
+    val wInit: InitializationMethod = RandomUniform(-stdv, stdv)
+    val bInit: InitializationMethod = Zeros
+    setInitMethod(wInit, bInit)
+  }
+
+  override def reset(): Unit = {
+    if (initWeight == null) {
+      weightInitMethod.init(weight.dense, VariableFormat.Default)
+    } else {
+      weight.dense.copy(initWeight)
+    }
+
+    if (initWeightIter == null) {
+      weightInitMethod.init(weight_i.dense, VariableFormat.Default)
+    } else {
+      weight_i.dense.copy(initWeightIter)
+    }
+
+    if (initBias == null) {
+      biasInitMethod.init(bias.dense, VariableFormat.Default)
+    } else {
+      bias.dense.copy(initBias)
+    }
+  }
+
+  override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+    val kind = if (!isTraining()) {
+      PropKind.ForwardInference
+    } else {
+      PropKind.ForwardTraining
+    }
+
+    /**
+     * TODO: The default format of input is TNC
+     * Batch size of input is needed by creating memory descriptors of src iter and dst iter.
+     * Step size of input is needed by creating memory descriptor of dst layer.
+     * By default, batch size of input is the second element of inputShape
+     * and step size is the first element of inputShape.
+     */
+
+    inputs(0).layout match {
+      case Memory.FormatTag.tnc =>
+        batchSize = inputs(0).shape(1)
+        stepSize = inputs(0).shape(0)
+      case Memory.FormatTag.ntc =>
+        batchSize = inputs(0).shape(0)
+        stepSize = inputs(0).shape(1)
+      case _ =>
+        throw new UnsupportedOperationException("Unsupported input format: " +
+          inputs(0).layout)
+    }
+
+    inputShape = Array(stepSize, batchSize, inputSize)
+    outputShape = Array(stepSize, batchSize, outputSizeFactor * hiddenSize)
+    commonIterShape = Array(layers, numOfDirections, nstates, batchSize, hiddenSize)
+
+    val src_layer = NativeData(inputShape, Memory.FormatTag.any)
+    val src_iter = NativeData(commonIterShape, Memory.FormatTag.any)
+    val wei_layer = NativeData(weightShape, Memory.FormatTag.any)
+    val wei_iter = NativeData(weightIterShape, Memory.FormatTag.any)
+    val bis = NativeData(biasShape, Memory.FormatTag.any)
+    val dst_layer = NativeData(outputShape, Memory.FormatTag.any)
+    val dst_iter = NativeData(commonIterShape, Memory.FormatTag.any)
+
+    val src_layer_MD = src_layer.getMemoryDescriptor()
+    val src_iter_MD = src_iter.getMemoryDescriptor()
+    val weights_layer_MD = wei_layer.getMemoryDescriptor()
+    val weights_iter_MD = wei_iter.getMemoryDescriptor()
+    val bis_MD = bis.getMemoryDescriptor()
+    val dist_layer_MD = dst_layer.getMemoryDescriptor()
+    val dist_iter_MD = dst_iter.getMemoryDescriptor()
+
+    rnnCellDesc = mode match {
+      case AlgKind.VanillaLstm =>
+        DnnlMemory.RNNCellDescInit(AlgKind.VanillaLstm, f, flags, alpha, clipping)
+      case AlgKind.VanillaGru =>
+        DnnlMemory.RNNCellDescInit(AlgKind.VanillaGru, f, flags, alpha, clipping)
+      case _ => throw new UnsupportedOperationException("Not support such RNN cell. " +
+        "Cell type: " + mode)
+    }
+
+    val description = DnnlMemory.RNNForwardDescInit(kind, rnnCellDesc, direction, src_layer_MD,
+      src_iter_MD, weights_layer_MD, weights_iter_MD, bis_MD, dist_layer_MD, dist_iter_MD)
+
+    fwdPD = DnnlMemory.PrimitiveDescCreate(description, runtime.engine, 0L)
+
+    val realSrc = MemoryData.operationWant(fwdPD, Query.SrcMd, 0)
+    val realSrc_iter = MemoryData.operationWant(fwdPD, Query.SrcMd, 1)
+    val realWei = MemoryData.operationWant(fwdPD, Query.WeightsMd, 0)
+    val realWei_iter = MemoryData.operationWant(fwdPD, Query.WeightsMd, 1)
+    val realBias = MemoryData.operationWant(fwdPD, Query.WeightsMd, 2)
+    val realDst = MemoryData.operationWant(fwdPD, Query.DstMd, 0)
+    val realDst_iter = MemoryData.operationWant(fwdPD, Query.DstMd, 1)
+
+    require(weight.size().product == realWei.shape.product,
+      s"${getName} weight shape is not correct.")
+    require(weight_i.size().product == realWei_iter.shape.product,
+      s"${getName} weight iter shape is not correct.")
+    require(bias.size().product == realBias.shape.product,
+      s"${getName} bias shape is not correct.")
+
+    weight.setMemoryData(HeapData(weightShape, Memory.FormatTag.ldigo), realWei, runtime)
+    weight_i.setMemoryData(HeapData(weightIterShape, Memory.FormatTag.ldigo), realWei_iter, runtime)
+    bias.setMemoryData(HeapData(biasShape, Memory.FormatTag.ldgo), realBias, runtime)
+
+    weight.sync()
+    weight_i.sync()
+    bias.sync()
+
+    src_i = initTensor(realSrc_iter).asInstanceOf[DnnTensor[Float]]
+    dst_i = initTensor(realDst_iter).asInstanceOf[DnnTensor[Float]]
+    src_i.zero()
+    dst_i.zero()
+
+//    val srcs = Array(
+//      realSrc.getMemoryObject(runtime), realSrc_iter.getMemoryObject(runtime),
+//      realWei.getMemoryObject(runtime), realWei_iter.getMemoryObject(runtime),
+//      realBias.getMemoryObject(runtime))
+//
+//    val indexes = Array.fill(srcs.length)(0)
+//
+//    val dsts = if (isTraining()) {
+//      Array(realDst.getMemoryObject(runtime),
+//        realDst_iter.getMemoryObject(runtime),
+//        workSpaceFormat.getMemoryObject(runtime))
+//    }
+//    else {
+//      Array(realDst.getMemoryObject(runtime),
+//        realDst_iter.getMemoryObject(runtime))
+//    }
+
+    fwdExecArgs = mutable.Map(
+      ArgType.DNNL_ARG_SRC -> realSrc.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_SRC_ITER -> realSrc_iter.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_WEIGHTS -> realWei.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_WEIGHTS_ITER -> realWei_iter.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_BIAS -> realBias.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DST -> realDst.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DST_ITER -> realDst_iter.getMemoryObject(runtime)
+    )
+
+    if (isTraining()) {
+      workSpaceFormat = MemoryData.operationWant(fwdPD, Query.WorkspaceMd, 0)
+      workSpace = initTensor(workSpaceFormat).asInstanceOf[Tensor[Float]]
+      fwdExecArgs(ArgType.DNNL_ARG_WORKSPACE) = workSpaceFormat.getMemoryObject(runtime)
+    }
+
+//    val primitive = DnnlMemory.PrimitiveCreate2(fwdPD, srcs, indexes,
+//      srcs.length, dsts, dsts.length)
+    val primitive = DnnlMemory.PrimitiveCreate(fwdPD)
+
+    updateOutputPrimitives = Array(primitive)
+    output = initTensor(realDst)
+
+    _inputFormats = Array(realSrc)
+    _outputFormats = Array(realDst)
+
+    (_inputFormats, _outputFormats)
+  }
+
+  override def updateOutput(input: Activity): Activity = {
+    if (updateOutputTensors == null) {
+      updateOutputTensors = mutable.Map(
+        ArgType.DNNL_ARG_SRC -> input.asInstanceOf[Tensor[Float]],
+        ArgType.DNNL_ARG_SRC_ITER -> src_i,
+        ArgType.DNNL_ARG_WEIGHTS -> weight.native,
+        ArgType.DNNL_ARG_WEIGHTS_ITER -> weight_i.native,
+        ArgType.DNNL_ARG_BIAS -> bias.native,
+        ArgType.DNNL_ARG_DST -> output.asInstanceOf[Tensor[Float]],
+        ArgType.DNNL_ARG_DST_ITER -> dst_i
+      )
+      if (isTraining()) {
+        updateOutputTensors(ArgType.DNNL_ARG_WORKSPACE) = workSpace
+      }
+    }
+
+    if (isTraining()) {
+      weight.sync()
+      weight_i.sync()
+      bias.sync()
+    }
+
+    updateWithNewTensor(updateOutputTensors, ArgType.DNNL_ARG_SRC, input)
+
+    // TODO:
+    MklDnnOps.streamSubmit(updateOutputPrimitives,
+      runtime.stream, fwdExecArgs, updateOutputTensors)
+
+    output
+  }
+
+  override private[mkldnn] def initBwdPrimitives(grad: Array[MemoryData], phase: Phase) = {
+    reorderManager.setRuntime(runtime)
+
+    val src_layer_bw = NativeData(inputShape, Memory.FormatTag.any)
+    val src_iter_bw = NativeData(commonIterShape, Memory.FormatTag.any)
+    val wei_layer_bw = NativeData(weightShape, Memory.FormatTag.any)
+    val wei_iter_bw = NativeData(weightIterShape, Memory.FormatTag.any)
+    val bis_bw = NativeData(biasShape, Memory.FormatTag.any)
+    val dst_layer_bw = NativeData(outputShape, Memory.FormatTag.any)
+    val dst_iter_bw = NativeData(commonIterShape, Memory.FormatTag.any)
+    val diff_src_layer = NativeData(inputShape, Memory.FormatTag.any)
+    val diff_src_iter = NativeData(commonIterShape, Memory.FormatTag.any)
+    val diff_weights_layer = NativeData(weightShape, Memory.FormatTag.ldigo)
+    // IMPORTANT : it has to be ldigo
+    val diff_weights_iter = NativeData(weightIterShape, Memory.FormatTag.ldigo)
+    // IMPORTANT : it has to be ldigo
+    val diff_bias = NativeData(biasShape, Memory.FormatTag.any)
+    val diff_dist_layer = NativeData(outputShape, Memory.FormatTag.any)
+    val diff_dist_iter = NativeData(commonIterShape, Memory.FormatTag.any)
+
+    val src_layer_bw_MD = src_layer_bw.getMemoryDescriptor()
+    val src_iter_bw_MD = src_iter_bw.getMemoryDescriptor()
+    val weights_layer_bw_MD = wei_layer_bw.getMemoryDescriptor()
+    val weights_iter_bw_MD = wei_iter_bw.getMemoryDescriptor()
+    val bis_bw_MD = bis_bw.getMemoryDescriptor()
+    val dist_layer_bw_MD = dst_layer_bw.getMemoryDescriptor()
+    val dist_iter_bw_MD = dst_iter_bw.getMemoryDescriptor()
+    val diff_src_layer_MD = diff_src_layer.getMemoryDescriptor()
+    val diff_src_iter_MD = diff_src_iter.getMemoryDescriptor()
+    val diff_weights_layer_MD = diff_weights_layer.getMemoryDescriptor()
+    val diff_weights_iter_MD = diff_weights_iter.getMemoryDescriptor()
+    val diff_bis_MD = diff_bias.getMemoryDescriptor()
+    val diff_dist_layer_MD = diff_dist_layer.getMemoryDescriptor()
+    val diff_dist_iter_MD = diff_dist_iter.getMemoryDescriptor()
+
+    val description = DnnlMemory.RNNBackwardDescInit(PropKind.Backward, rnnCellDesc,
+      direction, src_layer_bw_MD,
+      src_iter_bw_MD, weights_layer_bw_MD,
+      weights_iter_bw_MD, bis_bw_MD,
+      dist_layer_bw_MD, dist_iter_bw_MD,
+
+      diff_src_layer_MD, diff_src_iter_MD,
+      diff_weights_layer_MD, diff_weights_iter_MD,
+      diff_bis_MD, diff_dist_layer_MD,
+      diff_dist_iter_MD
+    )
+
+    val bwdPD = DnnlMemory.PrimitiveDescCreate(description, runtime.engine, fwdPD)
+
+    val realSrc = MemoryData.operationWant(bwdPD, Query.SrcMd, 0)
+    val realSrc_iter = MemoryData.operationWant(bwdPD, Query.SrcMd, 1)
+    val realWei = MemoryData.operationWant(bwdPD, Query.WeightsMd, 0)
+    val realWei_iter = MemoryData.operationWant(bwdPD, Query.WeightsMd, 1)
+    val realBias = MemoryData.operationWant(bwdPD, Query.WeightsMd, 2)
+    val realDst = MemoryData.operationWant(bwdPD, Query.DstMd, 0)
+    val realDst_iter = MemoryData.operationWant(bwdPD, Query.DstMd, 1)
+    val realDiffDst = MemoryData.operationWant(bwdPD, Query.DiffDstMd, 0)
+    val realDiffDst_iter = MemoryData.operationWant(bwdPD, Query.DiffDstMd, 1)
+
+    val realDiffSrc = MemoryData.operationWant(bwdPD, Query.DiffSrcMd, 0)
+    val realDiffSrc_iter = MemoryData.operationWant(bwdPD, Query.DiffSrcMd, 1)
+    val realDiffWei = MemoryData.operationWant(bwdPD, Query.DiffWeightsMd, 0)
+    val realDiffWei_iter = MemoryData.operationWant(bwdPD, Query.DiffWeightsMd, 1)
+    val realDiffBias = MemoryData.operationWant(bwdPD, Query.DiffWeightsMd, 2)
+
+    weightForBackwardMemoryData = realWei
+    reorderManager.register(weight.heapData, realWei)
+    weightForBackward = reorderManager
+      .infer(Array(weight.heapData), Array(weightForBackwardMemoryData), weight.dense)
+      .asInstanceOf[DnnTensor[Float]]
+
+    weightIterForBackwardMemoryData = realWei_iter
+    reorderManager.register(weight_i.heapData, realWei_iter)
+    weightIterForBackward = reorderManager
+      .infer(Array(weight_i.heapData), Array(weightIterForBackwardMemoryData), weight_i.dense)
+      .asInstanceOf[DnnTensor[Float]]
+
+    gradWeight.setMemoryData(realDiffWei, HeapData(weightShape, Memory.FormatTag.ldigo), runtime)
+    gradWeight_i.setMemoryData(realDiffWei_iter, HeapData(weightIterShape, Memory.FormatTag.ldigo),
+      runtime)
+    gradBias.setMemoryData(realDiffBias, HeapData(biasShape, Memory.FormatTag.ldgo), runtime)
+
+    gradWeight.zero()
+    gradWeight_i.zero()
+    gradBias.zero()
+
+    gradsrc_i = initTensor(realDiffSrc_iter).asInstanceOf[DnnTensor[Float]]
+    graddst_i = initTensor(realDiffDst_iter).asInstanceOf[DnnTensor[Float]]
+    gradsrc_i.zero()
+    graddst_i.zero()
+
+    val srcs = Array(realSrc.getMemoryObject(runtime), realSrc_iter.getMemoryObject(runtime),
+      realWei.getMemoryObject(runtime), realWei_iter.getMemoryObject(runtime),
+      realBias.getMemoryObject(runtime), realDst.getMemoryObject(runtime),
+      realDst_iter.getMemoryObject(runtime), realDiffDst.getMemoryObject(runtime),
+      realDiffDst_iter.getMemoryObject(runtime), workSpaceFormat.getMemoryObject(runtime))
+    val indexes = Array.fill(srcs.length)(0)
+
+    val dsts = Array(realDiffSrc.getMemoryObject(runtime),
+      realDiffSrc_iter.getMemoryObject(runtime),
+      realDiffWei.getMemoryObject(runtime), realDiffWei_iter.getMemoryObject(runtime),
+      realDiffBias.getMemoryObject(runtime)
+    )
+
+//    val primitive = DnnlMemory.PrimitiveCreate(bwdPD, srcs, indexes, srcs.length,
+//      dsts, dsts.length)
+    val primitive = DnnlMemory.PrimitiveCreate(bwdPD)
+
+//    updateGradInputMemoryPrimitives = srcs ++ dsts
+    updateGradInputPrimitives = Array(primitive)
+    gradInput = initTensor(realDiffSrc)
+
+    _gradInputFormats = Array(realDiffSrc)
+    _gradOutputFormats = Array(realDiffDst)
+    (_gradOutputFormats, _gradInputFormats)
+  }
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+//    if (updateGradInputTensors == null) {
+//      val buffer = new ArrayBuffer[Tensor[Float]]()
+//      buffer.append(input.asInstanceOf[Tensor[Float]])
+//      buffer.append(src_i)
+//      buffer.append(weightForBackward)
+//      buffer.append(weightIterForBackward)
+//      buffer.append(bias.native)
+//      buffer.append(output.asInstanceOf[Tensor[Float]])
+//      buffer.append(dst_i)
+//      buffer.append(gradOutput.asInstanceOf[Tensor[Float]])
+//      buffer.append(graddst_i)
+//      buffer.append(workSpace)
+//
+//      buffer.append(gradInput.asInstanceOf[Tensor[Float]])
+//      buffer.append(gradsrc_i)
+//      buffer.append(gradWeight.native)
+//      buffer.append(gradWeight_i.native)
+//      buffer.append(gradBias.native)
+//
+//      updateGradInputTensors = buffer.toArray
+//    }
+
+//    updateWithNewTensor(updateGradInputTensors, 0, input)
+//    updateWithNewTensor(updateGradInputTensors, 7, gradOutput)
+
+    // TODO:
+//    MklDnnOps.streamSubmit(runtime.stream, 1, updateGradInputPrimitives,
+//      updateGradInputPrimitives.length,
+//      updateGradInputMemoryPrimitives, updateGradInputTensors)
+
+    gradWeight.sync()
+    gradWeight_i.sync()
+    gradBias.sync()
+
+    gradInput
+  }
+
+  override def accGradParameters(input: Activity, gradOutput: Activity): Unit = {
+    // Do nothing
+  }
+
+  override def parameters(): (Array[Tensor[Float]], Array[Tensor[Float]]) = {
+    (Array(weight.dense, bias.dense, weight_i.dense),
+      Array(gradWeight.dense, gradBias.dense, gradWeight_i.dense))
+  }
+
+  override def zeroGradParameters(): Unit = {
+  }
+
+}
+
+object RNN{
+  def apply(
+   mode: Int,
+   inputSize: Int,
+   hiddenSize: Int,
+   f: Int,
+   direction: Int,
+   layers: Int = 1,
+   flags: Int = 0, // TODO: RNNCellFlags.RNNCellWithRelu,
+   alpha: Float = 0F,
+   clipping: Float = 0F,
+   initWeight: Tensor[Float] = null,
+   initWeightIter: Tensor[Float] = null,
+   initBias: Tensor[Float] = null
+ ): RNN = new RNN(mode, inputSize, hiddenSize, f, direction, layers, flags, alpha,
+    clipping, initWeight, initWeightIter, initBias)
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/ReLU.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/ReLU.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl._
+import com.intel.analytics.bigdl.nn.MklInt8Convertible
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.tensor.Tensor
+
+import scala.collection.mutable
+
+class ReLU(value: Float = 0.0f) extends MklDnnLayer with MklInt8Convertible {
+  private val UNDEFINED: Long = 0
+
+  @transient private var fwdPrimDesc: Long = UNDEFINED
+
+  override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+    _inputFormats = singleNativeData(inputs)
+    val description = DnnlMemory.EltwiseForwardDescInit(
+      PropKind.Forward, AlgKind.EltwiseRelu, _inputFormats(0).getMemoryDescriptor(), value, 0)
+    fwdPrimDesc = DnnlMemory.PrimitiveDescCreate(description, runtime.engine, 0L)
+    _outputFormats = Array(MemoryData.primitiveOutput(fwdPrimDesc))
+    updateOutputPrimitives = Array(
+      DnnlMemory.PrimitiveCreate(fwdPrimDesc)
+    )
+    initFwdExecArgs()
+    output = initTensor(_outputFormats(0))
+
+    (_inputFormats, _outputFormats)
+  }
+
+  override private[mkldnn] def initBwdPrimitives(grad: Array[MemoryData], phase: Phase) = {
+    _gradOutputFormats = singleNativeData(grad)
+    _gradOutputFormatsForWeight = _gradOutputFormats
+
+    val description = DnnlMemory.EltwiseBackwardDescInit(AlgKind.EltwiseRelu,
+      _gradOutputFormats(0).getMemoryDescriptor(), _inputFormats(0).getMemoryDescriptor(),
+      value, 0)
+    require(fwdPrimDesc != UNDEFINED, "You should call initFwdPrimitives first")
+    val primDesc = DnnlMemory.PrimitiveDescCreate(description, runtime.engine, fwdPrimDesc)
+    _gradInputFormats = Array(MemoryData.operationWant(primDesc, Query.DiffDstMd))
+    updateGradInputPrimitives = Array(
+      DnnlMemory.PrimitiveCreate(primDesc))
+    gradInput = initTensor(_gradInputFormats(0))
+    (_gradOutputFormats, _gradInputFormats)
+  }
+
+   override def initBwdExecArgs(): Unit = {
+    bwdExecArgs = mutable.Map(
+      ArgType.DNNL_ARG_DIFF_SRC ->
+        gradInputFormats().map(_.getMemoryObject(runtime)).head,
+      ArgType.DNNL_ARG_DIFF_DST ->
+        gradOutputFormats().map(_.getMemoryObject(runtime)).head,
+      ArgType.DNNL_ARG_SRC ->
+        inputFormats().map(_.getMemoryObject(runtime)).head
+    )
+  }
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    if (bwdExecArgs == null) {
+      initBwdExecArgs()
+    }
+
+    if (updateGradInputTensors == null) {
+      updateGradInputTensors = mutable.Map(
+        ArgType.DNNL_ARG_DIFF_SRC ->
+          gradInput.asInstanceOf[Tensor[Float]]
+      )
+    }
+
+    updateGradInputTensors(ArgType.DNNL_ARG_SRC) = input.asInstanceOf[Tensor[Float]]
+    updateGradInputTensors(ArgType.DNNL_ARG_DIFF_DST) = gradOutput.asInstanceOf[Tensor[Float]]
+
+    MklDnnOps.streamSubmit(updateGradInputPrimitives,
+      runtime.stream, bwdExecArgs,
+      updateGradInputTensors
+    )
+
+    gradInput
+  }
+}
+
+object ReLU {
+  def apply(value: Float = 0.0f): ReLU = new ReLU(value)
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/ReorderManager.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/ReorderManager.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.{DNNL, DataType}
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.T
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+private[mkldnn] class ReorderManager()(implicit owner: MemoryOwner) {
+  // (MemoryFormatId, TargetFormat) -> Reorder
+  val reorders = mutable.HashMap[(Int, MemoryData), ReorderMemory]()
+  // ReorderId -> RefCount
+  val refCounts = mutable.HashMap[Int, Int]()
+  val useCounts = mutable.HashMap[Int, Int]()
+
+  private var runtime: MklDnnRuntime = _
+
+  def register(from: MemoryData, to: MemoryData): Unit = {
+    require(runtime != null, "Please call setRuntime first")
+    val mId = System.identityHashCode(from)
+    if (needReorder(from, to)) {
+//      println("need reorder",
+//        s"from ${from.getMemoryDescriptor()}", s"to ${to.getMemoryDescriptor()}")
+      if (reorders.contains((mId, to))) {
+//        println("contains")
+        refCounts(System.identityHashCode(reorders((mId, to)))) += 1
+      } else {
+//        println("not contains")
+        val reorder = ReorderMemory(to)
+        reorder.setRuntime(runtime)
+        reorder.initFwdPrimitives(Array(from), Phase.InferencePhase)
+        reorders((mId, to)) = reorder
+        val reorderId = System.identityHashCode(reorder)
+        refCounts(reorderId) = 1
+        useCounts(reorderId) = 0
+      }
+    } else {
+//      println("dont need reorder")
+    }
+  }
+
+
+  def setRuntime(runtime: MklDnnRuntime): Unit = {
+    this.runtime = runtime
+  }
+
+  def infer(from: Array[MemoryData], to: Array[MemoryData], output: Activity)
+  : Activity = {
+    if (from.length == 1) {
+      require(output.isTensor, "output activity should be a tensor")
+      inferTensor(from(0), to(0), output.asInstanceOf[Tensor[Float]])
+    } else {
+      require(output.toTable.length() == from.length,
+        "output activity length doesn't match")
+      val outputTable = T()
+      var i = 0
+      while(i < from.length) {
+        outputTable(i + 1) = inferTensor(from(i), to(i), output.toTable(i + 1))
+        i += 1
+      }
+      outputTable
+    }
+  }
+
+  private def inferTensor(from: MemoryData, to : MemoryData, output: Tensor[Float])
+  : Tensor[Float] = {
+    val mId = System.identityHashCode(from)
+    if (reorders.contains((mId, to))) {
+      val reorder = reorders((mId, to))
+      val reorderId = System.identityHashCode(reorder)
+      val result = if (useCounts(reorderId) == 0) {
+        reorder.forward(output).asInstanceOf[Tensor[Float]]
+      } else {
+        reorder.output.asInstanceOf[Tensor[Float]]
+      }
+      useCounts(reorderId) += 1
+      if (useCounts(reorderId) == refCounts(reorderId)) {
+        useCounts(reorderId) = 0
+      }
+      result
+    } else {
+      output
+    }
+  }
+
+  private def needReorder(from: MemoryData, to: MemoryData): Boolean = {
+    from match {
+      case h: HeapData =>
+        to match {
+          case hh: HeapData => h.layout != hh.layout
+          case nn: NativeData => true
+          case _ => throw new UnsupportedOperationException("Not support such memory format")
+        }
+      case n: NativeData =>
+        to match {
+          case hh: HeapData => true
+          case nn: NativeData =>
+            n.getMemoryDescriptor()
+            nn.getMemoryDescriptor()
+            if (DNNL.MemoryPrimitiveDescEqual(n.getMemoryDescriptor(),
+              nn.getMemoryDescriptor()) == 1 && n.layout == nn.layout) {
+//              println(n.getMemoryDescriptor(), nn.getMemoryDescriptor())
+//              println(n.shape.mkString(" "), nn.shape.mkString(" "))
+//              println(n.dataType, nn.dataType)
+//              println(n.layout, nn.layout)
+//              println("Mds are equal")
+                false
+            } else {
+              if (n.dataType == DataType.S8 && nn.dataType == DataType.U8) {
+                false
+              } else {
+                true
+              }
+            }
+            case _ => throw new UnsupportedOperationException("Not support such memory format")
+        }
+      case _ => throw new UnsupportedOperationException("Not support such memory format")
+    }
+  }
+
+  def release(): Unit = { }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/ReorderMemory.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/ReorderMemory.scala
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.{ArgType, DNNL, DataType, Memory}
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.tensor.Tensor
+
+import scala.collection.mutable
+
+
+class ReorderMemory(inputFormat: MemoryData, outputFormat: MemoryData,
+                    gradInputFormat: MemoryData, gradOutputFormat: MemoryData,
+                    memoryOwner: MemoryOwner = null) extends MklDnnLayer with Releasable {
+  // ReorderMemory is a special layer. It can be owned by other layers.
+  // So there is an optional MemoryOwner that can be null.
+  // If it is null, this means the ReorderMemory is a normal layer.
+  // If it is not null, it means ReorderMemory is owned by another layer
+  if (memoryOwner != null) {
+    memoryOwner.registerResource(this)
+  }
+
+  _outputFormats = Array(outputFormat)
+  _gradInputFormats = Array(gradInputFormat)
+
+  private var realInput : Array[MemoryData] = null
+  private var realOutput : Array[MemoryData] = null
+  private var realgradInput : Array[MemoryData] = null
+  private var realgradOutput : Array[MemoryData] = null
+
+  private def initMemory(src: MemoryData, shape: Array[Int], layout: Int)
+  : Array[MemoryData] = {
+    val ret = src match {
+      case h: HeapData => Array(HeapData(shape, layout, src.dataType))
+      case n: NativeData =>
+        val memory = NativeData(shape, layout, src.dataType)
+        memory.getMemoryObject(runtime)
+        Array(memory)
+      case _ => throw new UnsupportedOperationException("Not support such memory format")
+    }
+
+    ret(0).setMask(src.mask)
+    ret(0).setScales(src.scales)
+    ret.asInstanceOf[Array[MemoryData]]
+  }
+
+  private def shapeToString(shape: Array[Int]): String = {
+    var name = ""
+    shape.foreach(s => name += s.toString + ",")
+    name
+  }
+
+  private def reshapeOutputIfNeeded(format: MemoryData, tensor: Tensor[Float]): Unit = {
+    // must pay attention to the shape of tensor when format is nhwc,
+    // the Tensor's shape in BigDL always be relevant with the format, such as
+    // [4, 3, 224, 224] will be nchw and [4, 224, 224, 3] will be nhwc.
+    // but for mkldnn, it always uses the nchw format shape, library will use
+    // correct shape by the format.
+    if (format.layout == Memory.FormatTag.nhwc && format.isInstanceOf[HeapData]) {
+      tensor.toTensor[Float].resize(format.shape)
+    }
+    // for mkldnn, it always use tnc format shape even though format is ntc
+    if (format.layout == Memory.FormatTag.ntc && format.isInstanceOf[HeapData]) {
+      tensor.toTensor[Float].resize(format.shape)
+    }
+  }
+
+  private def createInt8PrimDesc(inputMd: Long, outputMd: Long): Long = {
+    val attr = DnnlMemory.CreateAttr()
+    // TODO:
+    // DNNL.AttrSetIntOutputRoundMode(attr, 1)
+
+    if (realOutput(0).scales == null || realOutput(0).scales.isEmpty) {
+      realOutput(0).setMask(realInput(0).mask)
+      realOutput(0).setScales(realInput(0).scales)
+    }
+    // if convert s8/u8 to f32, we should set the scale factor to 1.0f/x
+    if (realOutput(0).dataType == DataType.F32) {
+      realOutput(0).setScales(realOutput(0).scales.map(1.0f / _))
+    }
+    // copy the scales back to outputFormats if not equal
+    if (realOutput(0) ne _outputFormats(0)) {
+      _outputFormats(0).setMask(realOutput(0).mask)
+      _outputFormats(0).setScales(realOutput(0).scales)
+    }
+
+    require(realOutput(0).scales.nonEmpty)
+    DNNL.AttrSetOutputScales(attr, realOutput(0).scales.length,
+      realOutput(0).mask, realOutput(0).scales)
+    DnnlMemory.ReorderPrimitiveDescCreate(inputMd, outputMd, runtime.engine, attr)
+  }
+
+  override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+    // 1. Get input's MemoryData
+    _inputFormats = if (inputFormat == null) inputs else Array(inputFormat)
+    require(_inputFormats.length == 1, "Only accept one tensor as input")
+
+    if (outputFormat == null) {
+      _outputFormats = _inputFormats
+    }
+
+    require(_inputFormats(0).shape.product == _outputFormats(0).shape.product,
+      "input output memory not match, input shape " + shapeToString(_inputFormats(0).shape)
+        + "output shape " + shapeToString(_outputFormats(0).shape))
+
+    val inputShape = _inputFormats(0).shape
+    val outputShape = _outputFormats(0).shape
+    val inputLayout = _inputFormats(0).layout
+    val outputLayout = _outputFormats(0).layout
+
+    realInput = _inputFormats
+    realOutput = _outputFormats
+    if (inputLayout != outputLayout) {
+      if (inputLayout == Memory.FormatTag.nhwc || inputLayout == Memory.FormatTag.ntc) {
+        // remind: if format of input MemoryData is nhwc or ntc,
+        // its shape should be output shape
+        realInput = initMemory(_inputFormats(0), outputShape, inputLayout)
+      } else if (outputLayout == Memory.FormatTag.nhwc || outputLayout == Memory.FormatTag.ntc) {
+        // remind: if format of output MemoryData is nhwc or ntc,
+        // its shape should be input shape
+        realOutput = initMemory(_outputFormats(0), inputShape, outputLayout)
+      }
+    }
+
+    val noInt8Formats = inputFormats()(0).dataType == DataType.F32 &&
+      outputFormats()(0).dataType == DataType.F32
+    val inputMd = realInput(0).getMemoryDescriptor()
+    val outputMd = realOutput(0).getMemoryDescriptor()
+
+    val fwdReorderPrimDesc = if (noInt8Formats) {
+      val engine = runtime.engine
+      DnnlMemory.ReorderPrimitiveDescCreate(inputMd, outputMd, engine, 0L)
+    } else {
+      createInt8PrimDesc(inputMd, outputMd)
+    }
+    val fwdReorderPrim = DnnlMemory.PrimitiveCreate(fwdReorderPrimDesc)
+    updateOutputPrimitives = Array(fwdReorderPrim)
+    // recover to original data
+    output = initTensor(realOutput(0))
+    reshapeOutputIfNeeded(_outputFormats(0), output.toTensor[Float])
+
+    // TODO: (realInput, realOutput)
+    (_inputFormats, _outputFormats)
+  }
+
+  override private[mkldnn] def initBwdPrimitives(grads: Array[MemoryData], phase: Phase) = {
+
+    _gradInputFormats = (gradInputFormat, inputFormat) match {
+      case (null, null) => inputFormats()
+      case (null, x) => Array(x)
+      case (x, _) => Array(x)
+    }
+
+    _gradOutputFormats = if (gradOutputFormat == null) grads else Array(gradOutputFormat)
+    require(_gradOutputFormats.length == 1, "Only accept one tensor as input")
+    require(_gradOutputFormats(0).shape.product == _gradInputFormats(0).shape.product,
+      "gradInput and gradOutput memory not match," +
+        "gradInput shape " + shapeToString(_gradInputFormats(0).shape)
+        + "gradOutput shape " + shapeToString(_gradOutputFormats(0).shape))
+
+    val gradInputShape = _gradInputFormats(0).shape
+    val gradOutputShape = _gradOutputFormats(0).shape
+    val gradInputLayout = _gradInputFormats(0).layout
+    val gradOutputLayout = _gradOutputFormats(0).layout
+
+    realgradInput = _gradInputFormats
+    realgradOutput = _gradOutputFormats
+
+    if (gradInputLayout != gradOutputLayout) {
+      if (gradOutputLayout == Memory.FormatTag.nhwc || gradOutputLayout == Memory.FormatTag.ntc) {
+        // remind: if format of gradOutput MemoryData is nhwc or ntc,
+        // its shape should be gradInput shape
+        realgradOutput = initMemory(_gradOutputFormats(0), gradInputShape, gradOutputLayout)
+      } else if (gradInputLayout == Memory.FormatTag.nhwc ||
+        gradInputLayout == Memory.FormatTag.ntc) {
+        // remind: if format of gradInput MemoryData is nhwc or ntc,
+        // its shape should be gradOutput shape
+        realgradInput = initMemory(_gradInputFormats(0), gradOutputShape, gradInputLayout)
+      }
+    }
+
+    val gradOutputMd = realgradOutput(0).getMemoryDescriptor()
+    val gradInputMd = realgradInput(0).getMemoryDescriptor()
+    val engine = runtime.engine
+    val bwdReorderPrimDesc = DnnlMemory.ReorderPrimitiveDescCreate(
+      gradOutputMd, gradInputMd, engine, 0L
+    )
+    val bwdReorderPrim = DnnlMemory.PrimitiveCreate(bwdReorderPrimDesc)
+    updateGradInputPrimitives = Array(bwdReorderPrim)
+    gradInput = initTensor(realgradInput(0))
+    reshapeOutputIfNeeded(_gradInputFormats(0), gradInput.toTensor[Float])
+
+    // TODO: (realgradOutput, realgradInput)
+    (_gradOutputFormats, _gradInputFormats)
+  }
+
+  override def updateOutput(input: Activity): Activity = {
+    fwdExecArgs = mutable.Map(
+      ArgType.DNNL_ARG_FROM -> realInput(0).getMemoryObject(runtime),
+      ArgType.DNNL_ARG_TO -> realOutput(0).getMemoryObject(runtime)
+    )
+    updateOutputTensors = mutable.Map(
+      ArgType.DNNL_ARG_FROM -> input.asInstanceOf[Tensor[Float]],
+      ArgType.DNNL_ARG_TO -> output.asInstanceOf[Tensor[Float]]
+    )
+    MklDnnOps.streamSubmit(updateOutputPrimitives,
+      runtime.stream, fwdExecArgs,
+      updateOutputTensors
+    )
+    output
+  }
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    bwdExecArgs = mutable.Map(
+      ArgType.DNNL_ARG_FROM -> realgradOutput(0).getMemoryObject(runtime),
+      ArgType.DNNL_ARG_TO -> realgradInput(0).getMemoryObject(runtime)
+    )
+    updateGradInputTensors = mutable.Map(
+      ArgType.DNNL_ARG_FROM -> gradOutput.asInstanceOf[Tensor[Float]],
+      ArgType.DNNL_ARG_TO -> gradInput.asInstanceOf[Tensor[Float]]
+    )
+    MklDnnOps.streamSubmit(updateGradInputPrimitives,
+      runtime.stream, bwdExecArgs,
+      updateGradInputTensors
+    )
+    gradInput
+  }
+
+  override def toString(): String = {
+    if (_inputFormats != null) {
+      s"nn.mkl.ReorderMemory(${_inputFormats(0)} -> ${outputFormat})"
+    } else {
+      s"nn.mkl.ReorderMemory(_ -> ${outputFormat})"
+    }
+  }
+}
+
+object ReorderMemory {
+  // We don't use "apply" as the function name here. The reason is that scala does not
+  // allow overloaded function (functions having the same name) with default parameters
+  // Hence, we bypass this issue by defining two functions.
+  def create(inputFormat: MemoryData, outputFormat: MemoryData, gradInputFormat: MemoryData,
+             gradOutputFomat: MemoryData)
+            (implicit memoryOwner: MemoryOwner = null): ReorderMemory = {
+    new ReorderMemory(inputFormat, outputFormat, gradInputFormat, gradOutputFomat, memoryOwner)
+  }
+
+  def apply(outputFormat: MemoryData, gradInputFormat: MemoryData = null)
+           (implicit memoryOwner: MemoryOwner = null): ReorderMemory = {
+    new ReorderMemory(null, outputFormat, gradInputFormat, null,
+      memoryOwner)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/SelectTable.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/SelectTable.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.nn.{Utils => NNUtils}
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.{T, Table}
+
+import scala.reflect.ClassTag
+
+/**
+ * Creates a module that takes a table as input and outputs the element at index `index`
+ * (positive or negative). This can be either a table or a Tensor.
+ * The gradients of the non-index elements are zeroed Tensors of the same size.
+ * This is true regardless of the depth of the encapsulated Tensor as the function used
+ * internally to do so is recursive.
+ * @param index the index to be selected
+ */
+@SerialVersionUID(- 7562114420457472987L)
+class SelectTable(val index: Int)(implicit ev: TensorNumeric[Float]) extends MklDnnLayer {
+
+  override def updateOutput(in: Activity): Activity = {
+    val input = in.asInstanceOf[Table]
+    val index = if (this.index < 0) input.length() + this.index else this.index
+
+    require(input.contains(index), "index does not exist in the input table")
+    output = input[Activity](index)
+
+    output
+  }
+
+  override def updateGradInput(in: Activity, gradOutput: Activity): Table = {
+    val input = in.asInstanceOf[Table]
+    gradInput = T()
+    NNUtils.zeroTableCopy(gradInput.asInstanceOf[Table], input)
+    val index = if (this.index < 0) {
+      input.length() + this.index + 1
+    } else {
+      this.index
+    }
+
+    NNUtils.recursiveCopy(gradInput.asInstanceOf[Table](index), gradOutput)
+
+    require(gradInput.asInstanceOf[Table].contains(index), "Index exceeds the size of input table")
+
+    gradInput.asInstanceOf[Table]
+  }
+
+  override def toString: String = s"mkldnn.SelectTable($index)"
+
+
+  override def canEqual(other: Any): Boolean = other.isInstanceOf[SelectTable]
+
+  override def equals(other: Any): Boolean = other match {
+    case that: SelectTable =>
+      super.equals(that) &&
+        (that canEqual this) &&
+        index == that.index
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    val state = Seq(super.hashCode(), index)
+    state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
+  }
+
+  override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+    _inputFormats = inputs
+    _outputFormats = Array(inputs(index - 1))
+    (inputs, _outputFormats)
+  }
+
+  override private[mkldnn] def initBwdPrimitives(grad: Array[MemoryData], phase: Phase) = {
+    _gradInputFormats = Array(grad(index - 1))
+    _gradOutputFormats = grad
+    (grad, _gradInputFormats)
+  }
+}
+
+object SelectTable {
+  def apply(dimension: Int)(implicit ev: TensorNumeric[Float]) : SelectTable = {
+    new SelectTable(dimension)
+  }
+}
+

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Sequential.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Sequential.scala
@@ -1,0 +1,444 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.Module
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.nn.{MklInt8Convertible, Sequential => Seq}
+import com.intel.analytics.bigdl.tensor.Tensor
+
+import scala.collection.mutable.ArrayBuffer
+
+class Sequential extends MklDnnContainer with MklInt8Convertible {
+
+  def fuse: Boolean = {
+    System.getProperty("bigdl.mkldnn.fusion", "false").toBoolean
+  }
+
+  private def fuseConvBn: Boolean = {
+    fuse || System.getProperty("bigdl.mkldnn.fusion.convbn", "false").toBoolean
+  }
+
+  private def fuseBnRelu: Boolean = {
+    fuse || System.getProperty("bigdl.mkldnn.fusion.bnrelu", "false").toBoolean
+  }
+
+  private def fuseConvRelu: Boolean = {
+    fuse || System.getProperty("bigdl.mkldnn.fusion.convrelu", "false").toBoolean
+  }
+
+  private def fuseConvSum: Boolean = {
+    fuse || System.getProperty("bigdl.mkldnn.fusion.convsum", "false").toBoolean
+  }
+
+  override def add(module: AbstractModule[_ <: Activity, _ <: Activity, Float]): this.type = {
+    require(mklDnnModules == null, "You should not call add after compilation")
+    require(module.isInstanceOf[MklDnnModule], "layer should be MklDnnModule")
+    super.add(module)
+  }
+
+  override private[mkldnn] def fusion(phase: Phase): Unit = {
+    modules.clear()
+    modules.appendAll(getFusedModules(phase).map {x =>
+      x.asInstanceOf[AbstractModule[Activity, Activity, Float]]
+    })
+    mklDnnModules = modules.map(_.asInstanceOf[MklDnnModule]).toArray
+  }
+
+  override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+
+    var lastOutputFormats = inputs
+    var firstRealInputFormats: Array[MemoryData] = null
+    for (i <- 0 until mklDnnModules.length) {
+      val m = mklDnnModules(i)
+      val (realInputFormats, outputFormats) = m.initFwdPrimitives(lastOutputFormats, phase)
+      lastOutputFormats.zip(realInputFormats).foreach {
+        case (o, i) =>
+          Utils.copyMaskAndScales(o, i)
+          reorderManager.register(o, i)
+      }
+      Utils.copyMaskAndScales(realInputFormats, outputFormats)
+      if (i == 0) firstRealInputFormats = realInputFormats
+      lastOutputFormats = outputFormats
+    }
+    (firstRealInputFormats, lastOutputFormats)
+  }
+
+  override private[mkldnn] def initBwdPrimitives(grads: Array[MemoryData], phase: Phase) = {
+    var lastGradInputFormats = grads
+    var firstRealGradOutputFormats: Array[MemoryData] = null
+    for (i <- mklDnnModules.length - 1 to 0 by -1) {
+      val m = mklDnnModules(i)
+      val (realGradOutput, gradInputFomrats) = m.initBwdPrimitives(lastGradInputFormats, phase)
+      lastGradInputFormats.zip(realGradOutput).foreach {
+        case (gi, go) =>
+          reorderManager.register(gi, go)
+      }
+      if (i == mklDnnModules.length - 1) firstRealGradOutputFormats = realGradOutput
+      lastGradInputFormats = gradInputFomrats
+    }
+    (firstRealGradOutputFormats, lastGradInputFormats)
+  }
+
+  override private[mkldnn] def initGradWPrimitives(grads: Array[MemoryData], phase: Phase) = {
+    var lastGradInputFormats = grads
+    var firstRealGradOutputFormats: Array[MemoryData] = null
+    for (i <- mklDnnModules.length - 1 to 0 by -1) {
+      val m = mklDnnModules(i)
+      val realGradOutput = m.initGradWPrimitives(lastGradInputFormats, phase)
+      lastGradInputFormats.zip(realGradOutput).foreach {
+        case (gi, go2) => reorderManager.register(gi, go2)
+      }
+      if (i == mklDnnModules.length - 1) firstRealGradOutputFormats = realGradOutput
+      lastGradInputFormats = m.gradInputFormats()
+    }
+    firstRealGradOutputFormats
+  }
+
+  override def updateOutput(input: Activity): Activity = {
+    var i = 0
+    var lastOutput = input
+    while (i < mklDnnModules.length - 1) {
+      modules(i).forward(lastOutput)
+
+      lastOutput = reorderManager.infer(
+        mklDnnModules(i).outputFormats(),
+        mklDnnModules(i + 1).inputFormats(),
+        modules(i).output
+      )
+      i += 1
+    }
+    this.output = modules(i).forward(lastOutput)
+    output
+  }
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    var i = modules.length - 1
+    var lastGradInput = gradOutput
+    while (i > 0) {
+      val curInput = reorderManager.infer(
+        mklDnnModules(i - 1).outputFormats(),
+        mklDnnModules(i).inputFormats(),
+        modules(i - 1).output
+      )
+      lastGradInput = reorderManager.infer(
+        mklDnnModules(i).gradInputFormats(),
+        mklDnnModules(i - 1).gradOutputFormats(),
+        modules(i).updateGradInput(curInput, lastGradInput)
+      )
+      i -= 1
+    }
+    lastGradInput = modules(0).updateGradInput(input, lastGradInput)
+    this.gradInput = lastGradInput
+    gradInput
+  }
+
+  override def accGradParameters(input: Activity, gradOutput: Activity): Unit = {
+    var i = modules.length - 1
+    var currentModule = modules(i)
+    var lastGradInput = gradOutput
+    while (i > 0) {
+      currentModule = modules(i)
+      val curInput = reorderManager.infer(
+        mklDnnModules(i - 1).outputFormats(),
+        mklDnnModules(i).inputFormats(),
+        modules(i - 1).output
+      )
+      currentModule.accGradParameters(curInput, lastGradInput)
+      currentModule.asyncGradient
+      lastGradInput = reorderManager.infer(
+        mklDnnModules(i).gradInputFormats(),
+        mklDnnModules(i - 1).gradOutputWeightFormats(),
+        modules(i).gradInput
+      )
+      i -= 1
+    }
+    modules(i).accGradParameters(input, lastGradInput)
+    modules(i).asyncGradient
+  }
+
+  override private[mkldnn] def inputFormats() = {
+    modules(0).asInstanceOf[MklDnnModule].inputFormats()
+  }
+
+  override private[mkldnn] def gradInputFormats() = {
+    modules(0).asInstanceOf[MklDnnModule].gradInputFormats()
+  }
+
+  override private[mkldnn] def outputFormats() = {
+    modules.last.asInstanceOf[MklDnnModule].outputFormats()
+  }
+
+  override private[mkldnn] def gradOutputFormats() = {
+    modules.last.asInstanceOf[MklDnnModule].gradOutputFormats()
+  }
+
+  override private[mkldnn] def gradOutputWeightFormats() = {
+    modules.last.asInstanceOf[MklDnnModule].gradOutputWeightFormats()
+  }
+
+  type ArrayBufferModules[Float] = ArrayBuffer[AbstractModule[Activity, Activity, Float]]
+  private def convWithBn(modules: Array[MklDnnModule], phase: Phase): Array[MklDnnModule] = {
+    if (fuseConvBn && phase == InferencePhase) {
+      val newModules: ArrayBuffer[MklDnnModule] = ArrayBuffer.empty
+      var lastBn: SpatialBatchNormalization = null
+      modules.zip(modules.drop(1) ++ Array(null)).foreach { case (f, s) =>
+        (f, s) match {
+          case (conv: SpatialConvolution, bn: SpatialBatchNormalization) =>
+            mergeConvBn(conv, bn)
+            newModules.append(conv)
+            lastBn = bn
+          case (f: MklDnnContainer, s) => f.fusion(phase); newModules.append(f)
+          case _ => if (lastBn != f) { newModules.append(f) }
+        }
+      }
+      newModules.toArray
+    } else {
+      modules
+    }
+  }
+
+  private def convWithReLU(modules: Array[MklDnnModule], phase: Phase): Array[MklDnnModule] = {
+    if (fuseConvRelu) {
+      val newModules: ArrayBuffer[MklDnnModule] = ArrayBuffer.empty
+      var lastReLU: ReLU = null
+
+      modules.zip(modules.drop(1) ++ Array(null)).foreach { case (f, s) =>
+        (f, s) match {
+          case (conv: SpatialConvolution, relu: ReLU) =>
+            newModules.append(conv)
+            conv.setReLU()
+            conv.setOutputScales(relu.getOutputScales())
+            lastReLU = relu
+          case (f: MklDnnContainer, s) =>
+            f.fusion(phase)
+            newModules.append(f)
+          case _ => if (lastReLU != f) {
+            newModules.append(f)
+          }
+        }
+      }
+
+      newModules.toArray
+    } else {
+      modules
+    }
+  }
+
+  private def bnWithReLU(modules: Array[MklDnnModule], phase: Phase): Array[MklDnnModule] = {
+    if (fuseBnRelu) {
+      val newModules: ArrayBuffer[MklDnnModule] = ArrayBuffer.empty
+      var lastReLU: ReLU = null
+
+      modules.zip(modules.drop(1) ++ Array(null)).foreach { case (f, s) =>
+        (f, s) match {
+          case (bn: SpatialBatchNormalization, relu: ReLU) =>
+            newModules.append(bn)
+            bn.setReLU(true)
+            lastReLU = relu
+          case (f: MklDnnContainer, s) => f.fusion(phase); newModules.append(f)
+          case _ => if (lastReLU != f) { newModules.append(f) }
+        }
+      }
+
+      newModules.toArray
+    } else {
+      modules
+    }
+  }
+
+  private def convWithSum(modules: Array[MklDnnModule], phase: Phase): Array[MklDnnModule] = {
+    val newModules: ArrayBuffer[MklDnnModule] = ArrayBuffer.empty
+    if (!fuseConvSum || modules.length <= 2 || phase == TrainingPhase) {
+      newModules.appendAll(modules)
+    } else {
+      var lastConv: SpatialConvolution = null
+      var lastReLU: ReLU = null
+
+      modules.zip(modules.drop(1) ++ Array(null)).foreach {
+        case (f: ConcatTable, s: CAddTable) => val (conv, sbt) = convSum(f, s)
+          newModules.append(f)
+          lastConv = conv
+          if (sbt != null) {
+            newModules.append(sbt)
+          }
+          conv.setOutputScales(s.getOutputScales())
+        case (f: MklDnnContainer, s) => f.fusion(phase); newModules.append(f)
+        case (f: CAddTable, s: ReLU) => if (lastConv != null) {
+          lastConv.setReLU()
+          lastConv.setOutputScales(s.getOutputScales())
+          lastReLU = s
+          lastConv = null
+        } else {
+          newModules.append(f)
+        }
+        case (f, s) => if (lastReLU != f) { newModules.append(f); lastReLU = null}
+      }
+    }
+
+    newModules.toArray
+  }
+
+  private def getFusedModules(phase: Phase): Array[MklDnnModule] = {
+    val f1Modules = convWithBn(mklDnnModules, phase)
+    val f2Modules = convWithReLU(f1Modules, phase)
+    val f3Modules = bnWithReLU(f2Modules, phase)
+    val f4Modules = convWithSum(f3Modules, phase)
+    f4Modules
+  }
+
+  private def mergeConvBn(conv: SpatialConvolution, bn: SpatialBatchNormalization): Unit = {
+
+    val originVar = Tensor[Float].resize(bn.runningVariance.size()).copy(bn.runningVariance.dense)
+    val originMean = Tensor[Float].resize(bn.runningMean.size()).copy(bn.runningMean.dense)
+
+    val convWeight = Tensor[Float].resize(conv.weight.size()).copy(conv.weight.dense)
+    val convBias = Tensor[Float].resize(conv.bias.size()).copy(conv.bias.dense)
+
+    val bnWeight = Tensor[Float].resizeAs(bn.weightAndBias.dense).copy(bn.weightAndBias.dense)
+
+    (0 until bn.nOutput).foreach { j =>
+      val variance = originVar.storage().array()(j + originVar.storageOffset() - 1)
+      val base = Math.sqrt(variance.asInstanceOf[Float] + bn.eps).toFloat
+      require(base != 0.0, s"the eps of ${bn.getName()} should be more than 0")
+
+      val alpha = bnWeight.storage().array()(bnWeight.storageOffset() - 1 + j)
+      val beta = bnWeight.storage().array()(bnWeight.storageOffset() - 1 + bn.nOutput + j)
+
+      val weight = if (conv.nGroup == 1) {
+        convWeight.select(1, j + 1)
+      } else {
+        convWeight.select(2, j + 1)
+      }
+      weight.div(base)
+      weight.mul(alpha)
+
+      val bias = convBias.storage().array()(j)
+      val mean = originMean.storage().array()(j)
+      convBias.storage().array()(j) = alpha / base * bias + beta - (alpha * mean) / base
+    }
+
+    conv.weight.copy(convWeight)
+    conv.bias.copy(convBias)
+
+    conv.flushWeightScales(conv.weight.dense)
+    conv.setOutputScales(bn.getOutputScales())
+  }
+
+  private type FloatActivityModule = AbstractModule[Activity, Activity, Float]
+  private def getLast(module: FloatActivityModule): FloatActivityModule = {
+    val ret = module match {
+      case sequential: Sequential => sequential.modules.last
+      case _ => module
+    }
+
+    ret.asInstanceOf[FloatActivityModule]
+  }
+
+  private def convSum(concatTable: ConcatTable, cAddTable: CAddTable): (SpatialConvolution,
+    SelectTable) = {
+    var branch1: FloatActivityModule = null
+    var branch2: FloatActivityModule = null
+
+    var continue = concatTable.modules.length == 2
+
+    if (continue) {
+      branch1 = getLast(concatTable.modules(0))
+      branch2 = getLast(concatTable.modules(1))
+
+      def isConvOrIdentity(module: AbstractModule[Activity, Activity, Float]): Boolean = {
+        module.isInstanceOf[SpatialConvolution] || module.isInstanceOf[Identity]
+      }
+
+      continue = continue && isConvOrIdentity(branch1) && isConvOrIdentity(branch2)
+    }
+
+    if (continue) {
+      // make sure the last module is conv
+      if (!branch2.isInstanceOf[SpatialConvolution]) {
+        // swap the modules
+        var tmp: AbstractModule[Activity, Activity, Float] = null
+
+        tmp = concatTable.modules(0)
+        concatTable.modules(0) = concatTable.modules(1)
+        concatTable.modules(1) = tmp
+
+        concatTable.reconstruct()
+
+        tmp = branch1
+        branch1 = branch2
+        branch2 = tmp
+      }
+
+      // get the index of conv, by default the output should be the first conv.
+      val (convIndex, conv, theOther) = (2, branch2.asInstanceOf[SpatialConvolution], branch1)
+      conv.setSum()
+
+      // delete CAddTable
+      val selectTable = SelectTable(convIndex)
+
+      // change the branch2's output to branch1's output
+      // FIXME maybe we should not set the conv operation
+      conv.setSumOp(theOther.asInstanceOf[Module[Float]])
+      (conv, selectTable)
+    } else {
+      (null, null)
+    }
+  }
+
+  override def calcScales(input: Activity): Unit = {
+    var i = 0
+    var lastOutput = input
+    while (i < this.modules.length - 1) {
+      Utils.calcScales(this.modules(i), lastOutput)
+
+      val curOutput = this.modules(i).output
+      require(mklDnnModules(i).outputFormats().length == mklDnnModules(i + 1).inputFormats().length)
+      lastOutput = reorderManager.infer(
+        mklDnnModules(i).outputFormats(),
+        mklDnnModules(i + 1).inputFormats(),
+        curOutput
+      )
+
+      i += 1
+    }
+
+    Utils.calcScales(this.modules(i), lastOutput)
+  }
+
+  override def toString(): String = {
+    val tab = "  "
+
+    s"${getPrintName}{${line + tab}[input -> ${
+      modules.zipWithIndex.map {
+        case (m: AbstractModule[Activity, Activity, Float], i: Int) => "(" + (i + 1) + ")"
+      }.
+        mkString(" -> ")
+    } -> output]${line + tab}" +
+      s"${
+        modules.zipWithIndex.map {
+          case (model: AbstractModule[Activity, Activity, Float], index: Int)
+          => s"(${index + 1}): ${model.setLine(line + tab)}"
+        }.
+          mkString(line + tab)
+      }$line}"
+  }
+}
+
+object Sequential {
+  def apply(): Sequential = new Sequential()
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/SoftMax.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/SoftMax.scala
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.{ArgType, DataType, Memory, PropKind}
+import com.intel.analytics.bigdl.nn
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.tensor.{DenseType, Tensor}
+import com.intel.analytics.bigdl.utils.Shape
+
+import scala.collection.mutable
+
+
+class SoftMax(val axis: Int = -1) extends MklDnnLayer {
+  private val nnSoftMax = nn.SoftMax[Float]()
+  @transient private var modelPhase: Phase = null
+
+  private def initPhase(phase: Phase): Unit = {
+    if (phase != null) return modelPhase = phase
+    isTraining() match {
+      case true =>
+        modelPhase = TrainingPhase
+      case false =>
+        modelPhase = InferencePhase
+    }
+  }
+
+  private def format(shape: Array[Int]): Int = {
+    shape.length match {
+      case 2 => Memory.FormatTag.nc
+      case 4 => Memory.FormatTag.nchw
+      case _ => throw new UnsupportedOperationException(s"${getName()} unsupported input shape")
+    }
+  }
+
+  override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+    initPhase(phase)
+    modelPhase match {
+      case TrainingPhase =>
+        _inputFormats = inputs.map(x => HeapData(x.shape, format(x.shape)))
+        _outputFormats = inputs.map(x => HeapData(x.shape, format(x.shape)))
+
+        (_inputFormats, _outputFormats)
+      case InferencePhase =>
+        val defaultAxis = inputs(0).shape.length match {
+          case 1 => 0
+          case 2 => 1
+          case 3 => 0
+          case 4 => 1
+          case _ => throw new UnsupportedOperationException("1D, 2D, 3D or 4D tensor expected")
+        }
+
+        _inputFormats = Array(NativeData(inputs(0).shape, inputs(0).layout, DataType.F32))
+
+        val localInputFormat = if (inputs(0).shape.length == 3 &&
+          inputs(0).layout == Memory.FormatTag.ntc) {
+          // note: here, the format and the true memory layout is not consistent.
+          // for ntc input, we should reshape the `shape` and make the format to tnc
+          val shape = Array(inputs(0).shape(1), inputs(0).shape(0), inputs(0).shape(2))
+          NativeData(shape, Memory.FormatTag.tnc)
+        } else {
+          _inputFormats(0)
+        }
+
+        val desc = DnnlMemory.SoftMaxForwardDescInit(PropKind.ForwardInference,
+          localInputFormat.getMemoryDescriptor(), if (axis == -1) defaultAxis else axis)
+
+        val forwardPrimDesc = DnnlMemory.PrimitiveDescCreate(desc, runtime.engine, 0L)
+
+        _outputFormats = if (inputs(0).shape.length ==3 &&
+          inputs(0).layout == Memory.FormatTag.ntc) {
+          // because set the input format as tnc first, we should set the output to ntc.
+          Array(NativeData(inputs(0).shape, Memory.FormatTag.ntc))
+        } else {
+          Array(MemoryData.primitiveOutput(forwardPrimDesc))
+        }
+
+        val primitive = DnnlMemory.PrimitiveCreate(forwardPrimDesc)
+        updateOutputPrimitives = Array(primitive)
+        fwdExecArgs = mutable.Map(
+          ArgType.DNNL_ARG_SRC -> inputs(0).getMemoryObject(runtime),
+          ArgType.DNNL_ARG_DST -> _outputFormats(0).getMemoryObject(runtime)
+        )
+
+        output = initTensor(_outputFormats(0))
+
+        (_inputFormats, _outputFormats)
+      case _ => throw new UnsupportedOperationException
+    }
+  }
+
+  override private[mkldnn] def initBwdPrimitives(grad: Array[MemoryData], phase: Phase) = {
+    _gradInputFormats = grad.clone()
+    _gradOutputFormats = grad.clone()
+    (_gradInputFormats, _gradOutputFormats)
+  }
+
+  override def updateOutput(input: Activity): Activity = {
+    if (this.isTraining()) {
+      nnSoftMax.forward(input)
+      output = nnSoftMax.output
+    } else {
+      if (updateOutputTensors == null) {
+        updateOutputTensors = mutable.Map(
+          ArgType.DNNL_ARG_SRC -> input.asInstanceOf[Tensor[Float]],
+          ArgType.DNNL_ARG_DST -> output.asInstanceOf[Tensor[Float]]
+        )
+      }
+      input.toTensor[Float].getTensorType match {
+        case DenseType =>
+          updateOutputTensors(ArgType.DNNL_ARG_SRC) = input.toTensor
+        case _ =>
+      }
+      MklDnnOps.streamSubmit(updateOutputPrimitives, runtime.stream,
+        fwdExecArgs, updateOutputTensors)
+    }
+
+    output
+  }
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    gradInput = nnSoftMax.backward(input, gradOutput)
+    gradInput
+  }
+
+  override def computeOutputShape(inputShape: Shape): Shape = {
+    inputShape
+  }
+}
+
+object SoftMax {
+  def apply(axis: Int = -1)(implicit ev: TensorNumeric[Float]): SoftMax = {
+    new SoftMax(axis)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/SpatialBatchNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/SpatialBatchNormalization.scala
@@ -195,7 +195,11 @@ class SpatialBatchNormalization(
     // so we do not need create weightAndBias native space again.
     if (output == null || output.isInstanceOf[DnnTensor[_]] &&
       output.toTensor[Float].size().deep != outputFormats()(0).shape.deep) {
+      if (output != null) { output.asInstanceOf[DnnTensor[Float]].release() }
       output = initTensor(outputFormats()(0))
+      if (updateOutputTensors != null) {
+        updateOutputTensors.put(ArgType.DNNL_ARG_DST, output.asInstanceOf[Tensor[Float]])
+      }
     }
 
     // init once

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/SpatialBatchNormalization.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/SpatialBatchNormalization.scala
@@ -1,0 +1,392 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl._
+import com.intel.analytics.bigdl.nn.abstractnn.{Activity, Initializable}
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.nn.{MklInt8Convertible, Ones, VariableFormat, Zeros}
+import com.intel.analytics.bigdl.tensor._
+
+import scala.collection.mutable
+
+
+class SpatialBatchNormalization(
+  val nOutput: Int,
+  val eps: Double = 1e-5,
+  val momentum: Double = 0.1,
+  private val initWeight: Tensor[Float] = null,
+  private val initBias: Tensor[Float] = null,
+  private val initGradWeight: Tensor[Float] = null,
+  private val initGradBias: Tensor[Float] = null
+) extends MklDnnLayer with Initializable with MklInt8Convertible {
+
+  @transient private var forwardDesc: Long = 0L
+  private var _relu: Boolean = false
+
+  def setReLU(value: Boolean): this.type = {
+    _relu = value
+    this
+  }
+  def relu: Boolean = _relu
+
+  // reminder: runningMean/runningVariance in blas batch_norm is
+  // same to scaled runningMean/runningVariance in dnn.
+  private[bigdl] var needScale = false
+
+  @transient private var modelPhase: Phase = null
+
+  private val mean: DnnTensor[Float] = DnnTensor[Float](nOutput)
+  private val variance: DnnTensor[Float] = DnnTensor[Float](nOutput)
+
+  private[mkldnn] val runningMean = new TensorMMap(Array(nOutput))
+  private[mkldnn] val runningVariance = new TensorMMap(Array(nOutput))
+  // TODO we should make it private. Currently, ResNet50 will use it out of this scope.
+  val weightAndBias = new TensorMMap(Array(nOutput * 2))
+  val gradWeightAndBias = new TensorMMap(Array(nOutput * 2))
+
+  // TODO the two should be learnable parameters
+  var scaleFactor: Float = 1.0f
+  var biasFactor: Float = 1.0f
+
+  private val runningMeanScaled = Tensor[Float].resizeAs(runningMean.dense)
+  private val runningVarianceScaled = Tensor[Float].resizeAs(runningVariance.dense)
+
+  // the blank shoud be here, otherwise the runningVarianceScaled will be a method
+  {
+    val wInit = Ones // RandomUniform(0, 1)
+    val bInit = Zeros
+    setInitMethod(wInit, bInit)
+  }
+
+  override def reset(): Unit = {
+    val init = Tensor[Float]().resize(Array(2, nOutput))
+    val weight = init.select(1, 1)
+    val bias = init.select(1, 2)
+
+    if (initWeight != null) {
+      require(initWeight.size(1) == nOutput)
+      weight.copy(initWeight)
+    } else {
+      weightInitMethod.init(weight, VariableFormat.ONE_D)
+    }
+
+    if (initBias != null) {
+      require(initBias.size(1) == nOutput)
+      bias.copy(initBias)
+    } else {
+      biasInitMethod.init(bias, VariableFormat.ONE_D)
+    }
+
+    weightAndBias.dense.copy(init.view(2 * nOutput))
+
+    val zeros = Tensor[Float](Array(nOutput)).fill(0)
+    mean.copy(zeros)
+    variance.copy(zeros)
+
+    runningMean.copy(zeros)
+    runningVariance.copy(zeros)
+  }
+
+  // move it into DnnBase
+  private def initPhase(phase: Phase): Unit = {
+    if (phase != null) modelPhase = phase
+    (isTraining(), modelPhase) match {
+      case (true, InferencePhase) =>
+        train = false
+      case (false, TrainingPhase) =>
+        train = true
+      case (true, null) =>
+        modelPhase = TrainingPhase
+      case (false, null) =>
+        modelPhase = InferencePhase
+      case _ =>
+    }
+  }
+
+  override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+
+    val m = inputs(0).shape.product / this.nOutput
+    biasFactor = if (m > 1) { m.toFloat / (m - 1) } else { 1 }
+
+    val List(mean, variance, runningMean, runningVariance): List[NativeData] =
+      (0 until 4).map { _ =>
+        NativeData(Array(nOutput), Memory.FormatTag.x)
+      }.toList
+
+    // weight and bias should be combined
+    val weightAndBias: NativeData = NativeData(Array(nOutput * 2), Memory.FormatTag.x)
+
+    _inputFormats = singleNativeData(inputs)
+
+//    val src = NativeData(inputs.head.shape, inputs.head.layout, DataType.F32)
+//    _inputFormats = Array(src)
+    // _inputFormats = Array(NativeData(inputs.head.shape, Memory.FormatTag.nchw))
+
+//    val src = NativeData(inputs.head.shape, inputs.head.layout, DataType.F32)
+//    _inputFormats = singleNativeData(inputs)
+//    _inputFormats = Array(NativeData(inputs.head.shape, Memory.FormatTag.nchw))
+    // init phase status
+    initPhase(phase)
+
+    val propKind = modelPhase match {
+      case TrainingPhase => PropKind.Forward
+      case InferencePhase => PropKind.ForwardInference
+      case _ => throw new UnsupportedOperationException("Unknown prop kind")
+    }
+    val normalizationFlag = modelPhase match {
+      case TrainingPhase => DNNL.BatchNormFlag.mkldnn_use_scaleshift
+      case InferencePhase => DNNL.BatchNormFlag.mkldnn_use_global_stats |
+        DNNL.BatchNormFlag.mkldnn_use_scaleshift
+      case _ => throw new UnsupportedOperationException("Unknown prop kind")
+    }
+
+    val desc = DnnlMemory.BatchNormForwardDescInit(
+      propKind,
+      inputFormats().head.getMemoryDescriptor(),
+      eps.toFloat,
+      normalizationFlag)
+
+    forwardDesc = if (relu) {
+      val postOps = DnnlMemory.CreatePostOps()
+      DNNL.PostOpsAppendEltwise(postOps, 1.0f, AlgKind.EltwiseRelu, 0.0f, 0.0f)
+      val attr = DnnlMemory.CreateAttr()
+      DNNL.AttrSetPostOps(attr, postOps)
+      DnnlMemory.PrimitiveDescCreateV2(desc, attr, runtime.engine, 0)
+    } else {
+      DnnlMemory.PrimitiveDescCreate(desc, runtime.engine, 0L)
+    }
+
+    val realDst = MemoryData.operationWant(forwardDesc, Query.DstMd)
+    _outputFormats = Array(realDst)
+    val primitive = DnnlMemory.PrimitiveCreate(forwardDesc)
+
+    fwdExecArgs = mutable.Map(
+      ArgType.DNNL_ARG_SRC ->
+        inputFormats().head.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_SCALE_SHIFT ->
+        weightAndBias.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_MEAN ->
+        mean.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_VARIANCE ->
+        variance.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DST ->
+        outputFormats().head.getMemoryObject(runtime)
+    )
+
+    updateOutputPrimitives = Array(primitive)
+
+    // init once
+    // if the output is not null, it means we have initialized the primitives before.
+    // so we do not need create weightAndBias native space again.
+    if (output == null || output.isInstanceOf[DnnTensor[_]] &&
+      output.toTensor[Float].size().deep != outputFormats()(0).shape.deep) {
+      output = initTensor(outputFormats()(0))
+    }
+
+    // init once
+    if (this.weightAndBias.native == null) {
+      if (modelPhase == InferencePhase) {
+        this.runningMean.setMemoryData(
+          HeapData(this.runningMean.size(), Memory.FormatTag.x), runningMean, runtime)
+        this.runningVariance.setMemoryData(
+          HeapData(this.runningVariance.size(), Memory.FormatTag.x), runningVariance, runtime)
+        // for inference, we must copy the heap memory to native first.
+        this.runningMean.sync()
+        this.runningVariance.sync()
+      } else {
+        this.runningMean.setMemoryData(runningMean,
+          HeapData(this.runningMean.size(), Memory.FormatTag.x), runtime)
+        this.runningVariance.setMemoryData(runningVariance,
+          HeapData(this.runningVariance.size(), Memory.FormatTag.x), runtime)
+      }
+      // for runningMean and runningVariance, we should copy them to native at first
+      this.weightAndBias.setMemoryData(HeapData(this.weightAndBias.size(), Memory.FormatTag.x),
+        weightAndBias, runtime)
+    }
+    this.weightAndBias.sync()
+    (inputFormats(), outputFormats())
+  }
+
+  override def updateOutput(input: Activity): Activity = {
+    if (updateOutputTensors == null) {
+      updateOutputTensors = mutable.Map(
+        ArgType.DNNL_ARG_SRC -> input.asInstanceOf[Tensor[Float]],
+        ArgType.DNNL_ARG_SCALE_SHIFT -> weightAndBias.native,
+        ArgType.DNNL_ARG_MEAN -> mean,
+        ArgType.DNNL_ARG_VARIANCE -> variance,
+        ArgType.DNNL_ARG_DST -> output.asInstanceOf[Tensor[Float]]
+      )
+    }
+
+    if (this.isTraining()) {
+      weightAndBias.sync()
+      scaleFactor = scaleFactor * momentum.toFloat + 1
+      mean.axpby(1, momentum.toFloat, runningMean.native)
+      variance.axpby(biasFactor, momentum.toFloat, runningVariance.native)
+      runningMean.sync()
+      runningVariance.sync()
+    } else {
+      // we should re-computing the running mean and running variance.
+      // FIXME should do it at `initFwdPrimitives`
+      mean.scale(runningMean.native, 1 / scaleFactor)
+      variance.scale(runningVariance.native, 1 / scaleFactor)
+    }
+
+    updateWithNewTensor(updateOutputTensors, ArgType.DNNL_ARG_SRC, input)
+    MklDnnOps.streamSubmit(updateOutputPrimitives, runtime.stream,
+      fwdExecArgs, updateOutputTensors)
+
+    if (this.isTraining()) {
+      // update running(Mean, Var) and scaleFactor
+      scaleFactor = scaleFactor * momentum.toFloat + 1
+      mean.axpby(1, momentum.toFloat, runningMean.native)
+      variance.axpby(biasFactor, momentum.toFloat, runningVariance.native)
+      runningMean.sync()
+      runningVariance.sync()
+    }
+
+    output
+  }
+
+
+  override private[mkldnn] def initBwdPrimitives(grad: Array[MemoryData], phase: Phase) = {
+    _gradOutputFormats = Array(NativeData(outputFormats()(0).shape, outputFormats()(0).layout))
+
+    // init phase status
+    initPhase(phase)
+    // [PERF] the format of gradInput should be the same as input
+    val backwardDesc = modelPhase match {
+      case TrainingPhase =>
+        DnnlMemory.BatchNormBackwardDescInit(PropKind.Backward,
+          inputFormats()(0).getMemoryDescriptor(),
+          inputFormats()(0).getMemoryDescriptor(), eps.toFloat,
+          DNNL.BatchNormFlag.mkldnn_use_scaleshift)
+      case _ => throw new UnsupportedOperationException
+    }
+
+    val gradWeightAndBias: NativeData = NativeData(Array(nOutput * 2), Memory.FormatTag.x)
+    val gradWeightPrimitive = gradWeightAndBias.getMemoryObject(runtime)
+
+    val primDesc = DnnlMemory.PrimitiveDescCreate(backwardDesc, runtime.engine, 0)
+
+    _gradInputFormats = Array(MemoryData.operationWant(primDesc, Query.DiffSrcMd))
+    _gradOutputFormats = Array(MemoryData.operationWant(primDesc, Query.DiffDstMd))
+
+    // maybe will throw null exception
+    bwdExecArgs = mutable.Map(
+      ArgType.DNNL_ARG_SRC -> inputFormats().head.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_MEAN -> fwdExecArgs.get(ArgType.DNNL_ARG_MEAN).get,
+      ArgType.DNNL_ARG_VARIANCE -> fwdExecArgs.get(ArgType.DNNL_ARG_VARIANCE).get,
+      ArgType.DNNL_ARG_DIFF_SRC -> grad(0).getMemoryObject(runtime),
+      ArgType.DNNL_ARG_SCALE_SHIFT -> fwdExecArgs.get(ArgType.DNNL_ARG_SCALE_SHIFT).get,
+      ArgType.DNNL_ARG_DIFF_SRC -> gradInputFormats()(0).getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DIFF_DST -> _gradOutputFormats(0).getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DIFF_SCALE_SHIFT -> gradWeightAndBias.getMemoryObject(runtime)
+    )
+
+    val primitive = DnnlMemory.PrimitiveCreate(primDesc)
+
+    updateGradInputPrimitives = Array(primitive)
+    gradInput = initTensor(gradInputFormats()(0))
+
+    this.gradWeightAndBias.setMemoryData(gradWeightAndBias,
+      HeapData(this.gradWeightAndBias.size(), Memory.FormatTag.x), runtime)
+    this.gradWeightAndBias.zero()
+
+    (_gradOutputFormats, gradInputFormats())
+  }
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    if (updateGradInputTensors == null) {
+      updateGradInputTensors = mutable.Map(
+        ArgType.DNNL_ARG_SRC -> input.asInstanceOf[Tensor[Float]],
+        ArgType.DNNL_ARG_MEAN -> mean,
+        ArgType.DNNL_ARG_VARIANCE -> variance,
+        ArgType.DNNL_ARG_DIFF_DST -> gradOutput.asInstanceOf[Tensor[Float]],
+        ArgType.DNNL_ARG_SCALE_SHIFT -> weightAndBias.native,
+        ArgType.DNNL_ARG_DIFF_SRC -> gradInput.asInstanceOf[Tensor[Float]],
+        ArgType.DNNL_ARG_DIFF_SCALE_SHIFT -> gradWeightAndBias.native
+      )
+    }
+    updateWithNewTensor(updateGradInputTensors, ArgType.DNNL_ARG_SRC, input)
+    updateWithNewTensor(updateGradInputTensors, ArgType.DNNL_ARG_DIFF_DST, gradOutput)
+    MklDnnOps.streamSubmit(updateGradInputPrimitives, runtime.stream,
+      bwdExecArgs, updateGradInputTensors)
+    gradWeightAndBias.sync()
+
+    gradInput
+  }
+
+  override def accGradParameters(input: Activity, gradOutput: Activity): Unit = {
+    // do nothing
+  }
+
+  override def zeroGradParameters(): Unit = {
+  }
+
+  override def parameters(): (Array[Tensor[Float]], Array[Tensor[Float]]) = {
+    (Array(weightAndBias.dense), Array(gradWeightAndBias.dense))
+  }
+
+  override def paramsMMap(): (Array[TensorMMap], Array[TensorMMap]) = {
+    (Array(weightAndBias), Array(gradWeightAndBias))
+  }
+
+  override def getExtraParameter(): Array[Tensor[Float]] = {
+    if (needScale) {
+      runningMeanScaled.copy(runningMean.dense).div(scaleFactor)
+      runningVarianceScaled.copy(runningVariance.dense).div(scaleFactor)
+      Array(runningMeanScaled, runningVarianceScaled)
+    } else {
+      Array(runningMean.dense, runningVariance.dense)
+    }
+  }
+
+  override def toString(): String = {
+    s"nn.mkl.SpatialBatchNormalization($nOutput, $eps, $momentum)"
+  }
+
+  override def evaluate(): this.type = {
+    if (modelPhase == TrainingPhase) {
+      initFwdPrimitives(inputFormats(), InferencePhase)
+    }
+    this
+  }
+
+  override def training(): this.type = {
+    if (modelPhase == InferencePhase) {
+      initFwdPrimitives(inputFormats(), TrainingPhase)
+    }
+    this
+  }
+}
+
+object SpatialBatchNormalization {
+  def apply(
+    nOutput: Int,
+    eps: Double = 1e-5,
+    momentum: Double = 0.1,
+    affine: Boolean = true,
+    initWeight: Tensor[Float] = null,
+    initBias: Tensor[Float] = null,
+    initGradWeight: Tensor[Float] = null,
+    initGradBias: Tensor[Float] = null): SpatialBatchNormalization = {
+    new SpatialBatchNormalization(nOutput, eps, momentum, initWeight, initBias, initGradWeight,
+      initGradBias)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/SpatialConvolution.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/SpatialConvolution.scala
@@ -1,0 +1,848 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.Module
+import com.intel.analytics.bigdl.dnnl._
+import com.intel.analytics.bigdl.nn.{Utils => NNUtils, _}
+import com.intel.analytics.bigdl.nn.abstractnn._
+import com.intel.analytics.bigdl.optim.Regularizer
+import com.intel.analytics.bigdl.tensor.{DenseTensorMath, DnnTensor, Tensor}
+
+import scala.collection.mutable
+
+/**
+ * Applies a 2D convolution over an input image composed of several input planes.
+ * The input tensor in forward(input) is expected to be
+ * a 3D tensor (nInputPlane x height x width).
+ *
+ * nInputPlane The number of expected input planes in the image given into forward()
+ * nOutputPlane: The number of output planes the convolution layer will produce.
+ * kernelW: the kernel width of the convolution
+ * kernelH: The kernel height of the convolution
+ * strideW: Int = 1, The step of the convolution in the width dimension.
+ * strideH: Int = 1, The step of the convolution in the height dimension
+ * padW: Int = 0, The additional zeros added per width to the input planes.
+ * padH: Int = 0, The additional zeros added per height to the input planes.
+ * nGroup: Int = 1, Kernel group number
+ * propagateBack: Boolean = true, propagate gradient back
+ * wRegularizer: Regularizer[Float] = null,
+ * bRegularizer: Regularizer[Float] = null,
+ * initWeight: Tensor[Float] = null,
+ * initBias: Tensor[Float] = null,
+ * initGradWeight: Tensor[Float] = null,
+ * initGradBias: Tensor[Float] = null,
+ * withBias: Boolean = true,
+ * format: DataFormat = DataFormat.NCHW,
+ * dilationW: Int = 1,
+ * dilationH: Int = 1
+ *
+ * When padW and padH are both -1, we use a padding algorithm similar to the "SAME"
+ * padding of tensorflow. That is
+ *
+ * outHeight = Math.ceil(inHeight.toFloat/strideH.toFloat)
+ * outWidth = Math.ceil(inWidth.toFloat/strideW.toFloat)
+ *
+ * padAlongHeight = Math.max(0, (outHeight - 1) * strideH + kernelH - inHeight)
+ * padAlongWidth = Math.max(0, (outWidth - 1) * strideW + kernelW - inWidth)
+ *
+ * padTop = padAlongHeight / 2
+ * padLeft = padAlongWidth / 2
+ *
+ * @param wRegularizer: instance of [[Regularizer]]
+ *                    (eg. L1 or L2 regularization), applied to the input weights matrices.
+ * @param bRegularizer: instance of [[Regularizer]]
+ *                    applied to the bias.
+ * @param dilationW: dilation width, default to 1
+ * @param dilationH: dilation height, default to 1
+ */
+class SpatialConvolution(
+  val nInputPlane: Int,
+  val nOutputPlane: Int,
+  val kernelW: Int,
+  val kernelH: Int,
+  val strideW: Int = 1,
+  val strideH: Int = 1,
+  val padW: Int = 0,
+  val padH: Int = 0,
+  val nGroup: Int = 1,
+  val propagateBack: Boolean = true,
+  var wRegularizer: Regularizer[Float] = null,
+  var bRegularizer: Regularizer[Float] = null,
+  val initWeight: Tensor[Float] = null,
+  val initBias: Tensor[Float] = null,
+  val initGradWeight: Tensor[Float] = null,
+  val initGradBias: Tensor[Float] = null,
+  val withBias: Boolean = true,
+  val format: DataFormat = DataFormat.NCHW,
+  val dilationW: Int = 1,
+  val dilationH: Int = 1
+) extends MklDnnLayer with Initializable with Serializable with MklInt8Convertible {
+  require(nInputPlane % nGroup == 0, s"Number of input channels " +
+    s"should be multiples of group " +
+    s"number of input channels ${nInputPlane}, " +
+    s"group ${nGroup}.")
+  require(nOutputPlane % nGroup == 0,
+    "Number of output channels " +
+      "should be multiples of group " +
+      s"(number of output channels ${nOutputPlane}, " +
+      s"group ${nGroup}).")
+
+  private val weightShape = if (nGroup == 1) {
+    Array(nOutputPlane, nInputPlane, kernelH, kernelW)
+  } else {
+    Array (nGroup, nOutputPlane / nGroup, nInputPlane / nGroup, kernelH, kernelW)
+  }
+
+  // !!!important!!! this is for weight and input conversion.
+  // The weight in forward and updateGradInput is different.
+  // The input in updateOutput and accGradParameters is different too.
+  // It's `lazy` so the reordermanager need not be serialized.
+  @transient private lazy val reorderManager = new ReorderManager
+
+  private[mkldnn] val weight = new TensorMMap(weightShape)
+  private[mkldnn] val bias = new TensorMMap(Array(nOutputPlane))
+  private[mkldnn] val gradWeight = new TensorMMap(weightShape)
+  private[mkldnn] val gradBias = new TensorMMap(Array(nOutputPlane))
+  private[mkldnn] var gradWeightMd: Long = _
+  private[mkldnn] var gradBiasMd: Long = _
+
+
+  // The weight maybe have different format between updateOutput and updateGradInput
+  private var weightForBackward: DnnTensor[Float] = _
+  private var weightForBackwardMemoryData: MemoryData = _
+
+  // The input maybe have different format between updateOutput and accGradParameters
+  private var inputForAcc: DnnTensor[Float] = _
+  private var inputForAccMemoryData: MemoryData = _
+
+  @transient private var forwardPrimDesc: Long = 0L
+  @transient
+  protected var updateGradWTensors: mutable.Map[Int, Tensor[Float]] = _
+
+  @transient private var paddingTL: Array[Int] = _
+  @transient private var paddingBR: Array[Int] = _
+
+  var needQuantize: Boolean = false
+  var negativeInput: Boolean = true
+
+  private var _relu = false
+  private var _sum = false
+  private var _batchNorm = false
+  private var _dim = 1
+  private var _sumInput = false
+
+
+  def relu: Boolean = _relu
+  def setReLU(value: Boolean = true): this.type = {
+    _relu = value
+    this
+  }
+
+  def batchNorm: Boolean = _batchNorm
+  def setBatchNorm(value: Boolean = true): this.type = {
+    _batchNorm = value
+    this
+  }
+
+  def sum: Boolean = _sum
+  def setSum(value: Boolean = true): this.type = {
+    _sum = value
+    this
+  }
+
+  var sumOp: MklDnnLayer = null
+  def setSumOp(conv: Module[Float], number: Int = 1): this.type = {
+    sumOp = conv.asInstanceOf[MklDnnLayer]
+    _dim = number
+    _sum = true
+    this
+  }
+
+  // get padding type
+  private val paddingType: PaddingType.Value = getPaddingType()
+
+  /*
+  Parameters for Dilated Convolution
+  In most deep learning frameworks,
+  the default value of dilation which defines regular convolution module is 1
+  BigDL follows this convention
+  However the default value used by mkl-dnn is 0;
+  in order to keep consistensy, we internally transform them with deducting by 1.
+  */
+  private val dilationW_mkldnn: Int = dilationW - 1
+  private val dilationH_mkldnn: Int = dilationH - 1
+
+  private def getOutputShape(oh: Int, ow: Int, batchSize: Int = -1): Array[Int] = {
+    format match {
+      case DataFormat.NCHW =>
+        if (batchSize == -1) {
+          Array(nOutputPlane, oh, ow)
+        } else {
+          Array(batchSize, nOutputPlane, oh, ow)
+        }
+      case DataFormat.NHWC =>
+        if (batchSize == -1) {
+          Array(oh, ow, nOutputPlane)
+        } else {
+          Array(batchSize, oh, ow, nOutputPlane)
+        }
+    }
+  }
+
+  {
+    val stdv = 1.0 / math.sqrt(kernelW * kernelH * nInputPlane)
+    val wInit: InitializationMethod = RandomUniform(-stdv, stdv)
+    val bInit: InitializationMethod = if (withBias) RandomUniform(-stdv, stdv)
+    else null
+    setInitMethod(wInit, bInit)
+  }
+
+  override def reset(): Unit = {
+    if (initWeight == null) { // TODO only support oihw format weights
+      weightInitMethod.init(weight.dense, if (nGroup == 1) {
+        VariableFormat.OUT_IN_KW_KH
+      } else {
+        VariableFormat.GP_OUT_IN_KW_KH
+      })
+    } else {
+      weight.dense.copy(initWeight)
+    }
+
+    if (initBias == null) {
+      biasInitMethod.init(bias.dense, VariableFormat.ONE_D)
+    } else {
+      bias.dense.copy(initBias)
+    }
+  }
+
+  private def setScalesOutForAttr(scaleIn: Array[Float], scaleOut: Array[Float],
+    attr: Long): Unit = {
+    require(this.getWeightScales() != null, s"you should use a model contains scales")
+    val scales = this.getWeightScales().flatten.map(w =>
+      if (Math.abs(w - 0.0f) < DenseTensorMath.floatEpsilon) {
+        0.0f
+      } else {
+        scaleOut(0) / (scaleIn(0) * 127.0f / w)
+      })
+    DNNL.AttrSetOutputScales(attr, scales.length, 2, scales)
+    // TODO
+//    DNNL.AttrSetIntOutputRoundMode(attr, 1)
+  }
+
+  override private[mkldnn] def initFwdPrimitives(inputs: Array[MemoryData], phase: Phase) = {
+    reorderManager.setRuntime(runtime)
+    // maybe the model has no scales, we can't do quantize here.
+    if (getInputScales().flatten.isEmpty || getOutputScales().flatten.isEmpty ||
+      getWeightScales().flatten.isEmpty) {
+      needQuantize = false
+    }
+
+    if (_sum && inputs.length > 1) {
+      _sumInput = true
+      require(inputs.length == 2,
+        s"inputs length should be 2 when having sum operation, but get ${inputs.length}")
+    }
+    // we should not use output branch
+    val inputMemoryData = inputs(inputs.length - _dim)
+    val inputHeight = inputMemoryData.shape(2) // TODO only supports 4-D and nchw
+    val inputWidth = inputMemoryData.shape(3)
+
+    val convPaddingShape = getConvPaddingShape(inputHeight, inputWidth, paddingType)
+    val convOutputShape = getConvOutputShape(inputHeight, inputWidth, convPaddingShape)
+
+    val padTop = convPaddingShape.top
+    val padBottom = convPaddingShape.bottom
+    val padLeft = convPaddingShape.left
+    val padRight = convPaddingShape.right
+    val outputHeight = convOutputShape.height
+    val outputWidth = convOutputShape.width
+
+    paddingTL = Array(padTop, padLeft)
+    paddingBR = Array(padBottom, padRight)
+
+    val inputShape = inputMemoryData.shape
+    val outputShape = Array(inputMemoryData.shape(0), nOutputPlane, outputHeight, outputWidth)
+
+    val inputDataType = if (needQuantize) {
+      if (negativeInput) {
+        DataType.S8
+      } else {
+        DataType.U8
+      }
+    } else {
+      DataType.F32
+    }
+    val weightDataType = if (needQuantize) DataType.S8 else DataType.F32
+    val biasDataType = if (needQuantize) DataType.S32 else DataType.F32
+    val outputDataType = if (needQuantize) {
+      // must use the same datatype with the sumOp, otherwise the result will be wrong.
+      if (!relu || (sum && sumOp.outputFormats()(0).dataType == DataType.S8)) {
+        DataType.S8
+      } else {
+        DataType.U8
+      }
+    } else {
+      DataType.F32
+    }
+
+    val src = NativeData(inputShape, Memory.FormatTag.any, inputDataType)
+    val wei = NativeData(weightShape, Memory.FormatTag.any, weightDataType)
+    val bis = NativeData(Array(nOutputPlane), Memory.FormatTag.x, biasDataType)
+    val dst = NativeData(outputShape, Memory.FormatTag.any, outputDataType)
+
+    val scaleIn = this.getInputScales().flatten.map { x =>
+      if (negativeInput) {
+        Scale.S8_MAX / x
+      } else {
+        Scale.U8_MAX / x
+      }
+    }
+
+    val scaleOut = this.getOutputScales().flatten.map { x =>
+      if (relu) {
+        Scale.U8_MAX / x
+      } else {
+        Scale.S8_MAX / x
+      }
+    }
+
+    val scaleWeight = this.getWeightScales().flatten.map { w => Scale.S8_MAX / w }
+
+    // TODO check wether ForwardInference and ForwardTraining is the same
+    val desc = DnnlMemory.DilatedConvForwardDescInit(
+      PropKind.ForwardTraining,
+      AlgKind.ConvolutionDirect,
+      src.getMemoryDescriptor(),
+      wei.getMemoryDescriptor(),
+      bis.getMemoryDescriptor(),
+      dst.getMemoryDescriptor(),
+      Array(strideW, strideH),
+      Array(dilationW_mkldnn, dilationH_mkldnn),
+      paddingTL, paddingBR,
+      DNNL.PaddingKind.mkldnnPaddingZero)
+
+    forwardPrimDesc = if (relu || sum) {
+      val attr = DnnlMemory.CreateAttr()
+
+      // create output scales for s8/u8 output
+      if (needQuantize) {
+        setScalesOutForAttr(scaleIn, scaleOut, attr)
+      }
+
+      val postOps = DnnlMemory.CreatePostOps()
+      if (sum) {
+        val sumScale = if (needQuantize) {
+          require(scaleOut.length == sumOp.outputFormats()(0).scales.length,
+            s"the output scales should be the same between ${getName()} and ${sumOp.getName()}")
+          scaleOut(0) / sumOp.outputFormats()(0).scales(0)
+        } else {
+          1.0f
+        }
+        DNNL.PostOpsAppendSum(postOps, sumScale)
+      }
+
+      if (relu) {
+        DNNL.PostOpsAppendEltwise(postOps, 1.0f, AlgKind.EltwiseRelu, 0.0f, 0.0f)
+      }
+      DNNL.AttrSetPostOps(attr, postOps)
+
+      DnnlMemory.PrimitiveDescCreateV2(desc, attr, runtime.engine, 0)
+      // TODO we should destroy these ops
+    } else if (needQuantize) {
+      val attr = DnnlMemory.CreateAttr()
+
+      setScalesOutForAttr(scaleIn, scaleOut, attr)
+
+      DnnlMemory.PrimitiveDescCreateV2(desc, attr, runtime.engine, 0)
+      // TODO we should destroy these ops
+    } else {
+      DnnlMemory.PrimitiveDescCreate(desc, runtime.engine, 0)
+    }
+
+    val List(realSrc, realWei, realDst) = List(Query.SrcMd, Query.WeightsMd, Query.DstMd).map {x =>
+      MemoryData.operationWant(forwardPrimDesc, x)
+    }
+
+    // The weight on heap should be oihw or goihw format and should reorder it first when using.
+    val defaultWeightLayout = if (nGroup == 1) {
+      Memory.FormatTag.oihw
+    } else {
+      Memory.FormatTag.goihw
+    }
+
+    val defaultWeight = HeapData(weight.dense.size(), defaultWeightLayout)
+    val defaultBias = HeapData(bias.dense.size(), Memory.FormatTag.x)
+
+    if (needQuantize) {
+      defaultWeight.setMask(getWeightDimMask())
+      defaultWeight.setScales(scaleWeight)
+      defaultBias.setMask(getWeightDimMask())
+      defaultBias.setScales(scaleWeight.map(w => w * scaleIn(0)))
+    }
+
+    weight.setMemoryData(defaultWeight, realWei, runtime)
+    bias.setMemoryData(defaultBias, bis, runtime)
+
+    weight.sync()
+    bias.sync()
+
+    val primitive = DnnlMemory.PrimitiveCreate(forwardPrimDesc)
+
+//    updateOutputMemoryPrimitives = srcs ++ dsts
+    fwdExecArgs = mutable.Map(
+      ArgType.DNNL_ARG_SRC -> realSrc.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_WEIGHTS -> realWei.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_BIAS -> bis.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DST -> realDst.getMemoryObject(runtime)
+    )
+
+    updateOutputPrimitives = Array(primitive)
+    output = initTensor(realDst)
+
+    // quantize weight from fp32 to int8
+    if (needQuantize) {
+      realSrc.setMask(this.getInputDimMask())
+      realSrc.setScales(scaleIn)
+    }
+
+    if (needQuantize) {
+      realDst.setMask(this.getOutputDimMask())
+      realDst.setScales(scaleOut)
+    }
+    _inputFormats = if (_sumInput) {
+      val formats = inputs.map(i => i).toArray
+      formats(inputs.length - _dim) = realSrc
+      formats
+    } else Array(realSrc)
+    _outputFormats = Array(realDst)
+
+    (_inputFormats, _outputFormats)
+  }
+
+  override def updateOutput(input: Activity): Activity = {
+    val inputTensor = if (input.isTensor) {
+      input.toTensor[Float]
+    } else {
+      // here we should not use the output branch
+      output = input.toTable.get[Tensor[Float]](_dim).get
+      input.toTable.get[Tensor[Float]](3 - _dim).get
+    }
+    if (updateOutputTensors == null) {
+      updateOutputTensors = mutable.Map(
+        ArgType.DNNL_ARG_SRC -> inputTensor.asInstanceOf[Tensor[Float]],
+        ArgType.DNNL_ARG_WEIGHTS -> weight.native,
+        ArgType.DNNL_ARG_BIAS -> bias.native
+      )
+
+      if (sum && input.isTensor) {
+        output = sumOp.output
+      }
+      updateOutputTensors.put(ArgType.DNNL_ARG_DST, output.asInstanceOf[Tensor[Float]])
+    }
+
+    updateWithNewTensor(updateOutputTensors, ArgType.DNNL_ARG_SRC, inputTensor)
+
+    if (isTraining()) {
+      weight.sync()
+      bias.sync()
+    }
+
+    // TODO:
+    MklDnnOps.streamSubmit(updateOutputPrimitives,
+      runtime.stream, fwdExecArgs, updateOutputTensors)
+
+    output
+  }
+
+  override private[mkldnn] def initBwdPrimitives(grad: Array[MemoryData], phase: Phase) = {
+    val inputShape = inputFormats()(0).shape.length match {
+      case 1 => inputFormats()(0).shape ++ Array(1) // TODO Test
+      case _ => inputFormats()(0).shape
+    }
+
+    val outputShape = outputFormats()(0).shape
+
+    val src = NativeData(inputShape, Memory.FormatTag.any)
+    val wei = NativeData(weightShape, Memory.FormatTag.any)
+    val bis = NativeData(Array(nOutputPlane), Memory.FormatTag.x)
+    val dst = NativeData(outputShape, Memory.FormatTag.any)
+
+    val desc = DnnlMemory.DilatedConvBackwardDataDescInit(
+      AlgKind.ConvolutionDirect,
+      src.getMemoryDescriptor(),
+      wei.getMemoryDescriptor(), // TODO check correctness of strides and padding
+      dst.getMemoryDescriptor(),
+      Array(strideW, strideH),
+      Array(dilationW_mkldnn, dilationH_mkldnn, 0),
+      paddingTL, paddingBR,
+      DNNL.PaddingKind.mkldnnPaddingZero)
+
+    val backwardPrimDesc = DnnlMemory.PrimitiveDescCreate(desc, runtime.engine, forwardPrimDesc)
+
+    val List(realDiffSrc, realWei, realDiffDst) =
+      List(Query.DiffSrcMd, Query.WeightsMd, Query.DiffDstMd).map {
+        x => MemoryData.operationWant(backwardPrimDesc, x)
+      }
+
+    weightForBackwardMemoryData = realWei
+
+    reorderManager.register(weight.heapData, realWei)
+
+    // computing gradient input doesn't need the input
+    val primitive = DnnlMemory.PrimitiveCreate(backwardPrimDesc)
+
+    bwdExecArgs = mutable.Map(
+      ArgType.DNNL_ARG_DIFF_DST -> realDiffDst.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_WEIGHTS  -> realWei.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DIFF_SRC -> realDiffSrc.getMemoryObject(runtime)
+    )
+
+    updateGradInputPrimitives = Array(primitive)
+
+    gradInput = initTensor(realDiffSrc)
+
+    _gradInputFormats = Array(realDiffSrc)
+    _gradOutputFormats = Array(realDiffDst)
+
+    (_gradOutputFormats, _gradInputFormats)
+  }
+
+
+  override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
+    // if needed, reorder manager will reorder the wegiht to mkldnn wants
+    weightForBackward = reorderManager.infer(Array(weight.heapData),
+      Array(weightForBackwardMemoryData), weight.dense).asInstanceOf[DnnTensor[Float]]
+
+    if (updateGradInputTensors == null) {
+      updateGradInputTensors = mutable.Map(
+        ArgType.DNNL_ARG_DIFF_DST -> gradOutput.asInstanceOf[Tensor[Float]],
+        ArgType.DNNL_ARG_WEIGHTS  -> weightForBackward,
+        ArgType.DNNL_ARG_DIFF_SRC -> gradInput.asInstanceOf[Tensor[Float]]
+      )
+    }
+
+    updateWithNewTensor(
+      updateGradInputTensors, ArgType.DNNL_ARG_DIFF_DST, gradOutput)
+    updateWithNewTensor(
+      updateGradInputTensors, ArgType.DNNL_ARG_WEIGHTS, weightForBackward)
+
+    // TODO:
+    MklDnnOps.streamSubmit(updateGradInputPrimitives,
+      runtime.stream, bwdExecArgs, updateGradInputTensors)
+
+    gradInput
+  }
+
+  override private[mkldnn] def initGradWPrimitives(grad: Array[MemoryData],
+                                                 phase: Phase): Array[MemoryData] = {
+
+    val inputShape = inputFormats()(0).shape
+
+    val src = NativeData(inputShape, Memory.FormatTag.any)
+    val wei = NativeData(weightShape, Memory.FormatTag.any)
+    val bis = NativeData(Array(nOutputPlane), Memory.FormatTag.x)
+    // Use format "any" to init weight desc, otherwise maybe poor performance
+    val gradMemoryData = NativeData(grad(0).shape, Memory.FormatTag.any)
+
+    val desc = DnnlMemory.DilatedConvBackwardWeightsDescInit(
+      AlgKind.ConvolutionDirect,
+      src.getMemoryDescriptor(),
+      wei.getMemoryDescriptor(),
+      bis.getMemoryDescriptor(),
+      gradMemoryData.getMemoryDescriptor(),
+      Array(strideW, strideH),
+      Array(dilationW_mkldnn, dilationH_mkldnn),
+      paddingTL, paddingBR,
+      DNNL.PaddingKind.mkldnnPaddingZero)
+
+    val gradWeightPrimDesc = DnnlMemory.PrimitiveDescCreate(desc, runtime.engine, forwardPrimDesc)
+
+    // TODO here seems some errors ?????? check the realSrc format.
+    val List(realSrc, realWei, realDiffDst) =
+      List(Query.SrcMd, Query.DiffWeightsMd, Query.DiffDstMd).map { x =>
+        MemoryData.operationWant(gradWeightPrimDesc, x)
+      }
+
+    // gradient weight should be the same format with weight
+    val defaultWeightLayout = if (nGroup == 1) {
+      Memory.FormatTag.oihw
+    } else {
+      Memory.FormatTag.goihw
+    }
+
+    gradWeight.setMemoryData(realWei,
+      HeapData(gradWeight.dense.size(), defaultWeightLayout), runtime)
+
+
+    gradBias.setMemoryData(bis,
+      HeapData(gradBias.dense.size(), Memory.FormatTag.x), runtime)
+
+    // save the real input format accGradParameters wants, and register the reorder operation
+    inputForAccMemoryData = realSrc
+    reorderManager.register(inputFormats()(0), realSrc)
+
+    weightUpdateExecArgs = mutable.Map(
+      ArgType.DNNL_ARG_SRC -> realSrc.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DIFF_DST -> realDiffDst.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DIFF_WEIGHTS -> realWei.getMemoryObject(runtime),
+      ArgType.DNNL_ARG_DIFF_BIAS -> bis.getMemoryObject(runtime)
+    )
+
+    val primitive = DnnlMemory.PrimitiveCreate(gradWeightPrimDesc)
+
+    accGradientPrimitives = Array(primitive)
+    _gradOutputFormatsForWeight = Array(realDiffDst)
+
+    (_gradOutputFormatsForWeight)
+  }
+
+
+
+  override def accGradParameters(input: Activity, gradOutput: Activity): Unit = {
+//    println("inside accGradParameters", gradOutput.toTensor[Float].size().mkString(" "))
+    // if needed, reorder manager will reorder input to mkldnn wants
+    val inputTensor = if (input.isTensor) {
+      input.toTensor[Float]
+    } else {
+      input.toTable.get[Tensor[Float]](_dim).get
+    }
+
+    inputForAcc = reorderManager.infer(Array(inputFormats()(0)),
+      Array(inputForAccMemoryData), inputTensor).asInstanceOf[DnnTensor[Float]]
+
+    if (updateGradWTensors == null) {
+      updateGradWTensors = mutable.Map(
+        ArgType.DNNL_ARG_DIFF_WEIGHTS -> gradWeight.native,
+        ArgType.DNNL_ARG_DIFF_BIAS -> gradBias.native)
+    }
+
+    updateGradWTensors.put(ArgType.DNNL_ARG_SRC, inputForAcc.asInstanceOf[Tensor[Float]])
+    updateGradWTensors.put(ArgType.DNNL_ARG_DIFF_DST, gradOutput.asInstanceOf[Tensor[Float]])
+
+    // TODO:
+    MklDnnOps.streamSubmit(accGradientPrimitives,
+      runtime.stream, weightUpdateExecArgs, updateGradWTensors)
+
+    gradWeight.sync()
+    gradBias.sync()
+
+    if (null != wRegularizer) {
+      wRegularizer.accRegularization(weight.dense, gradWeight.dense, scaleW)
+    }
+    if (withBias && null != bRegularizer) {
+      bRegularizer.accRegularization(bias.dense, gradBias.dense, scaleB)
+    }
+
+  }
+
+  override def parameters(): (Array[Tensor[Float]], Array[Tensor[Float]]) = {
+    if (withBias) {
+      (Array(weight.dense, bias.dense), Array(gradWeight.dense, gradBias.dense))
+    } else {
+      (Array(weight.dense), Array(gradWeight.dense))
+    }
+  }
+
+  override def paramsMMap(): (Array[TensorMMap], Array[TensorMMap]) = {
+    (Array(weight, bias), Array(gradWeight, gradBias))
+  }
+
+  // we need not implement it, because the grad parameters will clean by mkldnn
+  override def zeroGradParameters(): Unit = {
+  }
+
+  override def setQuantize(value: Boolean): this.type = {
+    needQuantize = value
+    this
+  }
+
+  /**
+   * TODO:
+   *   (1) add calculation logic for Full padding
+   *   (2) abstract and design an object type for return value, insteaof returnning
+   *       the result as an int array
+   * Calculate padding size
+   * @param inputHeight height of input
+   * @param inputWidth width of input
+   * @param paddingType one of Same, Valid, Full
+   * @return an int array of length 4 representing padding sizes
+   *         (top, bottom, left, right)
+   */
+  private def getConvPaddingShape(inputHeight: Int, inputWidth: Int,
+                                  paddingType: PaddingType.Value): ConvPaddingShape = {
+    paddingType match {
+      case PaddingType.Same =>
+        getConvPaddingShape(inputHeight, inputWidth, kernelH, kernelW,
+          strideH, strideW, dilationH, dilationW)
+      case PaddingType.Custom => ConvPaddingShape(padH, padH, padW, padW)
+      case _ => throw new IllegalArgumentException()
+    }
+  }
+
+  /**
+   * Helper function to get convolution padding shape for Same Padding
+   * Steps:
+   *   1). calculate the dimension of dilated kernel
+   *       dilated kernel = kernel + (kernel - 1) * (dilation - 1)
+   *   2). calculate the number of stride it would make
+   *       number of stride = (input + stride - 1) / stride
+   *   3). calculate the number of pad needed to make
+   *       number of pad = start of last stride + dilated kernel - input
+   *       start of last stride = (number of stride - 1) * stride
+   *   4). assign the number of pad to left & right side
+   * @param inputHeight height of input
+   * @param inputWidth width of input
+   * @param kernelHeight height of kernel
+   * @param kernelWidth width of kernel
+   * @param strideHeight height of stride
+   * @param strideWidth width of stride
+   * @param dilationHeight height of dilation
+   * @param dilationWidth width of dilation
+   * @return ConvPaddingShape
+   */
+  private def getConvPaddingShape(inputHeight: Int, inputWidth: Int,
+                                  kernelHeight: Int, kernelWidth: Int,
+                                  strideHeight: Int, strideWidth: Int,
+                                  dilationHeight: Int, dilationWidth: Int
+                                 ): ConvPaddingShape = {
+    val dilatedKernelHeight = kernelHeight + (kernelHeight - 1) * (dilationHeight - 1)
+    val dilatedKernelWidth = kernelWidth + (kernelWidth - 1) * (dilationWidth - 1)
+    val numOfStrideHeight = (inputHeight + strideHeight - 1) / strideHeight
+    val numOfStrideWidth = (inputWidth + strideWidth - 1) / strideWidth
+    val padAlongHeight = Math.max(0,
+      (numOfStrideHeight - 1) * strideHeight + dilatedKernelHeight - inputHeight)
+    val padAlongWidth = Math.max(0,
+      (numOfStrideWidth - 1) * strideWidth + dilatedKernelWidth - inputWidth)
+    val (padTop, padBottom) = (padAlongHeight / 2, (padAlongHeight + 1) / 2)
+    val (padLeft, padRight) = (padAlongWidth / 2, (padAlongWidth + 1) / 2)
+    ConvPaddingShape(padTop, padBottom, padLeft, padRight)
+  }
+
+
+  /**
+   * Calculate convolution output shape
+   * Please try to keep the logic in consistent with MKL-DNN
+   * Reffernce: https://github.com/intel/mkl-dnn/blob/master/src/common/convolution.cpp#L117
+   * @param inputH height of input
+   * @param inputW width of input
+   * @return a ConvOutputShape object
+   */
+  private def getConvOutputShape(inputH: Int, inputW: Int,
+                                 paddingShape: ConvPaddingShape): ConvOutputShape = {
+    def getOutputLength(inputLength: Int, padLeft: Int, padRight: Int,
+                        dilation: Int, kernelSize: Int, stride: Int): Int = {
+      val kernelRange = 1 + (kernelSize - 1) * (dilation + 1)
+      val outputLength = (inputLength - kernelRange + padLeft + padRight) / stride + 1
+      return outputLength
+    }
+    val (padTop, padBottom, padLeft, padRight) = (
+      paddingShape.top, paddingShape.bottom,
+      paddingShape.left, paddingShape.right
+    )
+    val outputHeight = getOutputLength(inputH, padTop, padBottom,
+      dilationH_mkldnn, kernelH, strideH)
+    val outputWidth = getOutputLength(inputW, padLeft, padRight,
+      dilationW_mkldnn, kernelW, strideH)
+
+    ConvOutputShape(outputHeight, outputWidth)
+  }
+
+
+  /**
+   * Get padding type
+   * @return PaddingType
+   */
+  private def getPaddingType(): PaddingType.Value = {
+    if (padH == -1 && padW == -1) {
+      PaddingType.Same
+    } else if (padH >= 0 && padW >= 0) {
+      PaddingType.Custom
+    } else {
+      throw new IllegalArgumentException("Invalid padding")
+    }
+  }
+
+}
+
+object SpatialConvolution {
+  def apply(
+    nInputPlane: Int,
+    nOutputPlane: Int,
+    kW: Int,
+    kH: Int,
+    dW: Int = 1,
+    dH: Int = 1,
+    padW: Int = 0,
+    padH: Int = 0,
+    nGroup: Int = 1,
+    propagateBack: Boolean = true,
+    wRegularizer: Regularizer[Float] = null,
+    bRegularizer: Regularizer[Float] = null,
+    initWeight: Tensor[Float] = null,
+    initBias: Tensor[Float] = null,
+    initGradWeight: Tensor[Float] = null,
+    initGradBias: Tensor[Float] = null,
+    withBias: Boolean = true,
+    format: DataFormat = DataFormat.NCHW,
+    dilationW: Int = 1,
+    dilationH: Int = 1): SpatialConvolution = {
+    new SpatialConvolution(nInputPlane, nOutputPlane, kW, kH, dW,
+      dH, padW, padH, nGroup, propagateBack, wRegularizer, bRegularizer,
+      initWeight, initBias, initGradWeight,
+      initGradBias, withBias, format, dilationW, dilationH)
+  }
+}
+
+object Scale {
+  val S8_MAX = 127.0f
+  val U8_MAX = 255.0f
+}
+
+
+/**
+ * Enum for padding type
+ * currently only support Same and Custom
+ */
+private[mkldnn] object PaddingType extends Enumeration {
+  val Same, Custom = Value
+}
+
+
+/**
+ * object to store meta for convolution padding shape
+ * @param top
+ * @param bottom
+ * @param left
+ * @param right
+ */
+private[mkldnn] case class ConvPaddingShape(
+  top: Int,
+  bottom: Int,
+  left: Int,
+  right: Int
+)
+
+/**
+ * case class to store meta for convolution output shape
+ * @param height
+ * @param width
+ */
+private[mkldnn] case class ConvOutputShape(
+  height: Int,
+  width: Int
+)

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/TensorMMap.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/TensorMMap.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.{Memory}
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase}
+import com.intel.analytics.bigdl.tensor.{DnnTensor, Tensor}
+
+import scala.reflect.ClassTag
+
+/**
+ * `TensorMMap` contains two tensors, dense and native, which are a map of each other.
+ * It's used in the layer which contains weights. For the weight, we should sync the
+ * dense tensor to native tensor before `submit`. For the gradient, we should sync the native
+ * tensor to dense tensor after `submit`.
+ *
+ * @param _size the shape of Tensor, such as Array(4, 3, 224, 224)
+ */
+private[bigdl] class TensorMMap(_size: Array[Int])(implicit owner: MemoryOwner)
+  extends Serializable {
+  // dense weight on heap is used to optimizer and so on, which is exposed to
+  // AbstractModule level.
+  val dense: Tensor[Float] = Tensor[Float](_size)
+
+  def native[T]: DnnTensor[T] = {
+    _native.asInstanceOf[DnnTensor[T]]
+  }
+
+  // the native DnnTensor. It's allocate at runtime when do primitive initialization.
+  // it has two benefits, the first is the clone will only clone one copy of weights and gradients
+  // before primitive initialized and the second is that we can determined the size, type, format
+  // when do initializing primitive.
+  @transient private var _native: DnnTensor[_] = _
+
+  @transient private var _from: MemoryData = null
+  @transient private var _to: MemoryData = null
+  @transient private var _reorder: ReorderMemory = null
+
+  @transient private var _heapData: HeapData = null
+
+  def heapData: HeapData = _heapData
+
+  def sync(): Unit = {
+    require(_reorder != null && _native != null,
+      "you should initialize the native relevant resources first")
+    _from match {
+      case _: HeapData => _reorder.forward(this.dense)
+      case _: NativeData => _reorder.forward(this.native)
+    }
+  }
+
+  def getFrom(): MemoryData = _from
+
+  def getTo(): MemoryData = _to
+
+  /**
+   * set the dense <-> native map, maintain the format to reorder
+   *
+   * Note, it will only create the native tensor based on the size and will not
+   * do the reorder. So you should call `sync()` by manual.
+   *
+   * @param from the source tensor memory data, could be HeapData or NativeData
+   * @param to the dest tensor memory data, could be HeapData or NativeData
+   * @param runtime the mkldnn runtime for reorder operation
+   */
+      def setMemoryData(from: MemoryData, to: MemoryData, runtime: MklDnnRuntime): Unit = {
+    require(_from == null && _to == null, "you only can set once the memory data")
+    _from = from
+    _to = to
+
+    _reorder = ReorderMemory(to)
+    _reorder.setRuntime(runtime)
+    _reorder.initFwdPrimitives(Array(_from), InferencePhase)
+
+    _from match {
+      case _: HeapData =>
+        this._native = _reorder.output.asInstanceOf[DnnTensor[Float]]
+        _heapData = _from.asInstanceOf[HeapData]
+      case _: NativeData =>
+        // the native tensor size should be determined by the memory description
+        // otherwise will be segmentfault
+        this._native = DnnTensor[Float](
+          Memory.GetPaddingShape(_from.getMemoryDescriptor()).map(_.toInt))
+        // the native initialize value should be all zeros.
+        this._native.zero()
+        _reorder.output.toTensor[Float].set(this.dense)
+        _heapData = _to.asInstanceOf[HeapData]
+    }
+
+  }
+
+  def zero(): Unit = {
+    dense.zero()
+    if (native != null) {
+      native.zero()
+    }
+  }
+
+  def copy(t: Tensor[Float]): Unit = {
+    dense.copy(t)
+  }
+
+  def size(): Array[Int] = {
+    dense.size()
+  }
+
+  def size(index: Int): Int = {
+    dense.size(index)
+  }
+
+  def release(): Unit = {
+    if (native != null) {
+      native.release()
+    }
+  }
+
+  def setNative(another: TensorMMap): Unit = {
+    if (native != null && another.native != null) {
+      native.set(another.native.asInstanceOf[Tensor[_]])
+    }
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Utils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/Utils.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.Memory
+import com.intel.analytics.bigdl.nn.MklInt8Convertible
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.InferencePhase
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.T
+
+private[bigdl] object Utils {
+  def copyMaskAndScales(from: MemoryData, to: MemoryData): Unit = {
+    // here we check the from and to, they should not be null ideally
+    // but if the model is mixin with blas layer, it may be null
+    if (from != null && to != null && to.scales.isEmpty) {
+      to.setScales(from.scales.clone())
+      to.setMask(from.mask)
+    }
+  }
+
+  def copyMaskAndScales(from: Array[MemoryData], to: Array[MemoryData]): Unit = {
+    // here we check the from and to, they should not be null ideally
+    // but if the model is mixin with blas layer, it may be null
+    if (from == null || to == null) return
+
+    val valid = (from.length == 1 || to.length == 1) || // the ConcatTable or JoinTable
+      (from.length == to.length) // the same length of from and to.
+
+    // if from has scales but to has no, copy them
+    val needCopy = from.ne(to) && from.forall(_.scales.nonEmpty) && to.forall(_.scales.isEmpty)
+
+    if (valid && needCopy) {
+      if (from.length == to.length) {
+        to.zip(from).foreach(x => if (x._1.scales.isEmpty) {
+          x._1.setScales(x._2.scales)
+          x._1.setMask(x._2.mask)
+        })
+      } else if (to.length == 1) {
+        to.head.setScales(from.map(_.scales).transpose.map(_.max))
+        require(from.map(_.mask).distinct.length == 1, s"only support the same mask")
+        to.head.setMask(from.map(_.mask).distinct.head)
+      } else if (to.length > 1) {
+        to.foreach(_.setScales(from.head.scales))
+        to.foreach(_.setMask(from.head.mask))
+      }
+    }
+  }
+
+  def getDefaultFormat(memoryData: MemoryData, isInOrOut: Boolean = true): Int = {
+    memoryData.shape.length match {
+      case 2 => if (isInOrOut) Memory.FormatTag.nc else Memory.FormatTag.oi
+      case 4 => if (isInOrOut) Memory.FormatTag.nchw else Memory.FormatTag.oihw
+      case _ => throw new UnsupportedOperationException("Linear only supports 2-D or 4-D")
+    }
+  }
+
+  private def denseTensor(format: MemoryData, tensor: Tensor[Float],
+    isInOrOut: Boolean = true, runtime: MklDnnRuntime): Tensor[Float] = {
+    val reorder = ReorderMemory(HeapData(format.shape, getDefaultFormat(format, isInOrOut)))
+    reorder.setRuntime(runtime)
+    reorder.initFwdPrimitives(Array(format), InferencePhase)
+    reorder.forward(tensor).toTensor[Float]
+  }
+
+  private def denseActivity(formats: Array[MemoryData], activity: Activity,
+    isInOrOut: Boolean = true, runtime: MklDnnRuntime): Activity = {
+    val ret = if (formats.length > 1) { // table
+      require(formats.length == activity.toTable.length(),
+        s"formats should be the same as activity")
+      val table = T()
+
+      var i = 1
+      while (i <= formats.length) {
+        val format = formats(i - 1)
+        val tensor = activity.toTable.get[Tensor[Float]](i).get
+        table(i) = denseTensor(format, tensor, isInOrOut, runtime)
+        i += 1
+      }
+
+      table
+    } else { // tensor
+      denseTensor(formats(0), activity.toTensor[Float], isInOrOut, runtime)
+    }
+
+    ret
+  }
+
+  def getDenseIn(module: MklInt8Convertible, input: Activity): Activity = {
+    if (module.isInstanceOf[MklDnnModule]) {
+      val mklDnnLayer = module.asInstanceOf[MklDnnModule]
+      Utils.denseActivity(mklDnnLayer.inputFormats(), input, true, mklDnnLayer.getRuntime)
+    } else {
+      input
+    }
+  }
+
+  def getDenseOut(module: MklInt8Convertible, output: Activity): Activity = {
+    if (module.isInstanceOf[MklDnnModule]) {
+      val mklDnnLayer = module.asInstanceOf[MklDnnModule]
+      Utils.denseActivity(mklDnnLayer.outputFormats(), output, true, mklDnnLayer.getRuntime)
+    } else {
+      output
+    }
+  }
+
+  private def setConvNegativeInput(module: MklInt8Convertible, input: Activity): Unit = {
+    if (module.isInstanceOf[SpatialConvolution]) {
+      val conv = module.asInstanceOf[SpatialConvolution]
+      val denseIn = getDenseIn(module, input)
+      val min = denseIn.toTensor[Float].min()
+      if (min >= 0.0f) {
+        conv.negativeInput = false
+      }
+    }
+  }
+
+  def calcScales(module: AbstractModule[_, _, _], input: Activity): Unit = {
+    module match {
+      case mkldnnModule: MklInt8Convertible =>
+        mkldnnModule.calcScales(input)
+        Utils.setConvNegativeInput(mkldnnModule, input)
+      case _ =>
+    }
+  }
+
+  def getOutput(module: AbstractModule[_, _, _], input: Activity): Activity = {
+    module match {
+      case mklDnnModule: MklDnnModule => module.output.asInstanceOf[Activity]
+      case _ => module.output.asInstanceOf[Activity]
+    }
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/models/Vgg16.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/dnnl/models/Vgg16.scala
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn.models
+
+import com.intel.analytics.bigdl.dnnl.Memory
+import com.intel.analytics.bigdl.nn.{ConstInitMethod, Xavier, Zeros}
+import com.intel.analytics.bigdl.nn.mkldnn._
+
+object Vgg_16 {
+  def apply(batchSize: Int, classNum: Int, hasDropout: Boolean = true): Sequential = {
+    val model = Sequential()
+    model.add(Input(Array(batchSize, 3, 224, 224), Memory.FormatTag.nchw))
+    model.add(Conv(3, 64, 3, 3, 1, 1, 1, 1).setName("conv1_1"))
+    model.add(ReLU().setName("relu1_1"))
+    model.add(Conv(64, 64, 3, 3, 1, 1, 1, 1).setName("conv1_2"))
+    model.add(ReLU().setName("relu1_2"))
+    model.add(MaxPooling(2, 2, 2, 2).setName("pool1"))
+
+    model.add(Conv(64, 128, 3, 3, 1, 1, 1, 1).setName("conv2_1"))
+    model.add(ReLU().setName("relu2_1"))
+    model.add(Conv(128, 128, 3, 3, 1, 1, 1, 1).setName("conv2_2"))
+    model.add(ReLU().setName("relu2_2"))
+    model.add(MaxPooling(2, 2, 2, 2).setName("pool2"))
+
+    model.add(Conv(128, 256, 3, 3, 1, 1, 1, 1).setName("conv3_1"))
+    model.add(ReLU().setName("relu3_1"))
+    model.add(Conv(256, 256, 3, 3, 1, 1, 1, 1).setName("conv3_2"))
+    model.add(ReLU().setName("relu3_2"))
+    model.add(Conv(256, 256, 3, 3, 1, 1, 1, 1).setName("conv3_3"))
+    model.add(ReLU().setName("relu3_3"))
+    model.add(MaxPooling(2, 2, 2, 2).setName("pool3"))
+
+    model.add(Conv(256, 512, 3, 3, 1, 1, 1, 1).setName("conv4_1"))
+    model.add(ReLU().setName("relu4_1"))
+    model.add(Conv(512, 512, 3, 3, 1, 1, 1, 1).setName("conv4_2"))
+    model.add(ReLU().setName("relu4_2"))
+    model.add(Conv(512, 512, 3, 3, 1, 1, 1, 1).setName("conv4_3"))
+    model.add(ReLU().setName("relu4_3"))
+    model.add(MaxPooling(2, 2, 2, 2).setName("pool4"))
+
+    model.add(Conv(512, 512, 3, 3, 1, 1, 1, 1).setName("conv5_1"))
+    model.add(ReLU().setName("relu5_1"))
+    model.add(Conv(512, 512, 3, 3, 1, 1, 1, 1).setName("conv5_2"))
+    model.add(ReLU().setName("relu5_2"))
+    model.add(Conv(512, 512, 3, 3, 1, 1, 1, 1).setName("conv5_3"))
+    model.add(ReLU().setName("relu5_3"))
+    model.add(MaxPooling(2, 2, 2, 2).setName("pool5"))
+
+    model.add(Linear(512 * 7 * 7, 4096).setInitMethod(Xavier, ConstInitMethod(0.1)).setName("fc6"))
+    model.add(ReLU().setName("relu6"))
+    if (hasDropout) model.add(Dropout(0.5).setName("drop6"))
+    model.add(Linear(4096, 4096).setInitMethod(Xavier, ConstInitMethod(0.1)).setName("fc7"))
+    model.add(ReLU().setName("relu7"))
+    if (hasDropout) model.add(Dropout(0.5).setName("drop7"))
+    model.add(Linear(4096, classNum).setInitMethod(Xavier, ConstInitMethod(0.1)).setName(("fc8")))
+    model.add(ReorderMemory(HeapData(Array(batchSize, classNum), Memory.FormatTag.nc)))
+
+    model
+  }
+
+  private object Conv {
+    def apply(
+      nInputPlane: Int,
+      nOutputPlane: Int,
+      kernelW: Int,
+      kernelH: Int,
+      strideW: Int = 1,
+      strideH: Int = 1,
+      padW: Int = 0,
+      padH: Int = 0,
+      nGroup: Int = 1,
+      propagateBack: Boolean = true): SpatialConvolution = {
+      val conv = SpatialConvolution(nInputPlane, nOutputPlane, kernelW, kernelH,
+        strideW, strideH, padW, padH, nGroup, propagateBack)
+      conv.setInitMethod(Xavier.setVarianceNormAverage(false), Zeros)
+      conv
+    }
+  }
+
+  def graph(batchSize: Int, classNum: Int, hasDropout: Boolean = true): DnnGraph = {
+    val input = Input(Array(batchSize, 3, 224, 224), Memory.FormatTag.nchw).inputs()
+    val conv1_1 = Conv(3, 64, 3, 3, 1, 1, 1, 1).setName("conv1_1").inputs(input)
+    val relu1_1 = ReLU().setName("relu1_1").inputs(conv1_1)
+    val conv1_2 = Conv(64, 64, 3, 3, 1, 1, 1, 1).setName("conv1_2").inputs(relu1_1)
+    val relu1_2 = ReLU().setName("relu1_2").inputs(conv1_2)
+    val pool1 = MaxPooling(2, 2, 2, 2).setName("pool1").inputs(relu1_2)
+
+    val conv2_1 = Conv(64, 128, 3, 3, 1, 1, 1, 1).setName("conv2_1").inputs(pool1)
+    val relu2_1 = ReLU().setName("relu2_1").inputs(conv2_1)
+    val conv2_2 = Conv(128, 128, 3, 3, 1, 1, 1, 1).setName("conv2_2").inputs(relu2_1)
+    val relu2_2 = ReLU().setName("relu2_2").inputs(conv2_2)
+    val pool2 = MaxPooling(2, 2, 2, 2).setName("pool2").inputs(relu2_2)
+
+    val conv3_1 = Conv(128, 256, 3, 3, 1, 1, 1, 1).setName("conv3_1").inputs(pool2)
+    val relu3_1 = ReLU().setName("relu3_1").inputs(conv3_1)
+    val conv3_2 = Conv(256, 256, 3, 3, 1, 1, 1, 1).setName("conv3_2").inputs(relu3_1)
+    val relu3_2 = ReLU().setName("relu3_2").inputs(conv3_2)
+    val conv3_3 = Conv(256, 256, 3, 3, 1, 1, 1, 1).setName("conv3_3").inputs(relu3_2)
+    val relu3_3 = ReLU().setName("relu3_3").inputs(conv3_3)
+    val pool3 = MaxPooling(2, 2, 2, 2).setName("pool3").inputs(relu3_3)
+
+    val conv4_1 = Conv(256, 512, 3, 3, 1, 1, 1, 1).setName("conv4_1").inputs(pool3)
+    val relu4_1 = ReLU().setName("relu4_1").inputs(conv4_1)
+    val conv4_2 = Conv(512, 512, 3, 3, 1, 1, 1, 1).setName("conv4_2").inputs(relu4_1)
+    val relu4_2 = ReLU().setName("relu4_2").inputs(conv4_2)
+    val conv4_3 = Conv(512, 512, 3, 3, 1, 1, 1, 1).setName("conv4_3").inputs(relu4_2)
+    val relu4_3 = ReLU().setName("relu4_3").inputs(conv4_3)
+    val pool4 = MaxPooling(2, 2, 2, 2).setName("pool4").inputs(relu4_3)
+
+    val conv5_1 = Conv(512, 512, 3, 3, 1, 1, 1, 1).setName("conv5_1").inputs(pool4)
+    val relu5_1 = ReLU().setName("relu5_1").inputs(conv5_1)
+    val conv5_2 = Conv(512, 512, 3, 3, 1, 1, 1, 1).setName("conv5_2").inputs(relu5_1)
+    val relu5_2 = ReLU().setName("relu5_2").inputs(conv5_2)
+    val conv5_3 = Conv(512, 512, 3, 3, 1, 1, 1, 1).setName("conv5_3").inputs(relu5_2)
+    val relu5_3 = ReLU().setName("relu5_3").inputs(conv5_3)
+    val pool5 = MaxPooling(2, 2, 2, 2).setName("pool5").inputs(relu5_3)
+
+    val fc6 = Linear(512 * 7 * 7, 4096).
+      setInitMethod(Xavier, ConstInitMethod(0.1)).setName("fc6").inputs(pool5)
+    val relu6 = ReLU().setName("relu6").inputs(fc6)
+    val drop6 = if (hasDropout) {
+      Dropout(0.5).setName("drop6").inputs(relu6)
+    } else {
+      relu6
+    }
+    val fc7 = Linear(4096, 4096).
+      setInitMethod(Xavier, ConstInitMethod(0.1)).setName("fc7").inputs(drop6)
+    val relu7 = ReLU().setName("relu7").inputs(fc7)
+    val drop7 = if (hasDropout) {
+      Dropout(0.5).setName("drop7").inputs(relu7)
+    } else {
+      relu7
+    }
+    val fc8 = Linear(4096, classNum).
+      setInitMethod(Xavier, ConstInitMethod(0.1)).setName(("fc8")).inputs(drop7)
+    val output = ReorderMemory(HeapData(Array(batchSize, classNum),
+      Memory.FormatTag.nc)).inputs(fc8)
+
+    DnnGraph(Array(input), Array(output))
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/LocalOptimizer.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.optim
 
 import com.intel.analytics.bigdl.dataset.{LocalDataSet, MiniBatch}
 import com.intel.analytics.bigdl._
-import com.intel.analytics.bigdl.mkl.Memory
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{MemoryWrapper => Memory}
 import com.intel.analytics.bigdl.models.utils.ModelBroadcast
 import com.intel.analytics.bigdl.nn.Utils
 import com.intel.analytics.bigdl.nn.abstractnn.Activity

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/ArrayStorage.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/tensor/ArrayStorage.scala
@@ -16,9 +16,8 @@
 
 package com.intel.analytics.bigdl.tensor
 
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{MemoryWrapper => Memory}
 import java.util
-
-import com.intel.analytics.bigdl.mkl.Memory
 
 import scala.reflect._
 
@@ -43,7 +42,12 @@ private[tensor] class ArrayStorage[@specialized(Double, Float) T: ClassTag](
       case s: DnnStorage[T] =>
         require(classTag[T] == ClassTag.Float, "Only support copy float dnn storage")
         require(sourceOffset == 0, "dnn storage offset should be 0")
-        Memory.CopyPtr2Array(s.ptr.address, 0, values.asInstanceOf[Array[Float]], offset, length,
+        Memory.copyPtr2Array(
+          s.ptr.address,
+          0,
+          values.asInstanceOf[Array[Float]],
+          offset,
+          length,
           DnnStorage.FLOAT_BYTES)
       case _ => throw new UnsupportedOperationException("Only support dnn or array storage")
     }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DistriParameterSynchronizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/DistriParameterSynchronizer.scala
@@ -20,7 +20,8 @@ import java.util
 import java.util.concurrent._
 import java.util.concurrent.atomic.AtomicInteger
 
-import com.intel.analytics.bigdl.mkl.hardware.{Affinity, CpuInfo}
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{AffinityWrapper => Affinity}
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{CpuInfoWrapper => CpuInfo}
 import com.intel.analytics.bigdl.parameters.{CompressedTensor, FP16CompressedTensor, SerializerInstance}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import org.apache.log4j.Logger
 import org.apache.spark._
-import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{CoreWrapper => MKL}
+import com.intel.analytics.bigdl.mkl.MKL
 import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{CpuInfoWrapper => CpuInfo}
 import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{AffinityWrapper => Affinity}
 import org.apache.spark.utils.SparkUtils

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/Engine.scala
@@ -22,8 +22,9 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import org.apache.log4j.Logger
 import org.apache.spark._
-import com.intel.analytics.bigdl.mkl.MKL
-import com.intel.analytics.bigdl.mkl.hardware.{Affinity, CpuInfo}
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{CoreWrapper => MKL}
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{CpuInfoWrapper => CpuInfo}
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{AffinityWrapper => Affinity}
 import org.apache.spark.utils.SparkUtils
 import py4j.GatewayServer
 
@@ -567,7 +568,6 @@ object Engine {
   }
 
   private def setMklDnnEnvironments(): Unit = {
-    import com.intel.analytics.bigdl.mkl.hardware.CpuInfo
     val affinityCores = Affinity.getAffinity
     val physicalCoreNum = CpuInfo.getPhysicalProcessorCount
     val affinityCoreNum = affinityCores.length

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/ThreadPool.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/ThreadPool.scala
@@ -19,7 +19,8 @@ package com.intel.analytics.bigdl.utils
 import java.util.concurrent._
 
 import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{AffinityWrapper => Affinity}
-import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{CoreWrapper => MKL}
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{CoreWrapper => CoreDNNL }
+import com.intel.analytics.bigdl.mkl.MKL
 import org.apache.commons.lang.exception.ExceptionUtils
 import org.apache.log4j.Logger
 
@@ -87,7 +88,7 @@ class ThreadPool(private var poolSize: Int) {
    * @return
    */
   def setMKLThread(size: Int): this.type = this.synchronized {
-    require(MKL.isLoaded)
+    require(MKL.isMKLLoaded)
     mklPoolSize = Some(size)
     (1 to poolSize).map(i => Future {
       MKL.setNumThreads(size)
@@ -103,14 +104,14 @@ class ThreadPool(private var poolSize: Int) {
 
     this.invokeAndWait2((0 until 1).map(_ => () => {
       if (System.getProperty("bigdl.flushDenormalState", "true").toBoolean) {
-        MKL.setFlushDenormalState()
+        CoreDNNL.setFlushDenormalState()
       }
 
-      require(MKL.isLoaded)
-      require(MKL.isLoaded)
+      require(MKL.isMKLLoaded)
+      require(CoreDNNL.isLoaded)
 
       MKL.setNumThreads(size)
-      MKL.setNumThreads(size)
+      CoreDNNL.setNumThreads(size)
       if (!System.getProperty("bigdl.disableOmpAffinity", "false").toBoolean) {
         Affinity.setOmpAffinity()
       }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/ThreadPool.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/ThreadPool.scala
@@ -18,8 +18,8 @@ package com.intel.analytics.bigdl.utils
 
 import java.util.concurrent._
 
-import com.intel.analytics.bigdl.mkl.hardware.Affinity
-import com.intel.analytics.bigdl.mkl.{MKL, MklDnn => BackendMklDnn}
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{AffinityWrapper => Affinity}
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{CoreWrapper => MKL}
 import org.apache.commons.lang.exception.ExceptionUtils
 import org.apache.log4j.Logger
 
@@ -87,7 +87,7 @@ class ThreadPool(private var poolSize: Int) {
    * @return
    */
   def setMKLThread(size: Int): this.type = this.synchronized {
-    require(MKL.isMKLLoaded)
+    require(MKL.isLoaded)
     mklPoolSize = Some(size)
     (1 to poolSize).map(i => Future {
       MKL.setNumThreads(size)
@@ -103,14 +103,14 @@ class ThreadPool(private var poolSize: Int) {
 
     this.invokeAndWait2((0 until 1).map(_ => () => {
       if (System.getProperty("bigdl.flushDenormalState", "true").toBoolean) {
-        BackendMklDnn.setFlushDenormalState()
+        MKL.setFlushDenormalState()
       }
 
-      require(MKL.isMKLLoaded)
-      require(BackendMklDnn.isLoaded)
+      require(MKL.isLoaded)
+      require(MKL.isLoaded)
 
       MKL.setNumThreads(size)
-      BackendMklDnn.setNumThreads(size)
+      MKL.setNumThreads(size)
       if (!System.getProperty("bigdl.disableOmpAffinity", "false").toBoolean) {
         Affinity.setOmpAffinity()
       }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/intermediate/IRGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/intermediate/IRGraph.scala
@@ -43,8 +43,8 @@ private[bigdl] class IRGraph[T: ClassTag](
     val outputs : Seq[Node[IRElement[T]]],
     val variables: Option[(Array[Tensor[T]], Array[Tensor[T]])] = None,
     val generateBackward: Boolean = true,
-    val inputFormats: Seq[Int] = Seq(Memory.Format.nchw),
-    val outputFormats: Seq[Int] = Seq(Memory.Format.nc))
+    val inputFormats: Seq[Int] = Seq(Memory.FormatTag.nchw),
+    val outputFormats: Seq[Int] = Seq(Memory.FormatTag.nc))
   (implicit ev: TensorNumeric[T]) extends AbstractModule[Activity, Activity, T] with Serializable {
 
   @transient private var initPrim: Boolean = false
@@ -148,10 +148,10 @@ private[bigdl] class IRGraph[T: ClassTag](
       if (input.isInstanceOf[Tensor[T]]) {
         // todo: handle for 3 dimensions, expand 3 dims to 4 dims
         val size = input.toTensor[T].size()
-        val sizeNew = if (size.length == 3 && inputFormats(0) != Memory.Format.ntc
-          && inputFormats(0) != Memory.Format.tnc) {
+        val sizeNew = if (size.length == 3 && inputFormats(0) != Memory.FormatTag.ntc
+          && inputFormats(0) != Memory.FormatTag.tnc) {
           Array(size(0), 1, size(1), size(2))
-        } else if (inputFormats(0) == Memory.Format.nhwc) {
+        } else if (inputFormats(0) == Memory.FormatTag.nhwc) {
           // always use NCHW to create heap data
           Array(size(0), size(3), size(1), size(2))
         } else size
@@ -165,7 +165,7 @@ private[bigdl] class IRGraph[T: ClassTag](
             "Only support input with tensor type, table not supported")
           val t1 = t._1.asInstanceOf[Int] // starts from 1
           val t2 = t._2.asInstanceOf[Tensor[T]]
-          if (inputFormats(t1 - 1 ) == Memory.Format.nhwc) {
+          if (inputFormats(t1 - 1 ) == Memory.FormatTag.nhwc) {
             val sizeNew = Array(t2.size(1), t2.size(4), t2.size(2), t2.size(3))
             inputMemory(t1 - 1) = HeapData(sizeNew, inputFormats(t1 - 1))
           } else {
@@ -208,8 +208,8 @@ object IRGraph {
     outputs: Seq[Node[IRElement[T]]],
     variables: Option[(Array[Tensor[T]], Array[Tensor[T]])] = None,
     generateBackward: Boolean = true,
-    inputFormats: Int = Memory.Format.nchw,
-    outputFormats: Int = Memory.Format.nc
+    inputFormats: Int = Memory.FormatTag.nchw,
+    outputFormats: Int = Memory.FormatTag.nc
   )( implicit ev: TensorNumeric[T]): IRGraph[T] = {
     new IRGraph[T](inputs, outputs, variables, generateBackward,
       Seq(inputFormats), Seq(outputFormats))

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/intermediate/IRGraph.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/intermediate/IRGraph.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.utils.intermediate
 
-import com.intel.analytics.bigdl.mkl.Memory
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{MemoryWrapper => Memory}
 import com.intel.analytics.bigdl.nn.{Graph, SpatialMaxPooling, keras}
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, DataFormat}
 import com.intel.analytics.bigdl.nn.mkldnn._

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/intermediate/IRToDnn.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/intermediate/IRToDnn.scala
@@ -17,7 +17,8 @@
 package com.intel.analytics.bigdl.utils.intermediate
 
 import com.intel.analytics.bigdl._
-import com.intel.analytics.bigdl.mkl.{AlgKind, Direction}
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{AlgKindWrapper => AlgKind}
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{DirectionWrapper => Direction}
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, DataFormat, TensorModule}
 import com.intel.analytics.bigdl.nn.{Module => _, _}
 import com.intel.analytics.bigdl.nn.mkldnn._

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/dnnl/AffinityWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/dnnl/AffinityWrapper.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.utils.wrapper.mkldnn
+import com.intel.analytics.bigdl.dnnl.hardware.Affinity
+import java.util.{Map, List}
+
+object AffinityWrapper {
+
+  def getAffinity(): Array[Int] = {
+    Affinity.getAffinity
+  }
+
+  def setAffinity(coreId: Int): Unit = {
+    Affinity.setAffinity(coreId)
+  }
+
+  def setAffinity(coreIds: Array[Int]): Unit = {
+    Affinity.setAffinity(coreIds)
+  }
+
+  def stats(): Map[Integer, List[java.lang.Long]] = {
+    Affinity.stats()
+  }
+
+  def getOmpAffinity(): Array[Int] = {
+    Affinity.getOmpAffinity()
+  }
+
+  def setOmpAffinity(): Unit = {
+    Affinity.setOmpAffinity()
+  }
+
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/dnnl/AlgKindWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/dnnl/AlgKindWrapper.scala
@@ -16,10 +16,11 @@
 
 package com.intel.analytics.bigdl.utils.wrapper.mkldnn
 
-import com.intel.analytics.bigdl.mkl.Direction
+import com.intel.analytics.bigdl.dnnl.AlgKind
 
-object DirectionWrapper {
-  val UnidirectionalLeft2Right = Direction.UnidirectionalLeft2Right
-  val BidirectionalConcat = Direction.BidirectionalConcat
-  val BidirectionalSum = Direction.BidirectionalSum
+object AlgKindWrapper {
+  val EltwiseTanh = AlgKind.EltwiseTanh
+  val VanillaLstm = AlgKind.VanillaLstm
+  val VanillaGru = AlgKind.VanillaGru
 }
+

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/dnnl/CoreWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/dnnl/CoreWrapper.scala
@@ -27,10 +27,6 @@ object CoreWrapper {
     DNNL.setNumThreads(n)
   }
 
-  def getMklNumThreads(): Int = {
-    0
-  }
-
   def setFlushDenormalState(): Unit = {
     DNNL.setFlushDenormalState()
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/dnnl/CoreWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/dnnl/CoreWrapper.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.utils.wrapper.mkldnn
+import com.intel.analytics.bigdl.dnnl.DNNL
+
+object CoreWrapper {
+
+  def isLoaded(): Boolean = {
+    DNNL.isLoaded()
+  }
+
+  def setNumThreads(n: Int): Unit = {
+    DNNL.setNumThreads(n)
+  }
+
+  def getMklNumThreads(): Int = {
+    0
+  }
+
+  def setFlushDenormalState(): Unit = {
+    DNNL.setFlushDenormalState()
+  }
+
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/dnnl/CpuInfoWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/dnnl/CpuInfoWrapper.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.utils.wrapper.mkldnn
+import com.intel.analytics.bigdl.dnnl.hardware.CpuInfo
+
+object CpuInfoWrapper {
+
+  def getPhysicalProcessorCount(): Int = {
+    CpuInfo.getPhysicalProcessorCount
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/dnnl/DirectionWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/dnnl/DirectionWrapper.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.utils.wrapper.mkldnn
 
-import com.intel.analytics.bigdl.mkl.Direction
+import com.intel.analytics.bigdl.dnnl.Direction
 
 object DirectionWrapper {
   val UnidirectionalLeft2Right = Direction.UnidirectionalLeft2Right

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/dnnl/MemoryWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/dnnl/MemoryWrapper.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.utils.wrapper.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.Memory
+
+object MemoryWrapper {
+
+  object FormatTag {
+    val nc = Memory.FormatTag.nc
+    val tnc = Memory.FormatTag.tnc
+    val ntc = Memory.FormatTag.ntc
+    val nchw = Memory.FormatTag.nchw
+    val nhwc = Memory.FormatTag.nhwc
+  }
+
+  def zero(data: Long, length: Int, elementSize: Int): Long = {
+    Memory.Zero(data, length, elementSize)
+  }
+
+  def copyPtr2Ptr(src: Long, srcOffset: Int, dst: Long, dstOffset: Int,
+    length: Int, elementSize: Int): Long = {
+      Memory.CopyPtr2Ptr(src, srcOffset, dst, dstOffset, length, elementSize)
+  }
+
+  def copyArray2Ptr(src: Array[Float], srcOffset: Int, dst: Long, dstOffset: Int,
+    length: Int, elementSize: Int): Long = {
+    Memory.CopyArray2Ptr(src, srcOffset, dst, dstOffset, length, elementSize)
+  }
+
+  def copyPtr2Array(src: Long, srcOffset: Int, dst: Array[Float], dstOffset: Int,
+    length: Int, elementSize: Int): Long = {
+    Memory.CopyPtr2Array(src, srcOffset, dst, dstOffset, length, elementSize)
+  }
+
+  def copyPtr2ByteArray(src: Long, srcOffset: Int, dst: Array[Byte], dstOffset: Int,
+    length: Int, elementSize: Int): Long = {
+    Memory.CopyPtr2ByteArray(src, srcOffset, dst, dstOffset, length, elementSize)
+  }
+
+  def copyPtr2IntArray(src: Long, srcOffset: Int, dst: Array[Int], dstOffset: Int,
+    length: Int, elementSize: Int): Long = {
+    Memory.CopyPtr2IntArray(src, srcOffset, dst, dstOffset, length, elementSize)
+  }
+
+  def sAdd(n: Int, aPtr: Long, aOffset: Int, bPtr: Long, bOffset: Int,
+    yPtr: Long, yOffset: Int): Unit = {
+    Memory.SAdd(n, aPtr, aOffset, bPtr, bOffset, yPtr, yOffset)
+  }
+
+  def scale(n: Int, scaleFactor: Float, from: Long, to: Long): Unit = {
+    Memory.Scale(n, scaleFactor, from, to)
+  }
+
+  def axpby(n: Int, a: Float, x: Long, b: Float, y: Long): Unit = {
+    Memory.Axpby(n, a, x, b, y)
+  }
+
+  def alignedMalloc(capacity: Int, size: Int): Long = {
+    Memory.AlignedMalloc(capacity, size)
+  }
+
+  def alignedFree(ptr: Long): Unit = {
+    Memory.AlignedFree(ptr)
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/dnnl/Version.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/dnnl/Version.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.utils.wrapper.mkldnn
+
+object NativeVersion {
+  def isDNNL: Boolean = true
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/mkldnn/AffinityWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/mkldnn/AffinityWrapper.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.utils.wrapper.mkldnn
+
+import java.util.{List, Map}
+import com.intel.analytics.bigdl.mkl.hardware.Affinity
+
+object AffinityWrapper {
+
+  def getAffinity(): Array[Int] = {
+    Affinity.getAffinity
+  }
+
+  def setAffinity(coreId: Int): Unit = {
+    Affinity.setAffinity(coreId)
+  }
+
+  def setAffinity(coreIds: Array[Int]): Unit = {
+    Affinity.setAffinity(coreIds)
+  }
+
+  def stats(): Map[Integer, List[java.lang.Long]] = {
+    Affinity.stats()
+  }
+
+  def getOmpAffinity(): Array[Int] = {
+    Affinity.getOmpAffinity()
+  }
+
+  def setOmpAffinity(): Unit = {
+    Affinity.setOmpAffinity()
+  }
+
+
+
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/mkldnn/AlgKindWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/mkldnn/AlgKindWrapper.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.utils.wrapper.mkldnn
+
+import com.intel.analytics.bigdl.mkl.AlgKind
+
+object AlgKindWrapper {
+  val EltwiseTanh = AlgKind.EltwiseTanh
+  val VanillaLstm = AlgKind.VanillaLstm
+  val VanillaGru = AlgKind.VanillaGru
+}
+

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/mkldnn/CoreWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/mkldnn/CoreWrapper.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.intel.analytics.bigdl.utils.wrapper.mkldnn
+import com.intel.analytics.bigdl.mkl.MKL
+
+object CoreWrapper {
+
+  def isLoaded(): Boolean = {
+    MKL.isMKLLoaded()
+  }
+
+  def setNumThreads(n: Int): Unit = {
+    MKL.setNumThreads(n)
+  }
+
+  def getMklNumThreads(): Int = {
+    MKL.getMklNumThreads
+  }
+
+  def setFlushDenormalState(): Unit = {
+
+  }
+
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/mkldnn/CoreWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/mkldnn/CoreWrapper.scala
@@ -16,20 +16,19 @@
 
 
 package com.intel.analytics.bigdl.utils.wrapper.mkldnn
-import com.intel.analytics.bigdl.mkl.MKL
+import com.intel.analytics.bigdl.mkl.MklDnn
 
 object CoreWrapper {
 
   def isLoaded(): Boolean = {
-    MKL.isMKLLoaded()
+    MklDnn.isLoaded
   }
 
   def setNumThreads(n: Int): Unit = {
-    MKL.setNumThreads(n)
+    MklDnn.setNumThreads(n)
   }
 
   def setFlushDenormalState(): Unit = {
-
+    MklDnn.setFlushDenormalState()
   }
-
 }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/mkldnn/CoreWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/mkldnn/CoreWrapper.scala
@@ -28,10 +28,6 @@ object CoreWrapper {
     MKL.setNumThreads(n)
   }
 
-  def getMklNumThreads(): Int = {
-    MKL.getMklNumThreads
-  }
-
   def setFlushDenormalState(): Unit = {
 
   }

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/mkldnn/CpuInfoWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/mkldnn/CpuInfoWrapper.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.utils.wrapper.mkldnn
+import com.intel.analytics.bigdl.mkl.hardware.CpuInfo
+
+object CpuInfoWrapper {
+
+  def getPhysicalProcessorCount(): Int = {
+    CpuInfo.getPhysicalProcessorCount
+  }
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/mkldnn/DirectionWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/mkldnn/DirectionWrapper.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.utils.wrapper.mkldnn
+
+import com.intel.analytics.bigdl.mkl.Direction
+object DirectionWrapper {
+  val UnidirectionalLeft2Right = Direction.UnidirectionalLeft2Right
+  val BidirectionalConcat = Direction.BidirectionalConcat
+  val BidirectionalSum = Direction.BidirectionalSum
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/mkldnn/MemoryWrapper.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/mkldnn/MemoryWrapper.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.utils.wrapper.mkldnn
+
+import com.intel.analytics.bigdl.mkl.Memory
+
+object MemoryWrapper {
+
+  object FormatTag {
+    val nc = Memory.Format.nc
+    val tnc = Memory.Format.tnc
+    val ntc = Memory.Format.ntc
+    val nchw = Memory.Format.nchw
+    val nhwc = Memory.Format.nhwc
+  }
+
+  def zero(data: Long, length: Int, elementSize: Int): Long = {
+    Memory.Zero(data, length, elementSize)
+  }
+
+  def copyPtr2Ptr(src: Long, srcOffset: Int, dst: Long, dstOffset: Int,
+    length: Int, elementSize: Int): Long = {
+      Memory.CopyPtr2Ptr(src, srcOffset, dst, dstOffset, length, elementSize)
+  }
+
+  def copyArray2Ptr(src: Array[Float], srcOffset: Int, dst: Long, dstOffset: Int,
+    length: Int, elementSize: Int): Long = {
+    Memory.CopyArray2Ptr(src, srcOffset, dst, dstOffset, length, elementSize)
+  }
+
+  def copyPtr2Array(src: Long, srcOffset: Int, dst: Array[Float], dstOffset: Int,
+    length: Int, elementSize: Int): Long = {
+    Memory.CopyPtr2Array(src, srcOffset, dst, dstOffset, length, elementSize)
+  }
+
+  def copyPtr2ByteArray(src: Long, srcOffset: Int, dst: Array[Byte], dstOffset: Int,
+    length: Int, elementSize: Int): Long = {
+    Memory.CopyPtr2ByteArray(src, srcOffset, dst, dstOffset, length, elementSize)
+  }
+
+  def copyPtr2IntArray(src: Long, srcOffset: Int, dst: Array[Int], dstOffset: Int,
+    length: Int, elementSize: Int): Long = {
+    Memory.CopyPtr2IntArray(src, srcOffset, dst, dstOffset, length, elementSize)
+  }
+
+  def sAdd(n: Int, aPtr: Long, aOffset: Int, bPtr: Long, bOffset: Int,
+    yPtr: Long, yOffset: Int): Unit = {
+    Memory.SAdd(n, aPtr, aOffset, bPtr, bOffset, yPtr, yOffset)
+  }
+
+  def scale(n: Int, scaleFactor: Float, from: Long, to: Long): Unit = {
+    Memory.Scale(n, scaleFactor, from, to)
+  }
+
+  def axpby(n: Int, a: Float, x: Long, b: Float, y: Long): Unit = {
+    Memory.Axpby(n, a, x, b, y)
+  }
+
+  def alignedMalloc(capacity: Int, size: Int): Long = {
+    Memory.AlignedMalloc(capacity, size)
+  }
+
+  def alignedFree(ptr: Long): Unit = {
+    Memory.AlignedFree(ptr)
+  }
+
+}

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/mkldnn/Version.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/utils/wrapper/mkldnn/Version.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.utils.wrapper.mkldnn
+
+object NativeVersion {
+  def isDNNL: Boolean = false
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/MklInt8ConvertibleSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/MklInt8ConvertibleSpec.scala
@@ -196,7 +196,7 @@ class MklInt8ConvertibleSpec extends FlatSpec with Matchers with BeforeAndAfter 
   }
 
   "Calculating scales" should "work correct for DNN Linear Module" in {
-    import com.intel.analytics.bigdl.mkl.Memory
+    import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{MemoryWrapper => Memory}
 
     val sampleMax = 999
     val inputSize = 2
@@ -324,7 +324,7 @@ class MklInt8ConvertibleSpec extends FlatSpec with Matchers with BeforeAndAfter 
   }
 
   "Calculating scales" should "work correct for DNN Spatial Convolution Module" in {
-    import com.intel.analytics.bigdl.mkl.Memory
+    import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{MemoryWrapper => Memory}
     val inputSize = 8
     val outputSize = 8
     var dimMaskIdx = 0
@@ -688,7 +688,7 @@ class MklInt8ConvertibleSpec extends FlatSpec with Matchers with BeforeAndAfter 
   }
 
   "Calculating scales" should "work correct for DNN Graph Module" in {
-    import com.intel.analytics.bigdl.mkl.Memory
+    import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{MemoryWrapper => Memory}
     System.setProperty("bigdl.mkldnn.fusion", "false")
 
     def dnnGraph(batchSize: Int, classNum: Int): mkldnn.DnnGraph = {

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/MklInt8ConvertibleSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/MklInt8ConvertibleSpec.scala
@@ -216,9 +216,9 @@ class MklInt8ConvertibleSpec extends FlatSpec with Matchers with BeforeAndAfter 
     // Global mask, non-null input
     val linear1 = mkldnn.Linear(inputSize, outputSize)
     val seq1 = mkldnn.Sequential()
-      .add(mkldnn.Input(Array(4, inputSize), Memory.Format.nc))
+      .add(mkldnn.Input(Array(4, inputSize), Memory.FormatTag.nc))
       .add(linear1)
-      .add(mkldnn.Output(Memory.Format.nc))
+      .add(mkldnn.Output(Memory.FormatTag.nc))
 
     seq1.compile(InferencePhase)
     seq1.forward(inputTensor)
@@ -232,9 +232,9 @@ class MklInt8ConvertibleSpec extends FlatSpec with Matchers with BeforeAndAfter 
     // Single dimension mask, non-null input
     val linear2 = mkldnn.Linear(inputSize, outputSize)
     val seq2 = mkldnn.Sequential()
-      .add(mkldnn.Input(Array(4, inputSize), Memory.Format.nc))
+      .add(mkldnn.Input(Array(4, inputSize), Memory.FormatTag.nc))
       .add(linear2)
-      .add(mkldnn.Output(Memory.Format.nc))
+      .add(mkldnn.Output(Memory.FormatTag.nc))
     seq2.compile(InferencePhase)
 
     inputMask = Math.pow(2, 0).toInt
@@ -340,9 +340,9 @@ class MklInt8ConvertibleSpec extends FlatSpec with Matchers with BeforeAndAfter 
     // Global mask, non-null input
     val spatialConv1 = mkldnn.SpatialConvolution(inputSize, outputSize, 1, 1)
     val seq1 = mkldnn.Sequential()
-      .add(mkldnn.Input(Array(4, 8, 8, 8), Memory.Format.nchw))
+      .add(mkldnn.Input(Array(4, 8, 8, 8), Memory.FormatTag.nchw))
       .add(spatialConv1)
-      .add(mkldnn.Output(Memory.Format.nchw))
+      .add(mkldnn.Output(Memory.FormatTag.nchw))
 
     seq1.compile(InferencePhase)
     seq1.forward(input)
@@ -360,9 +360,9 @@ class MklInt8ConvertibleSpec extends FlatSpec with Matchers with BeforeAndAfter 
     dimMaskIdx = 1
     val spatialConv2 = mkldnn.SpatialConvolution(inputSize, outputSize, 1, 1)
     val seq2 = mkldnn.Sequential()
-      .add(mkldnn.Input(Array(4, 8, 8, 8), Memory.Format.nchw))
+      .add(mkldnn.Input(Array(4, 8, 8, 8), Memory.FormatTag.nchw))
       .add(spatialConv2)
-      .add(mkldnn.Output(Memory.Format.nchw))
+      .add(mkldnn.Output(Memory.FormatTag.nchw))
     seq2.compile(InferencePhase)
     seq2.forward(input)
 
@@ -377,9 +377,9 @@ class MklInt8ConvertibleSpec extends FlatSpec with Matchers with BeforeAndAfter 
     dimMaskIdx = 2
     val spatialConv3 = mkldnn.SpatialConvolution(inputSize, outputSize, 1, 1)
     val seq3 = mkldnn.Sequential()
-      .add(mkldnn.Input(Array(4, 8, 8, 8), Memory.Format.nchw))
+      .add(mkldnn.Input(Array(4, 8, 8, 8), Memory.FormatTag.nchw))
       .add(spatialConv3)
-      .add(mkldnn.Output(Memory.Format.nchw))
+      .add(mkldnn.Output(Memory.FormatTag.nchw))
     seq3.compile(InferencePhase)
     seq3.forward(input)
 
@@ -396,9 +396,9 @@ class MklInt8ConvertibleSpec extends FlatSpec with Matchers with BeforeAndAfter 
     dimMaskIdx = 3
     val spatialConv4 = mkldnn.SpatialConvolution(inputSize, outputSize, 1, 1)
     val seq4 = mkldnn.Sequential()
-      .add(mkldnn.Input(Array(4, 8, 8, 8), Memory.Format.nchw))
+      .add(mkldnn.Input(Array(4, 8, 8, 8), Memory.FormatTag.nchw))
       .add(spatialConv4)
-      .add(mkldnn.Output(Memory.Format.nchw))
+      .add(mkldnn.Output(Memory.FormatTag.nchw))
     seq4.compile(InferencePhase)
     seq4.forward(input)
 
@@ -695,7 +695,7 @@ class MklInt8ConvertibleSpec extends FlatSpec with Matchers with BeforeAndAfter 
       val inputShape = Array(batchSize, 1, 28, 28)
       val outputShape = Array(batchSize, 10)
 
-      val input = mkldnn.Input(inputShape, Memory.Format.nchw).inputs()
+      val input = mkldnn.Input(inputShape, Memory.FormatTag.nchw).inputs()
       val conv1 = mkldnn.SpatialConvolution(1, 20, 5, 5).setName("conv1").inputs(input)
       val bn1 = mkldnn.SpatialBatchNormalization(20).setName("bn1").inputs(conv1)
       val pool1 = mkldnn.MaxPooling(2, 2, 2, 2).setName("pool1").inputs(bn1)
@@ -704,7 +704,7 @@ class MklInt8ConvertibleSpec extends FlatSpec with Matchers with BeforeAndAfter 
       val ip1 = mkldnn.Linear(50 * 4 * 4, 500).setName("ip1").inputs(pool2)
       val relu1 = mkldnn.ReLU().setName("relu1").inputs(ip1)
       val ip2 = mkldnn.Linear(500, 10).setName("ip2").inputs(relu1)
-      val output = mkldnn.ReorderMemory(mkldnn.HeapData(outputShape, Memory.Format.nc)).inputs(ip2)
+      val output = mkldnn.ReorderMemory(mkldnn.HeapData(outputShape, Memory.FormatTag.nc)).inputs(ip2)
 
       val graph = DnnGraph(Array(input), Array(output))
       graph.evaluate()

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/AvgPoolingSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/AvgPoolingSpec.scala
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.{DataType, Memory}
+import com.intel.analytics.bigdl.nn.SpatialAveragePooling
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.tensor.{DnnTensor, Tensor}
+import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, Engine}
+import com.intel.analytics.bigdl.utils.RandomGenerator.RNG
+import com.intel.analytics.bigdl.utils.intermediate.{BlasToIR, IRToDnn}
+import org.apache.commons.lang3.SerializationUtils
+
+import scala.util.Random
+
+class AvgPoolingSpec extends BigDLSpecHelper {
+  "Avg Pooling with same padding" should "be correct" in {
+    val batchSize = 2
+    val input = Tensor[Float](batchSize, 480, 28, 28).apply1(e => Random.nextFloat())
+    val gradOutput = Tensor[Float](batchSize, 480, 14, 14).apply1(e => Random.nextFloat())
+
+    val pad = -1
+    RNG.setSeed(100)
+    val pool = AvgPooling(3, 3, 2, 2, padH = pad, padW = pad)
+    RNG.setSeed(100)
+    val layer = SpatialAveragePooling[Float](3, 3, 2, 2, padH = pad, padW = pad).ceil()
+
+    val seq = Sequential()
+    seq.add(ReorderMemory(HeapData(Array(batchSize, 480, 28, 28), Memory.FormatTag.nchw),
+      HeapData(Array(batchSize, 480, 28, 28), Memory.FormatTag.nchw)))
+    seq.add(pool)
+    seq.add(ReorderMemory(HeapData(Array(batchSize, 480, 14, 14), Memory.FormatTag.nchw),
+      HeapData(Array(batchSize, 480, 14, 14), Memory.FormatTag.nchw)))
+    seq.compile(Phase.TrainingPhase, Array(HeapData(Array(batchSize, 480, 28, 28),
+      Memory.FormatTag.nchw)))
+
+    for (i <- 0 to 3) {
+      input.rand()
+      gradOutput.rand()
+
+      seq.forward(input)
+      seq.backward(input, gradOutput)
+
+      layer.forward(input)
+      layer.backward(input, gradOutput)
+    }
+    val output1 = seq.forward(input)
+    val output2 = layer.forward(input).toTensor[Float]
+    output1 should be(output2)
+
+    val grad2 = layer.backward(input, output2).toTensor[Float]
+    val grad1 = seq.backward(input, output2)
+    grad1 should be(grad2)
+  }
+
+  "Convert average pooling with ceilMode to dnn layer" should "be correct" in {
+    val batchSize = 2
+    val input = Tensor[Float](batchSize, 480, 28, 28).apply1(e => Random.nextFloat())
+    val gradOutput = Tensor[Float](batchSize, 480, 14, 14).apply1(e => Random.nextFloat())
+
+    RNG.setSeed(100)
+    val layer = SpatialAveragePooling[Float](3, 3, 2, 2).ceil()
+
+    val irelement = BlasToIR[Float].convertLayer(layer)
+    val pool = IRToDnn[Float].convertLayer(irelement)
+
+    val seq = Sequential()
+    seq.add(ReorderMemory(HeapData(Array(batchSize, 480, 28, 28), Memory.FormatTag.nchw),
+      HeapData(Array(batchSize, 480, 28, 28), Memory.FormatTag.nchw)))
+    seq.add(pool)
+    seq.add(ReorderMemory(HeapData(Array(batchSize, 480, 14, 14), Memory.FormatTag.nchw),
+      HeapData(Array(batchSize, 480, 14, 14), Memory.FormatTag.nchw)))
+    seq.compile(Phase.TrainingPhase, Array(HeapData(Array(batchSize, 480, 28, 28),
+      Memory.FormatTag.nchw)))
+
+    for (i <- 0 to 3) {
+      input.rand()
+      gradOutput.rand()
+
+      seq.forward(input)
+      seq.backward(input, gradOutput)
+
+      layer.forward(input)
+      layer.backward(input, gradOutput)
+    }
+
+    val output1 = seq.forward(input)
+    val output2 = layer.forward(input).toTensor[Float]
+
+    output1 should be(output2)
+
+    val grad2 = layer.backward(input, output2).toTensor[Float]
+    val grad1 = seq.backward(input, output2)
+    grad1 should be(grad2)
+  }
+
+  "Avg Pooling test1" should "be correct" in {
+    val batchSize = 2
+    val input = Tensor[Float](batchSize, 480, 28, 28).apply1(e => Random.nextFloat())
+
+    RNG.setSeed(100)
+    val pool = AvgPooling(3, 3, 2, 2)
+    RNG.setSeed(100)
+    val layer = SpatialAveragePooling[Float](3, 3, 2, 2).ceil()
+
+    val output2 = layer.forward(input).toTensor[Float]
+
+    val seq = Sequential()
+    seq.add(ReorderMemory(HeapData(Array(batchSize, 480, 28, 28), Memory.FormatTag.nchw),
+      HeapData(Array(batchSize, 480, 28, 28), Memory.FormatTag.nchw)))
+    seq.add(pool)
+    seq.add(ReorderMemory(HeapData(Array(batchSize, 480, 14, 14), Memory.FormatTag.nchw),
+      HeapData(Array(batchSize, 480, 14, 14), Memory.FormatTag.nchw)))
+    seq.compile(Phase.TrainingPhase, Array(HeapData(Array(batchSize, 480, 28, 28),
+      Memory.FormatTag.nchw)))
+    val output1 = seq.forward(input)
+    output1 should be(output2)
+
+    val grad2 = layer.backward(input, output2).toTensor[Float]
+    val grad1 = seq.backward(input, output2)
+    grad1 should be(grad2)
+  }
+
+  "Avg Pooling test2" should "be correct" in {
+    val batchSize = 2
+    val input = Tensor[Float](batchSize, 64, 112, 112).apply1(e => Random.nextFloat())
+
+    RNG.setSeed(100)
+    val pool = AvgPooling(3, 3, 2, 2)
+    RNG.setSeed(100)
+    val layer = SpatialAveragePooling[Float](3, 3, 2, 2).ceil()
+
+    val output2 = layer.forward(input).toTensor[Float]
+
+    val seq = Sequential()
+    seq.add(ReorderMemory(HeapData(Array(batchSize, 64, 112, 112), Memory.FormatTag.nchw),
+      HeapData(Array(batchSize, 64, 112, 112), Memory.FormatTag.nchw)))
+    seq.add(pool)
+    seq.add(ReorderMemory(HeapData(Array(batchSize, 64, 56, 56), Memory.FormatTag.nchw),
+      HeapData(Array(batchSize, 64, 56, 56), Memory.FormatTag.nchw)))
+    seq.compile(Phase.TrainingPhase, Array(HeapData(Array(batchSize, 64, 112, 112),
+      Memory.FormatTag.nchw)))
+    val output1 = seq.forward(input)
+    output1 should be(output2)
+
+    val grad2 = layer.backward(input, output2).toTensor[Float]
+    val grad1 = seq.backward(input, output2)
+    grad1 should be(grad2)
+  }
+
+  "avg with java serialization" should "work correctly" in {
+    val batchSize = 2
+    val inputShape = Array(batchSize, 64, 112, 112)
+    val outputShape = Array(batchSize, 64, 56, 56)
+
+    val input = Tensor[Float](batchSize, 64, 112, 112).rand(-1, 1)
+
+    val pool = AvgPooling(3, 3, 2, 2)
+    pool.setRuntime(new MklDnnRuntime)
+    pool.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    pool.initBwdPrimitives(Array(HeapData(outputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    pool.initGradWPrimitives(Array(HeapData(outputShape, Memory.FormatTag.nchw)), TrainingPhase)
+
+    val cloned = SerializationUtils.clone(pool)
+    cloned.setRuntime(new MklDnnRuntime)
+    cloned.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    cloned.initBwdPrimitives(Array(HeapData(outputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    cloned.initGradWPrimitives(Array(HeapData(outputShape, Memory.FormatTag.nchw)), TrainingPhase)
+
+    pool.forward(input)
+    cloned.forward(input)
+
+    Tools.dense(pool.output) should be (Tools.dense(cloned.output))
+
+    val gradOutput = Tensor[Float](outputShape)
+    pool.backward(input, gradOutput)
+    cloned.backward(input, gradOutput)
+
+    Tools.dense(pool.gradInput) should be (Tools.dense(cloned.gradInput))
+  }
+
+  "avg pooling with int8" should "be correct" in {
+    val inputShape = Array(4, 3, 5, 5)
+    val outputShape = Array(4, 3, 2, 2)
+
+    val kernel = 3
+    val pad = 1
+
+    val runtime = new MklDnnRuntime
+
+    val input = Tensor[Float](inputShape).rand(0, 1)
+
+    val heapData = HeapData(inputShape, Memory.FormatTag.nchw, DataType.F32)
+    val nativeData = NativeData(inputShape, Memory.FormatTag.nhwc, DataType.U8)
+    val inputScales = Array(input.max())
+
+    nativeData.setMask(0)
+    nativeData.setScales(inputScales.map(x => 255.0f / x))
+
+    val reorder = ReorderMemory(nativeData)
+    val pool = AvgPooling(3, 3, 2, 2)
+    val heapData2 = HeapData(outputShape, Memory.FormatTag.nchw, DataType.F32)
+    val reorder2 = ReorderMemory(heapData2)
+
+    val seq = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(reorder)
+      .add(pool)
+      .add(reorder2)
+
+    seq.evaluate()
+    seq.compile(InferencePhase)
+    seq.forward(input)
+
+    val seq2 = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(AvgPooling(3, 3, 2, 2))
+      .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw)))
+
+    seq2.evaluate()
+    seq2.compile(InferencePhase)
+    seq2.forward(input)
+
+    Equivalent.nearequals(seq.output.toTensor, seq2.output.toTensor, 1e-2) should be (true)
+  }
+
+  "global average pooling" should "work correctly" in {
+    val gap = AvgPooling(2, 2, globalPooling = true)
+    val ap = AvgPooling(3, 3)
+
+    val inputShape = Array(4, 2, 3, 3)
+    val input = Tensor[Float](inputShape).rand(-1, 1)
+
+    val seq1 = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(ap)
+      .add(Output(Memory.FormatTag.nchw))
+
+    val seq2 = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(gap)
+      .add(Output(Memory.FormatTag.nchw))
+
+    seq1.evaluate()
+    seq2.evaluate()
+
+    seq1.compile(InferencePhase)
+    seq2.compile(InferencePhase)
+
+    seq1.forward(input)
+    seq2.forward(input)
+
+    seq1.output should be (seq2.output)
+  }
+
+  "global average pooling" should "has same behavior with nn" in {
+    val gap = AvgPooling(2, 2, globalPooling = true)
+
+    val inputShape = Array(4, 2, 3, 3)
+    val input = Tensor[Float](inputShape).rand(-1, 1)
+
+    val seq1 = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(gap)
+      .add(Output(Memory.FormatTag.nchw))
+
+    seq1.evaluate()
+    seq1.compile(InferencePhase)
+    seq1.forward(input)
+
+    val nngap = SpatialAveragePooling[Float](2, 2, globalPooling = true)
+    nngap.forward(input)
+
+    seq1.output should be (nngap.output)
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/BlasWrapperSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/BlasWrapperSpec.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import breeze.linalg.reshape
+import com.intel.analytics.bigdl.dnnl.Memory
+import com.intel.analytics.bigdl.{Module, nn}
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity, DataFormat, TensorModule}
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.nn.{Graph, Squeeze, mkldnn}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, Engine, RandomGenerator, T}
+import com.intel.analytics.bigdl.utils.RandomGenerator._
+import com.intel.analytics.bigdl.numeric.NumericFloat
+
+class BlasWrapperSpec extends BigDLSpecHelper {
+
+  override def doBefore(): Unit = {
+     Engine.init(1, 4, true)
+  }
+
+  def modelBlas(format: DataFormat = DataFormat("NCHW")) : Module[Float] = {
+    val conv1 = nn.SpatialConvolution(1, 20, 5, 5, format = format).inputs()
+    val pool1 = nn.SpatialMaxPooling(2, 2, 2, 2, format = format).setName("pool").inputs(conv1)
+    val conv2 = nn.SpatialConvolution(20, 50, 5, 5, format = format).inputs(pool1)
+    val pool2 = nn.SpatialMaxPooling(2, 2, 2, 2, format = format).inputs(conv2)
+    val reshape = nn.Reshape(Array(50 * 4 * 4)).inputs(pool2)
+    val fc = nn.Linear(50 * 4 * 4, 500).inputs(reshape)
+    val relu = nn.ReLU().setName("relu1").inputs(fc)
+    val fc2 = nn.Linear(500, 10).setName("ip2").inputs(relu)
+    val log = nn.LogSoftMax().inputs(fc2)
+    Graph(conv1, log)
+  }
+
+  def modelWrapper(format: Int = Memory.FormatTag.nchw, shape: Array[Int]) : DnnGraph = {
+    val input = mkldnn.Input(shape, format).inputs()
+    val conv1 = BlasWrapper(nn.SpatialConvolution[Float](1, 20, 5, 5)).inputs(input)
+    val pool1 = mkldnn.MaxPooling(2, 2, 2, 2).setName("pool").inputs(conv1)
+    val conv2 = BlasWrapper(nn.SpatialConvolution[Float](20, 50, 5, 5)).inputs(pool1)
+    val pool2 = mkldnn.MaxPooling(2, 2, 2, 2).inputs(conv2)
+    val fc = mkldnn.Linear(50 * 4 * 4, 500).inputs(pool2)
+    val relu = mkldnn.ReLU().setName("relu1").inputs(fc)
+    val fc2 = mkldnn.Linear(500, 10).setName("ip2").inputs(relu)
+    val log = BlasWrapper(nn.LogSoftMax[Float]()).inputs(fc2)
+    DnnGraph(Array(input), Array(log))
+  }
+
+  "wrapper model" should "be correct" in {
+    val inputShape = Array(2, 1, 28, 28)
+    val outputShape = Array(2, 10)
+    val input = Tensor[Float](inputShape).rand()
+    val gradOutput = Tensor[Float](outputShape).rand()
+
+    RandomGenerator.RNG.setSeed(1)
+    val blas = modelBlas()
+    RandomGenerator.RNG.setSeed(1)
+    val wrapper = modelWrapper(Memory.FormatTag.nchw, inputShape)
+    wrapper.compile(TrainingPhase)
+
+    val out1 = blas.forward(input)
+    val out2 = wrapper.forward(input)
+
+    out1 should be(out2)
+
+    val grad1 = blas.backward(input, gradOutput)
+    val grad2 = wrapper.backward(input, gradOutput)
+
+    val weight1 = blas.getParameters()._1
+    val weight2 = wrapper.getParameters()._1
+
+    val gradWeight1 = blas.getParameters()._2
+    val gradWeight2 = wrapper.getParameters()._2
+
+    grad1 should be(grad2)
+
+    weight1 should be(weight2)
+    gradWeight1 should be(gradWeight2)
+  }
+
+  "wrapper model run with blas multithread" should "be correct" in {
+    val inputShape = Array(4, 1, 28, 28)
+    val input = Tensor[Float](inputShape).rand()
+
+    RandomGenerator.RNG.setSeed(1)
+    val wrapper = modelWrapper(Memory.FormatTag.nchw, inputShape)
+    wrapper.evaluate()
+    wrapper.compile(InferencePhase)
+    val out1 = wrapper.forward(input)
+
+    RandomGenerator.RNG.setSeed(1)
+    System.setProperty("multiThread", "true")
+    val wrapperMulti = modelWrapper(Memory.FormatTag.nchw, inputShape)
+    wrapperMulti.evaluate()
+    wrapperMulti.compile(InferencePhase)
+    val out2 = wrapperMulti.forward(input)
+
+    out1 should be(out2)
+    System.clearProperty("multiThread")
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/CAddTableSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/CAddTableSpec.scala
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.{DataType, Memory}
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.numeric.NumericFloat
+import com.intel.analytics.bigdl.tensor.{DnnTensor, Tensor}
+import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, T}
+import org.apache.commons.lang3.SerializationUtils
+
+class CAddTableSpec extends BigDLSpecHelper {
+
+  "CAddTable" should "be correct" in {
+    val layer = CAddTable()
+    val model = Sequential()
+    val concat = ConcatTable()
+    concat.add(ReorderMemory.create(HeapData(Array(2, 2), Memory.FormatTag.nc),
+      NativeData(Array(2, 2), Memory.FormatTag.nc), HeapData(Array(2, 2), Memory.FormatTag.nc),
+      NativeData(Array(2, 2), Memory.FormatTag.nc)))
+    concat.add(ReorderMemory.create(HeapData(Array(2, 2), Memory.FormatTag.nc),
+      NativeData(Array(2, 2), Memory.FormatTag.nc), HeapData(Array(2, 2), Memory.FormatTag.nc),
+      NativeData(Array(2, 2), Memory.FormatTag.nc)))
+    model.add(concat)
+    model.add(layer)
+    model.add(ReorderMemory.create(NativeData(Array(2, 2), Memory.FormatTag.nc),
+      HeapData(Array(2, 2), Memory.FormatTag.nc), NativeData(Array(2, 2), Memory.FormatTag.nc),
+      HeapData(Array(2, 2), Memory.FormatTag.nc)))
+    model.compile(Phase.TrainingPhase, Array(HeapData(Array(2, 2), Memory.FormatTag.nc)))
+
+    model.forward(Tensor[Float](T(T(1, 2), T(3, 4)))) should be(Tensor[Float](T(
+      T(2, 4),
+      T(6, 8)
+    )))
+
+    val dnnGrad = model.backward(Tensor[Float](T(T(1, 2), T(3, 4))),
+      Tensor[Float](T(
+        T(4, 5),
+        T(6, 7)
+      )
+      )).asInstanceOf[Tensor[Float]]
+
+    val heapGrad = Tensor[Float](2, 2)
+    heapGrad.copy(dnnGrad)
+    heapGrad should be (
+      Tensor[Float](T(T(8, 10), T(12, 14)))
+    )
+  }
+
+  "caddtable with java serialization" should "work correctly" in {
+    implicit object Owner extends MemoryOwner {
+    }
+    val shape = Array(2, 3, 4, 4)
+    val _1 = Tensor(shape).rand(-1, 1)
+    val _2 = Tensor(shape).rand(-1, 1)
+
+    val input1 = DnnTensor(shape).copy(_1)
+    val input2 = DnnTensor(shape).copy(_2)
+
+    val cat = CAddTable()
+    cat.setRuntime(new MklDnnRuntime)
+    cat.initFwdPrimitives(Array(
+      HeapData(shape, Memory.FormatTag.nchw),
+      HeapData(shape, Memory.FormatTag.nchw)), TrainingPhase)
+    cat.initBwdPrimitives(Array(
+      HeapData(shape, Memory.FormatTag.nchw),
+      HeapData(shape, Memory.FormatTag.nchw)), TrainingPhase)
+
+    cat.forward(T(input1, input2))
+
+    val cloned = SerializationUtils.clone(cat)
+    cloned.setRuntime(new MklDnnRuntime)
+    cloned.initFwdPrimitives(Array(
+      HeapData(shape, Memory.FormatTag.nchw),
+      HeapData(shape, Memory.FormatTag.nchw)), TrainingPhase)
+    cloned.initBwdPrimitives(Array(
+      HeapData(shape, Memory.FormatTag.nchw),
+      HeapData(shape, Memory.FormatTag.nchw)), TrainingPhase)
+    cloned.forward(T(input1, input2))
+
+    Tools.dense(cat.output) should be (Tools.dense(cloned.output))
+
+    val gradOutput = Tensor(shape).rand(-1, 1)
+    cat.backward(T(input1, input2), gradOutput)
+    cloned.backward(T(input1, input2), gradOutput)
+
+    Tools.dense(cat.gradInput.toTable(1)) should be (Tools.dense(cloned.gradInput.toTable(1)))
+    Tools.dense(cat.gradInput.toTable(2)) should be (Tools.dense(cloned.gradInput.toTable(2)))
+    Owner.releaseResources()
+  }
+
+  "CAddTable u8" should "be correct" in {
+    val shape = Array(4, 3, 5, 5)
+    val model = Sequential()
+    val concat = ConcatTable()
+    val cadd = CAddTable()
+
+    model.add(Input(shape, Memory.FormatTag.nchw))
+    model.add(concat).add(cadd)
+
+    val input = Tensor[Float](shape).rand(0, 1)
+
+    //    val nativeData1 = NativeData(shape, Memory.FormatTag.nhwc, DataType.U8)
+    //    val nativeData2 = NativeData(shape, Memory.FormatTag.nhwc, DataType.U8)
+
+    val nativeData1 = NativeData(shape, Memory.FormatTag.nhwc)
+    val nativeData2 = NativeData(shape, Memory.FormatTag.nhwc)
+
+    nativeData1.setMask(0)
+    nativeData1.setScales(Array(255.0f / input.clone().abs().max()))
+
+    nativeData2.setMask(0)
+    nativeData2.setScales(Array(255.0f / input.clone().abs().max()))
+
+    concat.add(ReorderMemory(nativeData1))
+    concat.add(ReorderMemory(nativeData2))
+
+    model.add(ReorderMemory(HeapData(shape, Memory.FormatTag.nchw)))
+
+    model.evaluate()
+    model.compile(InferencePhase)
+    model.forward(input)
+
+
+    val seq2 = Sequential()
+      .add(Input(shape, Memory.FormatTag.nchw))
+      .add(ConcatTable()
+        .add(ReorderMemory(NativeData(shape, Memory.FormatTag.nhwc)))
+        .add(ReorderMemory(NativeData(shape, Memory.FormatTag.nchw))))
+      .add(CAddTable())
+      .add(ReorderMemory(HeapData(shape, Memory.FormatTag.nchw)))
+
+    seq2.evaluate()
+    seq2.compile(InferencePhase)
+    seq2.forward(input)
+
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/ConcatTableSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/ConcatTableSpec.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.{DataType, Memory}
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.numeric.NumericFloat
+import com.intel.analytics.bigdl.tensor.{DnnTensor, Tensor}
+import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, T}
+import org.apache.commons.lang3.SerializationUtils
+
+class ConcatTableSpec extends BigDLSpecHelper {
+  "ConcatTable" should "be good" in {
+    val container = ConcatTable()
+    container.add(ReorderMemory.create(
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc)))
+    val subcontainer = Sequential()
+    subcontainer.add(ReorderMemory.create(
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      NativeData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      NativeData(Array(3, 4), Memory.FormatTag.nc)))
+    subcontainer.add(ReorderMemory(NativeData(Array(3, 4), Memory.FormatTag.io),
+      NativeData(Array(3, 4), Memory.FormatTag.nc)))
+    subcontainer.add(ReorderMemory(HeapData(Array(3, 4), Memory.FormatTag.nc),
+      NativeData(Array(3, 4), Memory.FormatTag.io)))
+    container.add(subcontainer)
+
+    container.compile(Phase.TrainingPhase, Array(HeapData(Array(3, 4), Memory.FormatTag.nc)))
+    val input1 = Tensor[Float](3, 4).rand()
+    val output1 = container.forward(input1).toTable
+    output1(1).asInstanceOf[Tensor[Float]] should be(input1)
+    output1(2).asInstanceOf[Tensor[Float]] should be(input1)
+
+    val grad1 = Tensor[Float](3, 4).rand()
+    val nativeGrad = container.backward(input1, T(grad1, grad1)).asInstanceOf[Tensor[Float]]
+    val heapGrad = Tensor[Float](3, 4).copy(nativeGrad)
+    heapGrad should be(grad1 * 2)
+    val input2 = Tensor[Float](3, 4).rand()
+    val output2 = container.forward(input2).toTable
+    output2(1).asInstanceOf[Tensor[Float]] should be(input2)
+    output2(2).asInstanceOf[Tensor[Float]] should be(input2)
+
+    val grad2 = Tensor[Float](3, 4).rand()
+    val nativeGrad2 = container.backward(input1, T(grad2, grad2)).asInstanceOf[Tensor[Float]]
+    val heapGrad2 = Tensor[Float](3, 4).copy(nativeGrad2)
+    heapGrad2 should be(grad2 * 2)
+  }
+
+  "concat table with java serialization" should "work correctly" in {
+    val shape = Array(2, 2)
+    val input = Tensor(shape).fill(1)
+    val gradOutput = T(Tensor(shape).fill(2), Tensor(shape).fill(2))
+
+    val ct = ConcatTable()
+    ct.add(Identity())
+    ct.add(Identity())
+
+    ct.compile(TrainingPhase, Array(HeapData(shape, Memory.FormatTag.nc)))
+
+    val cloned = SerializationUtils.clone(ct)
+    cloned.compile(TrainingPhase, Array(HeapData(shape, Memory.FormatTag.nc)))
+
+    ct.forward(input)
+    ct.backward(input, gradOutput)
+
+    cloned.forward(input)
+    cloned.backward(input, gradOutput)
+
+    Tools.dense(ct.output.toTable(1)) should be(Tools.dense(cloned.output.toTable(1)))
+    Tools.dense(ct.output.toTable(2)) should be(Tools.dense(cloned.output.toTable(2)))
+
+    Tools.dense(ct.gradInput) should be(Tools.dense(cloned.gradInput))
+  }
+
+  "ConcatTable with U8" should "be good" in {
+    val shape = Array(4, 3, 5, 5)
+    val input = Tensor[Float](shape).rand(0, 1)
+
+    val nativeData1 = NativeData(shape, Memory.FormatTag.nchw, DataType.U8)
+    val nativeData2 = NativeData(shape, Memory.FormatTag.nchw, DataType.U8)
+    val heapData = HeapData(shape, Memory.FormatTag.nchw, DataType.F32)
+    heapData.setMask(0)
+    val inputScales = Array(input.clone().abs().max())
+    heapData.setScales(inputScales.map(x => 255f / x))
+
+    val concat = ConcatTable()
+
+    concat.add(ReorderMemory(nativeData1))
+    concat.add(ReorderMemory(nativeData2))
+    concat.compile(Phase.InferencePhase, Array(heapData))
+
+    concat.forward(input)
+
+    val output1 = new Array[Byte](shape.product)
+    Memory.CopyPtr2ByteArray(
+      concat.output.toTable[Tensor[Float]](1)
+        .asInstanceOf[DnnTensor[Byte]].storageAddress(),
+      0, output1, 0, shape.product, 1)
+    output1.foreach(println)
+
+    val output2 = new Array[Byte](shape.product)
+    Memory.CopyPtr2ByteArray(
+      concat.output.toTable[Tensor[Float]](1)
+        .asInstanceOf[DnnTensor[Byte]].storageAddress(),
+      0, output2, 0, shape.product, 1)
+    output2.foreach(println)
+
+    output1 should be (output2)
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/DnnGraphSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/DnnGraphSpec.scala
@@ -1,0 +1,316 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import breeze.linalg.Axis._1
+import com.intel.analytics.bigdl._
+import com.intel.analytics.bigdl.example.languagemodel.PTBModel
+import com.intel.analytics.bigdl.dnnl.{AlgKind, Direction, Memory}
+import com.intel.analytics.bigdl.models.lenet.LeNet5
+import com.intel.analytics.bigdl.models.resnet.ResNet.{DatasetType, ShortcutType}
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.nn.{mkldnn, Graph, Module => _, _}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.RandomGenerator._
+import com.intel.analytics.bigdl.utils._
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+import com.intel.analytics.bigdl.models.resnet
+import com.intel.analytics.bigdl.models.utils.ModelBroadcast
+import com.intel.analytics.bigdl.utils.intermediate._
+import com.intel.analytics.bigdl.numeric.NumericFloat
+import org.apache.spark.SparkContext
+
+class DnnGraphSpec extends FlatSpec with Matchers with BeforeAndAfter {
+
+  private var sc: SparkContext = _
+
+  before {
+    val nodeNumber = 1
+    val coreNumber = 4
+    Engine.init(nodeNumber, coreNumber, onSpark = true)
+    sc = new SparkContext("local[1]", "DnnGraphSpec")
+  }
+
+  after {
+    if (sc != null) {
+      sc.stop()
+    }
+  }
+
+  def model(size: Array[Int]) : Module[Float] = {
+    val input = mkldnn.Input(size, Memory.FormatTag.nchw).inputs()
+    val conv1 = mkldnn.SpatialConvolution(1, 6, 5, 5).setName("conv1_5x5").inputs(input)
+    val tanh1 = mkldnn.BlasWrapper(Tanh[Float]()).inputs(conv1)
+    val pool1 = mkldnn.MaxPooling(2, 2, 2, 2).inputs(tanh1)
+    val conv2 = BlasWrapper(
+      nn.SpatialConvolution[Float](6, 12, 5, 5)).setName("conv2_5x5").inputs(pool1)
+    val tanh2 = mkldnn.BlasWrapper(Tanh[Float]()).inputs(conv2)
+    val pool2 = mkldnn.MaxPooling(2, 2, 2, 2).inputs(tanh2)
+    val fc1 = mkldnn.Linear(12 * 4 * 4, 100).setName("fc1").inputs(pool2)
+    val tanh3 = mkldnn.BlasWrapper(Tanh[Float]()).inputs(fc1)
+    val fc2 = mkldnn.BlasWrapper(nn.Linear[Float](100, 10)).setName("fc2").inputs(tanh3)
+    val output = mkldnn.BlasWrapper(LogSoftMax[Float]()).inputs(fc2)
+
+    DnnGraph(Seq(input), Seq(output))
+  }
+
+  "Dnn vgg16 graph model" should "be correct" in {
+    val batchSize = 2
+    val seed = 1
+    val inputFormat = Memory.FormatTag.nchw
+    val inputShape = Array(batchSize, 3, 224, 224)
+
+    RNG.setSeed(seed)
+    val graphModel = models.Vgg_16.graph(batchSize, 1000, false)
+    RNG.setSeed(seed)
+    val dnnModle = models.Vgg_16(batchSize, 1000, false)
+
+    graphModel.asInstanceOf[DnnGraph].compile(TrainingPhase)
+    dnnModle.compile(TrainingPhase)
+
+    val input = Tensor[Float](inputShape).rand()
+    val gradOutput = Tensor[Float](batchSize, 1000).rand()
+
+    for (i <- 0 to 2) {
+      graphModel.forward(input)
+      dnnModle.forward(input)
+
+      graphModel.backward(input, gradOutput)
+      dnnModle.backward(input, gradOutput)
+    }
+    val output = Tools.dense(graphModel.forward(input)).toTensor[Float]
+    val outputDnn = Tools.dense(dnnModle.forward(input)).toTensor[Float]
+
+    val gradInput = Tools.dense(graphModel.backward(input, gradOutput)).toTensor[Float]
+    val gradInputDnn = Tools.dense(dnnModle.backward(input, gradOutput)).toTensor[Float]
+
+    output.almostEqual(outputDnn, 1e-4) should be(true)
+    gradInput.almostEqual(gradInputDnn, 1e-4) should be (true)
+
+    val p1 = dnnModle.getParameters()
+    val p2 = graphModel.getParameters()
+    p1._1.almostEqual(p2._1, 1e-4) should be(true)
+    p1._2 almostEqual(p2._2, 1e-4) should be(true)
+  }
+
+  "Dnn Lenet graph model" should "be correct" in {
+    val batchSize = 2
+    val seed = 1
+    val inputFormat = Memory.FormatTag.nchw
+    val inputShape = Array(batchSize, 1, 28, 28)
+
+    RNG.setSeed(seed)
+    val graphModel = LeNet5.dnnGraph(batchSize, 10)
+
+    RNG.setSeed(seed)
+    val dnnModle = LeNet5.dnn(batchSize, 10)
+
+    graphModel.asInstanceOf[DnnGraph].compile(TrainingPhase)
+    dnnModle.compile(TrainingPhase)
+
+    val input = Tensor[Float](inputShape).rand()
+    val gradOutput = Tensor[Float](batchSize, 10).rand()
+
+    for (i <- 0 to 2) {
+      graphModel.forward(input)
+      dnnModle.forward(input)
+
+      graphModel.backward(input, gradOutput)
+      dnnModle.backward(input, gradOutput)
+    }
+    val output = Tools.dense(graphModel.forward(input)).toTensor[Float]
+    val outputDnn = Tools.dense(dnnModle.forward(input)).toTensor[Float]
+
+    val gradInput = Tools.dense(graphModel.backward(input, gradOutput)).toTensor[Float]
+    val gradInputDnn = Tools.dense(dnnModle.backward(input, gradOutput)).toTensor[Float]
+
+    output.almostEqual(outputDnn, 1e-4) should be(true)
+    gradInput.almostEqual(gradInputDnn, 1e-4) should be (true)
+
+    val p1 = dnnModle.getParameters()
+    val p2 = graphModel.getParameters()
+    p1._1.almostEqual(p2._1, 1e-4) should be(true)
+    p1._2 almostEqual(p2._2, 1e-4) should be(true)
+  }
+
+  "ResNet50 graph model" should "be correct" in {
+    val batchSize = 2
+    val seed = 1
+    val inputFormat = Memory.FormatTag.nchw
+    val inputShape = Array(batchSize, 3, 224, 224)
+
+    RNG.setSeed(seed)
+    val dnnModle = mkldnn.ResNet(batchSize, 1000, T("depth" -> 50,
+      "dataSet" -> ResNet.DatasetType.ImageNet))
+    RNG.setSeed(seed)
+    val graphModel = mkldnn.ResNet.graph(batchSize, 1000, T("depth" -> 50,
+      "dataSet" -> ResNet.DatasetType.ImageNet))
+
+    val input = Tensor[Float](inputShape).rand()
+    val gradOutput = Tensor[Float](batchSize, 1000).rand()
+
+    graphModel.asInstanceOf[DnnGraph].compile(TrainingPhase)
+    dnnModle.compile(TrainingPhase)
+
+    for (i <- 0 to 2) {
+      graphModel.forward(input)
+      dnnModle.forward(input)
+
+      graphModel.backward(input, gradOutput)
+      dnnModle.backward(input, gradOutput)
+    }
+    val output = Tools.dense(graphModel.forward(input)).toTensor[Float]
+    val outputDnn = Tools.dense(dnnModle.forward(input)).toTensor[Float]
+
+    val gradInput = Tools.dense(graphModel.backward(input, gradOutput)).toTensor[Float]
+    val gradInputDnn = Tools.dense(dnnModle.backward(input, gradOutput)).toTensor[Float]
+
+    output.almostEqual(outputDnn, 1e-4) should be(true)
+    gradInput.almostEqual(gradInputDnn, 1e-4) should be (true)
+
+    val p1 = graphModel.getParametersTable()
+    val p2 = dnnModle.getParametersTable()
+    val keys = p1.keySet
+    for (i <- keys) {
+      val k = i.asInstanceOf[String]
+      val t1 = p1[Table](k)
+      val t2 = p2[Table](k)
+      t1 should be(t2)
+    }
+  }
+
+  "DnnGraph skip primitives" should "be correct" in {
+    Engine.setEngineType(MklDnn)
+    val batchSize = 2
+    val inputShape = Array(batchSize, 1, 28, 28)
+    val input = Tensor[Float](inputShape).rand()
+
+    val dnn = model(inputShape).asInstanceOf[DnnGraph]
+    dnn.evaluate()
+    dnn.compile(Phase.InferencePhase)
+
+    dnn.forward(input).toTensor[Float]
+  }
+
+  "Dnn graph fusion operation for resnet50" should "be correct" in {
+    System.setProperty("bigdl.mkldnn.fusion.convbn", "true")
+    System.setProperty("bigdl.mkldnn.fusion.bnrelu", "true")
+    System.setProperty("bigdl.mkldnn.fusion.convrelu", "true")
+    System.setProperty("bigdl.mkldnn.fusion.convsum", "true")
+    System.setProperty("bigdl.mkldnn.fusion", "true")
+
+    val batchSize = 2
+    val seed = 1
+    val inputFormat = Memory.FormatTag.nchw
+    val inputShape = Array(batchSize, 3, 224, 224)
+
+    RNG.setSeed(seed)
+    val seqModel = mkldnn.ResNet(batchSize, 1000, T("depth" -> 50,
+      "dataSet" -> ResNet.DatasetType.ImageNet))
+    RNG.setSeed(seed)
+    val graphFuse = mkldnn.ResNet.graph(batchSize, 1000, T("depth" -> 50,
+      "dataSet" -> ResNet.DatasetType.ImageNet))
+
+    seqModel.getExtraParameter().map(_.fill(1.0f))
+    graphFuse.getExtraParameter().map(_.fill(1.0f))
+
+    seqModel.evaluate()
+    seqModel.asInstanceOf[MklDnnContainer].compile(
+      Phase.InferencePhase, Array(HeapData(inputShape, inputFormat)))
+    graphFuse.evaluate()
+    graphFuse.asInstanceOf[DnnGraph].compile(Phase.InferencePhase)
+
+    RNG.setSeed(100)
+    val input = Tensor[Float](inputShape).rand()
+
+    val output = seqModel.forward(input).toTensor[Float]
+    val outputFuse = graphFuse.forward(input).toTensor[Float]
+
+    output.almostEqual(outputFuse, 1e-4) should be(true)
+
+    System.clearProperty("bigdl.mkldnn.fusion.convbn")
+    System.clearProperty("bigdl.mkldnn.fusion.bnrelu")
+    System.clearProperty("bigdl.mkldnn.fusion.convrelu")
+    System.clearProperty("bigdl.mkldnn.fusion.convsum")
+    System.clearProperty("bigdl.mkldnn.fusion")
+  }
+
+  "Dnn graph fusion operation for vgg16" should "be correct" in {
+    System.setProperty("bigdl.mkldnn.fusion.convbn", "true")
+    System.setProperty("bigdl.mkldnn.fusion.bnrelu", "true")
+    System.setProperty("bigdl.mkldnn.fusion.convrelu", "true")
+    System.setProperty("bigdl.mkldnn.fusion.convsum", "true")
+    System.setProperty("bigdl.mkldnn.fusion", "true")
+
+    val batchSize = 2
+    val seed = 1
+    val inputFormat = Memory.FormatTag.nchw
+    val inputShape = Array(batchSize, 3, 224, 224)
+
+    RNG.setSeed(seed)
+    val seqModel = models.Vgg_16(batchSize, 1000, false)
+    RNG.setSeed(seed)
+    val graphFuse = models.Vgg_16.graph(batchSize, 1000, false)
+
+    seqModel.evaluate()
+    graphFuse.evaluate()
+    graphFuse.asInstanceOf[DnnGraph].compile(Phase.InferencePhase)
+    seqModel.compile(Phase.InferencePhase)
+
+    val input = Tensor[Float](inputShape).rand()
+
+    val output = Tools.dense(graphFuse.forward(input)).toTensor[Float]
+    val outputDnn = Tools.dense(seqModel.forward(input)).toTensor[Float]
+
+    output.almostEqual(outputDnn, 1e-4) should be(true)
+
+    System.clearProperty("bigdl.mkldnn.fusion.convbn")
+    System.clearProperty("bigdl.mkldnn.fusion.bnrelu")
+    System.clearProperty("bigdl.mkldnn.fusion.convrelu")
+    System.clearProperty("bigdl.mkldnn.fusion.convsum")
+    System.clearProperty("bigdl.mkldnn.fusion")
+  }
+
+  "DnnGraph fusion" should "not change model parameters" in {
+    Engine.setEngineType(MklDnn)
+    import com.intel.analytics.bigdl.models.resnet
+    RNG.setSeed(100)
+    val module = resnet.ResNet(1000, T("shortcutType" -> ShortcutType.B, "depth" -> 50,
+      "optnet" -> false, "dataSet" -> DatasetType.ImageNet))
+      .toGraph().asInstanceOf[StaticGraph[Float]]
+      .toIRgraph()
+
+    val bcast = ModelBroadcast[Float]().broadcast(sc, module.evaluate())
+    for(i <- 1 to 3) {
+      val data = sc.parallelize(0 to 10, 1)
+      data.mapPartitions(i => {
+        val tensor = Tensor[Float](2, 3, 224, 224).rand()
+        val mod = bcast.value()
+        Iterator(mod.forward(tensor).toTensor[Float])
+      }).count()
+
+      sc.parallelize(1 to 1, 1).mapPartitions(i => {
+        val weightSum = bcast.value().getWeightsBias().map(f => f.sum()).sum
+        require(weightSum == 11759.763f, s"sum of model weight " +
+          s"parameters should be 11759.764, but get ${weightSum}")
+        i
+      }).count()
+
+      Engine.setEngineType(MklBlas)
+    }
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/DropoutSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/DropoutSpec.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.Memory
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.tensor.Tensor
+import org.scalatest.{FlatSpec, Matchers}
+
+class DropoutSpec extends FlatSpec with Matchers {
+  "dropout output and gradinput" should "work correctly" in {
+    val input = Tensor[Float](Array(2, 3, 4, 4)).fill(1)
+    val zeros = Tensor[Float](Array(2, 3, 4, 4)).fill(0)
+
+    val dropout = Dropout()
+    dropout.setRuntime(new MklDnnRuntime)
+    dropout.initFwdPrimitives(Array(HeapData(Array(2, 3, 4, 4),
+      Memory.FormatTag.nchw)), TrainingPhase)
+
+    {
+      dropout.forward(input)
+
+      val notEqZeros = dropout.output.toTensor[Float].storage().array().count(_ != 0)
+      val total = input.nElement()
+      val ratio = notEqZeros.toDouble / total
+      ratio should not be (1.0)
+      ratio should not be (0.0)
+    }
+
+    {
+      dropout.backward(input, dropout.output)
+      val notEqZeros = dropout.gradInput.toTensor[Float].storage().array().count(_ != 0)
+      val total = input.nElement()
+      val ratio = notEqZeros.toDouble / total
+      ratio should not be (1.0)
+      ratio should not be (0.0)
+    }
+  }
+
+  "dropout infer" should "work correctly" in {
+    val input = Tensor[Float](Array(2, 3, 4, 4)).fill(1)
+    val zeros = Tensor[Float](Array(2, 3, 4, 4)).fill(0)
+
+    val dropout = Dropout()
+    dropout.setRuntime(new MklDnnRuntime)
+    dropout.initFwdPrimitives(Array(HeapData(Array(2, 3, 4, 4), Memory.FormatTag.nchw)),
+      InferencePhase)
+    dropout.evaluate()
+
+    dropout.forward(input)
+
+    val notEqZeros = dropout.output.toTensor[Float].storage().array().count(_ != 0)
+    val total = input.nElement()
+    val ratio = notEqZeros.toDouble / total
+    ratio should be (1.0)
+  }
+
+  "dropout in sequential" should "work correctly" in {
+    val shape = Array(2, 3, 4, 4)
+    val dropout = Dropout()
+    val seq = Sequential().add(Input(shape, Memory.FormatTag.nchw))
+      .add(dropout)
+      .add(Output(Memory.FormatTag.nchw))
+
+    seq.compile(TrainingPhase)
+
+    val input = Tensor[Float](shape).rand(-1, 1)
+    seq.forward(input)
+    seq.backward(input, seq.output)
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/FusionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/FusionSpec.scala
@@ -1,0 +1,409 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.Memory
+import com.intel.analytics.bigdl.nn.{Module, StaticGraph}
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.InferencePhase
+import org.scalatest.{FlatSpec, Matchers}
+import com.intel.analytics.bigdl.numeric.NumericFloat
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.{Engine, RandomGenerator}
+import com.intel.analytics.bigdl.utils.intermediate.ConversionUtils
+
+class FusionSpec extends FlatSpec with Matchers {
+  "Conv with relu" should "work correctly" in {
+    val batchSize = 2
+    val input = Tensor[Float](batchSize, 3, 224, 224).fill(1.0f)
+
+    val inputShape = Array(batchSize, 3, 224, 224)
+    val outputShape = Array(batchSize, 64, 112, 112)
+
+    val conv1 = SpatialConvolution(3, 64, 7, 7, 2, 2, 3, 3, 1, false)
+    val reorder1 = ReorderMemory(NativeData(inputShape, Memory.FormatTag.nchw))
+    val reorder11 = ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw))
+    val model1 = Sequential().add(reorder1).add(conv1).add(ReLU()).add(reorder11)
+    model1.compile(InferencePhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+
+    System.setProperty("bigdl.mkldnn.fusion.convrelu", "true")
+    val conv2 = SpatialConvolution(3, 64, 7, 7, 2, 2, 3, 3, 1, false,
+      initWeight = conv1.weight.dense, initBias = conv1.bias.dense)
+    val reorder2 = ReorderMemory(NativeData(inputShape, Memory.FormatTag.nchw))
+    val reorder22 = ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw))
+    val model2 = Sequential().add(reorder2).add(conv2).add(ReLU()).add(reorder22)
+    model2.compile(InferencePhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+    System.setProperty("bigdl.mkldnn.fusion.convrelu", "false")
+
+    model1.evaluate()
+    model2.evaluate()
+
+    model1.forward(input)
+    model2.forward(input)
+
+    model1.output should be (model2.output)
+    model1.modules.length should be (model2.modules.length + 1)
+  }
+
+  "Conv Bn merge" should "work correctly" in {
+    RandomGenerator.RNG.setSeed(1)
+    val batchSize = 4
+    val inputShape = Array(batchSize, 3, 224, 224)
+    val outputShape = Array(batchSize, 64, 112, 112)
+    val input = Tensor[Float](batchSize, 3, 224, 224).fill(1.0f)
+
+    val runningMean = Tensor[Float](64).rand(-1, 1)
+    val runningVar = Tensor[Float](64).fill(100)
+    val initWeight = Tensor[Float]().resize(Array(64, 3, 7, 7)).rand(-1, 1)
+    val initBias = Tensor[Float]().resize(Array(64)).rand(-100, 100)
+
+    val conv1 = SpatialConvolution(3, 64, 7, 7, 2, 2, 3, 3, 1, false, initWeight = initWeight,
+      initBias = initBias)
+    val bn1 = SpatialBatchNormalization(64)
+    bn1.runningMean.copy(runningMean)
+    bn1.runningVariance.copy(runningVar)
+    bn1.scaleFactor = 1.0f
+    val reorder1 = ReorderMemory(NativeData(inputShape, Memory.FormatTag.nchw))
+    val reorder11 = ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw))
+    val model1 = Sequential().add(reorder1).add(conv1).add(bn1).add(reorder11)
+    model1.compile(InferencePhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+
+    System.setProperty("bigdl.mkldnn.fusion.convbn", "true")
+    val conv2 = SpatialConvolution(3, 64, 7, 7, 2, 2, 3, 3, 1, false,
+      initWeight = initWeight, initBias = initBias)
+    val bn2 = SpatialBatchNormalization(64)
+    bn2.runningMean.copy(runningMean)
+    bn2.runningVariance.copy(runningVar)
+    bn2.scaleFactor = 1.0f
+    val reorder2 = ReorderMemory(NativeData(inputShape, Memory.FormatTag.nchw))
+    val reorder22 = ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw))
+    val model2 = Sequential().add(reorder2).add(conv2).add(bn2).add(reorder22)
+    model2.compile(InferencePhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+    System.setProperty("bigdl.mkldnn.fusion.convbn", "false")
+
+    model1.evaluate()
+    model2.evaluate()
+
+    model1.forward(input)
+    model2.forward(input)
+
+    Equivalent.nearequals(model1.output.toTensor, model2.output.toTensor, 1e-5) should be (true)
+//    model1.modules.length should be (model2.modules.length + 1)
+  }
+
+  "Conv sum fusion" should "work correctly" in {
+    import com.intel.analytics.bigdl.numeric.NumericFloat
+
+    val input = Tensor[Float](2, 1, 6, 6).rand(-1, 1)
+    val inputShape = Array(2, 1, 6, 6)
+    val outputShape = Array(2, 3, 4, 4)
+
+    val initWeight = Tensor[Float](3, 1, 2, 2).fill(1)
+    val initBias = Tensor[Float](3).fill(0)
+
+    val conv1 = SpatialConvolution(1, 3, 2, 2, 2, 2, 1, 1, 1, initWeight = initWeight,
+      initBias = initBias)
+    val conv2 = SpatialConvolution(1, 3, 2, 2, 2, 2, 1, 1, 1, initWeight = initWeight,
+      initBias = initBias)
+    val conv3 = SpatialConvolution(1, 3, 2, 2, 2, 2, 1, 1, 1, initWeight = initWeight,
+      initBias = initBias)
+    val conv4 = SpatialConvolution(1, 3, 2, 2, 2, 2, 1, 1, 1, initWeight = initWeight,
+      initBias = initBias)
+
+    val reorder1 = ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw))
+    val reorder2 = ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw))
+
+    val model1 = Sequential()
+      .add(ConcatTable()
+        .add(conv1)
+        .add(conv2))
+      .add(CAddTable())
+      .add(ReLU())
+      .add(reorder1)
+    model1.compile(InferencePhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+
+    System.setProperty("bigdl.mkldnn.fusion.convsum", "true")
+    System.setProperty("bigdl.mkldnn.fusion.convrelu", "true")
+    val model2 = Sequential()
+      .add(ConcatTable()
+        .add(conv3)
+        .add(conv4))
+      .add(CAddTable())
+      .add(ReLU())
+      .add(reorder2)
+
+    model1.evaluate()
+    model2.evaluate()
+
+    model2.compile(InferencePhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+    System.setProperty("bigdl.mkldnn.fusion.convsum", "false")
+    System.setProperty("bigdl.mkldnn.fusion.convrelu", "false")
+
+    model1.forward(input)
+    model2.forward(input)
+
+    model1.output should be (model2.output)
+  }
+
+  "Conv sum fusion quantize" should "work correctly" in {
+    import com.intel.analytics.bigdl.numeric.NumericFloat
+    RandomGenerator.RNG.setSeed(1000)
+
+    val input = Tensor[Float](2, 1, 6, 6).rand(-100, 100)
+    val inputShape = Array(2, 1, 6, 6)
+    val outputShape = Array(2, 3, 4, 4)
+
+    val initWeight = Tensor[Float](3, 1, 2, 2).fill(1)
+    val initBias = Tensor[Float](3).fill(0)
+
+    val conv1 = SpatialConvolution(1, 3, 2, 2, 2, 2, 1, 1, 1, initWeight = initWeight,
+      initBias = initBias)
+    val conv2 = SpatialConvolution(1, 3, 2, 2, 2, 2, 1, 1, 1, initWeight = initWeight,
+      initBias = initBias)
+    val conv3 = SpatialConvolution(1, 3, 2, 2, 2, 2, 1, 1, 1, initWeight = initWeight,
+      initBias = initBias)
+    val conv4 = SpatialConvolution(1, 3, 2, 2, 2, 2, 1, 1, 1, initWeight = initWeight,
+      initBias = initBias)
+
+    val reorder1 = ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw))
+    val reorder2 = ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw))
+
+    val model1 = Sequential()
+      .add(ConcatTable()
+        .add(Sequential().add(conv1))
+        .add(Sequential().add(conv2)))
+      .add(CAddTable())
+      .add(ReLU())
+      .add(reorder1)
+    model1.evaluate()
+    model1.compile(InferencePhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+
+    val model2 = Sequential()
+      .add(ConcatTable()
+        .add(Sequential().add(conv3))
+        .add(Sequential().add(conv4)))
+      .add(CAddTable())
+      .add(ReLU())
+      .add(reorder2)
+
+    model2.evaluate()
+
+    System.setProperty("bigdl.mkldnn.fusion.convsum", "true")
+    System.setProperty("bigdl.mkldnn.fusion.convrelu", "true")
+    model2.compile(InferencePhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+    model2.forward(input)
+    model2.setWeightDimMask(1, true)
+    model2.calcScales(input)
+    model2.release()
+    println(model2)
+    val quantized = model2.quantize()
+    quantized.asInstanceOf[Sequential].compile(InferencePhase,
+      Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+    println(quantized)
+    System.setProperty("bigdl.mkldnn.fusion.convsum", "false")
+    System.setProperty("bigdl.mkldnn.fusion.convrelu", "false")
+
+    model1.forward(input)
+    quantized.forward(input)
+    println(model1.output)
+    println("=" * 80)
+    println(quantized.output)
+
+    model1.output should be (model2.output)
+  }
+
+  "Conv Bn merge quantize" should "work correctly" in {
+    RandomGenerator.RNG.setSeed(1)
+    val batchSize = 4
+    val inputShape = Array(batchSize, 3, 224, 224)
+    val outputShape = Array(batchSize, 64, 112, 112)
+    val input = Tensor[Float](batchSize, 3, 224, 224).rand(-1, 1)
+
+    val runningMean = Tensor[Float](64).rand(-1, 1)
+    val runningVar = Tensor[Float](64).fill(100)
+    val initWeight = Tensor[Float]().resize(Array(64, 3, 7, 7)).rand(-1, 1)
+    val initBias = Tensor[Float]().resize(Array(64)).fill(0)
+
+    val conv1 = SpatialConvolution(3, 64, 7, 7, 2, 2, 3, 3, 1, false, initWeight = initWeight,
+      initBias = initBias)
+    val bn1 = SpatialBatchNormalization(64)
+    bn1.runningMean.copy(runningMean)
+    bn1.runningVariance.copy(runningVar)
+    bn1.scaleFactor = 1.0f
+    val reorder1 = ReorderMemory(HeapData(inputShape, Memory.FormatTag.nchw))
+    val reorder11 = ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw))
+    val model1 = Sequential().add(reorder1).add(conv1).add(bn1).add(reorder11)
+    model1.evaluate()
+
+    model1.compile(InferencePhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+
+    System.setProperty("bigdl.mkldnn.fusion.convbn", "true")
+    val conv2 = SpatialConvolution(3, 64, 7, 7, 2, 2, 3, 3, 1, false,
+      initWeight = initWeight, initBias = initBias)
+    val bn2 = SpatialBatchNormalization(64)
+    bn2.runningMean.copy(runningMean)
+    bn2.runningVariance.copy(runningVar)
+    bn2.scaleFactor = 1.0f
+    val reorder2 = ReorderMemory(NativeData(inputShape, Memory.FormatTag.nchw))
+    val reorder22 = ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw))
+    val model2 = Sequential().add(reorder2).add(conv2).add(bn2).add(reorder22)
+    model2.evaluate()
+    model2.compile(InferencePhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+    model2.forward(input)
+    model2.setWeightDimMask(1, true)
+    model2.calcScales(input)
+    model2.release()
+    val quantize = model2.quantize()
+    quantize.asInstanceOf[Sequential]
+      .compile(InferencePhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+    System.setProperty("bigdl.mkldnn.fusion.convbn", "false")
+
+    model1.forward(input)
+    quantize.forward(input)
+
+    Equivalent.nearequals(model1.output.toTensor, quantize.output.toTensor, 1e-1) should be (true)
+  }
+
+  "Conv sum fusion quantize 2" should "work correctly" in {
+    import com.intel.analytics.bigdl.numeric.NumericFloat
+    RandomGenerator.RNG.setSeed(1000)
+
+    val input = Tensor[Float](2, 1, 6, 6).rand(-1, 1)
+    val inputShape = Array(2, 1, 6, 6)
+    val outputShape = Array(2, 3, 4, 4)
+
+    val initWeight = Tensor[Float](3, 1, 2, 2).rand(-1, 1)
+    val initBias = Tensor[Float](3).fill(0)
+
+    val conv1 = SpatialConvolution(1, 3, 2, 2, 2, 2, 1, 1, 1, initWeight = initWeight,
+      initBias = initBias)
+    val conv2 = SpatialConvolution(1, 3, 2, 2, 2, 2, 1, 1, 1, initWeight = initWeight,
+      initBias = initBias)
+    val conv3 = SpatialConvolution(1, 3, 2, 2, 2, 2, 1, 1, 1, initWeight = initWeight,
+      initBias = initBias)
+    val conv4 = SpatialConvolution(1, 3, 2, 2, 2, 2, 1, 1, 1, initWeight = initWeight,
+      initBias = initBias)
+
+    val reorder1 = ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw))
+    val reorder2 = ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw))
+
+    val model1 = Sequential()
+      .add(ConcatTable()
+        .add(Sequential().add(conv1))
+        .add(Sequential().add(conv2)))
+      .add(CAddTable())
+      .add(ReLU())
+      .add(reorder1)
+    model1.evaluate()
+    model1.compile(InferencePhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+
+    val model2 = Sequential()
+      .add(ConcatTable()
+        .add(Sequential().add(conv3))
+        .add(Sequential().add(conv4)))
+      .add(CAddTable())
+      .add(ReLU())
+      .add(reorder2)
+
+    model2.evaluate()
+
+    System.setProperty("bigdl.mkldnn.fusion.convsum", "true")
+    System.setProperty("bigdl.mkldnn.fusion.convrelu", "true")
+    model2.compile(InferencePhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+    model2.forward(input)
+    model2.setWeightDimMask(1, true)
+    model2.calcScales(input)
+    model2.release()
+    println(model2)
+    val quantized = model2.quantize()
+    quantized.asInstanceOf[Sequential].compile(InferencePhase,
+      Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+    println(quantized)
+    System.setProperty("bigdl.mkldnn.fusion.convsum", "false")
+    System.setProperty("bigdl.mkldnn.fusion.convrelu", "false")
+
+    model1.forward(input)
+    quantized.forward(input)
+    println(model1.output)
+    println("=" * 80)
+    println(quantized.output)
+
+    model1.output should be (model2.output)
+  }
+
+  "multi-group conv fusion with bn" should "work correctly" in {
+    val inputShape = Array(4, 1024, 7, 7)
+    val input = Input(inputShape, Memory.FormatTag.nchw).inputs()
+    val conv1 = SpatialConvolution(1024, 1024, 3, 3, 1, 1, 1, 1, nGroup = 1024).inputs(input)
+    val bn1 = SpatialBatchNormalization(1024).inputs(conv1)
+    val output = Output(Memory.FormatTag.nchw).inputs(bn1)
+
+    // the running mean and running variance should be 1.
+    bn1.element.getExtraParameter().foreach(_.fill(1))
+
+    val model = DnnGraph(Seq(input), Seq(output))
+    val fused = model.cloneModule()
+
+    model.evaluate()
+    fused.evaluate()
+
+    val tensor = Tensor[Float](inputShape).rand(-1, 1)
+
+    System.setProperty("bigdl.mkldnn.fusion", "false")
+    model.compile(InferencePhase)
+    model.forward(tensor)
+
+    System.setProperty("bigdl.mkldnn.fusion", "true")
+    fused.compile(InferencePhase)
+    fused.forward(tensor)
+
+    model.output should be (fused.output)
+
+    System.clearProperty("bigdl.mkldnn.fusion")
+  }
+
+  "bn and scale fusion" should "work correctly" in {
+    import com.intel.analytics.bigdl.nn.{Scale => NNScale}
+    val inputShape = Array(4, 64, 3, 3)
+    val input = Input(inputShape, Memory.FormatTag.nchw).inputs()
+    val bn1 = SpatialBatchNormalization(64).inputs(input)
+    val scale1 = BlasWrapper(NNScale[Float](Array(1, 64, 1, 1))).inputs(bn1)
+    val output = Output(Memory.FormatTag.nchw).inputs(scale1)
+
+    // the running mean and running variance should be 1.
+    bn1.element.getExtraParameter().foreach(_.fill(1))
+
+    val model = DnnGraph(Seq(input), Seq(output))
+    val fused = model.cloneModule()
+
+    model.evaluate()
+    fused.evaluate()
+
+    val tensor = Tensor[Float](inputShape).rand(-1, 1)
+
+    System.setProperty("bigdl.mkldnn.fusion", "false")
+    model.compile(InferencePhase)
+    model.forward(tensor)
+
+    System.setProperty("bigdl.mkldnn.fusion", "true")
+    fused.compile(InferencePhase)
+    fused.forward(tensor)
+
+    Equivalent.nearequals(model.output.toTensor[Float], fused.output.toTensor[Float], 1e-7)
+
+    System.clearProperty("bigdl.mkldnn.fusion")
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/InputSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/InputSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.Memory
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.BigDLSpecHelper
+
+class InputSpec extends BigDLSpecHelper {
+  "Input" should "be correct" in {
+    val layer = Input(Array(2, 2), Memory.FormatTag.nc)
+    layer.setRuntime(new MklDnnRuntime())
+    layer.initFwdPrimitives(Array(), Phase.TrainingPhase)
+    layer.initBwdPrimitives(Array(), Phase.TrainingPhase)
+    val tensor = Tensor[Float](2, 2).rand()
+    val grad = Tensor[Float](2, 2).rand()
+    val output = layer.forward(tensor)
+    val gradInput = layer.backward(tensor, grad)
+    Tools.dense(output) should be(tensor)
+    Tools.dense(gradInput) should be(grad)
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/JoinTableSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/JoinTableSpec.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.Memory
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.InferencePhase
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, T}
+
+class JoinTableSpec extends BigDLSpecHelper {
+  "Join table" should "work correctly" in {
+    val layer = JoinTable(1)
+    val model = Sequential()
+    val concat = ConcatTable()
+    concat.add(ReorderMemory.create(HeapData(Array(2, 2), Memory.FormatTag.nc),
+      NativeData(Array(2, 2), Memory.FormatTag.nc), HeapData(Array(2, 2), Memory.FormatTag.nc),
+      NativeData(Array(2, 2), Memory.FormatTag.nc)))
+    concat.add(ReorderMemory.create(HeapData(Array(2, 2), Memory.FormatTag.nc),
+      NativeData(Array(2, 2), Memory.FormatTag.nc), HeapData(Array(2, 2), Memory.FormatTag.nc),
+      NativeData(Array(2, 2), Memory.FormatTag.nc)))
+    model.add(concat)
+    model.add(layer)
+    model.add(ReorderMemory.create(NativeData(Array(4, 2), Memory.FormatTag.nc),
+      HeapData(Array(4, 2), Memory.FormatTag.nc), NativeData(Array(4, 2), Memory.FormatTag.nc),
+      HeapData(Array(4, 2), Memory.FormatTag.nc)))
+    model.compile(Phase.TrainingPhase, Array(HeapData(Array(2, 2), Memory.FormatTag.nc)))
+    model.forward(Tensor[Float](T(T(1, 2), T(3, 4)))) should be (Tensor[Float](T(
+      T(1, 2),
+      T(3, 4),
+      T(1, 2),
+      T(3, 4)
+    )))
+
+    println(Tensor[Float](T(T(1, 2), T(3, 4))).toString)
+    println(model.output.toString)
+    println(Tensor[Float](T(
+      T(4, 5),
+      T(6, 7),
+      T(1, 3),
+      T(4, 2)
+    )
+    ).toString)
+
+    val dnnGrad = model.backward(Tensor[Float](T(T(1, 2), T(3, 4))),
+      Tensor[Float](T(
+        T(4, 5),
+        T(6, 7),
+        T(1, 3),
+        T(4, 2)
+      )
+      )).asInstanceOf[Tensor[Float]]
+    val heapGrad = Tensor[Float](2, 2)
+    heapGrad.copy(dnnGrad)
+    heapGrad should be(
+      Tensor[Float](T(T(5, 8), T(10, 9)))
+    )
+  }
+
+  "int8 of join table" should "work correctly" in {
+    val inputShape1 = Array[Int](4, 2, 4, 4)
+    val inputShape2 = Array[Int](4, 4, 4, 4)
+
+    val input1 = Input(inputShape1, Memory.FormatTag.nchw).inputs()
+    val input2 = Input(inputShape2, Memory.FormatTag.nchw).inputs()
+    val conv1 = SpatialConvolution(2, 4, 5, 5, 1, 1, 2, 2).inputs(input1)
+    val conv2 = SpatialConvolution(4, 4, 1, 1, 1, 1, 0, 0).inputs(input2)
+    val joinTable = JoinTable(2).inputs(conv1, conv2)
+    val output = Output(Memory.FormatTag.nchw).inputs(joinTable)
+
+    val model = DnnGraph(Seq(input1, input2), Seq(output))
+    model.evaluate()
+
+    val tensor1 = Tensor[Float](inputShape1).rand(-1, 1)
+    val tensor2 = Tensor[Float](inputShape2).rand(-0.1, 0.1)
+    val tableInput = T(tensor1, tensor2)
+
+    model.setWeightDimMask(1, overrideSubmodules = true)
+    model.compile(InferencePhase)
+    model.forward(tableInput)
+
+    model.calcScales(tableInput)
+
+    val outputOfModel = Tensor[Float]()
+      .resizeAs(model.output.toTensor[Float])
+      .copy(model.output.toTensor[Float])
+
+
+    model.clearState()
+
+    val quant = model.quantize().asInstanceOf[DnnGraph]
+    quant.compile(InferencePhase)
+    quant.forward(tableInput)
+
+    Equivalent.nearequals(outputOfModel, quant.output.toTensor[Float], 1e-1) should be (true)
+
+    model.release()
+    quant.release()
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/LRNSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/LRNSpec.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.{DataType, Memory}
+import com.intel.analytics.bigdl.nn.SpatialCrossMapLRN
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.BigDLSpecHelper
+import com.intel.analytics.bigdl.utils.RandomGenerator.RNG
+import org.apache.commons.lang3.SerializationUtils
+
+import scala.util.Random
+
+class LRNSpec extends BigDLSpecHelper {
+  "LRNDnn with format=nchw" should "work correctly" in {
+    val batchSize = 2
+    val input = Tensor[Float](batchSize, 7, 3, 3).apply1(e => Random.nextFloat())
+    val gradOutput = Tensor[Float](batchSize, 7, 3, 3).apply1(e => Random.nextFloat())
+
+    RNG.setSeed(100)
+    val lrnDnn = LRN(5, 0.0001, 0.75, 1.0)
+    RNG.setSeed(100)
+    val lrnBLAS = SpatialCrossMapLRN[Float](5, 0.0001, 0.75, 1.0)
+
+    val output2 = lrnBLAS.forward(input)
+    val grad2 = lrnBLAS.updateGradInput(input, gradOutput)
+
+    val seq = Sequential()
+    seq.add(ReorderMemory(HeapData(Array(batchSize, 7, 3, 3), Memory.FormatTag.nchw),
+      HeapData(Array(batchSize, 7, 3, 3), Memory.FormatTag.nchw)))
+    seq.add(lrnDnn)
+    seq.add(ReorderMemory(HeapData(Array(batchSize, 7, 3, 3), Memory.FormatTag.nchw),
+      HeapData(Array(batchSize, 7, 3, 3), Memory.FormatTag.nchw)))
+    seq.compile(Phase.TrainingPhase,
+      Array(HeapData(Array(batchSize, 7, 3, 3), Memory.FormatTag.nchw)))
+    val output = seq.forward(input)
+    output.asInstanceOf[Tensor[Float]] should be(output2)
+    val grad1 = seq.backward(input, gradOutput)
+    grad1.asInstanceOf[Tensor[Float]] should be(grad2)
+  }
+
+  "lrn with java serialization" should "work correctly" in {
+    val batchSize = 2
+    val inputShape = Array(batchSize, 7, 3, 3)
+    val input = Tensor[Float](batchSize, 7, 3, 3).rand(-1, 1)
+    val gradOutput = Tensor[Float](batchSize, 7, 3, 3).rand(-1, 1)
+
+    val lrn = LRN(5, 0.0001, 0.75, 1.0)
+    lrn.setRuntime(new MklDnnRuntime)
+    lrn.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    lrn.initBwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    lrn.initGradWPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+
+    lrn.forward(input)
+
+    val cloned = SerializationUtils.clone(lrn)
+    cloned.setRuntime(new MklDnnRuntime)
+    cloned.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    cloned.initBwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    cloned.initGradWPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+
+    cloned.forward(input)
+
+    Tools.dense(lrn.output) should be (Tools.dense(cloned.output))
+  }
+
+  "LRN in int8 model" should "work correctly" in {
+    RNG.setSeed(100)
+
+    val inputShape = Array(4, 8, 3, 3)
+    val input = Tensor[Float](inputShape).rand(-1, 1)
+
+    val int8NativeData = NativeData(inputShape, Memory.FormatTag.nhwc, DataType.S8)
+    int8NativeData.setMask(0)
+    int8NativeData.setScales(Array(127.0f / input.clone().abs().max()))
+    val reorderToInt8 = ReorderMemory(int8NativeData)
+
+    val seqInt8 = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(reorderToInt8)
+      .add(LRN(8, 0.0001, 0.75, 1.0))
+      .add(ReorderMemory(HeapData(inputShape, Memory.FormatTag.nchw)))
+
+    seqInt8.compile(InferencePhase)
+
+    seqInt8.forward(input)
+
+    val seqFP32 = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(LRN(8, 0.0001, 0.75, 1.0))
+      .add(ReorderMemory(HeapData(inputShape, Memory.FormatTag.nchw)))
+
+    seqFP32.compile(InferencePhase)
+    seqFP32.forward(input)
+
+    // here, the 1e-2 is experience value
+    Equivalent.nearequals(seqInt8.output.toTensor, seqFP32.output.toTensor, 1e-2) should be (true)
+
+    seqInt8.release()
+    seqFP32.release()
+
+    println()
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/LinearSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/LinearSpec.scala
@@ -1,0 +1,526 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.Memory
+import com.intel.analytics.bigdl.nn
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.TrainingPhase
+import com.intel.analytics.bigdl.numeric.NumericFloat
+import com.intel.analytics.bigdl.optim.L2Regularizer
+import com.intel.analytics.bigdl.tensor.{DnnStorage, Tensor}
+import com.intel.analytics.bigdl.utils.RandomGenerator._
+import org.apache.commons.lang3.SerializationUtils
+import org.scalatest.{FlatSpec, Matchers}
+
+class LinearSpec extends FlatSpec with Matchers {
+  "linear updateOutput" should "work correctly" in {
+    val inputSize = 2
+    val outputSize = 2
+    val batchSize = 2
+
+    val inputFormat = HeapData(Array(batchSize, inputSize), Memory.FormatTag.nc)
+    val outputFormat = HeapData(Array(batchSize, outputSize), Memory.FormatTag.nc)
+    val input = Tensor[Float](batchSize, inputSize).rand()
+
+    val initWeight = Tensor[Float](outputSize, inputSize).rand()
+    val initBias = Tensor[Float](outputSize).rand()
+
+    val linear = Linear(inputSize, outputSize, initWeight = initWeight, initBias = initBias)
+    linear.setRuntime(new MklDnnRuntime)
+    linear.initFwdPrimitives(Array(inputFormat), TrainingPhase)
+    linear.initBwdPrimitives(Array(outputFormat), TrainingPhase)
+    linear.initGradWPrimitives(Array(outputFormat), TrainingPhase)
+
+    val output = linear.forward(input)
+
+    val nnLinear = nn.Linear(inputSize, outputSize, initWeight = initWeight, initBias = initBias)
+    val nnOutput = nnLinear.forward(input)
+
+    Tools.dense(output) should be (nnOutput)
+  }
+
+  "Dnn Linear with regularizer" should "work correctly" in {
+    val inputSize = 2048
+    val outputSize = 1000
+    val batchSize = 2
+
+    RNG.setSeed(1000)
+    val inputFormat = HeapData(Array(batchSize, inputSize), Memory.FormatTag.nc)
+    val outputFormat = HeapData(Array(batchSize, outputSize), Memory.FormatTag.nc)
+    val input = Tensor[Float](batchSize, inputSize).rand()
+    val gradOutput = Tensor[Float](batchSize, outputSize).rand()
+
+    val initWeight = Tensor[Float](outputSize, inputSize).rand()
+    val initBias = Tensor[Float](outputSize).rand()
+
+    val wRegularizer = L2Regularizer(1e-4)
+    val bRegularizer = L2Regularizer(1e-4)
+
+    val linear = Linear(inputSize, outputSize, initWeight = initWeight, initBias = initBias,
+      wRegularizer = wRegularizer, bRegularizer = bRegularizer)
+    val nnLinear = nn.Linear(inputSize, outputSize, initWeight = initWeight, initBias = initBias,
+      wRegularizer = wRegularizer, bRegularizer = bRegularizer)
+
+    linear.setRuntime(new MklDnnRuntime)
+    linear.initFwdPrimitives(Array(inputFormat), TrainingPhase)
+    linear.initBwdPrimitives(Array(outputFormat), TrainingPhase)
+    linear.initGradWPrimitives(Array(outputFormat), TrainingPhase)
+
+
+    for (i <- 0 to 3) {
+      linear.zeroGradParameters()
+      nnLinear.zeroGradParameters()
+
+      nnLinear.forward(input)
+      nnLinear.backward(input, gradOutput)
+      linear.forward(input)
+      linear.backward(input, gradOutput)
+
+    }
+
+    Tools.dense(linear.output) should be (nnLinear.output)
+    Tools.dense(linear.gradInput) should be (nnLinear.gradInput)
+    
+    val p1 = linear.getParameters()
+    val p2 = linear.getParameters()
+
+    p1._1 should be (p2._1)
+    p1._2 should be (p2._2)
+  }
+
+  "linear updateOutput multi times" should "work correctly" in {
+    val inputSize = 2
+    val outputSize = 2
+    val batchSize = 2
+
+    val inputFormat = HeapData(Array(batchSize, inputSize), Memory.FormatTag.nc)
+    val outputFormat = HeapData(Array(batchSize, outputSize), Memory.FormatTag.nc)
+
+    val initWeight = Tensor[Float](outputSize, inputSize).rand()
+    val initBias = Tensor[Float](outputSize).rand()
+
+    val inputs = new Array[Tensor[Float]](100)
+    for (i <- inputs.indices) {
+      inputs(i) = Tensor[Float](batchSize, inputSize).rand()
+    }
+
+    val linear = Linear(inputSize, outputSize, initWeight = initWeight, initBias = initBias)
+    linear.setRuntime(new MklDnnRuntime)
+    linear.initFwdPrimitives(Array(inputFormat), TrainingPhase)
+    linear.initBwdPrimitives(Array(outputFormat), TrainingPhase)
+    linear.initGradWPrimitives(Array(outputFormat), TrainingPhase)
+
+    for (in <- inputs) {
+      linear.forward(in)
+    }
+
+    val nnLinear = nn.Linear(inputSize, outputSize, initWeight = initWeight, initBias = initBias)
+    for (in <- inputs) {
+      nnLinear.forward(in)
+    }
+
+    Tools.dense(linear.output) should be (nnLinear.output)
+  }
+
+  "linear updateGradInput" should "work correctly" in {
+    val inputSize = 2
+    val outputSize = 2
+    val batchSize = 2
+
+    val inputFormat = HeapData(Array(batchSize, inputSize), Memory.FormatTag.nc)
+    val outputFormat = HeapData(Array(batchSize, outputSize), Memory.FormatTag.nc)
+    val input = Tensor[Float](batchSize, inputSize).rand()
+    val gradOutput = Tensor().resize(outputFormat.shape).rand()
+
+    val initWeight = Tensor[Float](outputSize, inputSize).rand()
+    val initBias = Tensor[Float](outputSize).rand()
+
+    val linear = Linear(inputSize, outputSize, initWeight = initWeight, initBias = initBias)
+    linear.setRuntime(new MklDnnRuntime)
+    linear.initFwdPrimitives(Array(inputFormat), TrainingPhase)
+    linear.initBwdPrimitives(Array(outputFormat), TrainingPhase)
+    linear.initGradWPrimitives(Array(outputFormat), TrainingPhase)
+
+    val output = linear.forward(input)
+    val gradInput = linear.updateGradInput(input, gradOutput)
+
+    val nnLinear = nn.Linear(inputSize, outputSize, initWeight = initWeight, initBias = initBias)
+    val nnOutput = nnLinear.forward(input)
+    val nnGradInput = nnLinear.updateGradInput(input, gradOutput)
+
+    println(gradInput)
+    println("-" * 80)
+    println(nnGradInput)
+    Tools.dense(linear.weight.native) should be (linear.weight.dense.t())
+
+    Tools.dense(gradInput) should be (nnGradInput)
+  }
+
+  "linear updateGradInput multi times" should "work correctly" in {
+    val inputSize = 2
+    val outputSize = 2
+    val batchSize = 2
+
+    val inputFormat = HeapData(Array(batchSize, inputSize), Memory.FormatTag.nc)
+    val outputFormat = HeapData(Array(batchSize, outputSize), Memory.FormatTag.nc)
+
+    val initWeight = Tensor[Float](outputSize, inputSize).rand()
+    val initBias = Tensor[Float](outputSize).rand()
+
+    val inputs = new Array[Tensor[Float]](100)
+    for (i <- inputs.indices) {
+      inputs(i) = Tensor[Float](batchSize, inputSize).rand()
+    }
+
+    val linear = Linear(inputSize, outputSize, initWeight = initWeight, initBias = initBias)
+    linear.setRuntime(new MklDnnRuntime)
+    linear.initFwdPrimitives(Array(inputFormat), TrainingPhase)
+    linear.initBwdPrimitives(Array(outputFormat), TrainingPhase)
+    linear.initGradWPrimitives(Array(outputFormat), TrainingPhase)
+
+    for (i <- inputs.indices) {
+      inputs(i) = Tensor[Float](batchSize, inputSize).rand()
+    }
+
+    val gradOutputs = new Array[Tensor[Float]](100)
+    for (i <- gradOutputs.indices) {
+      gradOutputs(i) = Tensor[Float](batchSize, outputSize).rand()
+    }
+
+    linear.forward(inputs.last)
+
+    for (i <- inputs.indices) {
+      linear.updateGradInput(inputs(i), gradOutputs(i))
+    }
+
+    val nnLinear = nn.Linear(inputSize, outputSize, initWeight = initWeight, initBias = initBias)
+    val nnOutput = nnLinear.forward(inputs.last)
+
+    for (i <- inputs.indices) {
+      nnLinear.updateGradInput(inputs(i), gradOutputs(i))
+    }
+
+    Tools.dense(linear.gradInput) should be (nnLinear.gradInput)
+  }
+
+  "linear accGradParameters" should "work correctly" in {
+    val inputSize = 2
+    val outputSize = 2
+    val batchSize = 2
+
+    val inputFormat = HeapData(Array(batchSize, inputSize), Memory.FormatTag.nc)
+    val outputFormat = HeapData(Array(batchSize, outputSize), Memory.FormatTag.nc)
+    val input = Tensor[Float](batchSize, inputSize).rand()
+    val gradOutput = Tensor[Float]().resize(outputFormat.shape).rand()
+
+    val initWeight = Tensor[Float](outputSize, inputSize).rand()
+    val initBias = Tensor[Float](outputSize).rand()
+
+    val linear = Linear(inputSize, outputSize, initWeight = initWeight, initBias = initBias)
+    linear.setRuntime(new MklDnnRuntime)
+    linear.initFwdPrimitives(Array(inputFormat), TrainingPhase)
+    linear.initBwdPrimitives(Array(outputFormat), TrainingPhase)
+    linear.initGradWPrimitives(Array(outputFormat), TrainingPhase)
+
+    val output = linear.forward(input)
+
+    val gradInput = linear.updateGradInput(input, gradOutput)
+
+    val nnLinear = nn.Linear(inputSize, outputSize, initWeight = initWeight, initBias = initBias)
+    val nnOutput = nnLinear.forward(input)
+    val nnGradInput = nnLinear.updateGradInput(input, gradOutput)
+
+    linear.accGradParameters(input, gradOutput)
+    nnLinear.accGradParameters(input, gradOutput)
+
+    println(linear.gradWeight)
+    println(linear.gradBias)
+    println("-" * 80)
+    println(nnLinear.gradWeight)
+    println(nnLinear.gradBias)
+
+    Tools.dense(linear.gradWeight.native) should be (nnLinear.gradWeight.t())
+    Tools.dense(linear.gradBias.native) should be (nnLinear.gradBias)
+  }
+
+  "linear cloned" should "work correctly" in {
+    val inputSize = 2
+    val outputSize = 2
+    val batchSize = 2
+
+    val inputFormat = HeapData(Array(batchSize, inputSize), Memory.FormatTag.nc)
+    val outputFormat = HeapData(Array(batchSize, outputSize), Memory.FormatTag.nc)
+    val input = Tensor[Float](batchSize, inputSize).rand()
+    val gradOutput = Tensor[Float]().resize(outputFormat.shape).rand()
+
+    val initWeight = Tensor[Float](outputSize, inputSize).rand()
+    val initBias = Tensor[Float](outputSize).rand()
+
+    val linear = Linear(inputSize, outputSize, initWeight = initWeight, initBias = initBias)
+    linear.setRuntime(new MklDnnRuntime)
+    linear.initFwdPrimitives(Array(inputFormat), TrainingPhase)
+    linear.initBwdPrimitives(Array(outputFormat), TrainingPhase)
+    linear.initGradWPrimitives(Array(outputFormat), TrainingPhase)
+
+    val output = linear.forward(input)
+    val gradInput = linear.updateGradInput(input, gradOutput)
+    linear.accGradParameters(input, gradOutput)
+
+    val cloned = SerializationUtils.clone(linear)
+    cloned.setRuntime(new MklDnnRuntime)
+    cloned.initFwdPrimitives(Array(inputFormat), TrainingPhase)
+    cloned.initBwdPrimitives(Array(outputFormat), TrainingPhase)
+    cloned.initGradWPrimitives(Array(outputFormat), TrainingPhase)
+
+    cloned.forward(input)
+
+    Tools.dense(linear.output) should be (Tools.dense(cloned.output))
+
+    linear.backward(input, gradOutput)
+    cloned.backward(input, gradOutput)
+
+    Tools.dense(linear.gradInput) should be (Tools.dense(cloned.gradInput))
+    Tools.dense(linear.gradWeight.native) should be (Tools.dense(cloned.gradWeight.native))
+    Tools.dense(linear.gradBias.native) should be (Tools.dense(cloned.gradBias.native))
+  }
+
+  "linear released" should "work correctly" in {
+    val inputSize = 2
+    val outputSize = 2
+    val batchSize = 2
+
+    val inputFormat = HeapData(Array(batchSize, inputSize), Memory.FormatTag.nc)
+    val outputFormat = HeapData(Array(batchSize, outputSize), Memory.FormatTag.nc)
+    val input = Tensor[Float](batchSize, inputSize).rand()
+    val gradOutput = Tensor[Float]().resize(outputFormat.shape).rand()
+
+    val initWeight = Tensor[Float](outputSize, inputSize).rand()
+    val initBias = Tensor[Float](outputSize).rand()
+
+    val initCount = DnnStorage.get().count(!_._2)
+
+    val linear = Linear(inputSize, outputSize, initWeight = initWeight, initBias = initBias)
+    linear.setRuntime(new MklDnnRuntime)
+    linear.initFwdPrimitives(Array(inputFormat), TrainingPhase)
+    linear.initBwdPrimitives(Array(outputFormat), TrainingPhase)
+    linear.initGradWPrimitives(Array(outputFormat), TrainingPhase)
+
+    linear.forward(input)
+    linear.backward(input, gradOutput)
+
+    linear.release()
+    DnnStorage.get().count(_._2 == false) should be (initCount)
+  }
+
+  "linear with dense weights" should "work correctly" in {
+    val inputSize = 2
+    val outputSize = 2
+    val batchSize = 2
+
+    val inputFormat = HeapData(Array(batchSize, inputSize), Memory.FormatTag.nc)
+    val outputFormat = HeapData(Array(batchSize, outputSize), Memory.FormatTag.nc)
+    val input = Tensor[Float](batchSize, inputSize).rand()
+    val gradOutput = Tensor[Float]().resize(outputFormat.shape).rand()
+
+    val initWeight1 = Tensor[Float](outputSize, inputSize).rand()
+    val initBias1 = Tensor[Float](outputSize).rand()
+
+    val initWeight2 = Tensor[Float](outputSize, inputSize).rand()
+    val initBias2 = Tensor[Float](outputSize).rand()
+
+    val linear1 = Linear(inputSize, outputSize, initWeight = initWeight1, initBias = initBias1)
+    linear1.setRuntime(new MklDnnRuntime)
+    linear1.initFwdPrimitives(Array(inputFormat), TrainingPhase)
+    linear1.initBwdPrimitives(Array(outputFormat), TrainingPhase)
+    linear1.initGradWPrimitives(Array(outputFormat), TrainingPhase)
+
+    linear1.forward(input)
+    linear1.backward(input, gradOutput)
+
+    linear1.parameters()._1.zip(Array(initWeight2, initBias2)).foreach(x => x._1.copy(x._2))
+    linear1.forward(input)
+    linear1.backward(input, gradOutput)
+
+    val linear2 = Linear(inputSize, outputSize, initWeight = initWeight2, initBias = initBias2)
+    linear2.setRuntime(new MklDnnRuntime)
+    linear2.initFwdPrimitives(Array(inputFormat), TrainingPhase)
+    linear2.initBwdPrimitives(Array(outputFormat), TrainingPhase)
+    linear2.initGradWPrimitives(Array(outputFormat), TrainingPhase)
+
+    linear2.forward(input)
+    linear2.backward(input, gradOutput)
+
+    Tools.dense(linear1.output) should be (Tools.dense(linear2.output))
+    Tools.dense(linear1.gradInput) should be (Tools.dense(linear2.gradInput))
+    linear1.parameters()._2.zip(linear2.parameters()._2).foreach(x => x._1 should be (x._2))
+  }
+
+  "linear with maxpooling" should "work correctly" in {
+    val initWeight = Tensor[Float](4096, 256 * 6 * 6).rand()
+    val initBias = Tensor[Float](4096).rand()
+    val input = Tensor[Float](4, 256, 13, 13).rand()
+
+    val dnn = Sequential()
+      .add(MaxPooling(3, 3, 2, 2))
+      .add(Linear(256 * 6 * 6, 4096, initWeight = initWeight, initBias = initBias))
+      .add(ReorderMemory(HeapData(Array(4, 4096), Memory.FormatTag.nc)))
+    dnn.compile(TrainingPhase, Array(HeapData(input.size(), Memory.FormatTag.nchw)))
+
+    val blas = nn.Sequential()
+      .add(nn.SpatialMaxPooling(3, 3, 2, 2))
+      .add(nn.View(256 * 6 * 6))
+      .add(nn.Linear(256 * 6 * 6, 4096, initWeight = initWeight, initBias = initBias))
+
+    blas.forward(input)
+    dnn.forward(input)
+
+    val gradOutput = Tensor[Float]().resizeAs(blas.output.toTensor).rand()
+    dnn.backward(input, gradOutput)
+    blas.backward(input, gradOutput)
+
+    Tools.dense(dnn.output) should be (blas.output)
+    Tools.dense(dnn.gradInput) should be (blas.gradInput)
+  }
+
+//  "relu + linear with 1-D" should "work correctly" in {
+//    val initWeight = Tensor(10, 20).rand(-1, 1)
+//    val initBias = Tensor(10).rand(-1, 1)
+//
+//    val input = Tensor(20).rand()
+//    val inputFormat = HeapData(Array(20), Memory.FormatTag.x)
+//    val outputFormat = HeapData(Array(10), Memory.FormatTag.x)
+//
+//    val dnn = Sequential().add(ReLU()).add(Linear(20, 10, initWeight = initWeight,
+//      initBias = initBias))
+//    dnn.compile(TrainingPhase, Array(inputFormat))
+//
+//    val blas = nn.Sequential().add(nn.ReLU()).add(nn.Linear(20, 10, initWeight = initWeight,
+//      initBias = initBias))
+//
+//    dnn.forward(input)
+//    println("=" * 80)
+//    blas.forward(input)
+//
+//    val gradOutput = Tensor().resizeAs(blas.output.toTensor)
+//    dnn.backward(input, gradOutput)
+//    blas.backward(input, gradOutput)
+//  }
+
+//  "1-D input" should "work correctly" in {
+//    val input = Tensor(20).rand()
+//    val gradOutput = Tensor(10).rand()
+//
+//    val model = Linear(20, 10)
+//    model.setRuntime(new MklDnnRuntime)
+//    model.initFwdPrimitives(Array(HeapData(Array(20), Memory.FormatTag.x)), TrainingPhase)
+//    model.initBwdPrimitives(Array(HeapData(Array(10), Memory.FormatTag.x)), TrainingPhase)
+//    model.initGradWPrimitives(Array(HeapData(Array(10), Memory.FormatTag.x)), TrainingPhase)
+//
+//    model.forward(input)
+//
+//    model.updateGradInput(input, gradOutput)
+//  }
+
+  "linear + linear, the first linear with a 4-D input" should "work correctly" in {
+    val inputSize = 16 * 16 * 16
+    val outputSize = 16 * 16 * 16
+    val initWeight = Tensor[Float](outputSize, inputSize).rand()
+    val initBias = Tensor[Float](outputSize)
+
+    val input = Tensor[Float](16, inputSize).rand()
+    val input2 = Tensor[Float](16, 16, 16, 16).rand()
+
+    val inputShape1 = Array(16, inputSize)
+    val inputShape2 = Array(16, 16, 16, 16)
+
+    val seq = Sequential()
+      .add(Linear(outputSize, inputSize, initWeight = initWeight, initBias = initBias))
+      .add(Linear(outputSize, inputSize, initWeight = initWeight, initBias = initBias))
+
+    seq.compile(TrainingPhase, Array(HeapData(inputShape1, Memory.FormatTag.nc)))
+
+    val seq2 = Sequential()
+      .add(Linear(outputSize, inputSize, initWeight = initWeight, initBias = initBias))
+      .add(Linear(outputSize, inputSize, initWeight = initWeight, initBias = initBias))
+
+    seq2.compile(TrainingPhase, Array(HeapData(inputShape2, Memory.FormatTag.nchw)))
+
+    seq.forward(input)
+    seq.backward(input, input)
+
+    seq.forward(input2)
+    seq.backward(input2, input)
+  }
+
+
+  "linear " should "work correctly" in {
+    val (batchSize, nInput) = (4, 64)
+    val inputShape = Array(batchSize, nInput)
+    val nOutput = 1000
+    val outputShape = Array(batchSize, nOutput)
+    val name = "fc"
+
+    val prototxt =
+      s"""
+         |name: "relu-simple"
+         |force_backward: true
+         |layer {
+         |  name: "data"
+         |  type: "DummyData"
+         |  top: "data"
+         |  include {
+         |    phase: TRAIN
+         |  }
+         |  dummy_data_param {
+         |    data_filler {
+         |      type: "xavier"
+         |    }
+         |    shape: { ${shape2Dim(inputShape)} }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "data"
+         |  top: "$name"
+         |  name: "$name"
+         |  type: "InnerProduct"
+         |  inner_product_param {
+         |    num_output: $nOutput
+         |    weight_filler {
+         |      type: "gaussian"
+         |      std: 0.01
+         |    }
+         |    bias_filler {
+         |      type: "constant"
+         |      value: 0
+         |    }
+         |  }
+         |}
+       """.stripMargin
+    val linear = new Linear(nInput, nOutput).setName(name)
+    linear.setRuntime(new MklDnnRuntime)
+    linear.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nc)), TrainingPhase)
+    linear.initBwdPrimitives(Array(HeapData(outputShape, Memory.FormatTag.nc)), TrainingPhase)
+    linear.initGradWPrimitives(Array(HeapData(outputShape, Memory.FormatTag.nc)), TrainingPhase)
+
+    Tools.compare(prototxt, linear, inputShape, outputShape, 1e-5)
+  }
+
+  private def shape2Dim(shape: Array[Int]): String = {
+    shape.map(x => "dim: " + x).mkString(" ")
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/MaxPoolingSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/MaxPoolingSpec.scala
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.{AlgKind, DataType, Memory}
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.nn.{SpatialAveragePooling, SpatialMaxPooling}
+import com.intel.analytics.bigdl.tensor.{DnnTensor, Tensor}
+import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, Engine}
+import com.intel.analytics.bigdl.utils.RandomGenerator.RNG
+import com.intel.analytics.bigdl.utils.intermediate.{BlasToIR, IRToDnn}
+import org.apache.commons.lang3.SerializationUtils
+
+import scala.util.Random
+
+class MaxPoolingSpec extends BigDLSpecHelper {
+
+  "Max Pooling test1" should "be correct" in {
+    val batchSize = 2
+    val input = Tensor[Float](batchSize, 480, 28, 28).apply1(e => Random.nextFloat())
+    val gradOutput = Tensor[Float](batchSize, 480, 14, 14).apply1(e => Random.nextFloat())
+
+    val pad = -1
+    RNG.setSeed(100)
+    val pool = MaxPooling(3, 3, 2, 2, padH = pad, padW = pad)
+    RNG.setSeed(100)
+    val layer = SpatialMaxPooling[Float](3, 3, 2, 2, padH = pad, padW = pad).ceil()
+
+    val seq = Sequential()
+    seq.add(ReorderMemory(
+      HeapData(Array(batchSize, 480, 28, 28), Memory.FormatTag.nchw, DataType.F32),
+      HeapData(Array(batchSize, 480, 28, 28), Memory.FormatTag.nchw, DataType.F32)))
+
+    seq.add(pool)
+
+    seq.add(ReorderMemory(
+      HeapData(Array(batchSize, 480, 14, 14), Memory.FormatTag.nchw, DataType.F32),
+      HeapData(Array(batchSize, 480, 14, 14), Memory.FormatTag.nchw, DataType.F32)))
+
+    seq.compile(Phase.TrainingPhase, Array(HeapData(Array(batchSize, 480, 28, 28),
+      Memory.FormatTag.nchw)))
+
+    for (i <- 0 to 1) {
+      input.rand()
+      gradOutput.rand()
+
+      seq.forward(input)
+      seq.backward(input, gradOutput)
+
+      layer.forward(input)
+      layer.backward(input, gradOutput)
+    }
+
+    val output1 = seq.forward(input)
+    val output2 = layer.forward(input).toTensor[Float]
+
+    output1 should be(output2)
+
+    val grad2 = layer.backward(input, output2).toTensor[Float]
+    val grad1 = seq.backward(input, output2)
+    grad1 should be(grad2)
+  }
+
+  "Convert max pooling with ceilMode to dnn layer" should "be correct" in {
+    val batchSize = 2
+    val input = Tensor[Float](batchSize, 480, 28, 28).apply1(e => Random.nextFloat())
+    val gradOutput = Tensor[Float](batchSize, 480, 14, 14).apply1(e => Random.nextFloat())
+
+    RNG.setSeed(100)
+    val layer = SpatialMaxPooling[Float](3, 3, 2, 2).ceil()
+
+    val irelement = BlasToIR[Float].convertLayer(layer)
+    val pool = IRToDnn[Float].convertLayer(irelement)
+
+    val seq = Sequential()
+    seq.add(ReorderMemory(HeapData(Array(batchSize, 480, 28, 28), Memory.FormatTag.nchw),
+      HeapData(Array(batchSize, 480, 28, 28), Memory.FormatTag.nchw)))
+    seq.add(pool)
+    seq.add(ReorderMemory(HeapData(Array(batchSize, 480, 14, 14), Memory.FormatTag.nchw),
+      HeapData(Array(batchSize, 480, 14, 14), Memory.FormatTag.nchw)))
+    seq.compile(Phase.TrainingPhase, Array(HeapData(Array(batchSize, 480, 28, 28),
+      Memory.FormatTag.nchw)))
+
+    for (i <- 0 to 3) {
+      input.rand()
+      gradOutput.rand()
+
+      seq.forward(input)
+      seq.backward(input, gradOutput)
+
+      layer.forward(input)
+      layer.backward(input, gradOutput)
+    }
+
+    val output1 = seq.forward(input)
+    val output2 = layer.forward(input).toTensor[Float]
+    output1 should be(output2)
+
+    val grad2 = layer.backward(input, output2).toTensor[Float]
+    val grad1 = seq.backward(input, output2)
+    grad1 should be(grad2)
+  }
+
+  "Max Pooling test2" should "be correct" in {
+    val batchSize = 2
+    val input = Tensor[Float](batchSize, 64, 112, 112).apply1(e => Random.nextFloat())
+    val gradOutput = Tensor[Float](batchSize, 480, 14, 14).apply1(e => Random.nextFloat())
+
+    RNG.setSeed(100)
+    val pool = MaxPooling(3, 3, 2, 2)
+    RNG.setSeed(100)
+    val layer = SpatialMaxPooling[Float](3, 3, 2, 2).ceil()
+
+    val output2 = layer.forward(input).toTensor[Float]
+
+    val seq = Sequential()
+    seq.add(ReorderMemory(HeapData(Array(batchSize, 64, 112, 112), Memory.FormatTag.nchw),
+      HeapData(Array(batchSize, 64, 112, 112), Memory.FormatTag.nchw)))
+    seq.add(pool)
+    seq.add(ReorderMemory(HeapData(Array(batchSize, 64, 56, 56), Memory.FormatTag.nchw),
+      HeapData(Array(batchSize, 64, 56, 56), Memory.FormatTag.nchw)))
+    seq.compile(Phase.TrainingPhase, Array(HeapData(Array(batchSize, 64, 112, 112),
+      Memory.FormatTag.nchw)))
+    val output1 = seq.forward(input)
+    output1 should be(output2)
+
+    val grad2 = layer.backward(input, output2).toTensor[Float]
+    val grad1 = seq.backward(input, output2)
+    grad1 should be(grad2)
+  }
+
+  "max pooling with java serialization" should "be correct" in {
+    val batchSize = 2
+    val inputShape = Array(batchSize, 64, 112, 112)
+    val outputShape = Array(batchSize, 64, 56, 56)
+    val input = Tensor[Float](batchSize, 64, 112, 112).rand(-1, 1)
+
+    val pool = MaxPooling(3, 3, 2, 2)
+    pool.setRuntime(new MklDnnRuntime)
+    pool.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    pool.initBwdPrimitives(Array(HeapData(outputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    pool.initGradWPrimitives(Array(HeapData(outputShape, Memory.FormatTag.nchw)), TrainingPhase)
+
+    val cloned = SerializationUtils.clone(pool)
+    cloned.setRuntime(new MklDnnRuntime)
+    cloned.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    cloned.initBwdPrimitives(Array(HeapData(outputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    cloned.initGradWPrimitives(Array(HeapData(outputShape, Memory.FormatTag.nchw)), TrainingPhase)
+
+    pool.forward(input)
+    cloned.forward(input)
+
+    Tools.dense(pool.output) should be (Tools.dense(cloned.output))
+
+    val gradOutput = Tensor[Float](outputShape).rand(-1, 1)
+    pool.backward(input, gradOutput)
+    cloned.backward(input, gradOutput)
+
+    Tools.dense(pool.gradInput) should be (Tools.dense(cloned.gradInput))
+  }
+
+  "max pooling with int8" should "be correct" in {
+    val inputShape = Array(4, 3, 5, 5)
+    val outputShape = Array(4, 3, 2, 2)
+
+    val kernel = 3
+    val pad = 1
+
+    val runtime = new MklDnnRuntime
+
+    val input = Tensor[Float](inputShape).rand(0, 1)
+
+    val heapData = HeapData(inputShape, Memory.FormatTag.nchw, DataType.F32)
+    val nativeData = NativeData(inputShape, Memory.FormatTag.nhwc, DataType.U8)
+    val inputScales = Array(input.max())
+
+    nativeData.setMask(0)
+    nativeData.setScales(inputScales.map(x => 255.0f / x))
+
+    val reorder = ReorderMemory(nativeData)
+    val pool = MaxPooling(3, 3, 2, 2)
+    val heapData2 = HeapData(outputShape, Memory.FormatTag.nchw, DataType.F32)
+    val reorder2 = ReorderMemory(heapData2)
+
+    val seq = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(reorder)
+      .add(pool)
+      .add(reorder2)
+
+    seq.evaluate()
+    seq.compile(InferencePhase)
+    seq.forward(input)
+
+    val seq2 = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(MaxPooling(3, 3, 2, 2))
+      .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw)))
+
+    seq2.evaluate()
+    seq2.compile(InferencePhase)
+    seq2.forward(input)
+
+    Equivalent.nearequals(seq.output.toTensor, seq2.output.toTensor, 1e-2) should be (true)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/MemoryDataSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/MemoryDataSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.{DataType, Memory}
+import org.scalatest.{FlatSpec, Matchers}
+
+class MemoryDataSpec extends FlatSpec with Matchers {
+  "memory data hashCode comparison data" should "work correctly" in {
+    val fp32 = HeapData(Array(4, 3), Memory.FormatTag.nc, DataType.F32)
+    val int8 = HeapData(Array(4, 3), Memory.FormatTag.nc, DataType.S8)
+
+    fp32.hashCode() == int8.hashCode() should not be (true)
+  }
+
+  "memory data hashCode comparison native" should "work correctly" in {
+    val fp32 = NativeData(Array(3, 3), Memory.FormatTag.nc, DataType.F32)
+    val int8 = NativeData(Array(3, 3), Memory.FormatTag.nc, DataType.S8)
+
+    fp32.hashCode() == int8.hashCode() should not be (true)
+  }
+
+  "memory data hashCode comparison heap and native" should "work correctly" in {
+    val heap = HeapData(Array(3, 3), Memory.FormatTag.nc, DataType.F32)
+    val native = NativeData(Array(3, 3), Memory.FormatTag.nc, DataType.F32)
+    
+    heap.hashCode() == native.hashCode() should not be (true)
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/MultiModelsSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/MultiModelsSpec.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dataset.Sample
+import com.intel.analytics.bigdl.models.inception.Inception_v1_NoAuxClassifier
+import com.intel.analytics.bigdl.models.lenet.LeNet5
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.transform.vision.image.{ImageFeature, ImageFrame, ImageFrameToSample, MatToTensor}
+import com.intel.analytics.bigdl.transform.vision.image.augmentation.{CenterCrop, ChannelNormalize, Resize}
+import com.intel.analytics.bigdl.utils.{Engine, LoggerFilter}
+import com.intel.analytics.bigdl.utils.RandomGenerator._
+import org.apache.spark.SparkContext
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+
+class MultiModelsSpec extends FlatSpec with BeforeAndAfter with Matchers {
+  var sc: SparkContext = _
+  val nodeNumber = 1
+  val coreNumber = 2
+
+  before {
+    System.setProperty("bigdl.engineType", "mkldnn")
+    System.setProperty("bigdl.multiModels", "true")
+
+    LoggerFilter.redirectSparkInfoLogs()
+
+    val conf = Engine.createSparkConf()
+      .setMaster(s"local[$coreNumber]")
+      .setAppName("multi mkl-dnn models")
+    sc = SparkContext.getOrCreate(conf)
+
+    Engine.init
+  }
+
+  after {
+    System.clearProperty("bigdl.engineType")
+    System.clearProperty("bigdl.multiModels")
+
+    if (sc != null) {
+      sc.stop()
+    }
+  }
+
+  "model.predict" should "be correct" in {
+    RNG.setSeed(100)
+    val data = new Array[Sample[Float]](97)
+    var i = 0
+    while (i < data.length) {
+      val input = Tensor[Float](28, 28).apply1(_ =>
+        RNG.uniform(0.130660 + i, 0.3081078).toFloat)
+      val label = Tensor[Float](1).fill(1.0f)
+      data(i) = Sample(input, label)
+      i += 1
+    }
+    val model = LeNet5(classNum = 10)
+    val dataSet = sc.parallelize(data, coreNumber)
+
+    var result = model.predict(dataSet)
+    var prob = result.collect()
+
+    prob(0) should be (model.forward(data(0).feature))
+    prob(11) should be (model.forward(data(11).feature))
+    prob(31) should be (model.forward(data(31).feature))
+    prob(51) should be (model.forward(data(51).feature))
+    prob(71) should be (model.forward(data(71).feature))
+    prob(91) should be (model.forward(data(91).feature))
+
+    result = model.predict(dataSet, 20, true)
+    prob = result.collect()
+
+    prob(0) should be(prob(10))
+    prob(5) should be(prob(15))
+    prob(0) should be(prob(20))
+    prob(8) should be(prob(38))
+  }
+
+  "model.predictClass" should "be correct" in {
+    RNG.setSeed(100)
+    val data = new Array[Sample[Float]](97)
+    var i = 0
+    while (i < data.length) {
+      val input = Tensor[Float](28, 28).apply1(_ =>
+        RNG.uniform(0.130660 + i, 0.3081078).toFloat)
+      val label = Tensor[Float](1).fill(1.0f)
+      data(i) = Sample(input, label)
+      i += 1
+    }
+    val model = LeNet5(classNum = 10)
+    val dataSet = sc.parallelize(data, 2)
+    val result = model.predictClass(dataSet)
+
+    val prob = result.collect()
+    prob(0) should be
+    (model.forward(data(0).feature
+    ).toTensor[Float].max(1)._2.valueAt(1).toInt)
+    prob(11) should be
+    (model.forward(data(11).feature
+    ).toTensor[Float].max(1)._2.valueAt(1).toInt)
+    prob(31) should be
+    (model.forward(data(31).feature
+    ).toTensor[Float].max(1)._2.valueAt(1).toInt)
+    prob(51) should be
+    (model.forward(data(51).feature
+    ).toTensor[Float].max(1)._2.valueAt(1).toInt)
+    prob(71) should be
+    (model.forward(data(71).feature
+    ).toTensor[Float].max(1)._2.valueAt(1).toInt)
+    prob(91) should be
+    (model.forward(data(91).feature
+    ).toTensor[Float].max(1)._2.valueAt(1).toInt)
+  }
+
+  "model.predictImage" should "be correct" in {
+    import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric.NumericFloat
+    RNG.setSeed(100)
+    val resource = getClass.getClassLoader.getResource("pascal/")
+    val imageFrame = ImageFrame.read(resource.getFile, sc) ->
+      Resize(256, 256) -> CenterCrop(224, 224) ->
+      ChannelNormalize(0.485f, 0.456f, 0.406f, 0.229f, 0.224f, 0.225f) ->
+      MatToTensor() -> ImageFrameToSample()
+    val model = Inception_v1_NoAuxClassifier(classNum = 20)
+    val detection = model.predictImage(imageFrame).toDistributed()
+    val feature = detection.rdd.first()
+    val imageFeatures = detection.rdd.collect()
+    val prob = imageFeatures.map(x => x[Tensor[Float]](ImageFeature.predict))
+    val data = imageFeatures.map(_[Sample[Float]](ImageFeature.sample))
+    prob(0) should be (model.forward(data(0).feature.reshape(Array(1, 3, 224, 224)))
+      .toTensor[Float].squeeze)
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/OutputSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/OutputSpec.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.Memory
+import com.intel.analytics.bigdl.nn.{Graph, mkldnn}
+import com.intel.analytics.bigdl.{nn, _}
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.TrainingPhase
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.numeric.NumericFloat
+import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, RandomGenerator}
+
+class OutputSpec extends BigDLSpecHelper {
+  def model(shape: Array[Int], layout: Int) : DnnGraph = {
+    val input = mkldnn.Input(shape, layout).inputs()
+    val conv1 = mkldnn.SpatialConvolution(1, 20, 5, 5).inputs(input)
+    val pool1 = mkldnn.MaxPooling(2, 2, 2, 2).setName("pool").inputs(conv1)
+    val conv2 = mkldnn.SpatialConvolution(20, 50, 5, 5).inputs(pool1)
+    val out = mkldnn.Output(Memory.FormatTag.nchw).inputs(conv2)
+    DnnGraph(Array(input), Array(out))
+  }
+
+  def blas() : Module[Float] = {
+    val conv1 = nn.SpatialConvolution(1, 20, 5, 5).inputs()
+    val pool1 = nn.SpatialMaxPooling(2, 2, 2, 2).setName("pool").inputs(conv1)
+    val conv2 = nn.SpatialConvolution(20, 50, 5, 5).inputs(pool1)
+    Graph(conv1, conv2)
+  }
+
+  "test output" should "be right" in {
+    val inputShape = Array(2, 1, 28, 28)
+    val outputShape = Array(2, 50, 8, 8)
+    val input = Tensor[Float](inputShape).rand()
+    val gradOutput = Tensor[Float](outputShape).rand()
+
+    RandomGenerator.RNG.setSeed(1)
+    val modelDnn = model(inputShape, Memory.FormatTag.nchw)
+    modelDnn.compile(TrainingPhase)
+    RandomGenerator.RNG.setSeed(1)
+    val modelBlas = blas()
+
+    val out1 = modelBlas.forward(input)
+    val out2 = modelDnn.forward(input)
+
+    Equivalent.nearequals(out1.toTensor[Float], out2.toTensor[Float], 1e-6)
+
+    val grad1 = modelBlas.backward(input, gradOutput)
+    val grad2 = modelDnn.backward(input, gradOutput).toTensor[Float]
+
+    Equivalent.nearequals(grad1.toTensor[Float], grad2.toTensor[Float], 1e-6)
+
+    val weight1 = modelBlas.getParameters()._1
+    val weight2 = modelDnn.getParameters()._1
+
+    val gradWeight1 = modelBlas.getParameters()._2
+    val gradWeight2 = modelDnn.getParameters()._2
+
+    Equivalent.nearequals(weight1.toTensor[Float], weight2.toTensor[Float], 1e-6)
+    Equivalent.nearequals(gradWeight1.toTensor[Float], gradWeight2.toTensor[Float], 1e-6)
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/ReLUSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/ReLUSpec.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.Memory
+import com.intel.analytics.bigdl.nn
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.TrainingPhase
+import com.intel.analytics.bigdl.numeric.NumericFloat
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.T
+import org.apache.commons.lang3.SerializationUtils
+import org.scalatest.{FlatSpec, Matchers}
+
+class ReLUSpec extends FlatSpec with Matchers {
+  "a simple relu" should "be correct" in {
+    val layer = ReLU(0.0f)
+    val input = Tensor[Float](T(
+      T(1.0, 2.0),
+      T(-1.0, -2.0)
+    ))
+    val seq = Sequential()
+    seq.add(ReorderMemory(HeapData(Array(2, 2), Memory.FormatTag.nc),
+      HeapData(Array(2, 2), Memory.FormatTag.nc)))
+    seq.add(layer)
+    seq.add(ReorderMemory(HeapData(Array(2, 2), Memory.FormatTag.nc),
+      HeapData(Array(2, 2), Memory.FormatTag.nc)))
+    seq.compile(Phase.TrainingPhase, Array(HeapData(Array(2, 2), Memory.FormatTag.nc)))
+    seq.forward(input) should be(Tensor[Float](T(
+      T(1.0, 2.0),
+      T(0.0, 0.0)
+    )))
+    val grad = Tensor[Float](T(
+      T(-1.0, -2.0),
+      T(1.0, 2.0)
+    ))
+    seq.backward(input, grad) should be(Tensor[Float](T(
+      T(-1.0, -2.0),
+      T(0.0, 0.0)
+    )))
+  }
+
+  "Relu dnn should be same with bigdl relu" should "work correctly" in {
+    val input = Tensor(4, 96, 55, 55).rand(-1, 1)
+    val gradOutput = Tensor(4, 96, 55, 55).rand(-1, 1)
+
+    val relu = nn.ReLU(ip = false)
+    val reludnn = ReLU()
+    val defaultFormat = HeapData(input.size(), Memory.FormatTag.nchw)
+    reludnn.setRuntime(new MklDnnRuntime)
+    reludnn.initFwdPrimitives(Array(defaultFormat), TrainingPhase)
+    reludnn.initBwdPrimitives(Array(defaultFormat), TrainingPhase)
+
+    val output = relu.forward(input)
+    val gradInput = relu.backward(input, gradOutput)
+
+    val outputdnn = reludnn.forward(input)
+    val gradInputdnn = reludnn.backward(input, gradOutput)
+
+    Equivalent.nearequals(output, Tools.dense(outputdnn).toTensor) should be(true)
+    Equivalent.nearequals(gradInput, Tools.dense(gradInputdnn).toTensor) should be(true)
+  }
+
+  "relu with java serialization" should "work correctly" in {
+    val shape = Array(4, 96, 55, 55)
+    val input = Tensor(shape).rand(-1, 1)
+    val gradOutput = Tensor(shape).rand(-1, 1)
+
+    val relu = ReLU()
+    relu.setRuntime(new MklDnnRuntime)
+    relu.initFwdPrimitives(Array(HeapData(shape, Memory.FormatTag.nchw)), TrainingPhase)
+    relu.initBwdPrimitives(Array(HeapData(shape, Memory.FormatTag.nchw)), TrainingPhase)
+
+    val cloned = SerializationUtils.clone(relu)
+    cloned.setRuntime(new MklDnnRuntime)
+    cloned.initFwdPrimitives(Array(HeapData(shape, Memory.FormatTag.nchw)), TrainingPhase)
+    cloned.initBwdPrimitives(Array(HeapData(shape, Memory.FormatTag.nchw)), TrainingPhase)
+
+    relu.forward(input)
+    cloned.forward(input)
+
+    Tools.dense(relu.output) should be (Tools.dense(cloned.output))
+
+    relu.backward(input, gradOutput)
+    cloned.backward(input, gradOutput)
+
+    Tools.dense(relu.gradInput) should be (Tools.dense(cloned.gradInput))
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/ReflectionUtilsSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/ReflectionUtilsSpec.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.Memory
+import com.intel.analytics.bigdl.nn.mkldnn
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.TrainingPhase
+import com.intel.analytics.bigdl.numeric.NumericFloat
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, ReflectionUtils}
+import com.intel.analytics.bigdl.utils.intermediate.{IRToBlas, IRToDnn}
+import com.intel.analytics.bigdl.{Module, nn}
+
+class ReflectionUtilsSpec extends BigDLSpecHelper {
+
+  "test SpatialConvolution reflection" should "be right" in {
+    val model1 = nn.SpatialConvolution[Float](2, 4, 3, 3, 4, 4, 0, 0).asInstanceOf[Module[Float]]
+    val className = "com.intel.analytics.bigdl.utils.intermediate.IRSpatialConvolution"
+    val cls = Class.forName(className)
+    val ir = ReflectionUtils.reflectToIR[Float](model1, cls)
+    val cls2 = Class.forName(
+      "com.intel.analytics.bigdl.nn.SpatialConvolution")
+    val modelBlas = ReflectionUtils.reflectFromIR(ir, cls2)
+
+    val cls3 = Class.forName("com.intel.analytics.bigdl.nn.mkldnn.SpatialConvolution")
+    val modelDnn = ReflectionUtils.reflectFromIR(ir, cls3).asInstanceOf[mkldnn.SpatialConvolution]
+
+    val inputShape = Array(2, 2, 23, 23)
+    val outShape = Array(2, 4, 6, 6)
+
+    val seq = Sequential()
+        .add(Input(inputShape, Memory.FormatTag.nchw))
+        .add(modelDnn)
+        .add(Output(Memory.FormatTag.nchw))
+    seq.compile(TrainingPhase)
+
+    val input = Tensor[Float](inputShape).rand()
+    val gradOutput = Tensor[Float](outShape).rand()
+
+    val out = model1.forward(input).toTensor[Float]
+    val out1 = modelBlas.forward(input).toTensor[Float]
+    val out2 = seq.forward(input).toTensor[Float]
+
+    out should be(out1)
+    Equivalent.nearequals(out1, Tools.dense(out2).toTensor[Float], 1e-4) should be(true)
+
+    val grad = model1.backward(input, gradOutput)
+    val grad1 = modelBlas.backward(input, gradOutput)
+    val grad2 = seq.backward(input, gradOutput)
+
+    val gradWeight1 = modelDnn.getParameters()._2
+    val gradWeight2 = modelBlas.getParameters()._2
+
+    val weight1 = modelDnn.getParameters()._1
+    val weight2 = modelBlas.getParameters()._1
+
+    Equivalent.nearequals(weight1, weight2) should be (true)
+    Equivalent.nearequals(gradWeight1, gradWeight2) should be (true)
+
+    Equivalent.nearequals(Tools.dense(seq.gradInput).toTensor,
+      modelBlas.gradInput.toTensor[Float]) should be (true)
+  }
+
+  "test BatchNorm reflection" should "be right" in {
+    val model1 = nn.SpatialBatchNormalization(3).asInstanceOf[Module[Float]]
+    val className = "com.intel.analytics.bigdl.utils.intermediate.IRSpatialBatchNormalization"
+    val cls = Class.forName(className)
+    val ir = ReflectionUtils.reflectToIR[Float](model1, cls)
+
+    val modelBlas = IRToBlas[Float].convertLayer(ir)
+    val modelDnn = IRToDnn[Float].convertLayer(ir).asInstanceOf[mkldnn.SpatialBatchNormalization]
+
+    val inputShape = Array(16, 3, 4, 4)
+    modelDnn.setRuntime(new MklDnnRuntime)
+    modelDnn.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    modelDnn.initBwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    modelDnn.initGradWPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+
+
+    val input = Tensor[Float](16, 3, 4, 4).rand()
+    val gradOutput = Tensor[Float](16, 3, 4, 4).rand()
+
+    val out1 = modelBlas.forward(input).toTensor[Float]
+    val out2 = modelDnn.forward(input).toTensor[Float]
+
+    Equivalent.nearequals(out1, Tools.dense(out2).toTensor[Float], 1e-4) should be(true)
+
+    val grad1 = modelBlas.backward(input, gradOutput)
+    val grad2 = modelDnn.backward(input, gradOutput)
+
+    val gradWeight1 = Tools.dense(modelDnn.gradWeightAndBias.native).toTensor
+    val gradWeight2 = modelBlas.getParameters()._2
+
+    val weight1 = Tools.dense(modelDnn.weightAndBias.native).toTensor
+    val weight2 = modelBlas.getParameters()._1
+
+    Equivalent.nearequals(weight1, weight2) should be (true)
+    Equivalent.nearequals(gradWeight1, gradWeight2, 1e-4) should be (true)
+
+    Equivalent.nearequals(Tools.dense(modelDnn.gradInput).toTensor,
+      modelBlas.gradInput.toTensor[Float]) should be (true)
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/ReorderMemorySpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/ReorderMemorySpec.scala
@@ -1,0 +1,465 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.{DataType, Memory}
+import com.intel.analytics.bigdl.models.lenet.LeNet5
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.tensor.{DnnTensor, Storage, Tensor}
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.tensor.{DnnTensor, Tensor}
+import com.intel.analytics.bigdl.numeric.NumericFloat
+import com.intel.analytics.bigdl.utils.Engine
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+
+class ReorderMemorySpec extends FlatSpec with Matchers with BeforeAndAfter {
+
+  "From heap to native" should "be correct" in {
+    val layer = ReorderMemory(new NativeData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc))
+
+    layer.setRuntime(new MklDnnRuntime())
+    layer.initFwdPrimitives(Array(HeapData(Array(3, 4), Memory.FormatTag.nc)), Phase.TrainingPhase)
+    layer.initBwdPrimitives(Array(NativeData(Array(3, 4),
+      Memory.FormatTag.nc)), Phase.TrainingPhase)
+
+    val input = Tensor[Float](3, 4).rand(50, 100)
+
+    val output = layer.forward(input)
+    input should be (Tools.dense(output))
+    val grad = layer.backward(input, output)
+
+    grad should be(input)
+  }
+
+  "From heap to heap" should "be correct" in {
+    val layer = ReorderMemory.create(
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc)
+    )
+    layer.setRuntime(new MklDnnRuntime())
+    layer.initFwdPrimitives(Array(HeapData(Array(3, 4), Memory.FormatTag.nc)), Phase.TrainingPhase)
+    layer.initBwdPrimitives(Array(NativeData(Array(3, 4),
+      Memory.FormatTag.nc)), Phase.TrainingPhase)
+    val input = Tensor[Float](3, 4).rand()
+    val output = layer.forward(input)
+    val grad = layer.backward(input, output)
+    grad should be(input)
+  }
+
+  "Reorder from nhwc to nchw" should "be correct" in {
+    val shapeNCHW = Array(4, 3, 7, 7)
+    val shapeNHWC = Array(4, 7, 7, 3)
+    val inputFormats = HeapData(shapeNHWC, Memory.FormatTag.nhwc)
+    val outputFormats = HeapData(shapeNCHW, Memory.FormatTag.nchw)
+    val gradInputFormats = HeapData(shapeNCHW, Memory.FormatTag.nchw)
+    val gradOutputFormats = HeapData(shapeNHWC, Memory.FormatTag.nhwc)
+
+    val layer = ReorderMemory.create(inputFormat = inputFormats, outputFormat = outputFormats,
+      gradInputFormat = gradInputFormats, gradOutputFomat = gradOutputFormats)
+
+    layer.setRuntime(new MklDnnRuntime())
+    layer.initFwdPrimitives(Array(inputFormats), Phase.TrainingPhase)
+    layer.initBwdPrimitives(Array(gradOutputFormats), Phase.TrainingPhase)
+
+
+    val input = Tensor[Float](4, 7, 7, 3).rand()
+    val gradOutput = input.clone()
+    val output = layer.forward(input).toTensor[Float]
+    val grad = layer.backward(input, gradOutput)
+
+    val inputNHWC = input.transpose(2, 4).transpose(3, 4).contiguous().clone()
+
+    inputNHWC should be(output)
+    inputNHWC should be(grad)
+  }
+
+  "Reorder from ntc to tnc" should "be correct" in {
+    val shapeNTC = Array(4, 3, 7)
+    val shapeTNC = Array(3, 4, 7)
+
+    // for tnc case, users
+    val inputFormats = HeapData(shapeNTC, Memory.FormatTag.ntc)
+    val outputFormats = HeapData(shapeTNC, Memory.FormatTag.tnc)
+    val gradInputFormats = HeapData(shapeTNC, Memory.FormatTag.tnc)
+    val gradOutputFormats = HeapData(shapeNTC, Memory.FormatTag.ntc)
+
+    val layer = ReorderMemory.create(inputFormat = inputFormats, outputFormat = outputFormats,
+      gradInputFormat = gradInputFormats, gradOutputFomat = gradOutputFormats)
+
+    layer.setRuntime(new MklDnnRuntime())
+    layer.initFwdPrimitives(Array(inputFormats), Phase.TrainingPhase)
+    layer.initBwdPrimitives(Array(gradOutputFormats), Phase.TrainingPhase)
+
+    val input = Tensor[Float](4, 3, 7).rand()
+    val gradOutput = input.clone()
+    val output = layer.forward(input).toTensor[Float]
+    val grad = layer.backward(input, gradOutput)
+
+    val inputTNC = input.transpose(1, 2).contiguous().clone()
+    inputTNC should be(output)
+    inputTNC should be(grad)
+  }
+
+  "Reorder from tnc to ntc" should "be correct" in {
+    val shapeTNC = Array(4, 3, 7)
+    val shapeNTC = Array(3, 4, 7)
+
+    // for tnc case, users
+    val inputFormats = HeapData(shapeTNC, Memory.FormatTag.tnc)
+    val outputFormats = HeapData(shapeNTC, Memory.FormatTag.ntc)
+    val gradInputFormats = HeapData(shapeNTC, Memory.FormatTag.ntc)
+    val gradOutputFormats = HeapData(shapeTNC, Memory.FormatTag.tnc)
+
+    val layer = ReorderMemory.create(inputFormat = inputFormats, outputFormat = outputFormats,
+      gradInputFormat = gradInputFormats, gradOutputFomat = gradOutputFormats)
+
+    layer.setRuntime(new MklDnnRuntime())
+    layer.initFwdPrimitives(Array(inputFormats), Phase.TrainingPhase)
+    layer.initBwdPrimitives(Array(gradOutputFormats), Phase.TrainingPhase)
+
+    val input = Tensor[Float](4, 3, 7).rand()
+    val gradOutput = input.clone()
+    val output = layer.forward(input).toTensor[Float]
+    val grad = layer.backward(input, gradOutput)
+
+    val inputNTC = input.transpose(1, 2).contiguous().clone()
+    inputNTC should be(output)
+    inputNTC should be(grad)
+  }
+
+  "Reorder from nchw to nhwc" should "be correct" in {
+    val shapeNCHW = Array(4, 3, 7, 7)
+    val shapeNHWC = Array(4, 7, 7, 3)
+    val inputFormats = HeapData(shapeNCHW, Memory.FormatTag.nchw)
+    val outputFormats = HeapData(shapeNHWC, Memory.FormatTag.nhwc)
+    val gradInputFormats = HeapData(shapeNHWC, Memory.FormatTag.nhwc)
+    val gradOutputFormats = HeapData(shapeNCHW, Memory.FormatTag.nchw)
+
+    val layer = ReorderMemory.create(inputFormat = inputFormats, outputFormat = outputFormats,
+      gradInputFormat = gradInputFormats, gradOutputFomat = gradOutputFormats)
+
+    layer.setRuntime(new MklDnnRuntime())
+    layer.initFwdPrimitives(Array(inputFormats), Phase.TrainingPhase)
+    layer.initBwdPrimitives(Array(gradOutputFormats), Phase.TrainingPhase)
+
+    val input = Tensor[Float](4, 3, 7, 7).rand()
+    val gradOutput = input.clone()
+    val output = layer.forward(input).toTensor[Float]
+    val grad = layer.backward(input, gradOutput).toTensor[Float]
+
+    val inputNHWC = input.transpose(2, 3).transpose(3, 4).contiguous().clone()
+
+    // grad.resizeAs(inputNHWC)
+
+    inputNHWC should be(output)
+    inputNHWC should be(grad)
+  }
+
+  "oihw to Oihw8o" should "work correctly" in {
+    // after upgrade mkldnn to v0.17 from v0.15, the LeNet training is broken
+    // because Ohwi8o will pad the tensor
+    val from = HeapData(Array(20, 1, 5, 5), Memory.FormatTag.oihw)
+    val to = HeapData(Array(20, 1, 5, 5), Memory.FormatTag.Ohwi8o)
+
+    val runtime = new MklDnnRuntime
+    val reorder = ReorderMemory(to)
+    reorder.setRuntime(runtime)
+    reorder.initFwdPrimitives(Array(from), TrainingPhase)
+    reorder.initBwdPrimitives(Array(to), TrainingPhase)
+
+    val input = Tensor[Float](Array(20, 1, 5, 5)).rand(-1, 1)
+    val gradOutput = Tensor[Float](Array(24, 1, 5, 5)).rand(-1, 1)
+
+    val output = reorder.forward(input)
+    println(output.toTensor[Float].size().mkString("\t")) // here will be broken before fix
+
+    // we should check the backward Ohwi8o to oihw
+    val gradInput = reorder.backward(input, output)
+
+    println(reorder.gradInput.toTensor[Float].size().mkString("\t"))
+
+    output.toTensor[Float].size().deep == Array(24, 1, 5, 5).deep should be (true)
+    gradInput.toTensor[Float].size().deep == Array(20, 1, 5, 5).deep should be (true)
+
+    gradInput should be (input)
+  }
+
+  "lenet conv1" should "work correctly" in {
+    val inputShape = Array(4, 1, 28, 28)
+    val outputShape = Array(4, 20, 24, 24)
+    val input = Tensor[Float](4, 1, 28, 28).rand(-1, 1)
+    val gradOutput = Tensor[Float](outputShape).rand(-1, 1)
+
+    val blas = com.intel.analytics.bigdl.nn.SpatialConvolution(1, 20, 5, 5)
+    blas.forward(input)
+    blas.backward(input, gradOutput)
+
+    val dnn = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(SpatialConvolution(1, 20, 5, 5, initWeight = blas.weight, initBias = blas.bias))
+      .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw)))
+
+    dnn.compile(TrainingPhase)
+
+    dnn.forward(input)
+    dnn.updateGradInput(input, gradOutput)
+    dnn.accGradParameters(input, gradOutput)
+
+    Equivalent.nearequals(dnn.output.toTensor, blas.output.toTensor, 1e-4) should be (true)
+    Equivalent.nearequals(dnn.gradInput.toTensor, blas.gradInput.toTensor, 1e-4) should be (true)
+
+    Equivalent.nearequals(dnn.getParameters()._1, blas.getParameters()._1, 1e-4) should be (true)
+    Equivalent.nearequals(dnn.getParameters()._2, blas.getParameters()._2, 1e-4) should be (true)
+  }
+
+  "nchw to nChw8c" should "work correctly" in {
+    val t1Shape = Array(4, 3, 224, 224)
+    val t1 = Tensor[Float](4, 3, 224, 224).rand(-1, 1)
+    val t1Format = HeapData(t1Shape, Memory.FormatTag.nchw)
+
+    val t2Shape = Array(4, 3, 224, 224)
+    val t2 = Tensor[Float](t2Shape)
+    val t2Format = HeapData(t2Shape, Memory.FormatTag.nChw8c)
+
+    val reorder = ReorderMemory(t2Format, t1Format)
+
+    reorder.setRuntime(new MklDnnRuntime)
+    reorder.initFwdPrimitives(Array(t1Format), TrainingPhase)
+    reorder.initBwdPrimitives(Array(t2Format), TrainingPhase)
+
+    reorder.forward(t1)
+    reorder.backward(t1, reorder.output)
+
+    val reorder2 = ReorderMemory(t1Format, t2Format)
+    reorder2.setRuntime(new MklDnnRuntime)
+    reorder2.initFwdPrimitives(Array(t2Format), InferencePhase)
+
+    reorder2.forward(reorder.output)
+
+    reorder2.output.toTensor[Float] should be (t1)
+  }
+
+  "F32 to S8" should "work correctly" in {
+    val shape = Array[Int](2, 2)
+    val input = Tensor[Float](Array[Float](15, 14, 8, 10), shape).rand(0, 1)
+    val nativeData = NativeData(shape, Memory.FormatTag.nc, DataType.S8)
+    val heapData = HeapData(shape, Memory.FormatTag.nc)
+    heapData.setMask(0)
+    heapData.setScales(Array(127.0f / input.max()))
+    val f32ToS2 = ReorderMemory(nativeData)
+
+    f32ToS2.setRuntime(new MklDnnRuntime)
+    f32ToS2.initFwdPrimitives(Array(heapData), Phase.InferencePhase)
+
+    f32ToS2.forward(input)
+
+    val srcAddress = f32ToS2.output.asInstanceOf[DnnTensor[Byte]].storageAddress()
+
+    val len = shape.product
+    val output = new Array[Byte](len)
+    Memory.CopyPtr2ByteArray(srcAddress, 0, output, 0, len, 1)
+
+    output.foreach(println)
+
+    println(input)
+
+    val S8ToF32 = ReorderMemory(HeapData(shape, Memory.FormatTag.nc))
+    S8ToF32.setRuntime(new MklDnnRuntime)
+    S8ToF32.initFwdPrimitives(Array(nativeData), Phase.InferencePhase)
+
+    S8ToF32.forward(f32ToS2.output)
+
+    // the int part should be the same
+    S8ToF32.output.toTensor[Float].storage().array().map(_.toInt) should be (
+      input.storage().array().map(_.toInt))
+  }
+
+  "F32 to S8 NCHW" should "work correctly" in {
+    val shape = Array[Int](4, 3, 2, 2)
+    val input = Tensor[Float](shape).rand(0, 1)
+    val inputScales = input.max(1)._1.max(3)._1.max(4)._1.storage().array()
+    val nativeData = NativeData(shape, Memory.FormatTag.nhwc, DataType.U8)
+    val heapData = HeapData(shape, Memory.FormatTag.nchw, DataType.F32)
+    heapData.setMask(2)
+    heapData.setScales(inputScales.map(x => 255.0f / x))
+    val f32ToS2 = ReorderMemory(nativeData)
+    println(Memory.FormatTag.nchw)
+
+    f32ToS2.setRuntime(new MklDnnRuntime)
+    f32ToS2.initFwdPrimitives(Array(heapData), Phase.InferencePhase)
+
+    f32ToS2.forward(input)
+
+    val srcAddress = f32ToS2.output.asInstanceOf[DnnTensor[Byte]].storageAddress()
+
+    val len = shape.product
+    val output = new Array[Byte](len)
+    Memory.CopyPtr2ByteArray(srcAddress, 0, output, 0, len, 1)
+
+    output.foreach(println)
+
+    println(input)
+
+    val S8ToF32 = ReorderMemory(HeapData(shape, Memory.FormatTag.nchw, DataType.F32))
+    S8ToF32.setRuntime(new MklDnnRuntime)
+    S8ToF32.initFwdPrimitives(Array(f32ToS2.outputFormats()(0)), Phase.InferencePhase)
+
+    S8ToF32.forward(f32ToS2.output)
+    println(S8ToF32.output)
+
+    // the int part should be the same
+    S8ToF32.output.toTensor[Float].storage().array().map(_.toInt) should be (
+      input.storage().array().map(_.toInt))
+  }
+
+  "F32 to S32 Memory.FormatTag.x" should "work correctly" in {
+    val shape = Array[Int](2)
+    val inputData = Array[Float](10, 12)
+    val input = Tensor[Float](inputData, shape).rand(0, 1)
+    val nativeData = NativeData(shape, Memory.FormatTag.x, DataType.S32)
+    val heapData = HeapData(shape, Memory.FormatTag.x)
+    heapData.setMask(1)
+    heapData.setScales(inputData.map(x => 100 / inputData.max))
+
+    println(Integer.MAX_VALUE)
+
+    val f32ToS32 = ReorderMemory(nativeData)
+
+    f32ToS32.setRuntime(new MklDnnRuntime)
+    f32ToS32.initFwdPrimitives(Array(heapData), Phase.InferencePhase)
+
+    f32ToS32.forward(input)
+
+    println(input)
+    println(f32ToS32.output)
+
+    nativeData.setMask(1)
+    nativeData.setScales(inputData.map(x => 100 / inputData.max))
+    val S32ToF32 = ReorderMemory(HeapData(shape, Memory.FormatTag.x))
+    S32ToF32.setRuntime(new MklDnnRuntime)
+    S32ToF32.initFwdPrimitives(Array(nativeData), Phase.InferencePhase)
+
+    S32ToF32.forward(f32ToS32.output)
+
+    println(S32ToF32.output)
+
+    // the int part should be the same
+    S32ToF32.output.toTensor[Float].storage().array().map(_.toInt) should be (
+      input.storage().array().map(_.toInt))
+  }
+
+  "oihw" should "work correctly" in {
+    // this test case is used to test oihw -> hwio_s8s8 reordering.
+    // the hwio_s8s8 will need more space than padding shape, which is called additional space
+    // called by mkldnn.
+
+    // we will convert the hwio_s8s8 back to oihw, because mkldnn has not implemented it yet.
+    val shape = Array(50, 24, 5, 5)
+    val from = Tensor[Float](shape).rand(-1, 1)
+
+    val heap = HeapData(shape, Memory.FormatTag.oihw, DataType.F32)
+    // TODO:
+//    val native = NativeData(shape, Memory.FormatTag.hwios8s8, DataType.S8)
+    val native = NativeData(shape, Memory.FormatTag.hwio, DataType.S8)
+
+    val mask = 0
+    // (1 to 50).map(i => from.select(1, i).max()).toArray
+    val scales = Array(from.clone().abs().max() / 127.0f)
+
+    heap.setMask(mask)
+    heap.setScales(scales)
+    native.setMask(mask)
+    native.setScales(scales)
+
+    val runtime = new MklDnnRuntime
+    val reorder = ReorderMemory(native)
+    reorder.setRuntime(runtime)
+    reorder.initFwdPrimitives(Array(heap), InferencePhase)
+
+    (0 to 10).foreach ( i => {
+      println(s"do forward ${i}")
+      reorder.forward(from)
+    })
+  }
+
+  "lenet5 with reorder" should "works no segment fault" in {
+    // after upgrade to mkldnn v0.17, the thread local variables will cause spark to stop
+    // this test case tests the single pool
+    System.setProperty("bigdl.localMode", "true")
+    System.setProperty("bigdl.engineType", "mkldnn")
+    System.setProperty("bigdl.coreNumber", "1")
+    System.setProperty("bigdl.utils.Engine.defaultPoolSize", "1")
+    Engine.init
+
+    println(System.getProperty("bigdl.engineType"))
+
+    val inputShape = Array(100, 1, 28, 28)
+    val outputShape = Array(100, 10)
+
+    val model = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(SpatialConvolution(1, 20, 5, 5).setName("conv1"))
+      .add(SpatialBatchNormalization(20).setName("bn1"))
+      .add(MaxPooling(2, 2, 2, 2).setName("pool1"))
+      .add(SpatialConvolution(20, 50, 5, 5).setName("conv2"))
+      .add(MaxPooling(2, 2, 2, 2).setName("pool2"))
+      .add(Linear(50 * 4 * 4, 500).setName("ip1"))
+      .add(ReLU().setName("relu1"))
+      .add(Linear(500, 10).setName("ip2"))
+      .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nc)))
+
+    val input = Tensor[Float](inputShape).rand(-1, 1)
+    val gradOutput = Tensor[Float](outputShape).rand(-1, 1)
+
+    // we need to compile the model in the invokeAndWait2 threads.
+    Engine.dnnComputing.invokeAndWait2((0 until 1).map(i =>
+      () => {
+        model.compile(TrainingPhase)
+      }))
+
+    Engine.dnnComputing.invokeAndWait2((0 until 1).map(i =>
+      () => {
+        println(s"${Thread.currentThread().getId}")
+        model.training()
+        model.forward(input)
+        model.updateGradInput(input, gradOutput)
+        model.accGradParameters(input, gradOutput)
+        i
+      }
+    ), Long.MaxValue)
+
+    for (i <- 0 until 3) {
+      Engine.dnnComputing.invokeAndWait2((0 until 1).map(i =>
+        () => {
+          println(s"${Thread.currentThread().getId}")
+          model.training()
+          model.forward(input)
+          model.updateGradInput(input, gradOutput)
+          i
+        }
+      ), Long.MaxValue)
+    }
+
+    System.clearProperty("bigdl.localMode")
+    System.clearProperty("bigdl.engineType")
+    System.clearProperty("bigdl.coreNumber")
+    System.clearProperty("bigdl.utils.Engine.defaultPoolSize")
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/SequentialSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/SequentialSpec.scala
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.{Memory}
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.TrainingPhase
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.BigDLSpecHelper
+import org.apache.commons.lang3.SerializationUtils
+
+class SequentialSpec extends BigDLSpecHelper {
+
+  "Sequential" should "not be called add after compilation" in {
+    val layer = ReorderMemory(NativeData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc))
+    val layer2 = ReorderMemory(NativeData(Array(3, 4), Memory.FormatTag.nc),
+      NativeData(Array(3, 4), Memory.FormatTag.nc))
+    val seq = new Sequential()
+    seq.add(layer)
+    seq.compile(Phase.TrainingPhase, Array(HeapData(Array(3, 4), Memory.FormatTag.nc)))
+    intercept[IllegalArgumentException] {
+      seq.add(layer2)
+    }
+  }
+
+  "Sequential" should "be correct when no memory reorder happened" in {
+    val layer1 = ReorderMemory(NativeData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc))
+    val layer2 = ReorderMemory(NativeData(Array(3, 4), Memory.FormatTag.io),
+      NativeData(Array(3, 4), Memory.FormatTag.nc))
+    val layer3 = ReorderMemory(HeapData(Array(3, 4), Memory.FormatTag.nc),
+      NativeData(Array(3, 4), Memory.FormatTag.io))
+    val seq = new Sequential()
+    seq.add(layer1)
+    seq.add(layer2)
+    seq.add(layer3)
+    seq.compile(Phase.TrainingPhase, Array(HeapData(Array(3, 4), Memory.FormatTag.nc)))
+    val input1 = Tensor[Float](3, 4).rand()
+    val input2 = Tensor[Float](3, 4).rand()
+    val output1 = seq.forward(input1)
+    output1 should be(input1)
+    val output2 = seq.forward(input2)
+    output2 should be(input2)
+
+    val gradOutput1 = Tensor[Float](3, 4).rand()
+    val gradInput1 = seq.backward(input1, gradOutput1)
+    gradInput1 should be(gradOutput1)
+
+    val gradOutput2 = Tensor[Float](3, 4).rand()
+    val gradInput2 = seq.backward(input2, gradOutput2)
+    gradInput2 should be(gradOutput2)
+  }
+
+  "Sequential" should "be correct when auto add memory reorder" in {
+    val layer1 = ReorderMemory.create(
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc))
+    val layer2 = ReorderMemory.create(
+      NativeData(Array(3, 4), Memory.FormatTag.nc),
+      NativeData(Array(3, 4), Memory.FormatTag.io),
+      NativeData(Array(3, 4), Memory.FormatTag.nc),
+      NativeData(Array(3, 4), Memory.FormatTag.io))
+    val layer3 = ReorderMemory.create(
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc))
+    val seq = Sequential()
+    seq.add(layer1)
+    seq.add(layer2)
+    seq.add(layer3)
+    seq.compile(Phase.TrainingPhase, Array(HeapData(Array(3, 4), Memory.FormatTag.nc)))
+    val input1 = Tensor[Float](3, 4).rand()
+    val input2 = Tensor[Float](3, 4).rand()
+    println(s"Input1 is $input1")
+    println(s"Input2 is $input2")
+    val output1 = seq.forward(input1)
+    output1 should be(input1)
+    val output2 = seq.forward(input2)
+    output2 should be(input2)
+
+    val gradOutput1 = Tensor[Float](3, 4).rand()
+    val gradInput1 = seq.backward(input1, gradOutput1)
+    gradInput1 should be(gradOutput1)
+
+    val gradOutput2 = Tensor[Float](3, 4).rand()
+    val gradInput2 = seq.backward(input2, gradOutput2)
+    gradInput2 should be(gradOutput2)
+  }
+
+  "seq with java serialization" should "work correctly" in {
+    val layer1 = ReorderMemory.create(
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc))
+    val layer2 = ReorderMemory.create(
+      NativeData(Array(3, 4), Memory.FormatTag.nc),
+      NativeData(Array(3, 4), Memory.FormatTag.io),
+      NativeData(Array(3, 4), Memory.FormatTag.nc),
+      NativeData(Array(3, 4), Memory.FormatTag.io))
+    val layer3 = ReorderMemory.create(
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc),
+      HeapData(Array(3, 4), Memory.FormatTag.nc))
+    val seq = Sequential()
+    seq.add(layer1)
+    seq.add(layer2)
+    seq.add(layer3)
+    seq.compile(Phase.TrainingPhase, Array(HeapData(Array(3, 4), Memory.FormatTag.nc)))
+
+    val input = Tensor[Float](3, 4).rand()
+    val gradOutput = Tensor[Float](3, 4).rand()
+
+    seq.forward(input)
+    seq.backward(input, gradOutput)
+
+    val cloned = SerializationUtils.clone(seq)
+    cloned.compile(Phase.TrainingPhase, Array(HeapData(Array(3, 4), Memory.FormatTag.nc)))
+
+    cloned.forward(input)
+    cloned.backward(input, gradOutput)
+
+    Tools.dense(seq.output) should be (Tools.dense(cloned.output))
+    Tools.dense(seq.gradInput) should be (Tools.dense(cloned.gradInput))
+  }
+
+  "compile with input" should "work correctly" in {
+    val inputShape = Array(4, 1, 28, 28)
+    val outputShape = Array(4, 10)
+
+    val model = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(SpatialConvolution(1, 20, 5, 5).setName("conv1"))
+      .add(MaxPooling(2, 2, 2, 2).setName("pool1"))
+      .add(SpatialConvolution(20, 50, 5, 5).setName("conv2"))
+      .add(MaxPooling(2, 2, 2, 2).setName("pool2"))
+      .add(Linear(50 * 4 * 4, 500).setName("ip1"))
+      .add(ReLU().setName("relu1"))
+      .add(Linear(500, 10).setName("ip2"))
+      .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nc)))
+
+    model.compile(TrainingPhase)
+
+    val input = Tensor[Float](inputShape).rand(-1, 1)
+    val gradOutput = Tensor[Float](outputShape).rand(-1, 1)
+
+    model.forward(input)
+    model.backward(input, gradOutput)
+  }
+
+  "no input" should "throw exception" in {
+    val inputShape = Array(4, 1, 2, 2)
+    val outputShape = Array(4, 1, 2, 2)
+
+    val model1 = Sequential()
+      .add(ReLU().setName("relu1"))
+      .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nc)))
+
+    val model2 = Sequential()
+      .add(Sequential()
+        .add(ReLU().setName("relu1"))
+        .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nc))))
+
+    val model3 = Sequential()
+        .add(ConcatTable().add(ReLU()).add(ReLU()))
+
+    List(model1, model2, model3).foreach { model =>
+      intercept[IllegalArgumentException] {
+        model.compile(TrainingPhase)
+      }
+    }
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/SerializeModelSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/SerializeModelSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import java.nio.file.{Files, Paths}
+
+import com.intel.analytics.bigdl.nn.Module
+import com.intel.analytics.bigdl.nn.mkldnn.ResNet.DatasetType.ImageNet
+import com.intel.analytics.bigdl.utils.T
+import org.scalatest.{FlatSpec, Matchers}
+
+class SerializeModelSpec extends FlatSpec with Matchers {
+
+  "Save a model" should "work correctly" in {
+    val identity = System.identityHashCode(this).toString
+    val name = "resnet_50." + identity
+    val tmpdir = System.getProperty("java.io.tmpdir")
+    val path = Paths.get(tmpdir, name).toAbsolutePath
+
+    // do not use vgg16 model, the vgg16 model will set Xavier to average
+    // mode, which will influence other test cases because of Xavier is a
+    // case object.
+    val model = ResNet(32, 1000, T("depth" -> 50, "dataSet" -> ImageNet))
+    println(s"generate the model file ${path.toString}")
+    model.save(path.toString, true)
+    val loaded = Module.load[Float](path.toString)
+
+    val length = Files.size(path) / 1024.0 / 1024.0
+    length should be < 300.0
+
+    println(s"delete the model file ${path.toString}")
+    Files.deleteIfExists(path)
+  }
+
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/SingleLayerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/SingleLayerSpec.scala
@@ -1,0 +1,330 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.Memory
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.TrainingPhase
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+
+class SingleLayerSpec extends FlatSpec with Matchers with BeforeAndAfter {
+  "convolution" should "work correctly" in {
+    val inputShape = Array(4, 3, 5, 5)
+    val outputShape = Array(4, 2, 3, 3)
+    val name = "conv"
+    val nOutput = 2
+    val kernel = 3
+    val pad = 1
+    val stride = 2
+
+    val prototxt =
+      s"""
+         |name: "conv-simple"
+         |force_backward: true
+         |layer {
+         |  name: "data"
+         |  type: "DummyData"
+         |  top: "data"
+         |  include {
+         |    phase: TRAIN
+         |  }
+         |  dummy_data_param {
+         |    data_filler {
+         |      type: "xavier"
+         |    }
+         |    shape: { ${shape2Dim(inputShape)} }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "data"
+         |  top: "conv"
+         |  name: "$name"
+         |  type: "Convolution"
+         |  convolution_param {
+         |    num_output: $nOutput
+         |    kernel_size: $kernel
+         |    pad: $pad
+         |    stride: $stride
+         |    weight_filler {
+         |      type: "msra"
+         |      variance_norm: FAN_OUT
+         |    }
+         |    bias_filler {
+         |      type: "gaussian"
+         |    }
+         |  }
+         |}
+       """.stripMargin
+
+    val conv = SpatialConvolution(3, nOutput, kernel, kernel, stride, stride, pad, pad, 1)
+      .setName(name)
+    val seq = Sequential()
+        .add(Input(inputShape, Memory.FormatTag.nchw))
+        .add(conv)
+        .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw)))
+    seq.compile(TrainingPhase)
+
+    Tools.compare(prototxt, seq, inputShape, outputShape, 1e-6)
+  }
+
+  "convolution2" should "work correctly" in {
+    val inputShape = Array(4, 3, 224, 224)
+    val outputShape = Array(4, 64, 112, 112)
+    val name = "conv"
+    val nOutput = 64
+    val kernel = 7
+    val pad = 3
+    val stride = 2
+
+    val prototxt =
+      s"""
+         |name: "conv-simple"
+         |force_backward: true
+         |layer {
+         |  name: "data"
+         |  type: "DummyData"
+         |  top: "data"
+         |  include {
+         |    phase: TRAIN
+         |  }
+         |  dummy_data_param {
+         |    data_filler {
+         |      type: "xavier"
+         |    }
+         |    shape: { ${shape2Dim(inputShape)} }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "data"
+         |  top: "conv"
+         |  name: "$name"
+         |  type: "Convolution"
+         |  convolution_param {
+         |    num_output: $nOutput
+         |    kernel_size: $kernel
+         |    pad: $pad
+         |    stride: $stride
+         |    weight_filler {
+         |      type: "msra"
+         |      variance_norm: FAN_OUT
+         |    }
+         |    bias_filler {
+         |      type: "gaussian"
+         |    }
+         |  }
+         |}
+       """.stripMargin
+
+    val conv = SpatialConvolution(3, nOutput, kernel, kernel, stride, stride, pad, pad, 1)
+      .setName(name)
+    val seq = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(conv)
+      .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw)))
+
+    seq.compile(TrainingPhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+
+    Tools.compare(prototxt, seq, inputShape, outputShape, 1e-5)
+  }
+
+  "max pooling" should "work correctly" in {
+    val inputShape = Array(4, 64, 112, 112)
+    val outputShape = Array(4, 64, 56, 56)
+    val name = "pool"
+    val prototxt =
+      s"""
+         |name: "maxpool-simple"
+         |force_backward: true
+         |layer {
+         |  name: "data"
+         |  type: "DummyData"
+         |  top: "data"
+         |  include {
+         |    phase: TRAIN
+         |  }
+         |  dummy_data_param {
+         |    data_filler {
+         |      type: "xavier"
+         |    }
+         |    shape: { ${shape2Dim(inputShape)} }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "data"
+         |  top: "pool"
+         |  name: "$name"
+         |  type: "Pooling"
+         |  pooling_param {
+         |    kernel_size: 3
+         |    stride: 2
+         |    pool: MAX
+         |  }
+         |}
+       """.stripMargin
+
+    val maxPooling = MaxPooling(3, 3, 2, 2).setName(name)
+    maxPooling.setRuntime(new MklDnnRuntime)
+    maxPooling.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    maxPooling.initBwdPrimitives(Array(HeapData(outputShape, Memory.FormatTag.nchw)), TrainingPhase)
+
+    Tools.compare(prototxt, maxPooling, inputShape, outputShape)
+  }
+
+  "avg pooling" should "work correctly" in {
+    val inputShape = Array(4, 3, 7, 7)
+    val outputShape = Array(4, 3, 3, 3)
+    val name = "pool"
+    val prototxt =
+      s"""
+         |name: "maxpool-simple"
+         |force_backward: true
+         |layer {
+         |  name: "data"
+         |  type: "DummyData"
+         |  top: "data"
+         |  include {
+         |    phase: TRAIN
+         |  }
+         |  dummy_data_param {
+         |    data_filler {
+         |      type: "xavier"
+         |    }
+         |    shape: { ${shape2Dim(inputShape)} }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "data"
+         |  top: "pool"
+         |  name: "$name"
+         |  type: "Pooling"
+         |  pooling_param {
+         |    kernel_size: 3
+         |    stride: 2
+         |    pool: AVE
+         |  }
+         |}
+       """.stripMargin
+
+    val avgPooling = AvgPooling(3, 3, 2, 2).setName(name)
+    avgPooling.setRuntime(new MklDnnRuntime)
+    avgPooling.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    avgPooling.initBwdPrimitives(Array(HeapData(outputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    Tools.compare(prototxt, avgPooling, inputShape, outputShape)
+  }
+
+  "linear " should "work correctly" in {
+    val (batchSize, nInput) = (4, 64)
+    val inputShape = Array(batchSize, nInput)
+    val nOutput = 1000
+    val outputShape = Array(batchSize, nOutput)
+    val name = "fc"
+
+    val prototxt =
+      s"""
+         |name: "relu-simple"
+         |force_backward: true
+         |layer {
+         |  name: "data"
+         |  type: "DummyData"
+         |  top: "data"
+         |  include {
+         |    phase: TRAIN
+         |  }
+         |  dummy_data_param {
+         |    data_filler {
+         |      type: "xavier"
+         |    }
+         |    shape: { ${shape2Dim(inputShape)} }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "data"
+         |  top: "$name"
+         |  name: "$name"
+         |  type: "InnerProduct"
+         |  inner_product_param {
+         |    num_output: $nOutput
+         |    weight_filler {
+         |      type: "gaussian"
+         |      std: 0.01
+         |    }
+         |    bias_filler {
+         |      type: "constant"
+         |      value: 0
+         |    }
+         |  }
+         |}
+       """.stripMargin
+    val linear = Linear(nInput, nOutput).setName(name)
+    linear.setRuntime(new MklDnnRuntime)
+    linear.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nc)), TrainingPhase)
+    linear.initBwdPrimitives(Array(HeapData(outputShape, Memory.FormatTag.nc)), TrainingPhase)
+    linear.initGradWPrimitives(Array(HeapData(outputShape, Memory.FormatTag.nc)), TrainingPhase)
+
+    Tools.compare(prototxt, linear, inputShape, outputShape, 1e-5)
+  }
+
+  "relu" should "work correctly" in {
+    val (batchSize, channel, height, width) = (4, 64, 112, 112)
+    val inputShape = Array(batchSize, channel, height, width)
+    val outputShape = inputShape
+    val name = "relu"
+    val prototxt =
+      s"""
+         |name: "relu-simple"
+         |force_backward: true
+         |layer {
+         |  name: "data"
+         |  type: "DummyData"
+         |  top: "data"
+         |  include {
+         |    phase: TRAIN
+         |  }
+         |  dummy_data_param {
+         |    data_filler {
+         |      type: "xavier"
+         |    }
+         |    shape: { dim: $batchSize dim: $channel dim: $height dim: $width }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "data"
+         |  top: "relu"
+         |  name: "$name"
+         |  type: "ReLU"
+         |  relu_param {
+         |  }
+         |}
+       """.stripMargin
+
+    val relu = ReLU().setName(name)
+    relu.setRuntime(new MklDnnRuntime)
+    relu.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    relu.initBwdPrimitives(Array(HeapData(outputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    Tools.compare(prototxt, relu, inputShape, outputShape)
+  }
+
+  private def shape2Dim(shape: Array[Int]): String = {
+    shape.map(x => "dim: " + x).mkString(" ")
+  }
+}
+

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/SoftMaxSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/SoftMaxSpec.scala
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.Memory
+import com.intel.analytics.bigdl.nn
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.numeric.NumericFloat
+import com.intel.analytics.bigdl.tensor.Tensor
+import org.apache.commons.lang3.SerializationUtils
+import org.scalatest.{FlatSpec, Matchers}
+
+class SoftMaxSpec extends FlatSpec with Matchers {
+  "SoftMax forward 1-D" should "work correctly" in {
+    // we should test the cases which contain 1
+    val tests = List(2, 1)
+
+    for (x <- tests) {
+      val sm = SoftMax()
+      sm.evaluate()
+      sm.setRuntime(new MklDnnRuntime)
+      sm.initFwdPrimitives(Array(HeapData(Array(x), Memory.FormatTag.x)), InferencePhase)
+
+      val input = Tensor(x).rand()
+
+      val output = sm.forward(input)
+
+      val nnSm = nn.SoftMax()
+      val nnOutput = nnSm.forward(input)
+
+      Tools.dense(output) should be (nnOutput)
+    }
+  }
+
+  "SoftMax forward 2-D" should "work correctly" in {
+    val tests = List(
+      (2, 3),
+      (1, 3),
+      (1, 1),
+      (2, 1))
+
+    for ((batchSize, channel) <- tests) {
+      val sm = SoftMax()
+      sm.setRuntime(new MklDnnRuntime)
+      sm.initFwdPrimitives(Array(HeapData(Array(batchSize, channel), Memory.FormatTag.nc)),
+        InferencePhase)
+      sm.evaluate()
+
+      val input = Tensor(batchSize, channel).rand()
+
+      val output = sm.forward(input)
+
+      val nnSm = nn.SoftMax()
+      val nnOutput = nnSm.forward(input)
+
+      Tools.dense(output) shouldEqual nnOutput
+    }
+  }
+
+  "SoftMax forward 4-D" should "work correctly" in {
+    // we should test the cases which contain 1
+    val tests = List(
+      (2, 3, 4, 4),
+      (1, 3, 4, 4),
+      (1, 3, 1, 1),
+      (1, 1, 1, 1),
+      (1, 1, 3, 3),
+      (2, 1, 3, 3),
+      (2, 2, 1, 1))
+
+    for ((batchSize, channel, height, width) <- tests) {
+      val sm = SoftMax()
+      sm.setRuntime(new MklDnnRuntime)
+      sm.initFwdPrimitives(Array(HeapData(Array(batchSize, channel, height, width),
+        Memory.FormatTag.nchw)), InferencePhase)
+      sm.evaluate()
+
+      val input = Tensor(batchSize, channel, height, width).rand()
+
+      val output = sm.forward(input)
+
+      val nnSm = nn.SoftMax()
+      val nnOutput = nnSm.forward(input)
+
+      Tools.dense(output) should be (nnOutput)
+    }
+  }
+
+  "SoftMax forward 3-D" should "work correctly" in {
+    // we should test the cases which contain 1
+    val tests = List(
+      (3, 4, 4),
+      (3, 4, 4),
+      (3, 1, 1),
+      (1, 1, 1),
+      (1, 3, 3),
+      (1, 3, 3),
+      (2, 1, 1))
+
+    for ((i, j, k) <- tests) {
+      val sm = SoftMax()
+      sm.setRuntime(new MklDnnRuntime)
+      sm.initFwdPrimitives(Array(HeapData(Array(i, j, k),
+        Memory.FormatTag.ncw)), InferencePhase)
+      sm.evaluate()
+
+      val input = Tensor(i, j, k).rand()
+
+      val output = sm.forward(input)
+
+      val nnSm = nn.SoftMax()
+      val nnOutput = nnSm.forward(input)
+
+      Tools.dense(output) should be (nnOutput)
+    }
+  }
+
+  "SoftMax backward" should "work correctly" in {
+    val (batchSize, channel, height, width) = (2, 3, 4, 4)
+    val sm = SoftMax()
+    sm.setRuntime(new MklDnnRuntime)
+    sm.initFwdPrimitives(Array(HeapData(Array(batchSize, channel, height, width),
+      Memory.FormatTag.nchw)), InferencePhase)
+
+    val nnSm = nn.SoftMax()
+
+    val input = Tensor(batchSize, channel, height, width).rand()
+    val gradOutput = Tensor().resizeAs(input).rand(-10, 10)
+
+    sm.forward(input)
+    nnSm.forward(input)
+
+    sm.backward(input, gradOutput)
+    nnSm.backward(input, gradOutput)
+
+    sm.output should be (nnSm.output)
+    sm.gradInput should be (nnSm.gradInput)
+  }
+
+  "SoftMax multi times forward" should "work correctly" in {
+    val (batchSize, channel, height, width) = (2, 3, 4, 4)
+    val sm = SoftMax()
+    sm.setRuntime(new MklDnnRuntime)
+    sm.initFwdPrimitives(Array(HeapData(Array(batchSize, channel, height, width),
+      Memory.FormatTag.nchw)), InferencePhase)
+    sm.evaluate()
+
+    val nnSm = nn.SoftMax()
+
+    (0 until 5).foreach { _ =>
+      val input = Tensor(batchSize, channel, height, width).rand(-1, 1)
+      sm.forward(input)
+      nnSm.forward(input)
+
+      Tools.dense(sm.output) should be (nnSm.output)
+    }
+  }
+
+  "axis" should "work correctly" in {
+    val input = Tensor[Float](2, 24564, 21).rand(-1, 1)
+
+    val sm1 = SoftMax(axis = 2)
+    val seq1 = Sequential()
+      .add(Input(Array(2, 24564, 21), Memory.FormatTag.ntc))
+      .add(sm1)
+      .add(Output(Memory.FormatTag.ntc))
+    seq1.asInstanceOf[MklDnnContainer].compile(InferencePhase)
+    seq1.evaluate()
+
+    seq1.forward(input)
+
+    input.resize(Array(2 * 24564, 21))
+
+    val sm2 = SoftMax()
+    val seq2 = Sequential().add(Input(Array(2 * 24564, 21), Memory.FormatTag.nc))
+        .add(sm2)
+        .add(Output())
+    seq2.asInstanceOf[MklDnnContainer].compile(InferencePhase)
+    sm2.evaluate()
+
+    seq2.forward(input)
+
+    seq1.output.toTensor.view(Array(2 * 24564, 21)) should be (seq2.output)
+  }
+
+  "softmax with java serialization" should "work correctly" in {
+    val inputShape = Array(2, 3, 4, 4)
+
+    val sm = SoftMax()
+    sm.setRuntime(new MklDnnRuntime)
+    sm.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    sm.initBwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+
+    val cloned = SerializationUtils.clone(sm)
+    cloned.setRuntime(new MklDnnRuntime)
+    cloned.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    cloned.initBwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+
+    val input = Tensor(inputShape).rand(-1, 1)
+    val gradOutput = Tensor(inputShape).rand(-1, 1)
+
+    sm.forward(input)
+    cloned.forward(input)
+
+    Tools.dense(sm.output) should be (Tools.dense(cloned.output))
+
+    sm.backward(input, gradOutput)
+    cloned.backward(input, gradOutput)
+
+    Tools.dense(sm.gradInput) should be (Tools.dense(cloned.gradInput))
+
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/SpatialBatchNormalizationSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/SpatialBatchNormalizationSpec.scala
@@ -1,0 +1,674 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.dnnl.Memory
+import com.intel.analytics.bigdl.nn
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.TrainingPhase
+import com.intel.analytics.bigdl.numeric.NumericFloat
+import com.intel.analytics.bigdl.tensor.{DnnStorage, Tensor}
+import com.intel.analytics.bigdl.utils.RandomGenerator._
+import org.apache.commons.lang3.SerializationUtils
+import org.scalatest.{FlatSpec, Ignore, Matchers}
+
+class SpatialBatchNormalizationSpec extends FlatSpec with Matchers {
+  "a simple bn with random input" should "work correctly" in {
+    val batchSize = 2
+    RNG.setSeed(100)
+    val input = Tensor(100, 1, 10, 10).rand(-1, 1)
+    val (channel, height, width) = (1, 10, 10)
+
+    val initWeight = Tensor(channel).rand(-1, 1)
+    val initBias = Tensor(channel).fill(0)
+
+    val bn = SpatialBatchNormalization(1, 0.0, initWeight = initWeight, initBias = initBias)
+    val nnBn = nn.SpatialBatchNormalization(1, 0.0, initWeight = initWeight, initBias = initBias)
+
+    val inputShape = Array(100, 1, 10, 10)
+    bn.setRuntime(new MklDnnRuntime)
+    bn.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    bn.initBwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    bn.initGradWPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+
+    val out1 = bn.forward(input)
+    val out2 = nnBn.forward(input)
+
+    Equivalent.nearequals(Tools.dense(out1).toTensor, out2, 1e-4) should be(true)
+
+    val gradOutput = Tensor[Float]().resizeAs(input).rand()
+
+    bn.backward(input, gradOutput)
+    nnBn.backward(input, gradOutput)
+
+    val gradWeight1 = Tools.dense(bn.gradWeightAndBias.native).toTensor
+    val gradWeight2 = nnBn.getParameters()._2
+
+    val weight1 = Tools.dense(bn.weightAndBias.native).toTensor
+    val weight2 = nnBn.getParameters()._1
+
+    Equivalent.nearequals(weight1, weight2) should be (true)
+    Equivalent.nearequals(gradWeight1, gradWeight2) should be (true)
+
+    Equivalent.nearequals(Tools.dense(bn.gradInput).toTensor, nnBn.gradInput) should be (true)
+  }
+
+  "batch norm cloned" should "work correctly" in {
+    val batchSize = 2
+    RNG.setSeed(100)
+    val input = Tensor(100, 1, 10, 10).rand(-1, 1)
+    val (channel, height, width) = (1, 10, 10)
+
+    val initWeight = Tensor(channel).rand(-1, 1)
+    val initBias = Tensor(channel).fill(0)
+
+    val bn = SpatialBatchNormalization(1, 0.0, initWeight = initWeight, initBias = initBias)
+
+    val inputShape = Array(100, 1, 10, 10)
+    bn.setRuntime(new MklDnnRuntime)
+    bn.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    bn.initBwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    bn.initGradWPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+
+    bn.forward(input)
+
+    val cloned = SerializationUtils.clone(bn)
+    cloned.setRuntime(new MklDnnRuntime)
+    cloned.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    cloned.initBwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    cloned.initGradWPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+
+    cloned.forward(input)
+
+    Tools.dense(bn.output) should be (Tools.dense(cloned.output))
+
+    val gradOutput = Tensor(inputShape).rand(-1, 1)
+    bn.backward(input, gradOutput)
+    cloned.backward(input, gradOutput)
+    Tools.dense(bn.gradInput) should be (Tools.dense(cloned.gradInput))
+    Tools.dense(bn.gradWeightAndBias.native) should be (
+      Tools.dense(cloned.gradWeightAndBias.native))
+  }
+
+  "batch norm released" should "work correctly" in {
+    val batchSize = 2
+    RNG.setSeed(100)
+    val input = Tensor(100, 1, 10, 10).rand(-1, 1)
+    val (channel, height, width) = (1, 10, 10)
+
+    val initWeight = Tensor(channel).rand(-1, 1)
+    val initBias = Tensor(channel).fill(0)
+    val initCount = DnnStorage.get().count(!_._2)
+
+    val bn = SpatialBatchNormalization(1, 0.0, initWeight = initWeight, initBias = initBias)
+
+    val inputShape = Array(100, 1, 10, 10)
+    bn.setRuntime(new MklDnnRuntime)
+    bn.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    bn.initBwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    bn.initGradWPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+
+    bn.forward(input)
+    val gradOutput = Tensor(inputShape).rand(-1, 1)
+    bn.backward(input, gradOutput)
+
+    bn.release()
+    DnnStorage.get().count(_._2 == false) should be (initCount)
+  }
+
+  "batch norm with dense weights and gradients" should "work correctly" in {
+    val batchSize = 2
+    RNG.setSeed(100)
+    val input = Tensor(100, 1, 10, 10).rand(-1, 1)
+    val gradOutput = Tensor(100, 1, 10, 10).rand(-1, 1)
+    val (channel, height, width) = (1, 10, 10)
+
+    val initWeight1 = Tensor(channel).rand(-1, 1)
+    val initBias1 = Tensor(channel).fill(0)
+    val initWeight2 = Tensor(channel).rand(-1, 1)
+    val initBias2 = Tensor(channel).fill(0)
+
+    val bn1 = SpatialBatchNormalization(1, 0.0, initWeight = initWeight1, initBias = initBias1)
+    val bn2 = SpatialBatchNormalization(1, 0.0, initWeight = initWeight2, initBias = initBias2)
+
+    val inputShape = Array(100, 1, 10, 10)
+    for (bn <- List(bn1, bn2)) {
+      bn.setRuntime(new MklDnnRuntime)
+      bn.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+      bn.initBwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+      bn.initGradWPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    }
+
+    bn1.forward(input)
+    bn1.backward(input, gradOutput)
+
+    bn1.parameters()._1.zip(bn2.parameters()._1).foreach(x => x._1.copy(x._2))
+
+    bn1.forward(input)
+    bn1.backward(input, gradOutput)
+
+    bn2.forward(input)
+    bn2.backward(input, gradOutput)
+
+    Tools.dense(bn1.output) should be (Tools.dense(bn2.output))
+    Tools.dense(bn1.gradInput) should be (Tools.dense(bn2.gradInput))
+
+    bn1.parameters()._2.zip(bn2.parameters()._2).foreach(x => x._1 should be (x._2))
+  }
+
+  "bn updateOutput" should "work correctly" in {
+    val (batchSize, channel, height, width) = (4, 64, 112, 112)
+    val inputShape = Array(batchSize, channel, height, width)
+    val defaultFormat = HeapData(inputShape, Memory.FormatTag.nchw)
+    val epsilon = 1e-5
+
+    val input = Tensor(batchSize, channel, height, width).rand(-1, 1)
+    val initWeight = Tensor(channel).rand(-1, 1)
+    val initBias = Tensor(channel).fill(0)
+
+    val bn = SpatialBatchNormalization(channel, epsilon, initWeight = initWeight,
+      initBias = initBias)
+    bn.setRuntime(new MklDnnRuntime)
+    bn.initFwdPrimitives(Array(defaultFormat), TrainingPhase)
+    bn.initBwdPrimitives(Array(defaultFormat), TrainingPhase)
+    bn.initGradWPrimitives(Array(defaultFormat), TrainingPhase)
+
+    val output = Tools.toNCHW(bn.forward(input).toTensor, bn.outputFormats()(0))
+
+    val nnBn = nn.SpatialBatchNormalization(channel, epsilon,
+      initWeight = initWeight, initBias = initBias)
+    val nnOutput = nnBn.forward(input)
+
+    Equivalent.nearequals(output, nnOutput) should be (true)
+  }
+
+  "bn updateOutput multi times" should "work correctly" in {
+    val (batchSize, channel, height, width) = (2, 3, 4, 4)
+    val inputShape = Array(batchSize, channel, height, width)
+    val defaultFormat = HeapData(inputShape, Memory.FormatTag.nchw)
+    val epsilon = 1e-5
+
+    val input = Tensor(batchSize, channel, height, width).rand(-1, 1)
+    val initWeight = Tensor(channel).rand(-1, 1)
+    val initBias = Tensor(channel).rand(-1, 1)
+
+    val bn = SpatialBatchNormalization(channel, epsilon, initWeight = initWeight,
+      initBias = initBias)
+    bn.setRuntime(new MklDnnRuntime)
+    bn.initFwdPrimitives(Array(defaultFormat), TrainingPhase)
+    bn.initBwdPrimitives(Array(defaultFormat), TrainingPhase)
+    bn.initGradWPrimitives(Array(defaultFormat), TrainingPhase)
+
+    TestUtils.manyTimes(bn.forward(input))(10)
+
+    val nnBn = nn.SpatialBatchNormalization(channel, epsilon,
+      initWeight = initWeight, initBias = initBias)
+
+    TestUtils.manyTimes(nnBn.forward(input))(10)
+
+    val output = Tools.toNCHW(bn.output.toTensor, bn.outputFormats()(0))
+
+    Equivalent.nearequals(output, nnBn.output.toTensor) should be (true)
+  }
+
+  "bn backward" should "work correctly" in {
+    val (batchSize, channel, height, width) = (2, 3, 4, 4)
+    val inputShape = Array(batchSize, channel, height, width)
+    val defaultFormat = HeapData(inputShape, Memory.FormatTag.nchw)
+    val epsilon = 0.0f
+
+    val input = Tensor(batchSize, channel, height, width).rand(-1, 1)
+    val gradOutput = Tensor().resize(inputShape).rand(-1, 1)
+    val initWeight = Tensor(channel).rand(-1, 1)
+    val initBias = Tensor(channel).rand(-1, 1)
+
+    val bn = SpatialBatchNormalization(channel, epsilon, initWeight = initWeight,
+      initBias = initBias)
+    bn.setRuntime(new MklDnnRuntime)
+    bn.initFwdPrimitives(Array(defaultFormat), TrainingPhase)
+    bn.initBwdPrimitives(Array(defaultFormat), TrainingPhase)
+    bn.initGradWPrimitives(Array(defaultFormat), TrainingPhase)
+
+    val nnBn = nn.SpatialBatchNormalization(channel, epsilon,
+      initWeight = initWeight, initBias = initBias)
+
+    bn.forward(input)
+    nnBn.forward(input)
+
+    val output = Tools.toNCHW(bn.output.toTensor, bn.outputFormats()(0))
+
+    Equivalent.nearequals(output, nnBn.output) should be (true)
+
+    bn.backward(input, gradOutput)
+    val nnGradInput = nnBn.backward(input, gradOutput)
+
+    val gradInput = Tools.toNCHW(bn.gradInput.toTensor, bn.gradInputFormats()(0))
+    val weightAndBias = Tools.dense(bn.parameters()._2(0)).toTensor
+
+    Equivalent.nearequals(gradInput, nnGradInput.toTensor) should be (true)
+    Equivalent.nearequals(weightAndBias, nnBn.getParameters()._2) should be (true)
+  }
+
+//  "bn perf" should "work correctly" in {
+//    // For PERF test. It seems sometimes batch norm maybe slower than java version.
+//    val (batchSize, channel, height, width) = (4, 64, 112, 112)
+//    val inputShape = Array(batchSize, channel, height, width)
+//    val defaultFormat = HeapData(inputShape, Memory.FormatTag.nChw8c)
+//    val epsilon = 0.0f
+//
+//    val input = Tensor(batchSize, channel, height, width).rand(-1, 1)
+//    val gradOutput = Tensor().resizeAs(input).rand(-1, 1)
+//
+//    val initWeight = Tensor(channel).rand(-1, 1)
+//    val initBias = Tensor(channel).rand(-1, 1)
+//
+//    val bn = SpatialBatchNormalization(channel, epsilon, initWeight = initWeight,
+//      initBias = initBias)
+//    bn.setRuntime(new MklDnnRuntime)
+//    bn.initFwdPrimitives(Array(defaultFormat), TrainingPhase)
+//    bn.initBwdPrimitives(Array(defaultFormat), TrainingPhase)
+//    bn.initGradWPrimitives(Array(defaultFormat), TrainingPhase)
+//
+//    val nnBn = nn.SpatialBatchNormalization(channel, epsilon,
+//      initWeight = initWeight, initBias = initBias)
+//
+//    val times = Utils.manyTimes {
+//      bn.forward(input)
+//      bn.backward(input, gradOutput)
+//    } _
+//
+//    val nnTimes = Utils.manyTimes {
+//      nnBn.forward(input)
+//      nnBn.backward(input, gradOutput)
+//    } _
+//
+//    times(10)
+//    nnTimes(10)
+//
+//    val costs = times(50)._1
+//    val nnCosts = nnTimes(50)._1
+//
+//    costs should be < (nnCosts)
+//  }
+
+  "a complicated batch norm" should "work correctly" in {
+    val (channel, height, width) = (64, 112, 112)
+    val epsilon = 1e-3
+    val batchSize = 2
+
+    RNG.setSeed(100)
+    val input = Tensor[Float](Array(batchSize, 64, 112, 112)).rand(-1, 1)
+    val gradOutput = Tensor().resizeAs(input).copy(input)
+
+    RNG.setSeed(100)
+    val initWeight = Tensor(channel).rand(-1, 1)
+    val initBias = Tensor(channel).fill(0f)
+
+    val inputShape = input.size()
+    val outputShape = input.size()
+    val defaultFormat = HeapData(inputShape, Memory.FormatTag.nchw)
+
+    val bn = SpatialBatchNormalization(channel, epsilon, initWeight = initWeight,
+      initBias = initBias)
+    bn.setRuntime(new MklDnnRuntime)
+    bn.initFwdPrimitives(Array(defaultFormat), TrainingPhase)
+    bn.initBwdPrimitives(Array(defaultFormat), TrainingPhase)
+    bn.initGradWPrimitives(Array(defaultFormat), TrainingPhase)
+
+    val nnBn = nn.SpatialBatchNormalization(channel, epsilon, initWeight = initWeight,
+      initBias = initBias)
+
+    bn.zeroGradParameters()
+    nnBn.zeroGradParameters()
+
+    val (weight, gradWeight) = bn.parameters()
+    val (nnWeight, nnGradWeight) = nnBn.getParameters()
+    Equivalent.nearequals(Tools.dense(weight(0)).toTensor, nnWeight) should be(true)
+    Equivalent.nearequals(Tools.dense(gradWeight(0)).toTensor, nnGradWeight) should be(true)
+
+    val out1 = bn.forward(input)
+    val out2 = nnBn.forward(input)
+
+    Equivalent.nearequals(Tools.dense(bn.output).toTensor, nnBn.output) should be (true)
+
+    val gradInput = bn.backward(input, gradOutput)
+    val nnGradInput = nnBn.backward(input, gradOutput)
+
+    Equivalent.nearequals(Tools.dense(gradInput).toTensor, nnGradInput.toTensor,
+      1e-3) should be (true)
+    Equivalent.nearequals(Tools.dense(gradWeight(0)).toTensor, nnGradWeight, 1e-3) should be (true)
+  }
+
+  "A nChw8c input" should "work correctly" in {
+    RNG.setSeed(1)
+    val (batchSize, channel, height, width) = (2, 256, 56, 56)
+    val input = Tensor(batchSize, channel, height, width).rand(-1, 1)
+    val gradOutput = Tensor(batchSize, channel, height, width).rand(-1, 1)
+
+    val inputShape = input.size()
+    val reorder1 = ReorderMemory(HeapData(inputShape, Memory.FormatTag.nChw8c))
+    val reorder2 = ReorderMemory(HeapData(inputShape, Memory.FormatTag.nchw))
+
+    val initWeight = Tensor(channel).rand(-1, 1)
+    val initBias = Tensor(channel).rand(-1, 1)
+
+    val dnn = Sequential()
+      .add(reorder1)
+      .add(SpatialBatchNormalization(channel, 1e-3, initWeight = initWeight, initBias = initBias))
+      .add(reorder2)
+
+    dnn.compile(TrainingPhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+
+    val blas = nn.Sequential().add(
+        nn.SpatialBatchNormalization(channel, 1e-3, initWeight = initWeight, initBias = initBias))
+
+    dnn.forward(input)
+    blas.forward(input)
+
+    dnn.backward(input, gradOutput)
+    blas.backward(input, gradOutput)
+
+    val gradWeight = Tools.dense(dnn.parameters()._2(0)).toTensor
+
+    Equivalent.nearequals(dnn.output.toTensor, blas.output.toTensor, 1e-4) should be (true)
+    Equivalent.nearequals(dnn.gradInput.toTensor, blas.gradInput.toTensor, 1e-4) should be (true)
+    Equivalent.nearequals(gradWeight, blas.getParameters()._2, 1e-3) should be (true)
+  }
+
+//  "A nChw16c input" should "work correctly" in {
+//    // only works on avx512 (SKX->)
+//    val (batchSize, channel, height, width) = (2, 256, 56, 56)
+//    val input = Tensor(batchSize, channel, height, width).rand(-1, 1)
+//    val gradOutput = Tensor(batchSize, channel, height, width).rand(-1, 1)
+//
+//    val inputShape = input.size()
+//    val reorder1 = ReorderMemory(HeapData(inputShape, Memory.FormatTag.nChw16c))
+//    val reorder2 = ReorderMemory(HeapData(inputShape, Memory.FormatTag.nchw))
+//
+//    val initWeight = Tensor(channel).rand(-1, 1)
+//    val initBias = Tensor(channel).rand(-1, 1)
+//
+//    val dnn = Sequential()
+//      .add(reorder1)
+//      .add(SpatialBatchNormalization(channel, 1e-3, initWeight = initWeight, initBias = initBias))
+//      .add(reorder2)
+//
+//    dnn.compile(TrainingPhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+//
+//    val blas = nn.Sequential().add(
+//        nn.SpatialBatchNormalization(channel, 1e-3, initWeight = initWeight, initBias = initBias))
+//
+//    dnn.forward(input)
+//    blas.forward(input)
+//
+//    dnn.backward(input, gradOutput)
+//    blas.backward(input, gradOutput)
+//
+//    val gradWeight = Tools.dense(dnn.parameters()._2(0)).toTensor
+//
+//    DnnUtils.nearequals(dnn.output.toTensor, blas.output.toTensor, 1e-4) should be (true)
+//    DnnUtils.nearequals(dnn.gradInput.toTensor, blas.gradInput.toTensor, 1e-4) should be (true)
+//    DnnUtils.nearequals(gradWeight, blas.getParameters()._2, 1e-3) should be (true)
+//  }
+
+  "Sbn with relu fusion" should "work correctly" in {
+    val (batchSize, channel, height, width) = (4, 64, 112, 112)
+    val shape = Array(batchSize, channel, height, width)
+    val epsilon = 1e-5
+
+    val initWeight = Tensor(channel).rand(-1, 1)
+    val initBias = Tensor(channel).fill(0)
+
+    val bn1 = SpatialBatchNormalization(channel, epsilon, initWeight = initWeight,
+      initBias = initBias)
+    val reorder1 = ReorderMemory(HeapData(shape, Memory.FormatTag.nchw))
+    val bn2 = SpatialBatchNormalization(channel, epsilon, initWeight = initWeight,
+      initBias = initBias)
+    val reorder2 = ReorderMemory(HeapData(shape, Memory.FormatTag.nchw))
+
+    val model1 = Sequential().add(bn1).add(ReLU()).add(ReLU()).add(reorder1)
+    model1.compile(TrainingPhase, Array(HeapData(shape, Memory.FormatTag.nchw)))
+
+    System.setProperty("bigdl.mkldnn.fusion.bnrelu", "true")
+    val model2 = Sequential().add(bn2).add(ReLU()).add(ReLU()).add(reorder2)
+    model2.compile(TrainingPhase, Array(HeapData(shape, Memory.FormatTag.nchw)))
+    System.setProperty("bigdl.mkldnn.fusion.bnrelu", "false")
+
+    val input = Tensor(batchSize, channel, height, width).rand(-1, 1)
+
+    model1.forward(input)
+    model2.forward(input)
+
+    model1.output should be (model2.output)
+  }
+
+  "bn train and evaluate" should "work correctly" in {
+    val batchSize = 2
+    RNG.setSeed(100)
+    val input = Tensor(100, 1, 10, 10).fill(1.0f)
+    val gradOutput = Tensor[Float]().resizeAs(input).fill(0.5f)
+    val (channel, height, width) = (1, 10, 10)
+
+    val initWeight = Tensor(channel).fill(0.3f)
+    val initBias = Tensor(channel).fill(0)
+
+    val bn = SpatialBatchNormalization(1, 1e-3, initWeight = initWeight, initBias = initBias)
+
+    val runningMean = Tensor[Float](1).fill(1.0f)
+    val runningVariance = Tensor[Float](1).fill(0.0f)
+
+    val inputShape = Array(100, 1, 10, 10)
+    bn.setRuntime(new MklDnnRuntime)
+    bn.initFwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    bn.initBwdPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+    bn.initGradWPrimitives(Array(HeapData(inputShape, Memory.FormatTag.nchw)), TrainingPhase)
+
+    bn.forward(input)
+    bn.backward(input, gradOutput)
+    bn.runningMean.dense should be (runningMean)
+    bn.runningVariance.dense should be (runningVariance)
+
+    bn.evaluate()
+    bn.forward(input)
+
+    bn.runningMean.dense should be (runningMean)
+    bn.runningVariance.dense should be (runningVariance)
+  }
+
+  "a simple bach norm" should "work correctly" in {
+    val (batchSize, channel, height, width) = (4, 64, 2, 2)
+    val shape = Array(batchSize, channel, height, width)
+    val prototxt = s"""
+         |name: "relu-simple"
+         |force_backward: true
+         |layer {
+         |  name: "data"
+         |  type: "DummyData"
+         |  top: "data"
+         |  include {
+         |    phase: TRAIN
+         |  }
+         |  dummy_data_param {
+         |    data_filler {
+         |      type: "xavier"
+         |    }
+         |    shape: { dim: $batchSize dim: $channel dim: $height dim: $width }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "data"
+         |  top: "bn"
+         |  name: "bn"
+         |  type: "BatchNorm"
+         |
+         |  batch_norm_param {
+         |    moving_average_fraction: 1.0
+         |    filler { value: 1 }
+         |    bias_filler { value: 1 }
+         |    relu: false
+         |    eps: 0.0
+         |  }
+         |}
+       """.stripMargin
+
+    val identity = Collect.run(prototxt)
+
+    val input = Tools.getTensor("Fwrd_data", shape, identity)
+    val output = Tools.getTensor("Fwrd_bn", shape, identity)
+    val weight = Tools.getTensor("Fwrd_bn.Wght.3", Array(channel), identity)
+    val bias = Tools.getTensor("Fwrd_bn.Wght.4", Array(channel), identity)
+    val scale = Tools.getTensor("Fwrd_bn.Wght.2", Array(1), identity)
+    val runningMean = Tools.getTensor("Fwrd_bn.Wght.0", Array(channel), identity)
+    val runningVariance = Tools.getTensor("Fwrd_bn.Wght.1", Array(channel), identity)
+    val gradOutput = Tools.getTensor("Bwrd_bn.loss", shape, identity)
+    val gradInput = Tools.getTensor("Bwrd_bn", shape, identity)
+    val gradWeight = Tools.getTensor("Bwrd_bn.Grad.3", Array(channel), identity)
+    val gradBias = Tools.getTensor("Bwrd_bn.Grad.4", Array(channel), identity)
+
+    val bn = new SpatialBatchNormalization(channel, eps = 0.0, momentum = 1.0,
+      initWeight = weight, initBias = bias)
+
+    val reorder1 = ReorderMemory(HeapData(shape, Memory.FormatTag.nchw)).setName("reorder1")
+    val reorder2 = ReorderMemory(HeapData(shape, Memory.FormatTag.nchw)).setName("reorder2")
+    val reorder3 = ReorderMemory(HeapData(shape, Memory.FormatTag.nChw8c)).setName("reorder3")
+    val reorder4 = ReorderMemory(HeapData(shape, Memory.FormatTag.nchw)).setName("reorder4")
+
+    val seq = Sequential()
+    seq.add(reorder1)
+    seq.add(reorder3)
+    seq.add(bn)
+    seq.add(reorder2)
+    seq.compile(Phase.TrainingPhase, Array(HeapData(shape, Memory.FormatTag.nchw)))
+    seq.reset()
+
+    bn.zeroGradParameters()
+
+    seq.forward(input)
+    seq.backward(input, gradOutput)
+
+    val weightAndBias = Tensor[Float](Array(2, channel))
+    weightAndBias.select(1, 1).copy(weight)
+    weightAndBias.select(1, 2).copy(bias)
+
+    val gradWeightAndBias = Tensor[Float](Array(2, channel))
+    gradWeightAndBias.select(1, 1).copy(gradWeight)
+    gradWeightAndBias.select(1, 2).copy(gradBias)
+
+    compare(weightAndBias.view(Array(2 * channel)), bn.weightAndBias.native)
+    compare(output, seq.output)
+    compare(runningMean, bn.runningMean.native)
+    compare(runningVariance, bn.runningVariance.native)
+    compare(gradWeightAndBias.view(Array(2 * channel)), bn.gradWeightAndBias.native)
+    compare(gradInput, seq.gradInput)
+  }
+
+  "a simple bach norm inference" should "work correctly" in {
+    val (batchSize, channel, height, width) = (4, 64, 112, 112)
+    val shape = Array(batchSize, channel, height, width)
+    val prototxt = s"""
+         |name: "relu-simple"
+         |force_backward: true
+         |state {
+         |  phase: TEST
+         |}
+         |layer {
+         |  name: "data"
+         |  type: "DummyData"
+         |  top: "data"
+         |  include {
+         |    phase: TRAIN
+         |  }
+         |  dummy_data_param {
+         |    data_filler {
+         |      type: "xavier"
+         |    }
+         |    shape: { dim: $batchSize dim: $channel dim: $height dim: $width }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "data"
+         |  top: "bn"
+         |  name: "bn"
+         |  type: "BatchNorm"
+         |
+         |  batch_norm_param {
+         |    moving_average_fraction: 1.0
+         |    filler { value: 1 }
+         |    bias_filler { value: 0 }
+         |    relu: false
+         |    eps: 0.0
+         |  }
+         |
+         |  phase: TEST
+         |}
+       """.stripMargin
+
+    val identity = Collect.run(prototxt)
+
+    val input = Tools.getTensor("Fwrd_data", shape, identity)
+    val output = Tools.getTensor("Fwrd_bn", shape, identity)
+    val weight = Tools.getTensor("Fwrd_bn.Wght.3", Array(channel), identity)
+    val bias = Tools.getTensor("Fwrd_bn.Wght.4", Array(channel), identity)
+    val scale = Tools.getTensor("Fwrd_bn.Wght.2", Array(1), identity)
+    val runningMean = Tools.getTensor("Fwrd_bn.Wght.0", Array(channel), identity)
+    val runningVariance = Tools.getTensor("Fwrd_bn.Wght.1", Array(channel), identity)
+
+    val bn = new SpatialBatchNormalization(channel, eps = 0.0, momentum = 1.0,
+      initWeight = weight, initBias = bias)
+    bn.runningMean.copy(runningMean)
+    bn.runningVariance.copy(runningVariance)
+
+    val reorder1 = ReorderMemory(HeapData(shape, Memory.FormatTag.nchw)).setName("reorder1")
+    val reorder2 = ReorderMemory(HeapData(shape, Memory.FormatTag.nchw)).setName("reorder2")
+
+    val seq = Sequential()
+    seq.add(reorder1)
+    seq.add(bn)
+    seq.add(reorder2)
+    seq.compile(Phase.InferencePhase, Array(HeapData(shape, Memory.FormatTag.nchw)))
+    seq.reset()
+    seq.evaluate()
+
+    seq.forward(input)
+
+    val weightAndBias = Tensor[Float](Array(2, channel))
+    weightAndBias.select(1, 1).copy(weight)
+    weightAndBias.select(1, 2).copy(bias)
+
+    compare(weightAndBias.view(Array(2 * channel)), bn.weightAndBias.native)
+    compare(runningMean, bn.runningMean.native)
+    compare(runningVariance, bn.runningVariance.native)
+
+    val denseOutput = Tools.dense(bn.output).toTensor
+
+    denseOutput.storage().array().zip(output.storage().array()).foreach { x =>
+      if (x._2.isInfinity || x._2.isNaN)  x._1.isInfinity || x._1.isNaN should be (true)
+    }
+  }
+
+  private def compare(src: Activity, dst: Activity): Unit = {
+    if (src.isTensor) {
+      Equivalent.nearequals(Tools.dense(src).toTensor, Tools.dense(dst).toTensor) should be (true)
+    }
+  }
+
+  private def shape2Dim(shape: Array[Int]): String = {
+    shape.map(x => "dim: " + x).mkString(" ")
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/SpatialConvolutionSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/SpatialConvolutionSpec.scala
@@ -1,0 +1,895 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl._
+import com.intel.analytics.bigdl.dnnl._
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.nn.{Xavier, Zeros}
+import com.intel.analytics.bigdl.numeric.NumericFloat
+import com.intel.analytics.bigdl.tensor.{DnnStorage, Tensor}
+import com.intel.analytics.bigdl.utils.RandomGenerator._
+import org.apache.commons.lang3.SerializationUtils
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.util.Random
+
+class SpatialConvolutionSpec extends FlatSpec with Matchers {
+
+  "MKL-DNN Dilated Convolution compared with BLAS Dilated Convolution" should "work correctly" in {
+    val batch = 3
+    val nInputPlane = 3
+    val nOutputPlane = 4
+    val kW = 3
+    val kH = 3
+    val dW = 4
+    val dH = 4
+    val padW = 0
+    val padH = 0
+
+    def compareHelper(input: Tensor[Float], gradOutput: Tensor[Float],
+                      dilationHeight: Int, dilationWidth: Int): Unit = {
+      RNG.setSeed(100)
+      val mkldnnConv = SpatialConvolution(
+        nInputPlane, nOutputPlane, kW, kH, dW, dH,
+        padW, padH, dilationH = dilationHeight, dilationW = dilationWidth)
+
+      RNG.setSeed(100)
+      val blasConv = nn.SpatialDilatedConvolution[Float](
+        nInputPlane, nOutputPlane, kW, kH, dW, dH,
+        padW, padH, dilationH = dilationHeight, dilationW = dilationWidth)
+
+      val mkldnnSeq = Sequential()
+        .add(Input(input.size(), Memory.FormatTag.nchw))
+        .add(mkldnnConv)
+        .add(ReorderMemory(HeapData(gradOutput.size(), Memory.FormatTag.nchw)))
+
+      mkldnnSeq.compile(TrainingPhase)
+
+      val output = mkldnnSeq.forward(input)
+      val grad1 = mkldnnSeq.backward(input, gradOutput)
+
+      val weight1 = mkldnnConv.weight.dense
+      val gradweight1 = mkldnnConv.gradWeight.dense
+      val bias1 = mkldnnConv.bias.dense
+      val gradbias1 = mkldnnConv.gradBias.dense
+
+      val output2 = blasConv.forward(input)
+      val grad2 = blasConv.updateGradInput(input, gradOutput)
+      blasConv.accGradParameters(input, gradOutput)
+
+      val weight2 = blasConv.weight
+      val gradweight2 = blasConv.gradWeight
+      val bias2 = blasConv.bias
+      val gradbias2 = blasConv.gradBias
+
+      Equivalent.nearequals(output.toTensor, output2) should be (true)
+      Equivalent.nearequals(weight1, weight2.resizeAs(weight1)) should be (true)
+      Equivalent.nearequals(bias1, bias2) should be (true)
+
+      Equivalent.nearequals(grad1.toTensor, grad2) should be (true)
+      Equivalent.nearequals(gradweight1, gradweight2.resizeAs(gradweight1)) should be (true)
+      Equivalent.nearequals(gradbias1, gradbias2) should be (true)
+
+    }
+
+    var (dilationH, dilationW) = (1, 1)
+
+    var input = Tensor[Float](batch, nInputPlane, 23, 23).apply1(e => Random.nextFloat())
+    var gradOutput = Tensor[Float](batch, nOutputPlane, 6, 6).apply1(e => Random.nextFloat())
+
+    compareHelper(input, gradOutput, dilationH, dilationW)
+
+    dilationH = 2
+    dilationW = 2
+
+    input = Tensor[Float](batch, nInputPlane, 7, 7).apply1(e => Random.nextFloat())
+    gradOutput = Tensor[Float](batch, nOutputPlane, 1, 1).apply1(e => Random.nextFloat())
+
+    compareHelper(input, gradOutput, dilationH, dilationW)
+
+  }
+
+  "ConvolutionDnn with format=nchw and ngroup=1" should "work correctly" in {
+    val nInputPlane = 3
+    val nOutputPlane = 4
+    val kW = 3
+    val kH = 3
+    val dW = 4
+    val dH = 4
+    val padW = 0
+    val padH = 0
+
+    val (in, ic, ih, iw) = (2, nInputPlane, 23, 23)
+    val (on, oc, oh, ow) = (2, nOutputPlane, 6, 6)
+
+    val input = Tensor[Float](in, ic, ih, iw).apply1(e => Random.nextFloat())
+    val gradOutput = Tensor[Float](on, oc, oh, ow).apply1(e => Random.nextFloat())
+
+    RNG.setSeed(100)
+    val conv = SpatialConvolution(nInputPlane, nOutputPlane, kW, kH, dW, dH, padW, padH)
+
+    RNG.setSeed(100)
+    val layer = nn.SpatialConvolution[Float](nInputPlane, nOutputPlane, kW, kH, dW, dH, padW, padH)
+
+    val seq = Sequential()
+      .add(Input(input.size(), Memory.FormatTag.nchw))
+      .add(conv)
+      .add(ReorderMemory(HeapData(gradOutput.size(), Memory.FormatTag.nchw)))
+
+    seq.compile(TrainingPhase)
+
+    val output = seq.forward(input)
+    val grad1 = seq.backward(input, gradOutput)
+
+    val weight1 = conv.weight.dense
+    val gradweight1 = conv.gradWeight.dense
+    val bias1 = conv.bias.dense
+    val gradbias1 = conv.gradBias.dense
+
+    val output2 = layer.forward(input)
+    val grad2 = layer.updateGradInput(input, gradOutput)
+    layer.accGradParameters(input, gradOutput)
+
+    val weight2 = layer.weight
+    val gradweight2 = layer.gradWeight
+
+    val bias2 = layer.bias
+    val gradbias2 = layer.gradBias
+
+    Equivalent.nearequals(output.toTensor, output2) should be (true)
+    Equivalent.nearequals(weight1, weight2.resizeAs(weight1)) should be (true)
+    Equivalent.nearequals(bias1, bias2) should be (true)
+
+    Equivalent.nearequals(grad1.toTensor, grad2) should be (true)
+    Equivalent.nearequals(gradbias1, gradbias2) should be (true)
+    Equivalent.nearequals(gradweight1, gradweight2.resizeAs(gradweight1)) should be (true)
+  }
+
+  "ConvolutionDnn with same padding" should "work correctly" in {
+    val nInputPlane = 2
+    val nOutputPlane = 4
+    val kW = 3
+    val kH = 3
+    val dW = 4
+    val dH = 4
+    val padW = -1
+    val padH = -1
+
+    val input = Tensor[Float](2, 2, 23, 23).apply1(e => Random.nextFloat())
+    val gradOutput = Tensor[Float](2, 4, 6, 6).apply1(e => Random.nextFloat())
+    RNG.setSeed(100)
+    val conv = SpatialConvolution(nInputPlane, nOutputPlane, kW, kH, dW, dH, padW, padH)
+    RNG.setSeed(100)
+    val layer = nn.SpatialConvolution[Float](nInputPlane, nOutputPlane, kW, kH, dW, dH, padW, padH)
+
+    val seq = Sequential()
+        .add(Input(input.size(), Memory.FormatTag.nchw))
+        .add(conv)
+        .add(ReorderMemory(HeapData(gradOutput.size(), Memory.FormatTag.nchw)))
+
+    seq.compile(TrainingPhase)
+
+    val output = seq.forward(input)
+    val grad1 = seq.backward(input, gradOutput)
+
+    val weight1 = conv.weight.dense
+    val gradweight1 = conv.gradWeight.dense
+    val bias1 = Tools.dense(conv.bias.native[Float]).toTensor[Float]
+    val gradbias1 = Tools.dense(conv.gradBias.dense).toTensor
+
+    val output2 = layer.forward(input)
+    val grad2 = layer.updateGradInput(input, gradOutput)
+    layer.accGradParameters(input, gradOutput)
+
+    val weight2 = layer.weight
+    val gradweight2 = layer.gradWeight
+    val bias2 = layer.bias
+    val gradbias2 = layer.gradBias
+
+    Equivalent.nearequals(weight1, weight2.resizeAs(weight1)) should be(true)
+    Equivalent.nearequals(gradweight1, gradweight2.resizeAs(gradweight1)) should be(true)
+    Equivalent.nearequals(bias1, bias2) should be(true)
+    Equivalent.nearequals(gradbias1, gradbias2) should be(true)
+    Equivalent.nearequals(output.toTensor, output2) should be(true)
+    Equivalent.nearequals(grad1.toTensor, grad2) should be(true)
+  }
+
+  "ConvolutionDnn with format=nchw and ngroup=2" should "work correctly" in {
+    val nInputPlane = 2
+    val nOutputPlane = 4
+    val kW = 3
+    val kH = 3
+    val dW = 4
+    val dH = 4
+    val padW = 0
+    val padH = 0
+    val ngroup = 2
+
+    val input = Tensor[Float](2, 2, 23, 23).apply1(e => Random.nextFloat())
+    val gradOutput = Tensor[Float](2, 4, 6, 6).apply1(e => Random.nextFloat())
+    RNG.setSeed(100)
+    val conv = SpatialConvolution(nInputPlane, nOutputPlane, kW, kH, dW, dH,
+      padW, padH, ngroup)
+    RNG.setSeed(100)
+    val layer = nn.SpatialConvolution[Float](nInputPlane, nOutputPlane, kW, kH,
+      dW, dH, padW, padH, ngroup)
+
+    val seq = Sequential()
+        .add(Input(input.size(), Memory.FormatTag.nchw))
+        .add(conv)
+        .add(ReorderMemory(HeapData(gradOutput.size(), Memory.FormatTag.nchw)))
+
+    seq.compile(TrainingPhase)
+
+    val output2 = layer.forward(input)
+    val grad2 = layer.updateGradInput(input, gradOutput)
+    layer.accGradParameters(input, gradOutput)
+    val weight2 = layer.weight
+    val gradweight2 = layer.gradWeight
+    val bias2 = layer.bias
+    val gradbias2 = layer.gradBias
+
+    val output = seq.forward(input).toTensor[Float]
+    val grad1 = seq.backward(input, gradOutput).toTensor[Float]
+    val weight1 = conv.weight.dense
+    val gradweight1 = conv.gradWeight.dense
+    val bias1 = Tools.dense(conv.bias.native).toTensor[Float]
+    val gradbias1 = Tools.dense(conv.gradBias.native).toTensor[Float]
+
+    Equivalent.nearequals(weight1, weight2) should be(true)
+    Equivalent.nearequals(gradweight1, gradweight2) should be(true)
+    Equivalent.nearequals(bias1, bias2) should be(true)
+    Equivalent.nearequals(gradbias1, gradbias2) should be(true)
+    Equivalent.nearequals(output, output2) should be(true)
+    Equivalent.nearequals(grad1, grad2) should be(true)
+  }
+
+  "ConvolutionDnn with relu " should "work correctly" in {
+    val nInputPlane = 2
+    val nOutputPlane = 4
+    val kW = 3
+    val kH = 3
+    val dW = 4
+    val dH = 4
+    val padW = 0
+    val padH = 0
+    val ngroup = 2
+
+    val input = Tensor[Float](2, 2, 23, 23).apply1(e => Random.nextFloat())
+    val gradOutput = Tensor[Float](2, 4, 6, 6).apply1(e => Random.nextFloat())
+    RNG.setSeed(100)
+    val conv = SpatialConvolution(nInputPlane, nOutputPlane, kW, kH, dW, dH, padW, padH, ngroup)
+    RNG.setSeed(100)
+    val conv1 = nn.SpatialConvolution[Float](nInputPlane, nOutputPlane, kW, kH, dW, dH, padW, padH,
+      ngroup)
+
+    val relu = ReLU()
+    val relu1 = nn.ReLU[Float](ip = false)
+
+    val model = Sequential()
+      .add(Input(input.size(), Memory.FormatTag.nchw))
+      .add(conv)
+      .add(relu)
+      .add(ReorderMemory(HeapData(Array(2, 4, 6, 6), Memory.FormatTag.nchw)))
+    model.compile(TrainingPhase)
+
+    val model1 = nn.Sequential().add(conv1).add(relu1)
+
+    model.forward(input)
+    model.backward(input, gradOutput)
+
+    model1.forward(input)
+    model1.backward(input, gradOutput)
+
+    val output = Tools.toNCHW(conv.output.toTensor, conv.outputFormats()(0))
+    val gradInput = Tools.toNCHW(conv.gradInput.toTensor, conv.gradInputFormats()(0))
+
+    val weight = conv.weight.dense
+    val gradweight = conv.gradWeight.dense
+    val bias = Tools.dense(conv.bias.native).toTensor
+    val gradbias = Tools.dense(conv.gradBias.native).toTensor
+
+    val output1 = conv1.output.toTensor
+    val gradInput1 = conv1.gradInput
+
+    val weight1 = conv1.weight
+    val gradweight1 = conv1.gradWeight
+    val bias1 = conv1.bias
+    val gradbias1 = conv1.gradBias
+
+    Equivalent.nearequals(weight, weight1) should be(true)
+    Equivalent.nearequals(gradweight, gradweight1) should be(true)
+    Equivalent.nearequals(bias, bias1) should be(true)
+    Equivalent.nearequals(gradbias, gradbias1) should be(true)
+    Equivalent.nearequals(output, output1) should be(true)
+    Equivalent.nearequals(gradInput, gradInput1) should be(true)
+  }
+
+  "ConvolutionDnn with same params with vgg16" should "work correctly" in {
+    val batchSize = 2
+    val needPropagateBack: Boolean = true
+    val inputShape = Array(batchSize, 3, 224, 224)
+    val outputShape = Array(batchSize, 64, 112, 112)
+
+    RNG.setSeed(100)
+    val model1 = nn.SpatialConvolution[Float](3, 64, 7, 7, 2, 2, 3, 3, 1)
+      .setInitMethod(weightInitMethod = Xavier, Zeros)
+    model1.zeroGradParameters()
+    val (weightAll1, gradWeightAll1) = model1.parameters()
+
+    RNG.setSeed(100)
+    val conv = SpatialConvolution(3, 64, 7, 7, 2, 2, 3, 3, 1)
+    val model2 = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(conv)
+      .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw)))
+
+    model2.zeroGradParameters()
+    conv.weight.dense.copy(model1.weight)
+    conv.bias.copy(model1.bias)
+
+    model2.compile(TrainingPhase)
+
+    RNG.setSeed(1)
+    val input = Tensor(batchSize, 3, 224, 224).apply1(e => RNG.uniform(0, 1).toFloat)
+    val gradOutput = Tensor(outputShape).apply1(_ => RNG.uniform(0, 1).toFloat)
+
+    val (weightAll2, gradWeightAll2) = model2.parameters()
+
+    val out1 = model1.forward(input).toTensor[Float]
+    val out2 = model2.forward(input).toTensor[Float]
+
+    var userOut2 = Tools.toNCHW(out2, model2.outputFormats()(0))
+
+    Equivalent.nearequals(out1, userOut2, 1e-4) should be(true)
+
+    val grad1 = model1.updateGradInput(input, gradOutput).toTensor[Float]
+    val grad2 = model2.updateGradInput(input, gradOutput).toTensor[Float]
+
+    val userGradInput2 = Tools.toNCHW(grad2, model2.gradInputFormats()(0))
+
+    Equivalent.nearequals(grad1, userGradInput2, 1e-4) should be(true)
+
+    model1.accGradParameters(input, gradOutput)
+    model2.accGradParameters(input, gradOutput)
+
+    val gw1 = model1.gradWeight
+    val gb1 = model1.gradBias
+
+    val gw2 = conv.gradWeight.dense
+    val gb2 = conv.gradBias.dense
+
+    Equivalent.nearequals(gw1, gw2, 1e-4) should be(true)
+    Equivalent.nearequals(gb1, gb2, 1e-3) should be(true)
+  }
+
+  "a simple convolution compared with caffe" should "work correctly" in {
+    val inputShape = Array(4, 3, 5, 5)
+    val outputShape = Array(4, 2, 3, 3)
+    val name = "conv"
+    val nOutput = 2
+    val kernel = 3
+    val pad = 1
+    val stride = 2
+
+    val txt = prototxt(inputShape, name, nOutput, kernel, pad, stride)
+
+    val conv = new SpatialConvolution(3, nOutput, kernel, kernel, stride, stride, pad, pad, 1)
+    conv.setName(name)
+
+    val seq = Sequential()
+      .add(ReorderMemory(NativeData(inputShape, Memory.FormatTag.nchw)))
+      .add(conv)
+      .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw)))
+    seq.compile(TrainingPhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+
+    // because after upgrading v0.17, the epsilon should be not 1e-7.
+    Tools.compare(txt, seq, inputShape, outputShape, epsilon = 1e-5)
+  }
+
+  "conv exists some format conversion" should "work correctly" in {
+    val inputShape = Array(4, 3, 224, 224)
+    val outputShape = Array(4, 64, 112, 112)
+
+    val name = "conv"
+    val conv = SpatialConvolution(3, 64, 7, 7, 2, 2, 3, 3).setName(name)
+    // TODO we should insert a reorder manually
+    val reorder1 = ReorderMemory(HeapData(inputShape, Memory.FormatTag.nchw))
+    val reorder2 = ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw))
+
+    val seq = Sequential()
+    seq.add(reorder1)
+    seq.add(conv)
+    seq.add(reorder2)
+    seq.compile(Phase.TrainingPhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+    seq.reset()
+
+    val txt = prototxt(inputShape, name, outputShape(1), 7, 3, 2)
+    val identity = Collect.run(txt)
+
+    val input = Tools.getTensor("Fwrd_data", inputShape, identity)
+    val gradOutput = Tools.getTensor(s"Bwrd_$name.loss", outputShape, identity)
+    val output = Tools.getTensor(s"Fwrd_$name", outputShape, identity)
+    val gradInput = Tools.getTensor(s"Bwrd_$name", inputShape, identity)
+
+    if (conv.parameters() != null) {
+      val params = conv.parameters()._1
+      val name = conv.getName()
+
+      for (j <- params.indices) {
+        val w = Tools.getTensor(s"Fwrd_$name.Wght.$j", params(j).size(), identity)
+        params(j).copy(w)
+      }
+    }
+
+    seq.forward(input)
+    seq.backward(input, gradOutput)
+
+    Tools.compare2Tensors(Tools.dense(seq.output).toTensor, output, 1e-5) should be (true)
+    Tools.compare2Tensors(Tools.dense(seq.gradInput).toTensor, gradInput, 1e-5) should be (true)
+
+    val params = seq.parameters()._2
+    for (j <- params.indices) {
+      val w = Tools.getTensor(s"Bwrd_$name.Grad.$j", params(j).size(), identity)
+      Tools.compare2Tensors(params(j), w) should be (true)
+    }
+  }
+
+  "conv kernel 1x1 with reorder in container" should "work correctly" in {
+    val inputShape = Array(4, 64, 56, 56)
+    val outputShape = Array(4, 64, 56, 56)
+
+    val name = "conv"
+    val conv = SpatialConvolution(64, 64, 1, 1, 1, 1, 0, 0).setName(name)
+    // TODO we should insert a reorder manually
+    val reorder1 = ReorderMemory(HeapData(inputShape, Memory.FormatTag.nchw))
+    val reorder2 = ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw))
+
+    val seq = Sequential()
+    seq.add(reorder1)
+    seq.add(conv)
+    seq.add(reorder2)
+    seq.compile(Phase.TrainingPhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+    seq.reset()
+
+    val txt = prototxt(inputShape, name, outputShape(1), 1, 0, 1)
+    val identity = Collect.run(txt)
+
+    val input = Tools.getTensor("Fwrd_data", inputShape, identity)
+    val gradOutput = Tools.getTensor(s"Bwrd_$name.loss", outputShape, identity)
+    val output = Tools.getTensor(s"Fwrd_$name", outputShape, identity)
+    val gradInput = Tools.getTensor(s"Bwrd_$name", inputShape, identity)
+
+    if (conv.parameters() != null) {
+      val params = conv.parameters()._1
+      val name = conv.getName()
+
+      for (j <- params.indices) {
+        val w = Tools.getTensor(s"Fwrd_$name.Wght.$j", params(j).size(), identity)
+        params(j).copy(w)
+      }
+    }
+
+    seq.forward(input)
+    seq.backward(input, gradOutput)
+
+    Tools.compare2Tensors(Tools.dense(seq.output).toTensor, output) should be (true)
+    Tools.compare2Tensors(Tools.dense(seq.gradInput).toTensor, gradInput) should be (true)
+
+    val params = seq.parameters()._2
+    for (j <- params.indices.reverse) {
+      val w = Tools.getTensor(s"Bwrd_$name.Grad.$j", params(j).size(), identity)
+      Tools.compare2Tensors(params(j), w) should be (true)
+    }
+  }
+
+  "conv + bn" should "work correctly" in {
+    val inputShape = Array(4, 3, 224, 224)
+    val outputShape = Array(4, 64, 112, 112)
+    val channel = 64
+
+    val name = "conv"
+    val conv = SpatialConvolution(3, 64, 7, 7, 2, 2, 3, 3).setName("conv")
+    val bn = SpatialBatchNormalization(64, momentum = 1.0, eps = 100).setName("bn")
+    // TODO we should insert a reorder manually
+    val reorder1 = ReorderMemory(HeapData(inputShape, Memory.FormatTag.nchw)).setName("reorder1")
+    val reorder2 = ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw)).setName("reorder2")
+
+    val seq = Sequential()
+    seq.add(reorder1)
+    seq.add(conv)
+    seq.add(bn)
+    seq.add(reorder2)
+    seq.compile(Phase.TrainingPhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+    seq.reset()
+    seq.training()
+
+    val txt = prototxt2(inputShape, name, outputShape(1), 7, 3, 2) +
+              """
+                |layer {
+                |  bottom: "conv"
+                |  top: "bn"
+                |  name: "bn"
+                |  type: "BatchNorm"
+                |
+                |  batch_norm_param {
+                |    moving_average_fraction: 1.0
+                |    filler { value: 1 }
+                |    bias_filler { value: 0 }
+                |    relu: false
+                |    eps: 100
+                |  }
+                |}
+              """.stripMargin
+    Tools.compare(txt, seq, inputShape, outputShape, 1e-2)
+  }
+
+  "conv serialized with java serialization method" should "work correctly" in {
+    val inputShape = Array(4, 3, 5, 5)
+    val outputShape = Array(4, 2, 3, 3)
+    val name = "conv"
+    val nOutput = 2
+    val kernel = 3
+    val pad = 1
+    val stride = 2
+
+    val conv = new SpatialConvolution(3, nOutput, kernel, kernel, stride, stride, pad, pad, 1)
+    conv.setName(name)
+
+    val seq = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(conv)
+      .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw)))
+
+    seq.compile(TrainingPhase)
+
+    val input = Tensor(inputShape).rand(-1, 1)
+    seq.forward(input)
+
+    val cloned = SerializationUtils.clone(seq)
+    cloned.compile(TrainingPhase)
+
+    cloned.forward(input)
+
+    Tools.dense(seq.output) should be (Tools.dense(cloned.output))
+
+    val gradOutput = Tensor(outputShape).rand(-1, 1)
+
+    seq.backward(input, gradOutput)
+    cloned.backward(input, gradOutput)
+
+    Tools.dense(seq.gradInput) should be (Tools.dense(cloned.gradInput))
+    seq.getParameters()._1 should be (cloned.getParameters()._1)
+  }
+
+  "conv release" should "work correctly" in {
+    val inputShape = Array(4, 3, 5, 5)
+    val outputShape = Array(4, 2, 3, 3)
+    val name = "conv"
+    val nOutput = 2
+    val kernel = 3
+    val pad = 1
+    val stride = 2
+
+    val initCount = DnnStorage.get().count(!_._2)
+    val conv = new SpatialConvolution(3, nOutput, kernel, kernel, stride, stride, pad, pad, 1)
+    conv.setName(name)
+
+    val seq = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(conv)
+      .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw)))
+    seq.compile(TrainingPhase)
+
+    val input = Tensor(inputShape).rand(-1, 1)
+    val gradOutput = Tensor(outputShape).rand(-1, 1)
+    seq.forward(input)
+    seq.backward(input, gradOutput)
+
+    seq.release()
+    DnnStorage.get().count(_._2 == false) should be (initCount)
+  }
+
+  "conv with dense weights and gradients" should "work correctly" in {
+    val inputShape = Array(4, 3, 5, 5)
+    val outputShape = Array(4, 2, 3, 3)
+    val nOutput = 2
+    val kernel = 3
+    val pad = 1
+    val stride = 2
+
+    val input = Tensor(inputShape).rand(-1, 1)
+    val gradOutput = Tensor(outputShape).rand(-1, 1)
+
+    val initWeight1 = Tensor(Array(nOutput, inputShape(1), kernel, kernel)).rand(-1, 1)
+    val initWeight2 = Tensor(Array(nOutput, inputShape(1), kernel, kernel)).rand(-1, 1)
+    val initBias1 = Tensor(nOutput).rand(-1, 1)
+    val initBias2 = Tensor(nOutput).rand(-1, 1)
+
+    val conv1 = new SpatialConvolution(3, nOutput, kernel, kernel, stride, stride, pad, pad, 1,
+      initWeight = initWeight1, initBias = initBias1)
+    val seq1 = Sequential()
+        .add(Input(inputShape, Memory.FormatTag.nchw))
+        .add(conv1)
+        .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw)))
+    seq1.compile(TrainingPhase)
+
+    seq1.forward(input)
+    seq1.backward(input, gradOutput)
+
+    conv1.parameters()._1.zip(Array(initWeight2, initBias2)).foreach(x => x._1.copy(x._2))
+    seq1.forward(input)
+    seq1.backward(input, gradOutput)
+
+    val conv2 = new SpatialConvolution(3, nOutput, kernel, kernel, stride, stride, pad, pad, 1,
+      initWeight = initWeight2, initBias = initBias2)
+
+    val seq2 = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(conv2)
+      .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw)))
+    seq2.compile(TrainingPhase)
+
+    seq2.forward(input)
+    seq2.backward(input, gradOutput)
+
+    Tools.dense(conv1.output) should be (Tools.dense(conv2.output))
+    Tools.dense(conv1.gradInput) should be (Tools.dense(conv2.gradInput))
+
+    conv1.parameters()._2.zip(conv2.parameters()._2).foreach(x => x._1 should be (x._2))
+  }
+
+  "lenet conv1" should "work correctly" in {
+    // test the padding tensor
+    val inputShape = Array(4, 1, 28, 28)
+    val outputShape = Array(4, 20, 24, 24)
+    val dnn = SpatialConvolution(1, 20, 5, 5)
+    val blas = com.intel.analytics.bigdl.nn.SpatialConvolution[Float](1, 20, 5, 5)
+
+    val model = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(dnn)
+      .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw)))
+
+    model.compile(TrainingPhase)
+
+    val input = Tensor[Float](4, 1, 28, 28).rand(-1, 1)
+    val gradOutput = Tensor[Float](outputShape).rand(-1, 1)
+
+    model.forward(input)
+    model.updateGradInput(input, gradOutput)
+    model.accGradParameters(input, gradOutput)
+
+    blas.getParameters()._1.copy(dnn.getParameters()._1)
+
+    blas.forward(input)
+    blas.updateGradInput(input, gradOutput)
+    blas.accGradParameters(input, gradOutput)
+
+    Equivalent.nearequals(model.output.toTensor, blas.output) should be (true)
+    Equivalent.nearequals(model.gradInput.toTensor, blas.gradInput) should be (true)
+    Equivalent.nearequals(model.getParameters()._1, blas.getParameters()._1) should be (true)
+    // control the epsilon to 1e-4, not 1e-5
+    Equivalent.nearequals(model.getParameters()._2, blas.getParameters()._2, 1e-4) should be (true)
+  }
+
+  "conv quantization" should "work correctly" in {
+    System.setProperty("bigdl.mkldnn.fusion.convrelu", "true")
+    RNG.setSeed(1)
+    val inputShape = Array(1, 2, 12, 12)
+    val outputShape = Array(1, 8)
+    val model = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(SpatialConvolution(2, 4, 5, 5).setName("conv2"))
+      .add(ReLU()).setName("relu")
+      .add(MaxPooling(2, 2, 2, 2).setName("pool2"))
+      .add(Linear(4 * 4 * 4, 8).setName("ip1"))
+      .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nc)))
+    model.evaluate()
+
+    val input = Tensor[Float](inputShape).rand(-100, 100)
+    model.compile(InferencePhase)
+    println(model.forward(input))
+
+    val output = model.output.toTensor[Float].clone()
+
+    model.setInputDimMask(1, true)
+    model.calcScales(input)
+    model.release()
+
+    val quantized = model.cloneModule().quantize()
+    quantized.asInstanceOf[Sequential].compile(InferencePhase)
+
+    quantized.forward(input)
+    println(quantized.output)
+    System.clearProperty("bigdl.mkldnn.fusion.convrelu")
+
+    Equivalent.nearequals(output, quantized.output.toTensor, 1e-1) should be (true)
+  }
+
+  "unsigned input quantization" should "work correctly" in {
+    RNG.setSeed(1)
+
+    val inputShape = Array(1, 2, 12, 12)
+    val outputShape = Array(1, 4, 8, 8)
+
+    val initBias = Tensor[Float](4).fill(1.0f)
+
+    val model = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(SpatialConvolution(2, 4, 5, 5, initBias = initBias)).setName("conv2")
+      .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw)))
+
+    model.evaluate()
+    val input = Tensor[Float](inputShape).rand(-1, 1)
+    model.compile(InferencePhase)
+    val output = model.forward(input).toTensor.clone()
+    model.calcScales(input)
+
+    val quantized = model.quantize()
+    quantized.asInstanceOf[Sequential].compile(InferencePhase)
+    quantized.forward(input)
+    Equivalent.nearequals(output, quantized.output.toTensor, 1e-1) should be (true)
+  }
+
+  "generate the convolution scales with random" should "work correctly" in {
+    RNG.setSeed(1)
+    val inputShape = Array(1, 1, 2, 2)
+    val outputShape = Array(1, 2, 1, 1)
+
+    val inputData = Array[Float](-100, 12, 14, 67)
+    val input = Tensor[Float](inputShape).rand(-100, 100)
+
+    val initWeight = Tensor[Float](Array(2, 1, 2, 2)).rand(-10, 10)
+    val initBias = Tensor[Float](Array(2)).rand(-1, 1)
+
+    val conv = SpatialConvolution(1, 2, 2, 2)
+
+    val seq = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(conv)
+      .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw)))
+
+    seq.compile(InferencePhase)
+    seq.forward(input)
+
+    val outputFP32Model = seq.forward(input).toTensor.clone()
+
+    seq.calcScales(input)
+
+    val quantizedModel = seq.quantize()
+    quantizedModel.asInstanceOf[Sequential].compile(InferencePhase)
+
+    val outputInt8Model = quantizedModel.forward(input).toTensor.clone()
+
+    println(outputFP32Model)
+    println(outputInt8Model)
+
+    outputFP32Model.storage().array().zip(outputInt8Model.storage().array()).foreach { x =>
+      (Math.abs(x._1 - x._2) / Math.max(Math.abs(x._1), Math.abs(x._2)) <= 1e-1) should be (true)
+    }
+  }
+
+  def prototxt(inputShape: Array[Int], name: String,
+    nOutput: Int, kernel: Int, pad: Int, stride: Int): String = {
+      s"""
+         |name: "conv-simple"
+         |force_backward: true
+         |layer {
+         |  name: "data"
+         |  type: "DummyData"
+         |  top: "data"
+         |  include {
+         |    phase: TRAIN
+         |  }
+         |  dummy_data_param {
+         |    data_filler {
+         |      type: "xavier"
+         |    }
+         |    shape: { ${shape2Dim(inputShape)} }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "data"
+         |  top: "conv"
+         |  name: "$name"
+         |  type: "Convolution"
+         |  convolution_param {
+         |    num_output: $nOutput
+         |    kernel_size: $kernel
+         |    pad: $pad
+         |    stride: $stride
+         |    weight_filler {
+         |      type: "msra"
+         |      variance_norm: FAN_OUT
+         |    }
+         |    bias_filler {
+         |      type: "gaussian"
+         |    }
+         |  }
+         |}
+       """.stripMargin
+  }
+
+  def prototxt2(inputShape: Array[Int], name: String,
+    nOutput: Int, kernel: Int, pad: Int, stride: Int): String = {
+    s"""
+       |name: "conv-simple"
+       |force_backward: true
+       |layer {
+       |  name: "data"
+       |  type: "DummyData"
+       |  top: "data"
+       |  include {
+       |    phase: TRAIN
+       |  }
+       |  dummy_data_param {
+       |    data_filler {
+       |      type: "uniform"
+       |      min: -1000
+       |      max: 1000
+       |    }
+       |    shape: { ${shape2Dim(inputShape)} }
+       |  }
+       |}
+       |
+         |layer {
+       |  bottom: "data"
+       |  top: "conv"
+       |  name: "$name"
+       |  type: "Convolution"
+       |  convolution_param {
+       |    num_output: $nOutput
+       |    kernel_size: $kernel
+       |    pad: $pad
+       |    stride: $stride
+       |    weight_filler {
+       |      type: "msra"
+       |      variance_norm: FAN_OUT
+       |    }
+       |    bias_filler {
+       |      type: "gaussian"
+       |    }
+       |  }
+       |}
+       """.stripMargin
+  }
+
+  def normal(src: Tensor[Float], outputFormat: MemoryData): Tensor[Float] = {
+    val defaultFormat = src.size().length match {
+      case 1 => Memory.FormatTag.x
+      case 2 => Memory.FormatTag.oi
+      case 4 => Memory.FormatTag.oihw
+    }
+
+    if (defaultFormat != outputFormat.layout) {
+      val inputFormat = HeapData(src.size(), defaultFormat)
+      val reorder = ReorderMemory.create(inputFormat, outputFormat, null, null)
+      reorder.setRuntime(new MklDnnRuntime)
+      reorder.initFwdPrimitives(Array(inputFormat), TrainingPhase)
+      reorder.updateOutput(src).toTensor
+    } else {
+      src
+    }
+  }
+
+  private def shape2Dim(shape: Array[Int]): String = {
+    shape.map(x => "dim: " + x).mkString(" ")
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/TestUtils.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/TestUtils.scala
@@ -1,0 +1,520 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import java.io.{File, PrintWriter}
+import java.nio.channels.FileChannel
+import java.nio.file.{Files, Paths, StandardOpenOption}
+import java.nio.{ByteBuffer, ByteOrder}
+
+import breeze.numerics.abs
+import com.intel.analytics.bigdl.Module
+import com.intel.analytics.bigdl.dnnl.Memory
+import com.intel.analytics.bigdl.nn.Container
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.TrainingPhase
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.tensor.{DenseTensorMath, Storage, Tensor}
+
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
+import scala.sys.process._
+
+object Tools {
+  def error[@specialized(Float, Double) T: ClassTag](tensor1: Tensor[T], tensor2: Tensor[T])(
+      implicit ev: TensorNumeric[T]): Double = {
+    require(tensor1.nElement() == tensor2.nElement())
+    var ret = 0.0
+    val storage1 = tensor1.storage().array()
+    val storage2 = tensor2.storage().array()
+    for (i <- 0 until tensor1.nElement()) {
+      ret += math.abs(
+        ev.toType[Double](storage1(i)) - ev.toType[Double](storage2(i)))
+    }
+    ret
+  }
+
+  def cumulativeError[T: ClassTag](tensor1: Tensor[T], tensor2: Tensor[T], msg: String)(
+      implicit ev: TensorNumeric[T]): Double = {
+    val ret = error[T](tensor1, tensor2)
+    println((msg, "CUMULATIVE ERROR:", ret).productIterator.mkString(" ").toUpperCase)
+    ret
+  }
+
+  def averageError[T: ClassTag](tensor1: Tensor[T], tensor2: Tensor[T], msg: String)(
+      implicit ev: TensorNumeric[T]): Double = {
+    require(tensor1.nElement() > 0)
+    val ret = error[T](tensor1, tensor2) / tensor1.nElement()
+    println((msg, "AVERAGE ERROR:", ret).productIterator.mkString(" ").toUpperCase)
+    ret
+  }
+
+  def averageError[T: ClassTag](m1: Map[String, Tensor[T]],
+                                m2: Map[String, Tensor[T]],
+                                err: Map[String, Double])(implicit ev: TensorNumeric[T]): Unit = {
+    require(m1.keySet == m2.keySet)
+    require(m1.keySet subsetOf err.keySet)
+
+    m1.keySet.foreach(i => {
+      val err = error(m1(i), m2(i)) / m1(i).nElement()
+      printf("%20s = %E\n", i.toUpperCase(), err)
+    })
+  }
+
+  def averageAllTensors[T: ClassTag](tensor1: Tensor[T], msg: String = "Unknown")(
+      implicit ev: TensorNumeric[T]): Unit = {
+    val sum = tensor1.storage().array().foldLeft(ev.fromType[Int](0))((l, r) => ev.plus(l, r))
+    val num = ev.fromType[Int](tensor1.nElement())
+    println(("AVERGE", msg, ev.divide(sum, num)).productIterator.mkString(" ").toUpperCase())
+  }
+
+  def printTensor[T: ClassTag](tensor: Tensor[T], num: Int = 16, msg: String = "Unknown")(
+      implicit ev: TensorNumeric[T]): Unit = {
+    println(msg.toUpperCase)
+    for (i <- 0 until num) {
+      println((i, ev.toType[Double](tensor.storage().array()(i))).productIterator.mkString("\t"))
+    }
+  }
+
+  private def fileName(name: String, identity: String): String = {
+    val tmpdir = System.getProperty("java.io.tmpdir")
+    val dirname = if (tmpdir.endsWith("/")) {
+      tmpdir
+    } else {
+      tmpdir + "/"
+    }
+
+    val filename = if (identity.isEmpty) {
+      ".bin"
+    } else {
+      "." + identity + ".bin"
+    }
+
+    dirname + name + filename
+  }
+
+  /*
+   * @brief read binary in tmp dir to Tensor, which is used for comparing
+   *        with Intel Caffe with MKL-DNN
+   */
+  def getTensor(name: String, size: Array[Int], identity: String): Tensor[Float] = {
+    val tensor = Tensor[Float]()
+    val file = fileName(name, identity)
+
+    if (Files.exists(Paths.get(file))) {
+      println(s"[INFO] load $file")
+      setTensorFloat()
+
+      def loadData(name: String): ByteBuffer = {
+        val fileChannel: FileChannel = Files.newByteChannel(
+          Paths.get(name),
+          StandardOpenOption.READ,
+          StandardOpenOption.DELETE_ON_CLOSE).asInstanceOf[FileChannel]
+        val byteBuffer: ByteBuffer = ByteBuffer.allocate(fileChannel.size().toInt)
+        byteBuffer.order(ByteOrder.nativeOrder())
+        fileChannel.read(byteBuffer)
+        byteBuffer.flip()
+        byteBuffer
+      }
+
+
+      def setTensorFloat(): Unit = {
+        val data = loadData(file).asFloatBuffer()
+        val array = new Array[Float](data.limit())
+        data.get(array)
+        assert(size.product == array.length, s"the data length is not correct")
+        tensor.set(Storage(array), sizes = size)
+      }
+    }
+
+    tensor
+  }
+
+  def flattenModules(model: Module[Float], modules: ArrayBuffer[Module[Float]]): Unit = {
+    model match {
+      case container : Container[_, _, _] =>
+        if (container.modules.nonEmpty) {
+          for (i <- container.modules) {
+            flattenModules(i.asInstanceOf[Module[Float]], modules)
+          }
+        }
+      case x => if (!x.isInstanceOf[ReorderMemory] && !x.isInstanceOf[Identity]) {
+        modules += model
+      }
+    }
+  }
+
+  def randTimes(): Int = 10
+
+  def loadWeights(module: Module[Float], identity: String): Unit = {
+    val params = module.parameters()._1
+    val name = module.getName()
+    module match {
+      case bn: SpatialBatchNormalization =>
+        val channel = bn.weightAndBias.size(1) / 2
+
+        val weight = Tools.getTensor(s"Fwrd_${bn.getName}.Wght.3", Array(channel), identity)
+        val bias = Tools.getTensor(s"Fwrd_${bn.getName}.Wght.4", Array(channel), identity)
+        val weightAndBias = Tensor[Float].resize(Array(2, channel))
+        if (weight.isEmpty) {weight.resize(Array(channel)).fill(1)}
+        weightAndBias.select(1, 1).copy(weight)
+        if (bias.isEmpty) {
+          bias.resize(Array(channel)).fill(0)
+        }
+        weightAndBias.select(1, 2).copy(bias)
+        bn.weightAndBias.copy(weightAndBias.view(bn.weightAndBias.size()))
+      case _ =>
+        for (j <- params.indices) {
+          val w = Tools.getTensor(s"Fwrd_$name.Wght.$j", params(j).size(), identity)
+          module match {
+            case layer: MklDnnLayer =>
+              val weights = if (!w.isEmpty) {
+                params(j).copy(w)
+              } else {
+                val zeros = Tensor[Float]().resize(params(j).size()).fill(0)
+                params(j).copy(zeros)
+              }
+            case _ =>
+              params(j).copy(w)
+          }
+        }
+    }
+  }
+
+  def compareGradients(module: Module[Float], epsilon: Float, identity: String): Boolean = {
+    var ret = true
+
+    val name = module.getName()
+    val params = module.parameters()._2
+
+    module match {
+      case bn: SpatialBatchNormalization =>
+        val channel = bn.weightAndBias.size(1) / 2
+
+        val weight = Tools.getTensor(s"Bwrd_${bn.getName}.Grad.3", Array(channel), identity)
+        val bias = Tools.getTensor(s"Bwrd_${bn.getName}.Grad.4", Array(channel), identity)
+        val weightAndBias = Tensor[Float].resize(Array(2, channel))
+        weightAndBias.select(1, 1).copy(weight)
+        weightAndBias.select(1, 2).copy(bias)
+
+        ret &= Equivalent.nearequals(weightAndBias.view(bn.gradWeightAndBias.size()),
+          dense(bn.gradWeightAndBias.native).toTensor, epsilon)
+        val runningMean = Tools.getTensor(s"Fwrd_$name.Wght.0", Array(channel), identity)
+        val runningVariance = Tools.getTensor(s"Fwrd_$name.Wght.1", Array(channel), identity)
+
+        ret &= compare2Tensors(runningMean, dense(bn.runningMean.native).toTensor)
+        ret &= compare2Tensors(runningVariance, dense(bn.runningVariance.native).toTensor)
+
+        assert(ret, s"${module.getName()} gradient can't pass, please check")
+      case _ =>
+        for (j <- params.indices) {
+          val w = Tools.getTensor(s"Bwrd_$name.Grad.$j", params(j).size(), identity)
+          ret &= Equivalent.nearequals(params(j), w, epsilon)
+
+          assert(ret, s"${module.getName()} gradient $j can't pass, please check")
+        }
+    }
+
+    ret
+  }
+
+  def compare(prototxt: String, model: Module[Float], inputShape: Array[Int],
+    outputShape: Array[Int], epsilon: Double = 1e-7): Unit = {
+    val identity = Collect.run(prototxt, singleLayer = true)
+    val modules = ArrayBuffer[Module[Float]]()
+    Tools.flattenModules(model, modules)
+
+    val input = Tools.getTensor("Fwrd_data", inputShape, identity)
+    val gradOutput = Tools.getTensor(s"Bwrd_${modules.last.getName()}.loss", outputShape, identity)
+
+    modules.filter(_.parameters() != null).foreach(loadWeights(_, identity))
+
+    model.forward(input)
+    model.backward(input, gradOutput)
+
+    for (i <- modules.indices) {
+      compareSingleLayer(modules(i), identity)
+    }
+
+    def compareSingleLayer(module: Module[Float], identity: String): Boolean = {
+      val name = module.getName()
+      val bigdlOutput = module.output.toTensor[Float]
+      val bigdlGradInput = if (module.isInstanceOf[CAddTable]) {
+        module.gradInput.toTable.apply[Tensor[Float]](1)
+      } else {
+        module.gradInput.toTensor[Float]
+      }
+
+      val noPaddingOutputShape = if (module.isInstanceOf[MklDnnModule]) {
+        module.asInstanceOf[MklDnnModule].outputFormats()(0).shape
+      } else {
+        bigdlOutput.size()
+      }
+
+      val noPaddingGradInputShape = if (module.isInstanceOf[MklDnnModule]) {
+        module.asInstanceOf[MklDnnModule].gradInputFormats()(0).shape
+      } else {
+        bigdlGradInput.size()
+      }
+
+      val output = Tools.getTensor(s"Fwrd_$name", noPaddingOutputShape, identity)
+      val gradInput = Tools.getTensor(s"Bwrd_$name", noPaddingGradInputShape, identity)
+
+      var ret = true
+
+      module match {
+        case layer: MklDnnLayer =>
+          ret &= compare2Tensors(output, toNCHW(bigdlOutput, layer.outputFormats()(0)))
+          assert(ret, s"${module.getName()} output can't pass, please check")
+
+          ret &= compare2Tensors(gradInput, toNCHW(bigdlGradInput, layer.gradInputFormats()(0)), epsilon)
+          assert(ret, s"${module.getName()} gradInput can't pass, please check")
+        case _ =>
+          ret &= compare2Tensors(output, bigdlOutput)
+          assert(ret, s"${module.getName()} output can't pass, please check")
+
+          ret &= compare2Tensors(gradInput, bigdlGradInput)
+          assert(ret, s"${module.getName()} gradInput can't pass, please check")
+      }
+
+      if (module.parameters() == null) {
+        return ret
+      }
+
+      val params = module.parameters()._2
+      compareGradients(module, epsilon.toFloat, identity)
+
+      ret
+    }
+  }
+
+  def compare2Tensors(src: Tensor[Float], dst: Tensor[Float],
+    epsilon: Double = DenseTensorMath.floatEpsilon): Boolean = {
+    Equivalent.nearequals(dense(src).toTensor, dense(dst).toTensor, epsilon)
+  }
+
+  def dense(t: Activity): Activity = {
+    val ret = if (t.isTensor) {
+      val tt = t.asInstanceOf[Tensor[Float]]
+      Tensor[Float]().resize(tt.size()).copy(tt)
+    } else {
+      throw new UnsupportedOperationException
+    }
+
+    ret
+  }
+
+  def toNCHW(src: Tensor[Float], inputFormat: MemoryData): Tensor[Float] = {
+    val outputFormat = HeapData(inputFormat.shape,
+      if (src.size().length == 2) { Memory.FormatTag.nc } else { Memory.FormatTag.nchw })
+    val reorder = ReorderMemory.create(inputFormat, outputFormat, null, null)
+
+    reorder.setRuntime(new MklDnnRuntime)
+    reorder.initFwdPrimitives(Array(inputFormat), TrainingPhase)
+    reorder.forward(src).toTensor
+  }
+
+  def fromNCHW(src: Tensor[Float], outputFormat: MemoryData): Tensor[Float] = {
+    val defaultFormat = src.size().length match {
+      case 1 => Memory.FormatTag.x
+      case 2 => Memory.FormatTag.nc
+      case 4 => Memory.FormatTag.nchw
+    }
+
+    val inputFormat = HeapData(src.size(), defaultFormat)
+    val reorder = ReorderMemory.create(inputFormat, outputFormat, null, null)
+    reorder.setRuntime(new MklDnnRuntime)
+    reorder.initFwdPrimitives(Array(inputFormat), TrainingPhase)
+    reorder.forward(src).toTensor
+  }
+
+  def fromOIHW(src: Tensor[Float], outputFormat: MemoryData): Tensor[Float] = {
+    val defaultFormat = outputFormat.shape.length match {
+      case 1 => Memory.FormatTag.x
+      case 2 => Memory.FormatTag.oi
+      case 4 => Memory.FormatTag.oihw
+    }
+
+    val inputFormat = HeapData(outputFormat.shape, defaultFormat)
+    val reorder = ReorderMemory.create(inputFormat, outputFormat, null, null)
+    reorder.setRuntime(new MklDnnRuntime)
+    reorder.initFwdPrimitives(Array(inputFormat), TrainingPhase)
+    reorder.updateOutput(src).toTensor
+  }
+
+  def toOIHW(src: Tensor[Float], inputFormat: MemoryData): Tensor[Float] = {
+    val defaultFormat = inputFormat.shape.length match {
+      case 1 => Memory.FormatTag.x
+      case 2 => Memory.FormatTag.oi
+      case 4 => Memory.FormatTag.oihw
+      case 5 => Memory.FormatTag.goihw
+    }
+
+    val outputFormat = HeapData(inputFormat.shape, defaultFormat)
+    val reorder = ReorderMemory.create(inputFormat, outputFormat, null, null)
+    reorder.setRuntime(new MklDnnRuntime)
+    reorder.initFwdPrimitives(Array(inputFormat), TrainingPhase)
+    reorder.updateOutput(src).toTensor
+  }
+}
+
+/**
+ * Call "collect" command, which is a method to collect output binary files.
+ * It's similar to "caffe collect", the difference is that it supports collect
+ * single layers output and gradient through make a fake gradOutput/top_diff.
+ */
+object Collect {
+  val tmpdir: String = System.getProperty("java.io.tmpdir")
+  val collectPath: String = System.getProperty("collect.location")
+
+  def hasCollect: Boolean = {
+    val exitValue = if (collectPath != null) s"ls $collectPath".! else "which collect".!
+    exitValue == 0
+  }
+
+  /**
+   * save the prototxt to a temporary file and call collect
+   * @param prototxt prototxt with string
+   * @return the middle random number in temporary file, which is an identity for getTensor.
+   */
+  def run(prototxt: String, singleLayer: Boolean = true): String = {
+    def saveToFile(prototxt: String, name: String): String = {
+      val tmpFile = java.io.File.createTempFile(name, ".prototxt")
+      val absolutePath = tmpFile.getAbsolutePath
+
+      println(s"prototxt is saved to $absolutePath")
+
+      val writer = new PrintWriter(tmpFile)
+      writer.println(prototxt)
+      writer.close()
+
+      absolutePath
+    }
+
+    if (! hasCollect) {
+      throw new RuntimeException(s"Can't find collect command. Have you copy to the PATH?")
+    }
+
+    val file = saveToFile(prototxt, "UnitTest.") // UnitTest ends with dot for getting random number
+    val identity = file.split("""\.""").reverse(1) // get the random number
+
+    val cmd = Seq(s"$collectPath", "--model", file, "--type", "float", "--identity", identity)
+    val exitValue = if (singleLayer) {
+      Process(cmd :+ "--single", new File(tmpdir)).!
+    } else {
+      Process(cmd, new File(tmpdir)).!
+    }
+
+    Files.deleteIfExists(Paths.get(file))
+    require(exitValue == 0, s"Something wrong with collect command. Please check it.")
+
+    identity
+  }
+}
+
+object TestUtils {
+  def time[R](block: => R): (Double, R) = {
+    val t0 = System.nanoTime()
+    val result = block
+    val t1 = System.nanoTime()
+    val takes = (t1 - t0) / 1e9
+    (takes, result)
+  }
+
+  def manyTimes[R](block: => R)(iters: Int): (Double, R) = {
+    time[R] {
+      var i = 0
+      while (i < iters - 1) {
+        block
+        i += 1
+      }
+      block
+    }
+  }
+
+  def speedup(base: Double, after: Double): String = {
+    val result = (base - after) / base
+    ((result * 1000).toInt / 10.0).toString + "%"
+  }
+}
+
+object Equivalent {
+
+  def nearlyEqual(a: Float, b: Float, epsilon: Double): Boolean = {
+    val absA = math.abs(a)
+    val absB = math.abs(b)
+    val diff = math.abs(a - b)
+
+    val result = if (a == b) {
+      true
+    } else {
+      math.min(diff / (absA + absB), diff) < epsilon
+    }
+
+    result
+  }
+
+  def nearequals(t1: Tensor[Float], t2: Tensor[Float],
+    epsilon: Double = DenseTensorMath.floatEpsilon): Boolean = {
+    var result = true
+    t1.map(t2, (a, b) => {
+      if (result) {
+        result = nearlyEqual(a, b, epsilon)
+        if (!result) {
+          val diff = math.abs(a - b)
+          println("epsilon " + a + "***" + b + "***" + diff / (abs(a) + abs(b)) + "***" + diff)
+        }
+      }
+      a
+    })
+    result
+  }
+
+  def getunequals(t1: Tensor[Float], t2: Tensor[Float],
+    epsilon: Double = DenseTensorMath.floatEpsilon): Boolean = {
+    var result = true
+    var num = 0
+    t1.map(t2, (a, b) => {
+      if (true) {
+        result = nearlyEqual(a, b, epsilon)
+        if (!result) {
+          num += 1
+          val diff = math.abs(a - b)
+          println("epsilon " + a + "***" + b + "***" + diff / (abs(a) + abs(b)) + "***" + diff)
+        }
+      }
+      a
+    })
+    println("diff num " + num)
+    return true
+  }
+
+  def isEquals(t1: Tensor[Float], t2: Tensor[Float]): Boolean = {
+    var result = true
+    t1.map(t2, (a, b) => {
+      if (result) {
+        result = if (a == b) true else false
+        if (!result) {
+          val diff = Math.abs(a - b)
+          println("epsilon " + a + "***" + b + "***" + diff / (abs(a) + abs(b)) + "***" + diff)
+        }
+      }
+      a
+    })
+    return result
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/TopologySpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/nn/dnnl/TopologySpec.scala
@@ -1,0 +1,1211 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.nn.mkldnn
+
+import com.intel.analytics.bigdl.Module
+import com.intel.analytics.bigdl.dnnl.Memory
+import com.intel.analytics.bigdl.nn
+import com.intel.analytics.bigdl.nn.Graph.ModuleNode
+import com.intel.analytics.bigdl.nn.{Module, Zeros}
+import com.intel.analytics.bigdl.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
+import com.intel.analytics.bigdl.nn.mkldnn.ResNet.DatasetType.ImageNet
+import com.intel.analytics.bigdl.numeric.NumericFloat
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.{RandomGenerator, T}
+import org.scalatest.{FlatSpec, Matchers}
+
+class TopologySpec extends FlatSpec with Matchers {
+
+  "LeNet5 has no tanh" should "work correctly" in {
+    val inputShape = Array(4, 1, 28, 28)
+    val outputShape = Array(4, 10)
+    val prototxt = s"""
+         |name: "LeNet"
+         |force_backward: true
+         |layer {
+         |  name: "data"
+         |  type: "DummyData"
+         |  top: "data"
+         |  dummy_data_param {
+         |    data_filler {
+         |      type: "xavier"
+         |    }
+         |    shape: { ${shape2Dim(inputShape)} }
+         |  }
+         |}
+         |layer {
+         |  name: "conv1"
+         |  type: "Convolution"
+         |  bottom: "data"
+         |  top: "conv1"
+         |  param {
+         |    lr_mult: 1
+         |  }
+         |  param {
+         |    lr_mult: 2
+         |  }
+         |  convolution_param {
+         |    num_output: 20
+         |    kernel_size: 5
+         |    stride: 1
+         |    weight_filler {
+         |      type: "msra"
+         |      variance_norm: FAN_OUT
+         |    }
+         |    bias_filler {
+         |      type: "constant"
+         |      value: 0
+         |    }
+         |  }
+         |}
+         |layer {
+         |  name: "pool1"
+         |  type: "Pooling"
+         |  bottom: "conv1"
+         |  top: "pool1"
+         |  pooling_param {
+         |    pool: MAX
+         |    kernel_size: 2
+         |    stride: 2
+         |  }
+         |}
+         |layer {
+         |  name: "conv2"
+         |  type: "Convolution"
+         |  bottom: "pool1"
+         |  top: "conv2"
+         |  param {
+         |    lr_mult: 1
+         |  }
+         |  param {
+         |    lr_mult: 2
+         |  }
+         |  convolution_param {
+         |    num_output: 50
+         |    kernel_size: 5
+         |    stride: 1
+         |    weight_filler {
+         |      type: "xavier"
+         |    }
+         |    bias_filler {
+         |      type: "constant"
+         |    }
+         |  }
+         |}
+         |layer {
+         |  name: "pool2"
+         |  type: "Pooling"
+         |  bottom: "conv2"
+         |  top: "pool2"
+         |  pooling_param {
+         |    pool: MAX
+         |    kernel_size: 2
+         |    stride: 2
+         |  }
+         |}
+         |layer {
+         |  name: "ip1"
+         |  type: "InnerProduct"
+         |  bottom: "pool2"
+         |  top: "ip1"
+         |  param {
+         |    lr_mult: 1
+         |  }
+         |  param {
+         |    lr_mult: 2
+         |  }
+         |  inner_product_param {
+         |    num_output: 500
+         |    weight_filler {
+         |      type: "xavier"
+         |    }
+         |    bias_filler {
+         |      type: "constant"
+         |    }
+         |  }
+         |}
+         |layer {
+         |  name: "relu1"
+         |  type: "ReLU"
+         |  bottom: "ip1"
+         |  top: "ip1"
+         |}
+         |layer {
+         |  name: "ip2"
+         |  type: "InnerProduct"
+         |  bottom: "ip1"
+         |  top: "ip2"
+         |  param {
+         |    lr_mult: 1
+         |  }
+         |  param {
+         |    lr_mult: 2
+         |  }
+         |  inner_product_param {
+         |    num_output: 10
+         |    weight_filler {
+         |      type: "xavier"
+         |    }
+         |    bias_filler {
+         |      type: "constant"
+         |    }
+         |  }
+         |}
+       """.stripMargin
+//    |layer {
+//      |  name: "prob"
+//      |  type: "Softmax"
+//      |  bottom: "ip2"
+//      |  top: "prob"
+//      |}
+//    |
+
+    val bigdl = Sequential()
+      .add(SpatialConvolution(1, 20, 5, 5).setName("conv1"))
+      .add(MaxPooling(2, 2, 2, 2).setName("pool1"))
+      .add(SpatialConvolution(20, 50, 5, 5).setName("conv2"))
+      .add(MaxPooling(2, 2, 2, 2).setName("pool2"))
+      .add(Linear(50 * 4 * 4, 500).setName("ip1"))
+      .add(ReLU().setName("relu1"))
+      .add(Linear(500, 10).setName("ip2"))
+      .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nc)))
+//      .add(SoftMax().setName("prob")) // TODO SoftMax is totally different with Caffe.
+    bigdl.compile(TrainingPhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+
+    Tools.compare(prototxt, bigdl, inputShape, outputShape, 1e-6)
+  }
+
+  "eltwise" should "work correctly" in {
+    val nInput = 3
+    val nOutput = 2
+    val inputShape = Array(4, 3, 5, 5)
+    val outputShape = Array(4, 2, 3, 3)
+
+    val kernel = 3
+    val pad = 1
+    val stride = 2
+
+    val prototxt =
+      s"""
+          | name: "eltwise-simple"
+          |force_backward: true
+          |layer {
+          |  name: "data"
+          |  type: "DummyData"
+          |  top: "data"
+          |  include {
+          |    phase: TRAIN
+          |  }
+          |  dummy_data_param {
+          |    data_filler {
+          |      type: "xavier"
+          |    }
+          |    shape: { dim: 4 dim: 3 dim: 5 dim: 5 }
+          |  }
+          |}
+          |layer {
+          |  bottom: "data"
+          |  top: "conv1"
+          |  name: "conv1"
+          |  type: "Convolution"
+          |  convolution_param {
+          |    num_output: 2
+          |    kernel_size: 3
+          |    pad: 1
+          |    stride: 2
+          |    weight_filler {
+          |      # type: "msra"
+          |      # variance_norm: FAN_OUT
+          |      type: "constant"
+          |      value: 0.1
+          |    }
+          |    bias_filler {
+          |      # type: "gaussian"
+          |      type: "constant"
+          |      value: 0.1
+          |    }
+          |  }
+          |}
+          |layer {
+          |  bottom: "data"
+          |  top: "conv2"
+          |  name: "conv2"
+          |  type: "Convolution"
+          |  convolution_param {
+          |    num_output: 2
+          |    kernel_size: 3
+          |    pad: 1
+          |    stride: 2
+          |    weight_filler {
+          |      # type: "msra"
+          |      # variance_norm: FAN_OUT
+          |      type: "constant"
+          |      value: 0.1
+          |    }
+          |    bias_filler {
+          |      # type: "gaussian"
+          |      type: "constant"
+          |      value: 0.1
+          |    }
+          |  }
+          |}
+          |layer {
+          |  bottom: "conv1"
+          |  bottom: "conv2"
+          |  top: "eltwise"
+          |  name: "eltwise"
+          |  type: "Eltwise"
+          |  eltwise_param {
+          |  }
+          |}
+          |
+       """.stripMargin
+
+    val conv1 = SpatialConvolution(nInput, nOutput, kernel, kernel, stride, stride, pad, pad, 1)
+      .setName("conv1")
+    val conv2 = SpatialConvolution(nInput, nOutput, kernel, kernel, stride, stride, pad, pad, 1)
+      .setName("conv2")
+    val model = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(ConcatTable().add(conv2).add(conv1))
+      .add(CAddTable().setName("eltwise"))
+      .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw)))
+
+    model.compile(TrainingPhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+
+    Tools.compare(prototxt, model, inputShape, outputShape)
+  }
+
+  "resnet 50" should "work correctly" in {
+    val prototxt =
+      s"""
+         |name: "ResNet-50"
+         |force_backward: true
+         |layer {
+         |  name: "data"
+         |  type: "DummyData"
+         |  top: "data"
+         |  top: "label"
+         |  include {
+         |    phase: TRAIN
+         |  }
+         |  dummy_data_param {
+         |    data_filler {
+         |      type: "constant"
+         |      value: 0.01
+         |    }
+         |    shape: { dim: 4 dim: 3 dim: 224 dim: 224 }
+         |    shape: { dim: 4 dim: 1 dim: 1 dim: 1  }
+         |  }
+         |}
+         |
+         |layer {
+         |  name: "data"
+         |  type: "DummyData"
+         |  top: "data"
+         |  top: "label"
+         |  include {
+         |    phase: TEST
+         |  }
+         |  dummy_data_param {
+         |    data_filler {
+         |      type: "constant"
+         |      value: 0.01
+         |    }
+         |    shape: { dim: 32 dim: 3 dim: 224 dim: 224 }
+         |    shape: { dim: 32 dim: 1 dim: 1   dim: 1   }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "data"
+         |  top: "conv1"
+         |  name: "conv1"
+         |  type: "Convolution"
+         |  convolution_param {
+         |    num_output: 64
+         |    kernel_size: 7
+         |    pad: 3
+         |    stride: 2
+         |    weight_filler {
+         |      type: "msra"
+         |      variance_norm: FAN_OUT
+         |    }
+         |    bias_filler {
+         |      type: "constant"
+         |      value: 0
+         |    }
+         |  }
+         |}
+         |
+         |# layer {
+         |#   bottom: "conv1"
+         |#   top: "conv1"
+         |#   name: "bn_conv1"
+         |#   type: "BatchNorm"
+         |#   param { lr_mult: 0 }
+         |#   param { lr_mult: 0 }
+         |#   param { lr_mult: 0 }
+         |#   batch_norm_param {
+         |#     moving_average_fraction: 0.9
+         |#     filler { value: 1 }
+         |#   }
+         |# }
+         |
+         |layer {
+         |  bottom: "conv1"
+         |  top: "conv1"
+         |  name: "scale_conv1"
+         |  type: "Scale"
+         |  param { decay_mult: 0 }
+         |  param { decay_mult: 0 }
+         |  scale_param {
+         |    bias_term: true
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "conv1"
+         |  top: "conv1"
+         |  name: "conv1_relu"
+         |  type: "ReLU"
+         |  relu_param {
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "conv1"
+         |  top: "pool1"
+         |  name: "pool1"
+         |  type: "Pooling"
+         |  pooling_param {
+         |    kernel_size: 3
+         |    stride: 2
+         |    pool: MAX
+         |  }
+         |}
+       """.stripMargin
+    val inputShape = Array(4, 3, 224, 224)
+    val outputShape = Array(4, 64, 56, 56)
+
+    val model = Sequential()
+      .add(Input(inputShape, Memory.FormatTag.nchw))
+      .add(SpatialConvolution(3, 64, 7, 7, 2, 2, 3, 3, propagateBack = true).setName("conv1"))
+      .add(ReLU().setName("conv1_relu"))
+      .add(MaxPooling(3, 3, 2, 2).setName("pool1"))
+      .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw)))
+    model.compile(TrainingPhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+
+    Tools.compare(prototxt, model, inputShape, outputShape)
+  }
+
+  "bottleneck" should "work correctly" in {
+    val prototxt =
+      s"""
+         |name: "ResNet-50"
+         |force_backward: true
+         |layer {
+         |  name: "data"
+         |  type: "DummyData"
+         |  top: "data"
+         |  top: "label"
+         |  include {
+         |    phase: TRAIN
+         |  }
+         |  dummy_data_param {
+         |    data_filler {
+         |      type: "constant"
+         |      value: 0.01
+         |    }
+         |    shape: { dim: 4 dim: 3 dim: 224 dim: 224 }
+         |    shape: { dim: 4 dim: 1 dim: 1 dim: 1  }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "data"
+         |  top: "conv1"
+         |  name: "conv1"
+         |  type: "Convolution"
+         |  convolution_param {
+         |    num_output: 64
+         |    kernel_size: 7
+         |    pad: 3
+         |    stride: 2
+         |    weight_filler {
+         |      type: "msra"
+         |      variance_norm: FAN_OUT
+         |    }
+         |    bias_filler {
+         |      type: "constant"
+         |      value: 0
+         |    }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "conv1"
+         |  top: "conv1_relu" # delete inplace
+         |  name: "conv1_relu"
+         |  type: "ReLU"
+         |  relu_param {
+         |    fuse: false
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "conv1_relu"
+         |  top: "pool1"
+         |  name: "pool1"
+         |  type: "Pooling"
+         |  pooling_param {
+         |    kernel_size: 3
+         |    stride: 2
+         |    pool: MAX
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "pool1"
+         |  top: "res2a_branch1"
+         |  name: "res2a_branch1"
+         |  type: "Convolution"
+         |  convolution_param {
+         |    num_output: 256
+         |    kernel_size: 1
+         |    pad: 0
+         |    stride: 1
+         |    bias_term: true # change to true
+         |    weight_filler {
+         |      type: "msra"
+         |    }
+         |    bias_filler {
+         |      type: "constant"
+         |      value: 0
+         |    }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2a_branch1"
+         |  top: "res2a_branch1"
+         |  name: "scale2a_branch1"
+         |  type: "Scale"
+         |  param { decay_mult: 0 }
+         |  param { decay_mult: 0 }
+         |  scale_param {
+         |    bias_term: true
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "pool1"
+         |  top: "res2a_branch2a"
+         |  name: "res2a_branch2a"
+         |  type: "Convolution"
+         |  convolution_param {
+         |
+         |    num_output: 64
+         |    kernel_size: 1
+         |    pad: 0
+         |    stride: 1
+         |    bias_term: true # change to true.
+         |    weight_filler {
+         |      type: "msra"
+         |    }
+         |    bias_filler {
+         |      type: "constant"
+         |      value: 0
+         |    }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2a_branch2a"
+         |  top: "res2a_branch2a"
+         |  name: "scale2a_branch2a"
+         |  type: "Scale"
+         |  param { decay_mult: 0 }
+         |  param { decay_mult: 0 }
+         |  scale_param {
+         |    bias_term: true
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2a_branch2a"
+         |  top: "res2a_branch2a"
+         |  name: "res2a_branch2a_relu"
+         |  type: "ReLU"
+         |  relu_param {
+         |
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2a_branch2a"
+         |  top: "res2a_branch2b"
+         |  name: "res2a_branch2b"
+         |  type: "Convolution"
+         |  convolution_param {
+         |    num_output: 64
+         |    kernel_size: 3
+         |    pad: 1
+         |    stride: 1
+         |    bias_term: true # change to true
+         |    weight_filler {
+         |      type: "msra"
+         |    }
+         |    bias_filler {
+         |      type: "constant"
+         |      value: 0
+         |    }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2a_branch2b"
+         |  top: "res2a_branch2b"
+         |  name: "scale2a_branch2b"
+         |  type: "Scale"
+         |  param { decay_mult: 0 }
+         |  param { decay_mult: 0 }
+         |  scale_param {
+         |    bias_term: true
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2a_branch2b"
+         |  top: "res2a_branch2b"
+         |  name: "res2a_branch2b_relu"
+         |  type: "ReLU"
+         |  relu_param {
+         |
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2a_branch2b"
+         |  top: "res2a_branch2c"
+         |  name: "res2a_branch2c"
+         |  type: "Convolution"
+         |  convolution_param {
+         |    num_output: 256
+         |    kernel_size: 1
+         |    pad: 0
+         |    stride: 1
+         |    bias_term: true # change to true
+         |    weight_filler {
+         |      type: "msra"
+         |    }
+         |    bias_filler {
+         |      type: "constant"
+         |      value: 0
+         |    }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2a_branch2c"
+         |  top: "res2a_branch2c"
+         |  name: "scale2a_branch2c"
+         |  type: "Scale"
+         |  param { decay_mult: 0 }
+         |  param { decay_mult: 0 }
+         |  scale_param {
+         |    bias_term: true
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2a_branch1"
+         |  bottom: "res2a_branch2c"
+         |  top: "res2a"
+         |  name: "res2a"
+         |  type: "Eltwise"
+         |  eltwise_param {
+         |
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2a"
+         |  top: "res2a"
+         |  name: "res2a_relu"
+         |  type: "ReLU"
+         |  relu_param {
+         |
+         |  }
+         |}
+         |layer {
+         |  bottom: "res2a"
+         |  top: "res2b_branch2a"
+         |  name: "res2b_branch2a"
+         |  type: "Convolution"
+         |  convolution_param {
+         |    num_output: 64
+         |    kernel_size: 1
+         |    pad: 0
+         |    stride: 1
+         |    bias_term: true # change to true
+         |    weight_filler {
+         |      type: "msra"
+         |    }
+         |    bias_filler {
+         |      type: "constant"
+         |      value: 0
+         |    }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2b_branch2a"
+         |  top: "res2b_branch2a"
+         |  name: "scale2b_branch2a"
+         |  type: "Scale"
+         |  param { decay_mult: 0 }
+         |  param { decay_mult: 0 }
+         |  scale_param {
+         |    bias_term: true
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2b_branch2a"
+         |  top: "res2b_branch2a"
+         |  name: "res2b_branch2a_relu"
+         |  type: "ReLU"
+         |  relu_param {
+         |
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2b_branch2a"
+         |  top: "res2b_branch2b"
+         |  name: "res2b_branch2b"
+         |  type: "Convolution"
+         |  convolution_param {
+         |    num_output: 64
+         |    kernel_size: 3
+         |    pad: 1
+         |    stride: 1
+         |    bias_term: true # change to true
+         |    weight_filler {
+         |      type: "msra"
+         |    }
+         |    bias_filler {
+         |      type: "constant"
+         |      value: 0
+         |    }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2b_branch2b"
+         |  top: "res2b_branch2b"
+         |  name: "scale2b_branch2b"
+         |  type: "Scale"
+         |  param { decay_mult: 0 }
+         |  param { decay_mult: 0 }
+         |  scale_param {
+         |    bias_term: true
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2b_branch2b"
+         |  top: "res2b_branch2b"
+         |  name: "res2b_branch2b_relu"
+         |  type: "ReLU"
+         |  relu_param {
+         |
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2b_branch2b"
+         |  top: "res2b_branch2c"
+         |  name: "res2b_branch2c"
+         |  type: "Convolution"
+         |  convolution_param {
+         |    num_output: 256
+         |    kernel_size: 1
+         |    pad: 0
+         |    stride: 1
+         |    bias_term: true # change to true
+         |    weight_filler {
+         |      type: "msra"
+         |    }
+         |    bias_filler {
+         |      type: "constant"
+         |      value: 0
+         |    }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2b_branch2c"
+         |  top: "res2b_branch2c"
+         |  name: "scale2b_branch2c"
+         |  type: "Scale"
+         |  param { decay_mult: 0 }
+         |  param { decay_mult: 0 }
+         |  scale_param {
+         |    bias_term: true
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2a"
+         |  bottom: "res2b_branch2c"
+         |  top: "res2b"
+         |  name: "res2b"
+         |  type: "Eltwise"
+         |  eltwise_param {
+         |
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2b"
+         |  top: "res2b"
+         |  name: "res2b_relu"
+         |  type: "ReLU"
+         |  relu_param {
+         |
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2b"
+         |  top: "res2c_branch2a"
+         |  name: "res2c_branch2a"
+         |  type: "Convolution"
+         |  convolution_param {
+         |
+         |    num_output: 64
+         |    kernel_size: 1
+         |    pad: 0
+         |    stride: 1
+         |    bias_term: true # change to true
+         |    weight_filler {
+         |      type: "msra"
+         |    }
+         |    bias_filler {
+         |      type: "constant"
+         |      value: 0
+         |    }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2c_branch2a"
+         |  top: "res2c_branch2a"
+         |  name: "scale2c_branch2a"
+         |  type: "Scale"
+         |  param { decay_mult: 0 }
+         |  param { decay_mult: 0 }
+         |  scale_param {
+         |    bias_term: true
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2c_branch2a"
+         |  top: "res2c_branch2a"
+         |  name: "res2c_branch2a_relu"
+         |  type: "ReLU"
+         |  relu_param {
+         |
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2c_branch2a"
+         |  top: "res2c_branch2b"
+         |  name: "res2c_branch2b"
+         |  type: "Convolution"
+         |  convolution_param {
+         |    num_output: 64
+         |    kernel_size: 3
+         |    pad: 1
+         |    stride: 1
+         |    bias_term: true # change to true
+         |    weight_filler {
+         |      type: "msra"
+         |    }
+         |    bias_filler {
+         |      type: "constant"
+         |      value: 0
+         |    }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2c_branch2b"
+         |  top: "res2c_branch2b"
+         |  name: "scale2c_branch2b"
+         |  type: "Scale"
+         |  param { decay_mult: 0 }
+         |  param { decay_mult: 0 }
+         |  scale_param {
+         |    bias_term: true
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2c_branch2b"
+         |  top: "res2c_branch2b"
+         |  name: "res2c_branch2b_relu"
+         |  type: "ReLU"
+         |  relu_param {
+         |
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2c_branch2b"
+         |  top: "res2c_branch2c"
+         |  name: "res2c_branch2c"
+         |  type: "Convolution"
+         |  convolution_param {
+         |
+         |    num_output: 256
+         |    kernel_size: 1
+         |    pad: 0
+         |    stride: 1
+         |    bias_term: true # change to true
+         |    weight_filler {
+         |      type: "msra"
+         |    }
+         |    bias_filler {
+         |      type: "constant"
+         |      value: 0
+         |    }
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2c_branch2c"
+         |  top: "res2c_branch2c"
+         |  name: "scale2c_branch2c"
+         |  type: "Scale"
+         |  param { decay_mult: 0 }
+         |  param { decay_mult: 0 }
+         |  scale_param {
+         |    bias_term: true
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2b"
+         |  bottom: "res2c_branch2c"
+         |  top: "res2c"
+         |  name: "res2c"
+         |  type: "Eltwise"
+         |  eltwise_param {
+         |
+         |  }
+         |}
+         |
+         |layer {
+         |  bottom: "res2c"
+         |  top: "res2c_" # do not do inplace
+         |  name: "res2c_relu"
+         |  type: "ReLU"
+         |  relu_param {
+         |
+         |  }
+         |}
+       """.stripMargin
+    val inputShape = Array(4, 3, 224, 224)
+    val outputShape = Array(4, 256, 56, 56)
+
+    val model = ResNet50.getModel(inputShape, outputShape)
+    model.compile(TrainingPhase, Array(HeapData(inputShape, Memory.FormatTag.nchw)))
+
+    Tools.compare(prototxt, model, inputShape, outputShape, 1e-5)
+  }
+
+  "resnet50 bottleneck quantize" should "work correctly" in {
+    System.setProperty("bigdl.mkldnn.fusion.convsum", "true")
+    System.setProperty("bigdl.mkldnn.fusion.convbn", "true")
+    System.setProperty("bigdl.mkldnn.fusion.bnrelu", "true")
+    System.setProperty("bigdl.mkldnn.fusion.convrelu", "true")
+    RandomGenerator.RNG.setSeed(1)
+    val inputShape = Array(4, 3, 224, 224)
+    val outputShape = Array(4, 256, 56, 56)
+    val model = ResNet50.getModel(inputShape, outputShape)
+
+    model.evaluate()
+    model.compile(InferencePhase)
+
+    val input = Tensor[Float](inputShape).rand(-1, 1)
+    model.forward(input)
+    model.asInstanceOf[Sequential].setWeightDimMask(1, true)
+    model.asInstanceOf[Sequential].calcScales(input)
+
+    val output = model.output.toTensor[Float].clone()
+
+    val quant = model.quantize()
+    println(quant)
+    quant.evaluate()
+    quant.asInstanceOf[Sequential].compile(InferencePhase)
+    println(quant)
+    System.clearProperty("bigdl.mkldnn.fusion.convbn")
+    System.clearProperty("bigdl.mkldnn.fusion.bnrelu")
+    System.clearProperty("bigdl.mkldnn.fusion.convrelu")
+    System.clearProperty("bigdl.mkldnn.fusion.convsum")
+    quant.forward(input)
+
+    // we just compare the first three. because i can't static
+    quant.output.toTensor.storage().array().slice(0, 3) should be (
+      Array(0.23977348f, 0.3023231f, 0.19286129f))
+    output.storage().array().slice(0, 3) should be (
+      Array(0.24132696f, 0.29746482f, 0.19848186f))
+    println()
+  }
+
+  "resnet-50 block graph" should "work correctly" in {
+    System.setProperty("bigdl.mkldnn.fusion", "false")
+    RandomGenerator.RNG.setSeed(1)
+    val inputShape = Array(4, 3, 224, 224)
+    val outputShape = Array(4, 256, 56, 56)
+    val model = ResNet50.graph(inputShape, outputShape)
+
+    model.evaluate()
+    model.compile(InferencePhase)
+
+    val input = Tensor[Float](inputShape).rand(-1, 1)
+    model.forward(input)
+    val output = model.output.toTensor[Float].clone()
+
+    model.setWeightDimMask(1, true)
+    model.calcScales(input)
+    model.release()
+
+    val quant = model.cloneModule().setQuantize(true)
+    System.setProperty("bigdl.mkldnn.fusion", "true")
+    val fusion = model.cloneModule()
+    fusion.asInstanceOf[DnnGraph].compile(InferencePhase)
+    quant.asInstanceOf[DnnGraph].compile(InferencePhase)
+    fusion.forward(input)
+    quant.forward(input)
+
+    fusion.output.toTensor.storage().array().slice(0, 3) should be (
+      Array(0.40521193f, 0.25312302f, 0.3346515f))
+    quant.output.toTensor.storage().array.slice(0, 3) should be (
+      Array(0.39347494f, 0.25039315f, 0.30404884f))
+    System.clearProperty("bigdl.mkldnn.fusion")
+  }
+
+  "resnet50 model" should "work correctly" in {
+    def setRuningMeanAndVariance(model: DnnGraph): Unit = {
+      model.getForwardExecutions()
+        .filter(_.element.isInstanceOf[SpatialBatchNormalization])
+        .map(_.element.asInstanceOf[SpatialBatchNormalization])
+        .foreach(bn => {
+          bn.runningMean.dense.rand()
+          bn.runningVariance.dense.rand()
+        })
+    }
+
+    RandomGenerator.RNG.setSeed(1)
+    val model = ResNet.graph(4, 1000, T("depth" -> 50, "dataSet" -> ImageNet))
+    setRuningMeanAndVariance(model)
+    val inputShape = Array(4, 3, 224, 224)
+    val input = Tensor[Float](inputShape).rand(-1, 1)
+
+    model.evaluate()
+    model.compile(InferencePhase)
+
+    model.forward(input)
+    model.setWeightDimMask(1, true)
+    model.calcScales(input)
+    val output = model.output.toTensor[Float].clone()
+    model.release()
+
+    val quant = model.cloneModule().setQuantize(true)
+
+    System.setProperty("bigdl.mkldnn.fusion", "true")
+    val fusion = model.cloneModule()
+    fusion.asInstanceOf[DnnGraph].compile(InferencePhase)
+    quant.asInstanceOf[DnnGraph].compile(InferencePhase)
+    fusion.forward(input)
+    quant.forward(input)
+
+    val tmp = fusion.output.toTensor.max(1)
+
+    val softmax = SoftMax()
+
+    softmax.forward(fusion.output).toTensor.max(2) should be (
+      softmax.forward(quant.output).toTensor.max(2))
+
+    System.clearProperty("bigdl.mkldnn.fusion")
+  }
+
+  object ResNet50 {
+    var iChannels = 64
+
+    def shortcut(nInputPlane: Int, nOutputPlane: Int, stride: Int, name: String): Module[Float] = {
+      val useConv = nInputPlane != nOutputPlane
+
+      if (useConv) {
+        Sequential()
+          .add(SpatialConvolution(nInputPlane, nOutputPlane, 1, 1, stride, stride)
+            .setName(s"res${name}_branch1"))
+      } else if (nInputPlane != nOutputPlane) {
+        throw new IllegalArgumentException(s"useConv false")
+      } else {
+        Identity()
+      }
+    }
+
+    def bottleneck(n: Int, stride: Int, name: String = ""): Module[Float] = {
+      val nInputPlane = iChannels
+      iChannels = n * 4
+
+      val s = Sequential()
+      s.add(SpatialConvolution(nInputPlane, n, 1, 1, 1, 1, 0, 0).setName(s"res${name}_branch2a"))
+        .add(ReLU().setName(s"res${name}_branch2a_relu"))
+        .add(SpatialConvolution(n, n, 3, 3, stride, stride, 1, 1).setName(s"res${name}_branch2b"))
+        .add(ReLU().setName(s"res${name}_branch2b_relu"))
+        .add(SpatialConvolution(n, n*4, 1, 1, 1, 1, 0, 0).setName(s"res${name}_branch2c"))
+
+      val model = Sequential()
+        .add(ConcatTable()
+          .add(shortcut(nInputPlane, n*4, stride, name)).setName(s"$name/concatTable")
+          .add(s))
+        .add(CAddTable().setName(s"res$name"))
+        .add(ReLU().setName(s"res${name}_relu"))
+      model
+    }
+
+    def layer(block: (Int, Int, String) => Module[Float], features: Int,
+      count: Int, stride: Int = 1, name : String): Module[Float] = {
+      val s = Sequential()
+      for (i <- 1 to count) {
+        s.add(block(features, if (i == 1) stride else 1, getName(i, name)))
+      }
+      s
+    }
+
+    def getName(i: Int, name: String): String = {
+      i match {
+        case 1 => name + "a"
+        case 2 => name + "b"
+        case 3 => name + "c"
+        case 4 => name + "d"
+        case 5 => name + "e"
+        case 6 => name + "f"
+      }
+    }
+
+    def getModel(inputShape: Array[Int], outputShape: Array[Int]): MklDnnContainer = {
+      iChannels = 64
+
+      Sequential()
+        .add(Input(inputShape, Memory.FormatTag.nchw))
+        .add(SpatialConvolution(3, 64, 7, 7, 2, 2, 3, 3).setName("conv1").setReLU(true))
+        .add(ReLU().setName("conv1_relu"))
+        .add(MaxPooling(3, 3, 2, 2).setName("pool1"))
+        .add(layer(bottleneck, 64, 3, name = "2"))
+        .add(ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw)))
+    }
+
+    def graph(inputShape: Array[Int], outputShape: Array[Int]): DnnGraph = {
+
+      def shortcut(input: ModuleNode[Float], nInputPlane: Int, nOutputPlane: Int,
+                   stride: Int, name: String): ModuleNode[Float] = {
+        val useConv = nInputPlane != nOutputPlane
+
+        if (useConv) {
+          Convolution(nInputPlane, nOutputPlane, 1, 1, stride, stride)
+            .setName(s"res${name}_branch1").inputs(input)
+        } else if (nInputPlane != nOutputPlane) {
+          throw new IllegalArgumentException(s"useConv false")
+        } else {
+          Identity().inputs(input)
+        }
+      }
+
+      def bottleneck(input: ModuleNode[Float], n: Int, stride: Int, name: String = "")
+      : ModuleNode[Float] = {
+        val nInputPlane = iChannels
+        iChannels = n * 4
+
+        val conv1 = Convolution(nInputPlane, n, 1, 1, 1, 1, 0, 0)
+          .setName(s"res${name}_branch2a").inputs(input)
+        val relu1 = ReLU().setName(s"res${name}_branch2a_relu").inputs(conv1)
+        val conv2 = Convolution(n, n, 3, 3, stride, stride, 1, 1).setName(
+          s"res${name}_branch2b").inputs(relu1)
+        val relu3 = ReLU().setName(s"res${name}_branch2b_relu").inputs(conv2)
+        val conv3 = Convolution(n, n*4, 1, 1, 1, 1, 0, 0).setName(
+          s"res${name}_branch2c").inputs(relu3)
+
+        val short = shortcut(input, nInputPlane, n*4, stride, name)
+        val cadd = CAddTable().setName(s"res$name").
+          inputs(Array(conv3.asInstanceOf[ModuleNode[Float]], short))
+        val relu = ReLU().setName(s"res${name}_relu").inputs(cadd)
+        relu
+      }
+
+      def getName(i: Int, name: String): String = {
+        val name1 = i match {
+          case 1 => name + "a"
+          case 2 => name + "b"
+          case 3 => name + "c"
+          case 4 => name + "d"
+          case 5 => name + "e"
+          case 6 => name + "f"
+        }
+        return name1
+      }
+
+      def layer(input: ModuleNode[Float],
+                block: (ModuleNode[Float], Int, Int, String) => ModuleNode[Float],
+                features: Int,
+                count: Int, stride: Int = 1, name : String): ModuleNode[Float] = {
+        var in = input
+        for (i <- 1 to count) {
+          val res = block(in, features, if (i == 1) stride else 1, getName(i, name))
+          in = res
+        }
+        in
+      }
+
+      iChannels = 64
+
+      val input = Input(inputShape, Memory.FormatTag.nchw).inputs()
+      val conv1 = SpatialConvolution(3, 64, 7, 7, 2, 2, 3, 3, propagateBack = false)
+        .setName("conv1").inputs(input)
+      val relu1 = ReLU().setName("conv1_relu").inputs(conv1)
+      val pool1 = MaxPooling(3, 3, 2, 2).setName("pool1").inputs(relu1)
+      val layer1 = layer(pool1, bottleneck, 64, 3, name = "2")
+      val output = ReorderMemory(HeapData(outputShape, Memory.FormatTag.nchw)).inputs(layer1)
+
+      val model = DnnGraph(Array(input), Array(output))
+      model
+    }
+  }
+
+  private def shape2Dim(shape: Array[Int]): String = {
+    shape.map(x => "dim: " + x).mkString(" ")
+  }
+}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DistriOptimizerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DistriOptimizerSpec.scala
@@ -116,9 +116,9 @@ object DistriOptimizerSpecModel {
 
   def dnn: Module[Float] = {
     new nn.mkldnn.Sequential()
-      .add(nn.mkldnn.Input(Array(8, 4), Memory.Format.nc))
+      .add(nn.mkldnn.Input(Array(8, 4), Memory.FormatTag.nc))
       .add(nn.mkldnn.Linear(4, 2))
-      .add(nn.mkldnn.ReorderMemory(HeapData(Array(8, 2), Memory.Format.nc)))
+      .add(nn.mkldnn.ReorderMemory(HeapData(Array(8, 2), Memory.FormatTag.nc)))
   }
 }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DistriOptimizerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/DistriOptimizerSpec.scala
@@ -21,7 +21,7 @@ import java.nio.file.{Files, Paths}
 import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.dataset.image.{BGRImgToBatch, LabeledBGRImage}
 import com.intel.analytics.bigdl.dataset.{DataSet, DistributedDataSet, MiniBatch, Sample}
-import com.intel.analytics.bigdl.mkl.Memory
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{MemoryWrapper => Memory}
 import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.nn.abstractnn.Activity
 import com.intel.analytics.bigdl.nn.mkldnn.HeapData

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/LocalOptimizerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/LocalOptimizerSpec.scala
@@ -20,7 +20,7 @@ import com.intel.analytics.bigdl.dataset.{DataSet, LocalDataSet, MiniBatch}
 import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.dataset.image.{BGRImgToBatch, LabeledBGRImage}
-import com.intel.analytics.bigdl.mkl.Memory
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{MemoryWrapper => Memory}
 import com.intel.analytics.bigdl.nn.mkldnn.HeapData
 import com.intel.analytics.bigdl.tensor.{DnnStorage, Storage, Tensor}
 import com.intel.analytics.bigdl.utils.{Engine, RandomGenerator, T}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/LocalOptimizerSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/LocalOptimizerSpec.scala
@@ -122,9 +122,9 @@ object LocalOptimizerSpecModel {
 
   def dnnModel: Module[Float] = {
     new nn.mkldnn.Sequential()
-      .add(nn.mkldnn.Input(Array(4, 4), Memory.Format.nc))
+      .add(nn.mkldnn.Input(Array(4, 4), Memory.FormatTag.nc))
       .add(nn.mkldnn.Linear(4, 2))
-      .add(nn.mkldnn.ReorderMemory(HeapData(Array(4, 2), Memory.Format.nc)))
+      .add(nn.mkldnn.ReorderMemory(HeapData(Array(4, 2), Memory.FormatTag.nc)))
   }
 }
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DnnTensorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/tensor/DnnTensorSpec.scala
@@ -15,7 +15,6 @@
  */
 package com.intel.analytics.bigdl.tensor
 
-import com.intel.analytics.bigdl.mkl.MklDnn
 import com.intel.analytics.bigdl.nn.mkldnn.MemoryOwner
 import com.intel.analytics.bigdl.utils.{BigDLSpecHelper, T}
 import org.apache.commons.lang3.SerializationUtils

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/ThreadPoolSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/ThreadPoolSpec.scala
@@ -16,16 +16,17 @@
 
 package com.intel.analytics.bigdl.utils
 
-import com.intel.analytics.bigdl.mkl.hardware.Affinity
 import com.intel.analytics.bigdl.tensor.Tensor
 import org.scalatest.{FlatSpec, Matchers}
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{CoreWrapper => MKL}
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{AffinityWrapper => Affinity}
 
 import scala.concurrent.ExecutionException
 
 class ThreadPoolSpec extends FlatSpec with Matchers {
 
   "mkldnn backend" should "create omp threads and bind correctly" in {
-    com.intel.analytics.bigdl.mkl.MklDnn.isLoaded
+    MKL.isLoaded
     val poolSize = 1
     val ompSize = 4
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/BlasToDnnSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/BlasToDnnSpec.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.bigdl.utils.intermediate
 
 import breeze.numerics._
 import com.intel.analytics.bigdl.example.loadmodel.AlexNet
-import com.intel.analytics.bigdl.mkl.Memory
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{MemoryWrapper => Memory}
 import com.intel.analytics.bigdl.models.inception.{Inception_Layer_v1, Inception_v1_NoAuxClassifier}
 import com.intel.analytics.bigdl.models.lenet.LeNet5
 import com.intel.analytics.bigdl.models.resnet.ResNet

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/BlasToDnnSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/BlasToDnnSpec.scala
@@ -52,8 +52,8 @@ class BlasToDnnSpec extends BigDLSpecHelper {
       RandomGenerator.RNG.uniform(1.0, 1000.0).toFloat)
 
     val blas = Vgg_16.graph(classNum, false).asInstanceOf[StaticGraph[Float]]
-    blas.setInputFormats(Seq(Memory.Format.nchw))
-    blas.setOutputFormats(Seq(Memory.Format.nc))
+    blas.setInputFormats(Seq(Memory.FormatTag.nchw))
+    blas.setOutputFormats(Seq(Memory.FormatTag.nc))
     val irBlas = blas.cloneModule().toIRgraph()
 
     val outBlas = blas.forward(input).toTensor[Float]
@@ -69,15 +69,15 @@ class BlasToDnnSpec extends BigDLSpecHelper {
   "lenet5 blas to dnn" should "work properly" in {
     val batchSize = 2
     val seed = 1
-    val inputFormat = Memory.Format.nchw
+    val inputFormat = Memory.FormatTag.nchw
     val inputShape = Array(batchSize, 1, 28, 28)
 
     val input = Tensor[Float](inputShape).rand()
     val gradOutput = Tensor[Float](batchSize, 10).rand()
 
     val blas = LeNet5.graph(10).asInstanceOf[StaticGraph[Float]]
-    blas.setInputFormats(Seq(Memory.Format.nchw))
-    blas.setOutputFormats(Seq(Memory.Format.nc))
+    blas.setInputFormats(Seq(Memory.FormatTag.nchw))
+    blas.setOutputFormats(Seq(Memory.FormatTag.nc))
     val irBlas = blas.cloneModule().toIRgraph()
 
     val outBlas = blas.forward(input).toTensor[Float]
@@ -101,8 +101,8 @@ class BlasToDnnSpec extends BigDLSpecHelper {
       RandomGenerator.RNG.uniform(1, 10).toFloat)
 
     val blas = Inception_v1_NoAuxClassifier.graph(classNum, false).asInstanceOf[StaticGraph[Float]]
-    blas.setInputFormats(Seq(Memory.Format.nchw))
-    blas.setOutputFormats(Seq(Memory.Format.nc))
+    blas.setInputFormats(Seq(Memory.FormatTag.nchw))
+    blas.setOutputFormats(Seq(Memory.FormatTag.nc))
     val irBlas = blas.cloneModule().toIRgraph()
 
     val outBlas = blas.forward(input).toTensor[Float]

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/DnnPredictorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/DnnPredictorSpec.scala
@@ -189,8 +189,8 @@ class DnnPredictorSpec extends FlatSpec with Matchers with BeforeAndAfter {
     m.add(SpatialConvolution(3, 6, 5, 5))
     m.add(Tanh())
     val model = m.toGraph().asInstanceOf[StaticGraph[Float]]
-    model.setInputFormats(Seq(Memory.Format.nchw))
-    model.setOutputFormats(Seq(Memory.Format.nchw))
+    model.setInputFormats(Seq(Memory.FormatTag.nchw))
+    model.setOutputFormats(Seq(Memory.FormatTag.nchw))
 
     val detection = model.predictImage(imageFrame).toLocal()
     val feature = detection.array.head

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/DnnPredictorSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/DnnPredictorSpec.scala
@@ -16,7 +16,7 @@
 package com.intel.analytics.bigdl.utils.intermediate
 
 import com.intel.analytics.bigdl.dataset.{DataSet, MiniBatch, Sample}
-import com.intel.analytics.bigdl.mkl.Memory
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{MemoryWrapper => Memory}
 import com.intel.analytics.bigdl.models.inception.Inception_v1_NoAuxClassifier
 import com.intel.analytics.bigdl.models.lenet.LeNet5
 import com.intel.analytics.bigdl.nn._

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/IRGraphSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/IRGraphSpec.scala
@@ -158,6 +158,10 @@ class IRGraphSpec extends BigDLSpecHelper {
   }
 
   "PTB LSTM model running with mkldnn" should "work correctly" in {
+    import com.intel.analytics.bigdl.utils.wrapper.mkldnn.NativeVersion
+    if (NativeVersion.isDNNL) {
+      cancel("DNNL integration not supports LSTM now")
+    }
     Engine.init(1, 1, true)
     RandomGenerator.RNG.setSeed(1000)
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/IRGraphSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/IRGraphSpec.scala
@@ -17,7 +17,7 @@
 package com.intel.analytics.bigdl.utils.intermediate
 
 import com.intel.analytics.bigdl.example.languagemodel.PTBModel
-import com.intel.analytics.bigdl.mkl.Memory
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{MemoryWrapper => Memory}
 import com.intel.analytics.bigdl.nn.abstractnn.{Activity, DataFormat}
 import com.intel.analytics.bigdl.nn.mkldnn._
 import com.intel.analytics.bigdl.{Module, nn, utils}

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/IRGraphSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/IRGraphSpec.scala
@@ -26,8 +26,8 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils._
 
 class IRGraphSpec extends BigDLSpecHelper {
-  def modelIR(inputFormats: Int = Memory.Format.nchw,
-              outputFormats: Int = Memory.Format.nchw): IRGraph[Float] = {
+  def modelIR(inputFormats: Int = Memory.FormatTag.nchw,
+              outputFormats: Int = Memory.FormatTag.nchw): IRGraph[Float] = {
     val conv1 = Node(IRElement[Float]("", IRSpatialConvolution[Float](1, 20, 5, 5)))
     val bn1 = Node(IRElement[Float]("", IRSpatialBatchNormalization[Float](20)))
     val weightsAndBias = Tensor[Float](2 * 20).rand()
@@ -42,8 +42,8 @@ class IRGraphSpec extends BigDLSpecHelper {
     IRGraph(Array(conv1), Array(output), inputFormats = inputFormats, outputFormats = outputFormats)
   }
 
-  def modelIR2(inputFormats: Int = Memory.Format.nchw,
-               outputFormats: Int = Memory.Format.nc): IRGraph[Float] = {
+  def modelIR2(inputFormats: Int = Memory.FormatTag.nchw,
+               outputFormats: Int = Memory.FormatTag.nc): IRGraph[Float] = {
     val conv1 = Node(IRElement[Float]("", IRSpatialConvolution[Float](1, 20, 5, 5)))
     val pool1 = Node(IRElement[Float]("", IRSpatialMaxPooling[Float](2, 2, 2, 2)))
     val conv2 = Node(IRElement[Float]("", IRSpatialConvolution[Float](20, 50, 5, 5)))
@@ -60,8 +60,8 @@ class IRGraphSpec extends BigDLSpecHelper {
     IRGraph(Array(conv1), Array(output), inputFormats = inputFormats, outputFormats = outputFormats)
   }
 
-  def modelIR3(inputFormats: Int = Memory.Format.nchw,
-               outputFormats: Int = Memory.Format.nc): IRGraph[Float] = {
+  def modelIR3(inputFormats: Int = Memory.FormatTag.nchw,
+               outputFormats: Int = Memory.FormatTag.nc): IRGraph[Float] = {
     val conv1 = Node(IRElement[Float]("", IRSpatialConvolution[Float](1, 20, 5, 5)))
     val pool1 = Node(IRElement[Float]("", IRSpatialMaxPooling[Float](2, 2, 2, 2)))
     val conv2 = Node(IRElement[Float]("", IRSpatialConvolution[Float](20, 50, 5, 5)))
@@ -81,8 +81,8 @@ class IRGraphSpec extends BigDLSpecHelper {
     identity -> join
 
     new IRGraph(Array(conv1, identity), Array(join),
-      inputFormats = Seq(Memory.Format.nchw, Memory.Format.nc),
-      outputFormats = Seq(Memory.Format.nc))
+      inputFormats = Seq(Memory.FormatTag.nchw, Memory.FormatTag.nc),
+      outputFormats = Seq(Memory.FormatTag.nc))
   }
 
   "Convert IRgraph to Dnn or Blas Graph" should "be correct" in {
@@ -208,8 +208,8 @@ class IRGraphSpec extends BigDLSpecHelper {
     Engine.setEngineType(MklDnn)
     val dnn = blas.cloneModule()
       .asInstanceOf[StaticGraph[Float]]
-      .setInputFormats(Seq(Memory.Format.ntc))
-      .setOutputFormats(Seq(Memory.Format.ntc))
+      .setInputFormats(Seq(Memory.FormatTag.ntc))
+      .setOutputFormats(Seq(Memory.FormatTag.ntc))
       .toIRgraph()
       .evaluate()
 
@@ -230,8 +230,8 @@ class IRGraphSpec extends BigDLSpecHelper {
     Engine.setEngineType(MklDnn)
     val dnn = blas.cloneModule()
       .asInstanceOf[StaticGraph[Float]]
-      .setInputFormats(Seq(Memory.Format.nc))
-      .setOutputFormats(Seq(Memory.Format.nc))
+      .setInputFormats(Seq(Memory.FormatTag.nc))
+      .setOutputFormats(Seq(Memory.FormatTag.nc))
       .toIRgraph()
       .evaluate()
 

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/IRconvertSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/IRconvertSpec.scala
@@ -112,6 +112,10 @@ class IRconvertSpec extends BigDLSpecHelper {
   }
 
   "Convert Blas with NHWC" should "be correct" in {
+    import com.intel.analytics.bigdl.utils.wrapper.mkldnn.NativeVersion
+    if (NativeVersion.isDNNL) {
+      cancel("DNNL integration not supports NHWC")
+    }
     System.setProperty("bigdl.engineType", "mkldnn")
     val input = Tensor[Float](2, 28, 28, 1).rand()
     val gradOutput = Tensor[Float](2, 10).rand()

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/IRconvertSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/IRconvertSpec.scala
@@ -117,8 +117,8 @@ class IRconvertSpec extends BigDLSpecHelper {
     val gradOutput = Tensor[Float](2, 10).rand()
 
     val blas = modelBlas(format = DataFormat("NHWC")).asInstanceOf[StaticGraph[Float]]
-    blas.setInputFormats(Seq(Memory.Format.nhwc))
-    blas.setOutputFormats(Seq(Memory.Format.nc))
+    blas.setInputFormats(Seq(Memory.FormatTag.nhwc))
+    blas.setOutputFormats(Seq(Memory.FormatTag.nc))
     val dnn = blas.cloneModule().toIRgraph()
 
     val outBlas = blas.forward(input)
@@ -138,8 +138,8 @@ class IRconvertSpec extends BigDLSpecHelper {
 //    val model = keras(classNum = 10)
 //
 //    val blas = model.toGraph().asInstanceOf[StaticGraph[Float]]
-//    blas.setInputFormats(Seq(Memory.Format.nhwc))
-//    blas.setOutputFormats(Seq(Memory.Format.nc))
+//    blas.setInputFormats(Seq(Memory.FormatTag.nhwc))
+//    blas.setOutputFormats(Seq(Memory.FormatTag.nc))
 //
 //    val dnn = blas.cloneModule().asInstanceOf[StaticGraph[Float]].toIRgraph()
 //
@@ -174,8 +174,8 @@ class IRconvertSpec extends BigDLSpecHelper {
 //
 //    // For such cases, toSingleGraph() is unnecessary
 //    val graph = seq.toGraph().asInstanceOf[StaticGraph[Float]]
-//    graph.asInstanceOf[StaticGraph[Float]].setInputFormats(Seq(Memory.Format.ntc))
-//    graph.asInstanceOf[StaticGraph[Float]].setOutputFormats(Seq(Memory.Format.nc))
+//    graph.asInstanceOf[StaticGraph[Float]].setInputFormats(Seq(Memory.FormatTag.ntc))
+//    graph.asInstanceOf[StaticGraph[Float]].setOutputFormats(Seq(Memory.FormatTag.nc))
 //    // set gradWeight
 //    graph.getParameters()._2.rand()
 //
@@ -207,8 +207,8 @@ class IRconvertSpec extends BigDLSpecHelper {
 //    val model = nn.keras.Model[Float](input, d2)
 //
 //    val graph = model.toGraph().asInstanceOf[StaticGraph[Float]]
-//    graph.asInstanceOf[StaticGraph[Float]].setInputFormats(Seq(Memory.Format.nc))
-//    graph.asInstanceOf[StaticGraph[Float]].setOutputFormats(Seq(Memory.Format.nc))
+//    graph.asInstanceOf[StaticGraph[Float]].setInputFormats(Seq(Memory.FormatTag.nc))
+//    graph.asInstanceOf[StaticGraph[Float]].setOutputFormats(Seq(Memory.FormatTag.nc))
 //
 //    // set gradWeight
 //    graph.getParameters()._2.rand()
@@ -245,9 +245,9 @@ class IRconvertSpec extends BigDLSpecHelper {
     val inputsNodes = dnnNodes.filter(_.element.getName() == "input")(0)
     val outputsNodes = dnnNodes.filter(_.element.getName() == "output")(0)
 
-    val inputs = Input(Array(2, 1, 28, 28), Memory.Format.nchw).inputs()
+    val inputs = Input(Array(2, 1, 28, 28), Memory.FormatTag.nchw).inputs()
     inputsNodes.from(inputs)
-    val outputs = Output(Memory.Format.nc).inputs(outputsNodes)
+    val outputs = Output(Memory.FormatTag.nc).inputs(outputsNodes)
     val dnn = DnnGraph(Array(inputs), Array(outputs))
     dnn.compile(TrainingPhase)
 
@@ -283,9 +283,9 @@ class IRconvertSpec extends BigDLSpecHelper {
     val inputsNodes = dnnNodes.filter(_.element.getName() == "input")(0)
     val outputsNodes = dnnNodes.filter(_.element.getName() == "output")(0)
 
-    val inputs = Input(Array(2, 1, 28, 28), Memory.Format.nchw).inputs()
+    val inputs = Input(Array(2, 1, 28, 28), Memory.FormatTag.nchw).inputs()
     inputsNodes.from(inputs)
-    val outputs = Output(Memory.Format.nchw).inputs(outputsNodes)
+    val outputs = Output(Memory.FormatTag.nchw).inputs(outputsNodes)
     val dnn = DnnGraph(Array(inputs), Array(outputs))
     dnn.compile(TrainingPhase)
 
@@ -322,9 +322,9 @@ class IRconvertSpec extends BigDLSpecHelper {
     val inputsNodes = dnnNodes.filter(_.element.getName() == "input")(0)
     val outputsNodes = dnnNodes.filter(_.element.getName() == "output")(0)
 
-    val inputs = Input(Array(2, 1, 28, 28), Memory.Format.nchw).inputs()
+    val inputs = Input(Array(2, 1, 28, 28), Memory.FormatTag.nchw).inputs()
     inputsNodes.from(inputs)
-    val outputs = Output(Memory.Format.nc).inputs(outputsNodes)
+    val outputs = Output(Memory.FormatTag.nc).inputs(outputsNodes)
     val dnn = DnnGraph(Array(inputs), Array(outputs))
     dnn.compile(TrainingPhase)
 
@@ -389,7 +389,7 @@ class IRconvertSpec extends BigDLSpecHelper {
       .add(SpatialAveragePooling[Float](2, 2, globalPooling = true))
       .toGraph()
 
-    graph.asInstanceOf[StaticGraph[Float]].setOutputFormats(Seq(Memory.Format.nchw))
+    graph.asInstanceOf[StaticGraph[Float]].setOutputFormats(Seq(Memory.FormatTag.nchw))
     val dnn = ConversionUtils.convert(graph.cloneModule())
 
     graph.evaluate()

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/IRconvertSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/utils/intermediate/IRconvertSpec.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.utils.intermediate
 
-import com.intel.analytics.bigdl.mkl.Memory
+import com.intel.analytics.bigdl.utils.wrapper.mkldnn.{MemoryWrapper => Memory}
 import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
 import com.intel.analytics.bigdl.nn.keras._


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch contains the dnnl v1.1 integration, which enables ResNet-50 training, inference, including Int8 and fusion.

`make-dist.sh --dnnl` will build a jar with dnnl v1.1 library. By default, it will build a jar with legacy v0.19 mkldnn backend.

## How was this patch tested?
All unit tests compatibility testing. And model tests by manual.