### PR TITLE
Upload source distribution for Pypi and support conda build for bigdl-dllib

### DIFF
--- a/python/dev/add_suffix_spark2.sh
+++ b/python/dev/add_suffix_spark2.sh
@@ -35,6 +35,8 @@ sed -i "s/dist\/bigdl_dllib-/dist\/bigdl_dllib_spark2-/g" ${file}
 sed -i "s/dist\/bigdl_dllib_spark3-/dist\/bigdl_dllib_spark2-/g" ${file}
 sed -i "s/dist\/bigdl-dllib-/dist\/bigdl-dllib-spark2-/g" ${file}
 sed -i "s/dist\/bigdl-dllib-spark3-/dist\/bigdl-dllib-spark2-/g" ${file}
+sed -i "s/bigdl_dllib.egg-info/bigdl_dllib_spark2.egg-info/g" ${file}
+sed -i "s/bigdl_dllib_spark3.egg-info/bigdl_dllib_spark2.egg-info/g" ${file}
 
 sed -i "s/bigdl-orca==/bigdl-orca-spark2==/g" ${file}
 sed -i "s/bigdl-orca-spark3==/bigdl-orca-spark2==/g" ${file}
@@ -46,6 +48,8 @@ sed -i "s/dist\/bigdl-orca-/dist\/bigdl-orca-spark2-/g" ${file}
 sed -i "s/dist\/bigdl-orca-spark3-/dist\/bigdl-orca-spark2-/g" ${file}
 sed -i "s/bigdl-orca\[ray\]/bigdl-orca-spark2\[ray\]/g" ${file}
 sed -i "s/bigdl-orca-spark3\[ray\]/bigdl-orca-spark2\[ray\]/g" ${file}
+sed -i "s/bigdl_orca.egg-info/bigdl_orca_spark2.egg-info/g" ${file}
+sed -i "s/bigdl_orca_spark3.egg-info/bigdl_orca_spark2.egg-info/g" ${file}
 
 sed -i "s/bigdl-chronos==/bigdl-chronos-spark2==/g" ${file}
 sed -i "s/bigdl-chronos-spark3==/bigdl-chronos-spark2==/g" ${file}
@@ -55,6 +59,8 @@ sed -i "s/dist\/bigdl_chronos-/dist\/bigdl_chronos_spark2-/g" ${file}
 sed -i "s/dist\/bigdl_chronos_spark3-/dist\/bigdl_chronos_spark2-/g" ${file}
 sed -i "s/dist\/bigdl-chronos-/dist\/bigdl-chronos-spark2-/g" ${file}
 sed -i "s/dist\/bigdl-chronos-spark3-/dist\/bigdl-chronos-spark2-/g" ${file}
+sed -i "s/bigdl_chronos.egg-info/bigdl_chronos_spark2.egg-info/g" ${file}
+sed -i "s/bigdl_chronos_spark3.egg-info/bigdl_chronos_spark2.egg-info/g" ${file}
 
 sed -i "s/bigdl-friesian==/bigdl-friesian-spark2==/g" ${file}
 sed -i "s/bigdl-friesian-spark3==/bigdl-friesian-spark2==/g" ${file}
@@ -64,3 +70,5 @@ sed -i "s/dist\/bigdl_friesian-/dist\/bigdl_friesian_spark2-/g" ${file}
 sed -i "s/dist\/bigdl_friesian_spark3-/dist\/bigdl_friesian_spark2-/g" ${file}
 sed -i "s/dist\/bigdl-friesian-/dist\/bigdl-friesian-spark2-/g" ${file}
 sed -i "s/dist\/bigdl-friesian-spark3-/dist\/bigdl-friesian-spark2-/g" ${file}
+sed -i "s/bigdl_friesian.egg-info/bigdl_friesian_spark2.egg-info/g" ${file}
+sed -i "s/bigdl_friesian_spark3.egg-info/bigdl_friesian_spark2.egg-info/g" ${file}

