### PR TITLE
Add suffix to pypi release

### DIFF
--- a/python/chronos/dev/release/release_default_linux_spark246.sh
+++ b/python/chronos/dev/release/release_default_linux_spark246.sh
@@ -25,15 +25,28 @@
 set -e
 RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 echo $RUN_SCRIPT_DIR
+CHRONOS_DIR="$(cd ${RUN_SCRIPT_DIR}/../../; pwd)"
+echo $CHRONOS_DIR
+DEV_DIR="$(cd ${CHRONOS_DIR}/../dev/; pwd)"
+echo $DEV_DIR
 
-if (( $# < 2)); then
-  echo "Usage: release_default_linux_spark246.sh version upload"
-  echo "Usage example: bash release_default_linux_spark246.sh default true"
-  echo "Usage example: bash release_default_linux_spark246.sh 0.14.0.dev1 true"
+if (( $# < 3)); then
+  echo "Usage: release_default_linux_spark246.sh version upload suffix"
+  echo "Usage example: bash release_default_linux_spark246.sh default true true"
+  echo "Usage example: bash release_default_linux_spark246.sh 0.14.0.dev1 true false"
   exit -1
 fi
 
 version=$1
 upload=$2
+suffix=$3
+
+if [ ${suffix} == true ]; then
+    bash ${DEV_DIR}/add_suffix_spark2.sh $CHRONOS_DIR/src/setup.py
+    bash ${DEV_DIR}/add_suffix_spark2.sh ${RUN_SCRIPT_DIR}/release.sh
+else
+    bash ${DEV_DIR}/remove_spark_suffix.sh $CHRONOS_DIR/src/setup.py
+    bash ${DEV_DIR}/remove_spark_suffix.sh ${RUN_SCRIPT_DIR}/release.sh
+fi
 
 bash ${RUN_SCRIPT_DIR}/release.sh linux ${version} ${upload}

--- a/python/chronos/dev/release/release_default_linux_spark312.sh
+++ b/python/chronos/dev/release/release_default_linux_spark312.sh
@@ -27,22 +27,26 @@ RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 echo $RUN_SCRIPT_DIR
 CHRONOS_DIR="$(cd ${RUN_SCRIPT_DIR}/../../; pwd)"
 echo $CHRONOS_DIR
+DEV_DIR="$(cd ${CHRONOS_DIR}/../dev/; pwd)"
+echo $DEV_DIR
 
-if (( $# < 2)); then
-  echo "Usage: release_default_linux_spark312.sh version upload"
-  echo "Usage example: bash release_default_linux_spark312.sh default true"
-  echo "Usage example: bash release_default_linux_spark312.sh 0.14.0.dev1 true"
+if (( $# < 3)); then
+  echo "Usage: release_default_linux_spark312.sh version upload suffix"
+  echo "Usage example: bash release_default_linux_spark312.sh default true true"
+  echo "Usage example: bash release_default_linux_spark312.sh 0.14.0.dev1 true false"
   exit -1
 fi
 
 version=$1
 upload=$2
+suffix=$3
 
-# Add spark3 suffix to the project name to avoid conflict with the whl for spark2.
-# Add name=, == and - in pattern matching so that if the script runs twice,
-# it won't change anything in the second run.
-sed -i "s/bigdl-orca==/bigdl-orca-spark3==/g" $CHRONOS_DIR/src/setup.py
-sed -i "s/name='bigdl-chronos'/name='bigdl-chronos-spark3'/g" $CHRONOS_DIR/src/setup.py
-sed -i "s/dist\/bigdl_chronos-/dist\/bigdl_chronos_spark3-/g" ${RUN_SCRIPT_DIR}/release.sh
+if [ ${suffix} == true ]; then
+    bash ${DEV_DIR}/add_suffix_spark3.sh $CHRONOS_DIR/src/setup.py
+    bash ${DEV_DIR}/add_suffix_spark3.sh ${RUN_SCRIPT_DIR}/release.sh
+else
+    bash ${DEV_DIR}/remove_spark_suffix.sh $CHRONOS_DIR/src/setup.py
+    bash ${DEV_DIR}/remove_spark_suffix.sh ${RUN_SCRIPT_DIR}/release.sh
+fi
 
 bash ${RUN_SCRIPT_DIR}/release.sh linux ${version} ${upload}

--- a/python/chronos/dev/release/release_default_mac_spark246.sh
+++ b/python/chronos/dev/release/release_default_mac_spark246.sh
@@ -25,15 +25,28 @@
 set -e
 RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 echo $RUN_SCRIPT_DIR
+CHRONOS_DIR="$(cd ${RUN_SCRIPT_DIR}/../../; pwd)"
+echo $CHRONOS_DIR
+DEV_DIR="$(cd ${CHRONOS_DIR}/../dev/; pwd)"
+echo $DEV_DIR
 
-if (( $# < 2)); then
-  echo "Usage: release_default_mac_spark246.sh version upload"
-  echo "Usage example: bash release_default_mac_spark246.sh default true"
-  echo "Usage example: bash release_default_mac_spark246.sh 0.14.0.dev1 true"
+if (( $# < 3)); then
+  echo "Usage: release_default_mac_spark246.sh version upload suffix"
+  echo "Usage example: bash release_default_mac_spark246.sh default true true"
+  echo "Usage example: bash release_default_mac_spark246.sh 0.14.0.dev1 true false"
   exit -1
 fi
 
 version=$1
 upload=$2
+suffix=$3
+
+if [ ${suffix} == true ]; then
+    bash ${DEV_DIR}/add_suffix_spark2.sh $CHRONOS_DIR/src/setup.py
+    bash ${DEV_DIR}/add_suffix_spark2.sh ${RUN_SCRIPT_DIR}/release.sh
+else
+    bash ${DEV_DIR}/remove_spark_suffix.sh $CHRONOS_DIR/src/setup.py
+    bash ${DEV_DIR}/remove_spark_suffix.sh ${RUN_SCRIPT_DIR}/release.sh
+fi
 
 bash ${RUN_SCRIPT_DIR}/release.sh mac ${version} ${upload}

--- a/python/chronos/dev/release/release_default_mac_spark312.sh
+++ b/python/chronos/dev/release/release_default_mac_spark312.sh
@@ -27,22 +27,26 @@ RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 echo $RUN_SCRIPT_DIR
 CHRONOS_DIR="$(cd ${RUN_SCRIPT_DIR}/../../; pwd)"
 echo $CHRONOS_DIR
+DEV_DIR="$(cd ${CHRONOS_DIR}/../dev/; pwd)"
+echo $DEV_DIR
 
-if (( $# < 2)); then
-  echo "Usage: release_default_mac_spark312.sh version upload"
-  echo "Usage example: bash release_default_mac_spark312.sh default true"
-  echo "Usage example: bash release_default_mac_spark312.sh 0.14.0.dev1 true"
+if (( $# < 3)); then
+  echo "Usage: release_default_mac_spark312.sh version upload suffix"
+  echo "Usage example: bash release_default_mac_spark312.sh default true true"
+  echo "Usage example: bash release_default_mac_spark312.sh 0.14.0.dev1 true false"
   exit -1
 fi
 
 version=$1
 upload=$2
+suffix=$3
 
-# Add spark3 suffix to the project name to avoid conflict with the whl for spark2.
-# Add name=, == and - in pattern matching so that if the script runs twice,
-# it won't change anything in the second run.
-sed -i "s/bigdl-orca==/bigdl-orca-spark3==/g" $CHRONOS_DIR/src/setup.py
-sed -i "s/name='bigdl-chronos'/name='bigdl-chronos-spark3'/g" $CHRONOS_DIR/src/setup.py
-sed -i "s/dist\/bigdl_chronos-/dist\/bigdl_chronos_spark3-/g" ${RUN_SCRIPT_DIR}/release.sh
+if [ ${suffix} == true ]; then
+    bash ${DEV_DIR}/add_suffix_spark3.sh $CHRONOS_DIR/src/setup.py
+    bash ${DEV_DIR}/add_suffix_spark3.sh ${RUN_SCRIPT_DIR}/release.sh
+else
+    bash ${DEV_DIR}/remove_spark_suffix.sh $CHRONOS_DIR/src/setup.py
+    bash ${DEV_DIR}/remove_spark_suffix.sh ${RUN_SCRIPT_DIR}/release.sh
+fi
 
 bash ${RUN_SCRIPT_DIR}/release.sh mac ${version} ${upload}

--- a/python/dev/add_suffix_spark2.sh
+++ b/python/dev/add_suffix_spark2.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is the script to add spark2 suffix or change spark3 suffix to spark2
+# for all project names and dependencies.
+
+# Add name=, == and - in pattern matching so that if the script runs twice,
+# it won't change anything in the second run.
+
+file=$1
+
+sed -i "s/name='bigdl'/name='bigdl-spark2'/g" ${file}
+sed -i "s/name='bigdl-spark3'/name='bigdl-spark2'/g" ${file}
+
+sed -i "s/bigdl-dllib==/bigdl-dllib-spark2==/g" ${file}
+sed -i "s/bigdl-dllib-spark3==/bigdl-dllib-spark2==/g" ${file}
+sed -i "s/name='bigdl-dllib'/name='bigdl-dllib-spark2'/g" ${file}
+sed -i "s/name='bigdl-dllib-spark3'/name='bigdl-dllib-spark2'/g" ${file}
+sed -i "s/dist\/bigdl_dllib-/dist\/bigdl_dllib_spark2-/g" ${file}
+sed -i "s/dist\/bigdl_dllib_spark3-/dist\/bigdl_dllib_spark2-/g" ${file}
+
+sed -i "s/bigdl-orca==/bigdl-orca-spark2==/g" ${file}
+sed -i "s/bigdl-orca-spark3==/bigdl-orca-spark2==/g" ${file}
+sed -i "s/name='bigdl-orca'/name='bigdl-orca-spark2'/g" ${file}
+sed -i "s/name='bigdl-orca-spark3'/name='bigdl-orca-spark2'/g" ${file}
+sed -i "s/dist\/bigdl_orca-/dist\/bigdl_orca_spark2-/g" ${file}
+sed -i "s/dist\/bigdl_orca_spark3-/dist\/bigdl_orca_spark2-/g" ${file}
+sed -i "s/bigdl-orca\[ray\]/bigdl-orca-spark2\[ray\]/g" ${file}
+sed -i "s/bigdl-orca-spark3\[ray\]/bigdl-orca-spark2\[ray\]/g" ${file}
+
+sed -i "s/bigdl-chronos==/bigdl-chronos-spark2==/g" ${file}
+sed -i "s/bigdl-chronos-spark3==/bigdl-chronos-spark2==/g" ${file}
+sed -i "s/name='bigdl-chronos'/name='bigdl-chronos-spark2'/g" ${file}
+sed -i "s/name='bigdl-chronos-spark3'/name='bigdl-chronos-spark2'/g" ${file}
+sed -i "s/dist\/bigdl_chronos-/dist\/bigdl_chronos_spark2-/g" ${file}
+sed -i "s/dist\/bigdl_chronos_spark3-/dist\/bigdl_chronos_spark2-/g" ${file}
+
+sed -i "s/bigdl-friesian==/bigdl-friesian-spark2==/g" ${file}
+sed -i "s/bigdl-friesian-spark3==/bigdl-friesian-spark2==/g" ${file}
+sed -i "s/name='bigdl-friesian'/name='bigdl-friesian-spark2'/g" ${file}
+sed -i "s/name='bigdl-friesian-spark3'/name='bigdl-friesian-spark2'/g" ${file}
+sed -i "s/dist\/bigdl_friesian-/dist\/bigdl_friesian_spark2-/g" ${file}
+sed -i "s/dist\/bigdl_friesian_spark3-/dist\/bigdl_friesian_spark2-/g" ${file}

--- a/python/dev/add_suffix_spark3.sh
+++ b/python/dev/add_suffix_spark3.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is the script to add spark3 suffix or change spark2 suffix to spark3
+# for all project names and dependencies.
+
+# Add name=, == and - in pattern matching so that if the script runs twice,
+# it won't change anything in the second run.
+
+file=$1
+
+sed -i "s/name='bigdl'/name='bigdl-spark3'/g" ${file}
+sed -i "s/name='bigdl-spark2'/name='bigdl-spark3'/g" ${file}
+
+sed -i "s/bigdl-dllib==/bigdl-dllib-spark3==/g" ${file}
+sed -i "s/bigdl-dllib-spark2==/bigdl-dllib-spark3==/g" ${file}
+sed -i "s/name='bigdl-dllib'/name='bigdl-dllib-spark3'/g" ${file}
+sed -i "s/name='bigdl-dllib-spark2'/name='bigdl-dllib-spark3'/g" ${file}
+sed -i "s/dist\/bigdl_dllib-/dist\/bigdl_dllib_spark3-/g" ${file}
+sed -i "s/dist\/bigdl_dllib_spark2-/dist\/bigdl_dllib_spark3-/g" ${file}
+
+sed -i "s/bigdl-orca==/bigdl-orca-spark3==/g" ${file}
+sed -i "s/bigdl-orca-spark2==/bigdl-orca-spark3==/g" ${file}
+sed -i "s/name='bigdl-orca'/name='bigdl-orca-spark3'/g" ${file}
+sed -i "s/name='bigdl-orca-spark2'/name='bigdl-orca-spark3'/g" ${file}
+sed -i "s/dist\/bigdl_orca-/dist\/bigdl_orca_spark3-/g" ${file}
+sed -i "s/dist\/bigdl_orca_spark2-/dist\/bigdl_orca_spark3-/g" ${file}
+sed -i "s/bigdl-orca\[ray\]/bigdl-orca-spark3\[ray\]/g" ${file}
+sed -i "s/bigdl-orca-spark2\[ray\]/bigdl-orca-spark3\[ray\]/g" ${file}
+
+sed -i "s/bigdl-chronos==/bigdl-chronos-spark3==/g" ${file}
+sed -i "s/bigdl-chronos-spark2==/bigdl-chronos-spark3==/g" ${file}
+sed -i "s/name='bigdl-chronos'/name='bigdl-chronos-spark3'/g" ${file}
+sed -i "s/name='bigdl-chronos-spark2'/name='bigdl-chronos-spark3'/g" ${file}
+sed -i "s/dist\/bigdl_chronos-/dist\/bigdl_chronos_spark3-/g" ${file}
+sed -i "s/dist\/bigdl_chronos_spark2-/dist\/bigdl_chronos_spark3-/g" ${file}
+
+sed -i "s/bigdl-friesian==/bigdl-friesian-spark3==/g" ${file}
+sed -i "s/bigdl-friesian-spark2==/bigdl-friesian-spark3==/g" ${file}
+sed -i "s/name='bigdl-friesian'/name='bigdl-friesian-spark3'/g" ${file}
+sed -i "s/name='bigdl-friesian-spark2'/name='bigdl-friesian-spark3'/g" ${file}
+sed -i "s/dist\/bigdl_friesian-/dist\/bigdl_friesian_spark3-/g" ${file}
+sed -i "s/dist\/bigdl_friesian_spark2-/dist\/bigdl_friesian_spark3-/g" ${file}

--- a/python/dev/release_bigdl_spark2.sh
+++ b/python/dev/release_bigdl_spark2.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-# This is the script to release the single bigdl package for linux.
+# This is the script to release the single bigdl package for spark2.
 
 set -e
 RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
@@ -24,16 +24,25 @@ echo $RUN_SCRIPT_DIR
 BIGDL_PYTHON_DIR="$(cd ${RUN_SCRIPT_DIR}/..; pwd)"
 echo $BIGDL_PYTHON_DIR
 
-if (( $# < 3)); then
-  echo "Usage: release.sh platform version upload"
-  echo "Usage example: bash release.sh linux default false"
-  echo "Usage example: bash release.sh mac 0.14.0.dev1 true"
+if (( $# < 4)); then
+  echo "Usage: release_bigdl_spark2.sh platform version upload suffix"
+  echo "Usage example: bash release_bigdl_spark2.sh linux default false true"
+  echo "Usage example: bash release_bigdl_spark2.sh mac 0.14.0.dev1 true false"
   exit -1
 fi
 
 platform=$1
 version=$2
-upload=$3  # Whether to upload the whl to pypi
+upload=$3
+suffix=$4
+
+if [ ${suffix} == true ]; then
+    bash ${RUN_SCRIPT_DIR}/add_suffix_spark2.sh $BIGDL_PYTHON_DIR/setup.py
+    name="bigdl_spark2"
+else
+    bash ${RUN_SCRIPT_DIR}/remove_spark_suffix.sh $BIGDL_PYTHON_DIR/setup.py
+    name="bigdl"
+fi
 
 if [ "${version}" != "default" ]; then
     echo "User specified version: ${version}"
@@ -68,7 +77,7 @@ echo "Packing python distribution: $wheel_command"
 ${wheel_command}
 
 if [ ${upload} == true ]; then
-    upload_command="twine upload dist/bigdl-${bigdl_version}-py3-none-${verbose_pname}.whl"
+    upload_command="twine upload dist/${name}-${bigdl_version}-py3-none-${verbose_pname}.whl"
     echo "Please manually upload with this command: $upload_command"
     $upload_command
 fi

--- a/python/dev/release_bigdl_spark3.sh
+++ b/python/dev/release_bigdl_spark3.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is the script to release the single bigdl package for spark3.
+
+set -e
+RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
+echo $RUN_SCRIPT_DIR
+BIGDL_PYTHON_DIR="$(cd ${RUN_SCRIPT_DIR}/..; pwd)"
+echo $BIGDL_PYTHON_DIR
+
+if (( $# < 4)); then
+  echo "Usage: release.sh platform version upload suffix"
+  echo "Usage example: bash release.sh linux default false true"
+  echo "Usage example: bash release.sh mac 0.14.0.dev1 true false"
+  exit -1
+fi
+
+platform=$1
+version=$2
+upload=$3
+suffix=$4
+
+if [ ${suffix} == true ]; then
+    bash ${RUN_SCRIPT_DIR}/add_suffix_spark3.sh $BIGDL_PYTHON_DIR/setup.py
+    name="bigdl_spark3"
+else
+    bash ${RUN_SCRIPT_DIR}/remove_spark_suffix.sh $BIGDL_PYTHON_DIR/setup.py
+    name="bigdl"
+fi
+
+if [ "${version}" != "default" ]; then
+    echo "User specified version: ${version}"
+    echo $version > $BIGDL_PYTHON_DIR/version.txt
+fi
+
+bigdl_version=$(cat $BIGDL_PYTHON_DIR/version.txt | head -1)
+
+if [ "$platform" ==  "mac" ]; then
+    verbose_pname="macosx_10_11_x86_64"
+elif [ "$platform" == "linux" ]; then
+    verbose_pname="manylinux1_x86_64"
+else
+    echo "Unsupported platform"
+fi
+
+cd $BIGDL_PYTHON_DIR
+if [ -d "${BIGDL_PYTHON_DIR}/build" ]; then
+   rm -r ${BIGDL_PYTHON_DIR}/build
+fi
+
+if [ -d "${BIGDL_PYTHON_DIR}/dist" ]; then
+   rm -r ${BIGDL_PYTHON_DIR}/dist
+fi
+
+if [ -d "${BIGDL_PYTHON_DIR}/bigdl.egg-info" ]; then
+   rm -r ${BIGDL_PYTHON_DIR}/bigdl.egg-info
+fi
+
+wheel_command="python setup.py bdist_wheel --plat-name ${verbose_pname} --python-tag py3"
+echo "Packing python distribution: $wheel_command"
+${wheel_command}
+
+if [ ${upload} == true ]; then
+    upload_command="twine upload dist/${name}-${bigdl_version}-py3-none-${verbose_pname}.whl"
+    echo "Please manually upload with this command: $upload_command"
+    $upload_command
+fi

--- a/python/dev/release_default_linux.sh
+++ b/python/dev/release_default_linux.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is the default script with maven parameters to release all the bigdl sub-packages
+# built on top of both Spark2 and Spark3 version for linux.
+
+set -e
+RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
+echo $RUN_SCRIPT_DIR
+BIGDL_DIR="$(cd ${RUN_SCRIPT_DIR}/../..; pwd)"
+echo $BIGDL_DIR
+
+if (( $# < 2)); then
+  echo "Usage: release_default_linux.sh version upload"
+  echo "Usage example: bash release_default_linux.sh default true"
+  echo "Usage example: bash release_default_linux.sh 0.14.0.dev1 false"
+  exit -1
+fi
+
+version=$1
+upload=$2
+
+# Release nano and serving
+NANO_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/nano/dev; pwd)"
+echo $NANO_SCRIPT_DIR
+bash ${NANO_SCRIPT_DIR}/release_default_linux.sh ${version} ${upload}
+
+SERVING_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/serving/dev; pwd)"
+echo $SERVING_SCRIPT_DIR
+bash ${SERVING_SCRIPT_DIR}/release.sh ${version} ${upload}
+
+# Release default bigdl without suffix
+bash ${RUN_SCRIPT_DIR}/release_default_linux_spark246.sh ${version} false ${upload} false
+
+# Release bigdl-spark2. Using quick build as this will be the same as bigdl without suffix
+bash ${RUN_SCRIPT_DIR}/release_default_linux_spark246.sh ${version} true ${upload} true
+
+# Release bigdl-spark3
+bash ${RUN_SCRIPT_DIR}/release_default_linux_spark312.sh ${version} false ${upload} true
+
+# TODO: may need to upload all whls in the very end at the same time in case any build fails?

--- a/python/dev/release_default_linux_spark246.sh
+++ b/python/dev/release_default_linux_spark246.sh
@@ -26,42 +26,42 @@ BIGDL_DIR="$(cd ${RUN_SCRIPT_DIR}/../..; pwd)"
 echo $BIGDL_DIR
 
 if (( $# < 3)); then
-  echo "Usage: release_default_linux_spark246.sh version quick_build upload mvn_parameters"
-  echo "Usage example: bash release_default_linux_spark246.sh default false true"
-  echo "Usage example: bash release_default_linux_spark246.sh 0.14.0.dev1 false false"
-  echo "Usage example: bash release_default_linux_spark246.sh 0.14.0.dev1 false false -Ddata-store-url=.."
+  echo "Usage: release_default_linux_spark246.sh version quick_build upload suffix mvn_parameters"
+  echo "Usage example: bash release_default_linux_spark246.sh default false true true"
+  echo "Usage example: bash release_default_linux_spark246.sh 0.14.0.dev1 false false true"
+  echo "Usage example: bash release_default_linux_spark246.sh 0.14.0.dev1 false false false -Ddata-store-url=.."
   exit -1
 fi
 
 version=$1
 quick=$2
 upload=$3
-profiles=${*:4}
+if (( $# < 4)); then
+  suffix=false
+  profiles=${*:4}
+else
+  suffix=$4
+  profiles=${*:5}
+fi
 
-NANO_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/nano/dev; pwd)"
-echo $NANO_SCRIPT_DIR
-bash ${NANO_SCRIPT_DIR}/release_default_linux.sh ${version} ${upload}
+# Nano and serving are released in release_default_linux.sh as they don't rely on spark versions.
 
 # Only dllib is not using quick build.
 # Since make_dist is invoked in dllib, all other packages can directly use quick build.
 DLLIB_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/dllib/dev/release; pwd)"
 echo $DLLIB_SCRIPT_DIR
-bash ${DLLIB_SCRIPT_DIR}/release_default_linux_spark246.sh ${version} ${quick} ${upload} ${profiles}
+bash ${DLLIB_SCRIPT_DIR}/release_default_linux_spark246.sh ${version} ${quick} ${upload} ${suffix} ${profiles}
 
 ORCA_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/orca/dev/release; pwd)"
 echo $ORCA_SCRIPT_DIR
-bash ${ORCA_SCRIPT_DIR}/release_default_linux_spark246.sh ${version} true ${upload}
+bash ${ORCA_SCRIPT_DIR}/release_default_linux_spark246.sh ${version} true ${upload} ${suffix}
 
 FRIESIAN_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/friesian/dev/release; pwd)"
 echo $FRIESIAN_SCRIPT_DIR
-bash ${FRIESIAN_SCRIPT_DIR}/release_default_linux_spark246.sh ${version} true ${upload}
+bash ${FRIESIAN_SCRIPT_DIR}/release_default_linux_spark246.sh ${version} true ${upload} ${suffix}
 
 CHRONOS_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/chronos/dev/release; pwd)"
 echo $CHRONOS_SCRIPT_DIR
-bash ${CHRONOS_SCRIPT_DIR}/release_default_linux_spark246.sh ${version} ${upload}
+bash ${CHRONOS_SCRIPT_DIR}/release_default_linux_spark246.sh ${version} ${upload} ${suffix}
 
-SERVING_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/serving/dev; pwd)"
-echo $SERVING_SCRIPT_DIR
-bash ${SERVING_SCRIPT_DIR}/release.sh ${version} ${upload}
-
-# TODO: may need to upload all whls in the very end at the same time in case any build fails?
+bash ${RUN_SCRIPT_DIR}/release_bigdl_spark2.sh linux ${version} ${upload} ${suffix}

--- a/python/dev/release_default_linux_spark312.sh
+++ b/python/dev/release_default_linux_spark312.sh
@@ -26,34 +26,40 @@ BIGDL_DIR="$(cd ${RUN_SCRIPT_DIR}/../..; pwd)"
 echo $BIGDL_DIR
 
 if (( $# < 3)); then
-  echo "Usage: release_default_linux_spark312.sh version quick_build upload mvn_parameters"
-  echo "Usage example: bash release_default_linux_spark312.sh default false true"
-  echo "Usage example: bash release_default_linux_spark312.sh 0.14.0.dev1 false false"
-  echo "Usage example: bash release_default_linux_spark312.sh 0.14.0.dev1 false false -Ddata-store-url=.."
+  echo "Usage: release_default_linux_spark312.sh version quick_build upload suffix mvn_parameters"
+  echo "Usage example: bash release_default_linux_spark312.sh default false true true"
+  echo "Usage example: bash release_default_linux_spark312.sh 0.14.0.dev1 false false true"
+  echo "Usage example: bash release_default_linux_spark312.sh 0.14.0.dev1 false false false -Ddata-store-url=.."
   exit -1
 fi
 
 version=$1
 quick=$2
 upload=$3
-profiles=${*:4}
+if (( $# < 4)); then
+  suffix=true
+  profiles=${*:4}
+else
+  suffix=$4
+  profiles=${*:5}
+fi
 
 # Only dllib is not using quick build.
 # Since make_dist is invoked in dllib, all other packages can directly use quick build.
 DLLIB_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/dllib/dev/release; pwd)"
 echo $DLLIB_SCRIPT_DIR
-bash ${DLLIB_SCRIPT_DIR}/release_default_linux_spark312.sh ${version} ${quick} ${upload} ${profiles}
+bash ${DLLIB_SCRIPT_DIR}/release_default_linux_spark312.sh ${version} ${quick} ${upload} ${suffix} ${profiles}
 
 ORCA_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/orca/dev/release; pwd)"
 echo $ORCA_SCRIPT_DIR
-bash ${ORCA_SCRIPT_DIR}/release_default_linux_spark312.sh ${version} true ${upload}
+bash ${ORCA_SCRIPT_DIR}/release_default_linux_spark312.sh ${version} true ${upload} ${suffix}
 
 FRIESIAN_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/friesian/dev/release; pwd)"
 echo $FRIESIAN_SCRIPT_DIR
-bash ${FRIESIAN_SCRIPT_DIR}/release_default_linux_spark312.sh ${version} true ${upload}
+bash ${FRIESIAN_SCRIPT_DIR}/release_default_linux_spark312.sh ${version} true ${upload} ${suffix}
 
 CHRONOS_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/chronos/dev/release; pwd)"
 echo $CHRONOS_SCRIPT_DIR
-bash ${CHRONOS_SCRIPT_DIR}/release_default_linux_spark312.sh ${version} ${upload}
+bash ${CHRONOS_SCRIPT_DIR}/release_default_linux_spark312.sh ${version} ${upload} ${suffix}
 
-# Serving and nano has a universal jar for all spark versions and is released in the spark246 script.
+bash ${RUN_SCRIPT_DIR}/release_bigdl_spark3.sh linux ${version} ${upload} ${suffix}

--- a/python/dev/release_default_mac.sh
+++ b/python/dev/release_default_mac.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is the default script with maven parameters to release all the bigdl sub-packages
+# built on top of both Spark2 and Spark3 version for mac.
+
+set -e
+RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
+echo $RUN_SCRIPT_DIR
+BIGDL_DIR="$(cd ${RUN_SCRIPT_DIR}/../..; pwd)"
+echo $BIGDL_DIR
+
+if (( $# < 2)); then
+  echo "Usage: release_default_mac.sh version upload"
+  echo "Usage example: bash release_default_mac.sh default true"
+  echo "Usage example: bash release_default_mac.sh 0.14.0.dev1 false"
+  exit -1
+fi
+
+version=$1
+upload=$2
+
+# TODO: nano is currently not ready for mac.
+# Serving has a universal jar for all platforms and spark versions and is released in the release_default_linux.sh.
+
+# Release default bigdl without suffix
+bash ${RUN_SCRIPT_DIR}/release_default_mac_spark246.sh ${version} false ${upload} false
+
+# Release bigdl-spark2. Using quick build as this will be the same as bigdl without suffix
+bash ${RUN_SCRIPT_DIR}/release_default_mac_spark246.sh ${version} true ${upload} true
+
+# Release bigdl-spark3
+bash ${RUN_SCRIPT_DIR}/release_default_mac_spark312.sh ${version} false ${upload} true

--- a/python/dev/release_default_mac.sh
+++ b/python/dev/release_default_mac.sh
@@ -35,7 +35,10 @@ fi
 version=$1
 upload=$2
 
-# TODO: nano is currently not ready for mac.
+# Release nano.
+NANO_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/nano/dev; pwd)"
+echo $NANO_SCRIPT_DIR
+bash ${NANO_SCRIPT_DIR}/release_default_mac.sh ${version} ${upload}
 # Serving has a universal jar for all platforms and spark versions and is released in the release_default_linux.sh.
 
 # Release default bigdl without suffix

--- a/python/dev/release_default_mac_spark246.sh
+++ b/python/dev/release_default_mac_spark246.sh
@@ -26,17 +26,23 @@ BIGDL_DIR="$(cd ${RUN_SCRIPT_DIR}/../..; pwd)"
 echo $BIGDL_DIR
 
 if (( $# < 3)); then
-  echo "Usage: release_default_mac_spark246.sh version quick_build upload mvn_parameters"
-  echo "Usage example: bash release_default_mac_spark246.sh default false true"
-  echo "Usage example: bash release_default_mac_spark246.sh 0.14.0.dev1 false false"
-  echo "Usage example: bash release_default_mac_spark246.sh 0.14.0.dev1 false false -Ddata-store-url=.."
+  echo "Usage: release_default_mac_spark246.sh version quick_build upload suffix mvn_parameters"
+  echo "Usage example: bash release_default_mac_spark246.sh default false true true"
+  echo "Usage example: bash release_default_mac_spark246.sh 0.14.0.dev1 false false true"
+  echo "Usage example: bash release_default_mac_spark246.sh 0.14.0.dev1 false false false -Ddata-store-url=.."
   exit -1
 fi
 
 version=$1
 quick=$2
 upload=$3
-profiles=${*:4}
+if (( $# < 4)); then
+  suffix=false
+  profiles=${*:4}
+else
+  suffix=$4
+  profiles=${*:5}
+fi
 
 NANO_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/nano/dev; pwd)"
 echo $NANO_SCRIPT_DIR
@@ -46,18 +52,18 @@ bash ${NANO_SCRIPT_DIR}/release_default_mac.sh ${version} ${upload}
 # Since make_dist is invoked in dllib, all other packages can directly use quick build.
 DLLIB_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/dllib/dev/release; pwd)"
 echo $DLLIB_SCRIPT_DIR
-bash ${DLLIB_SCRIPT_DIR}/release_default_mac_spark246.sh ${version} ${quick} ${upload} ${profiles}
+bash ${DLLIB_SCRIPT_DIR}/release_default_mac_spark246.sh ${version} ${quick} ${upload} ${suffix} ${profiles}
 
 ORCA_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/orca/dev/release; pwd)"
 echo $ORCA_SCRIPT_DIR
-bash ${ORCA_SCRIPT_DIR}/release_default_mac_spark246.sh ${version} true ${upload}
+bash ${ORCA_SCRIPT_DIR}/release_default_mac_spark246.sh ${version} true ${upload} ${suffix}
 
 FRIESIAN_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/friesian/dev/release; pwd)"
 echo $FRIESIAN_SCRIPT_DIR
-bash ${FRIESIAN_SCRIPT_DIR}/release_default_mac_spark246.sh ${version} true ${upload}
+bash ${FRIESIAN_SCRIPT_DIR}/release_default_mac_spark246.sh ${version} true ${upload} ${suffix}
 
 CHRONOS_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/chronos/dev/release; pwd)"
 echo $CHRONOS_SCRIPT_DIR
-bash ${CHRONOS_SCRIPT_DIR}/release_default_mac_spark246.sh ${version} ${upload}
+bash ${CHRONOS_SCRIPT_DIR}/release_default_mac_spark246.sh ${version} ${upload} ${suffix}
 
-# Serving has a universal jar for all platforms and is released in the linux script.
+bash ${RUN_SCRIPT_DIR}/release_bigdl_spark2.sh mac ${version} ${upload} ${suffix}

--- a/python/dev/release_default_mac_spark246.sh
+++ b/python/dev/release_default_mac_spark246.sh
@@ -44,10 +44,6 @@ else
   profiles=${*:5}
 fi
 
-NANO_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/nano/dev; pwd)"
-echo $NANO_SCRIPT_DIR
-bash ${NANO_SCRIPT_DIR}/release_default_mac.sh ${version} ${upload}
-
 # Only dllib is not using quick build.
 # Since make_dist is invoked in dllib, all other packages can directly use quick build.
 DLLIB_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/dllib/dev/release; pwd)"

--- a/python/dev/release_default_mac_spark312.sh
+++ b/python/dev/release_default_mac_spark312.sh
@@ -26,34 +26,40 @@ BIGDL_DIR="$(cd ${RUN_SCRIPT_DIR}/../..; pwd)"
 echo $BIGDL_DIR
 
 if (( $# < 3)); then
-  echo "Usage: release_default_mac_spark312.sh version quick_build upload mvn_parameters"
-  echo "Usage example: bash release_default_mac_spark312.sh default false true"
-  echo "Usage example: bash release_default_mac_spark312.sh 0.14.0.dev1 false false"
-  echo "Usage example: bash release_default_mac_spark246.sh 0.14.0.dev1 false false -Ddata-store-url=.."
+  echo "Usage: release_default_mac_spark312.sh version quick_build upload suffix mvn_parameters"
+  echo "Usage example: bash release_default_mac_spark312.sh default false true true"
+  echo "Usage example: bash release_default_mac_spark312.sh 0.14.0.dev1 false false true"
+  echo "Usage example: bash release_default_mac_spark246.sh 0.14.0.dev1 false false false -Ddata-store-url=.."
   exit -1
 fi
 
 version=$1
 quick=$2
 upload=$3
-profiles=${*:4}
+if (( $# < 4)); then
+  suffix=true
+  profiles=${*:4}
+else
+  suffix=$4
+  profiles=${*:5}
+fi
 
 # Only dllib is not using quick build.
 # Since make_dist is invoked in dllib, all other packages can directly use quick build.
 DLLIB_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/dllib/dev/release; pwd)"
 echo $DLLIB_SCRIPT_DIR
-bash ${DLLIB_SCRIPT_DIR}/release_default_mac_spark312.sh ${version} ${quick} ${upload} ${profiles}
+bash ${DLLIB_SCRIPT_DIR}/release_default_mac_spark312.sh ${version} ${quick} ${upload} ${suffix} ${profiles}
 
 ORCA_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/orca/dev/release; pwd)"
 echo $ORCA_SCRIPT_DIR
-bash ${ORCA_SCRIPT_DIR}/release_default_mac_spark312.sh ${version} true ${upload}
+bash ${ORCA_SCRIPT_DIR}/release_default_mac_spark312.sh ${version} true ${upload} ${suffix}
 
 FRIESIAN_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/friesian/dev/release; pwd)"
 echo $FRIESIAN_SCRIPT_DIR
-bash ${FRIESIAN_SCRIPT_DIR}/release_default_mac_spark312.sh ${version} true ${upload}
+bash ${FRIESIAN_SCRIPT_DIR}/release_default_mac_spark312.sh ${version} true ${upload} ${suffix}
 
 CHRONOS_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/chronos/dev/release; pwd)"
 echo $CHRONOS_SCRIPT_DIR
-bash ${CHRONOS_SCRIPT_DIR}/release_default_mac_spark312.sh ${version} ${upload}
+bash ${CHRONOS_SCRIPT_DIR}/release_default_mac_spark312.sh ${version} ${upload} ${suffix}
 
-# Serving and nano has a universal jar for all spark versions and is released in the spark246 script.
+bash ${RUN_SCRIPT_DIR}/release_bigdl_spark3.sh mac ${version} ${upload} ${suffix}

--- a/python/dev/remove_spark_suffix.sh
+++ b/python/dev/remove_spark_suffix.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is the script to remove spark2 and spark3 suffix for all project
+# names and dependencies.
+
+file=$1
+
+sed -i "s/name='bigdl-spark2'/name='bigdl'/g" ${file}
+sed -i "s/name='bigdl-spark3'/name='bigdl'/g" ${file}
+
+sed -i "s/bigdl-dllib-spark2==/bigdl-dllib==/g" ${file}
+sed -i "s/bigdl-dllib-spark3==/bigdl-dllib==/g" ${file}
+sed -i "s/name='bigdl-dllib-spark2'/name='bigdl-dllib'/g" ${file}
+sed -i "s/name='bigdl-dllib-spark3'/name='bigdl-dllib'/g" ${file}
+sed -i "s/dist\/bigdl_dllib_spark2-/dist\/bigdl_dllib-/g" ${file}
+sed -i "s/dist\/bigdl_dllib_spark3-/dist\/bigdl_dllib-/g" ${file}
+
+sed -i "s/bigdl-orca-spark2==/bigdl-orca==/g" ${file}
+sed -i "s/bigdl-orca-spark3==/bigdl-orca==/g" ${file}
+sed -i "s/name='bigdl-orca-spark2'/name='bigdl-orca'/g" ${file}
+sed -i "s/name='bigdl-orca-spark3'/name='bigdl-orca'/g" ${file}
+sed -i "s/dist\/bigdl_orca_spark2-/dist\/bigdl_orca-/g" ${file}
+sed -i "s/dist\/bigdl_orca_spark3-/dist\/bigdl_orca-/g" ${file}
+sed -i "s/bigdl-orca-spark2\[ray\]/bigdl-orca\[ray\]/g" ${file}
+sed -i "s/bigdl-orca-spark3\[ray\]/bigdl-orca\[ray\]/g" ${file}
+
+sed -i "s/bigdl-chronos-spark2==/bigdl-chronos==/g" ${file}
+sed -i "s/bigdl-chronos-spark3==/bigdl-chronos==/g" ${file}
+sed -i "s/name='bigdl-chronos-spark2'/name='bigdl-chronos'/g" ${file}
+sed -i "s/name='bigdl-chronos-spark3'/name='bigdl-chronos'/g" ${file}
+sed -i "s/dist\/bigdl_chronos_spark2-/dist\/bigdl_chronos-/g" ${file}
+sed -i "s/dist\/bigdl_chronos_spark3-/dist\/bigdl_chronos-/g" ${file}
+
+sed -i "s/bigdl-friesian-spark2==/bigdl-friesian==/g" ${file}
+sed -i "s/bigdl-friesian-spark3==/bigdl-friesian==/g" ${file}
+sed -i "s/name='bigdl-friesian-spark2'/name='bigdl-friesian'/g" ${file}
+sed -i "s/name='bigdl-friesian-spark3'/name='bigdl-friesian'/g" ${file}
+sed -i "s/dist\/bigdl_friesian_spark2-/dist\/bigdl_friesian-/g" ${file}
+sed -i "s/dist\/bigdl_friesian_spark3-/dist\/bigdl_friesian-/g" ${file}

--- a/python/dllib/dev/release/release_default_linux_spark246.sh
+++ b/python/dllib/dev/release/release_default_linux_spark246.sh
@@ -25,17 +25,31 @@
 set -e
 RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 echo $RUN_SCRIPT_DIR
+DLLIB_DIR="$(cd ${RUN_SCRIPT_DIR}/../../; pwd)"
+echo $DLLIB_DIR
+DEV_DIR="$(cd ${DLLIB_DIR}/../dev/; pwd)"
+echo $DEV_DIR
 
-if (( $# < 3)); then
-  echo "Usage: release_default_linux_spark246.sh version quick_build upload"
-  echo "Usage example: bash release_default_linux_spark246.sh default true true"
-  echo "Usage example: bash release_default_linux_spark246.sh 0.14.0.dev1 false true"
+if (( $# < 4)); then
+  echo "Usage: release_default_linux_spark246.sh version quick_build upload suffix"
+  echo "Usage example: bash release_default_linux_spark246.sh default true true true"
+  echo "Usage example: bash release_default_linux_spark246.sh 0.14.0.dev1 false true false"
   exit -1
 fi
 
 version=$1
 quick=$2
 upload=$3
-profiles=${*:4}
+suffix=$4
+profiles=${*:5}
+
+sed -i "s/pyspark==3.1.2/pyspark==2.4.6/g" $DLLIB_DIR/src/setup.py
+if [ ${suffix} == true ]; then
+    bash ${DEV_DIR}/add_suffix_spark2.sh $DLLIB_DIR/src/setup.py
+    bash ${DEV_DIR}/add_suffix_spark2.sh ${RUN_SCRIPT_DIR}/release.sh
+else
+    bash ${DEV_DIR}/remove_spark_suffix.sh $DLLIB_DIR/src/setup.py
+    bash ${DEV_DIR}/remove_spark_suffix.sh ${RUN_SCRIPT_DIR}/release.sh
+fi
 
 bash ${RUN_SCRIPT_DIR}/release.sh linux ${version} ${quick} ${upload} -Dspark.version=2.4.6 -P spark_2.x ${profiles}

--- a/python/dllib/dev/release/release_default_linux_spark312.sh
+++ b/python/dllib/dev/release/release_default_linux_spark312.sh
@@ -27,24 +27,29 @@ RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 echo $RUN_SCRIPT_DIR
 DLLIB_DIR="$(cd ${RUN_SCRIPT_DIR}/../../; pwd)"
 echo $DLLIB_DIR
+DEV_DIR="$(cd ${DLLIB_DIR}/../dev/; pwd)"
+echo $DEV_DIR
 
-if (( $# < 3)); then
-  echo "Usage: release_default_linux_spark312.sh version quick_build upload"
-  echo "Usage example: bash release_default_linux_spark312.sh default true true"
-  echo "Usage example: bash release_default_linux_spark312.sh 0.14.0.dev1 false true"
+if (( $# < 4)); then
+  echo "Usage: release_default_linux_spark312.sh version quick_build upload suffix"
+  echo "Usage example: bash release_default_linux_spark312.sh default true true true"
+  echo "Usage example: bash release_default_linux_spark312.sh 0.14.0.dev1 false true false"
   exit -1
 fi
 
 version=$1
 quick=$2
 upload=$3
-profiles=${*:4}
+suffix=$4
+profiles=${*:5}
 
-# Add spark3 suffix to the project name to avoid conflict with the whl for spark2.
-# Add name= and - in pattern matching so that if the script runs twice,
-# it won't change anything in the second run.
 sed -i "s/pyspark==2.4.6/pyspark==3.1.2/g" $DLLIB_DIR/src/setup.py
-sed -i "s/name='bigdl-dllib'/name='bigdl-dllib-spark3'/g" $DLLIB_DIR/src/setup.py
-sed -i "s/dist\/bigdl_dllib-/dist\/bigdl_dllib_spark3-/g" ${RUN_SCRIPT_DIR}/release.sh
+if [ ${suffix} == true ]; then
+    bash ${DEV_DIR}/add_suffix_spark3.sh $DLLIB_DIR/src/setup.py
+    bash ${DEV_DIR}/add_suffix_spark3.sh ${RUN_SCRIPT_DIR}/release.sh
+else
+    bash ${DEV_DIR}/remove_spark_suffix.sh $DLLIB_DIR/src/setup.py
+    bash ${DEV_DIR}/remove_spark_suffix.sh ${RUN_SCRIPT_DIR}/release.sh
+fi
 
 bash ${RUN_SCRIPT_DIR}/release.sh linux ${version} ${quick} ${upload} -Dspark.version=3.1.2 -P spark_3.x ${profiles}

--- a/python/dllib/dev/release/release_default_mac_spark246.sh
+++ b/python/dllib/dev/release/release_default_mac_spark246.sh
@@ -25,17 +25,31 @@
 set -e
 RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 echo $RUN_SCRIPT_DIR
+DLLIB_DIR="$(cd ${RUN_SCRIPT_DIR}/../../; pwd)"
+echo $DLLIB_DIR
+DEV_DIR="$(cd ${DLLIB_DIR}/../dev/; pwd)"
+echo $DEV_DIR
 
-if (( $# < 3)); then
-  echo "Usage: release_default_mac_spark246.sh version quick_build upload"
-  echo "Usage example: bash release_default_mac_spark246.sh default true true"
-  echo "Usage example: bash release_default_mac_spark246.sh 0.14.0.dev1 false true"
+if (( $# < 4)); then
+  echo "Usage: release_default_mac_spark246.sh version quick_build upload suffix"
+  echo "Usage example: bash release_default_mac_spark246.sh default true true true"
+  echo "Usage example: bash release_default_mac_spark246.sh 0.14.0.dev1 false true false"
   exit -1
 fi
 
 version=$1
 quick=$2
 upload=$3
-profiles=${*:4}
+suffix=$4
+profiles=${*:5}
+
+sed -i "s/pyspark==3.1.2/pyspark==2.4.6/g" $DLLIB_DIR/src/setup.py
+if [ ${suffix} == true ]; then
+    bash ${DEV_DIR}/add_suffix_spark2.sh $DLLIB_DIR/src/setup.py
+    bash ${DEV_DIR}/add_suffix_spark2.sh ${RUN_SCRIPT_DIR}/release.sh
+else
+    bash ${DEV_DIR}/remove_spark_suffix.sh $DLLIB_DIR/src/setup.py
+    bash ${DEV_DIR}/remove_spark_suffix.sh ${RUN_SCRIPT_DIR}/release.sh
+fi
 
 bash ${RUN_SCRIPT_DIR}/release.sh mac ${version} ${quick} ${upload} -Dspark.version=2.4.6 -P spark_2.x ${profiles}

--- a/python/dllib/dev/release/release_default_mac_spark312.sh
+++ b/python/dllib/dev/release/release_default_mac_spark312.sh
@@ -27,24 +27,29 @@ RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 echo $RUN_SCRIPT_DIR
 DLLIB_DIR="$(cd ${RUN_SCRIPT_DIR}/../../; pwd)"
 echo $DLLIB_DIR
+DEV_DIR="$(cd ${DLLIB_DIR}/../dev/; pwd)"
+echo $DEV_DIR
 
-if (( $# < 3)); then
-  echo "Usage: release_default_mac_spark312.sh version quick_build upload"
-  echo "Usage example: bash release_default_mac_spark312.sh default true true"
-  echo "Usage example: bash release_default_mac_spark312.sh 0.14.0.dev1 false true"
+if (( $# < 4)); then
+  echo "Usage: release_default_mac_spark312.sh version quick_build upload suffix"
+  echo "Usage example: bash release_default_mac_spark312.sh default true true true"
+  echo "Usage example: bash release_default_mac_spark312.sh 0.14.0.dev1 false true false"
   exit -1
 fi
 
 version=$1
 quick=$2
 upload=$3
-profiles=${*:4}
+suffix=$4
+profiles=${*:5}
 
-# Add spark3 suffix to the project name to avoid conflict with the whl for spark2.
-# Add name= and - in pattern matching so that if the script runs twice,
-# it won't change anything in the second run.
 sed -i "s/pyspark==2.4.6/pyspark==3.1.2/g" $DLLIB_DIR/src/setup.py
-sed -i "s/name='bigdl-dllib'/name='bigdl-dllib-spark3'/g" $DLLIB_DIR/src/setup.py
-sed -i "s/dist\/bigdl_dllib-/dist\/bigdl_dllib_spark3-/g" ${RUN_SCRIPT_DIR}/release.sh
+if [ ${suffix} == true ]; then
+    bash ${DEV_DIR}/add_suffix_spark3.sh $DLLIB_DIR/src/setup.py
+    bash ${DEV_DIR}/add_suffix_spark3.sh ${RUN_SCRIPT_DIR}/release.sh
+else
+    bash ${DEV_DIR}/remove_spark_suffix.sh $DLLIB_DIR/src/setup.py
+    bash ${DEV_DIR}/remove_spark_suffix.sh ${RUN_SCRIPT_DIR}/release.sh
+fi
 
 bash ${RUN_SCRIPT_DIR}/release.sh mac ${version} ${quick} ${upload} -Dspark.version=3.1.2 -P spark_3.x ${profiles}

--- a/python/friesian/dev/release/release_default_linux_spark246.sh
+++ b/python/friesian/dev/release/release_default_linux_spark246.sh
@@ -25,16 +25,29 @@
 set -e
 RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 echo $RUN_SCRIPT_DIR
+FRIESIAN_DIR="$(cd ${RUN_SCRIPT_DIR}/../../; pwd)"
+echo $FRIESIAN_DIR
+DEV_DIR="$(cd ${FRIESIAN_DIR}/../dev/; pwd)"
+echo $DEV_DIR
 
-if (( $# < 3)); then
-  echo "Usage: release_default_linux_spark246.sh version quick_build upload"
-  echo "Usage example: bash release_default_linux_spark246.sh default true true"
-  echo "Usage example: bash release_default_linux_spark246.sh 0.14.0.dev1 false true"
+if (( $# < 4)); then
+  echo "Usage: release_default_linux_spark246.sh version quick_build upload suffix"
+  echo "Usage example: bash release_default_linux_spark246.sh default true true true"
+  echo "Usage example: bash release_default_linux_spark246.sh 0.14.0.dev1 false true false"
   exit -1
 fi
 
 version=$1
 quick=$2
 upload=$3
+suffix=$4
+
+if [ ${suffix} == true ]; then
+    bash ${DEV_DIR}/add_suffix_spark2.sh $FRIESIAN_DIR/src/setup.py
+    bash ${DEV_DIR}/add_suffix_spark2.sh ${RUN_SCRIPT_DIR}/release.sh
+else
+    bash ${DEV_DIR}/remove_spark_suffix.sh $FRIESIAN_DIR/src/setup.py
+    bash ${DEV_DIR}/remove_spark_suffix.sh ${RUN_SCRIPT_DIR}/release.sh
+fi
 
 bash ${RUN_SCRIPT_DIR}/release.sh linux ${version} ${quick} ${upload} -Dspark.version=2.4.6 -P spark_2.x

--- a/python/friesian/dev/release/release_default_linux_spark312.sh
+++ b/python/friesian/dev/release/release_default_linux_spark312.sh
@@ -27,24 +27,27 @@ RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 echo $RUN_SCRIPT_DIR
 FRIESIAN_DIR="$(cd ${RUN_SCRIPT_DIR}/../../; pwd)"
 echo $FRIESIAN_DIR
+DEV_DIR="$(cd ${FRIESIAN_DIR}/../dev/; pwd)"
+echo $DEV_DIR
 
-if (( $# < 3)); then
-  echo "Usage: release_default_linux_spark312.sh version quick_build upload"
-  echo "Usage example: bash release_default_linux_spark312.sh default true true"
-  echo "Usage example: bash release_default_linux_spark312.sh 0.14.0.dev1 false true"
+if (( $# < 4)); then
+  echo "Usage: release_default_linux_spark312.sh version quick_build upload suffix"
+  echo "Usage example: bash release_default_linux_spark312.sh default true true true"
+  echo "Usage example: bash release_default_linux_spark312.sh 0.14.0.dev1 false true false"
   exit -1
 fi
 
 version=$1
 quick=$2
 upload=$3
+suffix=$4
 
-# Add spark3 suffix to the project name to avoid conflict with the whl for spark2.
-# Add name=, == and - in pattern matching so that if the script runs twice,
-# it won't change anything in the second run.
-sed -i "s/bigdl-orca==/bigdl-orca-spark3==/g" $FRIESIAN_DIR/src/setup.py
-sed -i "s/name='bigdl-friesian'/name='bigdl-friesian-spark3'/g" $FRIESIAN_DIR/src/setup.py
-sed -i "s/bigdl-orca\[ray\]/bigdl-orca-spark3\[ray\]/g" $FRIESIAN_DIR/src/setup.py
-sed -i "s/dist\/bigdl_friesian-/dist\/bigdl_friesian_spark3-/g" ${RUN_SCRIPT_DIR}/release.sh
+if [ ${suffix} == true ]; then
+    bash ${DEV_DIR}/add_suffix_spark3.sh $FRIESIAN_DIR/src/setup.py
+    bash ${DEV_DIR}/add_suffix_spark3.sh ${RUN_SCRIPT_DIR}/release.sh
+else
+    bash ${DEV_DIR}/remove_spark_suffix.sh $FRIESIAN_DIR/src/setup.py
+    bash ${DEV_DIR}/remove_spark_suffix.sh ${RUN_SCRIPT_DIR}/release.sh
+fi
 
 bash ${RUN_SCRIPT_DIR}/release.sh linux ${version} ${quick} ${upload} -Dspark.version=3.1.2 -P spark_3.x

--- a/python/friesian/dev/release/release_default_mac_spark246.sh
+++ b/python/friesian/dev/release/release_default_mac_spark246.sh
@@ -25,16 +25,29 @@
 set -e
 RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 echo $RUN_SCRIPT_DIR
+FRIESIAN_DIR="$(cd ${RUN_SCRIPT_DIR}/../../; pwd)"
+echo $FRIESIAN_DIR
+DEV_DIR="$(cd ${FRIESIAN_DIR}/../dev/; pwd)"
+echo $DEV_DIR
 
-if (( $# < 3)); then
-  echo "Usage: release_default_mac_spark246.sh version quick_build upload"
-  echo "Usage example: bash release_default_mac_spark246.sh default true true"
-  echo "Usage example: bash release_default_mac_spark246.sh 0.14.0.dev1 false true"
+if (( $# < 4)); then
+  echo "Usage: release_default_mac_spark246.sh version quick_build upload suffix"
+  echo "Usage example: bash release_default_mac_spark246.sh default true true true"
+  echo "Usage example: bash release_default_mac_spark246.sh 0.14.0.dev1 false true false"
   exit -1
 fi
 
 version=$1
 quick=$2
 upload=$3
+suffix=$4
+
+if [ ${suffix} == true ]; then
+    bash ${DEV_DIR}/add_suffix_spark2.sh $FRIESIAN_DIR/src/setup.py
+    bash ${DEV_DIR}/add_suffix_spark2.sh ${RUN_SCRIPT_DIR}/release.sh
+else
+    bash ${DEV_DIR}/remove_spark_suffix.sh $FRIESIAN_DIR/src/setup.py
+    bash ${DEV_DIR}/remove_spark_suffix.sh ${RUN_SCRIPT_DIR}/release.sh
+fi
 
 bash ${RUN_SCRIPT_DIR}/release.sh mac ${version} ${quick} ${upload} -Dspark.version=2.4.6 -P spark_2.x

--- a/python/friesian/dev/release/release_default_mac_spark312.sh
+++ b/python/friesian/dev/release/release_default_mac_spark312.sh
@@ -27,24 +27,27 @@ RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 echo $RUN_SCRIPT_DIR
 FRIESIAN_DIR="$(cd ${RUN_SCRIPT_DIR}/../../; pwd)"
 echo $FRIESIAN_DIR
+DEV_DIR="$(cd ${FRIESIAN_DIR}/../dev/; pwd)"
+echo $DEV_DIR
 
-if (( $# < 3)); then
-  echo "Usage: release_default_mac_spark312.sh version quick_build upload"
-  echo "Usage example: bash release_default_mac_spark312.sh default true true"
-  echo "Usage example: bash release_default_mac_spark312.sh 0.14.0.dev1 false true"
+if (( $# < 4)); then
+  echo "Usage: release_default_mac_spark312.sh version quick_build upload suffix"
+  echo "Usage example: bash release_default_mac_spark312.sh default true true true"
+  echo "Usage example: bash release_default_mac_spark312.sh 0.14.0.dev1 false true false"
   exit -1
 fi
 
 version=$1
 quick=$2
 upload=$3
+suffix=$4
 
-# Add spark3 suffix to the project name to avoid conflict with the whl for spark2.
-# Add name=, == and - in pattern matching so that if the script runs twice,
-# it won't change anything in the second run.
-sed -i "s/bigdl-orca==/bigdl-orca-spark3==/g" $FRIESIAN_DIR/src/setup.py
-sed -i "s/name='bigdl-friesian'/name='bigdl-friesian-spark3'/g" $FRIESIAN_DIR/src/setup.py
-sed -i "s/bigdl-orca\[ray\]/bigdl-orca-spark3\[ray\]/g" $FRIESIAN_DIR/src/setup.py
-sed -i "s/dist\/bigdl_friesian-/dist\/bigdl_friesian_spark3-/g" ${RUN_SCRIPT_DIR}/release.sh
+if [ ${suffix} == true ]; then
+    bash ${DEV_DIR}/add_suffix_spark3.sh $FRIESIAN_DIR/src/setup.py
+    bash ${DEV_DIR}/add_suffix_spark3.sh ${RUN_SCRIPT_DIR}/release.sh
+else
+    bash ${DEV_DIR}/remove_spark_suffix.sh $FRIESIAN_DIR/src/setup.py
+    bash ${DEV_DIR}/remove_spark_suffix.sh ${RUN_SCRIPT_DIR}/release.sh
+fi
 
 bash ${RUN_SCRIPT_DIR}/release.sh mac ${version} ${quick} ${upload} -Dspark.version=3.1.2 -P spark_3.x

--- a/python/orca/dev/release/release_default_linux_spark246.sh
+++ b/python/orca/dev/release/release_default_linux_spark246.sh
@@ -25,16 +25,29 @@
 set -e
 RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 echo $RUN_SCRIPT_DIR
+ORCA_DIR="$(cd ${RUN_SCRIPT_DIR}/../../; pwd)"
+echo $ORCA_DIR
+DEV_DIR="$(cd ${ORCA_DIR}/../dev/; pwd)"
+echo $DEV_DIR
 
-if (( $# < 3)); then
-  echo "Usage: release_default_linux_spark246.sh version quick_build upload"
-  echo "Usage example: bash release_default_linux_spark246.sh default true true"
-  echo "Usage example: bash release_default_linux_spark246.sh 0.14.0.dev1 false true"
+if (( $# < 4)); then
+  echo "Usage: release_default_linux_spark246.sh version quick_build upload suffix"
+  echo "Usage example: bash release_default_linux_spark246.sh default true true true"
+  echo "Usage example: bash release_default_linux_spark246.sh 0.14.0.dev1 false true false"
   exit -1
 fi
 
 version=$1
 quick=$2
 upload=$3
+suffix=$4
+
+if [ ${suffix} == true ]; then
+    bash ${DEV_DIR}/add_suffix_spark2.sh $ORCA_DIR/src/setup.py
+    bash ${DEV_DIR}/add_suffix_spark2.sh ${RUN_SCRIPT_DIR}/release.sh
+else
+    bash ${DEV_DIR}/remove_spark_suffix.sh $ORCA_DIR/src/setup.py
+    bash ${DEV_DIR}/remove_spark_suffix.sh ${RUN_SCRIPT_DIR}/release.sh
+fi
 
 bash ${RUN_SCRIPT_DIR}/release.sh linux ${version} ${quick} ${upload} -Dspark.version=2.4.6 -P spark_2.x

--- a/python/orca/dev/release/release_default_linux_spark312.sh
+++ b/python/orca/dev/release/release_default_linux_spark312.sh
@@ -27,23 +27,27 @@ RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 echo $RUN_SCRIPT_DIR
 ORCA_DIR="$(cd ${RUN_SCRIPT_DIR}/../../; pwd)"
 echo $ORCA_DIR
+DEV_DIR="$(cd ${ORCA_DIR}/../dev/; pwd)"
+echo $DEV_DIR
 
-if (( $# < 3)); then
-  echo "Usage: release_default_linux_spark312.sh version quick_build upload"
-  echo "Usage example: bash release_default_linux_spark312.sh default true true"
-  echo "Usage example: bash release_default_linux_spark312.sh 0.14.0.dev1 false true"
+if (( $# < 4)); then
+  echo "Usage: release_default_linux_spark312.sh version quick_build upload suffix"
+  echo "Usage example: bash release_default_linux_spark312.sh default true true true"
+  echo "Usage example: bash release_default_linux_spark312.sh 0.14.0.dev1 false true false"
   exit -1
 fi
 
 version=$1
 quick=$2
 upload=$3
+suffix=$4
 
-# Add spark3 suffix to the project name to avoid conflict with the whl for spark2.
-# Add name=, == and - in pattern matching so that if the script runs twice,
-# it won't change anything in the second run.
-sed -i "s/bigdl-dllib==/bigdl-dllib-spark3==/g" $ORCA_DIR/src/setup.py
-sed -i "s/name='bigdl-orca'/name='bigdl-orca-spark3'/g" $ORCA_DIR/src/setup.py
-sed -i "s/dist\/bigdl_orca-/dist\/bigdl_orca_spark3-/g" ${RUN_SCRIPT_DIR}/release.sh
+if [ ${suffix} == true ]; then
+    bash ${DEV_DIR}/add_suffix_spark3.sh $ORCA_DIR/src/setup.py
+    bash ${DEV_DIR}/add_suffix_spark3.sh ${RUN_SCRIPT_DIR}/release.sh
+else
+    bash ${DEV_DIR}/remove_spark_suffix.sh $ORCA_DIR/src/setup.py
+    bash ${DEV_DIR}/remove_spark_suffix.sh ${RUN_SCRIPT_DIR}/release.sh
+fi
 
 bash ${RUN_SCRIPT_DIR}/release.sh linux ${version} ${quick} ${upload} -Dspark.version=3.1.2 -P spark_3.x

--- a/python/orca/dev/release/release_default_mac_spark246.sh
+++ b/python/orca/dev/release/release_default_mac_spark246.sh
@@ -25,16 +25,29 @@
 set -e
 RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 echo $RUN_SCRIPT_DIR
+ORCA_DIR="$(cd ${RUN_SCRIPT_DIR}/../../; pwd)"
+echo $ORCA_DIR
+DEV_DIR="$(cd ${ORCA_DIR}/../dev/; pwd)"
+echo $DEV_DIR
 
-if (( $# < 3)); then
-  echo "Usage: release_default_mac_spark246.sh version quick_build upload"
-  echo "Usage example: bash release_default_mac_spark246.sh default true true"
-  echo "Usage example: bash release_default_mac_spark246.sh 0.14.0.dev1 false true"
+if (( $# < 4)); then
+  echo "Usage: release_default_mac_spark246.sh version quick_build upload suffix"
+  echo "Usage example: bash release_default_mac_spark246.sh default true true true"
+  echo "Usage example: bash release_default_mac_spark246.sh 0.14.0.dev1 false true false"
   exit -1
 fi
 
 version=$1
 quick=$2
 upload=$3
+suffix=$4
+
+if [ ${suffix} == true ]; then
+    bash ${DEV_DIR}/add_suffix_spark2.sh $ORCA_DIR/src/setup.py
+    bash ${DEV_DIR}/add_suffix_spark2.sh ${RUN_SCRIPT_DIR}/release.sh
+else
+    bash ${DEV_DIR}/remove_spark_suffix.sh $ORCA_DIR/src/setup.py
+    bash ${DEV_DIR}/remove_spark_suffix.sh ${RUN_SCRIPT_DIR}/release.sh
+fi
 
 bash ${RUN_SCRIPT_DIR}/release.sh mac ${version} ${quick} ${upload} -Dspark.version=2.4.6 -P spark_2.x

--- a/python/orca/dev/release/release_default_mac_spark312.sh
+++ b/python/orca/dev/release/release_default_mac_spark312.sh
@@ -27,23 +27,27 @@ RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 echo $RUN_SCRIPT_DIR
 ORCA_DIR="$(cd ${RUN_SCRIPT_DIR}/../../; pwd)"
 echo $ORCA_DIR
+DEV_DIR="$(cd ${ORCA_DIR}/../dev/; pwd)"
+echo $DEV_DIR
 
-if (( $# < 3)); then
-  echo "Usage: release_default_mac_spark312.sh version quick_build upload"
-  echo "Usage example: bash release_default_mac_spark312.sh default true true"
-  echo "Usage example: bash release_default_mac_spark312.sh 0.14.0.dev1 false true"
+if (( $# < 4)); then
+  echo "Usage: release_default_mac_spark312.sh version quick_build upload suffix"
+  echo "Usage example: bash release_default_mac_spark312.sh default true true true"
+  echo "Usage example: bash release_default_mac_spark312.sh 0.14.0.dev1 false true false"
   exit -1
 fi
 
 version=$1
 quick=$2
 upload=$3
+suffix=$4
 
-# Add spark3 suffix to the project name to avoid conflict with the whl for spark2.
-# Add name=, == and - in pattern matching so that if the script runs twice,
-# it won't change anything in the second run.
-sed -i "s/bigdl-dllib==/bigdl-dllib-spark3==/g" $ORCA_DIR/src/setup.py
-sed -i "s/name='bigdl-orca'/name='bigdl-orca-spark3'/g" $ORCA_DIR/src/setup.py
-sed -i "s/dist\/bigdl_orca-/dist\/bigdl_orca_spark3-/g" ${RUN_SCRIPT_DIR}/release.sh
+if [ ${suffix} == true ]; then
+    bash ${DEV_DIR}/add_suffix_spark3.sh $ORCA_DIR/src/setup.py
+    bash ${DEV_DIR}/add_suffix_spark3.sh ${RUN_SCRIPT_DIR}/release.sh
+else
+    bash ${DEV_DIR}/remove_spark_suffix.sh $ORCA_DIR/src/setup.py
+    bash ${DEV_DIR}/remove_spark_suffix.sh ${RUN_SCRIPT_DIR}/release.sh
+fi
 
 bash ${RUN_SCRIPT_DIR}/release.sh mac ${version} ${quick} ${upload} -Dspark.version=3.1.2 -P spark_3.x

--- a/python/setup.py
+++ b/python/setup.py
@@ -33,7 +33,7 @@ def setup_package():
         author='BigDL Authors',
         author_email='bigdl-user-group@googlegroups.com',
         license='Apache License, Version 2.0',
-        url='https://github.com/intel-analytics/analytics-zoo',
+        url='https://github.com/intel-analytics/BigDL',
         install_requires=['bigdl-orca=='+VERSION, 'bigdl-nano=='+VERSION, 'bigdl-chronos=='+VERSION,
                           'bigdl-friesian=='+VERSION, 'bigdl-serving=='+VERSION],
         dependency_links=['https://d3kbcqa49mib13.cloudfront.net/spark-2.0.0-bin-hadoop2.7.tgz'],


### PR DESCRIPTION
release for `bigdl` `bigdl-spark2` and `bigdl-spark3` on pypi.
Currently bigdl==bigdl-spark2 and is very flexible to switch to spark3 as default in the future.