### PR TITLE
Add spark backend to orca pytorch examples

### DIFF
--- a/python/orca/example/learn/pytorch/cifar10/README.md
+++ b/python/orca/example/learn/pytorch/cifar10/README.md
@@ -1,5 +1,5 @@
 # PyTorch Cifar10 example
-We demonstrate how to easily run synchronous distributed PyTorch training using PyTorch Estimator of Project Orca in Analytics Zoo. We use a simple convolutional nueral network model to train on Cifar10 dataset, which is a dataset for image classification. See [here](https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html) for the original single-node version of this example provided by PyTorch. We provide two distributed PyTorch training backends for this example, namely "bigdl" and "torch_distributed". You can run with either backend as you wish.
+We demonstrate how to easily run synchronous distributed PyTorch training using PyTorch Estimator of Project Orca in Analytics Zoo. We use a simple convolutional nueral network model to train on Cifar10 dataset, which is a dataset for image classification. See [here](https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html) for the original single-node version of this example provided by PyTorch. We provide three distributed PyTorch training backends for this example, namely "bigdl", "torch_distributed" and "spark". You can run with either backend as you wish.
 
 ## Prepare the environment
 
@@ -19,6 +19,9 @@ pip install six cloudpickle
 
 # For torch_distributed backend:
 pip install analytics-zoo[ray]  # 0.10.0.dev3 or above
+
+# For spark backend
+pip install bigdl-orca
 ```
 
 ## Run on local after pip install
@@ -29,10 +32,16 @@ The default backend is `bigdl`.
 python cifar10.py
 ```
 
-You can also run with `torch_distributed` backend via:
+You can run with `torch_distributed` backend via:
 
 ```
 python cifar10.py --backend torch_distributed
+```
+
+You can run with `spark` backend via:
+
+```
+python cifar10.py --backend spark
 ```
 
 ## Run on yarn cluster for yarn-client mode after pip install
@@ -42,7 +51,7 @@ export HADOOP_CONF_DIR=the directory of the hadoop and yarn configurations
 python cifar10.py --cluster_mode yarn-client
 ```
 
-The default backend is `bigdl`. You can also run with `torch_distributed` by specifying the backend.
+The default backend is `bigdl`. You can also run with `torch_distributed` or `spark` by specifying the backend.
 
 ## Results
 
@@ -58,7 +67,7 @@ Final test results will be printed at the end:
 Accuracy of the network on the 10000 test images: 0.541100025177002 
 ```
 
-**For "torch_distributed" backend**
+**For "torch_distributed" and "spark" backend**
 
 Final test results will be printed at the end:
 ```

--- a/python/orca/example/learn/pytorch/cifar10/cifar10.py
+++ b/python/orca/example/learn/pytorch/cifar10/cifar10.py
@@ -41,7 +41,7 @@ parser.add_argument('--cluster_mode', type=str, default="local",
                     help='The cluster mode, such as local, yarn, spark-submit or k8s.')
 parser.add_argument('--backend', type=str, default="bigdl",
                     help='The backend of PyTorch Estimator; '
-                         'bigdl and torch_distributed are supported')
+                         'bigdl, torch_distributed and spark are supported')
 parser.add_argument('--batch_size', type=int, default=64, help='The training batch size')
 parser.add_argument('--epochs', type=int, default=2, help='The number of epochs to train for')
 args = parser.parse_args()
@@ -155,12 +155,12 @@ if args.backend == "bigdl":
 
     res = orca_estimator.evaluate(data=test_loader)
     print("Accuracy of the network on the test images: %s" % res)
-elif args.backend == "torch_distributed":
+elif args.backend in ["torch_distributed", "spark"]:
     orca_estimator = Estimator.from_torch(model=model_creator,
                                           optimizer=optim_creator,
                                           loss=criterion,
                                           metrics=[Accuracy()],
-                                          backend="torch_distributed",
+                                          backend=args.backend,
                                           config={"lr": 0.001,
                                                   "root": root_dir})
 

--- a/python/orca/example/learn/pytorch/fashion_mnist/README.md
+++ b/python/orca/example/learn/pytorch/fashion_mnist/README.md
@@ -1,12 +1,12 @@
 # PyTorch Fashion-MNIST example with Tensorboard visualization
-We demonstrate how to easily show the graphical results of running synchronous distributed PyTorch training using PyTorch Estimator of Project Orca in Analytics Zoo. We use a simple convolutional nueral network model to train on fashion-MNIST dataset. See [here](https://pytorch.org/tutorials/intermediate/tensorboard_tutorial.html) for the original single-node version of this example provided by PyTorch. We provide two distributed PyTorch training backends for this example, namely "bigdl" and "torch_distributed". You can run with either backend as you wish.
+We demonstrate how to easily show the graphical results of running synchronous distributed PyTorch training using PyTorch Estimator of Project Orca in Analytics Zoo. We use a simple convolutional nueral network model to train on fashion-MNIST dataset. See [here](https://pytorch.org/tutorials/intermediate/tensorboard_tutorial.html) for the original single-node version of this example provided by PyTorch. We provide three distributed PyTorch training backends for this example, namely "bigdl", "torch_distributed" and "spark". You can run with either backend as you wish.
 
 ## Prepare the environment
 
 We recommend you to use Anaconda to prepare the environment, especially if you want to run on a yarn cluster:
 
 ```
