### PR TITLE
Add UT for convergence and save/load for `PyTorchPySparkEstimator`

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-import io
 import types
 import logging
 import numbers
@@ -35,6 +34,7 @@ from bigdl.orca.learn.pytorch.torch_pyspark_runner import find_ip_and_port
 
 
 logger = logging.getLogger(__name__)
+
 
 def partition_to_creator(partition):
 
@@ -68,6 +68,7 @@ def partition_to_creator(partition):
         return data_loader
 
     return data_creator
+
 
 class PyTorchPySparkEstimator(BaseEstimator):
     def __init__(

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
@@ -162,6 +162,22 @@ class TestPyTorchEstimator(TestCase):
         assert 0 < val_stats["Accuracy"] < 1
         assert estimator.get_model()
 
+    def test_convergence(self):
+        estimator = get_estimator(workers_per_node=2)
+        start_val_stats = estimator.evaluate(val_data_loader, batch_size=64)
+        print(start_val_stats)
+        train_stats = estimator.fit(train_data_loader, epochs=2, batch_size=128)
+        print(train_stats)
+        end_val_stats = estimator.evaluate(val_data_loader, batch_size=64)
+        print(end_val_stats)
+        # sanity check that training worked
+        dloss = end_val_stats["val_loss"] - start_val_stats["val_loss"]
+        dacc = (end_val_stats["Accuracy"] -
+                start_val_stats["Accuracy"])
+        print(f"dLoss: {dloss}, dAcc: {dacc}")
+
+        assert dloss < 0 < dacc, "training sanity check failed. loss increased!"
+
     def test_spark_xshards(self):
         from bigdl.dllib.nncontext import init_nncontext
         from bigdl.orca.data import SparkXShards

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
@@ -134,6 +134,7 @@ def val_data_loader(config, batch_size):
 
 
 def get_model(config):
+    torch.manual_seed(0)
     return Net()
 
 
@@ -157,7 +158,7 @@ class TestPyTorchEstimator(TestCase):
         estimator = get_estimator(workers_per_node=2)
         start_val_stats = estimator.evaluate(val_data_loader, batch_size=64)
         print(start_val_stats)
-        train_stats = estimator.fit(train_data_loader, epochs=2, batch_size=128)
+        train_stats = estimator.fit(train_data_loader, epochs=4, batch_size=128)
         print(train_stats)
         end_val_stats = estimator.evaluate(val_data_loader, batch_size=64)
         print(end_val_stats)


### PR DESCRIPTION
This PR added UTs of

- [x] fit convergence
- [x] save/restore: prediction results keep same after save/restore

mentioned as future task in PR #3446 