### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/BigDL/Dockerfile
+++ b/docker/BigDL/Dockerfile
@@ -63,8 +63,8 @@ RUN wget https://d3kbcqa49mib13.cloudfront.net/spark-${SPARK_VERSION}-bin-hadoop
 #bigdl
 RUN git clone https://github.com/intel-analytics/BigDL-Tutorials.git 
 
-ADD ./start-notebook.sh /opt/work
-ADD ./download-bigdl.sh /opt/work
+COPY ./start-notebook.sh /opt/work
+COPY ./download-bigdl.sh /opt/work
 RUN chmod a+x start-notebook.sh && \
     chmod a+x download-bigdl.sh 
 RUN ./download-bigdl.sh


### PR DESCRIPTION
Solve for SDL requirement：

Problem
ADD instruction potentially could retrieve files from remote URLs and perform operations such as unpacking. Thus, ADD instruction introduces risks such as adding malicious files from URLs without scanning and unpacking procedure vulnerabilities.

Solution
Use COPY instruction instead of ADD instruction in the Dockerfile.

COPY instruction just copies the files from the local host machine to the container file system and you would need to take care of the functionalities provided by ADD instructions such as fetching files from remote URLs.