### PR TITLE
update Python User Guide and Scala User Guide with supported platforms info

### DIFF
--- a/docs/readthedocs/source/doc/UserGuide/python.md
+++ b/docs/readthedocs/source/doc/UserGuide/python.md
@@ -2,7 +2,7 @@
 
 ---
 Supported Platforms: Linux and macOS.<br>
- _**Note:** Windows is not supported._
+ _**Note:** Windows is currently not supported._
  
 ### **1. Install**
 - We recommend using [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/) to prepare the Python environment as follows:
@@ -28,8 +28,6 @@ Supported Platforms: Linux and macOS.<br>
   export PATH=$PATH:$JAVA_HOME/bin
   java -version  # Verify the version of JDK.
   ```
-- Supported Platforms: Linux and macOS.<br>
-  _**Note:** Windows is not supported._
 
 #### **1.1 Official Release**
 

--- a/docs/readthedocs/source/doc/UserGuide/python.md
+++ b/docs/readthedocs/source/doc/UserGuide/python.md
@@ -1,8 +1,7 @@
 # Python User Guide
 
 ---
-Supported Platforms: Linux and macOS.<br>
- _**Note:** Windows is currently not supported._
+Supported Platforms: Linux and macOS.   _**Note:** Windows is currently not supported._
  
 ### **1. Install**
 - We recommend using [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/) to prepare the Python environment as follows:

--- a/docs/readthedocs/source/doc/UserGuide/python.md
+++ b/docs/readthedocs/source/doc/UserGuide/python.md
@@ -1,6 +1,9 @@
 # Python User Guide
 
 ---
+Supported Platforms: Linux and macOS.<br>
+ _**Note:** Windows is not supported._
+ 
 ### **1. Install**
 - We recommend using [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/) to prepare the Python environment as follows:
 

--- a/docs/readthedocs/source/doc/UserGuide/python.md
+++ b/docs/readthedocs/source/doc/UserGuide/python.md
@@ -27,7 +27,7 @@
   ```
 - Supported Platforms: Linux and macOS.
 
- _**Note:** Windows is not supported._
+  _**Note:** Windows is not supported._
 
 #### **1.1 Official Release**
 

--- a/docs/readthedocs/source/doc/UserGuide/python.md
+++ b/docs/readthedocs/source/doc/UserGuide/python.md
@@ -25,8 +25,7 @@
   export PATH=$PATH:$JAVA_HOME/bin
   java -version  # Verify the version of JDK.
   ```
-- Supported Platforms: Linux and macOS.
-
+- Supported Platforms: Linux and macOS.<br>
   _**Note:** Windows is not supported._
 
 #### **1.1 Official Release**

--- a/docs/readthedocs/source/doc/UserGuide/python.md
+++ b/docs/readthedocs/source/doc/UserGuide/python.md
@@ -25,6 +25,9 @@
   export PATH=$PATH:$JAVA_HOME/bin
   java -version  # Verify the version of JDK.
   ```
+- Supported Platforms: Linux and macOS.
+
+ _**Note:** Windows is not supported._
 
 #### **1.1 Official Release**
 

--- a/docs/readthedocs/source/doc/UserGuide/scala.md
+++ b/docs/readthedocs/source/doc/UserGuide/scala.md
@@ -12,6 +12,9 @@ You can download the BigDL official releases and nightly build from the [Release
 export SPARK_HOME=folder path where you extract the Spark package
 export BIGDL_HOME=folder path where you extract the BigDL package
 ```
+Supported Platforms: Linux and macOS.
+
+ _**Note:** Windows is not supported._
 
 #### **1.2 Use Spark interactive shell**
 You can  try BigDL using the Spark interactive shell as follows:

--- a/docs/readthedocs/source/doc/UserGuide/scala.md
+++ b/docs/readthedocs/source/doc/UserGuide/scala.md
@@ -12,8 +12,7 @@ You can download the BigDL official releases and nightly build from the [Release
 export SPARK_HOME=folder path where you extract the Spark package
 export BIGDL_HOME=folder path where you extract the BigDL package
 ```
-Supported Platforms: Linux and macOS.
-
+Supported Platforms: Linux and macOS.<br>
  _**Note:** Windows is not supported._
 
 #### **1.2 Use Spark interactive shell**

--- a/docs/readthedocs/source/doc/UserGuide/scala.md
+++ b/docs/readthedocs/source/doc/UserGuide/scala.md
@@ -1,7 +1,9 @@
 # Scala User Guide
 
 ---
-
+Supported Platforms: Linux and macOS.<br>
+ _**Note:** Windows is not supported._
+ 
 ### **1. Try BigDL Examples**
 This section will show you how to download BigDL prebuild packages and run the build-in examples.
 

--- a/docs/readthedocs/source/doc/UserGuide/scala.md
+++ b/docs/readthedocs/source/doc/UserGuide/scala.md
@@ -14,8 +14,6 @@ You can download the BigDL official releases and nightly build from the [Release
 export SPARK_HOME=folder path where you extract the Spark package
 export BIGDL_HOME=folder path where you extract the BigDL package
 ```
-Supported Platforms: Linux and macOS.<br>
- _**Note:** Windows is not supported._
 
 #### **1.2 Use Spark interactive shell**
 You can  try BigDL using the Spark interactive shell as follows:

--- a/docs/readthedocs/source/doc/UserGuide/scala.md
+++ b/docs/readthedocs/source/doc/UserGuide/scala.md
@@ -1,8 +1,7 @@
 # Scala User Guide
 
 ---
-Supported Platforms: Linux and macOS.<br>
- _**Note:** Windows is not supported._
+Supported Platforms: Linux and macOS. _**Note:** Windows is currently not supported._
  
 ### **1. Try BigDL Examples**
 This section will show you how to download BigDL prebuild packages and run the build-in examples.


### PR DESCRIPTION
update python.md and scala.md with supported platforms info below: 

- Supported Platforms: Linux and macOS.<br> _**Note:** Windows is not supported._