### PR TITLE
Chronos: add two version fix for ray[tune] dependencies

### DIFF
--- a/python/chronos/src/setup.py
+++ b/python/chronos/src/setup.py
@@ -55,6 +55,7 @@ def setup_package():
         packages=get_bigdl_packages(),
         install_requires=['bigdl-orca=='+VERSION, 'torch>=1.7.1', 'pandas==1.0.3', 'scikit-learn'],
         extras_require={'all': ['tensorflow>=1.15.0,<2.0.0', 'h5py==2.10.0',
+                                'aiohttp==3.7.4', 'aioredis==1.3.1',
                                 'ray[tune]==1.2.0', 'tensorboard', 'scipy==1.5',
                                 'protobuf==3.12.0', 'tsfresh==0.17.0']},
         dependency_links=['https://d3kbcqa49mib13.cloudfront.net/spark-2.0.0-bin-hadoop2.7.tgz'],


### PR DESCRIPTION
This is reported by our internal users.

Cause: 
Ray == 1.2.0 did not claim the version so the latest version of these two lib will be installed
https://github.com/ray-project/ray/blob/ray-1.2.0/python/setup.py#L124-L147

The latest version will cause error (but does not block the search to complete) during the auto tuning.
