### PR TITLE
Kubernetes cluster api nncontext/init_orca_context (main br)

### DIFF
--- a/python/dllib/src/bigdl/dllib/nncontext.py
+++ b/python/dllib/src/bigdl/dllib/nncontext.py
@@ -347,6 +347,74 @@ def init_spark_on_k8s(master,
     return sc
 
 
+def init_spark_on_k8s_cluster(master,
+                              container_image,
+                              num_executors,
+                              executor_cores,
+                              executor_memory="2g",
+                              driver_memory="1g",
+                              driver_cores=4,
+                              extra_executor_memory_for_ray=None,
+                              extra_python_lib=None,
+                              penv_archive=None,
+                              spark_log_level="WARN",
+                              redirect_spark_log=True,
+                              jars=None,
+                              conf=None,
+                              python_location=None):
+    """
+    Create a SparkContext with BigDL configurations on Kubernetes cluster for k8s cluster
+    mode. You are recommended to use the Docker image intelanalytics/bigdl-k8s:latest.
+    You can refer to https://github.com/intel-analytics/BigDL/tree/branch-2.0/docker/bigdl-k8s
+    to build your own Docker image.
+    :param master: The master address of your k8s cluster.
+    :param container_image: The name of the docker container image for Spark executors.
+           For example, intelanalytics/bigdl-k8s:latest
+    :param executor_cores: The number of cores for each executor.
+    :param executor_memory: The memory for each executor. Default to be '2g'.
+    :param driver_cores: The number of cores for the Spark driver. Default to be 4.
+    :param driver_memory: The memory for the Spark driver. Default to be '1g'.
+    :param extra_executor_memory_for_ray: The extra memory for Ray services. Default to be None.
+    :param extra_python_lib: Extra python files or packages needed for distribution.
+           Default to be None.
+    :param penv_archive: the path to a packed conda file in "tar.gz" format here. The path should be
+           that k8s pod can access.
+           Default to be None.
+    :param spark_log_level: The log level for Spark. Default to be 'WARN'.
+    :param redirect_spark_log: Whether to redirect the Spark log to local file. Default to be True.
+    :param jars: Comma-separated list of jars to be included on driver and executor's classpath.
+           Default to be None.
+    :param conf: You can append extra conf for Spark in key-value format.
+           i.e conf={"spark.executor.extraJavaOptions": "-XX:+PrintGCDetails"}.
+           Default to be None.
+    :param python_location: The path to your running Python executable. If not specified, the
+           default Python interpreter in effect would be used.
+    :return: An instance of SparkContext.
+    """
+    if os.environ.get("onDriver", "False") == "True":
+        sc = init_internal_nncontext()
+        return sc
+    else:
+        from bigdl.dllib.utils.spark import SparkRunner
+        runner = SparkRunner(spark_log_level=spark_log_level,
+                             redirect_spark_log=redirect_spark_log)
+        return_value = runner.init_spark_on_k8s_cluster(
+            master=master,
+            container_image=container_image,
+            num_executors=num_executors,
+            executor_cores=executor_cores,
+            executor_memory=executor_memory,
+            driver_memory=driver_memory,
+            driver_cores=driver_cores,
+            extra_executor_memory_for_ray=extra_executor_memory_for_ray,
+            extra_python_lib=extra_python_lib,
+            penv_archive=penv_archive,
+            jars=jars,
+            conf=conf,
+            python_location=python_location)
+        sys.exit(return_value)
+
+
 def stop_spark_standalone():
     """
     Stop the Spark standalone cluster created from init_spark_standalone (master not specified).
@@ -508,24 +576,30 @@ def init_nncontext(conf=None, cluster_mode="spark-submit", spark_log_level="WARN
                                             executor_memory=memory,
                                             conf=spark_args)
     elif cluster_mode.startswith("k8s"):  # k8s or k8s-client
-        if cluster_mode == "k8s-cluster":
-            raise ValueError('For k8s-cluster mode, please set cluster_mode to "spark-submit" '
-                             'and submit the application via spark-submit instead')
-        assert "master" in kwargs, "Please specify master for k8s-client mode"
-        assert "container_image" in kwargs, "Please specify container_image for k8s-client mode"
+        assert "master" in kwargs, "Please specify master for k8s mode"
+        assert "container_image" in kwargs, "Please specify container_image for k8s mode"
         for key in ["driver_cores", "driver_memory", "extra_executor_memory_for_ray",
                     "extra_python_lib", "penv_archive", "jars", "python_location"]:
             if key in kwargs:
                 spark_args[key] = kwargs[key]
-        from bigdl.dllib.nncontext import init_spark_on_k8s
-        from bigdl.dllib.utils.utils import detect_conda_env_name
-
-        conda_env_name = detect_conda_env_name()
-        sc = init_spark_on_k8s(master=kwargs["master"],
-                               container_image=kwargs["container_image"],
-                               conda_name=conda_env_name,
-                               num_executors=num_nodes, executor_cores=cores,
-                               executor_memory=memory, **spark_args)
+        from bigdl.dllib.nncontext import init_spark_on_k8s, init_spark_on_k8s_cluster
+        if cluster_mode == "k8s-cluster":
+            sc = init_spark_on_k8s_cluster(master=kwargs["master"],
+                                           container_image=kwargs["container_image"],
+                                           num_executors=num_nodes,
+                                           executor_cores=cores,
+                                           executor_memory=memory,
+                                           **spark_args)
+        else:
+            from bigdl.dllib.utils.utils import detect_conda_env_name
+            conda_env_name = detect_conda_env_name()
+            sc = init_spark_on_k8s(master=kwargs["master"],
+                                   container_image=kwargs["container_image"],
+                                   conda_name=conda_env_name,
+                                   num_executors=num_nodes,
+                                   executor_cores=cores,
+                                   executor_memory=memory,
+                                   **spark_args)
     elif cluster_mode == "standalone":
         for key in ["driver_cores", "driver_memory", "extra_executor_memory_for_ray",
                     "extra_python_lib", "jars", "master", "python_location", "enable_numa_binding"]:

--- a/python/dllib/src/bigdl/dllib/utils/spark.py
+++ b/python/dllib/src/bigdl/dllib/utils/spark.py
@@ -24,6 +24,7 @@ from bigdl.dllib.nncontext import init_internal_nncontext, init_spark_conf
 from bigdl.dllib.utils.utils import detect_python_location, pack_penv, get_node_ip
 from bigdl.dllib.utils.utils import get_executor_conda_zoo_classpath
 from bigdl.dllib.utils.utils import get_zoo_bigdl_classpath_on_driver
+from bigdl.dllib.utils.utils import get_bigdl_class_version
 from bigdl.dllib.utils.engine import get_bigdl_jars
 
 
@@ -110,7 +111,7 @@ class SparkRunner:
                                          extra_executor_memory_for_ray)
             py_version = ".".join(platform.python_version().split(".")[0:2])
             preload_so = executor_python_env + "/lib/libpython" + py_version + "m.so"
-            ld_path = executor_python_env + "/lib:" + executor_python_env + "/lib/python" +\
+            ld_path = executor_python_env + "/lib:" + executor_python_env + "/lib/python" + \
                 py_version + "/lib-dynload"
             if "spark.executor.extraLibraryPath" in conf:
                 ld_path = "{}:{}".format(ld_path, conf["spark.executor.extraLibraryPath"])
@@ -188,7 +189,7 @@ class SparkRunner:
             conf["spark.executorEnv.PYSPARK_PYTHON"] = "{}/bin/python".format(executor_python_env)
             py_version = ".".join(platform.python_version().split(".")[0:2])
             preload_so = executor_python_env + "/lib/libpython" + py_version + "m.so"
-            ld_path = executor_python_env + "/lib:" + executor_python_env + "/lib/python" +\
+            ld_path = executor_python_env + "/lib:" + executor_python_env + "/lib/python" + \
                 py_version + "/lib-dynload"
             if "spark.executor.extraLibraryPath" in conf:
                 ld_path = "{}:{}".format(ld_path, conf["spark.executor.extraLibraryPath"])
@@ -385,6 +386,68 @@ class SparkRunner:
             if conda_name and penv_archive and pack_env:
                 os.remove(penv_archive)
         return sc
+
+
+def init_spark_on_k8s_cluster(self,
+                                  master,
+                                  container_image,
+                                  num_executors,
+                                  executor_cores,
+                                  executor_memory="2g",
+                                  driver_memory="1g",
+                                  driver_cores=4,
+                                  extra_executor_memory_for_ray=None,
+                                  extra_python_lib=None,
+                                  penv_archive=None,
+                                  conf=None,
+                                  jars=None,
+                                  python_location=None):
+        print("Initializing SparkContext for k8s-cluster mode")
+        executor_python_env = "python_env"
+
+        assert penv_archive, \
+            "You should specify penv_archive explicitly for k8s cluster mode"
+
+        archive = "{}#{}".format(penv_archive, executor_python_env)
+
+        submit_args = "--master " + master + " --deploy-mode cluster"
+        submit_args = submit_args + " --archives {}".format(archive)
+        submit_args = submit_args + gen_submit_args(
+            driver_cores, driver_memory, num_executors, executor_cores,
+            executor_memory, extra_python_lib, jars)
+
+        conf = enrich_conf_for_spark(conf, driver_cores, driver_memory, num_executors,
+                                     executor_cores, executor_memory, extra_executor_memory_for_ray)
+
+        conf["spark.pyspark.driver.python"] = "{}/bin/python".format(executor_python_env)
+        conf["spark.pyspark.python"] = "{}/bin/python".format(executor_python_env)
+        conf["spark.kubernetes.driverEnv.onDriver"] = "True"
+
+        py_version = ".".join(platform.python_version().split(".")[0:2])
+        preload_so = executor_python_env + "/lib/libpython" + py_version + "m.so"
+        ld_path = executor_python_env + "/lib:" + executor_python_env + "/lib/python" + \
+            py_version + "/lib-dynload"
+        if "spark.executor.extraLibraryPath" in conf:
+            ld_path = "{}:{}".format(ld_path, conf["spark.executor.extraLibraryPath"])
+        conf.update({"spark.cores.max": num_executors * executor_cores,
+                     "spark.executorEnv.PYTHONHOME": executor_python_env,
+                     "spark.executor.extraLibraryPath": ld_path,
+                     "spark.executorEnv.LD_PRELOAD": preload_so,
+                     "spark.kubernetes.container.image": container_image})
+        if "spark.executor.extraClassPath" in conf:
+            conf["spark.executor.extraClassPath"] = "{}:{}".format(
+                zoo_bigdl_path_on_executor, conf["spark.executor.extraClassPath"])
+        else:
+            # BigDL Class path in k8s image
+            bigdl_class_version = get_bigdl_class_version()
+            conf["spark.executor.extraClassPath"] = "/opt/" + bigdl_class_version + "/jars/*"
+        conf["spark.driver.extraClassPath"] = conf["spark.executor.extraClassPath"]
+        sys_args = "local://" + " ".join(sys.argv)
+        conf = " --conf " + " --conf ".join("{}={}".format(*i) for i in conf.items())
+        submit_commnad = "spark-submit " + submit_args + " " + conf + " " + sys_args
+        print("submit command", submit_commnad)
+        return_value = os.system(submit_commnad)
+        return return_value
 
 
 def gen_submit_args(driver_cores, driver_memory, num_executors, executor_cores, executor_memory,

--- a/python/dllib/src/bigdl/dllib/utils/spark.py
+++ b/python/dllib/src/bigdl/dllib/utils/spark.py
@@ -387,8 +387,7 @@ class SparkRunner:
                 os.remove(penv_archive)
         return sc
 
-
-def init_spark_on_k8s_cluster(self,
+    def init_spark_on_k8s_cluster(self,
                                   master,
                                   container_image,
                                   num_executors,

--- a/python/dllib/src/bigdl/dllib/utils/utils.py
+++ b/python/dllib/src/bigdl/dllib/utils/utils.py
@@ -20,6 +20,7 @@ import numpy as np
 from pyspark.ml.linalg import DenseVector, SparseVector, VectorUDT
 import sys
 import os
+import re
 
 if sys.version >= '3':
     long = int
@@ -158,6 +159,17 @@ def get_zoo_bigdl_classpath_on_driver():
 def set_python_home():
     if "PYTHONHOME" not in os.environ:
         os.environ['PYTHONHOME'] = "/".join(detect_python_location().split("/")[:-2])
+
+
+def get_bigdl_class_version():
+    from bigdl.dllib.utils.engine import get_bigdl_jars
+    bigdl_jars = get_bigdl_jars()
+    try:
+        bigdl_class_version = re.search('spark_(.+?)-jar', bigdl_jars[0]).group(1)[6:]
+    except AttributeError:
+        # not found
+        bigdl_class_version = 'Cannot find BigDL classpath, please check your installation'
+    return bigdl_class_version
 
 
 def _is_scalar_type(dtype, accept_str_col=False):

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -279,8 +279,6 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=2, memory="2g", 
                 assert "master" in kwargs, "Please specify master for k8s mode"
                 assert "container_image" in kwargs, ("Please specify container_image "
                                                      "for k8s mode")
-                from bigdl.dllib.utils.utils import detect_conda_env_name
-                conda_env_name = detect_conda_env_name()
                 for key in ["driver_cores", "driver_memory", "extra_executor_memory_for_ray",
                             "extra_python_lib", "penv_archive", "jars", "python_location"]:
                     if key in kwargs:

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -276,27 +276,33 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=2, memory="2g", 
                                             num_executors=num_nodes, executor_cores=cores,
                                             executor_memory=memory, **spark_args)
             elif cluster_mode.startswith("k8s"):  # k8s or k8s-client
-                if cluster_mode == "k8s-cluster":
-                    raise ValueError('For k8s-cluster mode, '
-                                     'please submit the application via spark-submit'
-                                     'and use the default cluster_mode instead')
-                assert "master" in kwargs, "Please specify master for k8s-client mode"
+                assert "master" in kwargs, "Please specify master for k8s mode"
                 assert "container_image" in kwargs, ("Please specify container_image "
-                                                     "for k8s-client mode")
+                                                     "for k8s mode")
                 from bigdl.dllib.utils.utils import detect_conda_env_name
                 conda_env_name = detect_conda_env_name()
                 for key in ["driver_cores", "driver_memory", "extra_executor_memory_for_ray",
                             "extra_python_lib", "penv_archive", "jars", "python_location"]:
                     if key in kwargs:
                         spark_args[key] = kwargs[key]
-                from bigdl.dllib.nncontext import init_spark_on_k8s
-                sc = init_spark_on_k8s(master=kwargs["master"],
-                                       container_image=kwargs["container_image"],
-                                       conda_name=conda_env_name,
-                                       num_executors=num_nodes,
-                                       executor_cores=cores,
-                                       executor_memory=memory,
-                                       **spark_args)
+                from bigdl.dllib.nncontext import init_spark_on_k8s, init_spark_on_k8s_cluster
+                if cluster_mode == "k8s-cluster":
+                    sc = init_spark_on_k8s_cluster(master=kwargs["master"],
+                                                   container_image=kwargs["container_image"],
+                                                   num_executors=num_nodes,
+                                                   executor_cores=cores,
+                                                   executor_memory=memory,
+                                                   **spark_args)
+                else:
+                    from bigdl.dllib.utils.utils import detect_conda_env_name
+                    conda_env_name = detect_conda_env_name()
+                    sc = init_spark_on_k8s(master=kwargs["master"],
+                                           container_image=kwargs["container_image"],
+                                           conda_name=conda_env_name,
+                                           num_executors=num_nodes,
+                                           executor_cores=cores,
+                                           executor_memory=memory,
+                                           **spark_args)
             elif cluster_mode == "standalone":
                 for key in ["driver_cores", "driver_memory", "extra_executor_memory_for_ray",
                             "extra_python_lib", "jars", "master", "python_location",


### PR DESCRIPTION
```

init_orca_context(cluster_mode="k8s-cluster", cores=4, num_nodes=1, 
                           penv_archive="local:///bigdl2.0/data/environment_cluster.tar.gz",
                           master="k8s://https://172.16.0.200:6443",
                           container_image="10.239.45.10/arda/intelanalytics/bigdl-k8s-spark-3.1.2:0.14.0-SNAPSHOT-20220116")
```


```
(clusterapi) [root@Almaren-Node-188 data]#pwd
/bigdl2.0/data
(clusterapi) [root@Almaren-Node-188 data]# conda pack -o environment_cluster.tar.gz
Collecting packages...
Packing environment at '/root/anaconda3/envs/clusterapi' to 'environment_cluster.tar.gz'
[########################################] | 100% Completed |  1min 27.3s
(clusterapi) [root@Almaren-Node-188 data]# python /bigdl2.0/data/spark_cluster.py
Initializing orca context
Current pyspark location is : /root/anaconda3/envs/clusterapi/lib/python3.7/site-packages/pyspark/__init__.py
Initializing SparkContext for k8s-cluster mode
submit command spark-submit --master k8s://https://172.16.0.200:6443 --deploy-mode cluster --archives local:///bigdl2.0/data/environment_cluster.tar.gz#python_env --driver-cores 4 --driver-memory 1g --num-executors 1 --executor-cores 4 --executor-memory 2g  --conf spark.kubernetes.driver.volumes.persistentVolumeClaim.nfsvolumeclaim.options.claimName=nfsvolumeclaim --conf spark.kubernetes.driver.volumes.persistentVolumeClaim.nfsvolumeclaim.mount.path=/bigdl2.0/data --conf spark.kubernetes.executor.volumes.persistentVolumeClaim.nfsvolumeclaim.options.claimName=nfsvolumeclaim --conf spark.kubernetes.executor.volumes.persistentVolumeClaim.nfsvolumeclaim.mount.path=/bigdl2.0/data --conf spark.kubernetes.authenticate.driver.serviceAccountName=spark --conf spark.kubernetes.node.selector.spark=true --conf spark.driver.cores=4 --conf spark.driver.memory=1g --conf spark.executor.instances=1 --conf spark.executor.cores=4 --conf spark.executor.memory=2g --conf spark.pyspark.driver.python=python_env/bin/python --conf spark.pyspark.python=python_env/bin/python --conf spark.kubernetes.driverEnv.onDriver=True --conf spark.cores.max=4 --conf spark.executorEnv.PYTHONHOME=python_env --conf spark.executor.extraLibraryPath=python_env/lib:python_env/lib/python3.7/lib-dynload --conf spark.executorEnv.LD_PRELOAD=python_env/lib/libpython3.7m.so --conf spark.kubernetes.container.image=10.239.45.10/arda/intelanalytics/bigdl-k8s-spark-3.1.2:0.14.0-SNAPSHOT-20220116 --conf spark.executor.extraClassPath=/opt/bigdl-0.14.0-SNAPSHOT/jars/* --conf spark.driver.extraClassPath=/opt/bigdl-0.14.0-SNAPSHOT/jars/* local:///bigdl2.0/data/spark_cluster.py
22/02/14 15:42:47 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
22/02/14 15:42:47 INFO SparkKubernetesClientFactory: Auto-configuring K8S client using current context from users K8S config file
22/02/14 15:42:48 INFO KerberosConfDriverFeatureStep: You have not specified a krb5.conf file locally or via a ConfigMap. Make sure that you have the krb5.conf locally on the driver image.
22/02/14 15:42:49 INFO LoggingPodStatusWatcherImpl: State changed, new state:
         pod name: sparkcluster-py-8ee7aa7ef72f1f4a-driver
         namespace: default
         labels: spark-app-selector -> spark-d42060dc390f45ba9641a093121c2370, spark-role -> driver
         pod uid: 51c262a5-8d6f-11ec-88b7-a4bf011c0026
         creation time: 2022-02-14T08:22:59Z
         service account name: spark
         volumes: nfsvolumeclaim, spark-local-dir-1, spark-conf-volume-driver, spark-token-l8wpb
         node name: almaren-node-275
         start time: 2022-02-14T08:20:57Z
         phase: Pending
         container status:
                 container name: spark-kubernetes-driver
                 container image: 10.239.45.10/arda/intelanalytics/bigdl-k8s-spark-3.1.2:0.14.0-SNAPSHOT-20220116
                 container state: waiting
                 pending reason: ContainerCreating
22/02/14 15:42:49 INFO LoggingPodStatusWatcherImpl: State changed, new state:
         pod name: sparkcluster-py-8ee7aa7ef72f1f4a-driver
         namespace: default
         labels: spark-app-selector -> spark-d42060dc390f45ba9641a093121c2370, spark-role -> driver
         pod uid: 51c262a5-8d6f-11ec-88b7-a4bf011c0026
         creation time: 2022-02-14T08:22:59Z
         service account name: spark
         volumes: nfsvolumeclaim, spark-local-dir-1, spark-conf-volume-driver, spark-token-l8wpb
         node name: almaren-node-275
         start time: 2022-02-14T08:20:57Z
         phase: Pending
         container status:
                 container name: spark-kubernetes-driver
                 container image: 10.239.45.10/arda/intelanalytics/bigdl-k8s-spark-3.1.2:0.14.0-SNAPSHOT-20220116
                 container state: waiting
                 pending reason: ContainerCreating
22/02/14 15:42:49 INFO LoggingPodStatusWatcherImpl: Waiting for application spark_cluster.py with submission ID default:sparkcluster-py-8ee7aa7ef72f1f4a-driver to finish...
22/02/14 15:42:50 INFO LoggingPodStatusWatcherImpl: Application status for spark-d42060dc390f45ba9641a093121c2370 (phase: Pending)
22/02/14 15:42:51 INFO LoggingPodStatusWatcherImpl: Application status for spark-d42060dc390f45ba9641a093121c2370 (phase: Pending)
22/02/14 15:42:52 INFO LoggingPodStatusWatcherImpl: State changed, new state:
         pod name: sparkcluster-py-8ee7aa7ef72f1f4a-driver
         namespace: default
         labels: spark-app-selector -> spark-d42060dc390f45ba9641a093121c2370, spark-role -> driver
         pod uid: 51c262a5-8d6f-11ec-88b7-a4bf011c0026
         creation time: 2022-02-14T08:22:59Z
         service account name: spark
         volumes: nfsvolumeclaim, spark-local-dir-1, spark-conf-volume-driver, spark-token-l8wpb
         node name: almaren-node-275
         start time: 2022-02-14T08:20:57Z
         phase: Running
         container status:
                 container name: spark-kubernetes-driver
                 container image: 10.239.45.10/arda/intelanalytics/bigdl-k8s-spark-3.1.2:0.14.0-SNAPSHOT-20220116
                 container state: running
                 container started at: 2022-02-14T08:20:59Z
22/02/14 15:42:52 INFO LoggingPodStatusWatcherImpl: Application status for spark-d42060dc390f45ba9641a093121c2370 (phase: Running)
22/02/14 15:42:53 INFO LoggingPodStatusWatcherImpl: Application status for spark-d42060dc390f45ba9641a093121c2370 (phase: Running)
22/02/14 15:42:54 INFO LoggingPodStatusWatcherImpl: Application status for spark-d42060dc390f45ba9641a093121c2370 (phase: Running)
22/02/14 15:42:55 INFO LoggingPodStatusWatcherImpl: Application status for spark-d42060dc390f45ba9641a093121c2370 (phase: Running)
22/02/14 15:42:56 INFO LoggingPodStatusWatcherImpl: Application status for spark-d42060dc390f45ba9641a093121c2370 (phase: Running)
22/02/14 15:42:57 INFO LoggingPodStatusWatcherImpl: Application status for spark-d42060dc390f45ba9641a093121c2370 (phase: Running)
22/02/14 15:42:58 INFO LoggingPodStatusWatcherImpl: Application status for spark-d42060dc390f45ba9641a093121c2370 (phase: Running)
22/02/14 15:42:59 INFO LoggingPodStatusWatcherImpl: Application status for spark-d42060dc390f45ba9641a093121c2370 (phase: Running)
22/02/14 15:43:00 INFO LoggingPodStatusWatcherImpl: Application status for spark-d42060dc390f45ba9641a093121c2370 (phase: Running)
22/02/14 15:43:01 INFO LoggingPodStatusWatcherImpl: Application status for spark-d42060dc390f45ba9641a093121c2370 (phase: Running)
22/02/14 15:43:02 INFO LoggingPodStatusWatcherImpl: Application status for spark-d42060dc390f45ba9641a093121c2370 (phase: Running)
22/02/14 15:43:03 INFO LoggingPodStatusWatcherImpl: Application status for spark-d42060dc390f45ba9641a093121c2370 (phase: Running)
22/02/14 15:43:04 INFO LoggingPodStatusWatcherImpl: Application status for spark-d42060dc390f45ba9641a093121c2370 (phase: Running)
...
22/02/14 15:44:29 INFO LoggingPodStatusWatcherImpl: State changed, new state:
         pod name: sparkcluster-py-8ee7aa7ef72f1f4a-driver
         namespace: default
         labels: spark-app-selector -> spark-d42060dc390f45ba9641a093121c2370, spark-role -> driver
         pod uid: 51c262a5-8d6f-11ec-88b7-a4bf011c0026
         creation time: 2022-02-14T08:22:59Z
         service account name: spark
         volumes: nfsvolumeclaim, spark-local-dir-1, spark-conf-volume-driver, spark-token-l8wpb
         node name: almaren-node-275
         start time: 2022-02-14T08:20:57Z
         phase: Succeeded
         container status:
                 container name: spark-kubernetes-driver
                 container image: 10.239.45.10/arda/intelanalytics/bigdl-k8s-spark-3.1.2:0.14.0-SNAPSHOT-20220116
                 container state: terminated
                 container started at: 2022-02-14T08:20:59Z
                 container finished at: 2022-02-14T08:22:35Z
                 exit code: 0
                 termination reason: Completed
22/02/14 15:44:29 INFO LoggingPodStatusWatcherImpl: Application status for spark-d42060dc390f45ba9641a093121c2370 (phase: Succeeded)
22/02/14 15:44:29 INFO LoggingPodStatusWatcherImpl: Container final statuses:


         container name: spark-kubernetes-driver
         container image: 10.239.45.10/arda/intelanalytics/bigdl-k8s-spark-3.1.2:0.14.0-SNAPSHOT-20220116
         container state: terminated
         container started at: 2022-02-14T08:20:59Z
         container finished at: 2022-02-14T08:22:35Z
         exit code: 0
         termination reason: Completed
22/02/14 15:44:29 INFO LoggingPodStatusWatcherImpl: Application spark_cluster.py with submission ID default:sparkcluster-py-8ee7aa7ef72f1f4a-driver finished
22/02/14 15:44:29 INFO ShutdownHookManager: Shutdown hook called
22/02/14 15:44:29 INFO ShutdownHookManager: Deleting directory /tmp/spark-cb2a64ea-97e9-4059-93f0-216bbcde1b53
```