### PR TITLE
Fix Lauguage Specific Issue when Physical Cores Detection

### DIFF
--- a/python/nano/script/bigdl-nano-init
+++ b/python/nano/script/bigdl-nano-init
@@ -128,8 +128,8 @@ if [ -f "${LIB_DIR}/libiomp5.so" ]; then
 	cpu_infos=($(lscpu -p=CPU,Socket,Core | grep -P '^(\d*),(\d*),(\d*)$'))
 	max_cpu_info=($(echo ${cpu_infos[-1]} | sed 's/,/\ /g')) 
 	let cpu_=${max_cpu_info[0]}+1
-    let sockets_=${max_cpu_info[1]}+1
-    let core_=${max_cpu_info[2]}+1
+	let sockets_=${max_cpu_info[1]}+1
+	let core_=${max_cpu_info[2]}+1
 	let threads_per_core=$cpu_/$core_
 	let cores_per_socket=$core_/$socket_
 

--- a/python/nano/script/bigdl-nano-init
+++ b/python/nano/script/bigdl-nano-init
@@ -125,10 +125,15 @@ if [ -f "${LIB_DIR}/libiomp5.so" ]; then
 	OPENMP=1
 
 	# detect number of physical cores
-	cores_per_socket=$(lscpu | grep "Core(s) per socket" | sed "s/.*://g" | sed -r "s/\s+//g")
-	threads_per_core=$(lscpu | grep "Thread(s) per core" | sed "s/.*://g" | sed -r "s/\s+//g")
-	sockets_=$(lscpu | grep "Socket(s)" | sed "s/.*://g" | sed -r "s/\s+//g")
-	
+	cpu_infos=($(lscpu -p=CPU,Socket,Core | grep -P '^(\d*),(\d*),(\d*)$'))
+	max_cpu_info=($(echo ${cpu_infos[-1]} | sed 's/,/\ /g')) 
+	let cpu_=${max_cpu_info[0]}+1
+    let sockets_=${max_cpu_info[1]}+1
+    let core_=${max_cpu_info[2]}+1
+	let threads_per_core=$cpu_/$core_
+	let cores_per_socket=$core_/$socket_
+
+
 	# set env variables
 	echo "Setting OMP_NUM_THREADS..."
 


### PR DESCRIPTION
According to discussions in https://github.com/intel-analytics/BigDL/issues/3568：

When the system language is not English, physical cores information cannot be obtained due to the mismatch of the lookup with `grep` in `bigdl-nano-init`. This will cause the setting of some environment variables to fail. 

This PR uses `lscpu -p`  to filter out the parameters to a parsable format, and obtains the physical CPU information according to the parameters. This will make this process unaffected by the system language settings.