### PR TITLE
upgrade log4j to 2.17.1

### DIFF
--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -160,7 +160,7 @@
         <thrift.path>thrift</thrift.path>
         <thrift.version>0.9.2</thrift.version>
         <slf4j.version>1.7.7</slf4j.version>
-        <log4j.version>2.17.0</log4j.version>
+        <log4j.version>2.17.1</log4j.version>
         <jetty.version>6.1.26</jetty.version>
         <jetty.jspapi.version>6.1.14</jetty.jspapi.version>
         <commons-cli.version>1.2</commons-cli.version>


### PR DESCRIPTION
https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core 
2.17.0 has Vulnerabilities.