### PR TITLE
[WIP] python error log organize

### DIFF
--- a/python/dllib/src/bigdl/dllib/nn/layer.py
+++ b/python/dllib/src/bigdl/dllib/nn/layer.py
@@ -492,7 +492,7 @@ class Layer(JavaValue, SharedStaticUtils):
         ... except Py4JJavaError as err:
         ...     print(err.java_exception)
         ...
-        java.lang.IllegalArgumentException: requirement failed: this layer does not have weight/bias
+        java.lang.IllegalArgumentException: this layer does not have weight/bias
         >>> relu.get_weights()
         The layer does not have weight/bias
         >>> add = Add(2)

--- a/python/dllib/src/bigdl/dllib/nncontext.py
+++ b/python/dllib/src/bigdl/dllib/nncontext.py
@@ -613,6 +613,9 @@ def init_nncontext(conf=None, cluster_mode="spark-submit", spark_log_level="WARN
         raise ValueError("cluster_mode can only be local, yarn-client, yarn-cluster, standalone or"
                          " spark-submit, "
                          "but got: %s".format(cluster_mode))
+
+    from bigdl.dllib.utils.errorutils import install_exception_handler
+    install_exception_handler()
     return sc
 
 

--- a/python/dllib/src/bigdl/dllib/utils/common.py
+++ b/python/dllib/src/bigdl/dllib/utils/common.py
@@ -623,6 +623,12 @@ def callBigDlFunc(bigdl_type, name, *args):
         except Exception as e:
             error = e
             if "does not exist" not in str(e):
+                from bigdl.dllib.utils.errorutils import convert_exception, UnknownException
+                # converted = convert_exception(e.java_exception)
+                # if not isinstance(converted, UnknownException):
+                #     raise converted from None
+                # else:
+                #     raise e
                 raise e
         else:
             return result

--- a/python/dllib/src/bigdl/dllib/utils/errorutils.py
+++ b/python/dllib/src/bigdl/dllib/utils/errorutils.py
@@ -1,0 +1,165 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This file is adapted from
+# https://github.com/apache/spark/blob/master/python/pyspark/sql/utils.py
+
+from typing import Any, Callable, Optional, cast
+
+import py4j
+from py4j.protocol import Py4JJavaError  # type: ignore[import]
+from py4j.java_gateway import (  # type: ignore[import]
+    JavaClass,
+    JavaGateway,
+    JavaObject,
+    is_instance_of,
+)
+from pyspark import SparkContext
+
+
+class CapturedException(Exception):
+    def __init__(
+        self,
+        desc: Optional[str] = None,
+        stackTrace: Optional[str] = None,
+        cause: Optional[Py4JJavaError] = None,
+        origin: Optional[Py4JJavaError] = None,
+    ):
+        # desc & stackTrace vs origin are mutually exclusive.
+        # cause is optional.
+        assert (origin is not None and desc is None and stackTrace is None) or (
+            origin is None and desc is not None and stackTrace is not None
+        )
+
+        self.desc = desc if desc is not None else cast(Py4JJavaError, origin).getMessage()
+        assert SparkContext._jvm is not None
+        self.stackTrace = (
+            stackTrace
+            if stackTrace is not None
+            else (SparkContext._jvm.org.apache.spark.util.Utils.exceptionString(origin))
+        )
+        self.cause = convert_exception(cause) if cause is not None else None
+        if self.cause is None and origin is not None and origin.getCause() is not None:
+            self.cause = convert_exception(origin.getCause())
+        self._origin = origin
+
+    def __str__(self) -> str:
+        # assert SparkContext._jvm is not None  # type: ignore[attr-defined]
+
+        # jvm = SparkContext._jvm  # type: ignore[attr-defined]
+        # sql_conf = jvm.org.apache.spark.sql.internal.SQLConf.get()
+        # debug_enabled = sql_conf.pysparkJVMStacktraceEnabled()
+        desc = self.desc
+        # if debug_enabled:
+        #     desc = desc + "\n\nJVM stacktrace:\n%s" % self.stackTrace
+        return str(desc)
+
+    # def getErrorClass(self) -> Optional[str]:
+    #     assert SparkContext._gateway is not None  # type: ignore[attr-defined]
+    #
+    #     gw = SparkContext._gateway  # type: ignore[attr-defined]
+    #     if self._origin is not None and is_instance_of(
+    #         gw, self._origin, "org.apache.spark.SparkThrowable"
+    #     ):
+    #         return self._origin.getErrorClass()
+    #     else:
+    #         return None
+    #
+    # def getSqlState(self) -> Optional[str]:
+    #     assert SparkContext._gateway is not None  # type: ignore[attr-defined]
+    #
+    #     gw = SparkContext._gateway  # type: ignore[attr-defined]
+    #     if self._origin is not None and is_instance_of(
+    #         gw, self._origin, "org.apache.spark.SparkThrowable"
+    #     ):
+    #         return self._origin.getSqlState()
+    #     else:
+    #         return None
+
+
+class IllegalArgumentException(CapturedException):
+    """
+    Passed an illegal or inappropriate argument.
+    """
+
+
+class InvalidOperationException(CapturedException):
+    """
+    Exceptions for an invalid operation.
+    """
+
+
+class UnknownException(CapturedException):
+    """
+    None of the above exceptions.
+    """
+
+
+def convert_exception(e: Py4JJavaError) -> CapturedException:
+    assert e is not None
+    assert SparkContext._jvm is not None  # type: ignore[attr-defined]
+    assert SparkContext._gateway is not None  # type: ignore[attr-defined]
+
+    jvm = SparkContext._jvm  # type: ignore[attr-defined]
+    gw = SparkContext._gateway  # type: ignore[attr-defined]
+
+    if is_instance_of(gw, e, "com.intel.analytics.bigdl.dllib.utils.InvalidOperationException"):
+        return InvalidOperationException(origin=e)
+    elif is_instance_of(gw, e, "java.lang.IllegalArgumentException"):
+        return IllegalArgumentException(origin=e)
+
+    c = e.getCause()
+    if is_instance_of(gw, c, "com.intel.analytics.bigdl.dllib.utils.InvalidOperationException"):
+        return InvalidOperationException(origin=c)
+    elif is_instance_of(gw, c, "java.lang.IllegalArgumentException"):
+        return IllegalArgumentException(origin=c)
+    stacktrace = jvm.org.apache.spark.util.Utils.exceptionString(e)
+
+    return UnknownException(desc=e.toString(), stackTrace=stacktrace, cause=c)
+
+
+def capture_exception(f: Callable[..., Any]) -> Callable[..., Any]:
+    def deco(*a: Any, **kw: Any) -> Any:
+        try:
+            return f(*a, **kw)
+        except Py4JJavaError as e:
+            converted = convert_exception(e.java_exception)
+            if not isinstance(converted, UnknownException):
+                # Hide where the exception came from that shows a non-Pythonic
+                # JVM exception message.
+                raise converted from None
+            else:
+                raise
+
+    return deco
+
+
+def install_exception_handler() -> None:
+    """
+    Hook an exception handler into Py4j, which could capture some SQL exceptions in Java.
+
+    When calling Java API, it will call `get_return_value` to parse the returned object.
+    If any exception happened in JVM, the result will be Java exception object, it raise
+    py4j.protocol.Py4JJavaError. We replace the original `get_return_value` with one that
+    could capture the Java exception and throw a Python one (with the same error message).
+
+    It's idempotent, could be called multiple times.
+    """
+    original = py4j.protocol.get_return_value
+    # The original `get_return_value` is not patched, it's idempotent.
+    patched = capture_exception(original)
+    # only patch the one used in py4j.java_gateway (call Java API)
+    py4j.java_gateway.get_return_value = patched


### PR DESCRIPTION
This PR adds python error handling api.

below are some sample error message:
1.
22-03-17 15:14:50 [default-thread-computing 72] ERROR Log4Error$:36 - 
*************************Usage Error: Invalid operations*********************
curTarget 3 is out of range, should be 1 to 2
22-03-17 15:14:50 [default-thread-computing 72] ERROR Log4Error$:38 - 
*************************How to fix*********************
Please make sure the label is 1 based and the range should be [1, 2]
Traceback (most recent call last):
  File "/home/ding/tools/pycharm-community-2017.1/helpers/pydev/pydevd.py", line 1578, in <module>
    globals = debugger.run(setup['file'], None, None, is_module)
  File "/home/ding/tools/pycharm-community-2017.1/helpers/pydev/pydevd.py", line 1015, in run
    pydev_imports.execfile(file, globals, locals)  # execute the script
  File "/home/ding/tools/pycharm-community-2017.1/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "/home/ding/proj/spark-dl-master/BigDL-dllib/python/dllib/examples/lenet/lenet.py", line 57, in <module>
    model.fit(df, feature_cols=["features"], label_cols=["label"], batch_size=4, nb_epoch=1)
  File "/home/ding/.local/lib/python3.6/site-packages/bigdl/dllib/keras/engine/topology.py", line 276, in fit
    validation_data)
  File "/home/ding/.local/lib/python3.6/site-packages/bigdl/dllib/utils/common.py", line 631, in callBigDlFunc
    raise converted from None