-conda create -n zoo python=3.7  # "zoo" is conda environment name, you can use any name you like.
+conda create -n zoo python=3.7  # "zoo" is conda environmenst name, you can use any name you like.
 conda activate zoo
 pip install torch
 pip install torchvision
@@ -20,6 +20,9 @@ pip install six cloudpickle
 
 # For torch_distributed backend:
 pip install analytics-zoo[ray]  # 0.10.0.dev3 or above
+
+# For spark backend
+pip install bigdl-orca
 ```
 
 ## Run on local after pip install
@@ -30,7 +33,7 @@ The default backend is `bigdl`.
 python fashion_mnist.py
 ```
 
-You can also run with `torch_distributed` backend via:
+You can run with `torch_distributed` backend via:
 
 ```
 python fashion_mnist.py --backend torch_distributed
@@ -44,6 +47,12 @@ tensorboard --logdir=runs
 
 Then open `https://localhost:6006`.
 
+You can run with `spark` backend via:
+
+```
+python fashion_mnist.py --backend spark
+```
+
 ## Run on yarn cluster for yarn-client mode after pip install
 
 ```
@@ -53,7 +62,7 @@ python fashion_mnist.py --cluster_mode yarn
 
 Then open `https://localhost:6006` on the local client machine to see the result figures.
 
-The default backend is `bigdl`. You can also run with `torch_distributed` by specifying the backend.
+The default backend is `bigdl`. You can also run with `torch_distributed` or `spark` by specifying the backend.
 
 ## Results
 
@@ -71,7 +80,7 @@ Final test results will be printed at the end:
 2021-03-24 14:39:43 INFO  DistriOptimizer$:1759 - Top1Accuracy is Accuracy(correct: 8851, count: 10000, accuracy: 0.8851)
 ```
 
-**For "torch_distributed" backend**
+**For "torch_distributed" and "spark" backend**
 
 You can find the results of training and validation as follows:
 

--- a/python/orca/example/learn/pytorch/fashion_mnist/fashion_mnist.py
+++ b/python/orca/example/learn/pytorch/fashion_mnist/fashion_mnist.py
@@ -111,7 +111,7 @@ def main():
                         help='The cluster mode, such as local, yarn, spark-submit or k8s.')
     parser.add_argument('--backend', type=str, default="bigdl",
                         help='The backend of PyTorch Estimator; '
-                             'bigdl and torch_distributed are supported.')
+                             'bigdl, torch_distributed and spark are supported.')
     parser.add_argument('--batch_size', type=int, default=64, help='The training batch size')
     parser.add_argument('--epochs', type=int, default=2, help='The number of epochs to train for')
     args = parser.parse_args()
@@ -169,12 +169,12 @@ def main():
 
         res = orca_estimator.evaluate(data=test_loader)
         print("Accuracy of the network on the test images: %s" % res)
-    elif args.backend == "torch_distributed":
+    elif args.backend in ["torch_distributed", "spark"]:
         orca_estimator = Estimator.from_torch(model=model_creator,
                                               optimizer=optimizer_creator,
                                               loss=criterion,
                                               metrics=[Accuracy()],
-                                              backend="torch_distributed")
+                                              backend=args.backend)
         stats = orca_estimator.fit(train_data_creator, epochs=epochs, batch_size=batch_size)
 
         for stat in stats:

--- a/python/orca/example/learn/pytorch/super_resolution/README.md
+++ b/python/orca/example/learn/pytorch/super_resolution/README.md
@@ -1,6 +1,6 @@
 # Orca PyTorch Super Resolution example on BSDS300 dataset
 
-We demonstrate how to easily run synchronous distributed Pytorch training using Pytorch Estimator of Project Orca in Analytics Zoo. This is an example using the efficient sub-pixel convolution layer to train on [BSDS3000 dataset](https://www2.eecs.berkeley.edu/Research/Projects/CS/vision/bsds/), using crops from the 200 training images, and evaluating on crops of the 100 test images. See [here](https://github.com/pytorch/examples/tree/master/super_resolution) for the original single-node version of this example provided by Pytorch. We provide two distributed PyTorch training backends for this example, namely "bigdl" and "torch_distributed". You can run with either backend as you wish.
+We demonstrate how to easily run synchronous distributed Pytorch training using Pytorch Estimator of Project Orca in Analytics Zoo. This is an example using the efficient sub-pixel convolution layer to train on [BSDS3000 dataset](https://www2.eecs.berkeley.edu/Research/Projects/CS/vision/bsds/), using crops from the 200 training images, and evaluating on crops of the 100 test images. See [here](https://github.com/pytorch/examples/tree/master/super_resolution) for the original single-node version of this example provided by Pytorch. We provide three distributed PyTorch training backends for this example, namely "bigdl", "torch_distributed" and "spark". You can run with either backend as you wish.
 
 ## Prepare the environment
 We recommend you to use [Anaconda](https://www.anaconda.com/distribution/#linux) to prepare the environment, especially if you want to run on a yarn cluster (yarn-client mode only).
@@ -18,6 +18,9 @@ pip install six cloudpickle
 
 # For torch_distributed backend:
 pip install analytics-zoo[ray]  # 0.10.0.dev3 or above
+
+# For spark backend
+pip install bigdl-orca
 ```
 
 ## Prepare Dataset
