### PR TITLE
Add document for Orca `PytorchRayEstimator` and `PytorchSparkEstimator`

### DIFF
--- a/docs/readthedocs/source/doc/PythonAPI/Orca/orca.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Orca/orca.rst
@@ -35,6 +35,29 @@ orca.learn.pytorch.estimator
     :undoc-members:
     :show-inheritance:
 
+
+orca.learn.pytorch.pytorch_ray_estimator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Orca Pytorch Estimator with backend of "horovod" or "torch-distributed"
+
+.. automodule:: bigdl.orca.learn.pytorch.pytorch_ray_estimator
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+orca.learn.pytorch.pytorch_spark_estimator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Orca Pytorch Estimator with backend of "bigdl"
+
+.. automodule:: bigdl.orca.learn.pytorch.pytorch_spark_estimator
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 orca.learn.openvino.estimator
 ------------------------------
 

--- a/docs/readthedocs/source/doc/PythonAPI/Orca/orca.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Orca/orca.rst
@@ -39,7 +39,7 @@ orca.learn.pytorch.estimator
 orca.learn.pytorch.pytorch_ray_estimator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Orca Pytorch Estimator with backend of "horovod" or "torch-distributed"
+Orca Pytorch Estimator with backend of "horovod" or "torch_distributed".
 
 .. autoclass:: bigdl.orca.learn.pytorch.pytorch_ray_estimator.PyTorchRayEstimator
     :members:
@@ -50,7 +50,7 @@ Orca Pytorch Estimator with backend of "horovod" or "torch-distributed"
 orca.learn.pytorch.pytorch_spark_estimator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Orca Pytorch Estimator with backend of "bigdl"
+Orca Pytorch Estimator with backend of "bigdl".
 
 .. autoclass:: bigdl.orca.learn.pytorch.pytorch_spark_estimator.PyTorchSparkEstimator
     :members:

--- a/docs/readthedocs/source/doc/PythonAPI/Orca/orca.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Orca/orca.rst
@@ -41,7 +41,7 @@ orca.learn.pytorch.pytorch_ray_estimator
 
 Orca Pytorch Estimator with backend of "horovod" or "torch-distributed"
 
-.. automodule:: bigdl.orca.learn.pytorch.pytorch_ray_estimator
+.. autoclass:: bigdl.orca.learn.pytorch.pytorch_ray_estimator.PyTorchRayEstimator
     :members:
     :undoc-members:
     :show-inheritance:
@@ -52,7 +52,7 @@ orca.learn.pytorch.pytorch_spark_estimator
 
 Orca Pytorch Estimator with backend of "bigdl"
 
-.. automodule:: bigdl.orca.learn.pytorch.pytorch_spark_estimator
+.. autoclass:: bigdl.orca.learn.pytorch.pytorch_spark_estimator.PyTorchSparkEstimator
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
This PR is to solve the remained issue introduced by PR #3399

After this PR, API doc for Orca will be updated to 
![image](https://user-images.githubusercontent.com/12656939/141292066-f3f54faf-26f7-42e2-befb-39ec4e7c513b.png)