--- a/python/dev/add_suffix_spark2.sh
+++ b/python/dev/add_suffix_spark2.sh
@@ -33,6 +33,8 @@ sed -i "s/name='bigdl-dllib'/name='bigdl-dllib-spark2'/g" ${file}
 sed -i "s/name='bigdl-dllib-spark3'/name='bigdl-dllib-spark2'/g" ${file}
 sed -i "s/dist\/bigdl_dllib-/dist\/bigdl_dllib_spark2-/g" ${file}
 sed -i "s/dist\/bigdl_dllib_spark3-/dist\/bigdl_dllib_spark2-/g" ${file}
+sed -i "s/dist\/bigdl-dllib-/dist\/bigdl-dllib-spark2-/g" ${file}
+sed -i "s/dist\/bigdl-dllib-spark3-/dist\/bigdl-dllib-spark2-/g" ${file}
 
 sed -i "s/bigdl-orca==/bigdl-orca-spark2==/g" ${file}
 sed -i "s/bigdl-orca-spark3==/bigdl-orca-spark2==/g" ${file}
@@ -40,6 +42,8 @@ sed -i "s/name='bigdl-orca'/name='bigdl-orca-spark2'/g" ${file}
 sed -i "s/name='bigdl-orca-spark3'/name='bigdl-orca-spark2'/g" ${file}
 sed -i "s/dist\/bigdl_orca-/dist\/bigdl_orca_spark2-/g" ${file}
 sed -i "s/dist\/bigdl_orca_spark3-/dist\/bigdl_orca_spark2-/g" ${file}
+sed -i "s/dist\/bigdl-orca-/dist\/bigdl-orca-spark2-/g" ${file}
+sed -i "s/dist\/bigdl-orca-spark3-/dist\/bigdl-orca-spark2-/g" ${file}
 sed -i "s/bigdl-orca\[ray\]/bigdl-orca-spark2\[ray\]/g" ${file}
 sed -i "s/bigdl-orca-spark3\[ray\]/bigdl-orca-spark2\[ray\]/g" ${file}
 
@@ -49,6 +53,8 @@ sed -i "s/name='bigdl-chronos'/name='bigdl-chronos-spark2'/g" ${file}
 sed -i "s/name='bigdl-chronos-spark3'/name='bigdl-chronos-spark2'/g" ${file}
 sed -i "s/dist\/bigdl_chronos-/dist\/bigdl_chronos_spark2-/g" ${file}
 sed -i "s/dist\/bigdl_chronos_spark3-/dist\/bigdl_chronos_spark2-/g" ${file}
+sed -i "s/dist\/bigdl-chronos-/dist\/bigdl-chronos-spark2-/g" ${file}
+sed -i "s/dist\/bigdl-chronos-spark3-/dist\/bigdl-chronos-spark2-/g" ${file}
 
 sed -i "s/bigdl-friesian==/bigdl-friesian-spark2==/g" ${file}
 sed -i "s/bigdl-friesian-spark3==/bigdl-friesian-spark2==/g" ${file}
@@ -56,3 +62,5 @@ sed -i "s/name='bigdl-friesian'/name='bigdl-friesian-spark2'/g" ${file}
 sed -i "s/name='bigdl-friesian-spark3'/name='bigdl-friesian-spark2'/g" ${file}
 sed -i "s/dist\/bigdl_friesian-/dist\/bigdl_friesian_spark2-/g" ${file}
 sed -i "s/dist\/bigdl_friesian_spark3-/dist\/bigdl_friesian_spark2-/g" ${file}
+sed -i "s/dist\/bigdl-friesian-/dist\/bigdl-friesian-spark2-/g" ${file}
+sed -i "s/dist\/bigdl-friesian-spark3-/dist\/bigdl-friesian-spark2-/g" ${file}

