### PR TITLE
Add upper version limit for pandas dependency

### DIFF
--- a/python/chronos/src/setup.py
+++ b/python/chronos/src/setup.py
@@ -54,7 +54,7 @@ def setup_package():
         url='https://github.com/intel-analytics/BigDL',
         packages=get_bigdl_packages(),
         install_requires=['bigdl-orca=='+VERSION, 'bigdl-nano[pytorch]',
-                          'pandas>=1.0.5, <=1.1.5', 'scikit-learn', 'statsmodels'],
+                          'pandas>=1.0.5, <1.3.0', 'scikit-learn', 'statsmodels'],
         extras_require={'all': ['bigdl-orca[automl]=='+VERSION, 'scipy==1.5',
                                 'protobuf==3.12.0', 'tsfresh==0.17.0']},
         dependency_links=['https://d3kbcqa49mib13.cloudfront.net/spark-2.0.0-bin-hadoop2.7.tgz'],

--- a/python/chronos/src/setup.py
+++ b/python/chronos/src/setup.py
@@ -54,7 +54,7 @@ def setup_package():
         url='https://github.com/intel-analytics/BigDL',
         packages=get_bigdl_packages(),
         install_requires=['bigdl-orca=='+VERSION, 'bigdl-nano[pytorch]',
-                          'pandas>=1.0.5', 'scikit-learn', 'statsmodels'],
+                          'pandas>=1.0.5, <=1.1.5', 'scikit-learn', 'statsmodels'],
         extras_require={'all': ['bigdl-orca[automl]=='+VERSION, 'scipy==1.5',
                                 'protobuf==3.12.0', 'tsfresh==0.17.0']},
         dependency_links=['https://d3kbcqa49mib13.cloudfront.net/spark-2.0.0-bin-hadoop2.7.tgz'],


### PR DESCRIPTION
Pandas 1.3.5 will cause error
http://10.112.231.51:18888/job/BigDL-PRVN-chronos-Python-Spark-3.1-py37-ray-part2/171/console 

pandas 1.0.5 and 1.1.5 works.