### PR TITLE
exclude high Vulnerabilities in ppml

### DIFF
--- a/scala/ppml/pom.xml
+++ b/scala/ppml/pom.xml
@@ -33,6 +33,22 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.media</groupId>
+                    <artifactId>jersey-media-jaxb</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -81,6 +97,12 @@
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
             <version>3.15.8</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>


### PR DESCRIPTION
Vulnerabilities scan link:
https://snyk.devtools.intel.com/org/le.zhengintel.com/project/708c310c-4bbd-48a7-9111-14fa6d249660 

scan report: 
```
com.fasterxml.jackson.core:jackson-databind@2.10.0
Introduced through
org.apache.spark:spark-mllib_2.12@3.1.2
Fixed in
com.fasterxml.jackson.core:jackson-databind@2.6.7.4, @2.9.10.7, @2.10.5.1

xerces:xercesImpl@2.9.1
Introduced through
org.apache.spark:spark-mllib_2.12@3.1.2
Fixed in
xerces:xercesImpl@2.12.0

com.google.code.gson:gson@2.8.6
Introduced through
com.google.protobuf:protobuf-java-util@3.15.8
Fixed in
com.google.code.gson:gson@2.8.9

org.glassfish.jersey.media:jersey-media-jaxb@2.30
Introduced through
org.apache.spark:spark-mllib_2.12@3.1.2
Fixed in
org.glassfish.jersey.media:jersey-media-jaxb@2.31
```