### PR TITLE
Change the params of embeddings.py

### DIFF
--- a/python/nano/src/bigdl/nano/tf/keras/layers/embeddings.py
+++ b/python/nano/src/bigdl/nano/tf/keras/layers/embeddings.py
@@ -15,6 +15,7 @@
 #
 
 import tensorflow as tf
+import warnings
 from tensorflow.keras.layers import Embedding as TFEmbedding
 
 
@@ -24,7 +25,8 @@ class Embedding(TFEmbedding):
                  input_dim,
                  output_dim,
                  embeddings_initializer='uniform',
-                 regularizer=None,
+                 embeddings_regularizer=None,
+                 activity_regularizer=None,
                  embeddings_constraint=None,
                  mask_zero=False,
                  input_length=None,
@@ -45,7 +47,10 @@ class Embedding(TFEmbedding):
         :param output_dim: Integer. Dimension of the dense embedding.
         :param embeddings_initializer: Initializer for the `embeddings`
             matrix (see `keras.initializers`).
-        :param regularizer: Regularizer function applied to
+        :param embeddings_regularizer: Regularizer function applied to
+            the `embeddings` matrix (see `keras.regularizers`).
+            We recommend you not using this parameter.
+        :param activity_regularizer: Regularizer function applied to
             the output tensor after looking up the `embeddings` matrix.
         :param embeddings_constraint: Constraint function applied to
             the `embeddings` matrix (see `keras.constraints`).
@@ -63,13 +68,35 @@ class Embedding(TFEmbedding):
             `Flatten` then `Dense` layers upstream
             (without it, the shape of the dense outputs cannot be computed).
         '''
-
-        super().__init__(input_dim=input_dim,
-                         output_dim=output_dim,
-                         embeddings_initializer=embeddings_initializer,
-                         embeddings_regularizer=None,
-                         embeddings_constraint=embeddings_constraint,
-                         activity_regularizer=regularizer,
-                         mask_zero=mask_zero,
-                         input_length=input_length,
-                         **kwargs)
+        if embeddings_regularizer is None:
+            super().__init__(input_dim=input_dim,
+                             output_dim=output_dim,
+                             embeddings_initializer=embeddings_initializer,
+                             embeddings_regularizer=embeddings_regularizer,
+                             activity_regularizer=activity_regularizer,
+                             embeddings_constraint=embeddings_constraint,
+                             mask_zero=mask_zero,
+                             input_length=input_length,
+                             **kwargs)
+        else:
+            warnings.warn('param: embeddings_regularizer is not supported and should be removed', UserWarning)
+            if activity_regularizer is None:
+                # Use the embeddings_regularizer to initialize param: activity_regularizer
+                super().__init__(input_dim=input_dim,
+                                 output_dim=output_dim,
+                                 embeddings_initializer=embeddings_initializer,
+                                 activity_regularizer=embeddings_regularizer,
+                                 embeddings_constraint=embeddings_constraint,
+                                 mask_zero=mask_zero,
+                                 input_length=input_length,
+                                 **kwargs)
+            else:
+                super().__init__(input_dim=input_dim,
+                                 output_dim=output_dim,
+                                 embeddings_initializer=embeddings_initializer,
+                                 embeddings_regularizer=embeddings_regularizer,
+                                 activity_regularizer=activity_regularizer,
+                                 embeddings_constraint=embeddings_constraint,
+                                 mask_zero=mask_zero,
+                                 input_length=input_length,
+                                 **kwargs)

--- a/python/nano/src/bigdl/nano/tf/keras/layers/embeddings.py
+++ b/python/nano/src/bigdl/nano/tf/keras/layers/embeddings.py
@@ -85,4 +85,3 @@ class Embedding(TFEmbedding):
                          mask_zero=mask_zero,
                          input_length=input_length,
                          **kwargs)
-

--- a/python/nano/src/bigdl/nano/tf/keras/layers/embeddings.py
+++ b/python/nano/src/bigdl/nano/tf/keras/layers/embeddings.py
@@ -47,9 +47,9 @@ class Embedding(TFEmbedding):
         :param output_dim: Integer. Dimension of the dense embedding.
         :param embeddings_initializer: Initializer for the `embeddings`
             matrix (see `keras.initializers`).
-        :param embeddings_regularizer: Regularizer function applied to
-            the `embeddings` matrix (see `keras.regularizers`).
-            We recommend you not using this parameter.
+        :param embeddings_regularizer: Applying regularizer directly on embeddings
+            will make the sparse gradient dense and may result in degraded performance.
+            We recommend you to use activity_regularizer.
         :param activity_regularizer: Regularizer function applied to
             the output tensor after looking up the `embeddings` matrix.
         :param embeddings_constraint: Constraint function applied to
@@ -68,36 +68,21 @@ class Embedding(TFEmbedding):
             `Flatten` then `Dense` layers upstream
             (without it, the shape of the dense outputs cannot be computed).
         '''
