### PR TITLE
Tiny fixes on lightning

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/lightning.py
+++ b/python/nano/src/bigdl/nano/pytorch/lightning.py
@@ -80,6 +80,9 @@ class LightningModuleFromTorch(LightningModule):
                    for i, metric in enumerate(self.metrics)}
             self.log_dict(acc, on_epoch=True, prog_bar=True, logger=True)
 
+    def predict_step(self, batch, batch_idx):
+        return self(*batch)
+
     def configure_optimizers(self):
         return [self.optimizer], [self.scheduler]
 

--- a/python/nano/src/bigdl/nano/pytorch/lightning.py
+++ b/python/nano/src/bigdl/nano/pytorch/lightning.py
@@ -84,7 +84,11 @@ class LightningModuleFromTorch(LightningModule):
         return self(*batch)
 
     def configure_optimizers(self):
-        return [self.optimizer], [self.scheduler]
+        optimizers = [self.optimizer]
+        schedulers = []
+        if self.scheduler:
+            schedulers.append(self.scheduler)
+        return optimizers, schedulers
 
     def load_state_dict(self, state_dict: 'OrderedDict[str, Tensor]',
                         strict: bool = True):

--- a/python/nano/src/bigdl/nano/pytorch/lightning.py
+++ b/python/nano/src/bigdl/nano/pytorch/lightning.py
@@ -21,10 +21,12 @@ from pytorch_lightning import LightningModule
 from torch import nn, Tensor
 from torch.nn.modules.loss import _Loss
 from torch.optim import Optimizer
+from torch.optim.lr_scheduler import _LRScheduler
 
 
 class LightningModuleFromTorch(LightningModule):
     def __init__(self, model: nn.Module, loss: _Loss = None, optimizer: Optimizer = None,
+                 scheduler: _LRScheduler = None,
                  metrics: List[Metric] = None):
         """
         Integrate pytorch modules, loss, optimizer to pytorch-lightning model.
@@ -32,12 +34,14 @@ class LightningModuleFromTorch(LightningModule):
         :param model:       Pytorch model to be converted.
         :param loss:        A torch loss function.
         :param optimizer:   A torch optimizer.
+        :param scheduler:   A torch scheduler.
         :param metrics:     A list of metrics to calculate accuracy of the model.
         """
         super().__init__()
         self.model = model
         self.loss = loss
         self.optimizer = optimizer
+        self.scheduler = scheduler
         self.metrics = metrics
 
     def forward(self, *args, **kwargs):
@@ -56,30 +60,24 @@ class LightningModuleFromTorch(LightningModule):
 
     def validation_step(self, batch, batch_idx):
         y_hat = self._forward(batch)
-        loss = self.loss(y_hat, batch[-1])  # use last output as target
-        self.log("val/loss", loss, on_epoch=True, prog_bar=True, logger=True)
+        if self.loss:
+            loss = self.loss(y_hat, batch[-1])  # use last output as target
+            self.log("val/loss", loss, on_epoch=True,
+                     prog_bar=True, logger=True)
         if self.metrics:
             acc = {"val/" + type(metric).__name__: metric(y_hat, batch[-1])
                    for i, metric in enumerate(self.metrics)}
             self.log_dict(acc, on_epoch=True, prog_bar=True, logger=True)
-        else:
-            acc = None
-        return loss, acc
 
     def test_step(self, batch, batch_idx):
         y_hat = self._forward(batch)
-        loss = self.loss(y_hat, batch[-1])  # use last output as target
-        self.log("test/loss", loss, on_epoch=True, prog_bar=True, logger=True)
         if self.metrics:
             acc = {"test/" + type(metric).__name__: metric(y_hat, batch[-1])
                    for i, metric in enumerate(self.metrics)}
             self.log_dict(acc, on_epoch=True, prog_bar=True, logger=True)
-        else:
-            acc = None
-        return loss, acc
 
     def configure_optimizers(self):
-        return self.optimizer
+        return [self.optimizer], [self.scheduler]
 
     def load_state_dict(self, state_dict: 'OrderedDict[str, Tensor]',
                         strict: bool = True):

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -25,7 +25,7 @@ from torch.fx.graph_module import GraphModule
 from torch.nn.modules.loss import _Loss
 from torch.utils.data import DataLoader
 from torchmetrics.metric import Metric
-
+from torch.optim.lr_scheduler import _LRScheduler
 from bigdl.nano.common import check_avx512
 from bigdl.nano.pytorch.lightning import LightningModuleFromTorch
 from bigdl.nano.pytorch.plugins.ddp_spawn import DDPSpawnPlugin
