### PR TITLE
[Orca]Update for Stopping Orca Context

### DIFF
--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -316,10 +316,10 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=2, memory="2g", 
                         "system_config"]:
                 if key in kwargs:
                     ray_args[key] = kwargs[key]
-            from bigdl.orca.ray import RayContext
-            ray_ctx = RayContext(runtime="spark", cores=cores, num_nodes=num_nodes,
-                                 sc=sc, **ray_args)
             if init_ray_on_spark:
+                from bigdl.orca.ray import RayContext
+                ray_ctx = RayContext(runtime="spark", cores=cores, num_nodes=num_nodes,
+                                    sc=sc, **ray_args)
                 driver_cores = 0  # This is the default value.
                 ray_ctx.init(driver_cores=driver_cores)
         return sc
@@ -339,9 +339,6 @@ def stop_orca_context():
     # should do nothing.
     if SparkContext._active_spark_context is not None:
         print("Stopping orca context")
-        ray_ctx = RayContext.get(initialize=False)
-        if ray_ctx.initialized:
-            ray_ctx.stop()
         sc = SparkContext.getOrCreate()
         if sc.getConf().get("spark.master").startswith("spark://"):
             from bigdl.dllib.nncontext import stop_spark_standalone

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -318,7 +318,7 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=2, memory="2g", 
                     ray_args[key] = kwargs[key]
             if init_ray_on_spark:
                 from bigdl.orca.ray import RayContext
-                ray_ctx = RayContext(runtime="spark", cores=cores, num_nodes=num_nodes, 
+                ray_ctx = RayContext(runtime="spark", cores=cores, num_nodes=num_nodes,
                                      sc=sc, **ray_args)
                 driver_cores = 0  # This is the default value.
                 ray_ctx.init(driver_cores=driver_cores)

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -316,10 +316,10 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=2, memory="2g", 
                         "system_config"]:
                 if key in kwargs:
                     ray_args[key] = kwargs[key]
+            from bigdl.orca.ray import RayContext
+            ray_ctx = RayContext(runtime="spark", cores=cores, num_nodes=num_nodes,
+                                 sc=sc, **ray_args)
             if init_ray_on_spark:
-                from bigdl.orca.ray import RayContext
-                ray_ctx = RayContext(runtime="spark", cores=cores, num_nodes=num_nodes,
-                                     sc=sc, **ray_args)
                 driver_cores = 0  # This is the default value.
                 ray_ctx.init(driver_cores=driver_cores)
         return sc
@@ -339,6 +339,11 @@ def stop_orca_context():
     # should do nothing.
     if SparkContext._active_spark_context is not None:
         print("Stopping orca context")
+        ray_ctx = RayContext.get(initialize=False)
+        if ray_ctx.initialized:
+            ray_ctx.stop()
+        else:
+            RayContext._active_ray_context = None
         sc = SparkContext.getOrCreate()
         if sc.getConf().get("spark.master").startswith("spark://"):
             from bigdl.dllib.nncontext import stop_spark_standalone

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -318,8 +318,8 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=2, memory="2g", 
                     ray_args[key] = kwargs[key]
             if init_ray_on_spark:
                 from bigdl.orca.ray import RayContext
-                ray_ctx = RayContext(runtime="spark", cores=cores, num_nodes=num_nodes,
-                                    sc=sc, **ray_args)
+                ray_ctx = RayContext(runtime="spark", cores=cores, num_nodes=num_nodes, 
+                                     sc=sc, **ray_args)
                 driver_cores = 0  # This is the default value.
                 ray_ctx.init(driver_cores=driver_cores)
         return sc


### PR DESCRIPTION
- Set ray context as None which was activated by spark runtime to avoid calling pure ray code when stopping spark orca context.(runtime = "spark")