### PR TITLE
Add manually save/load checkpoint for pytorch ray estimator

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -439,8 +439,8 @@ class PyTorchRayEstimator(OrcaRayEstimator):
         """
         Loads the Estimator state (including model and optimizer) from the provided model_path.
 
-        :param model_path: (str) Path to the existing model. Both local and remote path are supported.
-               e.g. "/tmp/estimator.ckpt" or "hdfs:///tmp/estimator.ckpt"
+        :param model_path: (str) Path to the existing model. Both local and remote path are
+               supported. e.g. "/tmp/estimator.ckpt" or "hdfs:///tmp/estimator.ckpt"
         :return: None
         """
         from bigdl.dllib.utils.file_utils import is_local_path

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -417,6 +417,14 @@ class PyTorchRayEstimator(OrcaRayEstimator):
         self.load_state_dict(state_dict)
 
     def save_checkpoint(self, model_path):
+        """
+        Manually saves the Estimator state (including model and optimizer) to the provided
+        model_path.
+
+        :param model_path: (str) Path to save the model. Both local and remote path are supported.
+               e.g. "/tmp/estimator.ckpt" or "hdfs:///tmp/estimator.ckpt"
+        :return: None
+        """
         from bigdl.dllib.utils.file_utils import is_local_path
         if is_local_path(model_path):
             self.save(model_path)
@@ -428,6 +436,13 @@ class PyTorchRayEstimator(OrcaRayEstimator):
             ray.get(results)
 
     def load_checkpoint(self, model_path):
+        """
+        Loads the Estimator state (including model and optimizer) from the provided model_path.
+
+        :param model_path: (str) Path to the existing model. Both local and remote path are supported.
+               e.g. "/tmp/estimator.ckpt" or "hdfs:///tmp/estimator.ckpt"
+        :return: None
+        """
         from bigdl.dllib.utils.file_utils import is_local_path
         if is_local_path(model_path):
             self.load(model_path)

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -418,7 +418,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
 
     def save_checkpoint(self, model_path):
         from bigdl.dllib.utils.file_utils import is_local_path
