### PR TITLE
Fix bugs, add detailed description and a python script.

### DIFF
--- a/python/friesian/example/wnd/README.md
+++ b/python/friesian/example/wnd/README.md
@@ -13,13 +13,28 @@ pip install --pre --upgrade analytics-zoo
 ## Prepare the data
 You can download the full __1TB__ Click Logs dataset from [here](https://ailab.criteo.com/download-criteo-1tb-click-logs-dataset/), which includes data of 24 days (day0 to day23) with 4,373,472,329 records in total.
 
-After you download the files, convert them to parquet files with the name `day_x.parquet` (x=0-23), and put all parquet files in one folder.
+After you download the files, convert them to parquet files with the name `day_x.parquet` (x=0-23), and put all parquet files in one folder. The convert from txt to parquet can be made by using the script `convert_txt_to_parquet.py`. Run it by the command below:
+```
+python convert_txt_to_parquet.py \
+    --input_files_path /path_to_txt_data/day_0.txt \
+    --output_folder_path /parquet/output/folder/path
+```
+
+You can also process many txt files by split them with comma in the `input_files_path`:
+```
+python convert_txt_to_parquet.py \
+    --input_files_path /path_to_txt_data/day_0.txt,/path_to_txt_data/day_1.txt \
+    --output_folder_path /parquet/output/folder/path
+```
+
 - The first 23 days (day0 to day22) are used for WND training with 4,195,197,692 records in total.
 - The first half (89,137,319 records in total) of the last day (day23) is used for test. To prepare the test dataset, you need to split the first half of day23 into a new file (e.g. using command `head -n 89137319 day_23 > day_23_test`) and finally convert to parquet files with the name `day_23_test.parquet` under the same folder with the train parquet files.
 
-If you want to use some sample data for test, you can download `dac_sample` from [here](https://labs.criteo.com/2014/02/download-dataset/), unzip and rename it to day0 and convert to parquet files.
+If you want to use some sample data for test, you can download `dac_sample` from [here](https://labs.criteo.com/2014/02/download-dataset/), unzip and rename it to day0 and convert to a parquet file. Then use the running commands in below sections with argument `days` set to `0-0`.
 
 ## Running command
+There is a description about the running arguments at the bottom as you need.
+
 * Spark local, we can use the first several days or some sample data to have a trial, example command:
 ```bash
 python wnd_preprocessing.py \
@@ -27,9 +42,9 @@ python wnd_preprocessing.py \
     --executor_memory 50g \
     --days 0-1 \
     --input_folder /path/to/the/folder/of/parquet_files \
-    --output_foler /path/to/the/folder/to/save/preprocessed/parquet_files \
+    --output_folder /path/to/the/folder/to/save/preprocessed/parquet_files \
     --frequency_limit 15 \
-    --cross_sizes 10000, 10000
+    --cross_sizes 10000,10000
 ```
 
 * Spark standalone, example command to run on the full Criteo dataset:
@@ -42,9 +57,9 @@ python wnd_preprocessing.py \
     --num_executor 8 \
     --days 0-23 \
     --input_folder /path/to/the/folder/of/parquet_files \
-    --output_foler /path/to/the/folder/to/save/preprocessed/parquet_files \
+    --output_folder /path/to/the/folder/to/save/preprocessed/parquet_files \
     --frequency_limit 15 \
-    --cross_sizes 10000, 10000
+    --cross_sizes 10000,10000
 ```
 
 * Spark yarn client mode, example command to run on the full Criteo dataset:
@@ -56,9 +71,9 @@ python wnd_preprocessing.py \
     --num_nodes 8 \
     --days 0-23 \
     --input_folder /path/to/the/folder/of/parquet_files \
-    --output_foler /path/to/the/folder/to/save/preprocessed/parquet_files \
+    --output_folder /path/to/the/folder/to/save/preprocessed/parquet_files \
     --frequency_limit 15 \
-    --cross_sizes 10000, 10000
+    --cross_sizes 10000,10000
 ```
 
 __Options:__
@@ -73,4 +88,4 @@ __Options:__
 * `frequency_limit`: Categories with frequency below this value will be omitted from encoding. We recommend using 15 when you preprocess the full 1TB dataset. Default to be 15.
 * `input_folder`: The path to the folder of parquet files, either a local path or an HDFS path.
 * `output_folder`: The path to save the preprocessed data to parquet files. HDFS path is recommended.
-* `cross_sizes`: bucket sizes for cross columns (`c14-c15` and `c16-c17`) seperated by comma. Default to be 10000, 10000.
+* `cross_sizes`: bucket sizes for cross columns (`c14-c15` and `c16-c17`) seperated by comma. Default to be 10000,10000. Please pay attention that there must not be a blank space between the two numbers.

--- a/python/friesian/example/wnd/convert_txt_to_parquet.py
+++ b/python/friesian/example/wnd/convert_txt_to_parquet.py
@@ -1,0 +1,60 @@
+from pyspark.sql import SparkSession
+
+from pyspark.sql.types import *
+
+import os
+
+from argparse import ArgumentParser
+
+
+
+LABEL_COL = 0
+
+INT_COLS = list(range(1, 14))
+
+CAT_COLS = list(range(14, 40))
+
+
+
+if __name__ == '__main__':
+
+   parser = ArgumentParser()
+
+   parser.add_argument('--input_files_path', type=str, required=True, help="Path to the txt file/files to be processed.")
+
+   parser.add_argument('--output_folder_path', type=str, default=".", help="The path of the folder to save the parquet data.")
+
+   args = parser.parse_args()
+
+   spark = SparkSession.builder.getOrCreate()
+
+   input_files_path = args.input_files_path.split(',')
+
+   output_folder_path = args.output_folder_path
+
+
+
+   label_fields = [StructField('_c%d' % LABEL_COL, IntegerType())]
+
+   int_fields = [StructField('_c%d' % i, IntegerType()) for i in INT_COLS]
+
+   str_fields = [StructField('_c%d' % i, StringType()) for i in CAT_COLS]
+
+
+
+   schema = StructType(label_fields + int_fields + str_fields)
+
+   # paths = [os.path.join(folder, 'day_%d' % i) for i in day_range]
+
+   for file in input_files_path:
+
+
+       df = spark.read.schema(schema).option('sep', '\t').csv(file)
+
+       file_name = file.split('/')[-1].split('.')[0]
+
+
+       output_file_path = os.path.join(output_folder_path, '{}.parquet'.format(file_name)).lstrip(".txt")
+
+
+       df.write.parquet(output_file_path, mode="overwrite")


### PR DESCRIPTION
The modifications are as below:

1. Add some detailed description words in README doc.
   - Replace the wrong argument name with the right one "output_folder" in running commands.
   - Modify wrong value of the argument cross_sizes in running commands.
2. Add a python script to convert txt data file to parquet one.