### PR TITLE
Chronos: Modify forecast metrics

### DIFF
--- a/python/chronos/dev/test/run-pytests.sh
+++ b/python/chronos/dev/test/run-pytests.sh
@@ -43,8 +43,9 @@ fi
 
 if [ $RUN_PART1 = 1 ]; then
 echo "Running chronos tests Part 1"
-python -m pytest -v test/bigdl/chronos/model
-python -m pytest -v test/bigdl/chronos/forecaster\
+python -m pytest -v test/bigdl/chronos/model \
+                    test/bigdl/chronos/forecaster \
+                    test/bigdl/chronos/metric \
        -k "not test_forecast_tcmf_distributed"
 exit_status_0=$?
 if [ $exit_status_0 -ne 0 ];

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -15,7 +15,7 @@
 #
 
 import torch
-import numpy
+from numpy import ndarray
 from functools import partial
 from torchmetrics.functional import mean_squared_error, mean_absolute_error,\
     mean_absolute_percentage_error, r2_score, symmetric_mean_absolute_percentage_error
@@ -43,10 +43,10 @@ def _standard_input(metrics, y_true, y_pred):
     assert all(metric in TORCHMETRICS_REGRESSION_MAP.keys() for metric in metrics),\
         f"metric should be one of {TORCHMETRICS_REGRESSION_MAP.keys()}, "\
         f"but get {metrics}."
-    assert type(y_true) is type(y_pred) and isinstance(y_pred, (numpy.ndarray, torch.Tensor)),\
+    assert type(y_true) is type(y_pred) and isinstance(y_pred, (ndarray, torch.Tensor)),\
         "y_pred and y_true type must be numpy.ndarray or torch.Tensor, "\
         f"but found {type(y_true), type(y_pred)}."
-    if isinstance(y_pred, numpy.ndarray) and isinstance(y_true, numpy.ndarray):
+    if isinstance(y_pred, ndarray) and isinstance(y_true, ndarray):
         y_true, y_pred = torch.from_numpy(y_true), torch.from_numpy(y_pred)
     assert y_true.shape == y_pred.shape,\
         "y_true and y_pred should have the same shape, "\

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -45,7 +45,7 @@ def _standard_input(metrics, y_true, y_pred):
         f"but get {metrics}."
     assert type(y_true) is type(y_pred) and isinstance(y_pred, ndarray),\
         "y_pred and y_true type must be numpy.ndarray, "\
-        f"but found {type(y_true)} and {type(y_pred)}."
+        f"but found {type(y_pred)} and {type(y_true)}."
     y_true, y_pred = torch.from_numpy(y_true), torch.from_numpy(y_pred)
 
     assert y_true.shape == y_pred.shape,\

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -43,11 +43,10 @@ def _standard_input(metrics, y_true, y_pred):
     assert all(metric in TORCHMETRICS_REGRESSION_MAP.keys() for metric in metrics),\
         f"metric should be one of {TORCHMETRICS_REGRESSION_MAP.keys()}, "\
         f"but get {metrics}."
-    assert type(y_true) is type(y_pred) and isinstance(y_pred, (ndarray, torch.Tensor)),\
-        "y_pred and y_true type must be numpy.ndarray or torch.Tensor, "\
-        f"but found {type(y_true), type(y_pred)}."
-    if isinstance(y_pred, ndarray) and isinstance(y_true, ndarray):
-        y_true, y_pred = torch.from_numpy(y_true), torch.from_numpy(y_pred)
+    assert type(y_true) is type(y_pred) and isinstance(y_pred, ndarray),\
+        "y_pred and y_true type must be numpy.ndarray, "\
+        f"but found {type(y_true)} and {type(y_pred)}."
+    y_true, y_pred = torch.from_numpy(y_true), torch.from_numpy(y_pred)
     assert y_true.shape == y_pred.shape,\
         "y_true and y_pred should have the same shape, "\
         f"but get {y_true.shape} and {y_pred.shape}."

--- a/python/chronos/test/bigdl/chronos/metric/test_forecast_metrics.py
+++ b/python/chronos/test/bigdl/chronos/metric/test_forecast_metrics.py
@@ -79,11 +79,6 @@ class TestChronosForecastMetrics(TestCase):
         assert_almost_equal(Evaluator.evaluate('smape', y_true, y_pred, aggregate=None)[0],
                             [0.33*2, 0.33+0.25], 2)
 
-        # 4-dim
-        y_true = np.arange(1, 21).reshape(5, 2, 2, 1)
-        y_pred = np.arange(0, 20).reshape(5, 2, 2, 1)
-        assert Evaluator.evaluate('mse', y_true, y_pred, aggregate='mean')[0] == 1
-
         # multi metrics
         y_true = np.array([[[3, -0.5], [2, 7]], [[3, -0.5], [2, 7]], [[3, -0.5], [2, 7]]])
         y_pred = np.array([[[2.5, -0.3], [2, 8]], [[2.5, -0.3], [2, 8]], [[2.5, -0.3], [2, 8]]])

--- a/python/chronos/test/bigdl/chronos/metric/test_forecast_metrics.py
+++ b/python/chronos/test/bigdl/chronos/metric/test_forecast_metrics.py
@@ -15,6 +15,7 @@
 #
 
 import numpy as np
