### PR TITLE
expose keeporder for dataset in training

### DIFF
--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/dataset/DataSet.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/dataset/DataSet.scala
@@ -368,7 +368,8 @@ object DataSet {
    * @tparam T
    * @return
    */
-  def rdd[T: ClassTag](data: RDD[T], partitionNum: Int = Engine.nodeNumber()
+  def rdd[T: ClassTag](data: RDD[T], partitionNum: Int = Engine.nodeNumber(),
+    keepOrder: Boolean = false, groupSize: Int = 1
     ): DistributedDataSet[T] = {
     new CachedDistriDataSet[T](
       data.coalesce(partitionNum, true)
@@ -376,7 +377,7 @@ object DataSet {
           Iterator.single(iter.toArray)
         }).setName("cached dataset")
         .cache()
-    )
+      ,keepOrder, groupSize)
   }
 
   def imageFrame(imageFrame: ImageFrame): DataSet[ImageFeature] = {

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/dataset/DataSet.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/dataset/DataSet.scala
@@ -369,7 +369,7 @@ object DataSet {
    * @return
    */
   def rdd[T: ClassTag](data: RDD[T], partitionNum: Int = Engine.nodeNumber(),
-    keepOrder: Boolean = false, groupSize: Int = 1
+    shuffleData: Boolean = false, groupSize: Int = 1
     ): DistributedDataSet[T] = {
     new CachedDistriDataSet[T](
       data.coalesce(partitionNum, true)
@@ -377,7 +377,7 @@ object DataSet {
           Iterator.single(iter.toArray)
         }).setName("cached dataset")
         .cache()
-      , keepOrder, groupSize)
+      , shuffleData, groupSize)
   }
 
   def imageFrame(imageFrame: ImageFrame): DataSet[ImageFeature] = {

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/dataset/DataSet.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/dataset/DataSet.scala
@@ -377,7 +377,7 @@ object DataSet {
           Iterator.single(iter.toArray)
         }).setName("cached dataset")
         .cache()
