### PR TITLE
[PPML] Fix yaml parse error in realtime/occlum/k8s

### DIFF
--- a/ppml/trusted-realtime-ml/scala/docker-occlum/kubernetes/templates/taskmanager-statefulset.yaml
+++ b/ppml/trusted-realtime-ml/scala/docker-occlum/kubernetes/templates/taskmanager-statefulset.yaml
@@ -83,9 +83,9 @@ spec:
               configMapKeyRef:
                 name: flink-config
                 key: sgx.mode
-         ports:
-        - containerPort: 6125
-          name: rpc
+        ports:
+          - containerPort: 6125
+            name: rpc
 #        resources:
 #          requests:
 #            cpu: 10


### PR DESCRIPTION
Line 86 used to not align to the above parameters.