### PR TITLE
Add Spark DataFrame support for AutoEstimator (same interface as Orca Estimators) 

### DIFF
--- a/python/orca/src/bigdl/orca/automl/auto_estimator.py
+++ b/python/orca/src/bigdl/orca/automl/auto_estimator.py
@@ -136,7 +136,7 @@ class AutoEstimator:
             scheduler=None,
             scheduler_params=None,
             feature_cols=None,
-            target_cols=None,
+            label_cols=None,
             ):
         """
         Automatically fit the model and search for the best hyperparameters.
@@ -176,17 +176,17 @@ class AutoEstimator:
         :param scheduler: str, all supported scheduler provided by ray tune
         :param scheduler_params: parameters for scheduler
         :param feature_cols: feature column names if data is Spark DataFrame.
-        :param target_cols: target column names if data is Spark DataFrame.
+        :param label_cols: target column names if data is Spark DataFrame.
         """
         if self._fitted:
             raise RuntimeError(
                 "This AutoEstimator has already been fitted and cannot fit again.")
 
         metric_mode = AutoEstimator._validate_metric_mode(metric, metric_mode)
-        feature_cols, target_cols = AutoEstimator._check_spark_dataframe_input(data,
-                                                                               validation_data,
-                                                                               feature_cols,
-                                                                               target_cols)
+        feature_cols, label_cols = AutoEstimator._check_spark_dataframe_input(data,
+                                                                              validation_data,
+                                                                              feature_cols,
+                                                                              label_cols)
 
         self.searcher.compile(data=data,
                               model_builder=self.model_builder,
@@ -202,7 +202,7 @@ class AutoEstimator:
                               scheduler=scheduler,
                               scheduler_params=scheduler_params,
                               feature_cols=feature_cols,
-                              target_cols=target_cols)
+                              label_cols=label_cols)
         self.searcher.run()
         self._fitted = True
 
@@ -267,7 +267,7 @@ class AutoEstimator:
     def _check_spark_dataframe_input(data,
                                      validation_data,
                                      feature_cols,
-                                     target_cols
+                                     label_cols
                                      ):
 
         def check_cols(cols, cols_name):
@@ -283,9 +283,9 @@ class AutoEstimator:
         from pyspark.sql import DataFrame
         if isinstance(data, DataFrame):
             feature_cols = check_cols(feature_cols, cols_name="feature_cols")
-            target_cols = check_cols(target_cols, cols_name="target_cols")
+            label_cols = check_cols(label_cols, cols_name="label_cols")
             if validation_data:
                 if not isinstance(validation_data, DataFrame):
                     raise ValueError(f"data and validation_data should be both Spark DataFrame, "
                                      f"but got validation_data of type {type(data)}")
-        return feature_cols, target_cols
+        return feature_cols, label_cols

--- a/python/orca/src/bigdl/orca/automl/auto_estimator.py
+++ b/python/orca/src/bigdl/orca/automl/auto_estimator.py
@@ -183,7 +183,10 @@ class AutoEstimator:
                 "This AutoEstimator has already been fitted and cannot fit again.")
 
         metric_mode = AutoEstimator._validate_metric_mode(metric, metric_mode)
-        AutoEstimator._check_spark_dataframe_input(data, validation_data, feature_cols, target_cols)
+        feature_cols, target_cols = AutoEstimator._check_spark_dataframe_input(data,
+                                                                               validation_data,
+                                                                               feature_cols,
+                                                                               target_cols)
 
         self.searcher.compile(data=data,
                               model_builder=self.model_builder,
@@ -285,3 +288,4 @@ class AutoEstimator:
                 if not isinstance(validation_data, DataFrame):
                     raise ValueError(f"data and validation_data should be both Spark DataFrame, "
                                      f"but got validation_data of type {type(data)}")
+        return feature_cols, target_cols

--- a/python/orca/src/bigdl/orca/automl/search/ray_tune/ray_tune_search_engine.py
+++ b/python/orca/src/bigdl/orca/automl/search/ray_tune/ray_tune_search_engine.py
@@ -81,7 +81,7 @@ class RayTuneSearchEngine(SearchEngine):
                 scheduler_params=None,
                 mc=False,
                 feature_cols=None,
-                target_cols=None,
+                label_cols=None,
                 ):
         """
         Do necessary preparations for the engine
@@ -112,7 +112,7 @@ class RayTuneSearchEngine(SearchEngine):
         :param scheduler_params: parameters for scheduler
         :param mc: if calculate uncertainty
         :param feature_cols: feature column names if data is Spark DataFrame.
-        :param target_cols: target column names if data is Spark DataFrame.
+        :param label_cols: target column names if data is Spark DataFrame.
         """
         # metric and metric's mode
         self.metric_name = metric.__name__ if callable(metric) else (metric or DEFAULT_METRIC_NAME)
