### PR TITLE
add scala212 check in TableSpec UT

### DIFF
--- a/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
+++ b/spark/dl/src/test/scala/com/intel/analytics/bigdl/optim/TableSpec.scala
@@ -84,12 +84,12 @@ class TableSpec extends FlatSpec with Matchers {
     state(1) = Tensor[Double](3, 3).zero()
     state(2) = T(1 -> "b", 2 -> T(1 -> "d"))
     print(state.toString)
-    // Handle different behavior of toString in scala 2.10 and 2.11
+    // Handle behavior of toString in 2.11/2.12
     if(Properties.versionNumberString.contains("2.11")) {
       state.toString() should be(" {\n\t2:  {\n\t   " +
         "\t2:  {\n\t   \t   \t1: d\n\t   \t    }\n\t   \t1: b\n\t    }" +
         "\n\t1: 0.0\t0.0\t0.0\t\n\t   0.0\t0.0\t0.0\t\n\t   0.0\t0.0\t0.0\t\n\t   " +
-        "[com.intel.analytics.bigdl.tensor.DenseTensor$mcD$sp of size 3x3]\n }")
+        "[com.intel.analytics.bigdl.tensor.DenseTensor of size 3x3]\n }")
     } else if (Properties.versionNumberString.contains("2.12")) {
       state.toString() should be(" {\n\t2:  {\n\t   " +
         "\t2:  {\n\t   \t   \t1: d\n\t   \t    }\n\t   \t1: b\n\t    }" +


### PR DESCRIPTION
Update UT TableSpec. Add Scala2.12 check. And remove Scala 2.10 since it has been deprecated since spark 2.1.0

