### PR TITLE
fix convert scalar to float64 error

### DIFF
--- a/python/dllib/src/bigdl/dllib/utils/utils.py
+++ b/python/dllib/src/bigdl/dllib/utils/utils.py
@@ -185,7 +185,7 @@ def convert_row_to_numpy(row, schema, feature_cols, label_cols, accept_str_col=F
                 if isinstance(feature_type, df_types.FloatType):
                     result.append(np.array(row[name]).astype(np.float32))
                 elif isinstance(feature_type, df_types.IntegerType):
-                    result.append(np.array(row[name]).astype(np.int32))  
+                    result.append(np.array(row[name]).astype(np.int32))
                 else:
                     result.append(np.array(row[name]))
             elif isinstance(feature_type, df_types.ArrayType):

--- a/python/dllib/src/bigdl/dllib/utils/utils.py
+++ b/python/dllib/src/bigdl/dllib/utils/utils.py
@@ -182,7 +182,11 @@ def convert_row_to_numpy(row, schema, feature_cols, label_cols, accept_str_col=F
         for name in cols:
             feature_type = schema[name].dataType
             if _is_scalar_type(feature_type, accept_str_col):
-                result.append(np.array(row[name]).astype(np.float32))
+                if isinstance(feature_type, df_types.FloatType):
+                    result.append(np.array(row[name]).astype(np.float32))    
+                elif isinstance(feature_type, df_types.IntegerType):
+                    result.append(np.array(row[name]).astype(np.int32))    
+                else: result.append(np.array(row[name]))
             elif isinstance(feature_type, df_types.ArrayType):
                 result.append(np.array(row[name]).astype(np.float32))
             elif isinstance(row[name], DenseVector):

--- a/python/dllib/src/bigdl/dllib/utils/utils.py
+++ b/python/dllib/src/bigdl/dllib/utils/utils.py
@@ -186,7 +186,8 @@ def convert_row_to_numpy(row, schema, feature_cols, label_cols, accept_str_col=F
                     result.append(np.array(row[name]).astype(np.float32))    
                 elif isinstance(feature_type, df_types.IntegerType):
                     result.append(np.array(row[name]).astype(np.int32))    
-                else: result.append(np.array(row[name]))
+                else: 
+                    result.append(np.array(row[name]))
             elif isinstance(feature_type, df_types.ArrayType):
                 result.append(np.array(row[name]).astype(np.float32))
             elif isinstance(row[name], DenseVector):

--- a/python/dllib/src/bigdl/dllib/utils/utils.py
+++ b/python/dllib/src/bigdl/dllib/utils/utils.py
@@ -182,7 +182,7 @@ def convert_row_to_numpy(row, schema, feature_cols, label_cols, accept_str_col=F
         for name in cols:
             feature_type = schema[name].dataType
             if _is_scalar_type(feature_type, accept_str_col):
-                result.append(np.array(row[name]))
+                result.append(np.array(row[name]).astype(np.float32))
             elif isinstance(feature_type, df_types.ArrayType):
                 result.append(np.array(row[name]).astype(np.float32))
             elif isinstance(row[name], DenseVector):

--- a/python/dllib/src/bigdl/dllib/utils/utils.py
+++ b/python/dllib/src/bigdl/dllib/utils/utils.py
@@ -183,10 +183,10 @@ def convert_row_to_numpy(row, schema, feature_cols, label_cols, accept_str_col=F
             feature_type = schema[name].dataType
             if _is_scalar_type(feature_type, accept_str_col):
                 if isinstance(feature_type, df_types.FloatType):
-                    result.append(np.array(row[name]).astype(np.float32))    
+                    result.append(np.array(row[name]).astype(np.float32))
                 elif isinstance(feature_type, df_types.IntegerType):
-                    result.append(np.array(row[name]).astype(np.int32))    
-                else: 
+                    result.append(np.array(row[name]).astype(np.int32))  
+                else:
                     result.append(np.array(row[name]))
             elif isinstance(feature_type, df_types.ArrayType):
                 result.append(np.array(row[name]).astype(np.float32))


### PR DESCRIPTION
if the input data is of any type of pyspark datatype, it will be convert to numpy.float64, which is conflict with that of torch.float32 if the input data is label. 