@@ -139,7 +139,7 @@ class RayTuneSearchEngine(SearchEngine):
                                                    remote_dir=self.remote_dir,
                                                    resources_per_trial=self.resources_per_trial,
                                                    feature_cols=feature_cols,
-                                                   target_cols=target_cols,
+                                                   label_cols=label_cols,
                                                    )
 
     @staticmethod
@@ -281,7 +281,7 @@ class RayTuneSearchEngine(SearchEngine):
                             remote_dir=None,
                             resources_per_trial=None,
                             feature_cols=None,
-                            target_cols=None,
+                            label_cols=None,
                             ):
         """
         Prepare the train function for ray tune
@@ -305,7 +305,7 @@ class RayTuneSearchEngine(SearchEngine):
             spark_xshards, val_spark_xshards = dataframe_to_xshards(data,
                                                                     validation_data=validation_data,
                                                                     feature_cols=feature_cols,
-                                                                    label_cols=target_cols,
+                                                                    label_cols=label_cols,
                                                                     mode="fit",
                                                                     num_workers=num_workers)
             ray_xshards = process_spark_xshards(spark_xshards, num_workers=num_workers)

--- a/python/orca/src/bigdl/orca/automl/search/ray_tune/ray_tune_search_engine.py
+++ b/python/orca/src/bigdl/orca/automl/search/ray_tune/ray_tune_search_engine.py
@@ -395,7 +395,8 @@ def trial_dirname_creator(trial):
 
 
 def get_data_from_part_refs(part_refs):
-    import numpy as np
+    from bigdl.orca.data.utils import ray_partitions_get_data_label
+
     partitions = ray.get(part_refs)
 
     # convert list of dicts to one dict
@@ -405,9 +406,9 @@ def get_data_from_part_refs(part_refs):
 
     # reorder dict with partition index
     parts = [result[idx] for idx in range(len(result.keys()))]
-    shards = [item for part in parts for item in part]
 
-    X = np.concatenate([np.stack(shard["x"], axis=1) for shard in shards], axis=0)
-    y = np.concatenate([shard["y"] for shard in shards], axis=0)
-
-    return X, y
+    data, label = ray_partitions_get_data_label(parts,
+                                                allow_tuple=True,
+                                                allow_list=False,
+                                                )
+    return data, label

--- a/python/orca/src/bigdl/orca/automl/xgboost/auto_xgb.py
+++ b/python/orca/src/bigdl/orca/automl/xgboost/auto_xgb.py
@@ -82,7 +82,7 @@ class AutoXGBClassifier(AutoEstimator):
             scheduler=None,
             scheduler_params=None,
             feature_cols=None,
-            target_cols=None,
+            label_cols=None,
             ):
         """
         Automatically fit the model and search for the best hyperparameters.
@@ -119,12 +119,12 @@ class AutoXGBClassifier(AutoEstimator):
         :param scheduler: str, all supported scheduler provided by ray tune
         :param scheduler_params: parameters for scheduler
         :param feature_cols: feature column names if data is Spark DataFrame.
-        :param target_cols: target column names if data is Spark DataFrame.
+        :param label_cols: target column names if data is Spark DataFrame.
         """
-        data, validation_data, feature_cols, target_cols = _merge_cols_for_spark_df(data,
-                                                                                    validation_data,
-                                                                                    feature_cols,
-                                                                                    target_cols)
+        data, validation_data, feature_cols, label_cols = _merge_cols_for_spark_df(data,
+                                                                                   validation_data,
+                                                                                   feature_cols,
+                                                                                   label_cols)
 
         super().fit(data=data,
                     epochs=epochs,
@@ -139,7 +139,7 @@ class AutoXGBClassifier(AutoEstimator):
                     scheduler=scheduler,
                     scheduler_params=scheduler_params,
                     feature_cols=feature_cols,
-                    target_cols=target_cols)
+                    label_cols=label_cols)
 
 
 class AutoXGBRegressor(AutoEstimator):
@@ -206,7 +206,7 @@ class AutoXGBRegressor(AutoEstimator):
             scheduler=None,
             scheduler_params=None,
             feature_cols=None,
-            target_cols=None,
+            label_cols=None,
             ):
         """
         Automatically fit the model and search for the best hyperparameters.
