### PR TITLE
Chronos: lazily import tsfresh to help no `[all]` installation.

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -28,16 +28,6 @@ from bigdl.chronos.data.utils.split import split_timeseries_dataframe
 from bigdl.chronos.data.utils.utils import _to_list, _check_type,\
     _check_col_within, _check_col_no_na, _check_is_aligned, _check_dt_is_sorted
 
-from tsfresh.utilities.dataframe_functions import roll_time_series
-from tsfresh.utilities.dataframe_functions import impute as impute_tsfresh
-from tsfresh import extract_features
-from tsfresh.feature_extraction import ComprehensiveFCParameters, \
-    MinimalFCParameters, EfficientFCParameters
-
-DEFAULT_PARAMS = {"comprehensive": ComprehensiveFCParameters(),
-                  "minimal": MinimalFCParameters(),
-                  "efficient": EfficientFCParameters()}
-
 _DEFAULT_ID_COL_NAME = "id"
 _DEFAULT_ID_PLACEHOLDER = "0"
 
@@ -372,6 +362,14 @@ class TSDataset:
 
         :return: the tsdataset instance.
         '''
+        from tsfresh import extract_features
+        from tsfresh.feature_extraction import ComprehensiveFCParameters, \
+            MinimalFCParameters, EfficientFCParameters
+
+        DEFAULT_PARAMS = {"comprehensive": ComprehensiveFCParameters(),
+                  "minimal": MinimalFCParameters(),
+                  "efficient": EfficientFCParameters()}
+
         assert not self._has_generate_agg_feature, \
             "Only one of gen_global_feature and gen_rolling_feature should be called."
         if full_settings is not None:
@@ -427,6 +425,16 @@ class TSDataset:
 
         :return: the tsdataset instance.
         '''
+        from tsfresh.utilities.dataframe_functions import roll_time_series
+        from tsfresh.utilities.dataframe_functions import impute as impute_tsfresh
+        from tsfresh import extract_features
+        from tsfresh.feature_extraction import ComprehensiveFCParameters, \
+            MinimalFCParameters, EfficientFCParameters
+
+        DEFAULT_PARAMS = {"comprehensive": ComprehensiveFCParameters(),
+                  "minimal": MinimalFCParameters(),
+                  "efficient": EfficientFCParameters()}
+
         assert not self._has_generate_agg_feature,\
             "Only one of gen_global_feature and gen_rolling_feature should be called."
         if isinstance(settings, str):

--- a/python/chronos/src/bigdl/chronos/data/utils/feature.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/feature.py
@@ -18,8 +18,6 @@ import pandas as pd
 import numpy as np
 from packaging import version
 
-import tsfresh
-from tsfresh import extract_features
 
 
 def _is_awake(hour):
@@ -147,6 +145,7 @@ def generate_global_features(input_df,
 
     :return : a new input_df that contains all generated feature.
     '''
+    from tsfresh import extract_features
     if kind_to_fc_parameters is not None:
         global_feature = extract_features(input_df,
                                           column_id=column_id,


### PR DESCRIPTION
help no `[all]` installation.

logger lazily import will be changed on next PR.