### PR TITLE
Simplify build jar in whl (reduce time)

### DIFF
--- a/python/dllib/test/dev/release/release.sh
+++ b/python/dllib/test/dev/release/release.sh
@@ -57,7 +57,7 @@ else
     echo "unsupport platform"
 fi
 
-bigdl_build_command="bash make-dist.sh ${dist_profile}"
+bigdl_build_command="mvn -f ${BIGDL_DIR}/scala clean package -DskipTests ${dist_profile}"
 if [ "$quick" == "true" ]; then
     echo "Skip disting BigDL"
 else

--- a/python/dllib/test/dev/release/release_default_linux_spark246.sh
+++ b/python/dllib/test/dev/release/release_default_linux_spark246.sh
@@ -36,4 +36,4 @@ fi
 version=$1
 
 # TODO: change upload to true after uploading to pypi is enabled
-bash ${RUN_SCRIPT_DIR}/release.sh linux ${version} false -Dspark.version=2.4.6 -P spark_2.x
+bash ${RUN_SCRIPT_DIR}/release.sh linux ${version} false -Dspark.version=2.4.6 -P spark_2.x -pl 'common/spark-version' -pl 'dllib'

--- a/python/dllib/test/dev/release/release_default_mac_spark246.sh
+++ b/python/dllib/test/dev/release/release_default_mac_spark246.sh
@@ -36,4 +36,4 @@ fi
 version=$1
 
 # TODO: change upload to true after uploading to pypi is enabled
-bash ${RUN_SCRIPT_DIR}/release.sh mac ${version} false -Dspark.version=2.4.6 -P spark_2.x
+bash ${RUN_SCRIPT_DIR}/release.sh mac ${version} false -Dspark.version=2.4.6 -P spark_2.x -pl 'common/spark-version' -pl 'dllib'

--- a/python/friesian/dev/release/release.sh
+++ b/python/friesian/dev/release/release.sh
@@ -59,7 +59,7 @@ else
     echo "Unsupported platform"
 fi
 
-bigdl_build_command="bash make-dist.sh ${dist_profile}"
+bigdl_build_command="mvn -f ${BIGDL_DIR}/scala clean package -DskipTests ${dist_profile}"
 if [ "$quick" == "true" ]; then
     echo "Skip disting BigDL"
 else

--- a/python/friesian/dev/release/release_default_linux_spark246.sh
+++ b/python/friesian/dev/release/release_default_linux_spark246.sh
@@ -36,4 +36,4 @@ fi
 version=$1
 
 # TODO: change upload to true after uploading to pypi is enabled
-bash ${RUN_SCRIPT_DIR}/release.sh linux ${version} false false -Dspark.version=2.4.6 -P spark_2.x
+bash ${RUN_SCRIPT_DIR}/release.sh linux ${version} false false -Dspark.version=2.4.6 -P spark_2.x -pl 'common/spark-version' -pl 'dllib' -pl 'orca' -pl 'friesian'

--- a/python/friesian/dev/release/release_default_mac_spark246.sh
+++ b/python/friesian/dev/release/release_default_mac_spark246.sh
@@ -36,4 +36,4 @@ fi
 version=$1
 
 # TODO: change upload to true after uploading to pypi is enabled
-bash ${RUN_SCRIPT_DIR}/release.sh mac ${version} false false -Dspark.version=2.4.6 -P spark_2.x
+bash ${RUN_SCRIPT_DIR}/release.sh mac ${version} false false -Dspark.version=2.4.6 -P spark_2.x -pl 'common/spark-version' -pl 'dllib' -pl 'orca' -pl 'friesian'

--- a/python/orca/dev/release/release.sh
+++ b/python/orca/dev/release/release.sh
@@ -57,7 +57,7 @@ else
     echo "unsupport platform"
 fi
 
-bigdl_build_command="bash make-dist.sh ${dist_profile}"
+bigdl_build_command="mvn -f ${BIGDL_DIR}/scala clean package -DskipTests ${dist_profile}"
 if [ "$quick" == "true" ]; then
     echo "Skip disting BigDL"
 else

--- a/python/orca/dev/release/release_default_linux_spark246.sh
+++ b/python/orca/dev/release/release_default_linux_spark246.sh
@@ -36,4 +36,4 @@ fi
 version=$1
 
 # TODO: change upload to true after uploading to pypi is enabled
-bash ${RUN_SCRIPT_DIR}/release.sh linux ${version} false -Dspark.version=2.4.6 -P spark_2.x
+bash ${RUN_SCRIPT_DIR}/release.sh linux ${version} false -Dspark.version=2.4.6 -P spark_2.x -pl 'common/spark-version' -pl 'dllib' -pl 'orca'

--- a/python/orca/dev/release/release_default_mac_spark246.sh
+++ b/python/orca/dev/release/release_default_mac_spark246.sh
@@ -36,4 +36,4 @@ fi
 version=$1
 
 # TODO: change upload to true after uploading to pypi is enabled
-bash ${RUN_SCRIPT_DIR}/release.sh mac ${version} false -Dspark.version=2.4.6 -P spark_2.x
+bash ${RUN_SCRIPT_DIR}/release.sh mac ${version} false -Dspark.version=2.4.6 -P spark_2.x -pl 'common/spark-version' -pl 'dllib' -pl 'orca'


### PR DESCRIPTION
Building whl will build all jars. Actually, we don't need to build each module. e,g, dllib whl only needs dllib jar. 
[INFO] BigDL .............................................. SUCCESS [ 22.820 s]
[INFO] spark-version ...................................... SUCCESS [  4.922 s]
[INFO] 2.0 ................................................ SUCCESS [01:07 min]
[INFO] bigdl-dllib-spark_2.4.6 ............................ SUCCESS [10:38 min]
[INFO] bigdl-orca-spark_2.4.6 ............................. SUCCESS [01:19 min]
[INFO] bigdl-friesian-spark_2.4.6 ......................... SUCCESS [  9.900 s]
[INFO] bigdl-grpc-spark_2.4.6 ............................. SUCCESS [  8.741 s]
[INFO] bigdl-friesian-serving-spark_2.4.6 ................. SUCCESS [04:31 min]
[INFO] bigdl-serving-spark_2.4.6 .......................... SUCCESS [01:20 min]
[INFO] bigdl-ppml-spark_2.4.6 ............................. SUCCESS [08:20 min]
[INFO] bigdl-assembly-spark_2.4.6 ......................... SUCCESS [20:02 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS

After updates 
[INFO] spark-version ...................................... SUCCESS [  0.616 s]
[INFO] bigdl-dllib-spark_2.4.6 ............................ SUCCESS [02:48 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