--- a/python/dev/add_suffix_spark2.sh
+++ b/python/dev/add_suffix_spark2.sh
@@ -46,10 +46,10 @@ sed -i "s/dist\/bigdl_orca-/dist\/bigdl_orca_spark2-/g" ${file}
 sed -i "s/dist\/bigdl_orca_spark3-/dist\/bigdl_orca_spark2-/g" ${file}
 sed -i "s/dist\/bigdl-orca-/dist\/bigdl-orca-spark2-/g" ${file}
 sed -i "s/dist\/bigdl-orca-spark3-/dist\/bigdl-orca-spark2-/g" ${file}
-sed -i "s/bigdl-orca\[ray\]/bigdl-orca-spark2\[ray\]/g" ${file}
-sed -i "s/bigdl-orca-spark3\[ray\]/bigdl-orca-spark2\[ray\]/g" ${file}
 sed -i "s/bigdl_orca.egg-info/bigdl_orca_spark2.egg-info/g" ${file}
 sed -i "s/bigdl_orca_spark3.egg-info/bigdl_orca_spark2.egg-info/g" ${file}
+sed -i "s/bigdl-orca\[ray\]/bigdl-orca-spark2\[ray\]/g" ${file}
+sed -i "s/bigdl-orca-spark3\[ray\]/bigdl-orca-spark2\[ray\]/g" ${file}
 
 sed -i "s/bigdl-chronos==/bigdl-chronos-spark2==/g" ${file}
 sed -i "s/bigdl-chronos-spark3==/bigdl-chronos-spark2==/g" ${file}

--- a/python/dev/add_suffix_spark3.sh
+++ b/python/dev/add_suffix_spark3.sh
@@ -35,6 +35,8 @@ sed -i "s/dist\/bigdl_dllib-/dist\/bigdl_dllib_spark3-/g" ${file}
 sed -i "s/dist\/bigdl_dllib_spark2-/dist\/bigdl_dllib_spark3-/g" ${file}
 sed -i "s/dist\/bigdl-dllib-/dist\/bigdl-dllib-spark3-/g" ${file}
 sed -i "s/dist\/bigdl-dllib-spark2-/dist\/bigdl-dllib-spark3-/g" ${file}
+sed -i "s/bigdl_dllib.egg-info/bigdl_dllib_spark3.egg-info/g" ${file}
+sed -i "s/bigdl_dllib_spark2.egg-info/bigdl_dllib_spark3.egg-info/g" ${file}
 
 sed -i "s/bigdl-orca==/bigdl-orca-spark3==/g" ${file}
 sed -i "s/bigdl-orca-spark2==/bigdl-orca-spark3==/g" ${file}
@@ -46,6 +48,8 @@ sed -i "s/dist\/bigdl-orca-/dist\/bigdl-orca-spark3-/g" ${file}
 sed -i "s/dist\/bigdl-orca-spark2-/dist\/bigdl-orca-spark3-/g" ${file}
 sed -i "s/bigdl-orca\[ray\]/bigdl-orca-spark3\[ray\]/g" ${file}
 sed -i "s/bigdl-orca-spark2\[ray\]/bigdl-orca-spark3\[ray\]/g" ${file}
+sed -i "s/bigdl_orca.egg-info/bigdl_orca_spark3.egg-info/g" ${file}
+sed -i "s/bigdl_orca_spark2.egg-info/bigdl_orca_spark3.egg-info/g" ${file}
 
 sed -i "s/bigdl-chronos==/bigdl-chronos-spark3==/g" ${file}
 sed -i "s/bigdl-chronos-spark2==/bigdl-chronos-spark3==/g" ${file}
@@ -55,6 +59,8 @@ sed -i "s/dist\/bigdl_chronos-/dist\/bigdl_chronos_spark3-/g" ${file}
 sed -i "s/dist\/bigdl_chronos_spark2-/dist\/bigdl_chronos_spark3-/g" ${file}
 sed -i "s/dist\/bigdl-chronos-/dist\/bigdl-chronos-spark3-/g" ${file}
 sed -i "s/dist\/bigdl-chronos-spark2-/dist\/bigdl-chronos-spark3-/g" ${file}
