### PR TITLE
Chronos: add import changing for chronos.autots

### DIFF
--- a/python/chronos/src/bigdl/chronos/autots/__init__.py
+++ b/python/chronos/src/bigdl/chronos/autots/__init__.py
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import warnings
 
-from .autotsestimator import AutoTSEstimator
+try:
+    from .autotsestimator import AutoTSEstimator
+except ImportError:
+    warnings.warn("Please install `bigdl-nano[all]` to use AutoTSEstimator")
 from .tspipeline import TSPipeline


### PR DESCRIPTION
This change is to make TSPipeline import available when user only `pip install bigdl-chronos`