### PR TITLE
update release pip and UTonscala212

### DIFF
--- a/pyspark/setup.py
+++ b/pyspark/setup.py
@@ -89,7 +89,7 @@ def setup_package():
         license='Apache License, Version 2.0',
         url='https://github.com/intel-analytics/Bigdl',
         packages=get_bigdl_packages(),
-        install_requires=['numpy>=1.7', 'pyspark==3.0.0', 'six>=1.10.0'],
+        install_requires=['numpy>=1.7', 'pyspark==2.4.3', 'six>=1.10.0'],
         dependency_links=['https://archive.apache.org/dist/spark/spark-3.0.0/spark-3.0.0-bin-hadoop2.7.tgz'],
         include_package_data=True,
         package_data={"bigdl.share": ['bigdl/share/lib', 'bigdl/share/conf', 'bigdl/share/bin']},

--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
@@ -85,12 +85,12 @@ class TableSpec extends FlatSpec with Matchers {
     state(2) = T(1 -> "b", 2 -> T(1 -> "d"))
     print(state.toString)
     // Handle different behavior of toString in scala 2.10 and 2.11
-    if(Properties.versionNumberString.contains("2.10")) {
+    if(Properties.versionNumberString.contains("2.11")) {
       state.toString() should be(" {\n\t2:  {\n\t   " +
         "\t2:  {\n\t   \t   \t1: d\n\t   \t    }\n\t   \t1: b\n\t    }" +
         "\n\t1: 0.0\t0.0\t0.0\t\n\t   0.0\t0.0\t0.0\t\n\t   0.0\t0.0\t0.0\t\n\t   " +
         "[com.intel.analytics.bigdl.tensor.DenseTensor$mcD$sp of size 3x3]\n }")
-    } else if (Properties.versionNumberString.contains("2.11")) {
+    } else if (Properties.versionNumberString.contains("2.12")) {
       state.toString() should be(" {\n\t2:  {\n\t   " +
         "\t2:  {\n\t   \t   \t1: d\n\t   \t    }\n\t   \t1: b\n\t    }" +
         "\n\t1: 0.0\t0.0\t0.0\t\n\t   0.0\t0.0\t0.0\t\n\t   0.0\t0.0\t0.0\t\n\t   " +


### PR DESCRIPTION
## What changes were proposed in this pull request?

release PyPI BigDL 0.12.1 on spark 2.4.3 
Update UT TableSpec. Scala 2.10 has been deprecated since spark 2.1.0



