### PR TITLE
[PPML] Seperate device-plugin section from README and rename k8s app to bigdl

### DIFF
--- a/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/README.md
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/README.md
@@ -2,27 +2,8 @@
 
 ## Deploy the Intel SGX Device Plugin for Kubenetes
 
-The instructions in this section are modified from the [Intel SGX Device Plugin homepage][intelSGX], to which please refer should questions arise.
+Please refer to the document [here][devicePluginK8sQuickStart].
 
-### Prerequisites
-Prerequisites for building and running these device plugins include:
-- Appropriate hardware
-- A fully configured Kubernetes cluster
-- A working Go environment, of at least version v1.16
-
-Here we would want to deploy the plugin as a DaemonSet, so pull the [source code][pluginCode]. In the working directory, compile with 
-``` bash
-make intel-sgx-plugin
-make intel-sgx-initcontainer
-```
-Deploy the DaemonSet with
-```bash
-kubectl apply -k deployments/sgx_plugin/overlays/epc-register/
-```
-Verify with (replace the `<node name>` with your own node name)
-```
-kubectl describe node <node name> | grep sgx.intel.com
-```
 ## Deploying Trusted Realtime ML for Kubernetes
 
 ### Configurables
@@ -90,3 +71,4 @@ The same goes for the master deployment's ports 6379, 10020, and 10023. Remember
 [pluginCode]: https://github.com/intel/intel-device-plugins-for-kubernetes
 [keysNpassword]: https://github.com/intel-analytics/analytics-zoo/tree/master/ppml/trusted-realtime-ml/scala/docker-graphene#prepare-the-keys
 [helmsite]: https://helm.sh/
+[devicePluginK8sQuickStart]: https://bigdl.readthedocs.io/en/latest/doc/PPML/QuickStart/deploy_intel_sgx_device_plugin_for_kubernets.html

--- a/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/taskmanager-deployment.yaml.back
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/taskmanager-deployment.yaml.back
@@ -6,12 +6,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: analytics-zoo-ppml-trusted-realtime-ml-graphene
+      app: bigdl-ppml-trusted-realtime-ml-graphene
       component: taskmanager
   template:
     metadata:
       labels:
-        app: analytics-zoo-ppml-trusted-realtime-ml-graphene
+        app: bigdl-ppml-trusted-realtime-ml-graphene
         component: taskmanager
     spec:
       tolerations:

--- a/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/flink-configuration-configmap.yaml
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/flink-configuration-configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: flink-config
   labels:
-    app: analytics-zoo-ppml-trusted-realtime-ml-graphene
+    app: bigdl-ppml-trusted-realtime-ml-graphene
 data:
   flink.jobmanager.ip: flink-jobmanager
   taskmanager.memory.managed.size: 8192mb

--- a/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/jobmanager-deployment.yaml
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/jobmanager-deployment.yaml
@@ -6,12 +6,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: analytics-zoo-ppml-trusted-realtime-ml-graphene
+      app: bigdl-ppml-trusted-realtime-ml-graphene
       component: jobmanager
   template:
     metadata:
       labels:
-        app: analytics-zoo-ppml-trusted-realtime-ml-graphene
+        app: bigdl-ppml-trusted-realtime-ml-graphene
         component: jobmanager
     spec:
       tolerations:

--- a/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/jobmanager-service.yaml
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/jobmanager-service.yaml
@@ -12,5 +12,5 @@ spec:
   - name: webui
     port: 8081
   selector:
-    app: analytics-zoo-ppml-trusted-realtime-ml-graphene
+    app: bigdl-ppml-trusted-realtime-ml-graphene
     component: jobmanager

--- a/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/master-deployment.yaml
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/master-deployment.yaml
@@ -6,12 +6,12 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: analytics-zoo-ppml-trusted-realtime-ml-graphene
+      app: bigdl-ppml-trusted-realtime-ml-graphene
   replicas: 1
   template:
     metadata:
       labels:
-        app: analytics-zoo-ppml-trusted-realtime-ml-graphene
+        app: bigdl-ppml-trusted-realtime-ml-graphene
         component: master
     spec:
       tolerations:

--- a/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/redis-service.yaml
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/redis-service.yaml
@@ -8,5 +8,5 @@ spec:
   - name: redisport
     port: 6379
   selector:
-    app: analytics-zoo-ppml-trusted-realtime-ml-graphene
+    app: bigdl-ppml-trusted-realtime-ml-graphene
     component: master

--- a/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/taskmanager-statefulset.yaml
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/taskmanager-statefulset.yaml
@@ -8,7 +8,7 @@ spec:
   - name: rpc
     port: 6125
   selector:
-    app: analytics-zoo-ppml-trusted-realtime-ml-graphene
+    app: bigdl-ppml-trusted-realtime-ml-graphene
     component: flinkmanager
 
 ---
@@ -22,12 +22,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: analytics-zoo-ppml-trusted-realtime-ml-graphene
+      app: bigdl-ppml-trusted-realtime-ml-graphene
       component: taskmanager
   template:
     metadata:
       labels:
-        app: analytics-zoo-ppml-trusted-realtime-ml-graphene
+        app: bigdl-ppml-trusted-realtime-ml-graphene
         component: taskmanager
     spec:
       tolerations:


### PR DESCRIPTION
1. Seperate **device-plugin** section from README, which is replaced with a **QuicStart** link.
2. Rename the k8s app name in yaml files from **analytics-*** to **bigdl-***.