### PR TITLE
Chronos: add example for quantization

### DIFF
--- a/python/chronos/dev/example/run-example-tests-pip-ray.sh
+++ b/python/chronos/dev/example/run-example-tests-pip-ray.sh
@@ -79,6 +79,7 @@ if [ ! -f ~/.chronos/dataset/nyc_taxi/nyc_taxi_data.csv ]; then
   mv ~/.chronos/dataset/nyc_taxi/nyc_taxi.csv ~/.chronos/dataset/nyc_taxi/nyc_taxi_data.csv
 fi
 
+sed -i 's/epochs=10/epochs=1/' "${BIGDL_ROOT}/python/chronos/example/quantization/quantization_tcnforecaster_nyc_taxi.py"
 execute_ray_test quantization_tcnforecaster_nyc_taxi "${BIGDL_ROOT}/python/chronos/example/quantization/quantization_tcnforecaster_nyc_taxi.py"
 time7=$?
 

--- a/python/chronos/dev/example/run-example-tests-pip-ray.sh
+++ b/python/chronos/dev/example/run-example-tests-pip-ray.sh
@@ -58,7 +58,7 @@ if [ ! -f ~/.chronos/dataset/nyc_taxi/nyc_taxi_data.csv ]; then
 fi
 
 # When the thread of onnxruntime is None, "pthread_setaffinity_np failed" may appear.
-sed -i '/onnx/d' ${BIGDL_ROOT}/python/chronos/example/onnx/onnx_autotsestimator_nyc_taxi.py
+# sed -i '/onnx/d' ${BIGDL_ROOT}/python/chronos/example/onnx/onnx_autotsestimator_nyc_taxi.py
 
 execute_ray_test onnx_autotsestimator_nyc_taxi "${BIGDL_ROOT}/python/chronos/example/onnx/onnx_autotsestimator_nyc_taxi.py"
 time5=$?
@@ -69,10 +69,18 @@ if [ ! -f ~/.chronos/dataset/network_traffic/network_traffic_data.csv ]; then
 fi
 
 # When the thread of onnxruntime is None, "pthread_setaffinity_np failed" may appear.
-sed -i '/onnx/d' ${BIGDL_ROOT}/python/chronos/example/onnx/onnx_forecaster_network_traffic.py
+# sed -i '/onnx/d' ${BIGDL_ROOT}/python/chronos/example/onnx/onnx_forecaster_network_traffic.py
 
 execute_ray_test onnx_forecaster_network_traffic "${BIGDL_ROOT}/python/chronos/example/onnx/onnx_forecaster_network_traffic.py"
 time6=$?
+
+if [ ! -f ~/.chronos/dataset/nyc_taxi/nyc_taxi_data.csv ]; then
+  wget -nv $FTP_URI/analytics-zoo-data/apps/nyc-taxi/nyc_taxi.csv -P ~/.chronos/dataset/nyc_taxi/
+  mv ~/.chronos/dataset/nyc_taxi/nyc_taxi.csv ~/.chronos/dataset/nyc_taxi/nyc_taxi_data.csv
+fi
+
+execute_ray_test quantization_tcnforecaster_nyc_taxi "${BIGDL_ROOT}/python/chronos/example/quantization/quantization_tcnforecaster_nyc_taxi.py"
+time7=$?
 
 echo "#1 autolstm_nyc_taxi time used:$time1 seconds"
 echo "#2 autoprophet_nyc_taxi time used:$time2 seconds"
@@ -80,5 +88,6 @@ echo "#3 dpgansimulator_wwt time used:$time3 seconds"
 echo "#4 distributed_training_network_traffic time used:$time4 seconds"
 echo "#5 onnx_autotsestimator_nyc_taxi time used:$time5 seconds"
 echo "#6 onnx_forecaster_network_traffic used:$time6 seconds"
+echo "#7 quantization_tcnforecaster_nyc_taxi used:$time7 seconds"
 
 clear_up

