### PR TITLE
Chronos: Support `validation_data=None` in `ProphetForecaster`

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/prophet_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/prophet_forecaster.py
@@ -70,7 +70,7 @@ class ProphetForecaster(Forecaster):
 
         super().__init__()
 
-    def fit(self, data, validation_data):
+    def fit(self, data, validation_data=None):
         """
         Fit(Train) the forecaster.
 
@@ -87,8 +87,9 @@ class ProphetForecaster(Forecaster):
     def _check_data(self, data, validation_data):
         assert 'ds' in data.columns and 'y' in data.columns, \
             "data should be a pandas dataframe that has at least 2 columns 'ds' and 'y'."
-        assert 'ds' in validation_data.columns and 'y' in validation_data.columns, \
-            "validation_data should be a dataframe that has at least 2 columns 'ds' and 'y'."
+        if validation_data is not None:
+            assert 'ds' in validation_data.columns and 'y' in validation_data.columns, \
+                "validation_data should be a dataframe that has at least 2 columns 'ds' and 'y'."
 
     def predict(self, horizon=1, freq="D", ds_data=None):
         """

--- a/python/chronos/src/bigdl/chronos/model/prophet.py
+++ b/python/chronos/src/bigdl/chronos/model/prophet.py
@@ -85,15 +85,17 @@ class ProphetModel:
         """
         self._fit(data, **config)
 
+        # cross_validation
+        cross_validation = config.get('cross_validation', False)
+        expected_horizon = config.get('expect_horizon', int(0.1*len(data)))
+        if cross_validation:
+            return self._eval_cross_validation(expected_horizon)
+
+        # normal validation process
         if validation_data is not None:
-            cross_validation = config.get('cross_validation', False)
-            expected_horizon = config.get('expect_horizon', int(0.1*len(data)))
-            if cross_validation:
-                return self._eval_cross_validation(expected_horizon)
-            else:
-                val_metric = self.evaluate(target=validation_data,
-                                           metrics=[self.metric])[0].item()
-                return {self.metric: val_metric}
+            val_metric = self.evaluate(target=validation_data,
+                                        metrics=[self.metric])[0].item()
+            return {self.metric: val_metric}
 
     def _eval_cross_validation(self, expected_horizon):
         df_cv = cross_validation(self.model, horizon=expected_horizon)

--- a/python/chronos/src/bigdl/chronos/model/prophet.py
+++ b/python/chronos/src/bigdl/chronos/model/prophet.py
@@ -92,7 +92,7 @@ class ProphetModel:
                 return self._eval_cross_validation(expected_horizon)
             else:
                 val_metric = self.evaluate(target=validation_data,
-                                        metrics=[self.metric])[0].item()
+                                           metrics=[self.metric])[0].item()
                 return {self.metric: val_metric}
 
     def _eval_cross_validation(self, expected_horizon):

--- a/python/chronos/src/bigdl/chronos/model/prophet.py
+++ b/python/chronos/src/bigdl/chronos/model/prophet.py
@@ -94,7 +94,7 @@ class ProphetModel:
         # normal validation process
         if validation_data is not None:
             val_metric = self.evaluate(target=validation_data,
-                                        metrics=[self.metric])[0].item()
+                                       metrics=[self.metric])[0].item()
             return {self.metric: val_metric}
 
     def _eval_cross_validation(self, expected_horizon):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_prophet_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_prophet_forecaster.py
@@ -44,17 +44,18 @@ class TestChronosModelProphetForecaster(TestCase):
 
     def test_prophet_forecaster_fit_eval_pred(self):
         data, validation_data = create_data()
-        forecaster = ProphetForecaster(changepoint_prior_scale=0.05,
-                                       seasonality_prior_scale=10.0,
-                                       holidays_prior_scale=10.0,
-                                       seasonality_mode='additive',
-                                       changepoint_range=0.8,
-                                       metric="mse",
-                                       )
-        train_loss = forecaster.fit(data, validation_data)
-        test_pred = forecaster.predict(validation_data.shape[0])
-        assert test_pred.shape[0] == validation_data.shape[0]
-        test_mse = forecaster.evaluate(validation_data)
+        for valid_data in [None, validation_data]:
+            forecaster = ProphetForecaster(changepoint_prior_scale=0.05,
+                                        seasonality_prior_scale=10.0,
+                                        holidays_prior_scale=10.0,
+                                        seasonality_mode='additive',
+                                        changepoint_range=0.8,
+                                        metric="mse",
+                                        )
+            train_loss = forecaster.fit(data, valid_data)
+            test_pred = forecaster.predict(validation_data.shape[0])
+            assert test_pred.shape[0] == validation_data.shape[0]
+            test_mse = forecaster.evaluate(validation_data)
 
     def test_prophet_forecaster_save_restore(self):
         data, validation_data = create_data()


### PR DESCRIPTION
One of our customers suggest us to have an option to disable validation process to save time.