### PR TITLE
Add model checkpoint callback and checkpoints methods to torch_runner

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/model_checkpoint.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/model_checkpoint.py
@@ -1,0 +1,121 @@
+from bigdl.orca.learn.pytorch.callbacks import Callback
+import os
+import re
+import warnings
+
+
+class ModelCheckpoint(Callback):
+    def __init__(self,
+                 filepath=None,
+                 save_weights_only=False,
+                 ):
+        """
+        ModelCheckpoint callback is used in conjunction with training using estimator.fit() to save
+        a model or weights (in a checkpoint file) at some interval, so the model or weights can be
+        loaded later to continue the training from the state saved.
+        Example:
+            >>> checkpoint_callback = ModelCheckpoint(
+            ...     filepath='my/path/sample-mnist-{epoch:02d}',
+            ... )
+        :param filepath: path to save the model file.
+        """
+        super().__init__()
+        self.filepath = filepath
+        self.save_weights_only = save_weights_only
+        self.last_ckpt_path = ""
+
+    def on_batch_begin(self, batch):
+        """
+        Called at the beginning of a training batch in `fit` methods.
+        Subclasses should override for any actions to run.
+        @param batch: Integer, index of batch within the current epoch.
+        """
+        pass
+
+    def on_batch_end(self, batch):
+        """
+        Called at the end of a training batch in `fit` methods.
+        Subclasses should override for any actions to run.
+        @param batch: Integer, index of batch within the current epoch.
+        """
+        pass
+
+    def on_epoch_begin(self, epoch):
+        """
+        Called at the start of an epoch.
+        Subclasses should override for any actions to run. This function should only
+        be called during TRAIN mode.
+        @param epoch: Integer, index of epoch.
+        @param logs: Dict. Currently, saved stats in last epoch has been passed to this argument
+        for this method but may change in the future.
+        """
+        pass
+
+    def on_epoch_end(self, epoch):
+        """
+        Called at the end of an epoch.
+        Subclasses should override for any actions to run. This function should only
+        be called during TRAIN mode.
+        @param epoch:  Integer, index of epoch.
+        """
+        stats = {"epoch": self.trainer.epochs}
+        last_ckpt_path = self._format_checkpoint_name(self.filepath, stats)
+        self.trainer.save_checkpoint(last_ckpt_path, self.save_weights_only)
+
+    def on_train_begin(self):
+        """
+        Called at the beginning of training.
+        Subclasses should override for any actions to run.
+        @param logs: Dict. Currently, no data is passed to this argument for this method
+          but that may change in the future.
+        """
+        # todo: support resume training
+        from bigdl.orca.learn.pytorch.utils import get_filesystem
+        dirname = os.path.dirname(self.filepath)
+        fs = get_filesystem(dirname)
+        if fs.exists(dirname):
+            raise ValueError(f"Find non-empty dirname with filepath of {self.filepath}.")
+        fs.mkdirs(dirname)
+
+    def on_train_end(self):
+        """
+        Called at the end of training.
+        Subclasses should override for any actions to run.
+        """
+        stats = {"epoch": self.trainer.epochs}
+        last_ckpt_path = self._format_checkpoint_name(self.filepath, stats, last=True)
+        previous, self.last_ckpt_path = self.last_ckpt_path, last_ckpt_path
+        self.trainer.save_checkpoint(last_ckpt_path, self.save_weights_only)
+        if previous and previous != last_ckpt_path:
+            self.trainer.remove_checkpoint(previous)
+
+    def set_model(self, model):
+        self.model = model
+
+    def set_param(self, param):
+        self.params = param
+
+    @staticmethod
+    def _format_checkpoint_name(filepath, stats, last=False):
+        """
+        checkpoint name is in the format of 'epoch={epoch}.ckpt'
+        """
+        filename = os.path.basename(filepath) if not last else "last"
+
+        # check and parse user passed keys in the string
+        groups = re.findall(r"(\{.*?)[:\}]", filename)
+        if len(groups) >= 0:
+            for group in groups:
+                name = group[1:]
+
+                if name != "epoch":
+                    warnings.warn("We only support filepath with {epoch} for now.")
+
+                filename = filename.replace(group, name + "={" + name)
+
+                if name not in stats:
+                    stats[name] = 0
+            filename = filename.format(**stats)
+        ckpt_name = f"{filename}.ckpt"
+        ckpt_path = os.path.join(os.path.dirname(filepath), ckpt_name)
+        return ckpt_path

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/model_checkpoint.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/model_checkpoint.py
@@ -74,8 +74,13 @@ class ModelCheckpoint(Callback):
         dirname = os.path.dirname(self.filepath)
         fs = get_filesystem(dirname)
         if fs.exists(dirname):