-        if is_local_path:
+        if is_local_path(model_path):
             self.save(model_path)
         else:
             results = [
@@ -429,7 +429,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
 
     def load_checkpoint(self, model_path):
         from bigdl.dllib.utils.file_utils import is_local_path
-        if is_local_path:
+        if is_local_path(model_path):
             self.load(model_path)
         else:
             results = [

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -422,7 +422,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
             self.save(model_path)
         else:
             results = [
-                worker.save_checkpoint(model_path)
+                worker.save_checkpoint.remote(model_path)
                 for worker in self.remote_workers
             ]
             ray.get(results)
@@ -433,7 +433,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
             self.load(model_path)
         else:
             results = [
-                worker.load_checkpoint(model_path)
+                worker.load_checkpoint.remote(model_path)
                 for worker in self.remote_workers
             ]
             ray.get(results)

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -416,6 +416,28 @@ class PyTorchRayEstimator(OrcaRayEstimator):
         state_dict = torch.load(model_path)
         self.load_state_dict(state_dict)
 
+    def save_checkpoint(self, model_path):
+        from bigdl.dllib.utils.file_utils import is_local_path
+        if is_local_path:
+            self.save(model_path)
+        else:
+            results = [
+                worker.save_checkpoint(model_path)
+                for worker in self.remote_workers
+            ]
+            ray.get(results)
+
+    def load_checkpoint(self, model_path):
+        from bigdl.dllib.utils.file_utils import is_local_path
+        if is_local_path:
+            self.load(model_path)
+        else:
+            results = [
+                worker.load_checkpoint(model_path)
+                for worker in self.remote_workers
+            ]
+            ray.get(results)
+
     def shutdown(self, force=False):
         """
         Shuts down workers and releases resources.

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -45,6 +45,7 @@ from bigdl.orca import OrcaContext
 from bigdl.orca.learn.pytorch.constants import SCHEDULER_STEP, NUM_STEPS
 from bigdl.orca.learn.pytorch.training_operator import TrainingOperator
 from bigdl.orca.learn.pytorch import utils
+from bigdl.orca.learn.pytorch.utils import get_filesystem
 
 try:
     from collections.abc import Iterable
@@ -452,7 +453,6 @@ class TorchRunner:
             f.write(byte_obj)
 
     def load_checkpoint(self, filepath):
-        from utils import get_filesystem
         fs = get_filesystem(filepath)
         if not fs.exists(filepath):
             raise FileNotFoundError(f"Checkpoint at {filepath} not found. Aborting training.")
@@ -465,7 +465,6 @@ class TorchRunner:
             self._remove_checkpoint(filepath)
 
     def _remove_checkpoint(self, filepath):
-        from utils import get_filesystem
         fs = get_filesystem(filepath)
         if fs.exists(filepath):
             fs.rm(filepath, recursive=True)

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -436,6 +436,7 @@ class TorchRunner:
         if self.rank == 0:
             self._save_checkpoint(filepath, save_weights_only)
             self.logger.debug(f"Saved checkpoint: {filepath}")
+        return filepath
 
     def _save_checkpoint(self, filepath, save_weights_only=False):
         import fsspec

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
@@ -493,6 +493,7 @@ class TestPyTorchEstimator(TestCase):
         df = rdd.map(lambda x: (np.random.randn(50).astype(np.float).tolist(),
                                 [int(np.random.randint(0, 2, size=()))])
                      ).toDF(["feature", "label"])
+        df = df.cache()
 
         estimator = get_estimator(workers_per_node=2, log_level=logging.DEBUG)
 
@@ -536,6 +537,7 @@ class TestPyTorchEstimator(TestCase):
         df = rdd.map(lambda x: (np.random.randn(50).astype(np.float).tolist(),
                                 [int(np.random.randint(0, 2, size=()))])
                      ).toDF(["feature", "label"])
+        df = df.cache()
 
         estimator = get_estimator(workers_per_node=2)
         estimator.fit(df, batch_size=4, epochs=epochs,

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
@@ -506,20 +506,59 @@ class TestPyTorchEstimator(TestCase):
                           callbacks=callbacks,
                           feature_cols=["feature"],
                           label_cols=["label"])
-            estimator.evaluate(df, batch_size=4,
-                               feature_cols=["feature"],
-                               label_cols=["label"])
+            eval_before = estimator.evaluate(df, batch_size=4,
+                                             feature_cols=["feature"],
+                                             label_cols=["label"])
             for i in range(epochs):
                 assert os.path.isfile(os.path.join(temp_dir, f"test-epoch={i + 1}.ckpt"))
 
             latest_checkpoint_path = Estimator.latest_checkpoint(temp_dir)
             assert os.path.isfile(latest_checkpoint_path)
-
+            estimator.shutdown()
+            new_estimator = get_estimator(workers_per_node=2, log_level=logging.DEBUG)
+            new_estimator.load_checkpoint(latest_checkpoint_path)
+            eval_after = new_estimator.evaluate(df, batch_size=4,
+                                                feature_cols=["feature"],
+                                                label_cols=["label"])
+            for name, value in eval_before.items():
+                np.testing.assert_almost_equal(value, eval_after[name])
+            res = new_estimator.predict(df, feature_cols=["feature"]).collect()
         finally:
             shutil.rmtree(temp_dir)
 
         with pytest.raises(FileNotFoundError):
             Estimator.latest_checkpoint(temp_dir)
+
+    def test_manual_ckpt(self):
+        sc = OrcaContext.get_spark_context()
+        rdd = sc.range(0, 100)
+        epochs = 2
+        df = rdd.map(lambda x: (np.random.randn(50).astype(np.float).tolist(),
+                                [int(np.random.randint(0, 2, size=()))])
+                     ).toDF(["feature", "label"])
+
+        estimator = get_estimator(workers_per_node=2)
+        estimator.fit(df, batch_size=4, epochs=epochs,
+                      feature_cols=["feature"],
+                      label_cols=["label"])
+        eval_before = estimator.evaluate(df, batch_size=4,
+                                         feature_cols=["feature"],
+                                         label_cols=["label"])
+
+        try:
+            temp_dir = tempfile.mkdtemp()
+            ckpt_file = os.path.join(temp_dir, "manual.ckpt")
+            estimator.save_checkpoint(ckpt_file)
+            estimator.shutdown()
+            new_estimator = get_estimator(workers_per_node=2)
+            new_estimator.load_checkpoint(ckpt_file)
+            eval_after = new_estimator.evaluate(df, batch_size=4,
+                                                feature_cols=["feature"],
+                                                label_cols=["label"])
+            for name, value in eval_before.items():
+                np.testing.assert_almost_equal(value, eval_after[name])
+        finally:
+            shutil.rmtree(temp_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For using the latest checkpoint to continue training
```python
model_dir = "/tmp/test"  # or remote path like hdfs:///tmp/test 
latest_checkpoint_path = Estimator.latest_checkpoint(model_dir)

new_estimator.load_checkpoint(latest_checkpoint_path)
new_estimator.evaluate()
```
For manually save and load checkpoint:
```python
ckpt_file = os.path.join(temp_dir, "manual.ckpt")
estimator.save_checkpoint(ckpt_file)

new_estimator.load_checkpoint(ckpt_file)
new_estimator.predict()
```