### PR TITLE
[PPML] Fix Occlum Epc Conflict

### DIFF
--- a/ppml/trusted-big-data-ml/scala/docker-occlum/run_spark_on_occlum_glibc.sh
+++ b/ppml/trusted-big-data-ml/scala/docker-occlum/run_spark_on_occlum_glibc.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -x
-export SGX_MEM_SIZE=64GB
 
 BLUE='\033[1;34m'
 NC='\033[0m'

--- a/ppml/trusted-big-data-ml/scala/docker-occlum/start-spark-local.sh
+++ b/ppml/trusted-big-data-ml/scala/docker-occlum/start-spark-local.sh
@@ -9,7 +9,7 @@ sudo docker run -it \
 	--device=/dev/sgx/enclave \
 	--device=/dev/sgx/provision \
 	-v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
-    -v data:/opt/occlum_spark/data \
+	-v data:/opt/occlum_spark/data \
 	-e LOCAL_IP=$LOCAL_IP \
 	-e SGX_MEM_SIZE=24GB \
 	intelanalytics/bigdl-ppml-trusted-big-data-ml-scala-occlum:0.14.0-SNAPSHOT \


### PR DESCRIPTION
* Delete `export SGX_MEM_SIZE=64GB` in `run_spark_on_occlum_glibc.sh`.
* Update space to tab in `start-spark-local/sh`.