### PR TITLE
Expose `remote_dir` for AutoXGBoost

### DIFF
--- a/python/orca/example/automl/autoxgboost/AutoXGBoostClassifier.py
+++ b/python/orca/example/automl/autoxgboost/AutoXGBoostClassifier.py
@@ -131,7 +131,13 @@ if __name__ == '__main__':
         scheduler = None
         scheduler_params = None
 
-    auto_xgb_clf = AutoXGBClassifier(cpus_per_trial=4, name="auto_xgb_classifier", **config)
+    remote_dir = "hdfs:///tmp/auto_xgb_regressor" if opt.cluster_mode == "yarn" else None
+
+    auto_xgb_clf = AutoXGBClassifier(cpus_per_trial=4,
+                                     name="auto_xgb_classifier",
+                                     remote_dir=remote_dir,
+                                     **config)
+
     import time
     start = time.time()
     auto_xgb_clf.fit(data=(X_train, y_train),

--- a/python/orca/example/automl/autoxgboost/AutoXGBoostRegressor.py
+++ b/python/orca/example/automl/autoxgboost/AutoXGBoostRegressor.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='AutoXGBRegressor example')
     parser.add_argument('-p', '--path', type=str,
-                        default="./data/incd.csv",
+                        default="~/data/incd.csv",
                         help='Training data path')
     parser.add_argument('--cluster_mode',
                         type=str,
@@ -182,9 +182,12 @@ if __name__ == '__main__':
         scheduler = None
         scheduler_params = None
 
+    remote_dir = "hdfs:///tmp/auto_xgb_regressor" if opt.cluster_mode == "yarn" else None
+
     auto_xgb_reg = AutoXGBRegressor(
         cpus_per_trial=2,
         name="auto_xgb_regressor",
+        remote_dir=remote_dir,
         **config)
     auto_xgb_reg.fit(data=(X_train, y_train),
                      validation_data=(X_val, y_val),

--- a/python/orca/example/automl/autoxgboost/AutoXGBoostRegressor.py
+++ b/python/orca/example/automl/autoxgboost/AutoXGBoostRegressor.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='AutoXGBRegressor example')
     parser.add_argument('-p', '--path', type=str,
-                        default="~/data/incd.csv",
+                        default="./data/incd.csv",
                         help='Training data path')
     parser.add_argument('--cluster_mode',
                         type=str,

--- a/python/orca/src/bigdl/orca/automl/search/ray_tune/ray_tune_search_engine.py
+++ b/python/orca/src/bigdl/orca/automl/search/ray_tune/ray_tune_search_engine.py
@@ -60,7 +60,8 @@ class RayTuneSearchEngine(SearchEngine):
             return None
         else:
             default_remote_dir = f"hdfs:///tmp/{name}"
-            process(command=f"hadoop fs -mkdir -p {default_remote_dir}")
+            process(command=f"hadoop fs -mkdir -p {default_remote_dir}; "
+                            f"hadoop fs -chmod 777 {default_remote_dir}")
             return default_remote_dir
 
     def compile(self,

--- a/python/orca/src/bigdl/orca/automl/search/utils.py
+++ b/python/orca/src/bigdl/orca/automl/search/utils.py
@@ -18,7 +18,7 @@ import os
 IDENTIFIER_LEN = 27
 
 
-def process(command, fail_fast=False, timeout=120):
+def process(command, fail_fast=True, timeout=120):
     import subprocess
     pro = subprocess.Popen(
         command,

--- a/python/orca/src/bigdl/orca/automl/xgboost/auto_xgb.py
+++ b/python/orca/src/bigdl/orca/automl/xgboost/auto_xgb.py
@@ -23,6 +23,7 @@ class AutoXGBClassifier(AutoEstimator):
                  logs_dir="/tmp/auto_xgb_classifier_logs",
                  cpus_per_trial=1,
                  name=None,
+                 remote_dir=None,
                  **xgb_configs
                  ):
         """
@@ -49,6 +50,9 @@ class AutoXGBClassifier(AutoEstimator):
             The value will also be assigned to n_jobs in xgboost,
             which is the number of parallel threads used to run xgboost.
         :param name: Name of the auto xgboost classifier.
+        :param remote_dir: String. Remote directory to sync training results and checkpoints. It
+            defaults to None and doesn't take effects while running in local. While running in
+            cluster, it defaults to "hdfs:///tmp/{name}".
         :param xgb_configs: Other scikit learn xgboost parameters. You may refer to
            https://xgboost.readthedocs.io/en/latest/python/python_api.html#module-xgboost.sklearn
            for the parameter names to specify. Note that we will directly use cpus_per_trial value
@@ -61,6 +65,7 @@ class AutoXGBClassifier(AutoEstimator):
         super().__init__(model_builder=xgb_model_builder,
                          logs_dir=logs_dir,
                          resources_per_trial=resources_per_trial,
+                         remote_dir=remote_dir,
                          name=name)
 
     def fit(self,
@@ -140,6 +145,7 @@ class AutoXGBRegressor(AutoEstimator):
                  logs_dir="/tmp/auto_xgb_regressor_logs",
                  cpus_per_trial=1,
                  name=None,
+                 remote_dir=None,
                  **xgb_configs
                  ):
         """
@@ -166,6 +172,9 @@ class AutoXGBRegressor(AutoEstimator):
         :param cpus_per_trial: Int. Number of cpus for each trial. The value will also be assigned
             to n_jobs, which is the number of parallel threads used to run xgboost.
         :param name: Name of the auto xgboost classifier.
+        :param remote_dir: String. Remote directory to sync training results and checkpoints. It
+            defaults to None and doesn't take effects while running in local. While running in
+            cluster, it defaults to "hdfs:///tmp/{name}".
         :param xgb_configs: Other scikit learn xgboost parameters. You may refer to
            https://xgboost.readthedocs.io/en/latest/python/python_api.html#module-xgboost.sklearn
            for the parameter names to specify. Note that we will directly use cpus_per_trial value
@@ -178,6 +187,7 @@ class AutoXGBRegressor(AutoEstimator):
         super().__init__(model_builder=xgb_model_builder,
                          logs_dir=logs_dir,
                          resources_per_trial=resources_per_trial,
+                         remote_dir=remote_dir,
                          name=name)
 
     def fit(self,


### PR DESCRIPTION
This PR includes

- Expose `remote_dir` for `AutoXGBRegressor` and `AutoXGBClassifier`.
- Change permission for the default remote directory after `mkdir`, so that workers could have the write permission of the default remote directory.  
