### PR TITLE
add stats log after each epoch for pytorch ray and pyspark

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
@@ -64,6 +64,13 @@ class Estimator(object):
                model_dir.
         :param backend: You can choose "horovod",  "torch_distributed", "bigdl" or "spark" as
                backend. Default: `bigdl`.
+        :param sync_stats: Whether to sync metrics across all distributed workers after each epoch.
+               If set to False, only rank 0's metrics are printed. This param only works horovod,
+               torch_distributed and pyspark backend. For spark backend, the metrics printed are
+               are always synced. This param only affects the printed metrics, the returned metrics
+               are always averaged across workers. Default: True
+        :param log_level: Setting the log_level of each distributed worker. This param only works
+               horovod, torch_distributed and pyspark backend.
         :return: an Estimator object.
         """
         if backend in {"horovod", "torch_distributed"}:

--- a/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import logging
 from bigdl.orca.learn.pytorch.training_operator import TrainingOperator
 
 
@@ -32,7 +33,9 @@ class Estimator(object):
                    use_tqdm=False,
                    workers_per_node=1,
                    model_dir=None,
-                   backend="bigdl"):
+                   backend="bigdl",
+                   sync_stats=True,
+                   log_level=logging.INFO):
         """
         Create an Estimator for torch.
 
@@ -76,7 +79,9 @@ class Estimator(object):
                                        scheduler_step_freq=scheduler_step_freq,
                                        use_tqdm=use_tqdm,
                                        workers_per_node=workers_per_node,
-                                       backend=backend)
+                                       backend=backend,
+                                       sync_stats=sync_stats,
+                                       log_level=log_level)
         elif backend == "bigdl":
             from bigdl.orca.learn.pytorch.pytorch_spark_estimator import PyTorchSparkEstimator
             return PyTorchSparkEstimator(model=model,
@@ -98,7 +103,9 @@ class Estimator(object):
                                            config=config,
                                            scheduler_step_freq=scheduler_step_freq,
                                            use_tqdm=use_tqdm,
-                                           workers_per_node=workers_per_node)
+                                           workers_per_node=workers_per_node,
+                                           sync_stats=sync_stats,
+                                           log_level=log_level)
         else:
             raise ValueError("Only horovod, torch_distributed, bigdl and spark backends are "
                              f"supported for now, got backend: {backend}")

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -84,7 +84,9 @@ class PyTorchPySparkEstimator(BaseEstimator):
             config=None,
             scheduler_step_freq="batch",
             use_tqdm=False,
-            workers_per_node=1):
+            workers_per_node=1,
+            sync_stats=True,
+            log_level=logging.INFO):
         if config is not None and "batch_size" in config:
             raise Exception("Please do not specify batch_size in config. Input batch_size in the"
                             " fit/evaluate/predict function of the estimator instead.")
@@ -124,8 +126,9 @@ class PyTorchPySparkEstimator(BaseEstimator):
             metrics=metrics,
             size=self.num_workers,
             cores_per_worker=self.cores_per_worker,
-            cluster_info=self._get_cluster_info(sc)
-        )
+            cluster_info=self._get_cluster_info(sc),
+            sync_stats=sync_stats,
+            log_level=log_level)
 
         self.driver_runner = PytorchPysparkWorker(**self.worker_init_params, mode='predict')
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
@@ -34,6 +34,7 @@ from contextlib import closing
 import socket
 from bigdl.orca.learn.pytorch.torch_runner import TorchRunner
 import torch.distributed as dist
+import logging
 
 
 def find_ip_and_port(pre_iter):
@@ -65,9 +66,12 @@ class PytorchPysparkWorker(TorchRunner):
                  scheduler_step_freq=None,
                  state_dict=None,
                  backend="torch-distributed",
-                 mode="fit"):
+                 mode="fit",
+                 sync_stats=True,
+                 log_level=logging.INFO):
         super().__init__(model_creator, optimizer_creator, loss_creator, metrics, scheduler_creator,
-                         training_operator_cls, config, use_tqdm, scheduler_step_freq)
+                         training_operator_cls, config, use_tqdm, scheduler_step_freq, sync_stats,
+                         log_level=log_level)
 
         self.state_dict = state_dict
         self.size = size

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -105,7 +105,9 @@ class PyTorchRayEstimator(OrcaRayEstimator):
             scheduler_step_freq="batch",
             use_tqdm=False,
             backend="torch_distributed",
