### PR TITLE
Nano: Add onnxruntime quantization to nano.pytorch

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/runtime_binding/base_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/runtime_binding/base_inference.py
@@ -93,34 +93,47 @@ def inference(self,
         input_sample_list = [input_data]
 
     if backend == "onnx":
-        self.eval()
-        assert not quantize,\
-            "quantized inference has not been supported by onnx backend, please set `backend=None`"
-        if not self._ortsess_up_to_date:
-            warnings.warn("Onnxruntime session will be built implicitly,"
-                          " this may harm your inference latency.")
-            # generate input_sample for ortsess building
-            # defaultly set all input to a Tensor(TODO: might be an issue)
-            input_sample = []
-            for input_sample_item in input_sample_list:
-                input_sample.append(torch.Tensor(input_sample_item))
-            self._build_ortsess(input_sample=tuple(input_sample),
-                                file_path="model.onnx",
-                                sess_options=sess_options,
-                                **kwargs)
+        if not quantize:
+            if not self._ortsess_up_to_date:
+                warnings.warn("Onnxruntime session will be built implicitly,"
+                            " this may harm your inference latency.")
+                # generate input_sample for ortsess building
+                # defaultly set all input to a Tensor(TODO: might be an issue)
+                self.eval()
+                input_sample = []
+                for input_sample_item in input_sample_list:
+                    input_sample.append(torch.Tensor(input_sample_item))
+                self._build_ortsess(input_sample=tuple(input_sample),
+                                    file_path="model.onnx",
+                                    sess_options=sess_options,
+                                    **kwargs)
+        else:
+            if not self._quantized_ortsess_up_to_date:
+                raise RuntimeError("Please run trainer.quantize again since "
+                                   "the quantized onnxruntime session is out-of-date.")
         # generate ort_inputs
         if batch_size is None:
             # this branch is only to speed up the inferencing when batch_size is set to None.
-            return self._forward_onnx(*input_sample_list)
+            if not quantize:
+                return self._forward_onnx(*input_sample_list)
+            else:
+                return self._forward_onnx_quantized(*input_sample_list)
         else:
             yhat_list = []
             sample_num = input_sample_list[0].shape[0]  # the first dim should be sample_num
             batch_num = math.ceil(sample_num / batch_size)
-            for batch_id in range(batch_num):
-                yhat_list.append(self._forward_onnx(
-                    *tuple(map(lambda x: x[batch_id * batch_size:
-                                           (batch_id + 1) * batch_size],
-                               input_sample_list))))
+            if not quantize:
+                for batch_id in range(batch_num):
+                    yhat_list.append(self._forward_onnx(
+                        *tuple(map(lambda x: x[batch_id * batch_size:
+                                            (batch_id + 1) * batch_size],
+                                input_sample_list))))
+            else:
+                for batch_id in range(batch_num):
+                    yhat_list.append(self._forward_onnx_quantized(
+                        *tuple(map(lambda x: x[batch_id * batch_size:
+                                            (batch_id + 1) * batch_size],
+                                input_sample_list))))
             # this operation may cause performance degradation
             yhat = np.concatenate(yhat_list, axis=0)
             return yhat

--- a/python/nano/src/bigdl/nano/pytorch/runtime_binding/base_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/runtime_binding/base_inference.py
@@ -22,8 +22,7 @@ import warnings
 import math
 import numpy as np
 
-BASE_BINDED_COMPONENTS = ['_on_fit_start_old',
-                          '_train_old',
+BASE_BINDED_COMPONENTS = ['_train_old',
                           '_torch_forward',
                           '_eval_old',
                           'inference']
@@ -96,7 +95,7 @@ def inference(self,
         if not quantize:
             if not self._ortsess_up_to_date:
                 warnings.warn("Onnxruntime session will be built implicitly,"
-                            " this may harm your inference latency.")
+                              " this may harm your inference latency.")
                 # generate input_sample for ortsess building
                 # defaultly set all input to a Tensor(TODO: might be an issue)
                 self.eval()
@@ -126,14 +125,14 @@ def inference(self,
                 for batch_id in range(batch_num):
                     yhat_list.append(self._forward_onnx(
                         *tuple(map(lambda x: x[batch_id * batch_size:
-                                            (batch_id + 1) * batch_size],
-                                input_sample_list))))
+                                               (batch_id + 1) * batch_size],
+                                   input_sample_list))))
             else:
                 for batch_id in range(batch_num):
                     yhat_list.append(self._forward_onnx_quantized(
                         *tuple(map(lambda x: x[batch_id * batch_size:
-                                            (batch_id + 1) * batch_size],
-                                input_sample_list))))
+                                               (batch_id + 1) * batch_size],
+                                   input_sample_list))))
             # this operation may cause performance degradation
             yhat = np.concatenate(yhat_list, axis=0)
             return yhat

