### PR TITLE
Fix test of TF2Estimator on Pyspark backend

### DIFF
--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
@@ -88,16 +88,15 @@ class TestTFEstimator(TestCase):
                               validation_data=df,
                               validation_steps=1)
 
-            res = trainer.evaluate(df, batch_size=4, num_steps=25, feature_cols=["feature"],
-                                   label_cols=["label"])
-            print("validation result: ", res)
-
             print("start saving")
-
             trainer.save_weights(os.path.join(temp_dir, "cifar10_keras.h5"))
             trainer.load_weights(os.path.join(temp_dir, "cifar10_keras.h5"))
             trainer.save(os.path.join(temp_dir, "a.model"))
             trainer.load(os.path.join(temp_dir, "a.model"))
+            res = trainer.evaluate(df, batch_size=4, num_steps=25, feature_cols=["feature"],
+                                   label_cols=["label"])
+            print("validation result: ", res)
+
             res = trainer.predict(df, feature_cols=["feature"]).collect()
         finally:
             shutil.rmtree(temp_dir)


### PR DESCRIPTION
Related: https://github.com/intel-analytics/arda-docker/issues/508