-            workers_per_node=1):
+            workers_per_node=1,
+            sync_stats=True,
+            log_level=logging.INFO):
         if config is not None and "batch_size" in config:
             raise Exception("Please do not specify batch_size in config. Input batch_size in the"
                             " fit/evaluate/predict function of the estimator instead.")
@@ -124,6 +126,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
         self.training_operator_cls = training_operator_cls
         self.scheduler_step_freq = scheduler_step_freq
         self.use_tqdm = use_tqdm
+        self.sync_stats = sync_stats
 
         if not training_operator_cls and not loss_creator:
             raise ValueError("If a loss_creator is not provided, you must "
@@ -141,7 +144,9 @@ class PyTorchRayEstimator(OrcaRayEstimator):
             scheduler_step_freq=self.scheduler_step_freq,
             use_tqdm=self.use_tqdm,
             config=worker_config,
-            metrics=metrics
+            metrics=metrics,
+            sync_stats=sync_stats,
+            log_level=log_level
         )
 
         if backend == "torch_distributed":

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -59,9 +59,6 @@ class DistBackend:
     def all_reduce(self, *args, **kwargs):
         pass
 
-    def is_initialized(self):
-        pass
-
 
 class HorovodDistBackend(DistBackend):
 
@@ -72,10 +69,6 @@ class HorovodDistBackend(DistBackend):
     def all_reduce(self, *args, **kwargs):
         import horovod.torch as hvd
         return hvd.all_reduce(*args, **kwargs)
-
-    def is_initialized(self):
-        import horovod.torch as hvd
-        return hvd.is_initialized()
 
 
 class TorchDistBackend(DistBackend):

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -68,7 +68,7 @@ class HorovodDistBackend(DistBackend):
 
     def all_reduce(self, *args, **kwargs):
         import horovod.torch as hvd
-        return hvd.all_reduce(*args, **kwargs)
+        return hvd.allreduce(*args, **kwargs)
 
 
 class TorchDistBackend(DistBackend):

--- a/python/orca/src/bigdl/orca/learn/pytorch/training_operator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/training_operator.py
@@ -52,7 +52,6 @@ def _is_multiple(component):
     """Checks if a component (optimizer, model, etc) is not singular."""
     return isinstance(component, collections.Iterable) and len(component) > 1
 
-
 class TrainingOperator:
     """Abstract class for custom training or validation loops.
 
@@ -86,8 +85,7 @@ class TrainingOperator:
                  use_fp16=False,
                  use_tqdm=False,
                  sync_stats=False,
-                 dist_backend=None,
-                 world_size=None):
+                 dist_backend=None):
         # You are not expected to override this method.
         self._models = models  # List of models
         assert isinstance(
@@ -115,7 +113,6 @@ class TrainingOperator:
         self.global_step = 0
         self.sync_stats = sync_stats
         self.dist_backend = dist_backend
-        self.world_size = world_size
 
         if type(self) is TrainingOperator:
             for component in (models, schedulers, optimizers):
@@ -222,8 +219,7 @@ class TrainingOperator:
             self.scheduler.step()
 
         return metric_meters.summary(sync_stats=self.sync_stats,
-                                     dist_backend=self.dist_backend,
-                                     world_size=self.world_size)
+                                     dist_backend=self.dist_backend)
 
     def train_batch(self, batch, batch_info):
         """Computes loss and updates the model over one batch.

--- a/python/orca/src/bigdl/orca/learn/pytorch/training_operator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/training_operator.py
@@ -85,7 +85,9 @@ class TrainingOperator:
                  schedulers=None,
                  use_fp16=False,
                  use_tqdm=False,