--- a/python/nano/src/bigdl/nano/pytorch/runtime_binding/onnxrt_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/runtime_binding/onnxrt_inference.py
@@ -54,6 +54,11 @@ def _build_ortsess(self,
     :param **kwargs: will be passed to torch.onnx.export function.
     '''
 
+    # quantized model will not be supported
+    if "_quantized_model" in dir(self):
+        self._quantized_model = None
+        self._quantized_model_up_to_date = False
+
     if input_sample is None and self.example_input_array is not None:
         input_sample = self.example_input_array  # use internal example_input_array
     else:

--- a/python/nano/src/bigdl/nano/pytorch/runtime_binding/onnxrt_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/runtime_binding/onnxrt_inference.py
@@ -19,6 +19,7 @@ import torch
 from torch.utils.data import DataLoader
 from bigdl.nano.pytorch.lightning import LightningModuleFromTorch
 import onnxruntime as ort
+import onnx
 from functools import partial, wraps
 import warnings
 import torch
@@ -29,9 +30,13 @@ import inspect
 
 ONNXRT_BINDED_COMPONENTS = ['_ortsess_up_to_date',
                             '_ortsess',
+                            '_onnx_graph',
                             '_build_ortsess',
                             'update_ortsess',
-                            '_forward_onnx']
+                            '_forward_onnx',
+                            '_quantized_ortsess',
+                            '_quantized_ortsess_up_to_date'
+                            ]
 
 
 # internal function to build an ortsess
@@ -63,7 +68,7 @@ def _build_ortsess(self,
     dynamic_axes['output'] = {0: 'batch_size'}
 
     default_onnx_export_args = {'export_params': True,
-                                'opset_version': 10,  # version = 10 by default
+                                'opset_version': 11,  # version = 11 by default
                                 'do_constant_folding': True,
                                 'input_names': self._forward_args,
                                 'output_names': ['output'],  # TODO: only support single output
@@ -76,6 +81,7 @@ def _build_ortsess(self,
                       **default_onnx_export_args)
 
     self._ortsess = ort.InferenceSession(file_path, sess_options=sess_options)
+    self._onnx_graph = onnx.load(file_path)
     self._ortsess_up_to_date = True
 
 
@@ -105,12 +111,15 @@ def update_ortsess(self,
 def _onnx_on_fit_start(self):
     self._ortsess_up_to_date = False
     self._ortsess = None
+    self._quantized_ortsess_up_to_date = False
+    self._quantized_ortsess = None
     self.exit_onnx()
 
 
 def _onnx_on_train(self, mode=True):
     self.exit_onnx()
     self._ortsess_up_to_date = False
+    self._quantized_ortsess_up_to_date = False
 
 
 def _forward_onnx(self, *args):
@@ -123,7 +132,17 @@ def _forward_onnx(self, *args):
     return torch.from_numpy(ort_outs[0])
 
 
-def eval_onnx(self, input_sample=None, file_path="model.onnx", sess_options=None, **kwargs):
+def _forward_onnx_quantized(self, *args):
+    ort_inputs = {}
+    for i, ort_input_item in enumerate(args):
+        if isinstance(ort_input_item, torch.Tensor):
+            ort_input_item = ort_input_item.numpy()
+        ort_inputs[self._forward_args[i]] = ort_input_item
+    ort_outs = self._quantized_ortsess.run(None, ort_inputs)
+    return torch.from_numpy(ort_outs[0])
+
+
+def eval_onnx(self, input_sample=None, file_path="model.onnx", sess_options=None, quantize=False, **kwargs):
     '''
     This method change the `forward` method to an onnxruntime backed forwarding.
 
@@ -135,43 +154,58 @@ def eval_onnx(self, input_sample=None, file_path="model.onnx", sess_options=None
            list of them for the model tracing.
     :param file_path: (optional) The path to save onnx model file.
     :param sess_options: (optional) ortsess options in ort.SessionOptions type.
+    :param quantize: Bool, state if we need to use quantized onnxruntime session.
     :param **kwargs: (optional) will be passed to torch.onnx.export function.
     '''
-    # change to eval mode
-    self.eval()
-
-    # get input_sample
-    if isinstance(input_sample, DataLoader):
-        input_sample = tuple(next(iter(input_sample))[:-1])
-    if input_sample is None and self.example_input_array:
-        input_sample = self.example_input_array
-    if input_sample is None and self.trainer is None:
-        raise RuntimeError("You must specify an input_sample or call `Trainer.fit` "
-                           "on the model first to use `eval_onnx`")
-    if input_sample is None and self.trainer.train_dataloader:
-        input_sample = tuple(next(iter(self.trainer.train_dataloader))[:-1])
-    if input_sample is None and self.trainer.datamodule:
-        input_sample = tuple(next(iter(self.trainer.datamodule.train_dataloader()))[:-1])
-    assert input_sample is not None,\
-        "You must state an input_sample or fit on the model to use `eval_onnx`."
-
     # build ortsess
-    self._build_ortsess(input_sample=input_sample,
-                        file_path=file_path,
-                        sess_options=sess_options,
-                        **kwargs)
+    if quantize:
+        assert self._quantized_ortsess_up_to_date, \
+            "Please run trainer.quantize again since the quantized onnxruntime session is out-of-date."
+    else:
+        # change to eval mode
+        self.eval()
+        # get input_sample
+        if isinstance(input_sample, DataLoader):
+            input_sample = tuple(next(iter(input_sample))[:-1])
+        if input_sample is None and self.example_input_array:
+            input_sample = self.example_input_array
+        if input_sample is None and self.trainer is None:
+            raise RuntimeError("You must specify an input_sample or call `Trainer.fit` "
+                            "on the model first to use `eval_onnx`")
+        if input_sample is None and self.trainer.train_dataloader:
+            input_sample = tuple(next(iter(self.trainer.train_dataloader))[:-1])
+        if input_sample is None and self.trainer.datamodule:
+            input_sample = tuple(next(iter(self.trainer.datamodule.train_dataloader()))[:-1])
+        assert input_sample is not None,\
+            "You must state an input_sample or fit on the model to use `eval_onnx`."
+        self._build_ortsess(input_sample=input_sample,
+                            file_path=file_path,
+                            sess_options=sess_options,
+                            **kwargs)
 
-    self.forward = self._forward_onnx
+    if quantize:
+        self.forward = self._forward_onnx_quantized
+    else:
+        self.forward = self._forward_onnx
 
 
 def exit_onnx(self):
     self.forward = self._torch_forward
 
 
-def bind_onnxrt_methods(pl_model: LightningModule):
+def bind_onnxrt_methods(pl_model: LightningModule, q_onnx_model=None, sess_options=None):
     # class type check
     assert isinstance(pl_model, LightningModule),\
         f"onnxruntime support is only valid for a LightningModule, but found a {type(pl_model)}."
+
+    if q_onnx_model:
+        onnx.save(q_onnx_model, "_model_quantized_cache.onnx")
+        pl_model._quantized_ortsess = ort.InferenceSession("_model_quantized_cache.onnx", sess_options=sess_options)
+        pl_model._quantized_ortsess_up_to_date = True
+
+    # if all needed method has been binded, return the same model
+    if set(ONNXRT_BINDED_COMPONENTS) <= set(dir(pl_model)):
+        return pl_model
 
     # check conflicts
     for component in ONNXRT_BINDED_COMPONENTS:
@@ -183,6 +217,7 @@ def bind_onnxrt_methods(pl_model: LightningModule):
     # additional attributes
     pl_model._ortsess_up_to_date = False  # indicate if we need to build ortsess again
     pl_model._ortsess = None  # ortsess instance
+    pl_model._onnx_graph = None  # onnx graph for quantization
     if isinstance(pl_model, LightningModuleFromTorch):  # forward param list for compiled model
         pl_model._forward_args = inspect.getfullargspec(pl_model.model.forward).args[1:]
     else:  # forward param list
@@ -196,5 +231,6 @@ def bind_onnxrt_methods(pl_model: LightningModule):
     pl_model._forward_onnx = partial(_forward_onnx, pl_model)
     pl_model.exit_onnx = partial(exit_onnx, pl_model)
     pl_model._onnx_on_train = partial(_onnx_on_train, pl_model)
+    pl_model._forward_onnx_quantized = partial(_forward_onnx_quantized, pl_model)
 
     return pl_model

--- a/python/nano/src/bigdl/nano/pytorch/runtime_binding/onnxrt_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/runtime_binding/onnxrt_inference.py
@@ -161,7 +161,7 @@ def eval_onnx(self, input_sample=None, file_path="model.onnx",
     '''
     This method change the `forward` method to an onnxruntime backed forwarding.
 
-    >>> model.eval_onnx()
+    >>> model.eval_onnx(quantize=True/False)
     >>> pred = model(x)  # onnxruntime forwarding
     >>> model.exit_onnx()
 

--- a/python/nano/src/bigdl/nano/pytorch/runtime_binding/onnxrt_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/runtime_binding/onnxrt_inference.py
@@ -34,7 +34,7 @@ ONNXRT_BINDED_COMPONENTS = ['_ortsess_up_to_date',
                             '_build_ortsess',
                             'update_ortsess',
                             '_forward_onnx',
-                            'to_quantize_onnx'
+                            'to_quantized_onnx'
                             ]
 
 
@@ -128,7 +128,7 @@ def _onnx_on_train(self, mode=True):
     self._quantized_ortsess = None
 
 
-def to_quantize_onnx(self, file_path):
+def to_quantized_onnx(self, file_path):
     if self._quantized_ortsess_up_to_date:
         onnx.save(self._q_onnx_model, file_path)
     else:
@@ -250,6 +250,6 @@ def bind_onnxrt_methods(pl_model: LightningModule, q_onnx_model=None, sess_optio
     pl_model.exit_onnx = partial(exit_onnx, pl_model)
     pl_model._onnx_on_train = partial(_onnx_on_train, pl_model)
     pl_model._forward_onnx_quantized = partial(_forward_onnx_quantized, pl_model)
-    pl_model.to_quantize_onnx = partial(to_quantize_onnx, pl_model)
+    pl_model.to_quantized_onnx = partial(to_quantized_onnx, pl_model)
 
     return pl_model

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -220,12 +220,14 @@ class Trainer(pl.Trainer):
         for framework_item in framework:
             if "pytorch" in framework_item:
                 if has_pytorch:
-                    raise RuntimeError("You should choose one from {'pytorch'|'pytorch_fx'|'pytorch_ipex'}")
+                    raise RuntimeError("You should choose one from "
+                                       "{'pytorch'|'pytorch_fx'|'pytorch_ipex'}")
                 has_pytorch = True
                 continue
             if "onnx" in framework_item:
                 if has_onnx:
-                    raise RuntimeError("You should choose one from {'onnxrt_integerops'|'onnxrt_qlinearops'}")
+                    raise RuntimeError("You should choose one from "
+                                       "{'onnxrt_integerops'|'onnxrt_qlinearops'}")
                 has_onnx = True
                 continue
 
@@ -252,7 +254,8 @@ class Trainer(pl.Trainer):
                     # for 'pytorch'|'pytorch_fx'|'pytorch_ipex'
                     model: nn.Module = pl_model
                     if isinstance(pl_model, LightningModuleFromTorch):
-                        # LightningModuleFromTorch.forward fails to trace in FX, so replace it temporarily
+                        # LightningModuleFromTorch.forward fails to trace in FX
+                        # so replace it temporarily
                         model = pl_model.model
                 else:
                     # for 'onnxrt_integerops'|'onnxrt_qlinearops'
@@ -263,12 +266,14 @@ class Trainer(pl.Trainer):
                         assert calib_dataloader, \
                             "calib_calib_dataloader must not be None when approach is " \
                             "post-training static quantization."
-                        pl_model.update_ortsess(input_sample=tuple(next(iter(calib_dataloader))[:-1]),
-                                                file_path="model.onnx")
+                        pl_model.update_ortsess(input_sample=tuple(next(iter(
+                            calib_dataloader))[:-1]),
+                            file_path="model.onnx")
                         model = pl_model._onnx_graph
                     else:
                         assert pl_model._ortsess_up_to_date, \
-                            "Please call `update_ortsess` on model to update/build your onnx structure."
+                            "Please call `update_ortsess` on model to " \
+                            "update/build your onnx structure."
                         model = pl_model._onnx_graph
                 quantized_models.append(quantizer.post_training_quantize(model, calib_dataloader,
                                                                          val_dataloader, metric))
@@ -292,8 +297,8 @@ class Trainer(pl.Trainer):
                 from bigdl.nano.pytorch.runtime_binding.onnxrt_inference import \
                     bind_onnxrt_methods
                 return bind_onnxrt_methods(
-                        bind_quantize_methods(
-                            bind_base_inference_rt_methods(pl_model), quantized_pytorch_model),
-                            quantized_onnx_model)
+                    bind_quantize_methods(
+                        bind_base_inference_rt_methods(pl_model), quantized_pytorch_model),
+                    quantized_onnx_model)
         else:
             raise NotImplementedError("Backend {} is not implemented.".format(backend))

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -192,7 +192,8 @@ class Trainer(pl.Trainer):
         :param backend:             Only 'inc' is supported. Default: 'inc'.
         :param conf:        A path to conf yaml file for quantization.
                             Default: None, using default config.
-        :param framework:   'pytorch', 'pytorch_fx', 'pytorch_ipex'. Default: 'pytorch_fx'.
+        :param framework:   string or list, [{'pytorch'|'pytorch_fx'|'pytorch_ipex'},
+                            {'onnxrt_integerops'|'onnxrt_qlinearops'}]. Default: 'pytorch_fx'.
                             Consistent with Intel Neural Compressor.
         :param approach:    'static' or 'dynamic'.
                             'static': post_training_static_quant,
@@ -214,6 +215,20 @@ class Trainer(pl.Trainer):
                             returned. If set to False, a pytorch lightning module will be returned.
         :return:            A GraphModule. If there is no model found, return None.
         """
+        has_pytorch = False
+        has_onnx = False
+        for framework_item in framework:
+            if "pytorch" in framework_item:
+                if has_pytorch:
+                    raise RuntimeError("You should choose one from {'pytorch'|'pytorch_fx'|'pytorch_ipex'}")
+                has_pytorch = True
+                continue
+            if "onnx" in framework_item:
+                if has_onnx:
+                    raise RuntimeError("You should choose one from {'onnxrt_integerops'|'onnxrt_qlinearops'}")
+                has_onnx = True
+                continue
+
         if backend == 'inc':
             from bigdl.nano.quantization.neural_compressor import QuantizationINC
 
@@ -226,25 +241,59 @@ class Trainer(pl.Trainer):
             }
             approach = approach_map.get(approach)
 
-            quantizer = QuantizationINC(framework=framework, conf=conf, approach=approach,
-                                        tuning_strategy=tuning_strategy,
-                                        accuracy_criterion=accuracy_criterion,
-                                        timeout=timeout, max_trials=max_trials)
-            model: nn.Module = pl_model
-            if isinstance(pl_model, LightningModuleFromTorch):
-                # LightningModuleFromTorch.forward fails to trace in FX, so replace it temporarily
-                model = pl_model.model
-
-            quantized = quantizer.post_training_quantize(model, calib_dataloader, val_dataloader,
-                                                         metric)
+            framework = [framework] if isinstance(framework, str) else framework
+            quantized_models = []
+            for framework_item in framework:
+                quantizer = QuantizationINC(framework=framework_item, conf=conf, approach=approach,
+                                            tuning_strategy=tuning_strategy,
+                                            accuracy_criterion=accuracy_criterion,
+                                            timeout=timeout, max_trials=max_trials)
+                if "pytorch" in framework_item:
+                    # for 'pytorch'|'pytorch_fx'|'pytorch_ipex'
+                    model: nn.Module = pl_model
+                    if isinstance(pl_model, LightningModuleFromTorch):
+                        # LightningModuleFromTorch.forward fails to trace in FX, so replace it temporarily
+                        model = pl_model.model
+                else:
+                    # for 'onnxrt_integerops'|'onnxrt_qlinearops'
+                    from bigdl.nano.pytorch.runtime_binding.onnxrt_inference import\
+                        bind_onnxrt_methods
+                    pl_model = bind_onnxrt_methods(pl_model)
+                    if approach == "post_training_static_quant":
+                        assert calib_dataloader, \
+                            "calib_calib_dataloader must not be None when approach is " \
+                            "post-training static quantization."
+                        pl_model.update_ortsess(input_sample=tuple(next(iter(calib_dataloader))[:-1]),
+                                                file_path="model.onnx")
+                        model = pl_model._onnx_graph
+                    else:
+                        assert pl_model._ortsess_up_to_date, \
+                            "Please call `update_ortsess` on model to update/build your onnx structure."
+                        model = pl_model._onnx_graph
+                quantized_models.append(quantizer.post_training_quantize(model, calib_dataloader,
+                                                                         val_dataloader, metric))
             if raw_return:
-                return quantized.model
+                if len(quantized_models) == 1:
+                    return quantized_models[0].model
+                else:
+                    return quantized_models[0].model, quantized_models[1].model
             else:
+                quantized_pytorch_model = None
+                quantized_onnx_model = None
+                for i, framework_item in enumerate(framework):
+                    if "pytorch" in framework_item:
+                        quantized_pytorch_model = quantized_models[i].model
+                    else:
+                        quantized_onnx_model = quantized_models[i].model
                 from bigdl.nano.pytorch.runtime_binding.base_inference import \
                     bind_base_inference_rt_methods
                 from bigdl.nano.pytorch.runtime_binding.quantization_inference import \
                     bind_quantize_methods
-                return bind_quantize_methods(
-                    bind_base_inference_rt_methods(pl_model), quantized.model)
+                from bigdl.nano.pytorch.runtime_binding.onnxrt_inference import \
+                    bind_onnxrt_methods
+                return bind_onnxrt_methods(
+                        bind_quantize_methods(
+                            bind_base_inference_rt_methods(pl_model), quantized_pytorch_model),
+                            quantized_onnx_model)
         else:
             raise NotImplementedError("Backend {} is not implemented.".format(backend))

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -252,7 +252,7 @@ class Trainer(pl.Trainer):
                                             timeout=timeout, max_trials=max_trials)
                 if "pytorch" in framework_item:
                     # for 'pytorch'|'pytorch_fx'|'pytorch_ipex'
-                    model: nn.Module = pl_model
+                    model: Any = pl_model  # state model to be 'Any' since we may have pl or onnx
                     if isinstance(pl_model, LightningModuleFromTorch):
                         # LightningModuleFromTorch.forward fails to trace in FX
                         # so replace it temporarily

--- a/python/nano/src/bigdl/nano/quantization/neural_compressor/metric/__init__.py
+++ b/python/nano/src/bigdl/nano/quantization/neural_compressor/metric/__init__.py
@@ -18,5 +18,6 @@ from .metrics import *
 
 METRICS = {
     'pytorch': PytorchINCMetric,
-    'tensorflow': TensorflowINCMetric
+    'tensorflow': TensorflowINCMetric,
+    'onnx': ONNXRuntimeINCMetic
 }

--- a/python/nano/src/bigdl/nano/quantization/neural_compressor/metric/metrics.py
+++ b/python/nano/src/bigdl/nano/quantization/neural_compressor/metric/metrics.py
@@ -22,7 +22,6 @@ class PytorchINCMetric(INCMetric):
         # calculate accuracy
         preds = torch.stack(preds)
         labels = torch.stack(labels)
-        print("DDDDDDDDDDDDDDDDDD", preds.shape, labels.shape)
         return preds, labels
 
     def to_scalar(self, tensor):
@@ -39,6 +38,7 @@ class TensorflowINCMetric(INCMetric):
 
     def to_scalar(self, tensor):
         return tensor.numpy()
+
 
 class ONNXRuntimeINCMetic(INCMetric):
     '''

--- a/python/nano/src/bigdl/nano/quantization/neural_compressor/metric/metrics.py
+++ b/python/nano/src/bigdl/nano/quantization/neural_compressor/metric/metrics.py
@@ -22,6 +22,7 @@ class PytorchINCMetric(INCMetric):
         # calculate accuracy
         preds = torch.stack(preds)
         labels = torch.stack(labels)
+        print("DDDDDDDDDDDDDDDDDD", preds.shape, labels.shape)
         return preds, labels
 
     def to_scalar(self, tensor):
@@ -46,11 +47,10 @@ class ONNXRuntimeINCMetic(INCMetric):
     '''
     def stack(self, preds, labels):
         import torch
+        import numpy as np
         # calculate accuracy
-        preds = [torch.from_numpy(pred) for pred in preds]
-        labels = [torch.from_numpy(label) for label in labels]
-        preds = torch.stack(preds)
-        labels = torch.stack(labels)
+        preds = torch.from_numpy(np.concatenate(preds))
+        labels = torch.from_numpy(np.concatenate(labels))
         return preds, labels
 
     def to_scalar(self, tensor):

--- a/python/nano/src/bigdl/nano/quantization/neural_compressor/metric/metrics.py
+++ b/python/nano/src/bigdl/nano/quantization/neural_compressor/metric/metrics.py
@@ -38,3 +38,20 @@ class TensorflowINCMetric(INCMetric):
 
     def to_scalar(self, tensor):
         return tensor.numpy()
+
+class ONNXRuntimeINCMetic(INCMetric):
+    '''
+    ONNXRuntime will use numpy as data type.
+    ONNXRuntime quantization in torch will use torchmetrics
+    '''
+    def stack(self, preds, labels):
+        import torch
+        # calculate accuracy
+        preds = [torch.from_numpy(pred) for pred in preds]
+        labels = [torch.from_numpy(label) for label in labels]
+        preds = torch.stack(preds)
+        labels = torch.stack(labels)
+        return preds, labels
+
+    def to_scalar(self, tensor):
+        return tensor.item()

--- a/python/nano/src/bigdl/nano/quantization/neural_compressor/quantization.py
+++ b/python/nano/src/bigdl/nano/quantization/neural_compressor/quantization.py
@@ -76,7 +76,8 @@ class QuantizationINC(Quantization):
     def post_training_quantize(self, model, calib_dataloader=None, val_dataloader=None,
                                metric=None):
         self.check(calib_dataloader, val_dataloader, metric)
-        self.model = model
+        self.model = common.Model(model)
+
         def func(data):
             # TODO: only x, y are supported here for onnx quantization
             import torch

--- a/python/nano/src/bigdl/nano/quantization/neural_compressor/quantization.py
+++ b/python/nano/src/bigdl/nano/quantization/neural_compressor/quantization.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 #
 from neural_compressor.conf.config import Quantization_Conf
-from neural_compressor.experimental import Quantization
+from neural_compressor.experimental import Quantization, common
 from neural_compressor.experimental.common import Metric
+
 
 from .metric import METRICS
 
@@ -75,15 +76,40 @@ class QuantizationINC(Quantization):
     def post_training_quantize(self, model, calib_dataloader=None, val_dataloader=None,
                                metric=None):
         self.check(calib_dataloader, val_dataloader, metric)
-        self.model = model
+        self.model = common.Model(model)
+        def func(data):
+            # TODO: only x, y are supported here for onnx quantization
+            import torch
+            x, y = zip(*data)
+            if isinstance(x[0], torch.Tensor):
+                x = torch.stack(x, dim=0).numpy()
+            if isinstance(y[0], torch.Tensor):
+                y = torch.stack(y, dim=0).numpy()
+            return x, y
         if calib_dataloader:
-            self.calib_dataloader = calib_dataloader
+            if "pytorch" in self.cfg.model.framework:
+                self.calib_dataloader = calib_dataloader
+            else:
+                assert isinstance(calib_dataloader, torch.utils.data.DataLoader), \
+                    "Only torch dataloader is supported for onnx quantization."
+                # add a collate_fn to transform torch dataloader to a numpy dataloader
+                calib_dataloader.collate_fn = func
+                self.calib_dataloader = calib_dataloader
         if val_dataloader:
-            self.eval_dataloader = val_dataloader
+            if "pytorch" in self.cfg.model.framework:
+                self.eval_dataloader = val_dataloader
+            else:
+                assert isinstance(val_dataloader, torch.utils.data.DataLoader), \
+                    "Only torch dataloader is supported for onnx quantization."
+                # add a collate_fn to transform torch dataloader to a numpy dataloader
+                val_dataloader.collate_fn = func
+                self.eval_dataloader = val_dataloader
             if metric:
                 framework = self.cfg.model.framework
                 if 'pytorch' in framework:
                     framework_metric = METRICS['pytorch']
+                elif 'onnx' in framework:
+                    framework_metric = METRICS['onnx']
                 else:
                     framework_metric = METRICS[framework]
 

--- a/python/nano/test/mypy.ini
+++ b/python/nano/test/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 ignore_missing_imports = True
+disable_error_code = operator
 
 [mypy-torchvision.*]
 ignore_missing_imports = True

--- a/python/nano/test/pytorch/tests/test_onnx.py
+++ b/python/nano/test/pytorch/tests/test_onnx.py
@@ -18,6 +18,7 @@
 import pytest
 import os
 from unittest import TestCase
+import tempfile
 
 import torch
 from torch import nn
@@ -176,6 +177,11 @@ class TestOnnx(TestCase):
             pl_model.eval_onnx(quantize=True)
             forward_res = pl_model(x).numpy()
             np.testing.assert_almost_equal(onnx_res, forward_res, decimal=5)  # same result
+
+        # save the quantized model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            ckpt_name = os.path.join(tmp_dir_name, ".onnx")
+            pl_model.to_quantize_onnx(ckpt_name)
 
 
 if __name__ == '__main__':

--- a/python/nano/test/pytorch/tests/test_onnx.py
+++ b/python/nano/test/pytorch/tests/test_onnx.py
@@ -181,7 +181,7 @@ class TestOnnx(TestCase):
         # save the quantized model
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             ckpt_name = os.path.join(tmp_dir_name, ".onnx")
-            pl_model.to_quantize_onnx(ckpt_name)
+            pl_model.to_quantized_onnx(ckpt_name)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Here is a use-case in pytorch example
https://github.com/TheaperDeng/git_learning/compare/mnist-quantization-onnxrt

For this toy model and mnist dataset, onnxruntime with int8 quantization is slower than onnxruntime with fp32. I don't think we need to worry about it too much since some real model with larger dataset is more realistic.