+sed -i "s/bigdl_chronos.egg-info/bigdl_chronos_spark3.egg-info/g" ${file}
+sed -i "s/bigdl_chronos_spark2.egg-info/bigdl_chronos_spark3.egg-info/g" ${file}
 
 sed -i "s/bigdl-friesian==/bigdl-friesian-spark3==/g" ${file}
 sed -i "s/bigdl-friesian-spark2==/bigdl-friesian-spark3==/g" ${file}
@@ -64,3 +70,5 @@ sed -i "s/dist\/bigdl_friesian-/dist\/bigdl_friesian_spark3-/g" ${file}
 sed -i "s/dist\/bigdl_friesian_spark2-/dist\/bigdl_friesian_spark3-/g" ${file}
 sed -i "s/dist\/bigdl-friesian-/dist\/bigdl-friesian-spark3-/g" ${file}
 sed -i "s/dist\/bigdl-friesian-spark2-/dist\/bigdl-friesian-spark3-/g" ${file}
+sed -i "s/bigdl_friesian.egg-info/bigdl_friesian_spark3.egg-info/g" ${file}
+sed -i "s/bigdl_friesian_spark2.egg-info/bigdl_friesian_spark3.egg-info/g" ${file}

--- a/python/dev/add_suffix_spark3.sh
+++ b/python/dev/add_suffix_spark3.sh
@@ -46,10 +46,10 @@ sed -i "s/dist\/bigdl_orca-/dist\/bigdl_orca_spark3-/g" ${file}
 sed -i "s/dist\/bigdl_orca_spark2-/dist\/bigdl_orca_spark3-/g" ${file}
 sed -i "s/dist\/bigdl-orca-/dist\/bigdl-orca-spark3-/g" ${file}
 sed -i "s/dist\/bigdl-orca-spark2-/dist\/bigdl-orca-spark3-/g" ${file}
-sed -i "s/bigdl-orca\[ray\]/bigdl-orca-spark3\[ray\]/g" ${file}
-sed -i "s/bigdl-orca-spark2\[ray\]/bigdl-orca-spark3\[ray\]/g" ${file}
 sed -i "s/bigdl_orca.egg-info/bigdl_orca_spark3.egg-info/g" ${file}
 sed -i "s/bigdl_orca_spark2.egg-info/bigdl_orca_spark3.egg-info/g" ${file}
+sed -i "s/bigdl-orca\[ray\]/bigdl-orca-spark3\[ray\]/g" ${file}
+sed -i "s/bigdl-orca-spark2\[ray\]/bigdl-orca-spark3\[ray\]/g" ${file}
 
 sed -i "s/bigdl-chronos==/bigdl-chronos-spark3==/g" ${file}
 sed -i "s/bigdl-chronos-spark2==/bigdl-chronos-spark3==/g" ${file}

--- a/python/dev/add_suffix_spark3.sh
+++ b/python/dev/add_suffix_spark3.sh
@@ -33,6 +33,8 @@ sed -i "s/name='bigdl-dllib'/name='bigdl-dllib-spark3'/g" ${file}
 sed -i "s/name='bigdl-dllib-spark2'/name='bigdl-dllib-spark3'/g" ${file}
 sed -i "s/dist\/bigdl_dllib-/dist\/bigdl_dllib_spark3-/g" ${file}
 sed -i "s/dist\/bigdl_dllib_spark2-/dist\/bigdl_dllib_spark3-/g" ${file}
+sed -i "s/dist\/bigdl-dllib-/dist\/bigdl-dllib-spark3-/g" ${file}
+sed -i "s/dist\/bigdl-dllib-spark2-/dist\/bigdl-dllib-spark3-/g" ${file}
 
 sed -i "s/bigdl-orca==/bigdl-orca-spark3==/g" ${file}
 sed -i "s/bigdl-orca-spark2==/bigdl-orca-spark3==/g" ${file}
