### PR TITLE
Adding options for changing hadoop version for spark in Dockerfile

### DIFF
--- a/docker/bigdl-k8s/Dockerfile
+++ b/docker/bigdl-k8s/Dockerfile
@@ -1,6 +1,8 @@
 ARG SPARK_VERSION=2.4.6
+ARG HADOOP_VERSION=2.7
 ARG SPARK_HOME=/opt/spark
 ARG JDK_VERSION=8u192
+ARG JDK_FILE_PREPEND=jdk
 ARG JDK_URL=your_jdk_url
 ARG BIGDL_VERSION=0.14.0-SNAPSHOT
 ARG TINI_VERSION=v0.18.0
@@ -9,7 +11,9 @@ ARG PYTHON_ENV_NAME=tf1
 # stage.1 jdk & spark
 FROM ubuntu:18.04 as spark
 ARG SPARK_VERSION
+ARG HADOOP_VERSION
 ARG JDK_VERSION
+ARG JDK_FILE_PREPEND
 ARG JDK_URL
 ARG SPARK_HOME
 ARG TINI_VERSION
@@ -20,16 +24,16 @@ RUN apt-get update --fix-missing && \
     apt-get install -y apt-utils vim curl nano wget unzip maven git && \
 # java
     wget $JDK_URL && \
-    gunzip jdk-$JDK_VERSION-linux-x64.tar.gz && \
-    tar -xf jdk-$JDK_VERSION-linux-x64.tar -C /opt && \
-    rm jdk-$JDK_VERSION-linux-x64.tar && \
-    mv /opt/jdk* /opt/jdk$JDK_VERSION && \
+    gunzip $JDK_FILE_PREPEND-$JDK_VERSION-linux-x64.tar.gz && \
+    tar -xf $JDK_FILE_PREPEND-$JDK_VERSION-linux-x64.tar -C /opt && \
+    rm $JDK_FILE_PREPEND-$JDK_VERSION-linux-x64.tar && \
+    mv /opt/$JDK_FILE_PREPEND* /opt/jdk$JDK_VERSION && \
     ln -s /opt/jdk$JDK_VERSION /opt/jdk && \
 # spark
-    wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop2.7.tgz && \
-    tar -zxvf spark-${SPARK_VERSION}-bin-hadoop2.7.tgz && \
-    mv spark-${SPARK_VERSION}-bin-hadoop2.7 /opt/spark && \
-    rm spark-${SPARK_VERSION}-bin-hadoop2.7.tgz && \
+    wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz && \
+    tar -zxvf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz && \
+    mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} /opt/spark && \
+    rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz && \
     cp /opt/spark/kubernetes/dockerfiles/spark/entrypoint.sh /opt 
 
 RUN ln -fs /bin/bash /bin/sh

--- a/docker/bigdl-k8s/Dockerfile
+++ b/docker/bigdl-k8s/Dockerfile
@@ -2,7 +2,6 @@ ARG SPARK_VERSION=2.4.6
 ARG HADOOP_VERSION=2.7
 ARG SPARK_HOME=/opt/spark
 ARG JDK_VERSION=8u192
-ARG JDK_FILE_PREPEND=jdk
 ARG JDK_URL=your_jdk_url
 ARG BIGDL_VERSION=0.14.0-SNAPSHOT
 ARG TINI_VERSION=v0.18.0
@@ -13,7 +12,6 @@ FROM ubuntu:18.04 as spark
 ARG SPARK_VERSION
 ARG HADOOP_VERSION
 ARG JDK_VERSION
-ARG JDK_FILE_PREPEND
 ARG JDK_URL
 ARG SPARK_HOME
 ARG TINI_VERSION
@@ -23,11 +21,11 @@ ENV SPARK_HOME                          ${SPARK_HOME}
 RUN apt-get update --fix-missing && \
     apt-get install -y apt-utils vim curl nano wget unzip maven git && \
 # java
-    wget $JDK_URL && \
-    gunzip $JDK_FILE_PREPEND-$JDK_VERSION-linux-x64.tar.gz && \
-    tar -xf $JDK_FILE_PREPEND-$JDK_VERSION-linux-x64.tar -C /opt && \
-    rm $JDK_FILE_PREPEND-$JDK_VERSION-linux-x64.tar && \
-    mv /opt/$JDK_FILE_PREPEND* /opt/jdk$JDK_VERSION && \
+    wget -O jdk.tar.gz $JDK_URL && \
+    gunzip jdk.tar.gz && \
+    mkdir /opt/jdk$JDK_VERSION && \
+    tar -xf jdk.tar -C /opt/jdk$JDK_VERSION --strip-components 1 && \
+    rm jdk.tar && \
     ln -s /opt/jdk$JDK_VERSION /opt/jdk && \
 # spark
     wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz && \


### PR DESCRIPTION
I'm using BigDL in a project where I need Hadoop 3.2.0, and edited the BigDL Dockerfile to allow this. There's also improved functionality for open JDK downloads now. I successfully used the hadoop 3.2.0 image in a project using Orca. I couldn't see any contribution guidelines for this project, so please let me know if anything is needed from me!