@@ -51,6 +54,12 @@ python super_resolution.py --backend bigdl
 - Run with torch_distributed backend:
 ```bash
 python super_resolution.py --backend torch_distributed
+
+
+- Run with spark backend:
+```bash
+python super_resolution.py --backend spark
+
 ```
 
 **Options**
@@ -60,7 +69,7 @@ python super_resolution.py --backend torch_distributed
 * `--lr` Learning Rate. Default is 0.01.
 * `--epochs` The number of epochs to train for. Default is 2.
 * `--cluster_mode` The mode of spark cluster. Either "local" or "yarn". Default is "local".
-* `--backend` The backend of PyTorch Estimator. Either "bigdl" or "torch_distributed". Default is "bigdl".
+* `--backend` The backend of PyTorch Estimator. Either "bigdl", "torch_distributed" or "spark. Default is "bigdl".
 * `--data_dir` The path of datesets. Default is "./dataset".
 
 ## Results
@@ -77,7 +86,7 @@ You can find the result for validation as follows:
 ===> Validation Complete: Avg. PSNR: 12.3136 dB, Avg. Loss: 0.0587
 ```
 
-**For "torch_distributed" backend**
+**For "torch_distributed" and "spark" backend**
 
 You can find the result for training as follows:
 ```

--- a/python/orca/example/learn/pytorch/super_resolution/super_resolution.py
+++ b/python/orca/example/learn/pytorch/super_resolution/super_resolution.py
@@ -56,7 +56,7 @@ parser.add_argument('--cluster_mode', type=str,
                     default='local', help='The mode of spark cluster.')
 parser.add_argument('--backend', type=str, default="bigdl",
                     help='The backend of PyTorch Estimator; '
-                         'bigdl and torch_distributed are supported.')
+                         'bigdl, torch_distributed and spark are supported.')
 parser.add_argument('--data_dir', type=str, default="./dataset", help='The path of datesets.')                         
 opt = parser.parse_args()
 
@@ -268,12 +268,12 @@ if opt.backend == "bigdl":
     print("===> Validation Complete: Avg. PSNR: {:.4f} dB, Avg. Loss: {:.4f}"
           .format(10 * log10(1. / val_stats["MSE"]), val_stats["MSE"]))
 
-elif opt.backend == "torch_distributed":
+elif opt.backend in ["torch_distributed", "spark"]:
     estimator = Estimator.from_torch(
         model=model_creator,
         optimizer=optim_creator,
         loss=criterion,
-        backend="torch_distributed",
+        backend=opt.backend,
         config={
             "lr": opt.lr,
             "upscale_factor": opt.upscale_factor,


### PR DESCRIPTION
The evaluation results for "spark" backend are the same with "torch_distributed" backend with the same seed. 