### PR TITLE
Add method to get quantized model size

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/runtime_binding/quantization_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/runtime_binding/quantization_inference.py
@@ -16,7 +16,11 @@
 
 import warnings
 from functools import partial
+from io import BytesIO
+
+import torch
 from bigdl.nano.pytorch.lightning import LightningModuleFromTorch
+from pytorch_lightning import LightningModule
 
 QUANTIZATION_BINDED_COMPONENTS = ['_quantized_model',
                                   '_quantized_model_up_to_date',
@@ -55,6 +59,27 @@ def _fx_quantize_eval(self, quantize=False):
 def quantized_state_dict(self):
     if self._quantized_model_up_to_date:
         return self._quantized_model.state_dict()
+    else:
+        raise RuntimeError("Please call trainer.quantize again since the quantized model is"
+                           " not up-to-date.")
+
+
+def quantized_model_size(self):
+    if self._quantized_model_up_to_date:
+        """
+        This part is from https://github.com/PyTorchLightning/pytorch-lightning/blob
+        /master/pytorch_lightning/utilities/memory.py
+        Calculates the size of a Module in megabytes.
+        The computation includes everything in the :meth:`~torch.nn.Module.state_dict`,
+        i.e., by default the parameters and buffers.
+        Returns:
+            Number of megabytes in the parameters of the input module.
+        """
+        # TODO when pytorch-lightning is upgraded to 1.5, we can refactor this part
+        model_size = BytesIO()
+        torch.save(self._quantized_model.state_dict(), model_size)
+        size_mb = model_size.getbuffer().nbytes / 1e6
+        return size_mb
     else:
         raise RuntimeError("Please call trainer.quantize again since the quantized model is"
                            " not up-to-date.")
@@ -105,6 +130,7 @@ def bind_quantize_methods(pl_model, q_model):
     pl_model._fx_quantize_on_train = partial(_fx_quantize_on_train, pl_model)
     pl_model._fx_quantize_on_fit_start = partial(_fx_quantize_on_fit_start, pl_model)
     pl_model.quantized_state_dict = partial(quantized_state_dict, pl_model)
+    pl_model.quantized_model_size = partial(quantized_model_size, pl_model)
     pl_model.load_quantized_state_dict = partial(load_quantized_state_dict, pl_model)
     pl_model.on_save_checkpoint = partial(on_save_checkpoint, pl_model)
 

--- a/python/nano/test/pytorch/tests/test_quantize_inference.py
+++ b/python/nano/test/pytorch/tests/test_quantize_inference.py
@@ -64,7 +64,7 @@ class LitResNet18(LightningModule):
         y_hat = self(batch[0])
         loss = self.loss(y_hat, batch[1])
         return loss
-    
+
     def configure_optimizers(self):
         return torch.optim.Adam(self.parameters())
 
@@ -120,3 +120,11 @@ class TestQuantizeInference(TestCase):
         model = trainer.quantize(model, train_loader)
         trainer.save_checkpoint("example.ckpt")
         model_load = LitResNet18.load_from_checkpoint("example.ckpt", num_classes=10)
+
+    def test_quantized_model_size(self):
+        model = LitResNet18(10, pretrained=False, include_top=False, freeze=True)
+        trainer = Trainer(max_epochs=1)
+        train_loader = create_data_loader(data_dir, batch_size,
+                                          num_workers, data_transform, subset=200)
+        model = trainer.quantize(model, train_loader)
+        assert model.model_size > model.quantized_model_size()


### PR DESCRIPTION
This is a entry to get the quantized model size similar to https://github.com/PyTorchLightning/pytorch-lightning/blob/release/1.4.x/pytorch_lightning/core/lightning.py#L1982-L1993.  

This function should be removed in Pytorch-Lightning v1.7 and replaced by `get_model_size_mb(model)` from v1.5.