### PR TITLE
Chronos: Add customized metrics' support to AutoTSEstimator & AutoModels' `fit` interface

### DIFF
--- a/python/chronos/src/bigdl/chronos/autots/autotsestimator.py
+++ b/python/chronos/src/bigdl/chronos/autots/autotsestimator.py
@@ -49,6 +49,7 @@ class AutoTSEstimator:
                  model="lstm",
                  search_space=dict(),
                  metric="mse",
+                 metric_mode=None,
                  loss=None,
                  optimizer="Adam",
                  past_seq_len='auto',
@@ -85,7 +86,14 @@ class AutoTSEstimator:
                parameter. search_space should contain those parameters other than the keyword
                arguments in this constructor in its key. If a 3rd parth model is used, then you
                must set search_space to a dict.
-        :param metric: String. The evaluation metric name to optimize. e.g. "mse"
+        :param metric: String or customized evaluation metric function.
+            If string, metric is the evaluation metric name to optimize, e.g. "mse".
+            If callable function, it signature should be func(y_true, y_pred), where y_true and
+            y_pred are numpy ndarray. The function should return a float value as evaluation result.
+        :param metric_mode: One of ["min", "max"]. "max" means greater metric value is better.
+            You have to specify metric_mode if you use a customized metric function.
+            You don't have to specify metric_mode if you use the built-in metric in
+            bigdl.orca.automl.metrics.Evaluator.
         :param loss: String or pytorch/tf.keras loss instance or pytorch loss creator function. The
                default loss function for pytorch backend is nn.MSELoss().
         :param optimizer: String or pyTorch optimizer creator function or
@@ -142,6 +150,7 @@ class AutoTSEstimator:
                                                   resources_per_trial={"cpu": cpus_per_trial},
                                                   name=name)
             self.metric = metric
