### PR TITLE
Add installation guide in Orca AutoML Doc

### DIFF
--- a/docs/readthedocs/source/doc/Orca/Overview/distributed-tuning.md
+++ b/docs/readthedocs/source/doc/Orca/Overview/distributed-tuning.md
@@ -16,7 +16,7 @@ You can install the latest release version of BigDL Orca as follows:
 pip install --pre --upgrade bigdl-orca[automl]
 ```
 _Note that with extra key of [automl], `pip` will automatically install the additional dependencies for distributed hyper-parameter tuning,
-including `ray[tune]==1.2.0`, `psutil`, `aiohttp==3.7.0`, `aioredis==1.1.0`, `setproctitle`, `hiredis==1.1.0`, `async-timeout==3.0.1`, `xgboost`._
+including `ray[tune]==1.2.0`, `psutil`, `aiohttp==3.7.0`, `aioredis==1.1.0`, `setproctitle`, `hiredis==1.1.0`, `async-timeout==3.0.1`, `scikit-learn`, `tensorboard`, `xgboost`._
 
 To use [Pytorch Estimator](#pytorch-autoestimator), you need to install Pytorch with `pip install torch==1.8.1`.
 


### PR DESCRIPTION
May related to issue #3192.
The installation guide for Orca AutoML will be used in quick starts and examples. 