### PR TITLE
Chronos: add `forecaster.fit`'s support on dataloader

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -17,10 +17,14 @@
 from bigdl.chronos.forecaster.abstract import Forecaster
 from bigdl.orca.data.shard import SparkXShards
 from bigdl.chronos.forecaster.utils import\
-    np_to_creator, set_pytorch_seed, check_data, xshard_to_np, np_to_xshard
+    np_to_creator, set_pytorch_seed, check_data,\
+        xshard_to_np, np_to_xshard, loader_to_creator
 import numpy as np
 from bigdl.orca.learn.pytorch.estimator import Estimator
 from bigdl.orca.learn.metrics import MSE, MAE
+
+import warnings
+import torch
 
 ORCA_METRICS = {"mse": MSE, "mae": MAE}
 
@@ -61,12 +65,22 @@ class BasePytorchForecaster(Forecaster):
                | should be the same as past_seq_len and input_feature_num.
                | y's shape is (num_samples, horizon, target_dim), where horizon and target_dim
                | should be the same as future_seq_len and output_feature_num.
+               |
                | 2. a xshard item:
                | each partition can be a dictionary of {'x': x, 'y': y}, where x and y's shape
                | should follow the shape stated before.
+               |
+               | 3. pytorch dataloader:
+               | the dataloader should return x, y in each iteration with the shape as following:
+               | x's shape is (num_samples, lookback, feature_dim) where lookback and feature_dim
+               | should be the same as past_seq_len and input_feature_num.
+               | y's shape is (num_samples, horizon, target_dim), where horizon and target_dim
+               | should be the same as future_seq_len and output_feature_num.
 
         :param epochs: Number of epochs you want to train. The value defaults to 1.
         :param batch_size: Number of batch size you want to train. The value defaults to 32.
+               if you input a pytorch dataloader for `data`, the batch_size will follow the
+               batch_size setted in `data`.
 
         :return: Evaluation results on data.
         """
@@ -75,6 +89,8 @@ class BasePytorchForecaster(Forecaster):
         self.config["batch_size"] = batch_size
 
         # input transform
+        if isinstance(data, torch.utils.data.DataLoader) and self.distributed:
+            data = loader_to_creator(data)
         if isinstance(data, tuple) and self.distributed:
             data = np_to_creator(data)
         if isinstance(data, SparkXShards) and not self.distributed:
@@ -86,12 +102,15 @@ class BasePytorchForecaster(Forecaster):
                                      epochs=epochs,
                                      batch_size=batch_size)
         else:
-            check_data(data[0], data[1], self.data_config)
+            if isinstance(data, tuple):
+                check_data(data[0], data[1], self.data_config)
+            else:
+                warnings.warn("Data shape checking is not supported by dataloader input.")
             return self.internal.fit_eval(data=data,
                                           validation_data=data,
                                           epochs=epochs,
                                           metric=self.metrics[0],  # only use the first metric
-                                          **self.config)
+                                          **{**self.config, **self.data_config})
 
     def predict(self, data, batch_size=32):
         """

--- a/python/chronos/src/bigdl/chronos/forecaster/utils.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/utils.py
@@ -22,6 +22,13 @@ import numpy as np
 from bigdl.orca.data import XShards
 
 