bigdl.dllib.utils.errorutils.InvalidOperationException: curTarget 3 is out of range, should be 1 to 2

JAVA CALL STACK 

2.
22-03-17 14:52:37 [Thread-4] ERROR Log4Error$:47 - 
************************* Error *********************
Total size after reshape must be unchanged. But in Reshape93584f13: input size is: 144, while reshape size is: 169

************************* STACK *********************
Traceback (most recent call last):
  File "/home/ding/tools/pycharm-community-2017.1/helpers/pydev/pydevd.py", line 1578, in <module>
    globals = debugger.run(setup['file'], None, None, is_module)
  File "/home/ding/tools/pycharm-community-2017.1/helpers/pydev/pydevd.py", line 1015, in run
    pydev_imports.execfile(file, globals, locals)  # execute the script
  File "/home/ding/tools/pycharm-community-2017.1/helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "/home/ding/proj/spark-dl-master/BigDL-dllib/python/dllib/examples/lenet/lenet.py", line 34, in <module>
    model.add(Reshape([169]))
  File "/home/ding/.local/lib/python3.6/site-packages/bigdl/dllib/keras/models.py", line 123, in add
    self.value.add(model.value)
  File "/home/ding/.local/lib/python3.6/site-packages/py4j/java_gateway.py", line 1257, in __call__
    answer, self.gateway_client, self.target_id, self.name)
  File "/home/ding/.local/lib/python3.6/site-packages/pyspark/sql/utils.py", line 63, in deco
    return f(*a, **kw)
  File "/home/ding/.local/lib/python3.6/site-packages/py4j/protocol.py", line 328, in get_return_value
    format(target_id, ".", name), value)
