### PR TITLE
[PPML] Fix bugs in occlum realtime

### DIFF
--- a/ppml/trusted-realtime-ml/scala/docker-occlum/check-status.sh
+++ b/ppml/trusted-realtime-ml/scala/docker-occlum/check-status.sh
@@ -3,7 +3,7 @@
 
 REDISLOG="/opt/redis/redis-sgx.log"
 JMSGXLOG="/opt/flink-jobmanager-sgx.log"
-STANDALONELOG="/opt/${FLINK_VERSION}/log/flink-sgx-standalonesession-*.log"
+STANDALONELOG="/opt/flink-${FLINK_VERSION}/log/flink-sgx-standalonesession-*.log"
 TMSGXLOG="/opt/flink/flink---0.log"
 FRONTENDLOG="/opt/http-frontend-sgx.log"
 SERVINGLOG="/opt/cluster-serving-job-sgx.log"

--- a/ppml/trusted-realtime-ml/scala/docker-occlum/start-flink-jobmanager.sh
+++ b/ppml/trusted-realtime-ml/scala/docker-occlum/start-flink-jobmanager.sh
@@ -24,7 +24,7 @@ java \
     -Dorg.apache.flink.shaded.netty4.io.netty.eventLoopThreads=${core_num} \
     -Dcom.intel.analytics.zoo.shaded.io.netty.tryReflectionSetAccessible=true \
     -Dlog.file=${flink_home}/log/flink-sgx-standalonesession-1-sgx-ICX-LCC.log \
-    -Dlog4j.configuration=file:${flink_home}/conf/log4j.properties \
+    -Dlog4j.configurationFile=file:${flink_home}/conf/log4j.properties \
     -Dlogback.configurationFile=file:${flink_home}/conf/logback.xml \
     -classpath ${jars_cp} org.apache.flink.runtime.entrypoint.StandaloneSessionClusterEntrypoint \
     --configDir ${flink_home}/conf \


### PR DESCRIPTION
1. Flink prefix was missed in check-status.sh, which led to a logfile-not-found error.
2. Convert argument name from Dlog4j.configuration to Dlog4j.configurationFile, which can avoid a configure-not-found error.