### PR TITLE
Nano: add quantized model save&load API

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/runtime_binding/quantization_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/runtime_binding/quantization_inference.py
@@ -15,7 +15,6 @@
 #
 
 import warnings
-import pickle
 from functools import partial
 from bigdl.nano.pytorch.lightning import LightningModuleFromTorch
 

--- a/python/nano/src/bigdl/nano/pytorch/runtime_binding/quantization_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/runtime_binding/quantization_inference.py
@@ -47,7 +47,7 @@ def _fx_quantize_eval(self, quantize=False):
             self.forward = self._forward_fx_quantize
         else:
             raise RuntimeError("Please call trainer.quantize again since the quantized model is"
-                               "not up-to-date")
+                               " not up-to-date")
     else:
         self.forward = self._torch_forward
 
@@ -57,7 +57,7 @@ def quantized_state_dict(self):
         return self._quantized_model.state_dict()
     else:
         raise RuntimeError("Please call trainer.quantize again since the quantized model is"
-                           "not up-to-date.")
+                           " not up-to-date.")
 
 
 def load_quantized_state_dict(self, state_dict):
@@ -77,8 +77,7 @@ def load_quantized_state_dict(self, state_dict):
     if back_to_train:
         self.train()
     self._quantized_model = qmodel
-    self._quantized_model_up_to_date = True  # set to true
-
+    self._quantized_model_up_to_date = True  # set to true before training next time
 
 def bind_quantize_methods(pl_model, q_model):
     # check conflicts

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -165,7 +165,7 @@ class Trainer(pl.Trainer):
                 bind_base_inference_rt_methods
             return bind_quantize_methods(bind_base_inference_rt_methods(pl_model), None)
 
-        return pl_model
+        return bind_base_inference_rt_methods(pl_model)
 
     def quantize(self, pl_model: LightningModule,
                  calib_dataloader: DataLoader = None,

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -117,7 +117,8 @@ class Trainer(pl.Trainer):
                 loss: _Loss = None,
                 optimizer: torch.optim.Optimizer = None,
                 metrics: List[Metric] = None,
-                onnx: bool = False):
+                onnx: bool = False,
+                quantize: bool = True):
         """
         Construct a pytorch-lightning model. If model is already a pytorch-lightning model,
         return model. If model is pytorch model, construct a new pytorch-lightning module
@@ -130,6 +131,8 @@ class Trainer(pl.Trainer):
                             if model is instance of pl.LightningModule.
         :param metrics:     A list of torchmetrics to validate/test performance.
         :param onnx:        Indicates if onnxruntime support should be binded to the
+                            returned model.
+        :param quantize:    Indicates if quantization support should be binded to the
                             returned model.
         :return:            A LightningModule object.
         """
@@ -154,8 +157,15 @@ class Trainer(pl.Trainer):
             except ImportError:
                 raise RuntimeError("You should install onnx and onnxruntime to set `onnx=True`, "
                                    "or just set `onnx=False`.")
-        else:
-            return pl_model
+
+        if quantize:
+            from bigdl.nano.pytorch.runtime_binding.quantization_inference import\
+                bind_quantize_methods
+            from bigdl.nano.pytorch.runtime_binding.base_inference import\
+                bind_base_inference_rt_methods
+            return bind_quantize_methods(bind_base_inference_rt_methods(pl_model), None)
+
+        return pl_model
 
     def quantize(self, pl_model: LightningModule,
                  calib_dataloader: DataLoader = None,

--- a/python/nano/test/pytorch/tests/test_quantize_inference.py
+++ b/python/nano/test/pytorch/tests/test_quantize_inference.py
@@ -72,6 +72,7 @@ class TestQuantizeInference(TestCase):
         trainer.fit(pl_model, train_loader)
         assert pl_model._quantized_model_up_to_date is False  # qmodel is not up-to-date after training
 
+        # test save/load dict
         pl_model = trainer.quantize(pl_model, train_loader)
         assert pl_model._quantized_model_up_to_date is True  # qmodel is up-to-date after building
 


### PR DESCRIPTION
### Save and load
reference to https://pytorch.org/tutorials/beginner/saving_loading_models.html#saving-loading-model-for-inference

#### save
```python
# torch model
torch.save(model.state_dict(), PATH)  # fp32 pytorch model
torch.save(model.quantized_state_dict(), PATH)  # int8 pytorch model
```

#### load

since onnx file is easy to load we only consider torch model.

```python
# torch model
model = TheModelClass(*args, **kargs)
model = Trainer.compile(model)
model.load_state_dict(torch.load(PATH))  # fp32
model.load_quantized_state_dict(torch.load(PATH))  # int8
```