### PR TITLE
Resolve inc metric duplicate registration

### DIFF
--- a/python/nano/src/bigdl/nano/quantization/neural_compressor/metric/base_metric.py
+++ b/python/nano/src/bigdl/nano/quantization/neural_compressor/metric/base_metric.py
@@ -17,6 +17,8 @@ from abc import ABC, abstractmethod
 
 
 class INCMetric(ABC):
+    METRIC_ID = 0
+
     def __init__(self):
         self.pred_list = []
         self.label_list = []
@@ -55,3 +57,8 @@ class INCMetric(ABC):
     @abstractmethod
     def to_scalar(self, tensor):
         pass
+
+    @staticmethod
+    def get_next_metric_id():
+        INCMetric.METRIC_ID += 1
+        return INCMetric.METRIC_ID

--- a/python/nano/src/bigdl/nano/quantization/neural_compressor/quantization.py
+++ b/python/nano/src/bigdl/nano/quantization/neural_compressor/quantization.py
@@ -96,9 +96,11 @@ class QuantizationINC(Quantization):
                         to the new local class to avoid that.
                         """
                         self.metric = metric
+
                 self.metric = Metric(
                     MyMetric,
-                    name=f"nano_metric_{framework_metric.get_next_metric_id()}"
+                    name=f"{framework}_{type(metric).__name__}_"
+                         f"{framework_metric.get_next_metric_id()}"
                 )
 
         quantized = self()

--- a/python/nano/src/bigdl/nano/quantization/neural_compressor/quantization.py
+++ b/python/nano/src/bigdl/nano/quantization/neural_compressor/quantization.py
@@ -96,10 +96,9 @@ class QuantizationINC(Quantization):
                         to the new local class to avoid that.
                         """
                         self.metric = metric
-
                 self.metric = Metric(
                     MyMetric,
-                    name="%s_%s" % (framework_metric.__name__, type(metric).__name__)
+                    name=f"nano_metric_{framework_metric.get_next_metric_id()}"
                 )
 
         quantized = self()


### PR DESCRIPTION
resolves https://github.com/intel-analytics/BigDL/issues/4002
In previous implementation, each call of quantization, a metric will be registered.  
This causes error when we call quantization with a same metric in one script twice.

### previous implementation :
Each metric is registered at runtime, so there can be name conflict.
```python
  self.metric = Metric(
      MyMetric,
      name="%s_%s" % (framework_metric.__name__, type(metric).__name__)
  )
```
### After this fix:
Customized metrics firstly are registered once for all statically.
```python
METRICS('pytorch').register('PytorchINCMetric', PytorchINCMetric)
METRICS('tensorflow').register('TensorflowINCMetric', TensorflowINCMetric)
```
Then at runtime, we modify the real metric inside `INCMetric` by:
```python
PytorchINCMetric.set_metric(metric)
```
And fetch the registered metric by class name:
```python
self.cfg.evaluation.accuracy.metric = {PytorchINCMetric.__name__: None}
```

### Modifications

- [x]  Add default criterion to INC, allowing 0.99 acc drop by default
- [x]  Fix metric registered in second time
- [x]  Add test with metric assigned second time
