### PR TITLE
Add manually save/load checkpoint for pytorch pyspark estimator

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -481,14 +481,14 @@ class PyTorchPySparkEstimator(BaseEstimator):
 
     def save_checkpoint(self, model_path):
         from bigdl.dllib.utils.file_utils import is_local_path
-        if is_local_path:
+        if is_local_path(model_path):
             self.save(model_path)
         else:
             self.driver_runner.save_checkpoint(filepath=model_path)
 
     def load_checkpoint(self, model_path):
         from bigdl.dllib.utils.file_utils import is_local_path
-        if is_local_path:
+        if is_local_path(model_path):
             self.load(model_path)
         else:
             self.driver_runner.load_checkpoint(filepath=model_path)

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -484,6 +484,7 @@ class PyTorchPySparkEstimator(BaseEstimator):
         if is_local_path(model_path):
             self.save(model_path)
         else:
+            self.driver_runner.load_state_dict(self.state_dict)
             self.driver_runner.save_checkpoint(filepath=model_path)
 
     def load_checkpoint(self, model_path):

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -479,6 +479,21 @@ class PyTorchPySparkEstimator(BaseEstimator):
         state_dict = torch.load(model_path)
         self.state_dict = state_dict
 
+    def save_checkpoint(self, model_path):
+        from bigdl.dllib.utils.file_utils import is_local_path
+        if is_local_path:
+            self.save(model_path)
+        else:
+            self.driver_runner.save_checkpoint(filepath=model_path)
+
+    def load_checkpoint(self, model_path):
+        from bigdl.dllib.utils.file_utils import is_local_path
+        if is_local_path:
+            self.load(model_path)
+        else:
+            self.driver_runner.load_checkpoint(filepath=model_path)
+            self.state_dict = self.driver_runner.get_state_dict()
+
     def _process_stats(self, worker_stats):
         stats = {
             "num_samples": sum(

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -480,6 +480,13 @@ class PyTorchPySparkEstimator(BaseEstimator):
         self.state_dict = state_dict
 
     def save_checkpoint(self, model_path):
+        """
+        Manually saves the Estimator state (including model and optimizer) to the provided
+        model_path.
+        :param model_path: (str) Path to save the model. Both local and remote path are supported.
+               e.g. "/tmp/estimator.ckpt" or "hdfs:///tmp/estimator.ckpt"
+        :return: None
+        """
         from bigdl.dllib.utils.file_utils import is_local_path
         if is_local_path(model_path):
             self.save(model_path)
@@ -488,6 +495,12 @@ class PyTorchPySparkEstimator(BaseEstimator):
             self.driver_runner.save_checkpoint(filepath=model_path)
 
     def load_checkpoint(self, model_path):
+        """
+        Loads the Estimator state (including model and optimizer) from the provided model_path.
+        :param model_path: (str) Path to the existing model. Both local and remote path are supported.
+               e.g. "/tmp/estimator.ckpt" or "hdfs:///tmp/estimator.ckpt"
+        :return: None
+        """
         from bigdl.dllib.utils.file_utils import is_local_path
         if is_local_path(model_path):
             self.load(model_path)

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -497,8 +497,8 @@ class PyTorchPySparkEstimator(BaseEstimator):
     def load_checkpoint(self, model_path):
         """
         Loads the Estimator state (including model and optimizer) from the provided model_path.
-        :param model_path: (str) Path to the existing model. Both local and remote path are supported.
-               e.g. "/tmp/estimator.ckpt" or "hdfs:///tmp/estimator.ckpt"
+        :param model_path: (str) Path to the existing model. Both local and remote path are
+               supported. e.g. "/tmp/estimator.ckpt" or "hdfs:///tmp/estimator.ckpt"
         :return: None
         """
         from bigdl.dllib.utils.file_utils import is_local_path

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
@@ -458,14 +458,10 @@ class TestPyTorchEstimator(TestCase):
             temp_dir = tempfile.mkdtemp()
             ckpt_file = os.path.join(temp_dir, "manual.ckpt")
             estimator.save_checkpoint(ckpt_file)
-            state_dict1 = estimator.get_state_dict()
-            print(state_dict1)
             estimator.shutdown()
             new_estimator = get_estimator(workers_per_node=2, model_dir=self.model_dir,
                                           log_level=logging.DEBUG)
             new_estimator.load_checkpoint(ckpt_file)
-            state_dict2 = new_estimator.get_state_dict()
-            print(state_dict2)
             eval_after = new_estimator.evaluate(df, batch_size=4,
                                                 feature_cols=["feature"],
                                                 label_cols=["label"])


### PR DESCRIPTION
For using the latest checkpoint to continue training
```python
model_dir = "/tmp/test"  # or remote path like hdfs:///tmp/test 
latest_checkpoint_path = Estimator.latest_checkpoint(model_dir)

new_estimator.load_checkpoint(latest_checkpoint_path)
new_estimator.evaluate()
```
For manually save and load checkpoint:
```python
ckpt_file = os.path.join(temp_dir, "manual.ckpt")
estimator.save_checkpoint(ckpt_file)

new_estimator.load_checkpoint(ckpt_file)
new_estimator.predict()
```