### PR TITLE
Nano: add transparent forward with ort

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/lightning.py
+++ b/python/nano/src/bigdl/nano/pytorch/lightning.py
@@ -24,7 +24,7 @@ from torch.optim import Optimizer
 
 
 class LightningModuleFromTorch(LightningModule):
-    def __init__(self, model: nn.Module, loss: _Loss, optimizer: Optimizer,
+    def __init__(self, model: nn.Module, loss: _Loss = None, optimizer: Optimizer = None,
                  metrics: List[Metric] = None):
         """
         Integrate pytorch modules, loss, optimizer to pytorch-lightning model.

--- a/python/nano/src/bigdl/nano/pytorch/onnx/onnxrt_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/onnx/onnxrt_inference.py
@@ -188,6 +188,11 @@ def on_fit_start(self):
 
 
 def _forward_onnx(self, *args):
+    # if self.train() is called without calling self.exit_onnx()
+    if self.training:
+        self.exit_onnx()
+        return self.forward(*args)
+
     ort_inputs = {}
     for i, ort_input_item in enumerate(args):
         ort_inputs[self._forward_args[i]] = ort_input_item.numpy()
@@ -208,6 +213,9 @@ def eval_onnx(self, input_sample=None, file_path="model.onnx", sess_options=None
     :param sess_options: (optional) ortsess options in ort.SessionOptions type.
     :param **kwargs: (optional) will be passed to torch.onnx.export function.
     '''
+    # change to eval mode
+    self.eval()
+
     # get input_sample
     if input_sample is None and self.example_input_array:
         input_sample = self.example_input_array

--- a/python/nano/src/bigdl/nano/pytorch/onnx/onnxrt_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/onnx/onnxrt_inference.py
@@ -211,10 +211,12 @@ def eval_onnx(self, input_sample=None, file_path="model.onnx", sess_options=None
     # get input_sample
     if input_sample is None and self.example_input_array:
         input_sample = self.example_input_array
+    if input_sample is None and self.trainer is None:
+        raise RuntimeError("You must state an input_sample or fit on the model to use `eval_onnx`.")
     if input_sample is None and self.trainer.train_dataloader:
-        input_sample = list(next(iter(self.trainer.train_dataloader))[:-1])
+        input_sample = tuple(next(iter(self.trainer.train_dataloader))[:-1])
     if input_sample is None and self.trainer.datamodule:
-        input_sample = list(next(iter(self.trainer.datamodule.train_dataloader()))[:-1])
+        input_sample = tuple(next(iter(self.trainer.datamodule.train_dataloader()))[:-1])
     assert input_sample is not None,\
         "You must state an input_sample or fit on the model to use `eval_onnx`."
 

--- a/python/nano/src/bigdl/nano/pytorch/onnx/onnxrt_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/onnx/onnxrt_inference.py
@@ -161,9 +161,10 @@ def inference(self,
             sample_num = input_sample_list[0].shape[0]  # the first dim should be sample_num
             batch_num = math.ceil(sample_num / batch_size)
             for batch_id in range(batch_num):
-                yhat_list.append(self._forward_onnx(*tuple(map(lambda x:x[batch_id * batch_size:
-                                                                          (batch_id + 1) * batch_size],
-                                                               input_sample_list))))
+                yhat_list.append(self._forward_onnx(
+                    *tuple(map(lambda x: x[batch_id * batch_size:
+                                           (batch_id + 1) * batch_size],
+                               input_sample_list))))
             # this operation may cause performance degradation
             yhat = np.concatenate(yhat_list, axis=0)
             return yhat

--- a/python/nano/src/bigdl/nano/pytorch/onnx/onnxrt_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/onnx/onnxrt_inference.py
@@ -31,7 +31,6 @@ ONNXRT_BINDED_COMPONENTS = ['_ortsess_up_to_date',
                             '_ortsess',
                             '_build_ortsess',
                             'update_ortsess',
-                            'on_fit_start',
                             '_forward_onnx',
                             '_torch_forward',
                             'inference']
@@ -188,6 +187,7 @@ def inference(self,
 # on_fit_start (LightningModule method overwrite)
 def on_fit_start(self):
     self._ortsess_up_to_date = False
+    self.exit_onnx()
     return self._on_fit_start_old()
 
 

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -143,8 +143,6 @@ class Trainer(pl.Trainer):
                 "Loss and optimizer should be None if model is a pytorch-lightning model."
             pl_model = model
         else:
-            assert loss and optimizer, \
-                "Loss and optimizer are required to construct a LightningModule instance."
             pl_model = LightningModuleFromTorch(model, loss, optimizer, metrics)
 
         if onnx:

--- a/python/nano/test/test_models_onnx.py
+++ b/python/nano/test/test_models_onnx.py
@@ -80,8 +80,12 @@ class TestModelsOnnx(TestCase):
         for x, y in train_loader:
             onnx_res = pl_model.inference(x.numpy())  # onnxruntime
             pytorch_res = pl_model.inference(x, backend=None).numpy()  # native pytorch
+            pl_model.eval_onnx()
+            forward_res = pl_model(x).numpy()
+            pl_model.exit_onnx()
             assert pl_model._ortsess_up_to_date is True  # ortsess is up-to-date while inferencing
             np.testing.assert_almost_equal(onnx_res, pytorch_res, decimal=5)  # same result
+            np.testing.assert_almost_equal(onnx_res, forward_res, decimal=5)  # same result
 
         trainer = Trainer(max_epochs=1)
         trainer.fit(pl_model, train_loader)
@@ -111,9 +115,13 @@ class TestModelsOnnx(TestCase):
         for x1, x2, y in train_loader:
             onnx_res = pl_model.inference([x1.numpy(), x2.numpy()])  # onnxruntime
             pytorch_res = pl_model.inference([x1, x2], backend=None).numpy()  # native pytorch
+            pl_model.eval_onnx()
+            forward_res = pl_model(x1, x2).numpy()
+            pl_model.exit_onnx()
             assert pl_model._ortsess_up_to_date is True  # ortsess is up-to-date while inferencing
             np.testing.assert_almost_equal(onnx_res, pytorch_res, decimal=5)  # same result
-        
+            np.testing.assert_almost_equal(onnx_res, forward_res, decimal=5)  # same result
+
         trainer = Trainer(max_epochs=1)
         trainer.fit(pl_model, train_loader)
         assert pl_model._ortsess_up_to_date is False # ortsess is not up-to-date after training


### PR DESCRIPTION
```python
# inferencing with `.forward()` (onnx)
model.eval_onnx()
pred = model(x)
```
related to issue #3667 

------------------------------------------------------------------------
After benchmarking, we find that this will give us a 10~20% speed up on ResNet18 with Cifar10 inference latency on i7-9700. (median)

This is a smaller speed up since the onnx forward needs to do 2 extra casts (tensor -> numpy array -> tensor) to support the transparent speed up. Still the influence is not that much.

```python
pl_model.eval()
pytorch_latency = []
with torch.no_grad():
    for i, batch in enumerate(train_loader):
        x, y = batch
        start_time = time.time()
        pl_model(x)
        pytorch_latency.append(time.time() - start_time)
    print("pytorch_latency:", np.median(pytorch_latency)*1000, 'ms')


pl_model.eval_onnx()
onnx_latency = []
with torch.no_grad(): # useless but I leave here for transparent test
    for i, batch in enumerate(train_loader):
        x, y = batch
        start_time = time.time()
        pl_model(x)
        onnx_latency.append(time.time() - start_time)
    print("onnx_latency:", np.median(onnx_latency)*1000, 'ms')
```