### PR TITLE
Bump 0.11 fix KerasLayer parameters()

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasLayer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/nn/keras/KerasLayer.scala
@@ -268,14 +268,6 @@ abstract class KerasLayer[A <: Activity: ClassTag, B <: Activity: ClassTag, T: C
   }
  // scalastyle:on
 
-  override def parameters(): (Array[Tensor[T]], Array[Tensor[T]]) = {
-    if (isBuilt()) {
-      labor.parameters()
-    } else {
-      null
-    }
-  }
-
   override def updateOutput(input: A): B = {
     output = labor.updateOutput(input)
     output


### PR DESCRIPTION
## What changes were proposed in this pull request?

Not found the usage of this override parameters(). Zoo KerasLayer should call the existed parameters( ) in Container.

## How was this patch tested?

Jenkins

## Related links or issues (optional)
fixed https://github.com/intel-analytics/BigDL/issues/3032