-        if embeddings_regularizer is None:
-            super().__init__(input_dim=input_dim,
-                             output_dim=output_dim,
-                             embeddings_initializer=embeddings_initializer,
-                             embeddings_regularizer=embeddings_regularizer,
-                             activity_regularizer=activity_regularizer,
-                             embeddings_constraint=embeddings_constraint,
-                             mask_zero=mask_zero,
-                             input_length=input_length,
-                             **kwargs)
-        else:
-            warnings.warn('param: embeddings_regularizer is not supported\
-                          and should be removed', UserWarning)
-            if activity_regularizer is None:
-                # Use the embeddings_regularizer to initialize param: activity_regularizer
-                super().__init__(input_dim=input_dim,
-                                 output_dim=output_dim,
-                                 embeddings_initializer=embeddings_initializer,
-                                 activity_regularizer=embeddings_regularizer,
-                                 embeddings_constraint=embeddings_constraint,
-                                 mask_zero=mask_zero,
-                                 input_length=input_length,
-                                 **kwargs)
-            else:
-                super().__init__(input_dim=input_dim,
-                                 output_dim=output_dim,
-                                 embeddings_initializer=embeddings_initializer,
-                                 embeddings_regularizer=embeddings_regularizer,
-                                 activity_regularizer=activity_regularizer,
-                                 embeddings_constraint=embeddings_constraint,
-                                 mask_zero=mask_zero,
-                                 input_length=input_length,
-                                 **kwargs)
+        if embeddings_regularizer is not None and activity_regularizer is None:
+            warnings.warn(
+                'Apply regularizer directly on embeddings will make the sparse gradient dense and\
+                 may result in degraded performance. We are changing your regularizer\
+                 to apply on the output tensors ', UserWarning)
+            activity_regularizer = embeddings_regularizer
+            embeddings_regularizer = None
+
+        super().__init__(input_dim=input_dim,
+                         output_dim=output_dim,
+                         embeddings_initializer=embeddings_initializer,
+                         embeddings_regularizer=embeddings_regularizer,
+                         activity_regularizer=activity_regularizer,
+                         embeddings_constraint=embeddings_constraint,
+                         mask_zero=mask_zero,
+                         input_length=input_length,
+                         **kwargs)
+

--- a/python/nano/src/bigdl/nano/tf/keras/layers/embeddings.py
+++ b/python/nano/src/bigdl/nano/tf/keras/layers/embeddings.py
@@ -79,7 +79,8 @@ class Embedding(TFEmbedding):
                              input_length=input_length,
                              **kwargs)
         else:
-            warnings.warn('embeddings_regularizer is not supported and should be removed', UserWarning)
+            warnings.warn('param: embeddings_regularizer is not supported\
+                          and should be removed', UserWarning)
             if activity_regularizer is None:
                 # Use the embeddings_regularizer to initialize param: activity_regularizer
                 super().__init__(input_dim=input_dim,
@@ -100,4 +101,3 @@ class Embedding(TFEmbedding):
                                  mask_zero=mask_zero,
                                  input_length=input_length,
                                  **kwargs)
-                

--- a/python/nano/src/bigdl/nano/tf/keras/layers/embeddings.py
+++ b/python/nano/src/bigdl/nano/tf/keras/layers/embeddings.py
@@ -79,7 +79,7 @@ class Embedding(TFEmbedding):
                              input_length=input_length,
                              **kwargs)
         else:
-            warnings.warn('param: embeddings_regularizer is not supported and should be removed', UserWarning)
+            warnings.warn('embeddings_regularizer is not supported and should be removed', UserWarning)
             if activity_regularizer is None:
                 # Use the embeddings_regularizer to initialize param: activity_regularizer
                 super().__init__(input_dim=input_dim,
@@ -100,3 +100,4 @@ class Embedding(TFEmbedding):
                                  mask_zero=mask_zero,
                                  input_length=input_length,
                                  **kwargs)
+                

--- a/python/nano/test/tf/keras/test_embeddings.py
+++ b/python/nano/test/tf/keras/test_embeddings.py
@@ -24,7 +24,7 @@ def test_embedding_gradient_sparse():
     from bigdl.nano.tf.keras import Sequential
     import tensorflow as tf
     model = Sequential()
-    model.add(Embedding(1000, 64, input_length=10, activity_regularizer=tf.keras.regularizers.L2()))
+    model.add(Embedding(1000, 64, input_length=10, embeddings_regularizer=tf.keras.regularizers.L2()))
     model.compile('rmsprop', 'mse')
     input_array = np.random.randint(1000, size=(32, 10))
 

--- a/python/nano/test/tf/keras/test_embeddings.py
+++ b/python/nano/test/tf/keras/test_embeddings.py
@@ -24,7 +24,7 @@ def test_embedding_gradient_sparse():
     from bigdl.nano.tf.keras import Sequential
     import tensorflow as tf
     model = Sequential()
-    model.add(Embedding(1000, 64, input_length=10, regularizer=tf.keras.regularizers.L2()))
+    model.add(Embedding(1000, 64, input_length=10, activity_regularizer=tf.keras.regularizers.L2()))
     model.compile('rmsprop', 'mse')
     input_array = np.random.randint(1000, size=(32, 10))
 


### PR DESCRIPTION
Change the params to accept both `embeddings_regularizer` and `activity_regularizer`. When `embeddings_regularizer` is not `None`, the user will get a warning.