@@ -243,12 +243,12 @@ class AutoXGBRegressor(AutoEstimator):
         :param scheduler: str, all supported scheduler provided by ray tune
         :param scheduler_params: parameters for scheduler
         :param feature_cols: feature column names if data is Spark DataFrame.
-        :param target_cols: target column names if data is Spark DataFrame.
+        :param label_cols: target column names if data is Spark DataFrame.
         """
-        data, validation_data, feature_cols, target_cols = _merge_cols_for_spark_df(data,
-                                                                                    validation_data,
-                                                                                    feature_cols,
-                                                                                    target_cols)
+        data, validation_data, feature_cols, label_cols = _merge_cols_for_spark_df(data,
+                                                                                   validation_data,
+                                                                                   feature_cols,
+                                                                                   label_cols)
 
         super().fit(data=data,
                     epochs=epochs,
@@ -263,35 +263,35 @@ class AutoXGBRegressor(AutoEstimator):
                     scheduler=scheduler,
                     scheduler_params=scheduler_params,
                     feature_cols=feature_cols,
-                    target_cols=target_cols)
+                    label_cols=label_cols)
 
 
 def _merge_cols_for_spark_df(data,
                              validation_data,
                              feature_cols,
-                             target_cols):
-    # merge feature_cols/target_cols to one column, to adapt to the meanings of feature_cols and
-    # target_cols in AutoEstimator, which correspond to the model inputs/outputs.
+                             label_cols):
+    # merge feature_cols/label_cols to one column, to adapt to the meanings of feature_cols and
+    # label_cols in AutoEstimator, which correspond to the model inputs/outputs.
     from pyspark.sql import DataFrame
     from pyspark.sql.functions import array
 
-    def concat_cols(data, feature_cols, target_cols):
+    def concat_cols(data, feature_cols, label_cols):
         combined_feature_name = "combined_features"
         combined_target_name = "combined_targets"
         data = data.select(array(*feature_cols).alias(combined_feature_name),
-                           array(*target_cols).alias(combined_target_name))
+                           array(*label_cols).alias(combined_target_name))
         return data, combined_feature_name, combined_target_name
 
-    feature_cols, target_cols = AutoEstimator._check_spark_dataframe_input(data,
-                                                                           validation_data,
-                                                                           feature_cols,
-                                                                           target_cols)
+    feature_cols, label_cols = AutoEstimator._check_spark_dataframe_input(data,
+                                                                          validation_data,
+                                                                          feature_cols,
+                                                                          label_cols)
     if isinstance(data, DataFrame):
         data, combined_feature_name, combined_target_name = concat_cols(data,
                                                                         feature_cols,
-                                                                        target_cols)
+                                                                        label_cols)
         if validation_data is not None:
-            validation_data, _, _ = concat_cols(validation_data, feature_cols, target_cols)
+            validation_data, _, _ = concat_cols(validation_data, feature_cols, label_cols)
         feature_cols = [combined_feature_name]
-        target_cols = [combined_target_name]
-    return data, validation_data, feature_cols, target_cols
+        label_cols = [combined_target_name]
+    return data, validation_data, feature_cols, label_cols

--- a/python/orca/test/bigdl/orca/automl/autoestimator/test_autoestimator_keras.py
+++ b/python/orca/test/bigdl/orca/automl/autoestimator/test_autoestimator_keras.py
@@ -30,6 +30,61 @@ def model_creator(config):
     return model
 
 
+def model_creator_multi_inputs(config):
+    from tensorflow.keras.layers import Input, Dense, Concatenate
+    from tensorflow.keras.models import Model
+    input_1 = Input(shape=(32,))
+    input_2 = Input(shape=(64,))
+
+    x = Dense(config["dense_1"], activation="relu")(input_1)
+    x = Model(inputs=input_1, outputs=x)
+
+    y = Dense(config["dense_1"], activation="relu")(input_2)
+    y = Model(inputs=input_2, outputs=y)
+
+    combined = Concatenate(axis=1)([x.output, y.output])
+
+    z = Dense(config["dense_2"], activation="relu")(combined)
+    z = Dense(1, activation="linear")(z)
+
+    model = Model(inputs=[x.input, y.input], outputs=z)
+
+    model.compile(loss="mse",
+                 optimizer=tf.keras.optimizers.Adam(config["lr"]),
+                 metrics=["mse"])
+
+    return model
+
+
+def get_search_space_multi_inputs():
+    from bigdl.orca.automl import hp
+    return {
+        "dense_1": hp.choice([8, 16]),
+        "dense_2": hp.choice([2, 4]),
+        "lr": hp.choice([0.001, 0.003, 0.01]),
+        "batch_size": hp.choice([32, 64])
+    }
+
+
+def get_multi_inputs_data():
+    def get_df(size):
+        rdd = sc.parallelize(range(size))
+        df = rdd.map(lambda x: ([float(x)] * 32, [float(x)] * 64,
+                        [int(np.random.randint(0, 2, size=()))])
+                ).toDF(["f1", "f2", "label"])
+        return df
+
+    from pyspark.sql import SparkSession
+    from bigdl.orca import OrcaContext
+    sc = OrcaContext.get_spark_context()
+    spark = SparkSession(sc)
+    feature_cols = ["f1", "f2"]
+    label_cols = ["label"]
+    train_df = get_df(size=100)
+    val_df = get_df(size=30)
+    return train_df, val_df, feature_cols, label_cols
+
+
 def get_train_val_data():
     def get_x_y(size):
         x = np.random.rand(size)
@@ -129,6 +184,27 @@ class TestTFKerasAutoEstimator(TestCase):
                      epochs=1,
                      metric=pyrmsle,
                      metric_mode="min")
+
+    def test_multiple_inputs_model(self):
+        auto_est = AutoEstimator.from_keras(model_creator=model_creator_multi_inputs,
+                                            logs_dir="/tmp/zoo_automl_logs",
+                                            resources_per_trial={"cpu": 2},
+                                            name="test_fit")
+
+        data, validation_data, feature_cols, label_cols = get_multi_inputs_data()
+        auto_est.fit(data=data,
+                     validation_data=validation_data,
+                     search_space=get_search_space_multi_inputs(),
+                     n_sampling=2,
+                     epochs=1,
+                     metric="mse",
+                     feature_cols=feature_cols,
+                     label_cols=label_cols,
+                     )
+        assert auto_est.get_best_model()
+        best_config = auto_est.get_best_config()
+        assert "lr" in best_config
+        assert all(k in best_config.keys() for k in get_search_space_multi_inputs().keys())
 
 
 if __name__ == "__main__":

--- a/python/orca/test/bigdl/orca/automl/xgboost/test_auto_xgb.py
+++ b/python/orca/test/bigdl/orca/automl/xgboost/test_auto_xgb.py
@@ -188,7 +188,7 @@ class TestAutoXGBRegressor(TestCase):
                          search_space=search_space,
                          n_sampling=2,
                          feature_cols=feature_cols,
-                         target_cols=label_cols,
+                         label_cols=label_cols,
                          )
         best_model = auto_xgb_reg.get_best_model()
         assert 5 <= best_model.n_estimators <= 10


### PR DESCRIPTION
**The PR includes**
1. Spark `DataFrame` input for `AutoEstimator`, with same interface as Orca Estimators. Note that the previous `target_cols` has been changed into `label_cols`.
```python
  rdd = sc.parallelize(range(size))
  data = rdd.map(lambda x: ([float(x)] * 32, [float(x)] * 64,
                  [int(np.random.randint(0, 2, size=()))])
          ).toDF(["f1", "f2", "label"])

  auto_est.fit(data=data,
               validation_data=validation_data,
               search_space=get_search_space_multi_inputs(),
               n_sampling=2,
               epochs=1,
               metric="mse",
               feature_cols=["f1", "f2"],
               label_cols=["label"],
               )
```
2. Change the internal implementation for `AutoXGBoost` with Spark `DataFrame` input
3. Other refactors...