### PR TITLE
Fix the issue that NPE thrown by ClusterServing.jedisPool with Kafka

### DIFF
--- a/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/preprocessing/PreProcessing.scala
+++ b/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/preprocessing/PreProcessing.scala
@@ -85,12 +85,15 @@ class PreProcessing()
       case e: Exception =>
         logger.error(s"Preprocessing error, msg ${e.getMessage}")
         logger.error(s"Error stack trace ${e.getStackTrace.mkString("\n")}")
-        val tmpJedis = RedisUtils.getRedisClient(ClusterServing.jedisPool)
-        val hKey = Conventions.RESULT_PREFIX + ClusterServing.helper.jobName + ":" + key
 
-        val hValue = Map[String, String]("value" -> "NaN").asJava
-        tmpJedis.hset(hKey, hValue)
-        tmpJedis.close()
+        if (ClusterServing.helper.queueUsed == "redis") {
+          val tmpJedis = RedisUtils.getRedisClient(ClusterServing.jedisPool)
+          val hKey = Conventions.RESULT_PREFIX + ClusterServing.helper.jobName + ":" + key
+          val hValue = Map[String, String]("value" -> "NaN").asJava
+          tmpJedis.hset(hKey, hValue)
+          tmpJedis.close()
+        }
+
         null
     }
   }


### PR DESCRIPTION
Fix the issue that NPE thrown by ClusterServing.jedisPool when queueUsed was configured as kafka

In PreProcessing.scala if there is an error when invoking decodeArrowBase64, it will unconditionally store the NAN value into Redis. ClusterService.jedisPool would not be initialized if queueUsed was set as kafka in config.yaml. Then it will lead to this issue.