-                 sync_stats=False):
+                 sync_stats=False,
+                 dist_backend=None,
+                 world_size=None):
         # You are not expected to override this method.
         self._models = models  # List of models
         assert isinstance(
@@ -112,6 +114,8 @@ class TrainingOperator:
         self._use_tqdm = use_tqdm
         self.global_step = 0
         self.sync_stats = sync_stats
+        self.dist_backend = dist_backend
+        self.world_size = world_size
 
         if type(self) is TrainingOperator:
             for component in (models, schedulers, optimizers):
@@ -217,7 +221,9 @@ class TrainingOperator:
         if self.scheduler and info.get(SCHEDULER_STEP) == SCHEDULER_STEP_EPOCH:
             self.scheduler.step()
 
-        return metric_meters.summary(sync_stats=self.sync_stats)
+        return metric_meters.summary(sync_stats=self.sync_stats,
+                                     dist_backend=self.dist_backend,
+                                     world_size=self.world_size)
 
     def train_batch(self, batch, batch_info):
         """Computes loss and updates the model over one batch.

--- a/python/orca/src/bigdl/orca/learn/pytorch/training_operator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/training_operator.py
@@ -84,7 +84,8 @@ class TrainingOperator:
                  criterion=None,
                  schedulers=None,
                  use_fp16=False,
-                 use_tqdm=False):
+                 use_tqdm=False,
+                 sync_stats=False):
         # You are not expected to override this method.
         self._models = models  # List of models
         assert isinstance(
@@ -110,6 +111,7 @@ class TrainingOperator:
             raise ValueError("tqdm must be installed to use tqdm in training.")
         self._use_tqdm = use_tqdm
         self.global_step = 0
+        self.sync_stats = sync_stats
 
         if type(self) is TrainingOperator:
             for component in (models, schedulers, optimizers):
@@ -215,7 +217,7 @@ class TrainingOperator:
         if self.scheduler and info.get(SCHEDULER_STEP) == SCHEDULER_STEP_EPOCH:
             self.scheduler.step()
 
-        return metric_meters.summary()
+        return metric_meters.summary(sync_stats=self.sync_stats)
 
     def train_batch(self, batch, batch_info):
         """Computes loss and updates the model over one batch.
@@ -269,11 +271,7 @@ class TrainingOperator:
         # Compute gradients in a backward pass.
         with self.timers.record("grad"):
             self.optimizer.zero_grad()
-            if self.use_fp16:
-                with amp.scale_loss(loss, self.optimizer) as scaled_loss:
-                    scaled_loss.backward()
-            else:
-                loss.backward()
+            loss.backward()
 
         # Call step of optimizer to update model params.
         with self.timers.record("apply"):

--- a/python/orca/src/bigdl/orca/learn/pytorch/utils.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/utils.py
@@ -221,7 +221,7 @@ class AverageMeterCollection:
         for metric, value in metrics.items():
             self._meters[metric].update(value, n=n)
 
-    def summary(self, sync_stats=False, dist_backend=None, world_size=None):
+    def summary(self, sync_stats=False, dist_backend=None):
         """Returns a dict of average and most recent values for each metric."""
         stats = {BATCH_COUNT: self._batch_count, NUM_SAMPLES: self.n}
         if sync_stats:

--- a/python/orca/src/bigdl/orca/learn/pytorch/utils.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/utils.py
@@ -224,9 +224,6 @@ class AverageMeterCollection:
     def summary(self, sync_stats=False, dist_backend=None):
         """Returns a dict of average and most recent values for each metric."""
         stats = {BATCH_COUNT: self._batch_count, NUM_SAMPLES: self.n}
-        if sync_stats:
-            if dist_backend is None or not dist_backend.is_initialized():
-                raise ValueError("dist_backend must be initialized to use sync_stats")
         for metric, meter in self._meters.items():
             if sync_stats:
                 world_size = dist_backend.get_world_size()

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
@@ -360,7 +360,6 @@ class TestPyTorchEstimator(TestCase):
                         f"but got worker_0_stat0: {worker_0_stat0}, " \
                         f"worker_1_stats: {worker_1_stats}"
             assert abs(v1 - v0) < 1e-6, error_msg
-            assert abs(v1 - 0.5) < 1e-6, "loss should be 0.5"
 
     def test_not_sync_stats(self):
         sc = init_nncontext()

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
@@ -88,6 +88,17 @@ class IdentityNet(nn.Module):
     def forward(self, input_):
         return input_
 
+class IdentityNet2(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # need this line to avoid optimizer raise empty variable list
+        self.fc1 = nn.Linear(1, 1)
+        self.fc1.weight.data.fill_(1.0)
+        self.fc1.bias.data.fill_(0.0)
+
+    def forward(self, input_):
+        return self.fc1(input_)
+
 
 class MultiInputNet(nn.Module):
     def __init__(self):
@@ -143,11 +154,14 @@ def get_optimizer(model, config):
     return torch.optim.SGD(model.parameters(), lr=config.get("lr", 1e-2))
 
 
+def get_zero_optimizer(model, config):
+    return torch.optim.SGD(model.parameters(), lr=0.0)
+
 def get_estimator(workers_per_node=1, model_fn=get_model, sync_stats=False,
-                  log_level=logging.INFO):
+                  log_level=logging.INFO, loss=nn.BCELoss(), optimizer=get_optimizer):
     estimator = Estimator.from_torch(model=model_fn,
-                                     optimizer=get_optimizer,
-                                     loss=nn.BCELoss(),
+                                     optimizer=optimizer,
+                                     loss=loss,
                                      metrics=Accuracy(),
                                      config={"lr": 1e-2},
                                      workers_per_node=workers_per_node,
@@ -320,34 +334,50 @@ class TestPyTorchEstimator(TestCase):
 
     def test_sync_stats(self):
         sc = init_nncontext()
-        rdd = sc.range(0, 100)
-        df = rdd.map(lambda x: (np.random.randn(50).astype(np.float).tolist(),
-                                [int(np.random.randint(0, 2, size=()))])
-                     ).toDF(["feature", "label"])
+        rdd = sc.range(0, 100).repartition(2)
+        # the data and model are constructed that loss on worker 0 is always 0.0
+        # and loss on worker 1 is always 1.0
 
-        estimator = get_estimator(workers_per_node=2, sync_stats=True)
+        df = rdd.mapPartitionsWithIndex(lambda idx, iter: [([float(idx)], [0.0]) for _ in iter]
+                        ).toDF(["feature", "label"])
+
+        estimator = get_estimator(workers_per_node=2,
+                                    model_fn=lambda config: IdentityNet2(),
+                                    loss=nn.MSELoss(),
+                                    optimizer=get_zero_optimizer,
+                                    sync_stats=True)
         stats = estimator.fit(df, batch_size=4, epochs=2,
-                              feature_cols=["feature"],
-                              label_cols=["label"],
-                              reduce_results=False)
+                                feature_cols=["feature"],
+                                label_cols=["label"],
+                                reduce_results=False)
         worker_0_stat0, worker_1_stats = stats[0]
 
         for k in worker_0_stat0:
+            if k in {"num_samples"}:
+                continue
             v0 = worker_0_stat0[k]
             v1 = worker_1_stats[k]
             error_msg = f"stats from all workers should be the same, " \
                         f"but got worker_0_stat0: {worker_0_stat0}, " \
                         f"worker_1_stats: {worker_1_stats}"
             assert abs(v1 - v0) < 1e-6, error_msg
+            assert abs(v1 = 0.5) < 1e-6, "loss should be 0.5"
 
     def test_not_sync_stats(self):
         sc = init_nncontext()
-        rdd = sc.range(0, 100)
-        df = rdd.map(lambda x: (np.random.randn(50).astype(np.float).tolist(),
-                                [int(np.random.randint(0, 2, size=()))])
+        rdd = sc.range(0, 100).repartition(2)
+
+        # the data and model are constructed that loss on worker 0 is always 0.0
+        # and loss on worker 1 is always 1.0
+
+        df = rdd.mapPartitionsWithIndex(lambda idx, iter: [([float(idx)], [0.0]) for _ in iter]
                      ).toDF(["feature", "label"])
 
-        estimator = get_estimator(workers_per_node=2, sync_stats=False)
+        estimator = get_estimator(workers_per_node=2,
+                                  model_fn=lambda config: IdentityNet2(),
+                                  loss=nn.MSELoss(),
+                                  optimizer=get_zero_optimizer,
+                                  sync_stats=False)
         stats = estimator.fit(df, batch_size=4, epochs=2,
                               feature_cols=["feature"],
                               label_cols=["label"],
@@ -357,7 +387,7 @@ class TestPyTorchEstimator(TestCase):
         train_loss_1 = worker_1_stats["train_loss"]
         error_msg = f"stats from all workers should not be the same, " \
                     f"but got worker_0_stats: {worker_0_stats}, worker_1_stats: {worker_1_stats}"
-        assert abs(train_loss_0 - train_loss_1) > 1e-6, error_msg
+        assert abs(train_loss_0 - train_loss_1) > 0.9, error_msg
 
     # not work right now
     # ray logs cannot be captured

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
@@ -92,9 +92,8 @@ class IdentityNet2(nn.Module):
     def __init__(self):
         super().__init__()
         # need this line to avoid optimizer raise empty variable list
-        self.fc1 = nn.Linear(1, 1)
+        self.fc1 = nn.Linear(1, 1, bias=False)
         self.fc1.weight.data.fill_(1.0)
-        self.fc1.bias.data.fill_(0.0)
 
     def forward(self, input_):
         return self.fc1(input_)
@@ -342,14 +341,14 @@ class TestPyTorchEstimator(TestCase):
                         ).toDF(["feature", "label"])
 
         estimator = get_estimator(workers_per_node=2,
-                                    model_fn=lambda config: IdentityNet2(),
-                                    loss=nn.MSELoss(),
-                                    optimizer=get_zero_optimizer,
-                                    sync_stats=True)
+                                  model_fn=lambda config: IdentityNet2(),
+                                  loss=nn.MSELoss(),
+                                  optimizer=get_zero_optimizer,
+                                  sync_stats=True)
         stats = estimator.fit(df, batch_size=4, epochs=2,
-                                feature_cols=["feature"],
-                                label_cols=["label"],
-                                reduce_results=False)
+                              feature_cols=["feature"],
+                              label_cols=["label"],
+                              reduce_results=False)
         worker_0_stat0, worker_1_stats = stats[0]
 
         for k in worker_0_stat0:
@@ -361,7 +360,7 @@ class TestPyTorchEstimator(TestCase):
                         f"but got worker_0_stat0: {worker_0_stat0}, " \
                         f"worker_1_stats: {worker_1_stats}"
             assert abs(v1 - v0) < 1e-6, error_msg
-            assert abs(v1 = 0.5) < 1e-6, "loss should be 0.5"
+            assert abs(v1 - 0.5) < 1e-6, "loss should be 0.5"
 
     def test_not_sync_stats(self):
         sc = init_nncontext()


### PR DESCRIPTION

### logging each epoches metrics (including loss) synced across all workers.

sync metrics can be disbaled by setting `sync_stats=False` in estimator.

logging level can be changed by settting `log_level=logging.XXX` in estimator.

#### Example: INFO level log

```python
est = Estimator.from_pytorch(..., log_level=logging.INFO)
est.fit(...)
```

Output:

```python
Successfully got a SparkContext
2021-11-23 16:37:21,776 INFO services.py:1174 -- View the Ray dashboard at http://10.239.10.109:8265
{'node_ip_address': '10.239.10.109', 'raylet_ip_address': '10.239.10.109', 'redis_address': '10.239.10.109:6379', 'object_store_address': '/tmp/ray/session_2021-11-23_16-37-21_361492_31463/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2021-11-23_16-37-21_361492_31463/sockets/raylet', 'webui_url': '10.239.10.109:8265', 'session_dir': '/tmp/ray/session_2021-11-23_16-37-21_361492_31463', 'metrics_export_port': 62543, 'node_id': '558e2957757bdbdc221788254252f8ceb8d5748e0eaff8deb3f93007'}
(pid=31681) INFO:torch.distributed.distributed_c10d:Added key: store_based_barrier_key:1 to store for rank: 1
(pid=31681) INFO:torch.distributed.distributed_c10d:Rank 1: Completed store-based barrier for 2 nodes.
(pid=31682) INFO:torch.distributed.distributed_c10d:Added key: store_based_barrier_key:1 to store for rank: 0
(pid=31682) INFO:torch.distributed.distributed_c10d:Rank 0: Completed store-based barrier for 2 nodes.
(pid=31681) INFO:root:Reducer buckets have been rebuilt in this iteration.
(pid=31682) INFO:root:Reducer buckets have been rebuilt in this iteration.
(pid=31682) INFO:bigdl.orca.learn.pytorch.torch_runner:Finished training epoch 1, stats: {'epoch': 1, 'batch_count': 94, 'num_samples': 30000, 'train_loss': 0.3356403708457947, 'last_train_loss': 0.09787400811910629}
(pid=31682) INFO:bigdl.orca.learn.pytorch.torch_runner:Finished training epoch 2, stats: {'epoch': 2, 'batch_count': 94, 'num_samples': 30000, 'train_loss': 0.07354243099689484, 'last_train_loss': 0.05228743702173233}
(pid=31682) INFO:bigdl.orca.learn.pytorch.torch_runner:Finished training epoch 3, stats: {'epoch': 3, 'batch_count': 94, 'num_samples': 30000, 'train_loss': 0.04938770830631256, 'last_train_loss': 0.04068942740559578}
(pid=31682) INFO:bigdl.orca.learn.pytorch.torch_runner:Finished training epoch 4, stats: {'epoch': 4, 'batch_count': 94, 'num_samples': 30000, 'train_loss': 0.04067262262105942, 'last_train_loss': 0.04784297198057175}
(pid=31682) INFO:bigdl.orca.learn.pytorch.torch_runner:Finished training epoch 5, stats: {'epoch': 5, 'batch_count': 94, 'num_samples': 30000, 'train_loss': 0.03372194990515709, 'last_train_loss': 0.03526700288057327}
Stopping orca context
```

