### PR TITLE
Add bigdl release to combined release script

### DIFF
--- a/python/dev/release_default_linux_spark246.sh
+++ b/python/dev/release_default_linux_spark246.sh
@@ -61,4 +61,7 @@ SERVING_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/serving/dev; pwd)"
 echo $SERVING_SCRIPT_DIR
 bash ${SERVING_SCRIPT_DIR}/release.sh ${version} ${upload}
 
+BIGDL_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/dev; pwd)"
+echo $BIGDL_SCRIPT_DIR
+bash ${BIGDL_SCRIPT_DIR}/release.sh linux ${version} ${upload}
 # TODO: may need to upload all whls in the very end at the same time in case any build fails?

--- a/python/dev/release_default_mac_spark246.sh
+++ b/python/dev/release_default_mac_spark246.sh
@@ -53,4 +53,7 @@ CHRONOS_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/chronos/dev/release; pwd)"
 echo $CHRONOS_SCRIPT_DIR
 bash ${CHRONOS_SCRIPT_DIR}/release_default_mac_spark246.sh ${version} ${upload}
 
+BIGDL_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/dev; pwd)"
+echo $BIGDL_SCRIPT_DIR
+bash ${BIGDL_SCRIPT_DIR}/release.sh mac ${version} ${upload}
 # Serving has a universal jar for all platforms and is released in the linux script.


### PR DESCRIPTION
This PR has added bigdl release to linux and mac pyspark 2.4.6 in the combined release scripts.

Note that we currently only support `pip install bigdl` with pypi source, therefore it is added in spark2.4.6 only since we release packages of spark2.4.6 on pypi nightly.
