### PR TITLE
[backport #3111] fix callBigDLFunc return a Int while the true return value from java is a byte array.

### DIFF
--- a/pyspark/bigdl/util/common.py
+++ b/pyspark/bigdl/util/common.py
@@ -634,8 +634,8 @@ def _java2py(gateway, r, encoding="bytes"):
             except Py4JJavaError:
                 pass  # not pickable
 
-    if isinstance(r, (bytearray, bytes)):
-        r = PickleSerializer().loads(bytes(r), encoding=encoding)
+        if isinstance(r, (bytearray, bytes)):
+            r = PickleSerializer().loads(bytes(r), encoding=encoding)
     return r
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
[backport #3111] fix callBigDLFunc return a Int while the true return value from java is a byte array.

## How was this patch tested?

unit tests

