### PR TITLE
[PPML] Correctly read device files whose size are always zero

### DIFF
--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/attestation/GramineQuoteGeneratorImpl.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/attestation/GramineQuoteGeneratorImpl.scala
@@ -29,8 +29,8 @@ import scala.collection.Iterator
 class GramineQuoteGeneratorImpl extends QuoteGenerator {
 
   val logger = LogManager.getLogger(getClass)
-  val UserReportPath = "/dev/attestation/user_report_data"
-  val QuotePath = "/dev/attestation/quote"
+  val USER_REPORT_PATH = "/dev/attestation/user_report_data"
+  val QUOTE_PATH = "/dev/attestation/quote"
 
   @throws(classOf[AttestationRuntimeException])
   override def getQuote(userReportData: Array[Byte]): Array[Byte] = {
@@ -42,7 +42,7 @@ class GramineQuoteGeneratorImpl extends QuoteGenerator {
 
     try {
       // write userReport
-      val out = new BufferedOutputStream(new FileOutputStream(UserReportPath))
+      val out = new BufferedOutputStream(new FileOutputStream(USER_REPORT_PATH))
       out.write(userReportData)
       out.close()
     } catch {
@@ -54,7 +54,7 @@ class GramineQuoteGeneratorImpl extends QuoteGenerator {
 
     try {
       // read quote
-      val quoteFile = new File(QuotePath)
+      val quoteFile = new File(QUOTE_PATH)
       val in = new FileInputStream(quoteFile)
       val bufIn = new BufferedInputStream(in)
       val quote = Iterator.continually(bufIn.read()).takeWhile(_ != -1).map(_.toByte).toArray

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/attestation/GramineQuoteGeneratorImpl.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/attestation/GramineQuoteGeneratorImpl.scala
@@ -17,10 +17,11 @@
 package com.intel.analytics.bigdl.ppml.attestation
 
 import org.apache.logging.log4j.LogManager
-import java.io.BufferedOutputStream;
+import java.io.{BufferedOutputStream, BufferedInputStream};
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import scala.collection.Iterator
 
 /**
  * QuoteGenerator for Gramine (https://github.com/gramineproject/gramine)
@@ -28,9 +29,8 @@ import java.io.FileOutputStream;
 class GramineQuoteGeneratorImpl extends QuoteGenerator {
 
   val logger = LogManager.getLogger(getClass)
-
-  val userReportPath = "/dev/attestation/user_report_data"
-  val quotePath = "/dev/attestation/quote"
+  val UserReportPath = "/dev/attestation/user_report_data"
+  val QuotePath = "/dev/attestation/quote"
 
   @throws(classOf[AttestationRuntimeException])
   override def getQuote(userReportData: Array[Byte]): Array[Byte] = {
@@ -42,7 +42,7 @@ class GramineQuoteGeneratorImpl extends QuoteGenerator {
 
     try {
       // write userReport
-      val out = new BufferedOutputStream(new FileOutputStream(userReportPath))
+      val out = new BufferedOutputStream(new FileOutputStream(UserReportPath))
       out.write(userReportData)
       out.close()
     } catch {
@@ -54,16 +54,17 @@ class GramineQuoteGeneratorImpl extends QuoteGenerator {
 
     try {
       // read quote
-      val quoteFile = new File(quotePath)
-      if (quoteFile.length == 0) {
+      val quoteFile = new File(QuotePath)
+      val in = new FileInputStream(quoteFile)
+      val bufIn = new BufferedInputStream(in)
+      val quote = Iterator.continually(bufIn.read()).takeWhile(_ != -1).map(_.toByte).toArray
+      bufIn.close()
+      in.close()
+      if (quote.length == 0) {
         logger.error("Invalid quote file length.")
         throw new AttestationRuntimeException("Retrieving Gramine quote " +
           "returned Invalid file length!")
       }
-      val in = new FileInputStream(quoteFile)
-      val quote = new Array[Byte](quoteFile.length.toInt)
-      in.read(quote)
-      in.close()
       return quote
     } catch {
       case e: Exception =>


### PR DESCRIPTION
In Gramine, the size of /dev/attestation/quote is always zero. Since the size of an actual quote (DCAP) is not a fixed value, BufferedInputStream is used to read the whole quote. Then the quote Array size is validated.