+import pytest
 from unittest import TestCase
 from numpy.testing import assert_almost_equal
 from numpy.testing import assert_array_almost_equal
@@ -38,6 +39,16 @@ class TestChronosForecastMetrics(TestCase):
         assert_almost_equal(Evaluator.evaluate("mae", y_true, y_pred, aggregate="mean")[0], 1.)
         assert_almost_equal(Evaluator.evaluate("r2", y_true, y_pred, aggregate="mean")[0], 0.995, 2)
         assert_almost_equal(Evaluator.evaluate("smape", y_true, y_pred, aggregate="mean")[0], 3.89*2/100, 2)
+        # 3-dim r2
+        assert_almost_equal(Evaluator.evaluate("r2",
+                                               y_true.reshape(5, 5, 2),
+                                               y_pred.reshape(5, 5, 2),
+                                               aggregate='mean')[0], 0.995, 2)
+        # 2-dim r2
+        assert_almost_equal(np.mean(Evaluator.evaluate("r2",
+                                                       y_true.reshape(25, 2),
+                                                       y_pred.reshape(25, 2),
+                                                       aggregate=None)[0]), 0.995, 2)
 
         y_true = np.array([3, -0.5, 2, 7])
         y_pred = np.array([2.5, -0.3, 2, 8])
@@ -49,6 +60,8 @@ class TestChronosForecastMetrics(TestCase):
         y_true = np.array([[[3, -0.5], [2, 7]], [[3, -0.5], [2, 7]], [[3, -0.5], [2, 7]]])
         y_pred = np.array([[[2.5, -0.3], [2, 8]], [[2.5, -0.3], [2, 8]], [[2.5, -0.3], [2, 8]]])
 
+        # single metric
+        # 3-dim
         assert_almost_equal(Evaluator.evaluate("smape", y_true, y_pred, aggregate=None)[0],
                             [[9.09*2/100, 25*2/100], [0*2/100, 6.67*2/100]], 2)
         assert_almost_equal(Evaluator.evaluate("mape", y_true, y_pred, aggregate=None)[0],
@@ -57,3 +70,40 @@ class TestChronosForecastMetrics(TestCase):
                             [[0.5, 0.2], [0, 1]], 2)
         assert_almost_equal(Evaluator.evaluate("mse", y_true, y_pred, aggregate=None)[0],
                             [[0.25, 0.04], [0, 1]], 2)
+
+        # 2-dim
+        y_true = np.array([[1, 2], [0.4, 5], [1, 2], [0.4, 5]])
+        y_pred = np.array([[2, 1], [0.2, 3], [2, 1], [0.2, 3]])
+        assert_almost_equal(Evaluator.evaluate("mse", y_true, y_pred, aggregate=None)[0],
+                            [0.52, 2.5], 2)
+        assert_almost_equal(Evaluator.evaluate('smape', y_true, y_pred, aggregate=None)[0],
+                            [0.33*2, 0.33+0.25], 2)
+
+        # 4-dim
+        y_true = np.arange(1, 21).reshape(5, 2, 2, 1)
+        y_pred = np.arange(0, 20).reshape(5, 2, 2, 1)
+        assert Evaluator.evaluate('mse', y_true, y_pred, aggregate='mean')[0] == 1
+
+        # multi metrics
+        y_true = np.array([[[3, -0.5], [2, 7]], [[3, -0.5], [2, 7]], [[3, -0.5], [2, 7]]])
+        y_pred = np.array([[[2.5, -0.3], [2, 8]], [[2.5, -0.3], [2, 8]], [[2.5, -0.3], [2, 8]]])
+        mse, rmse, mape, smape = Evaluator.evaluate(['mse', 'rmse', 'mape', 'smape'],
+                                                    y_true,
+                                                    y_pred,
+                                                    aggregate=None)
+        assert_almost_equal(mse, [[0.25, 0.04], [0, 1]], 2)
+        assert_almost_equal(rmse, [[0.5, 0.2], [0, 1]], 2)
+        assert_almost_equal(mape, [[16.67/100, 40.00/100], [0/100, 14.29/100]], 2)
+        assert_almost_equal(smape, [[9.09*2/100, 25*2/100], [0*2/100, 6.67*2/100]], 2)
+
+    def test_standard_input(self):
+        y_true = np.random.randn(100, 2, 2)
+        y_pred = np.random.randn(100, 2, 2)
+
+        with pytest.raises(AssertionError):
+            Evaluator.evaluate("test_smape", y_true, y_pred, aggregate=None)
+        with pytest.raises(AssertionError):
+            Evaluator.evaluate("mse", y_true, y_pred.reshape(100, 4))
+        y_true = [10, 2, 5]
+        with pytest.raises(AssertionError):
+            Evaluator.evaluate('mse', y_true, y_true)


### PR DESCRIPTION
* metrics-dim: Supports data input of any dimension(Only 1-3dim can use `aggregate`=None).
* data type: Add input data type check, support `numpy.ndarray`.
* Add forecast metrics ut, and add test_forecast_metrics to run_pytests.sh.