### PR TITLE
Fix pytorch pyspark estimator to keep return value consistent with ray estimator

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -290,7 +290,7 @@ class PyTorchPySparkEstimator(BaseEstimator):
 
     def evaluate(self,
                  data,
-                 batch_size=32,../../../src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+                 batch_size=32,
                  num_steps=None,
                  profile=False,
                  info=None,

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
@@ -128,7 +128,7 @@ class PytorchPysparkWorker(TorchRunner):
         if self.rank == 0:
             return [(state_dict, stats_list)]
         else:
-            return []
+            return [(None, stats_list)]
 
     def validate(self, data_creator, batch_size=32, num_steps=None, profile=False,
                  info=None, wrap_dataloader=None):
@@ -136,10 +136,7 @@ class PytorchPysparkWorker(TorchRunner):
         self.load_state_dict(self.state_dict)
         validation_stats = super().validate(data_creator, batch_size, num_steps, profile, info,
                                             wrap_dataloader)
-        if self.rank == 0:
-            return [validation_stats]
-        else:
-            return []
+        return [validation_stats]
 
     def predict(self, data_creator, batch_size=32, profile=False):
         """Evaluates the model on the validation data set."""

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
@@ -164,6 +164,7 @@ class TestPyTorchEstimator(TestCase):
         print(end_val_stats)
         assert 0 < end_val_stats["Accuracy"] < 1
         assert estimator.get_model()
+
         # sanity check that training worked
         dloss = end_val_stats["val_loss"] - start_val_stats["val_loss"]
         dacc = (end_val_stats["Accuracy"] -

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
@@ -134,6 +134,7 @@ def val_data_loader(config, batch_size):
 
 
 def get_model(config):
+    torch.manual_seed(0)
     return Net()
 
 


### PR DESCRIPTION
Changes:

In `PyTorchPySparkEstimator`:

- `fit`: `reduce_result` takes effect
- `evaluate`: return reduced result of `validate_stats` on all workers.

In UT of `PytorchRayEstimator`:

- Add convergence test