### PR TITLE
Add data creator function support for tf.keras in AutoEstimator

### DIFF
--- a/python/orca/src/bigdl/orca/automl/auto_estimator.py
+++ b/python/orca/src/bigdl/orca/automl/auto_estimator.py
@@ -146,7 +146,8 @@ class AutoEstimator:
             ndarrays or a PyTorch DataLoader or a function that takes a config dictionary as
             parameter and returns a PyTorch DataLoader.
             If the AutoEstimator is created with from_keras, data can be a tuple of
-            ndarrays.
+            ndarrays or a function that takes a config dictionary as
+            parameter and returns a Tensorflow Dataset.
             If data is a tuple of ndarrays, it should be in the form of (x, y),
             where x is training input data and y is training target data.
         :param epochs: Max number of epochs to train in each trial. Defaults to 1.


### PR DESCRIPTION
This PR adds data creator function input support for `AutoEstimator.from_keras`, which takes config as input and return a tensorflow Dataset.
For tuple of numpy input, we will also convert to tensorflow Dataset internally and then feed into model. 