@@ -40,6 +42,8 @@ sed -i "s/name='bigdl-orca'/name='bigdl-orca-spark3'/g" ${file}
 sed -i "s/name='bigdl-orca-spark2'/name='bigdl-orca-spark3'/g" ${file}
 sed -i "s/dist\/bigdl_orca-/dist\/bigdl_orca_spark3-/g" ${file}
 sed -i "s/dist\/bigdl_orca_spark2-/dist\/bigdl_orca_spark3-/g" ${file}
+sed -i "s/dist\/bigdl-orca-/dist\/bigdl-orca-spark3-/g" ${file}
+sed -i "s/dist\/bigdl-orca-spark2-/dist\/bigdl-orca-spark3-/g" ${file}
 sed -i "s/bigdl-orca\[ray\]/bigdl-orca-spark3\[ray\]/g" ${file}
 sed -i "s/bigdl-orca-spark2\[ray\]/bigdl-orca-spark3\[ray\]/g" ${file}
 
@@ -49,6 +53,8 @@ sed -i "s/name='bigdl-chronos'/name='bigdl-chronos-spark3'/g" ${file}
 sed -i "s/name='bigdl-chronos-spark2'/name='bigdl-chronos-spark3'/g" ${file}
 sed -i "s/dist\/bigdl_chronos-/dist\/bigdl_chronos_spark3-/g" ${file}
 sed -i "s/dist\/bigdl_chronos_spark2-/dist\/bigdl_chronos_spark3-/g" ${file}
+sed -i "s/dist\/bigdl-chronos-/dist\/bigdl-chronos-spark3-/g" ${file}
+sed -i "s/dist\/bigdl-chronos-spark2-/dist\/bigdl-chronos-spark3-/g" ${file}
 
 sed -i "s/bigdl-friesian==/bigdl-friesian-spark3==/g" ${file}
 sed -i "s/bigdl-friesian-spark2==/bigdl-friesian-spark3==/g" ${file}
@@ -56,3 +62,5 @@ sed -i "s/name='bigdl-friesian'/name='bigdl-friesian-spark3'/g" ${file}
 sed -i "s/name='bigdl-friesian-spark2'/name='bigdl-friesian-spark3'/g" ${file}
 sed -i "s/dist\/bigdl_friesian-/dist\/bigdl_friesian_spark3-/g" ${file}
 sed -i "s/dist\/bigdl_friesian_spark2-/dist\/bigdl_friesian_spark3-/g" ${file}
+sed -i "s/dist\/bigdl-friesian-/dist\/bigdl-friesian-spark3-/g" ${file}
+sed -i "s/dist\/bigdl-friesian-spark2-/dist\/bigdl-friesian-spark3-/g" ${file}

--- a/python/dev/remove_spark_suffix.sh
+++ b/python/dev/remove_spark_suffix.sh
@@ -32,6 +32,8 @@ sed -i "s/dist\/bigdl_dllib_spark2-/dist\/bigdl_dllib-/g" ${file}
 sed -i "s/dist\/bigdl_dllib_spark3-/dist\/bigdl_dllib-/g" ${file}
 sed -i "s/dist\/bigdl-dllib-spark2-/dist\/bigdl-dllib-/g" ${file}
 sed -i "s/dist\/bigdl-dllib-spark3-/dist\/bigdl-dllib-/g" ${file}
+sed -i "s/bigdl_dllib_spark2.egg-info/bigdl_dllib.egg-info/g" ${file}
+sed -i "s/bigdl_dllib_spark3.egg-info/bigdl_dllib.egg-info/g" ${file}
 
 sed -i "s/bigdl-orca-spark2==/bigdl-orca==/g" ${file}
 sed -i "s/bigdl-orca-spark3==/bigdl-orca==/g" ${file}