py4j.protocol.Py4JJavaError: An error occurred while calling o59.add.
: com.intel.analytics.bigdl.dllib.utils.UnKnownException: Total size after reshape must be unchanged. But in Reshape93584f13: input size is: 144, while reshape size is: 169
	at com.intel.analytics.bigdl.dllib.utils.Log4Error$.unKnowExceptionError(Log4Error.scala:54)
	at com.intel.analytics.bigdl.dllib.keras.layers.Reshape.computeOutputShape(Reshape.scala:84)
	at com.intel.analytics.bigdl.dllib.nn.abstractnn.InferShape$class.build(InferShape.scala:76)
	at com.intel.analytics.bigdl.dllib.nn.internal.KerasLayer.build(KerasLayer.scala:316)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.intel.analytics.bigdl.dllib.keras.layers.utils.KerasUtils$.invokeMethod(KerasUtils.scala:304)
	at com.intel.analytics.bigdl.dllib.keras.layers.utils.AbstractModuleRef.build(Reflection.scala:70)
	at com.intel.analytics.bigdl.dllib.keras.Sequential.buildModule(Sequential.scala:95)
	at com.intel.analytics.bigdl.dllib.keras.Sequential.add(Sequential.scala:137)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
	at py4j.Gateway.invoke(Gateway.java:282)
	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
	at py4j.commands.CallCommand.execute(CallCommand.java:79)
	at py4j.GatewayConnection.run(GatewayConnection.java:238)
	at java.lang.Thread.run(Thread.java:748)