+            files = [os.path.basename(f["name"]) for f in fs.listdir(dirname)]
+            files = [x for x in files if "ckpt" in x]
+            if len(files) == 0:
+                return None
             raise ValueError(f"Find non-empty dirname with filepath of {self.filepath}.")
-        fs.mkdirs(dirname)
+        else:
+            fs.mkdirs(dirname)
 
     def on_train_end(self):
         """
@@ -108,7 +113,7 @@ class ModelCheckpoint(Callback):
             for group in groups:
                 name = group[1:]
 
-                if name != "epoch":
+                if "epoch" not in name:
                     warnings.warn("We only support filepath with {epoch} for now.")
 
                 filename = filename.replace(group, name + "={" + name)

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/model_checkpoint.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/model_checkpoint.py
@@ -17,6 +17,8 @@ class ModelCheckpoint(Callback):
             >>> checkpoint_callback = ModelCheckpoint(
             ...     filepath='my/path/sample-mnist-{epoch:02d}',
             ... )
+        And checkpoints will be saved as file with path like 'my/path/sample-mnist-epoch=1.ckpt'
+        with different epoch values.
         :param filepath: path to save the model file.
         """
         super().__init__()

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -435,6 +435,7 @@ class TorchRunner:
     def save_checkpoint(self, filepath, save_weights_only=False):
         if self.rank == 0:
             self._save_checkpoint(filepath, save_weights_only)
+            self.logger.debug(f"Saved checkpoint: {filepath}")
 
     def _save_checkpoint(self, filepath, save_weights_only=False):
         import fsspec

--- a/python/orca/src/bigdl/orca/learn/pytorch/utils.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/utils.py
@@ -272,3 +272,9 @@ def override(interface_class):
         return method
 
     return overrider
+
+
+def get_filesystem(filepath):
+    from fsspec.core import url_to_fs
+    fs, _ = url_to_fs(str(filepath))
+    return fs

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
@@ -399,6 +399,7 @@ class TestPyTorchEstimator(TestCase):
         from bigdl.orca.learn.pytorch.callbacks.model_checkpoint import ModelCheckpoint
         sc = OrcaContext.get_spark_context()
         rdd = sc.range(0, 100)
+        epochs = 2
         df = rdd.map(lambda x: (np.random.randn(50).astype(np.float).tolist(),
                                 [int(np.random.randint(0, 2, size=()))])
                      ).toDF(["feature", "label"])
@@ -410,13 +411,16 @@ class TestPyTorchEstimator(TestCase):
             ModelCheckpoint(filepath=os.path.join(self.model_dir, "test-{epoch}"),
                             save_weights_only=True)
         ]