+def loader_to_creator(loader):
+    # Warning, this data creator will not respect the batch_size changing.
+    def data_creator(config, batch_size):
+            return loader
+    return data_creator
+
+
 def np_to_creator(data):
     def data_creator(config, batch_size):
             return DataLoader(TensorDataset(torch.from_numpy(data[0]).float(),

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -25,7 +25,7 @@ from unittest import TestCase
 import pytest
 
 
-def create_data():
+def create_data(loader=False):
     num_train_samples = 1000
     num_val_samples = 400
     num_test_samples = 400
@@ -43,7 +43,18 @@ def create_data():
     train_data = get_x_y(num_train_samples)
     val_data = get_x_y(num_val_samples)
     test_data = get_x_y(num_test_samples)
-    return train_data, val_data, test_data
+
+    if loader:
+        from torch.utils.data import DataLoader, TensorDataset
+        train_loader = DataLoader(TensorDataset(torch.from_numpy(train_data[0]),
+                                                torch.from_numpy(train_data[1])), batch_size=32)
+        val_loader = DataLoader(TensorDataset(torch.from_numpy(val_data[0]),
+                                              torch.from_numpy(val_data[1])), batch_size=32)
+        test_loader = DataLoader(TensorDataset(torch.from_numpy(test_data[0]),
+                                               torch.from_numpy(test_data[1])), batch_size=32)
+        return train_loader, val_loader, test_loader
+    else:
+        return train_data, val_data, test_data
 
 
 class TestChronosModelLSTMForecaster(TestCase):
@@ -54,7 +65,7 @@ class TestChronosModelLSTMForecaster(TestCase):
     def tearDown(self):
         pass
 
-    def test_tcn_forecaster_fit_eva_pred(self):
+    def test_lstm_forecaster_fit_eva_pred(self):
         train_data, val_data, test_data = create_data()
         forecaster = LSTMForecaster(past_seq_len=24,
                                     input_feature_num=2,
@@ -69,7 +80,19 @@ class TestChronosModelLSTMForecaster(TestCase):
         assert test_pred.shape == test_data[1].shape
         test_mse = forecaster.evaluate(test_data)
 
-    def test_tcn_forecaster_onnx_methods(self):
+    def test_lstm_forecaster_fit_loader(self):
+        train_loader, _, _ = create_data(loader=True)
+        forecaster = LSTMForecaster(past_seq_len=24,
+                                    input_feature_num=2,
+                                    output_feature_num=2,
+                                    hidden_dim=[32, 16],
+                                    layer_num=2,
+                                    dropout=[0.1, 0.2],
+                                    loss="mae",
+                                    lr=0.01)
+        train_loss = forecaster.fit(train_loader, epochs=2)
+
+    def test_lstm_forecaster_onnx_methods(self):
         train_data, val_data, test_data = create_data()
         forecaster = LSTMForecaster(past_seq_len=24,
                                     input_feature_num=2,
@@ -98,7 +121,7 @@ class TestChronosModelLSTMForecaster(TestCase):
         except ImportError:
             pass
 
-    def test_tcn_forecaster_save_load(self):
+    def test_lstm_forecaster_save_load(self):
         train_data, val_data, test_data = create_data()
         forecaster = LSTMForecaster(past_seq_len=24,
                                     input_feature_num=2,
@@ -114,7 +137,7 @@ class TestChronosModelLSTMForecaster(TestCase):
             test_pred_load = forecaster.predict(test_data[0])
         np.testing.assert_almost_equal(test_pred_save, test_pred_load)
 
-    def test_tcn_forecaster_runtime_error(self):
+    def test_lstm_forecaster_runtime_error(self):
         train_data, val_data, test_data = create_data()
         forecaster = LSTMForecaster(past_seq_len=24,
                                     input_feature_num=2,
@@ -130,7 +153,7 @@ class TestChronosModelLSTMForecaster(TestCase):
         with pytest.raises(RuntimeError):
             forecaster.evaluate(test_data)
 
-    def test_tcn_forecaster_shape_error(self):
+    def test_lstm_forecaster_shape_error(self):
         train_data, val_data, test_data = create_data()
         forecaster = LSTMForecaster(past_seq_len=24,
                                     input_feature_num=2,
@@ -140,7 +163,7 @@ class TestChronosModelLSTMForecaster(TestCase):
         with pytest.raises(AssertionError):
             forecaster.fit(train_data, epochs=2)
 
-    def test_tcn_forecaster_xshard_input(self):
+    def test_lstm_forecaster_xshard_input(self):
         train_data, val_data, test_data = create_data()
         print("original", train_data[0].dtype)
         init_orca_context(cores=4, memory="2g")
@@ -166,7 +189,7 @@ class TestChronosModelLSTMForecaster(TestCase):
             distributed_eval = forecaster.evaluate(val_data)
         stop_orca_context()
 
-    def test_tcn_forecaster_distributed(self):
+    def test_lstm_forecaster_distributed(self):
         train_data, val_data, test_data = create_data()
         init_orca_context(cores=4, memory="2g")
 

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -25,7 +25,7 @@ from unittest import TestCase
 import pytest
 
 
-def create_data():
+def create_data(loader=False):
     num_train_samples = 1000
     num_val_samples = 400
     num_test_samples = 400
@@ -43,7 +43,18 @@ def create_data():
     train_data = get_x_y(num_train_samples)
     val_data = get_x_y(num_val_samples)
     test_data = get_x_y(num_test_samples)
-    return train_data, val_data, test_data
+
+    if loader:
+        from torch.utils.data import DataLoader, TensorDataset
+        train_loader = DataLoader(TensorDataset(torch.from_numpy(train_data[0]),
+                                                torch.from_numpy(train_data[1])), batch_size=32)
+        val_loader = DataLoader(TensorDataset(torch.from_numpy(val_data[0]),
+                                              torch.from_numpy(val_data[1])), batch_size=32)
+        test_loader = DataLoader(TensorDataset(torch.from_numpy(test_data[0]),
+                                               torch.from_numpy(test_data[1])), batch_size=32)
+        return train_loader, val_loader, test_loader
+    else:
+        return train_data, val_data, test_data
 
 
 class TestChronosModelTCNForecaster(TestCase):
@@ -68,6 +79,18 @@ class TestChronosModelTCNForecaster(TestCase):
         test_pred = forecaster.predict(test_data[0])
         assert test_pred.shape == test_data[1].shape
         test_mse = forecaster.evaluate(test_data)
+
+    def test_tcn_forecaster_fit_loader(self):
+        train_loader, _, _ = create_data(loader=True)
+        forecaster = TCNForecaster(past_seq_len=24,
+                                   future_seq_len=5,
+                                   input_feature_num=1,
+                                   output_feature_num=1,
+                                   kernel_size=4,
+                                   num_channels=[16, 16],
+                                   loss="mae",
+                                   lr=0.01)
+        train_loss = forecaster.fit(train_loader, epochs=2)
 
     def test_tcn_forecaster_onnx_methods(self):
         train_data, val_data, test_data = create_data()

--- a/python/orca/src/bigdl/orca/automl/model/base_pytorch_model.py
+++ b/python/orca/src/bigdl/orca/automl/model/base_pytorch_model.py
@@ -104,9 +104,9 @@ class PytorchBaseModel(BaseModel):
                torch.utils.data.DataLoader. torch.Tensor should be generated from the
                dataloader.
         :param validation_data: validation data could be a tuple with numpy ndarray
-               with form (x, y) or a data creator which takes a config dict and returns a
-               torch.utils.data.DataLoader. torch.Tensor should be generated from the
-               dataloader.
+               with form (x, y), a PyTorch DataLoader or a data creator which takes
+               a config dict and returns a torch.utils.data.DataLoader. torch.Tensor
+               should be generated from the dataloader.
         fit_eval will build a model at the first time it is built
         config will be updated for the second or later times with only non-model-arch
         params be functional
@@ -125,7 +125,7 @@ class PytorchBaseModel(BaseModel):
 
         # update config settings
         def update_config():
-            if not isinstance(data, types.FunctionType):
+            if not isinstance(data, types.FunctionType) and not isinstance(data, DataLoader):
                 x = self._reshape_input(data[0])
                 y = self._reshape_input(data[1])
                 config.setdefault("past_seq_len", x.shape[-2])


### PR DESCRIPTION
This support will be inherited by future nano based forecaster as well