### PR TITLE
Support Ray_dataset in Pytorch Estimator

### DIFF
--- a/python/orca/dev/test/run-pytests-ray
+++ b/python/orca/dev/test/run-pytests-ray
@@ -44,6 +44,7 @@ echo "Running orca learn ray tests"
 python -m pytest -v test/bigdl/orca/learn/ray \
       --ignore=test/bigdl/orca/learn/ray/pytorch/test_estimator_horovod_backend.py \
       --ignore=test/bigdl/orca/learn/ray/pytorch/test_ray_pytorch_estimator.py \
+      --ignore=test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_dataset.py \
       --ignore=test/bigdl/orca/learn/ray/tf/
 exit_status_2=$?
 if [ $exit_status_2 -ne 0 ];

--- a/python/orca/dev/test/run-pytests-ray-ctx.sh
+++ b/python/orca/dev/test/run-pytests-ray-ctx.sh
@@ -56,4 +56,12 @@ then
     exit $exit_status_3
 fi
 
+echo "Running Ray Dataset tests"
+python -m pytest -v test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_dataset.py
+exit_status_4=$?
+if [ $exit_status_4 -ne 0 ];
+then
+    exit $exit_status_4
+fi
+
 ray stop -f

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -262,7 +262,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
 
             def data_creator(config, batch_size):
                 torch_datashard = shard.to_torch(label_column=label_cols,
-                                                     batch_size=batch_size)
+                                                 batch_size=batch_size)
                 return torch_datashard
 
             remote_worker_stats = []

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -266,13 +266,13 @@ class PyTorchRayEstimator(OrcaRayEstimator):
 
                 def get_shard(self):
                     return self.shard
-                
+
                 def get_rank(self):
                     return self.rank
 
             shards = data.split(n=self.num_workers)
             actors = [TrainingWorker.remote(rank, shard) for rank, shard in enumerate(shards)]