@@ -116,6 +116,7 @@ class Trainer(pl.Trainer):
     def compile(model: nn.Module,
                 loss: _Loss = None,
                 optimizer: torch.optim.Optimizer = None,
+                scheduler: _LRScheduler = None,
                 metrics: List[Metric] = None,
                 onnx: bool = False,
                 quantize: bool = True):
@@ -145,7 +146,7 @@ class Trainer(pl.Trainer):
                 "Loss and optimizer should be None if model is a pytorch-lightning model."
             pl_model = model
         else:
-            pl_model = LightningModuleFromTorch(model, loss, optimizer, metrics)
+            pl_model = LightningModuleFromTorch(model, loss, optimizer, scheduler, metrics)
 
         if onnx:
             try:

--- a/python/nano/src/bigdl/nano/quantization/neural_compressor/quantization.py
+++ b/python/nano/src/bigdl/nano/quantization/neural_compressor/quantization.py
@@ -88,8 +88,6 @@ class QuantizationINC(Quantization):
                 y = torch.stack(y, dim=0).numpy()
             return x, y
         if calib_dataloader:
-            self.cfg.quantization.calibration.sampling_size = len(
-                calib_dataloader.dataset)
             if "pytorch" in self.cfg.model.framework or "tensorflow" in self.cfg.model.framework:
                 self.calib_dataloader = calib_dataloader
             if "onnx" in self.cfg.model.framework:

--- a/python/nano/src/bigdl/nano/quantization/neural_compressor/quantization.py
+++ b/python/nano/src/bigdl/nano/quantization/neural_compressor/quantization.py
@@ -88,6 +88,8 @@ class QuantizationINC(Quantization):
                 y = torch.stack(y, dim=0).numpy()
             return x, y
         if calib_dataloader:
+            self.cfg.quantization.calibration.sampling_size = len(
+                calib_dataloader.dataset)
             if "pytorch" in self.cfg.model.framework or "tensorflow" in self.cfg.model.framework:
                 self.calib_dataloader = calib_dataloader
             if "onnx" in self.cfg.model.framework:

--- a/python/nano/test/pytorch/tests/test_lightning.py
+++ b/python/nano/test/pytorch/tests/test_lightning.py
@@ -54,7 +54,7 @@ class TestLightningModuleFromTorch(TestCase):
     def test_resnet18(self):
         pl_model = LightningModuleFromTorch(
             model, loss, optimizer,
-            [torchmetrics.F1(num_classes), torchmetrics.Accuracy(num_classes=10)]
+            metrics=[torchmetrics.F1(num_classes), torchmetrics.Accuracy(num_classes=10)]
         )
         data_loader = create_data_loader(data_dir, batch_size, num_workers, data_transform)
         trainer = Trainer(max_epochs=4, log_every_n_steps=1)

--- a/python/nano/test/pytorch/tests/test_quantize_inference.py
+++ b/python/nano/test/pytorch/tests/test_quantize_inference.py
@@ -84,7 +84,7 @@ class TestQuantizeInference(TestCase):
         test_loader = create_test_data_loader(data_dir, batch_size, \
                                               num_workers, test_data_transform, subset=200)
         trainer.fit(pl_model, test_loader)
-        nonquantized_loss = trainer.test(pl_model, test_loader)  # fp32
+        nonquantized_loss = trainer.validate(pl_model, test_loader)  # fp32
         assert pl_model._default_inference_quantize is False
         pl_model = trainer.quantize(pl_model, train_loader)
 
@@ -97,9 +97,9 @@ class TestQuantizeInference(TestCase):
             np.testing.assert_almost_equal(quantized_res, forward_res, decimal=5)  # same result
 
         assert pl_model._default_inference_quantize is True
-        quantized_loss = trainer.test(pl_model, test_loader)  # quantized
-        print(nonquantized_loss[0]['test/loss'], quantized_loss[0]['test/loss'])
-        assert abs(nonquantized_loss[0]['test/loss'] - quantized_loss[0]['test/loss']) > 1e-5
+        quantized_loss = trainer.validate(pl_model, test_loader)  # quantized
+        print(nonquantized_loss[0]['val/loss'], quantized_loss[0]['val/loss'])
+        assert abs(nonquantized_loss[0]['val/loss'] - quantized_loss[0]['val/loss']) > 1e-5
 
         trainer.fit(pl_model, train_loader)
         assert pl_model._quantized_model_up_to_date is False  # qmodel is not up-to-date after training


### PR DESCRIPTION
- Carefully handle loss, metrics in LightningModule
- add `pred_step`
- Add argument `scheduler` to configure scheduler
- Add argument `scheduler` to compile scheduler through `trainer.compile`
- Rename metrics with indexes as suffix to avoid different metrics with same class