### PR TITLE
Serving BigDL model from NNModel UT

### DIFF
--- a/scala/serving/pom.xml
+++ b/scala/serving/pom.xml
@@ -50,6 +50,12 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.16</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
             <version>${scala.version}</version>

--- a/scala/serving/src/test/scala/com/intel/analytics/bigdl/serving/models/BigDLModelSpec.scala
+++ b/scala/serving/src/test/scala/com/intel/analytics/bigdl/serving/models/BigDLModelSpec.scala
@@ -1,0 +1,18 @@
+package com.intel.analytics.bigdl.serving.models
+
+import com.intel.analytics.bigdl.dllib.tensor.Tensor
+import com.intel.analytics.bigdl.serving.{ClusterServing, ClusterServingHelper}
+import org.scalatest.{FlatSpec, Matchers}
+
+class BigDLModelSpec extends FlatSpec with Matchers {
+  "BigDL NNModel" should "work" in {
+    ClusterServing.helper = new ClusterServingHelper()
+    val helper = ClusterServing.helper
+    helper.modelType = "bigdl"
+    helper.weightPath = "/home/litchy/models/linear.model"
+    ClusterServing.model = helper.loadInferenceModel()
+    val tensor = Tensor[Float](1, 2).rand()
+    val result = ClusterServing.model.doPredict(tensor)
+    require(result.toTensor[Float].size().sameElements(Array(1, 1)), "shape error")
+  }
+}

--- a/scala/serving/src/test/scala/com/intel/analytics/bigdl/serving/models/BigDLModelSpec.scala
+++ b/scala/serving/src/test/scala/com/intel/analytics/bigdl/serving/models/BigDLModelSpec.scala
@@ -3,14 +3,18 @@ package com.intel.analytics.bigdl.serving.models
 import com.intel.analytics.bigdl.dllib.tensor.Tensor
 import com.intel.analytics.bigdl.serving.{ClusterServing, ClusterServingHelper}
 import org.scalatest.{FlatSpec, Matchers}
+import scala.sys.process._
 
 class BigDLModelSpec extends FlatSpec with Matchers {
   "BigDL NNModel" should "work" in {
+    ("wget --no-check-certificate -O /tmp/linear.model https://sourceforge.net/" +
+      "projects/analytics-zoo/files/analytics-zoo-data/linear.model").!
     ClusterServing.helper = new ClusterServingHelper()
     val helper = ClusterServing.helper
     helper.modelType = "bigdl"
-    helper.weightPath = "/home/litchy/models/linear.model"
+    helper.weightPath = "/tmp/linear.model"
     ClusterServing.model = helper.loadInferenceModel()
+    "rm /tmp/linear.model".!
     val tensor = Tensor[Float](1, 2).rand()
     val result = ClusterServing.model.doPredict(tensor)
     require(result.toTensor[Float].size().sameElements(Array(1, 1)), "shape error")

--- a/scala/serving/src/test/scala/com/intel/analytics/bigdl/serving/models/BigDLModelSpec.scala
+++ b/scala/serving/src/test/scala/com/intel/analytics/bigdl/serving/models/BigDLModelSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.intel.analytics.bigdl.serving.models
 
 import com.intel.analytics.bigdl.dllib.tensor.Tensor


### PR DESCRIPTION
This UT is based on branch 2.0, it passed. However if I change to zoo branch 0.9, the load would fail.

By the way I am using branch 2.0 bigdl python keras module to export NNModel. The API is `saveModel` instead of `save` and `save` could not be used in branch 2.0. Thus so far I do not know what are the incompatibilities in this case.

* The issue link: https://github.com/intel-analytics/BigDL/issues/3797
* save API link: https://github.com/intel-analytics/BigDL/blob/1725d1156dd992b057a61c0d16ddd4bdfeef1003/python/dllib/src/bigdl/dllib/keras/engine/topology.py#L32

@jason-dai @dding3 