### PR TITLE
Chronos: split chronos ut to two parts and shrink some of the tests

### DIFF
--- a/python/chronos/dev/test/run-pytests.sh
+++ b/python/chronos/dev/test/run-pytests.sh
@@ -28,13 +28,43 @@ fi
 
 ray stop -f
 
-echo "Running chronos tests"
-python -m pytest -v test/bigdl/chronos \
+RUN_PART1=0
+RUN_PART2=0
+if [ $1 = 1 ]; then
+RUN_PART1=1
+RUN_PART2=0
+elif [ $1 = 2 ]; then
+RUN_PART1=0
+RUN_PART2=1
+else
+RUN_PART1=1
+RUN_PART2=1
+fi
+
+if [ $RUN_PART1 = 1 ]; then
+echo "Running chronos tests Part 1"
+python -m pytest -v test/bigdl/chronos/model\
+                    test/bigdl/chronos/forecaster \
        -k "not test_forecast_tcmf_distributed"
 exit_status_0=$?
 if [ $exit_status_0 -ne 0 ];
 then
     exit $exit_status_0
+fi
+fi
+
+if [ $RUN_PART2 = 1 ]; then
+echo "Running chronos tests Part 2"
+python -m pytest -v test/bigdl/chronos/autots\
+                    test/bigdl/chronos/data \
+                    test/bigdl/chronos/simulator \
+                    test/bigdl/chronos/detector \
+       -k "not test_forecast_tcmf_distributed"
+exit_status_0=$?
+if [ $exit_status_0 -ne 0 ];
+then
+    exit $exit_status_0
+fi
 fi
 
 ray stop -f

--- a/python/chronos/test/bigdl/chronos/forecaster/test_mtnet_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_mtnet_forecaster.py
@@ -48,8 +48,8 @@ class TestChronosModelMTNetForecaster(TestCase):
             x = self.ft._roll_test(test_data, past_seq_len=past_seq_len)
             return x
 
-        self.long_num = 6
-        self.time_step = 2
+        self.long_num = 4
+        self.time_step = 1
         look_back = (self.long_num + 1) * self.time_step
         look_forward = 1
         self.x_train, self.y_train = gen_train_sample(data=np.random.randn(

--- a/python/chronos/test/bigdl/chronos/model/test_Seq2Seq.py
+++ b/python/chronos/test/bigdl/chronos/model/test_Seq2Seq.py
@@ -44,7 +44,8 @@ class TestSeq2Seq(ZooTestCase):
 
         self.config = {
             'batch_size': 32,
-            'epochs': 1
+            'epochs': 1,
+            'latent_dim': 8
         }
 
         self.model_1 = LSTMSeq2Seq(check_optional_config=False,
@@ -84,7 +85,7 @@ class TestSeq2Seq(ZooTestCase):
         model_config = {
             'batch_size': 32,
             'epochs': 1,
-            'latent_dim': 128,
+            'latent_dim': 8,
             'dropout': 0.2
         }
         model.fit_eval((x_train, y_train), **model_config)
@@ -178,7 +179,7 @@ class TestSeq2Seq(ZooTestCase):
         assert_array_almost_equal(predict_before, predict_after, decimal=2), \
             "Prediction values are not the same after restore: " \
             "predict before is {}, and predict after is {}".format(predict_before, predict_after)
-        new_config = {'epochs': 1}
+        new_config = {'epochs': 1, 'latent_dim': 8}
         new_model.fit_eval((x_train, y_train), **new_config)
         os.remove(ckpt)
 
@@ -201,7 +202,7 @@ class TestSeq2Seq(ZooTestCase):
         assert_array_almost_equal(predict_before, predict_after, decimal=2), \
             "Prediction values are not the same after restore: " \
             "predict before is {}, and predict after is {}".format(predict_before, predict_after)
-        new_config = {'epochs': 1}
+        new_config = {'epochs': 1, 'latent_dim': 8}
         new_model.fit_eval((x_train, y_train), **new_config)
         os.remove(ckpt)
 

--- a/python/chronos/test/bigdl/chronos/model/test_mtnet.py
+++ b/python/chronos/test/bigdl/chronos/model/test_mtnet.py
@@ -35,8 +35,10 @@ class TestMTNetKeras(ZooTestCase):
         self.model = MTNetKeras()
         self.config = {"long_num": self.long_num,
                        "time_step": self.time_step,
-                       "ar_window": np.random.randint(1, 3),
-                       "cnn_height": np.random.randint(1, 3),
+                       "ar_window": 1, # np.random.randint(1, 3),
+                       "cnn_height": 1, # np.random.randint(1, 3),
+                       "cnn_hid_size": 2,
+                       "rnn_hid_sizes": [2, 2],
                        "epochs": 1}
 
     def teardown_method(self, method):
@@ -56,12 +58,12 @@ class TestMTNetKeras(ZooTestCase):
             x = self.ft._roll_test(test_data, past_seq_len=past_seq_len)
             return x
 
-        self.long_num = 6
-        self.time_step = 2
+        self.long_num = 2
+        self.time_step = 1
         look_back = (self.long_num + 1) * self.time_step
         look_forward = 1
         self.x_train, self.y_train = gen_train_sample(data=np.random.randn(
-            64, 4), past_seq_len=look_back, future_seq_len=look_forward)
+            32, 4), past_seq_len=look_back, future_seq_len=look_forward)
         self.x_val, self.y_val = gen_train_sample(data=np.random.randn(16, 4),
                                                   past_seq_len=look_back,
                                                   future_seq_len=look_forward)


### PR DESCRIPTION
Chronos uts has been splitted to 2 parts to meet the all-ut-within-30-mins requirement.

These two parts all cost ~7min on my 8c8t dev server.