-      ,keepOrder, groupSize)
+      , keepOrder, groupSize)
   }
 
   def imageFrame(imageFrame: ImageFrame): DataSet[ImageFeature] = {

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/models/Topology.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/models/Topology.scala
@@ -315,7 +315,9 @@ abstract class KerasNet[T](implicit val tag: ClassTag[T], implicit val ev: Tenso
    */
   private def toDataSet(x: RDD[Sample[T]], batchSize: Int,
     featurePaddingParam: PaddingParam[T] = null,
-    labelPaddingParam: PaddingParam[T] = null): DataSet[MiniBatch[T]] = {
+    labelPaddingParam: PaddingParam[T] = null,
+    keepOrder: Boolean = false,
+    groupSize: Int = 1): DataSet[MiniBatch[T]] = {
     val _featurePaddingParam = if (featurePaddingParam != null) {
       Some(featurePaddingParam)
     } else None
@@ -323,8 +325,8 @@ abstract class KerasNet[T](implicit val tag: ClassTag[T], implicit val ev: Tenso
       Some(labelPaddingParam)
     } else None
 
-    if (x != null) DataSet.rdd(x) -> SampleToMiniBatch[T](batchSize, _featurePaddingParam,
-      _labelPaddingParam)
+    if (x != null) DataSet.rdd(x, keepOrder = keepOrder, groupSize = groupSize) ->
+      SampleToMiniBatch[T](batchSize, _featurePaddingParam, _labelPaddingParam)
     else null
   }
 
@@ -438,10 +440,12 @@ abstract class KerasNet[T](implicit val tag: ClassTag[T], implicit val ev: Tenso
       nbEpoch: Int = 10,
       validationData: RDD[Sample[T]] = null,
       featurePaddingParam: PaddingParam[T] = null,
-      labelPaddingParam: PaddingParam[T] = null)(implicit ev: TensorNumeric[T]): Unit = {
+      labelPaddingParam: PaddingParam[T] = null,
+      keepOrder: Boolean = false,
+      groupSize: Int = 1)(implicit ev: TensorNumeric[T]): Unit = {
     KerasUtils.validateBatchSize(batchSize)
-    val trainData = toDataSet(x, batchSize, featurePaddingParam, labelPaddingParam)
-    val valData = toDataSet(validationData, batchSize, featurePaddingParam, labelPaddingParam)
+    val trainData = toDataSet(x, batchSize, featurePaddingParam, labelPaddingParam, keepOrder, groupSize)
+    val valData = toDataSet(validationData, batchSize, featurePaddingParam, labelPaddingParam, keepOrder, groupSize)
     this.fit(trainData, nbEpoch, valData)
 
     releaseDataSets(Array(trainData, valData))

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/models/Topology.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/models/Topology.scala
@@ -316,7 +316,7 @@ abstract class KerasNet[T](implicit val tag: ClassTag[T], implicit val ev: Tenso
   private def toDataSet(x: RDD[Sample[T]], batchSize: Int,
     featurePaddingParam: PaddingParam[T] = null,
     labelPaddingParam: PaddingParam[T] = null,
-    keepOrder: Boolean = false,
+    shuffleData: Boolean = false,
     groupSize: Int = 1): DataSet[MiniBatch[T]] = {
     val _featurePaddingParam = if (featurePaddingParam != null) {
       Some(featurePaddingParam)
@@ -325,7 +325,7 @@ abstract class KerasNet[T](implicit val tag: ClassTag[T], implicit val ev: Tenso
       Some(labelPaddingParam)
     } else None
 
-    if (x != null) DataSet.rdd(x, keepOrder = keepOrder, groupSize = groupSize) ->
+    if (x != null) DataSet.rdd(x, shuffleData = shuffleData, groupSize = groupSize) ->
       SampleToMiniBatch[T](batchSize, _featurePaddingParam, _labelPaddingParam)
     else null
   }
@@ -435,19 +435,19 @@ abstract class KerasNet[T](implicit val tag: ClassTag[T], implicit val ev: Tenso
    * @param validationData RDD of Sample, or null if validation is not configured. Default is null.
    */
   def fit(
-      x: RDD[Sample[T]],
-      batchSize: Int = 32,
-      nbEpoch: Int = 10,
-      validationData: RDD[Sample[T]] = null,
-      featurePaddingParam: PaddingParam[T] = null,
-      labelPaddingParam: PaddingParam[T] = null,
-      keepOrder: Boolean = false,
-      groupSize: Int = 1)(implicit ev: TensorNumeric[T]): Unit = {
+           x: RDD[Sample[T]],
+           batchSize: Int = 32,
+           nbEpoch: Int = 10,
+           validationData: RDD[Sample[T]] = null,
+           featurePaddingParam: PaddingParam[T] = null,
+           labelPaddingParam: PaddingParam[T] = null,
+           shuffleData: Boolean = false,
+           groupSize: Int = 1)(implicit ev: TensorNumeric[T]): Unit = {
     KerasUtils.validateBatchSize(batchSize)
     val trainData = toDataSet(x, batchSize, featurePaddingParam, labelPaddingParam,
-      keepOrder, groupSize)
+      shuffleData, groupSize)
     val valData = toDataSet(validationData, batchSize, featurePaddingParam,
-      labelPaddingParam, keepOrder, groupSize)
+      labelPaddingParam, shuffleData, groupSize)
     this.fit(trainData, nbEpoch, valData)
 
     releaseDataSets(Array(trainData, valData))

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/models/Topology.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/models/Topology.scala
@@ -444,8 +444,10 @@ abstract class KerasNet[T](implicit val tag: ClassTag[T], implicit val ev: Tenso
       keepOrder: Boolean = false,
       groupSize: Int = 1)(implicit ev: TensorNumeric[T]): Unit = {
     KerasUtils.validateBatchSize(batchSize)
-    val trainData = toDataSet(x, batchSize, featurePaddingParam, labelPaddingParam, keepOrder, groupSize)
-    val valData = toDataSet(validationData, batchSize, featurePaddingParam, labelPaddingParam, keepOrder, groupSize)
+    val trainData = toDataSet(x, batchSize, featurePaddingParam, labelPaddingParam,
+      keepOrder, groupSize)
+    val valData = toDataSet(validationData, batchSize, featurePaddingParam,
+      labelPaddingParam, keepOrder, groupSize)
     this.fit(trainData, nbEpoch, valData)
 
     releaseDataSets(Array(trainData, valData))


### PR DESCRIPTION
For some senarios, use need keeping original data order for training, eg. gcn network. However our current implementation will shuffle the data and doesn't keep the original order. The PR is used to support user specfiy whether need keep the training data's original order.