### PR TITLE
Nano: Onnxruntime/pytorch default quantize and accumulated enhancement

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -567,4 +567,4 @@ class BasePytorchForecaster(Forecaster):
                                               accuracy_criterion=accuracy_criterion,
                                               timeout=timeout,
                                               max_trials=max_trials,
-                                              raw_return=False)
+                                              return_pl=True)

--- a/python/nano/src/bigdl/nano/pytorch/lightning.py
+++ b/python/nano/src/bigdl/nano/pytorch/lightning.py
@@ -46,7 +46,7 @@ class LightningModuleFromTorch(LightningModule):
     def _forward(self, batch):
         # Handle different numbers of input for various models
         nargs = self.model.forward.__code__.co_argcount
-        return self.model(*(batch[:nargs - 1]))
+        return self(*(batch[:nargs - 1]))
 
     def training_step(self, batch, batch_idx):
         y_hat = self._forward(batch)

--- a/python/nano/src/bigdl/nano/pytorch/runtime_binding/base_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/runtime_binding/base_inference.py
@@ -140,7 +140,7 @@ def inference(self,
             return yhat
     else:
         # inference w/o onnxruntime (fallback to pytorch native forward)
-        quantize = self._default_inference_quantize if quantize is None else quantize
+        quantize = quantize if quantize is not None else self._default_inference_quantize
         self.eval(quantize=quantize)
         with torch.no_grad():
             yhat_list = []

--- a/python/nano/src/bigdl/nano/pytorch/runtime_binding/base_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/runtime_binding/base_inference.py
@@ -166,6 +166,7 @@ def bind_base_inference_rt_methods(pl_model):
     pl_model._train_old = pl_model.train
     pl_model._torch_forward = pl_model.forward
     pl_model._eval_old = pl_model.eval
+    pl_model._default_inference_quantize = False
 
     pl_model.eval = partial(eval, pl_model)
     pl_model.on_fit_start = partial(on_fit_start, pl_model)

--- a/python/nano/src/bigdl/nano/pytorch/runtime_binding/onnxrt_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/runtime_binding/onnxrt_inference.py
@@ -239,6 +239,7 @@ def bind_onnxrt_methods(pl_model: LightningModule, q_onnx_model=None, sess_optio
     # additional attributes
     pl_model._ortsess_up_to_date = False  # indicate if we need to build ortsess again
     pl_model._ortsess = None  # ortsess instance
+    pl_model._default_ortsess_inference_quantize = False
     pl_model._onnx_graph = None  # onnx graph for quantization
     if isinstance(pl_model, LightningModuleFromTorch):  # forward param list for compiled model
         pl_model._forward_args = inspect.getfullargspec(pl_model.model.forward).args[1:]

--- a/python/nano/src/bigdl/nano/pytorch/runtime_binding/quantization_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/runtime_binding/quantization_inference.py
@@ -102,7 +102,10 @@ def bind_quantize_methods(pl_model, q_model):
 
     pl_model._quantized_model = q_model
     pl_model._quantized_model_up_to_date = True
-    pl_model._default_inference_quantize = True
+    if q_model:
+        pl_model._default_inference_quantize = True
+    else:
+        pl_model._default_inference_quantize = False
     pl_model._forward_fx_quantize = partial(_forward_fx_quantize, pl_model)
     pl_model._fx_quantize_eval = partial(_fx_quantize_eval, pl_model)
     pl_model._fx_quantize_on_train = partial(_fx_quantize_on_train, pl_model)

--- a/python/nano/src/bigdl/nano/pytorch/runtime_binding/quantization_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/runtime_binding/quantization_inference.py
@@ -26,6 +26,7 @@ QUANTIZATION_BINDED_COMPONENTS = ['_quantized_model',
 
 
 def _forward_fx_quantize(self, *args):
+    print("DDDDDDDDDDDDDDDDDDDDDDD I AM CALLED _forward_fx_quantize")
     return self._quantized_model(*args)
 
 

--- a/python/nano/src/bigdl/nano/pytorch/runtime_binding/quantization_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/runtime_binding/quantization_inference.py
@@ -26,7 +26,6 @@ QUANTIZATION_BINDED_COMPONENTS = ['_quantized_model',
 
 
 def _forward_fx_quantize(self, *args):
-    print("DDDDDDDDDDDDDDDDDDDDDDD I AM CALLED _forward_fx_quantize")
     return self._quantized_model(*args)
 
 

--- a/python/nano/src/bigdl/nano/pytorch/runtime_binding/quantization_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/runtime_binding/quantization_inference.py
@@ -31,12 +31,14 @@ def _forward_fx_quantize(self, *args):
 
 def _fx_quantize_on_train(self, mode=True):
     self._quantized_model_up_to_date = False
+    self._default_inference_quantize = False
     self._quantized_model = None
     self.forward = self._torch_forward
 
 
 def _fx_quantize_on_fit_start(self):
     self._quantized_model_up_to_date = False
+    self._default_inference_quantize = False
     self._quantized_model = None
     self.forward = self._torch_forward
 
@@ -100,6 +102,7 @@ def bind_quantize_methods(pl_model, q_model):
 
     pl_model._quantized_model = q_model
     pl_model._quantized_model_up_to_date = True
+    pl_model._default_inference_quantize = True
     pl_model._forward_fx_quantize = partial(_forward_fx_quantize, pl_model)
     pl_model._fx_quantize_eval = partial(_fx_quantize_eval, pl_model)
     pl_model._fx_quantize_on_train = partial(_fx_quantize_on_train, pl_model)

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -179,7 +179,7 @@ class Trainer(pl.Trainer):
                  accuracy_criterion: dict = None,
                  timeout=0,
                  max_trials=1,
-                 raw_return=False
+                 return_pl=True
                  ):
         """
         Calibrate a Pytorch-Lightning model for post-training quantization.
@@ -211,7 +211,7 @@ class Trainer(pl.Trainer):
                             Combine with timeout field to decide when to exit.
                             "timeout=0, max_trials=1" means it will try quantization only once and
                             return satisfying best model.
-        :param raw_return:  Decide which type to return. If set to True, a GraphModule will be
+        :param return_pl:   Decide which type to return. If set to True, a GraphModule will be
                             returned. If set to False, a pytorch lightning module will be returned.
         :return:            A GraphModule. If there is no model found, return None.
         """
@@ -277,7 +277,7 @@ class Trainer(pl.Trainer):
                         model = pl_model._onnx_graph
                 quantized_models.append(quantizer.post_training_quantize(model, calib_dataloader,
                                                                          val_dataloader, metric))
-            if raw_return:
+            if not return_pl:
                 if len(quantized_models) == 1:
                     return quantized_models[0].model
                 else:

--- a/python/nano/test/pytorch/tests/test_onnx.py
+++ b/python/nano/test/pytorch/tests/test_onnx.py
@@ -162,7 +162,7 @@ class TestOnnx(TestCase):
             np.testing.assert_almost_equal(onnx_res, forward_res, decimal=5)  # same result
 
         # quantization with tunning
-        pl_model.eval()
+        pl_model.eval(quantize=False)
         pl_model = trainer.quantize(pl_model,
                                     calib_dataloader=train_loader,
                                     val_dataloader=train_loader,
@@ -174,7 +174,7 @@ class TestOnnx(TestCase):
         assert pl_model._quantized_model_up_to_date is True
         for x, y in train_loader:
             onnx_res = pl_model.inference(x, backend="onnx", quantize=True).numpy()
-            pl_model.eval_onnx(quantize=True)
+            pl_model.eval_onnx()
             forward_res = pl_model(x).numpy()
             np.testing.assert_almost_equal(onnx_res, forward_res, decimal=5)  # same result
 

--- a/python/nano/test/pytorch/tests/test_quantize_inference.py
+++ b/python/nano/test/pytorch/tests/test_quantize_inference.py
@@ -27,7 +27,8 @@ from pytorch_lightning import LightningModule
 
 import numpy as np
 
-from test.pytorch.utils._train_torch_lightning import create_data_loader, data_transform
+from test.pytorch.utils._train_torch_lightning import create_data_loader, data_transform,\
+    create_test_data_loader, test_data_transform
 from bigdl.nano.pytorch.trainer import Trainer
 from bigdl.nano.pytorch.vision.models import vision
 
@@ -80,8 +81,10 @@ class TestQuantizeInference(TestCase):
         pl_model = Trainer.compile(model, loss, optimizer)
         train_loader = create_data_loader(data_dir, batch_size, \
                                           num_workers, data_transform, subset=200)
-        trainer.fit(pl_model, train_loader)
-        nonquantized_loss = trainer.test(pl_model, train_loader)  # fp32
+        test_loader = create_test_data_loader(data_dir, batch_size, \
+                                              num_workers, test_data_transform, subset=200)
+        trainer.fit(pl_model, test_loader)
+        nonquantized_loss = trainer.test(pl_model, test_loader)  # fp32
         assert pl_model._default_inference_quantize is False
         pl_model = trainer.quantize(pl_model, train_loader)
 
@@ -94,7 +97,7 @@ class TestQuantizeInference(TestCase):
             np.testing.assert_almost_equal(quantized_res, forward_res, decimal=5)  # same result
 
         assert pl_model._default_inference_quantize is True
-        quantized_loss = trainer.test(pl_model, train_loader)  # quantized
+        quantized_loss = trainer.test(pl_model, test_loader)  # quantized
         print(nonquantized_loss[0]['test/loss'], quantized_loss[0]['test/loss'])
         assert abs(nonquantized_loss[0]['test/loss'] - quantized_loss[0]['test/loss']) > 1e-5
 

--- a/python/nano/test/pytorch/utils/_train_torch_lightning.py
+++ b/python/nano/test/pytorch/utils/_train_torch_lightning.py
@@ -36,6 +36,13 @@ data_transform = transforms.Compose([
     transforms.ToTensor()
 ])
 
+test_data_transform = transforms.Compose([
+    transforms.Resize(256),
+    transforms.ColorJitter(),
+    transforms.Resize(128),
+    transforms.ToTensor()
+])
+
 
 class Net(ImageClassifier):
     # Common case: fully-connected top layer
@@ -55,6 +62,20 @@ def create_data_loader(dir, batch_size, num_workers, transform, subset=50):
     mask = list(range(0, len(train_set), subset))
     train_subset = torch.utils.data.Subset(train_set, mask)
     data_loader = DataLoader(train_subset, batch_size=batch_size, shuffle=True,
+                             num_workers=num_workers)
+    return data_loader
+
+
+def create_test_data_loader(dir, batch_size, num_workers, transform, subset=50):
+    '''
+    This function is to create a fixed dataset without any randomness
+    '''
+    train_set = CIFAR10(root=dir, train=False,
+                        download=True, transform=transform)
+    # `subset` is the number of subsets. The larger the number, the smaller the training set.
+    mask = list(range(0, len(train_set), subset))
+    train_subset = torch.utils.data.Subset(train_set, mask)
+    data_loader = DataLoader(train_subset, batch_size=batch_size, shuffle=False,
                              num_workers=num_workers)
     return data_loader
 


### PR DESCRIPTION
This PR is to support `trainer.test` for our examples

1. support(and test `trainer.test` works for quantized model)
2. change `raw_return` to `return_pl` for better understanding
3. Now, quantized model is the default model right after the calling of `trainer.quantize`, here is an example:
```python
# ...
# training process

# defaultly using quantized model
model = trainer.quantize(model, dataloader, ...)
model.eval()  
with torch.no_grad():
    model(x)  # quantized model

# explicitly call quantize=False for fp32 model
model.eval(quantize=False)  
with torch.no_grad():
    model(x)  # fp32 model

# defaultly using fp32 model
trainer.fit(model, data)
model.eval()  
with torch.no_grad():
    model(x)  # fp32 model

```