### PR TITLE
Update scala maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,8 +107,8 @@
         <findbugs.version>3.0.0</findbugs.version>
 
         <!-- define the Java language version used by the compiler -->
-        <java.version>1.8</java.version>
-        <javac.version>1.8</javac.version>
+        <java.version>1.7</java.version>
+        <javac.version>1.7</javac.version>
         <scala.major.version>2.11</scala.major.version>
         <scala.version>2.11.8</scala.version>
         <scala.macros.version>2.1.0</scala.macros.version>
@@ -172,6 +172,8 @@
         <commons-math.version>2.2</commons-math.version>
         <collections.version>3.2.1</collections.version>
         <scoverage.plugin.version>1.1.1</scoverage.plugin.version>
+        <spark-version.project>2.0</spark-version.project>
+        <spark.version>2.4.3</spark.version>
         <breeze.version>0.13.2</breeze.version>
         <spark-scope>provided</spark-scope>
 
@@ -542,90 +544,9 @@
             <id>spark_2.x</id>
             <properties>
                 <spark-version.project>2.0</spark-version.project>
-                <spark.version>2.1.1</spark.version>
+                <spark.version>2.4.3</spark.version>
                 <scala.major.version>2.11</scala.major.version>
                 <scala.version>2.11.8</scala.version>
-                <scala.macros.version>2.1.0</scala.macros.version>
-            </properties>
-            <build>
-                <plugins>
-                    <!-- Redefine the plugin to enable fatal warninings -->
-                    <plugin>
-                        <groupId>net.alchim31.maven</groupId>
-                        <artifactId>scala-maven-plugin</artifactId>
-                        <version>3.4.2</version>
-                        <executions>
-                            <execution>
-                                <id>eclipse-add-source</id>
-                                <goals>
-                                    <goal>add-source</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>scala-compile-first</id>
-                                <phase>process-resources</phase>
-                                <goals>
-                                    <goal>compile</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>scala-test-compile-first</id>
-                                <phase>process-test-resources</phase>
-                                <goals>
-                                    <goal>testCompile</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>attach-scaladocs</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>doc-jar</goal>
-                                </goals>
-                                <configuration>
-                                    <args>
-                                        <!-- Do not change the arg orders. It is a weird way to pass in
-                                        this arg. Maybe it is a bug of the plugin. -->
-                                        <arg>-skip-packages</arg>
-                                        <arg>caffe:org.tensorflow:netty:org.apache.spark.sparkExtension:org.apache.spark.rdd:org.apache.spark.storage:org.apache.spark.bigdl</arg>
-                                    </args>
-                                </configuration>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <scalaVersion>${scala.version}</scalaVersion>
-                            <recompileMode>incremental</recompileMode>
-                            <useZincServer>false</useZincServer>
-                            <args>
-                                <arg>-unchecked</arg>
-                                <!-- Too many deprecation usage, let's suspend it temporary-->
-                                <arg>-deprecation:false</arg>
-                                <arg>-feature</arg>
-                                <arg>-Xfatal-warnings</arg>
-                            </args>
-                            <!-- The following plugin is required to use quasiquotes in Scala 2.10 and is used
-                                 by Spark SQL for code generation. -->
-                            <compilerPlugins>
-                                <compilerPlugin>
-                                    <groupId>org.scalamacros</groupId>
-                                    <artifactId>paradise_${scala.version}</artifactId>
-                                    <version>${scala.macros.version}</version>
-                                </compilerPlugin>
-                            </compilerPlugins>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>spark_2.4.x</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <spark-version.project>2.0</spark-version.project>
-                <spark.version>2.4.3</spark.version>
-                <scala.major.version>2.12</scala.major.version>
-                <scala.version>2.12.8</scala.version>
                 <scala.macros.version>2.1.0</scala.macros.version>
             </properties>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -172,8 +172,6 @@
         <commons-math.version>2.2</commons-math.version>
         <collections.version>3.2.1</collections.version>
         <scoverage.plugin.version>1.1.1</scoverage.plugin.version>
-        <spark-version.project>2.0</spark-version.project>
-        <spark.version>2.4.0</spark.version>
         <breeze.version>0.13.2</breeze.version>
         <spark-scope>provided</spark-scope>
 
@@ -404,7 +402,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.4.2</version>
                 <executions>
                     <execution>
                         <id>eclipse-add-source</id>
@@ -504,7 +502,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.4.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -544,7 +542,7 @@
             <id>spark_2.x</id>
             <properties>
                 <spark-version.project>2.0</spark-version.project>