@@ -41,6 +43,8 @@ sed -i "s/dist\/bigdl_orca_spark2-/dist\/bigdl_orca-/g" ${file}
 sed -i "s/dist\/bigdl_orca_spark3-/dist\/bigdl_orca-/g" ${file}
 sed -i "s/dist\/bigdl-orca-spark2-/dist\/bigdl-orca-/g" ${file}
 sed -i "s/dist\/bigdl-orca-spark3-/dist\/bigdl-orca-/g" ${file}
+sed -i "s/bigdl_orca_spark2.egg-info/bigdl_orca.egg-info/g" ${file}
+sed -i "s/bigdl_orca_spark3.egg-info/bigdl_orca.egg-info/g" ${file}
 sed -i "s/bigdl-orca-spark2\[ray\]/bigdl-orca\[ray\]/g" ${file}
 sed -i "s/bigdl-orca-spark3\[ray\]/bigdl-orca\[ray\]/g" ${file}
 
@@ -52,6 +56,8 @@ sed -i "s/dist\/bigdl_chronos_spark2-/dist\/bigdl_chronos-/g" ${file}
 sed -i "s/dist\/bigdl_chronos_spark3-/dist\/bigdl_chronos-/g" ${file}
 sed -i "s/dist\/bigdl-chronos-spark2-/dist\/bigdl-chronos-/g" ${file}
 sed -i "s/dist\/bigdl-chronos-spark3-/dist\/bigdl-chronos-/g" ${file}
+sed -i "s/bigdl_chronos_spark2.egg-info/bigdl_chronos.egg-info/g" ${file}
+sed -i "s/bigdl_chronos_spark3.egg-info/bigdl_chronos.egg-info/g" ${file}
 
 sed -i "s/bigdl-friesian-spark2==/bigdl-friesian==/g" ${file}
 sed -i "s/bigdl-friesian-spark3==/bigdl-friesian==/g" ${file}
@@ -61,3 +67,5 @@ sed -i "s/dist\/bigdl_friesian_spark2-/dist\/bigdl_friesian-/g" ${file}
 sed -i "s/dist\/bigdl_friesian_spark3-/dist\/bigdl_friesian-/g" ${file}
 sed -i "s/dist\/bigdl-friesian-spark2-/dist\/bigdl-friesian-/g" ${file}
 sed -i "s/dist\/bigdl-friesian-spark3-/dist\/bigdl-friesian-/g" ${file}
+sed -i "s/bigdl_friesian_spark2.egg-info/bigdl_friesian.egg-info/g" ${file}
+sed -i "s/bigdl_friesian_spark3.egg-info/bigdl_friesian.egg-info/g" ${file}

--- a/python/dev/remove_spark_suffix.sh
+++ b/python/dev/remove_spark_suffix.sh
@@ -30,6 +30,8 @@ sed -i "s/name='bigdl-dllib-spark2'/name='bigdl-dllib'/g" ${file}
 sed -i "s/name='bigdl-dllib-spark3'/name='bigdl-dllib'/g" ${file}
 sed -i "s/dist\/bigdl_dllib_spark2-/dist\/bigdl_dllib-/g" ${file}
 sed -i "s/dist\/bigdl_dllib_spark3-/dist\/bigdl_dllib-/g" ${file}
+sed -i "s/dist\/bigdl-dllib-spark2-/dist\/bigdl-dllib-/g" ${file}
+sed -i "s/dist\/bigdl-dllib-spark3-/dist\/bigdl-dllib-/g" ${file}
 
 sed -i "s/bigdl-orca-spark2==/bigdl-orca==/g" ${file}
 sed -i "s/bigdl-orca-spark3==/bigdl-orca==/g" ${file}