-        estimator.fit(df, batch_size=4, epochs=2,
+        estimator.fit(df, batch_size=4, epochs=epochs,
                       callbacks=callbacks,
                       feature_cols=["feature"],
                       label_cols=["label"])
         estimator.evaluate(df, batch_size=4,
                            feature_cols=["feature"],
                            label_cols=["label"])
+        for i in range(epochs):
+            assert os.path.isfile(os.path.join(self.model_dir, f"test-epoch={i + 1}.ckpt"))
+        assert os.path.isfile(os.path.join(self.model_dir, f"last.ckpt"))
 
 
 if __name__ == "__main__":

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
@@ -33,6 +33,7 @@ from bigdl.orca.data.image.utils import chunks
 
 import tempfile
 import shutil
+import logging
 
 np.random.seed(1337)  # for reproducibility
 resource_path = os.path.join(
@@ -155,7 +156,8 @@ def get_optimizer(model, config):
     return torch.optim.SGD(model.parameters(), lr=config.get("lr", 1e-2))
 
 
-def get_estimator(workers_per_node=1, model_fn=get_model, model_dir=None):
+def get_estimator(workers_per_node=1, model_fn=get_model, sync_stats=False,
+                  log_level=logging.INFO, model_dir=None):
     estimator = Estimator.from_torch(model=model_fn,
                                      optimizer=get_optimizer,
                                      loss=nn.BCELoss(),
@@ -163,6 +165,8 @@ def get_estimator(workers_per_node=1, model_fn=get_model, model_dir=None):
                                      config={"lr": 1e-2},
                                      workers_per_node=workers_per_node,
                                      backend="spark",
+                                     sync_stats=sync_stats,
+                                     log_level=log_level,
                                      model_dir=model_dir)
     return estimator
 
@@ -390,6 +394,29 @@ class TestPyTorchEstimator(TestCase):
 
         state = estimator.get_state_dict()
         assert state['models'][0]['fc1.weight'].item() == 0.25
+
+    def test_checkpoint_callback(self):
+        from bigdl.orca.learn.pytorch.callbacks.model_checkpoint import ModelCheckpoint
+        sc = OrcaContext.get_spark_context()
+        rdd = sc.range(0, 100)
+        df = rdd.map(lambda x: (np.random.randn(50).astype(np.float).tolist(),
+                                [int(np.random.randint(0, 2, size=()))])
+                     ).toDF(["feature", "label"])
+
+        estimator = get_estimator(workers_per_node=2, model_dir=self.model_dir,
+                                  log_level=logging.DEBUG)
+
+        callbacks = [
+            ModelCheckpoint(filepath=os.path.join(self.model_dir, "test-{epoch}"),
+                            save_weights_only=True)
+        ]
+        estimator.fit(df, batch_size=4, epochs=2,
+                      callbacks=callbacks,
+                      feature_cols=["feature"],
+                      label_cols=["label"])
+        estimator.evaluate(df, batch_size=4,
+                           feature_cols=["feature"],
+                           label_cols=["label"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR supports saving checkpoint every epoch and at train end.

User could automatically save checkpoint files like `my/path/test-epoch=1.ckpt` for each epoch, and the latest checkpoint file of `my/path/last.ckpt` at the end of all train process. 
```python
callbacks = [
            ModelCheckpoint(filepath=os.path.join("my/path", "test-{epoch}"),
                            save_weights_only=True)
        ]
estimator.fit(df, batch_size=4, epochs=epochs,
              callbacks=callbacks,
              feature_cols=["feature"],
              label_cols=["label"])
```
Note that the `filepath` could be either a local path or a remote path.

Below tests has been conducted on yarn cluster and checkpoints have been successfully saved.
```python
conf = { ...,  "spark.executorEnv.ARROW_LIBHDFS_DIR": "/opt/cloudera/parcels/CDH/lib64",}
sc = init_orca_context("yarn", conf=conf)

remote_dir = "hdfs:///tmp/test_checkpoint"
callbacks = [
            ModelCheckpoint(filepath=os.path.join(remote_dir, "test-{epoch}"),
                            save_weights_only=True)
        ]
...
```

This PR used `fsspec` ([doc](https://filesystem-spec.readthedocs.io/en/latest/)), which provides a unified pythonic interface to local, remote and embedded file systems and bytes storage, to support both local and remote `filepath` in `ModelCheckpoint`. Note that `fsspec` is **not** a newly introduced dependency, but an existed one.