--- a/python/chronos/example/quantization/README.md
+++ b/python/chronos/example/quantization/README.md
@@ -1,0 +1,33 @@
+# Use Chronos forecasters' quantization method to speed-up inference
+LSTM, TCN and NBeats users can easily quantize their forecasters to low precision and speed up the inference process (both throughput and latency) by on a single node. The functionality is powered by Project Nano.
+
+## Prepare the environment
+We recommend you to use Anaconda to prepare the environment, especially if you want to run on a yarn cluster:
+```bash
+conda create -n my_env python=3.7 # "my_env" is conda environment name, you can use any name you like.
+conda activate my_env
+pip install --pre --upgrade bigdl-chronos[all]
+pip install neural-compressor==1.8.1
+```
+Please refer to [Chronos Install Guide](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install)
+
+## Prepare data
+We are using the nyc taxi provided by NAB, from 2014-07-01 to 2015-01-31 taxi fare information For more details, you can refer to the detailed information [here](https://github.com/numenta/NAB/tree/master/data). The dataset will be downloaded automatically for you.
+
+## Run the example
+For tcn forecaster example
+```bash
+python quantization_tcnforecaster_nyc_taxi.py
+```
+
+## Sample output
+In this example, we perform post-training quantization on pytorch model for inference throughput and on onnxruntime model for inference latency. Both of them are significantly improved by 339.5% and 89.4%.
+```bash
+# ... <skip some training progress bar>
+# ... <skip some Intel Neural Compressor log>
+Pytorch Quantization helps increase inference throughput by 339.49 %
+Onnx Quantization helps decrease inference latency by 89.39 %
+fp32 pytorch smape: 0.21
+int8 pytorch smape: 0.21
+int8 onnx smape: 0.21
+```

--- a/python/chronos/example/quantization/quantization_tcnforecaster_nyc_taxi.py
+++ b/python/chronos/example/quantization/quantization_tcnforecaster_nyc_taxi.py
@@ -89,6 +89,6 @@ if __name__ == "__main__":
 
     print("Pytorch Quantization helps increase inference throughput by", round(fp32_pytorch_time/int8_pytorch_time*100-100, 2), "%")
     print("Onnx Quantization helps decrease inference latency by", round((np.median(fp32_pytorch_latency)-np.median(int8_onnx_latency))/np.median(fp32_pytorch_latency)*100, 2), "%")
-    print("fp32 pytorch smape:", avg_smape_fp32_pytorch)
-    print("int8 pytorch smape:", avgr_smape_int8_pytorch)
-    print("int8 onnx smape:", avgr_smape_int8_onnx)
+    print("fp32 pytorch smape:", round(float(avg_smape_fp32_pytorch), 2))
+    print("int8 pytorch smape:", round(float(avgr_smape_int8_pytorch), 2))
+    print("int8 onnx smape:", round(float(avgr_smape_int8_onnx), 2))

--- a/python/chronos/example/quantization/quantization_tcnforecaster_nyc_taxi.py
+++ b/python/chronos/example/quantization/quantization_tcnforecaster_nyc_taxi.py
@@ -1,0 +1,94 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from bigdl.chronos.data.repo_dataset import get_public_dataset
+from bigdl.chronos.forecaster import TCNForecaster
+from sklearn.preprocessing import StandardScaler
+from bigdl.chronos.metric.forecast_metrics import Evaluator
+import time
+import numpy as np
+
+
+def get_tsdata(lookback=96, horizon=24):
+    name = 'nyc_taxi'
+    tsdata_train, _, tsdata_test = get_public_dataset(name, val_ratio=0, test_ratio=0.4)
+    stand_scaler = StandardScaler()
+    for tsdata in [tsdata_train, tsdata_test]:
+        tsdata.gen_dt_feature(features=["HOUR"], one_hot_features=["HOUR"])\
+              .impute(mode="linear")\
+              .scale(stand_scaler, fit=(tsdata is tsdata_train))\
+              .roll(lookback=lookback, horizon=horizon)
+    return tsdata_train, tsdata_test
+
+
+if __name__ == "__main__":
+    tsdata_train, tsdata_test = get_tsdata()
+    x_train, y_train = tsdata_train.to_numpy()
+    x_test, y_test = tsdata_test.to_numpy()
+    print(x_train.shape, y_train.shape, x_test.shape, y_test.shape)
+    forecaster = TCNForecaster(past_seq_len = 96,
+                               future_seq_len = 24,
+                               input_feature_num = x_train.shape[-1],
+                               output_feature_num = 1,
+                               num_channels = [48] * 7,
+                               repo_initialization = False,
+                               kernel_size = 3,
+                               dropout = 0.1,
+                               lr = 0.001,
+                               seed = 0)
+    forecaster.fit((x_train, y_train), epochs=10, batch_size=32)
+
+    st = time.time()
+    y_pred = forecaster.predict(x_test)
+    fp32_pytorch_time = time.time()-st
+
+    y_pred_unscale = tsdata_test.unscale_numpy(y_pred)
+    y_test_unscale = tsdata_test.unscale_numpy(y_test)
+    avg_smape_fp32_pytorch = Evaluator.evaluate("smape", y_test_unscale, y_pred_unscale, aggregate='mean')[0]
+
+    forecaster.quantize((x_train, y_train), framework=['pytorch_fx', 'onnxrt_qlinearops'])
+    st = time.time()
+    y_pred = forecaster.predict(x_test, quantize=True)
+    int8_pytorch_time = time.time()-st
+
+    y_pred_unscale = tsdata_test.unscale_numpy(y_pred)
+    y_test_unscale = tsdata_test.unscale_numpy(y_test)
+    avgr_smape_int8_pytorch = Evaluator.evaluate("smape", y_test_unscale, y_pred_unscale, aggregate='mean')[0]
+
+    y_pred = forecaster.predict_with_onnx(x_test, quantize=True)
+    y_pred_unscale = tsdata_test.unscale_numpy(y_pred)
+    y_test_unscale = tsdata_test.unscale_numpy(y_test)
+    avgr_smape_int8_onnx = Evaluator.evaluate("smape", y_test_unscale, y_pred_unscale, aggregate='mean')[0]
+
+    fp32_pytorch_latency = []
+    for i in range(x_test.shape[0]):
+        x = x_test[i:i+1]
+        st = time.time()
+        y_pred = forecaster.predict(x)
+        fp32_pytorch_latency.append(time.time()-st)
+
+    int8_onnx_latency = []
+    for i in range(x_test.shape[0]):
+        x = x_test[i:i+1]
+        st = time.time()
+        y_pred = forecaster.predict_with_onnx(x, quantize=True)
+        int8_onnx_latency.append(time.time()-st)
+
+    print("Pytorch Quantization helps increase inference throughput by", round(fp32_pytorch_time/int8_pytorch_time*100-100, 2), "%")
+    print("Onnx Quantization helps decrease inference latency by", round((np.median(fp32_pytorch_latency)-np.median(int8_onnx_latency))/np.median(fp32_pytorch_latency)*100, 2), "%")
+    print("fp32 pytorch smape:", avg_smape_fp32_pytorch)
+    print("int8 pytorch smape:", avgr_smape_int8_pytorch)
+    print("int8 onnx smape:", avgr_smape_int8_onnx)


### PR DESCRIPTION
TODO:

- [x] test scripts
- [x] readme

```bash
Pytorch Quantization helps increase inference throughput by 330.14 %
Onnx Quantization helps decrease inference latency by 89.54 %
fp32 pytorch smape: 0.20904364947766307
int8 pytorch smape: 0.2083426712220019
int8 onnx smape: 0.20743921328123868
```