@@ -37,6 +39,8 @@ sed -i "s/name='bigdl-orca-spark2'/name='bigdl-orca'/g" ${file}
 sed -i "s/name='bigdl-orca-spark3'/name='bigdl-orca'/g" ${file}
 sed -i "s/dist\/bigdl_orca_spark2-/dist\/bigdl_orca-/g" ${file}
 sed -i "s/dist\/bigdl_orca_spark3-/dist\/bigdl_orca-/g" ${file}
+sed -i "s/dist\/bigdl-orca-spark2-/dist\/bigdl-orca-/g" ${file}
+sed -i "s/dist\/bigdl-orca-spark3-/dist\/bigdl-orca-/g" ${file}
 sed -i "s/bigdl-orca-spark2\[ray\]/bigdl-orca\[ray\]/g" ${file}
 sed -i "s/bigdl-orca-spark3\[ray\]/bigdl-orca\[ray\]/g" ${file}
 
@@ -46,6 +50,8 @@ sed -i "s/name='bigdl-chronos-spark2'/name='bigdl-chronos'/g" ${file}
 sed -i "s/name='bigdl-chronos-spark3'/name='bigdl-chronos'/g" ${file}
 sed -i "s/dist\/bigdl_chronos_spark2-/dist\/bigdl_chronos-/g" ${file}
 sed -i "s/dist\/bigdl_chronos_spark3-/dist\/bigdl_chronos-/g" ${file}
+sed -i "s/dist\/bigdl-chronos-spark2-/dist\/bigdl-chronos-/g" ${file}
+sed -i "s/dist\/bigdl-chronos-spark3-/dist\/bigdl-chronos-/g" ${file}
 
 sed -i "s/bigdl-friesian-spark2==/bigdl-friesian==/g" ${file}
 sed -i "s/bigdl-friesian-spark3==/bigdl-friesian==/g" ${file}
@@ -53,3 +59,5 @@ sed -i "s/name='bigdl-friesian-spark2'/name='bigdl-friesian'/g" ${file}
 sed -i "s/name='bigdl-friesian-spark3'/name='bigdl-friesian'/g" ${file}
 sed -i "s/dist\/bigdl_friesian_spark2-/dist\/bigdl_friesian-/g" ${file}
 sed -i "s/dist\/bigdl_friesian_spark3-/dist\/bigdl_friesian-/g" ${file}
+sed -i "s/dist\/bigdl-friesian-spark2-/dist\/bigdl-friesian-/g" ${file}
+sed -i "s/dist\/bigdl-friesian-spark3-/dist\/bigdl-friesian-/g" ${file}

--- a/python/dllib/dev/release/release.sh
+++ b/python/dllib/dev/release/release.sh
@@ -46,6 +46,8 @@ fi
 bigdl_version=$(cat $BIGDL_DIR/python/version.txt | head -1)
 echo "The effective version is: ${bigdl_version}"
 
+echo "__version__ = '"$bigdl_version"'" > $BIGDL_PYTHON_DIR/bigdl/dllib/version.py
+
 cd ${BIGDL_DIR}/scala
 if [ "$platform" ==  "mac" ]; then
     echo "Building bigdl for mac system"
@@ -68,11 +70,6 @@ else
     $bigdl_build_command
 fi
 
-cd $BIGDL_PYTHON_DIR
-sdist_command="python setup.py sdist"
-echo "Packing source code: ${sdist_command}"
-$sdist_command
-
 if [ -d "${BIGDL_DIR}/python/dllib/src/build" ]; then
    rm -r ${BIGDL_DIR}/python/dllib/src/build
 fi
@@ -85,12 +82,21 @@ if [ -d "${BIGDL_DIR}/python/dllib/src/bigdl_dllib.egg-info" ]; then
    rm -r ${BIGDL_DIR}/python/dllib/src/bigdl_dllib.egg-info
 fi
 
