### PR TITLE
exclude high Vulnerabilities in friesian

### DIFF
--- a/scala/friesian/pom.xml
+++ b/scala/friesian/pom.xml
@@ -80,6 +80,18 @@
                     <artifactId>jackson-module-scala_${scala.major.version}</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.glassfish.jersey.media</groupId>
+                    <artifactId>jersey-media-jaxb</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
@@ -135,6 +147,12 @@
             <artifactId>java-grpc-prometheus</artifactId>
             <version>0.4.0</version>
             <scope>${serving.scope}</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-codec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- The client -->
         <dependency>


### PR DESCRIPTION
scan report:
```
xerces:xercesImpl@2.9.1
Introduced through
org.apache.spark:spark-core_2.12@3.1.2
Fixed in
xerces:xercesImpl@2.12.0

io.netty:netty-codec@4.1.48.Final
Introduced through
me.dinowernli:java-grpc-prometheus@0.4.0
Fixed in
io.netty:netty-codec@4.1.68.Final

org.glassfish.jersey.media:jersey-media-jaxb@2.30
Introduced through
org.apache.spark:spark-core_2.12@3.1.2
Fixed in
org.glassfish.jersey.media:jersey-media-jaxb@2.31
```