### PR TITLE
[Orca] Update Orca Python API Docs

### DIFF
--- a/docs/readthedocs/requirements-doc.txt
+++ b/docs/readthedocs/requirements-doc.txt
@@ -28,4 +28,3 @@ sphinx_markdown_tables
 numpy==1.21.2
 xgboost
 torchmetrics
-openvino

--- a/docs/readthedocs/requirements-doc.txt
+++ b/docs/readthedocs/requirements-doc.txt
@@ -28,3 +28,4 @@ sphinx_markdown_tables
 numpy==1.21.2
 xgboost
 torchmetrics
+openvino

--- a/docs/readthedocs/source/doc/PythonAPI/Orca/orca.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Orca/orca.rst
@@ -19,6 +19,15 @@ orca.learn.tf.estimator
     :show-inheritance:
 
 
+orca.learn.tf2.estimator
+-------------------------
+
+.. automodule:: bigdl.orca.learn.tf2.estimator
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 orca.learn.tf2.tf2_ray_estimator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/readthedocs/source/doc/PythonAPI/Orca/orca.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Orca/orca.rst
@@ -19,13 +19,27 @@ orca.learn.tf.estimator
     :show-inheritance:
 
 
-orca.learn.tf2.estimator
--------------------------
+orca.learn.tf2.tf2_ray_estimator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. automodule:: bigdl.orca.learn.tf2.estimator
+Orca TF2Estimator with backend of "horovod" or "tf2".
+
+.. autoclass:: bigdl.orca.learn.tf2.ray_estimator.TensorFlow2Estimator
     :members:
     :undoc-members:
     :show-inheritance:
+
+
+orca.learn.tf2.tf2_spark_estimator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Orca TF2Estimator with backend of "spark".
+
+.. autoclass:: bigdl.orca.learn.tf2.pyspark_estimator.SparkTFEstimator
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 orca.learn.pytorch.estimator
 -----------------------------


### PR DESCRIPTION
1. Add orca API docs for tf2_ray_estimator and tf2_spark_estimator.
2. Update PyTorch API Docs for the new ray dataset backend.