### PR TITLE
Support get latest checkpoint path for Pytorch Estimators

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/model_checkpoint.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/model_checkpoint.py
@@ -3,6 +3,8 @@ import os
 import re
 import warnings
 
+from bigdl.orca.learn.pytorch.utils import get_filesystem
+
 
 class ModelCheckpoint(Callback):
 
@@ -81,7 +83,6 @@ class ModelCheckpoint(Callback):
           but that may change in the future.
         """
         # todo: support resume training
-        from bigdl.orca.learn.pytorch.utils import get_filesystem
         dirname = os.path.dirname(self.filepath)
         fs = get_filesystem(dirname)
         if fs.exists(dirname):
@@ -112,6 +113,19 @@ class ModelCheckpoint(Callback):
 
     def set_param(self, param):
         self.params = param
+
+    @classmethod
+    def get_latest_checkpoint(cls, dirname):
+        """
+        Finds the filepath of latest saved checkpoint file.
+        :param dirname: directory where the checkpoints were saved
+        return: The full path to the latest checkpoint or `None` if no checkpoint was found.
+        """
+        ckpt_path = cls._format_checkpoint_name(dirname, filename=cls.CHECKPOINT_NAME_LAST)
+        fs = get_filesystem(ckpt_path)
+        if not fs.exists(ckpt_path):
+            raise FileNotFoundError(f"Latest checkpoint at {ckpt_path} not found.")
+        return ckpt_path
 
     @classmethod
     def _format_checkpoint_name(cls, dirname, filename, stats=None):

--- a/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
@@ -123,3 +123,9 @@ class Estimator(object):
         else:
             raise ValueError("Only horovod, torch_distributed, bigdl and spark backends are "
                              f"supported for now, got backend: {backend}")
+
+    @staticmethod
+    def latest_checkpoint(checkpoint_dir):
+        from .callbacks.model_checkpoint import ModelCheckpoint
+        checkpoint_path = ModelCheckpoint.get_latest_checkpoint(checkpoint_dir)
+        return checkpoint_path

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
@@ -420,7 +420,9 @@ class TestPyTorchEstimator(TestCase):
                            label_cols=["label"])
         for i in range(epochs):
             assert os.path.isfile(os.path.join(self.model_dir, f"test-epoch={i + 1}.ckpt"))
-        assert os.path.isfile(os.path.join(self.model_dir, f"last.ckpt"))
+
+        latest_checkpoint_path = Estimator.latest_checkpoint(self.model_dir)
+        assert os.path.isfile(latest_checkpoint_path)
 
 
 if __name__ == "__main__":

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
@@ -511,10 +511,15 @@ class TestPyTorchEstimator(TestCase):
                                label_cols=["label"])
             for i in range(epochs):
                 assert os.path.isfile(os.path.join(temp_dir, f"test-epoch={i + 1}.ckpt"))
-            assert os.path.isfile(os.path.join(temp_dir, f"last.ckpt"))
+
+            latest_checkpoint_path = Estimator.latest_checkpoint(temp_dir)
+            assert os.path.isfile(latest_checkpoint_path)
 
         finally:
             shutil.rmtree(temp_dir)
+
+        with pytest.raises(FileNotFoundError):
+            Estimator.latest_checkpoint(temp_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
User could get the latest checkpoint path for Orca Pytorch Estimators with
```python
from bigdl.orca.learn.pytorch.callbacks.model_checkpoint import ModelCheckpoint
callbacks = [
    ModelCheckpoint(filepath=os.path.join(model_dir, "test-{epoch}"),
                    save_weights_only=True)
]
estimator.fit(df, batch_size=4, epochs=epochs,
              callbacks=callbacks,
              feature_cols=["feature"],
              label_cols=["label"])

latest_checkpoint_path = Estimator.latest_checkpoint(model_dir)
```

The returned `latest_checkpoint_path` could be either a local path or a remote path. `Estimator.latest_checkpoint` will raise `FileNotFoundError` if the latest checkpoint file not found in input `model_dir`.