+            self.metric_mode = metric_mode
             search_space.update({"past_seq_len": past_seq_len,
                                  "future_seq_len": future_seq_len,
                                  "input_feature_num": input_feature_num,
@@ -157,6 +166,7 @@ class AutoTSEstimator:
                                  "output_target_num": output_target_num,
                                  "loss": loss,
                                  "metric": metric,
+                                 "metric_mode": metric_mode,
                                  "optimizer": optimizer,
                                  "backend": backend,
                                  "logs_dir": logs_dir,
@@ -237,6 +247,7 @@ class AutoTSEstimator:
                 epochs=epochs,
                 validation_data=val_d,
                 metric=self.metric,
+                metric_mode=self.metric_mode,
                 metric_threshold=metric_threshold,
                 n_sampling=n_sampling,
                 search_space=self.search_space,

--- a/python/chronos/src/bigdl/chronos/autots/model/auto_lstm.py
+++ b/python/chronos/src/bigdl/chronos/autots/model/auto_lstm.py
@@ -28,6 +28,7 @@ class AutoLSTM(BasePytorchAutomodel):
                  optimizer,
                  loss,
                  metric,
+                 metric_mode=None,
                  hidden_dim=32,
                  layer_num=1,
                  lr=0.001,
@@ -48,7 +49,14 @@ class AutoLSTM(BasePytorchAutomodel):
         :param optimizer: String or pyTorch optimizer creator function or
                tf.keras optimizer instance.
         :param loss: String or pytorch/tf.keras loss instance or pytorch loss creator function.
-        :param metric: String. The evaluation metric name to optimize. e.g. "mse"
+        :param metric: String or customized evaluation metric function.
+            If string, metric is the evaluation metric name to optimize, e.g. "mse".
+            If callable function, it signature should be func(y_true, y_pred), where y_true and
+            y_pred are numpy ndarray. The function should return a float value as evaluation result.
+        :param metric_mode: One of ["min", "max"]. "max" means greater metric value is better.
+            You have to specify metric_mode if you use a customized metric function.
+            You don't have to specify metric_mode if you use the built-in metric in
+            bigdl.orca.automl.metrics.Evaluator.
         :param hidden_dim: Int or hp sampling function from an integer space. The number of features
                in the hidden state `h`. For hp sampling, see bigdl.chronos.orca.automl.hp for more
                details. e.g. hp.grid_search([32, 64]).
@@ -81,6 +89,7 @@ class AutoLSTM(BasePytorchAutomodel):
             future_seq_len=1
         )
         self.metric = metric
+        self.metric_mode = metric_mode
         model_builder = PytorchModelBuilder(model_creator=model_creator,
                                             optimizer_creator=optimizer,
                                             loss_creator=loss,

--- a/python/chronos/src/bigdl/chronos/autots/model/auto_seq2seq.py
+++ b/python/chronos/src/bigdl/chronos/autots/model/auto_seq2seq.py
@@ -29,6 +29,7 @@ class AutoSeq2Seq(BasePytorchAutomodel):
                  optimizer,
                  loss,
                  metric,
+                 metric_mode=None,
                  lr=0.001,
                  lstm_hidden_dim=128,
                  lstm_layer_num=2,
@@ -50,7 +51,14 @@ class AutoSeq2Seq(BasePytorchAutomodel):
         :param optimizer: String or pyTorch optimizer creator function or
                tf.keras optimizer instance.
         :param loss: String or pytorch/tf.keras loss instance or pytorch loss creator function.
-        :param metric: String. The evaluation metric name to optimize. e.g. "mse"
+        :param metric: String or customized evaluation metric function.
+            If string, metric is the evaluation metric name to optimize, e.g. "mse".
+            If callable function, it signature should be func(y_true, y_pred), where y_true and
+            y_pred are numpy ndarray. The function should return a float value as evaluation result.
+        :param metric_mode: One of ["min", "max"]. "max" means greater metric value is better.
+            You have to specify metric_mode if you use a customized metric function.
+            You don't have to specify metric_mode if you use the built-in metric in
+            bigdl.orca.automl.metrics.Evaluator.
         :param lr: float or hp sampling function from a float space. Learning rate.
                e.g. hp.choice([0.001, 0.003, 0.01])
         :param lstm_hidden_dim: LSTM hidden channel for decoder and encoder.
@@ -87,6 +95,7 @@ class AutoSeq2Seq(BasePytorchAutomodel):
             teacher_forcing=teacher_forcing
         )
         self.metric = metric
+        self.metric_mode = metric_mode
         model_builder = PytorchModelBuilder(model_creator=model_creator,
                                             optimizer_creator=optimizer,
                                             loss_creator=loss,

--- a/python/chronos/src/bigdl/chronos/autots/model/auto_tcn.py
+++ b/python/chronos/src/bigdl/chronos/autots/model/auto_tcn.py
@@ -29,6 +29,7 @@ class AutoTCN(BasePytorchAutomodel):
                  optimizer,
                  loss,
                  metric,
+                 metric_mode=None,
                  hidden_units=None,
                  levels=None,
                  num_channels=None,
@@ -51,7 +52,14 @@ class AutoTCN(BasePytorchAutomodel):
         :param optimizer: String or pyTorch optimizer creator function or
                tf.keras optimizer instance.
         :param loss: String or pytorch/tf.keras loss instance or pytorch loss creator function.
-        :param metric: String. The evaluation metric name to optimize. e.g. "mse"
+        :param metric: String or customized evaluation metric function.
+            If string, metric is the evaluation metric name to optimize, e.g. "mse".
+            If callable function, it signature should be func(y_true, y_pred), where y_true and
+            y_pred are numpy ndarray. The function should return a float value as evaluation result.
+        :param metric_mode: One of ["min", "max"]. "max" means greater metric value is better.
+            You have to specify metric_mode if you use a customized metric function.
+            You don't have to specify metric_mode if you use the built-in metric in
+            bigdl.orca.automl.metrics.Evaluator.
         :param hidden_units: Int or hp sampling function from an integer space. The number of hidden
                units or filters for each convolutional layer. It is similar to `units` for LSTM.
                It defaults to 30. We will omit the hidden_units value if num_channels is specified.
@@ -96,6 +104,7 @@ class AutoTCN(BasePytorchAutomodel):
             dropout=dropout,
         )
         self.metric = metric
+        self.metric_mode = metric_mode
         model_builder = PytorchModelBuilder(model_creator=model_creator,
                                             optimizer_creator=optimizer,
                                             loss_creator=loss,

--- a/python/chronos/src/bigdl/chronos/autots/model/base_automodel.py
+++ b/python/chronos/src/bigdl/chronos/autots/model/base_automodel.py
@@ -74,6 +74,7 @@ class BasePytorchAutomodel:
             epochs=epochs,
             validation_data=validation_data,
             metric=self.metric,
+            metric_mode=self.metric_mode,
             metric_threshold=metric_threshold,
             n_sampling=n_sampling,
             search_space=self.search_space,


### PR DESCRIPTION
This PR will:
add support to `__init__`(`fit`) interface of `AutoTSEstimator`, `AutoLSTM`, `AutoTCN`, `AutoSeq2seq`.
Next PR will:
add support of customized metric to `chronos.metric` and support all `evaluate` and `evaluate_with_onnx` interface as well as `AutoProphet` and `AutoARIMA`