-                <spark.version>2.4.3</spark.version>
+                <spark.version>2.1.1</spark.version>
                 <scala.major.version>2.11</scala.major.version>
                 <scala.version>2.11.8</scala.version>
                 <scala.macros.version>2.1.0</scala.macros.version>
@@ -555,7 +553,88 @@
                     <plugin>
                         <groupId>net.alchim31.maven</groupId>
                         <artifactId>scala-maven-plugin</artifactId>
-                        <version>3.2.0</version>
+                        <version>3.4.2</version>
+                        <executions>
+                            <execution>
+                                <id>eclipse-add-source</id>
+                                <goals>
+                                    <goal>add-source</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>scala-compile-first</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>scala-test-compile-first</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>testCompile</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>attach-scaladocs</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>doc-jar</goal>
+                                </goals>
+                                <configuration>
+                                    <args>
+                                        <!-- Do not change the arg orders. It is a weird way to pass in
+                                        this arg. Maybe it is a bug of the plugin. -->
+                                        <arg>-skip-packages</arg>
+                                        <arg>caffe:org.tensorflow:netty:org.apache.spark.sparkExtension:org.apache.spark.rdd:org.apache.spark.storage:org.apache.spark.bigdl</arg>
+                                    </args>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <scalaVersion>${scala.version}</scalaVersion>
+                            <recompileMode>incremental</recompileMode>
+                            <useZincServer>false</useZincServer>
+                            <args>
+                                <arg>-unchecked</arg>
+                                <!-- Too many deprecation usage, let's suspend it temporary-->
+                                <arg>-deprecation:false</arg>
+                                <arg>-feature</arg>
+                                <arg>-Xfatal-warnings</arg>
+                            </args>
+                            <!-- The following plugin is required to use quasiquotes in Scala 2.10 and is used
+                                 by Spark SQL for code generation. -->
+                            <compilerPlugins>
+                                <compilerPlugin>
+                                    <groupId>org.scalamacros</groupId>
+                                    <artifactId>paradise_${scala.version}</artifactId>
+                                    <version>${scala.macros.version}</version>
+                                </compilerPlugin>
+                            </compilerPlugins>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>spark_2.4.x</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <spark-version.project>2.0</spark-version.project>
+                <spark.version>2.4.3</spark.version>
+                <scala.major.version>2.12</scala.major.version>
+                <scala.version>2.12.8</scala.version>
+                <scala.macros.version>2.1.0</scala.macros.version>
+            </properties>
+            <build>
+                <plugins>
+                    <!-- Redefine the plugin to enable fatal warninings -->
+                    <plugin>
+                        <groupId>net.alchim31.maven</groupId>
+                        <artifactId>scala-maven-plugin</artifactId>
+                        <version>3.4.2</version>
                         <executions>
                             <execution>
                                 <id>eclipse-add-source</id>
@@ -633,7 +712,7 @@
                     <plugin>
                         <groupId>net.alchim31.maven</groupId>
                         <artifactId>scala-maven-plugin</artifactId>
-                        <version>3.2.0</version>
+                        <version>3.4.2</version>
                         <executions>
                             <execution>
                                 <id>eclipse-add-source</id>

--- a/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/maskrcnn/Utils.scala
+++ b/spark/dl/src/main/scala/com/intel/analytics/bigdl/models/maskrcnn/Utils.scala
@@ -21,8 +21,6 @@ import breeze.linalg.{*, dim, max}
 import com.intel.analytics.bigdl.nn.ResizeBilinear
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.sun.xml.internal.bind.v2.TODO
-
 import scala.collection.mutable.ArrayBuffer
 
 private[bigdl] object Utils {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update scala/maven plugin to support jdk11. 

1.  `./make-dist.sh` is default-compile spark2.4.3 with jdk8. 
2. To compile specified Spark2.x with scala 2.11 and jdk8 is using like: `./make-dist.sh -P spark_2.x -Dspark.version=2.3.1`
3. To compile Spark3.x with scala 2.12 and jdk8: `./make-dist.sh -P spark_3.x`

`mvn` is used similarly as `./make-dist.sh`, e.g. mvn clean package -DskipTests -P spark_2.x

If we would like to compile with jdk 11, it requires to add below in pom.xml
```
<java.version>11</java.version>
<javac.version>11</javac.version>
<maven.compiler.source>1.6</maven.compiler.source>
<maven.compiler.target>1.6</maven.compiler.target>
```

## How was this patch tested?

Jenkins