-            
+
             def data_creator(config, batch_size):
                 torch_datashard = ray.get(actors[rank].get_shard.remote()).to_torch(
                     label_column=label_cols,

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -263,7 +263,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                 def __init__(self, rank: int, shard: Dataset):
                     self.rank = rank
                     self.shard = shard
-                
+
                 def get_shard(self):
                     return self.shard
                 
@@ -283,7 +283,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
 
             remote_worker_stats = []
             for rank, worker in enumerate(self.remote_workers):
-                stats = worker.train_epochs.remote(data_creator, epochs, batch_size, profile, 
+                stats = worker.train_epochs.remote(data_creator, epochs, batch_size, profile,
                                                    info, False, callbacks)
                 remote_worker_stats.append(stats)
             success = check_for_failure(remote_worker_stats)

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -277,8 +277,8 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                 worker_stats = None
         else:
             assert isinstance(data, types.FunctionType), \
-                "data should be either an instance of SparkXShards or a callable function, but " \
-                "got type: {}".format(type(data))
+                "data should be either an instance of SparkXShards, Ray Dataset " \
+                "or a callable function, but got type: {}".format(type(data))
 
             success, worker_stats = self._train_epochs(data,
                                                        epochs=epochs,

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -262,7 +262,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
 
             def data_creator(config, batch_size):
                 torch_datashard = shard.to_torch(label_column=label_cols,
-                                                 feature_column=feature_cols,
+                                                 feature_columns=feature_cols,
                                                  batch_size=batch_size)
                 return torch_datashard
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -259,6 +259,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                                                                     transform_func)
         elif isinstance(data, Dataset):
             shards = data.split(n=self.num_workers)
+
             def data_creator(config, batch_size):
                 torch_datashard = shards[i].to_torch(label_column=label_cols,
                                                      batch_size=batch_size)

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -207,8 +207,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
         underneath the hood.
 
         :param data: An instance of SparkXShards, a Ray Dataset, a Spark DataFrame or a function
-               that takes config and batch_size as argument and returns a PyTorch DataLoader or
-               a PyTorch IterableDataset (when the data is an instance of a Ray Dataset) for
+               that takes config and batch_size as argument and returns a PyTorch DataLoader for
                training.
         :param epochs: The number of epochs to train the model. Default is 1.
         :param batch_size: The number of samples per batch for each worker. Default is 32.

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -223,7 +223,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                Default is True.
         :param info: An optional dictionary that can be passed to the TrainingOperator for
                train_epoch and train_batch.
-        :param feature_cols: feature column names if data is Spark DataFrame.
+        :param feature_cols: feature column names if data is Spark DataFrame or Ray Dataset.
         :param label_cols: label column names if data is Spark DataFrame or Ray Dataset.
         :param callbacks: A list for all callbacks.
 
@@ -262,6 +262,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
 
             def data_creator(config, batch_size):
                 torch_datashard = shard.to_torch(label_column=label_cols,
+                                                 feature_column=feature_cols,
                                                  batch_size=batch_size)
                 return torch_datashard
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -224,7 +224,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
         :param info: An optional dictionary that can be passed to the TrainingOperator for
                train_epoch and train_batch.
         :param feature_cols: feature column names if data is Spark DataFrame.
-        :param label_cols: label column names if data is Spark DataFrame and Ray Dataset.
+        :param label_cols: label column names if data is Spark DataFrame or Ray Dataset.
         :param callbacks: A list for all callbacks.
 
         :return: A list of dictionary of metrics for every training epoch. If reduce_results is

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -263,9 +263,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
             def data_creator(config, batch_size):
                 torch_datashard = shards[i].to_torch(label_column=label_cols,
                                                      batch_size=batch_size)
-                for batch_idx, data in enumerate(torch_datashard):
-                    dataloader = torch.utils.data.DataLoader(data, batch_size=batch_size)
-                return dataloader
+                return torch_datashard
 
             remote_worker_stats = []
             for i, worker in enumerate(self.remote_workers):

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -278,14 +278,13 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                 data_creator = partition_ray_dataset_to_creator(data_shard, label_cols)
                 return self._train_epochs(
                     data_creator, epochs, batch_size, profile, info, False, callbacks)
-            
+
             trainer = Trainer(backend="torch", num_workers=self.num_workers)
             trainer.start()
 
-            success, worker_stats = trainer.run(
-                train_func=train_func,
-                config=None,
-                dataset=data)
+            success, worker_stats = trainer.run(train_func=train_func,
+                                                config=None,
+                                                dataset=data)
         else:
             assert isinstance(data, types.FunctionType), \
                 "data should be either an instance of SparkXShards or a callable function, but " \

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -206,8 +206,9 @@ class PyTorchRayEstimator(OrcaRayEstimator):
         Calls `TrainingOperator.train_epoch()` on N parallel workers simultaneously
         underneath the hood.
 
-        :param data: An instance of SparkXShards, a Spark DataFrame or a function that
-               takes config and batch_size as argument and returns a PyTorch DataLoader for
+        :param data: An instance of SparkXShards, a Ray Dataset, a Spark DataFrame or a function
+               that takes config and batch_size as argument and returns a PyTorch DataLoader or
+               a PyTorch IterableDataset (when the data is an instance of a Ray Dataset) for
                training.
         :param epochs: The number of epochs to train the model. Default is 1.
         :param batch_size: The number of samples per batch for each worker. Default is 32.
@@ -224,7 +225,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
         :param info: An optional dictionary that can be passed to the TrainingOperator for
                train_epoch and train_batch.
         :param feature_cols: feature column names if data is Spark DataFrame.
-        :param label_cols: label column names if data is Spark DataFrame.
+        :param label_cols: label column names if data is Spark DataFrame and Ray Dataset.
         :param callbacks: A list for all callbacks.
 
         :return: A list of dictionary of metrics for every training epoch. If reduce_results is

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -289,9 +289,8 @@ class PyTorchRayEstimator(OrcaRayEstimator):
             success = check_for_failure(remote_worker_stats)
             if success:
                 worker_stats = ray.get(remote_worker_stats)
-                return worker_stats
             else:
-                return success, None
+                worker_stats = None
         else:
             assert isinstance(data, types.FunctionType), \
                 "data should be either an instance of SparkXShards or a callable function, but " \

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_dataset.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_dataset.py
@@ -1,0 +1,78 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pytest
+from unittest import TestCase
+
+import ray
+from ray.data import Dataset
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+from bigdl.orca import init_orca_context, stop_orca_context
+from bigdl.orca.learn.pytorch import Estimator
+from bigdl.orca.learn.metrics import Accuracy
+
+def train_data_creator(a=5, b=10, size=1000):
+    def get_dataset(a, b, size) -> Dataset:
+        items = [i / size for i in range(size)]
+        dataset = ray.data.from_items([{
+            "x": x,
+            "y": a * x + b
+        } for x in items])
+        return dataset
+
+    ray_dataset = get_dataset(a, b, size)
+    return ray_dataset
+
+def model_creator(config):
+    net = nn.Linear(1, 1)
+    net = net.double()
+    return net
+
+def optim_creator(model, config):
+    optimizer = optim.SGD(model.parameters(),
+                          lr=config.get("lr", 0.001),
+                          momentum=config.get("momentum", 0.9))
+    return optimizer
+
+class TestPytorchEstimator(TestCase):
+    def setUp(self):
+        init_orca_context(runtime="ray", address="localhost:6379")
+
+    def tearDown(self):
+        stop_orca_context()
+
+    def test_train(self):
+        dataset = train_data_creator()
+        orca_estimator = Estimator.from_torch(model=model_creator,
+                                            optimizer=optim_creator,
+                                            loss=nn.MSELoss(),
+                                            metrics=[Accuracy()],
+                                            config={"lr": 0.001},
+                                            workers_per_node=2,
+                                            backend="torch_distributed",
+                                            sync_stats=True)
+        train_stats = orca_estimator.fit(data=dataset, 
+                                         epochs=2, 
+                                         batch_size=32, 
+                                         label_cols="y")
+
+        assert orca_estimator.get_model()
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
This PR supports the ray dataset as a backend in PyTorch ray estimator, users just need to read data by ray data read_api to get a ray dataset. The estimator would automatically convert the input ray dataset to an iterable PyTorch dataset and conduct the training pipeline.

ie.

```
def transform():
      ...

ray_dataset = ray.data.read_csv(path)
ray_dataset.map(transform)

orca_estimator = Estimator.from_torch(...)
stats = orca.estimator(data=ray_dataset, label_cols="the label column")
```


- [x] Split data to shards when input is ray dataset.
- [x] Allocate data shard to workers.
- [x] Convert ray data shard to torch dataset on workers.
- [x] Training on each worker and reducing all worker stats. 