### PR TITLE
fix torch model in python under 3.7.4

### DIFF
--- a/python/orca/src/bigdl/orca/torch/torch_model.py
+++ b/python/orca/src/bigdl/orca/torch/torch_model.py
@@ -58,7 +58,7 @@ class TorchModel(Layer):
         """
         weights = []
         import types
-        if isinstance(model, types.FunctionType) or isinstance(model, types.ClassType):
+        if isinstance(model, types.FunctionType) or isinstance(model, type):
             for param in trainable_param(model()):
                 weights.append(param.view(-1))
         else:
@@ -83,7 +83,7 @@ class TorchModel(Layer):
         # set weights
         m = torch.load(io.BytesIO(self.module_bytes), pickle_module=zoo_pickle_module)
         import types
-        if isinstance(m, types.FunctionType) or isinstance(m, types.ClassType):
+        if isinstance(m, types.FunctionType) or isinstance(m, type):
             m = m()
         w = torch.Tensor(new_weight[0])
         torch.nn.utils.vector_to_parameters(w, trainable_param(m))


### PR DESCRIPTION
Python under 3.7.4 can't find  `types.ClassType`