-wheel_command="python setup.py bdist_wheel --plat-name ${verbose_pname} --python-tag py3"
-echo "Packing python distribution: $wheel_command"
+if [ -d "${BIGDL_DIR}/python/dllib/src/bigdl/scripts" ]; then
+   rm -r ${BIGDL_DIR}/python/dllib/src/bigdl/scripts
+fi
+cp -r ${BIGDL_DIR}/scripts/ ${BIGDL_DIR}/python/dllib/src/bigdl/scripts
+
+cd $BIGDL_PYTHON_DIR
+wheel_command="python setup.py sdist bdist_wheel --plat-name ${verbose_pname} --python-tag py3"
+echo "Packing python source code and distribution: $wheel_command"
 ${wheel_command}
 
 if [ ${upload} == true ]; then
     upload_command="twine upload dist/bigdl_dllib-${bigdl_version}-py3-none-${verbose_pname}.whl"
     echo "Please manually upload with this command: $upload_command"
     $upload_command
+    upload_command2="twine upload dist/bigdl-dllib-${bigdl_version}.tar.gz"
+    echo "Please manually upload with this command: $upload_command2"
+    $upload_command2
 fi

--- a/python/dllib/dev/release/release.sh
+++ b/python/dllib/dev/release/release.sh
@@ -93,10 +93,12 @@ echo "Packing python source code and distribution: $wheel_command"
 ${wheel_command}
 
 if [ ${upload} == true ]; then
-    upload_command="twine upload dist/bigdl_dllib-${bigdl_version}-py3-none-${verbose_pname}.whl"
-    echo "Please manually upload with this command: $upload_command"
-    $upload_command
-    upload_command2="twine upload dist/bigdl-dllib-${bigdl_version}.tar.gz"
-    echo "Please manually upload with this command: $upload_command2"
-    $upload_command2
+    upload_wheel_command="twine upload dist/bigdl_dllib-${bigdl_version}-py3-none-${verbose_pname}.whl"
+    echo "Uploading wheel with this command: $upload_wheel_command"
+    $upload_wheel_command
+    if [ "$platform" == "linux" ]; then
+        upload_source_command="twine upload dist/bigdl-dllib-${bigdl_version}.tar.gz"
+        echo "Uploading source with this command: $upload_source_command"
+        $upload_source_command
+    fi
 fi

--- a/python/dllib/src/bigdl/dllib/contrib/onnx/onnx_loader.py
+++ b/python/dllib/src/bigdl/dllib/contrib/onnx/onnx_loader.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-import onnx
-from bigdl.dllib.nn.onnx.layer import *
 from bigdl.dllib.nn.layer import Identity, Model
 from .ops_mapping import _convert_map as convert_map
 from .converter_utils import parse_node_attr, parse_tensor_data
@@ -24,6 +22,7 @@ from .converter_utils import parse_node_attr, parse_tensor_data
 class OnnxLoader(object):
 
     def load_model(self, file_path):
+        import onnx
         model_proto = onnx.load_model(file_path)
         # self._ir_version = model_proto.ir_version
         # self._opset_import = model_proto.opset_import


### PR DESCRIPTION
Conda support directly building conda packages from pypi packages using `conda skeleton` and `conda build`.
https://conda.io/projects/conda-build/en/latest/user-guide/tutorials/build-pkgs-skeleton.html

But the source (tar.gz file, platform independent) is needed to do this.
When installing from source, all the files needed in setup.py should be in the source package (i.e. scripts, version info)

This PR modifies the setup and release script to release the source distribution to pypi, builds the conda package of bigdl-dllib and installs to conda.

After bigdl-dllib is OK, we can do the same for other packages (under the condition that all the dependencies are available on conda).
TODO: add some documentation and description in conda page?

See the comments for steps and issues encountered and workarounds.

References:
https://blog.artwolf.in/a?ID=78598faa-bc1e-4d9b-8366-da5e3fccba63
https://docs.python.org/3/distutils/sourcedist.html
https://stackoverflow.com/questions/62568178/distribution-format-for-python-libraries-uploaded-on-pypi
Also referred to pyspark setup (for get version in setup.py).