#### Example: DEBUG level log
```python
est = Estimator.from_pytorch(..., log_level=logging.DEBUG)
est.fit(...)
```
Output:
```
Successfully got a SparkContext
2021-11-23 16:32:56,865 INFO services.py:1174 -- View the Ray dashboard at http://10.239.10.109:8265
{'node_ip_address': '10.239.10.109', 'raylet_ip_address': '10.239.10.109', 'redis_address': '10.239.10.109:6379', 'object_store_address': '/tmp/ray/session_2021-11-23_16-32-56_450696_28757/sockets/plasma_store', 'raylet_socket_name': '/tmp/ray/session_2021-11-23_16-32-56_450696_28757/sockets/raylet', 'webui_url': '10.239.10.109:8265', 'session_dir': '/tmp/ray/session_2021-11-23_16-32-56_450696_28757', 'metrics_export_port': 54572, 'node_id': '3a5f83ff9644dc82b81ac6e0b8fef91a40a4e5e8bd45e94e1b2b5f8a'}
(pid=28956) INFO:torch.distributed.distributed_c10d:Added key: store_based_barrier_key:1 to store for rank: 1
(pid=28956) INFO:torch.distributed.distributed_c10d:Rank 1: Completed store-based barrier for 2 nodes.
(pid=28956) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Creating model
(pid=28956) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Creating optimizer.
(pid=28956) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Creating loss.
(pid=28957) INFO:torch.distributed.distributed_c10d:Added key: store_based_barrier_key:1 to store for rank: 0
(pid=28957) INFO:torch.distributed.distributed_c10d:Rank 0: Completed store-based barrier for 2 nodes.
(pid=28957) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Creating model
(pid=28957) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Creating optimizer.
(pid=28957) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Creating loss.
(pid=28956) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Wrapping DistributedSampler on DataLoader
(pid=28956) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Begin Training Step 1
(pid=28957) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Wrapping DistributedSampler on DataLoader
(pid=28957) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Begin Training Step 1
(pid=28956) INFO:root:Reducer buckets have been rebuilt in this iteration.
(pid=28957) INFO:root:Reducer buckets have been rebuilt in this iteration.
(pid=28956) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Begin Training Step 2
(pid=28957) INFO:bigdl.orca.learn.pytorch.torch_runner:Finished training epoch 1, stats: {'epoch': 1, 'batch_count': 94, 'num_samples': 30000, 'train_loss': 0.3555848002433777, 'last_train_loss': 0.11077268421649933}
(pid=28957) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Begin Training Step 2
(pid=28956) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Begin Training Step 3
(pid=28957) INFO:bigdl.orca.learn.pytorch.torch_runner:Finished training epoch 2, stats: {'epoch': 2, 'batch_count': 94, 'num_samples': 30000, 'train_loss': 0.07694147527217865, 'last_train_loss': 0.06013388931751251}
(pid=28957) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Begin Training Step 3
(pid=28956) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Begin Training Step 4
(pid=28957) INFO:bigdl.orca.learn.pytorch.torch_runner:Finished training epoch 3, stats: {'epoch': 3, 'batch_count': 94, 'num_samples': 30000, 'train_loss': 0.05263303220272064, 'last_train_loss': 0.04599946737289429}
(pid=28957) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Begin Training Step 4
(pid=28956) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Begin Training Step 5
(pid=28957) INFO:bigdl.orca.learn.pytorch.torch_runner:Finished training epoch 4, stats: {'epoch': 4, 'batch_count': 94, 'num_samples': 30000, 'train_loss': 0.0419841930270195, 'last_train_loss': 0.038237836211919785}
(pid=28957) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Begin Training Step 5
(pid=28956) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Wrapping DistributedSampler on DataLoader
(pid=28957) INFO:bigdl.orca.learn.pytorch.torch_runner:Finished training epoch 5, stats: {'epoch': 5, 'batch_count': 94, 'num_samples': 30000, 'train_loss': 0.03563499450683594, 'last_train_loss': 0.0326559916138649}
(pid=28957) DEBUG:bigdl.orca.learn.pytorch.torch_runner:Wrapping DistributedSampler on DataLoader
Stopping orca context
```

fix #3457 