### PR TITLE
multiple job share one process can use multiple inference model in flink

### DIFF
--- a/scala/serving/pom.xml
+++ b/scala/serving/pom.xml
@@ -225,7 +225,35 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>3.4.1</version>
+                <executions>
+                    <execution>
+                        <id>scala-compile-first</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <!--Please don't merge this shade plugin with spark-version's shade plugin to spark/pom.xml,
                  or shade plugin will be executed after assembly plugin. -->

--- a/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/ClusterServing.scala
+++ b/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/ClusterServing.scala
@@ -34,6 +34,7 @@ object ClusterServing {
   var helper: ClusterServingHelper = _
   var streamingEnv: StreamExecutionEnvironment = _
   var model: InferenceModel = _
+  var jobModelMap: Map[String, InferenceModel] = Map[String, InferenceModel]()
   var jedisPool: JedisPool = _
   val jedisPoolConfig = new JedisPoolConfig()
   jedisPoolConfig.setMaxTotal(256)

--- a/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/ClusterServingHelper.scala
+++ b/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/ClusterServingHelper.scala
@@ -89,12 +89,17 @@ class ClusterServingHelper
       chwFlag = false
     }
     // Allow concurrent number overwrite
-    if (concurrentNum > 0) {
+    val model = if (concurrentNum > 0) {
       modelParallelism = concurrentNum
+      ClusterServing.logger.info(
+        s"Cluster Serving load Inference Model with Parallelism $modelParallelism")
+      new InferenceModel(modelParallelism)
+    } else {
+      ClusterServing.logger.info(
+        s"Cluster Serving load Inference Model with auto-scaling Parallelism")
+      new InferenceModel()
     }
-    ClusterServing.logger.info(
-      s"Cluster Serving load Inference Model with Parallelism $modelParallelism")
-    val model = new InferenceModel(modelParallelism)
+
 
     // Used for Tensorflow Model, it could not have intraThreadNum > 2^8
     // in some models, thus intraThreadNum should be limited
@@ -280,7 +285,7 @@ object ClusterServingHelper {
    * @param concurrentNumber model concurrent number
    * @return
    */
-  def loadModelfromDir(modelDir: String, concurrentNumber: Int = 1): (InferenceModel, String) = {
+  def loadModelfromDir(modelDir: String, concurrentNumber: Int = 0): (InferenceModel, String) = {
     val helper = new ClusterServingHelper()
     helper.modelPath = modelDir
     helper.parseModelType(modelDir)

--- a/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/flink/FlinkInference.scala
+++ b/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/flink/FlinkInference.scala
@@ -46,20 +46,23 @@ class FlinkInference()
 //    val b = StreamSerializer.objToBytes(x)
 //    val o = StreamSerializer.bytesToObj(b).asInstanceOf[Activity]
 //    println(s"directly deser -> ${o.getClass}")
+    var localModelDir: String = null
     try {
       if (ClusterServing.model == null) {
         ClusterServing.synchronized {
           if (ClusterServing.model == null) {
-            val localModelDir = getRuntimeContext.getDistributedCache
+            localModelDir = getRuntimeContext.getDistributedCache
               .getFile(Conventions.SERVING_MODEL_TMP_DIR).getPath
 
             logger.info(s"Model loaded at executor at path ${localModelDir}")
             helper.modelPath = localModelDir
+
             ClusterServing.model = ClusterServing.helper.loadInferenceModel()
+            ClusterServing.jobModelMap += (localModelDir -> ClusterServing.model)
           }
         }
       }
-      inference = new ClusterServingInference()
+      inference = new ClusterServingInference(localModelDir)
     }
 
     catch {

--- a/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/operator/ClusterServingFunction.scala
+++ b/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/operator/ClusterServingFunction.scala
@@ -52,13 +52,14 @@ class ClusterServingFunction()
           logger.info("Loading Cluster Serving model...")
           val info = ClusterServingHelper
             .loadModelfromDir(modelLocalPath, clusterServingParams._modelConcurrent)
+          ClusterServing.jobModelMap += (modelPath -> info._1)
           ClusterServing.model = info._1
           clusterServingParams._modelType = info._2
           ClusterServing.helper.modelType = clusterServingParams._modelType
         }
       }
     }
-    inference = new ClusterServingInference()
+    inference = new ClusterServingInference(modelPath)
 
   }
 

--- a/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/operator/ClusterServingParams.scala
+++ b/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/operator/ClusterServingParams.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.serving.operator
 
-class ClusterServingParams(modelConcurrent: Int = 1,
+class ClusterServingParams(modelConcurrent: Int = 0,
                            inferenceMode: String = "single",
                            coreNum: Int = 4) extends Serializable {
   val _modelConcurrent = modelConcurrent


### PR DESCRIPTION
This PR is to support multiple Flink jobs using multiple Cluster Serving model (inferenceModel)

There are concerns from Flink team that users start multiple job on same JVM and singleton object would prevent them creating multiple models. Thus this PR is pushed.