### PR TITLE
[Orca] Support Ray Dataset in PyTorch Ray Estimator Predict

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -344,7 +344,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                 worker_stats = worker.predict.remote(data_creator, batch_size, profile)
                 remote_worker_stats.append(worker_stats)
             result = ray.data.from_numpy(remote_worker_stats).map(
-                   lambda r: {"prediction_result": r["value"]})
+                lambda r: {"prediction_result": r["value"]})
         else:
             raise ValueError("Only xshards, Spark DataFrame or Ray Dataset"
                              " is supported for predict")

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -305,12 +305,14 @@ class PyTorchRayEstimator(OrcaRayEstimator):
         """
         Using this PyTorch model to make predictions on the data.
 
-        :param data: An instance of SparkXShards or a Spark DataFrame
+        :param data: An instance of SparkXShards, a Ray Dataset or a Spark DataFrame
         :param batch_size: The number of samples per batch for each worker. Default is 32.
         :param profile: Boolean. Whether to return time stats for the training procedure.
                Default is False.
-        :param feature_cols: feature column names if data is a Spark DataFrame.
-        :return: A SparkXShards that contains the predictions with key "prediction" in each shard
+        :param feature_cols: feature column names if data is a Spark DataFrame or a Ray Dataset.
+        :param feature_cols: feature column names if data is a Spark DataFrame or a Ray Dataset.
+        :return: A SparkXShards or Ray Shard that contains the predictions with key "prediction" 
+               in each shard
         """
         from bigdl.orca.data import SparkXShards
         param = dict(

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -343,8 +343,8 @@ class PyTorchRayEstimator(OrcaRayEstimator):
             for shard, worker in zip(shards, self.remote_workers):
                 worker_stats = worker.predict.remote(data_creator, batch_size, profile)
                 remote_worker_stats.append(worker_stats)
-            result = ray.data.from_numpy(remote_worker_stats).\
-                     map(lambda r: {"prediction_result": r["value"]})
+            result = ray.data.from_numpy(remote_worker_stats).map(
+                     lambda r: {"prediction_result": r["value"]})
         else:
             raise ValueError("Only xshards, Spark DataFrame or Ray Dataset"
                              " is supported for predict")

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -345,11 +345,8 @@ class PyTorchRayEstimator(OrcaRayEstimator):
             remote_worker_stats = []
             for shard, worker in zip(shards, self.remote_workers):
                 worker_stats = worker.predict.remote(data_creator, batch_size, profile)
-                pred_stats = ray.get(worker_stats)
-                for stat in pred_stats:
-                    stat.update(stat)
-                remote_worker_stats.append(stat)
-            result = remote_worker_stats
+                remote_worker_stats.append(worker_stats)
+            result = ray.data.from_numpy(remote_worker_stats)
         else:
             raise ValueError("Only xshards, Spark DataFrame or Ray Dataset"
                              " is supported for predict")

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -311,7 +311,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                Default is False.
         :param feature_cols: feature column names if data is a Spark DataFrame or a Ray Dataset.
         :param feature_cols: feature column names if data is a Spark DataFrame or a Ray Dataset.
-        :return: A SparkXShards or Ray Shard that contains the predictions with key "prediction" 
+        :return: A SparkXShards or Ray Shard that contains the predictions with key "prediction"
                in each shard
         """
         from bigdl.orca.data import SparkXShards

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -311,7 +311,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                Default is False.
         :param feature_cols: feature column names if data is a Spark DataFrame or a Ray Dataset.
         :param feature_cols: feature column names if data is a Spark DataFrame or a Ray Dataset.
-        :return: A SparkXShards or Ray Shard that contains the predictions with key "prediction"
+        :return: A SparkXShards or a list that contains the predictions with key "prediction"
                in each shard
         """
         from bigdl.orca.data import SparkXShards
@@ -347,7 +347,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                 remote_worker_stats.append(stat)
             result = remote_worker_stats
         else:
-            raise ValueError("Only xshards or Spark DataFrame is supported for predict")
+            raise ValueError("Only xshards, Spark DataFrame or Ray Dataset is supported for predict")
 
         return result
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -335,8 +335,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
             shards = data.split(n=self.num_workers, locality_hints=self.remote_workers)
 
             def data_creator(config, batch_size):
-                torch_datashard = shard.to_torch(label_column=None,
-                                                 feature_columns=feature_cols,
+                torch_datashard = shard.to_torch(feature_columns=feature_cols,
                                                  batch_size=batch_size)
                 return torch_datashard
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -344,7 +344,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                 worker_stats = worker.predict.remote(data_creator, batch_size, profile)
                 remote_worker_stats.append(worker_stats)
             result = ray.data.from_numpy(remote_worker_stats).map(
-                     lambda r: {"prediction_result": r["value"]})
+                   lambda r: {"prediction_result": r["value"]})
         else:
             raise ValueError("Only xshards, Spark DataFrame or Ray Dataset"
                              " is supported for predict")

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -347,7 +347,8 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                 remote_worker_stats.append(stat)
             result = remote_worker_stats
         else:
-            raise ValueError("Only xshards, Spark DataFrame or Ray Dataset is supported for predict")
+            raise ValueError("Only xshards, Spark DataFrame or Ray Dataset"
+                             " is supported for predict")
 
         return result
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -343,7 +343,8 @@ class PyTorchRayEstimator(OrcaRayEstimator):
             for shard, worker in zip(shards, self.remote_workers):
                 worker_stats = worker.predict.remote(data_creator, batch_size, profile)
                 remote_worker_stats.append(worker_stats)
-            result = ray.data.from_numpy(remote_worker_stats)
+            result = result = ray.data.from_numpy(remote_worker_stats).\
+                     map(lambda r: {"prediction_result": r["value"]})
         else:
             raise ValueError("Only xshards, Spark DataFrame or Ray Dataset"
                              " is supported for predict")

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -343,7 +343,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
             for shard, worker in zip(shards, self.remote_workers):
                 worker_stats = worker.predict.remote(data_creator, batch_size, profile)
                 remote_worker_stats.append(worker_stats)
-            result = result = ray.data.from_numpy(remote_worker_stats).\
+            result = ray.data.from_numpy(remote_worker_stats).\
                      map(lambda r: {"prediction_result": r["value"]})
         else:
             raise ValueError("Only xshards, Spark DataFrame or Ray Dataset"

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -299,7 +299,6 @@ class PyTorchRayEstimator(OrcaRayEstimator):
     def predict(self,
                 data,
                 batch_size=32,
-                label_cols=None,
                 feature_cols=None,
                 profile=False):
         """
@@ -309,7 +308,6 @@ class PyTorchRayEstimator(OrcaRayEstimator):
         :param batch_size: The number of samples per batch for each worker. Default is 32.
         :param profile: Boolean. Whether to return time stats for the training procedure.
                Default is False.
-        :param label_cols: label column names if data is a Spark DataFrame or Ray Dataset.
         :param feature_cols: feature column names if data is a Spark DataFrame or Ray Dataset.
         :return: A SparkXShards or a list that contains the predictions with key "prediction"
                in each shard
@@ -337,7 +335,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
             shards = data.split(n=self.num_workers, locality_hints=self.remote_workers)
 
             def data_creator(config, batch_size):
-                torch_datashard = shard.to_torch(label_column=label_cols,
+                torch_datashard = shard.to_torch(label_column=None,
                                                  feature_columns=feature_cols,
                                                  batch_size=batch_size)
                 return torch_datashard

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
@@ -112,17 +112,16 @@ class PytorchRayWorker(TorchRunner):
         self._create_schedulers_if_available()
         self._create_loss()
 
-    def predict(self, data_creator, batch_size=32, profile=False, label_cols=None):
+    def predict(self, data_creator, batch_size=32, profile=False):
         """Evaluates the model on the validation data set."""
         config = self.config.copy()
         self._toggle_profiling(profile=profile)
 
         shards_ref = data_creator(config, batch_size)
-        if isinstance(shards_ref, ray.data.Dataset):
+        if isinstance(shards_ref, Iterable):
             partition = shards_ref
         else:
             if not isinstance(shards_ref, ray.ObjectID):
                 raise ValueError("Only xshards and Ray Dataset is supported for predict")
             partition = ray.get(shards_ref)
-        return super().predict(partition=partition, batch_size=batch_size, profile=profile,
-                               label_cols=label_cols)
+        return super().predict(partition=partition, batch_size=batch_size, profile=profile)

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
@@ -32,6 +32,7 @@ import ray
 from bigdl.orca.learn.pytorch.utils import find_free_port
 from bigdl.orca.learn.pytorch.torch_runner import TorchRunner
 import torch.nn as nn
+from torch.utils.data import IterableDataset
 
 
 import logging
@@ -118,7 +119,7 @@ class PytorchRayWorker(TorchRunner):
         self._toggle_profiling(profile=profile)
 
         shards_ref = data_creator(config, batch_size)
-        if isinstance(shards_ref, Iterable):
+        if isinstance(shards_ref, IterableDataset):
             pred_stats = super().predict(partition=shards_ref, batch_size=batch_size,
                                          profile=profile)
             for pred_stat in pred_stats:

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
@@ -123,11 +123,11 @@ class PytorchRayWorker(TorchRunner):
                                          profile=profile)
             for pred_stat in pred_stats:
                 pred_stat.update(pred_stat)
-                pred_data = pred_stat["prediction"]
-            result = pred_data
+            worker_stats = pred_stat["prediction"]
         else:
             if not isinstance(shards_ref, ray.ObjectID):
                 raise ValueError("Only xshards and Ray Dataset is supported for predict")
             partition = ray.get(shards_ref)
-            result = super().predict(partition=partition, batch_size=batch_size, profile=profile)
-        return result
+            worker_stats = super().predict(partition=partition, batch_size=batch_size,
+                                           profile=profile)
+        return worker_stats

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
@@ -122,7 +122,7 @@ class PytorchRayWorker(TorchRunner):
             partition = shards_ref
         else:
             if not isinstance(shards_ref, ray.ObjectID):
-                raise ValueError("Only xshards is supported for predict")
+                raise ValueError("Only xshards and Ray Dataset is supported for predict")
             partition = ray.get(shards_ref)
         return super().predict(partition=partition, batch_size=batch_size, profile=profile,
                                label_cols=label_cols)

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
@@ -119,9 +119,15 @@ class PytorchRayWorker(TorchRunner):
 
         shards_ref = data_creator(config, batch_size)
         if isinstance(shards_ref, Iterable):
-            partition = shards_ref
+            pred_stats = super().predict(partition=shards_ref, batch_size=batch_size,
+                                         profile=profile)
+            for pred_stat in pred_stats:
+                pred_stat.update(pred_stat)
+                pred_data = pred_stat["prediction"]
+            result = pred_data
         else:
             if not isinstance(shards_ref, ray.ObjectID):
                 raise ValueError("Only xshards and Ray Dataset is supported for predict")
             partition = ray.get(shards_ref)
-        return super().predict(partition=partition, batch_size=batch_size, profile=profile)
+            result = super().predict(partition=partition, batch_size=batch_size, profile=profile)
+        return result

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -367,7 +367,7 @@ class TorchRunner:
                 data_loader = DataLoader(dataset, **params)
                 y = self.training_operator.predict(iter(data_loader))
             return {"prediction": y}
-        
+
         with self.timers.record("predict"):
             if isinstance(partition, ray.data.Dataset):
                 torch_dataset = partition.to_torch(label_column=label_cols,

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -368,7 +368,10 @@ class TorchRunner:
             return {"prediction": y}
 
         with self.timers.record("predict"):
-            new_part = [predict_fn(shard) for shard in partition]
+            if isinstance(partition, Iterable):
+                new_part = [predict_fn(shard) for shard, shard_idx in partition]
+            else:
+                new_part = [predict_fn(shard) for shard in partition]
         return new_part
 
     def _toggle_profiling(self, profile=False):

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -39,7 +39,7 @@ import os
 import tempfile
 import torch
 import torch.nn as nn
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, IterableDataset
 from torch.utils.data.distributed import DistributedSampler
 from bigdl.orca import OrcaContext
 from bigdl.orca.learn.pytorch.constants import SCHEDULER_STEP, NUM_STEPS
@@ -355,7 +355,7 @@ class TorchRunner:
                 params[arg] = config[arg]
 
         def predict_fn(shard):
-            if isinstance(shard, Iterable):
+            if isinstance(partition, IterableDataset):
                 y = self.training_operator.predict(shard)
             else:
                 if isinstance(shard["x"], tuple) or isinstance(shard["x"], list):
@@ -368,7 +368,7 @@ class TorchRunner:
             return {"prediction": y}
 
         with self.timers.record("predict"):
-            if isinstance(partition, Iterable):
+            if isinstance(partition, IterableDataset):
                 new_part = [predict_fn(shard) for shard, shard_idx in partition]
             else:
                 new_part = [predict_fn(shard) for shard in partition]

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_dataset.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_dataset.py
@@ -134,12 +134,10 @@ class TestPytorchEstimator(TestCase):
         orca_estimator = get_estimator(workers_per_node=2)
         train_dataset = train_data_creator()
         result_shards = orca_estimator.predict(data=train_dataset,
-                                               label_cols="x",
                                                feature_cols=["y"])
         print('Finished Training:', result_shards)
-
-        result = np.concatenate([shard["prediction"] for shard in result_shards])
-        print(result)
+        result_shards.show()
+        assert isinstance(result_shards, ray.data.Dataset)
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_dataset.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_dataset.py
@@ -14,18 +14,19 @@
 # limitations under the License.
 #
 import pytest
+import logging
 from unittest import TestCase
 
 import ray
 from ray.data import Dataset
-
 import torch
 import torch.nn as nn
 import torch.optim as optim
+import numpy as np
 
 from bigdl.orca import init_orca_context, stop_orca_context
 from bigdl.orca.learn.pytorch import Estimator
-from bigdl.orca.learn.metrics import Accuracy
+from bigdl.orca.learn.metrics import MSE, Accuracy
 
 def train_data_creator(a=5, b=10, size=1000):
     def get_dataset(a, b, size) -> Dataset:
@@ -35,12 +36,43 @@ def train_data_creator(a=5, b=10, size=1000):
             "y": a * x + b
         } for x in items])
         return dataset
+    train_dataset = get_dataset(a, b, size)
+    return train_dataset
 
-    ray_dataset = get_dataset(a, b, size)
-    return ray_dataset
+def val_data_creator(a=5, b=10, size=100):
+    def get_dataset(a, b, size) -> Dataset:
+        items = [i / size for i in range(size)]
+        dataset = ray.data.from_items([{
+            "x": x,
+            "y": a * x + b
+        } for x in items])
+        return dataset
+    val_dataset = get_dataset(a, b, size)
+    return val_dataset
+
+class Net(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(1, 50)
+        self.relu1 = nn.ReLU()
+        self.dout = nn.Dropout(0.2)
+        self.fc2 = nn.Linear(50, 100)
+        self.prelu = nn.PReLU(1)
+        self.out = nn.Linear(100, 1)
+        self.out_act = nn.Sigmoid()
+
+    def forward(self, input_):
+        a1 = self.fc1(input_)
+        h1 = self.relu1(a1)
+        dout = self.dout(h1)
+        a2 = self.fc2(dout)
+        h2 = self.prelu(a2)
+        a3 = self.out(h2)
+        y = self.out_act(a3)
+        return y
 
 def model_creator(config):
-    net = nn.Linear(1, 1)
+    net = Net()
     net = net.double()
     return net
 
@@ -50,6 +82,19 @@ def optim_creator(model, config):
                           momentum=config.get("momentum", 0.9))
     return optimizer
 
+def get_estimator(workers_per_node=2, model_fn=model_creator, sync_stats=False,
+                  log_level=logging.INFO, loss=nn.MSELoss(), optimizer=optim_creator):
+    estimator = Estimator.from_torch(model=model_fn,
+                                     optimizer=optimizer,
+                                     loss=loss,
+                                     metrics=[MSE()],
+                                     config={"lr": 1e-2},
+                                     workers_per_node=workers_per_node,
+                                     backend="torch_distributed",
+                                     sync_stats=sync_stats,
+                                     log_level=log_level)
+    return estimator
+
 class TestPytorchEstimator(TestCase):
     def setUp(self):
         init_orca_context(runtime="ray", address="localhost:6379")
@@ -57,22 +102,44 @@ class TestPytorchEstimator(TestCase):
     def tearDown(self):
         stop_orca_context()
 
-    def test_train(self):
-        dataset = train_data_creator()
-        orca_estimator = Estimator.from_torch(model=model_creator,
-                                            optimizer=optim_creator,
-                                            loss=nn.MSELoss(),
-                                            metrics=[Accuracy()],
-                                            config={"lr": 0.001},
-                                            workers_per_node=2,
-                                            backend="torch_distributed",
-                                            sync_stats=True)
-        train_stats = orca_estimator.fit(data=dataset, 
-                                         epochs=2, 
-                                         batch_size=32, 
-                                         label_cols="y")
+    def test_train_and_evaluate(self):
+        orca_estimator = get_estimator(workers_per_node=2)
+        train_dataset = train_data_creator()
+        val_dataset = val_data_creator()
+
+        start_val_stats = orca_estimator.evaluate(data=val_dataset,
+                                                  batch_size=32,
+                                                  label_cols="y",
+                                                  feature_cols=["x"])
+        print(start_val_stats)
+
+        train_stats = orca_estimator.fit(data=train_dataset,
+                                         epochs=2,
+                                         batch_size=32,
+                                         label_cols="y",
+                                         feature_cols=["x"])
+
+        end_val_stats = orca_estimator.evaluate(data=val_dataset,
+                                                batch_size=32,
+                                                label_cols="y",
+                                                feature_cols=["x"])
+        print(end_val_stats)
 
         assert orca_estimator.get_model()
+        dloss = end_val_stats["val_loss"] - start_val_stats["val_loss"]
+        print(f"dLoss: {dloss}")
+        assert dloss < 0, "training sanity check failed. loss increased!"
+
+    def test_predict(self):
+        orca_estimator = get_estimator(workers_per_node=2)
+        train_dataset = train_data_creator()
+        result_shards = orca_estimator.predict(data=train_dataset,
+                                               label_cols="x",
+                                               feature_cols=["y"])
+        print('Finished Training:', result_shards)
+
+        result = np.concatenate([shard["prediction"] for shard in result_shards])
+        print(result)
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
This is a PR to support ray dataset in `estimator.predict( )`, just the same as in `estimator.fit( )`. 

To conduct the predicted processing, you only need to set the input as a ray dataset and specify the label column.