### PR TITLE
add the missing localStates for Cache[T]

### DIFF
--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala
@@ -66,9 +66,10 @@ object DistriOptimizer extends AbstractOptimizer {
     def modelWeights: Array[Tensor[T]]
     def modelGradients: Array[Tensor[T]]
     def localCriterions: Array[Criterion[T]]
+    def localStates: Array[Table]
+    def moduleTimeList: Array[Long]
     def localMethods: Array[Option[Array[ValidationMethod[T]]]]
     def optimMethods: Map[String, OptimMethod[T]]
-    def moduleTimeList: Array[Long]
     def parameterSynchronizer: DistriParameterSynchronizer[T]
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

To use the extended Cache[T] in Zoo. Both DistriOptimizerV1 and V2 Cache require `localStates: Array[Table]`. 

## How was this patch tested?

Jenkins

