### PR TITLE
fix run pytorch finetune example in jupyter notebook

### DIFF
--- a/python/nano/example/pytorch/pl-finetune/pl-finetune.py
+++ b/python/nano/example/pytorch/pl-finetune/pl-finetune.py
@@ -293,6 +293,9 @@ class TransferLearningModel(pl.LightningModule):
 
 
 class MyLightningCLI(LightningCLI):
+    def parse_arguments(self):
+        self.config = self.parser.parse_args(args=[])
+
     def add_arguments_to_parser(self, parser):
         parser.add_class_arguments(MilestonesFinetuning, "finetuning")
         parser.link_arguments("data.batch_size", "model.batch_size")

--- a/python/nano/example/pytorch/pl-finetune/pl-finetune.py
+++ b/python/nano/example/pytorch/pl-finetune/pl-finetune.py
@@ -293,7 +293,7 @@ class TransferLearningModel(pl.LightningModule):
 
 
 class MyLightningCLI(LightningCLI):
-    # Jupyter notebook
+    # add this while using jupyter notebook
     # def parse_arguments(self):
     #     self.config = self.parser.parse_args(args=[])
 

--- a/python/nano/example/pytorch/pl-finetune/pl-finetune.py
+++ b/python/nano/example/pytorch/pl-finetune/pl-finetune.py
@@ -293,8 +293,9 @@ class TransferLearningModel(pl.LightningModule):
 
 
 class MyLightningCLI(LightningCLI):
-    def parse_arguments(self):
-        self.config = self.parser.parse_args(args=[])
+    # Jupyter notebook
+    # def parse_arguments(self):
+    #     self.config = self.parser.parse_args(args=[])
 
     def add_arguments_to_parser(self, parser):
         parser.add_class_arguments(MilestonesFinetuning, "finetuning")

--- a/python/nano/example/pytorch/pl-finetune/pl-finetune.py
+++ b/python/nano/example/pytorch/pl-finetune/pl-finetune.py
@@ -293,7 +293,7 @@ class TransferLearningModel(pl.LightningModule):
 
 
 class MyLightningCLI(LightningCLI):
-    # add this while using jupyter notebook
+    # overwrite this function while using jupyter notebook
     # def parse_arguments(self):
     #     self.config = self.parser.parse_args(args=[])
 


### PR DESCRIPTION
Since the newest pytorch_lightning (unreleased now) change `self.parser`  to `LightningArgumentParser`, to gurantee this example can run in future version of Pytorch_Lightning,  I annote additional code.