### PR TITLE
Refactor RayXShards to easily get partition and shard ObjectRefs

### DIFF
--- a/python/orca/src/bigdl/orca/automl/search/ray_tune/ray_tune_search_engine.py
+++ b/python/orca/src/bigdl/orca/automl/search/ray_tune/ray_tune_search_engine.py
@@ -407,17 +407,9 @@ def trial_dirname_creator(trial):
 def get_data_from_part_refs(part_refs):
     from bigdl.orca.data.utils import ray_partitions_get_data_label
 
-    partitions = ray.get(part_refs)
+    partitions = [ray.get(part_ref) for part_ref in part_refs]
 
-    # convert list of dicts to one dict
-    result = {}
-    for part in partitions:
-        result.update(part)
-
-    # reorder dict with partition index
-    parts = [result[idx] for idx in range(len(result.keys()))]
-
-    data, label = ray_partitions_get_data_label(parts,
+    data, label = ray_partitions_get_data_label(partitions,
                                                 allow_tuple=True,
                                                 allow_list=False,
                                                 )


### PR DESCRIPTION
Before: 

- The `LocalStore` in `RayXShards` holds all the partition data, but not Ray `ObjectRef`s.

After:

- `LocalStore` holds the `ObjectRef`s of partitions and shards.

- Add `get_partition_ref` which returns a list of `shard_ref`s or a `part_ref`.  