### PR TITLE
Nano: support an option to start process by "fork" on UNIX-like OS for multiprocessing training

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/plugins/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/plugins/ddp_spawn.py
@@ -118,6 +118,8 @@ class DDPSpawnPlugin(pl.plugins.DDPSpawnPlugin):
         cpu_for_each_process: Optional[List[List[int]]] = None,
         use_ipex=False,
         enable_bf16=False,
+        process_start_method: str = "spawn",
+        **kwargs: Any,
     ):
         """Create a DDPSpawnPlugin, adding a cpu_for_each_process parameter."""
         device = ipex_device() if use_ipex and TORCH_VERSION_LESS_1_10 else 'cpu'
@@ -127,6 +129,7 @@ class DDPSpawnPlugin(pl.plugins.DDPSpawnPlugin):
         super().__init__(parallel_devices,
                          cluster_environment=cluster_environment)
         self.cpu_for_each_process = cpu_for_each_process
+        self.process_start_method = process_start_method
         self.is_distributed = True
         self.use_ipex = use_ipex
         self.enable_bf16 = enable_bf16
@@ -137,7 +140,8 @@ class DDPSpawnPlugin(pl.plugins.DDPSpawnPlugin):
         return {
             "args": (self.lightning_module.trainer, self.mp_queue),
             "nprocs": self.num_processes,
-            "cpu_procs": self.cpu_for_each_process
+            "cpu_procs": self.cpu_for_each_process,
+            "start_method": self.process_start_method,
         }
 
     def start_training(self, trainer):

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -106,9 +106,9 @@ class Trainer(pl.Trainer):
                 raise ValueError(f"The length of `cpu_for_each_process` ("
                                  f"{len(cpu_for_each_process)}) is not equal to the number of"
                                  f" processes {num_processes}.")
-        if cpu_for_each_process not in ["spawn", "fork"]:
-            raise ValueError(f"`cpu_for_each_process` can only be one of"
-                             f"[\"spawn\", \"fork\"], but get {cpu_for_each_process}.")
+        if process_start_method not in ["spawn", "fork"]:
+            raise ValueError(f"`process_start_method` can only be one of"
+                             f"[\"spawn\", \"fork\"], but get {process_start_method}.")
 
         # Initialize trainer
         if use_ipex and not check_avx512():

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -187,6 +187,7 @@ class Trainer(pl.Trainer):
                 plugin = DDPSpawnPlugin(parallel_devices=[
                     torch.device(device) for _ in range(num_processes)],
                     cpu_for_each_process=cpu_for_each_process,
+                    process_start_method=process_start_method,
                     cluster_environment=LightningEnvironment())
             elif distributed_backend == "subprocess":
                 from bigdl.nano.pytorch.plugins.ddp_subprocess import DDPSubprocessPlugin
@@ -198,7 +199,6 @@ class Trainer(pl.Trainer):
                 plugin = DDPSubprocessPlugin(parallel_devices=[
                     torch.device(device) for _ in range(num_processes)],
                     cpu_for_each_process=cpu_for_each_process,
-                    process_start_method=process_start_method,
                     cluster_environment=LightningEnvironment())
             elif distributed_backend == "ray":
                 # Import RayPlugins may entangle with openmp even if it has not been used,

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -106,7 +106,7 @@ class Trainer(pl.Trainer):
                 raise ValueError(f"The length of `cpu_for_each_process` ("
                                  f"{len(cpu_for_each_process)}) is not equal to the number of"
                                  f" processes {num_processes}.")
-        if not cpu_for_each_process in ["spawn", "fork"]:
+        if cpu_for_each_process not in ["spawn", "fork"]:
             raise ValueError(f"`cpu_for_each_process` can only be one of"
                              f"[\"spawn\", \"fork\"], but get {cpu_for_each_process}.")
 

--- a/python/nano/test/pytorch/tests/test_plugin.py
+++ b/python/nano/test/pytorch/tests/test_plugin.py
@@ -125,6 +125,16 @@ class TestPlugin(TestCase):
 
         assert pl_model.model.fc1.weight.data == 0.25, "spawn plugin works incorrect"
         return 
+    def test_trainer_fork_plugin(self):
+        pl_model = LightningModuleFromTorch(
+            self.model, self.loss, self.optimizer,
+            metrics=[torchmetrics.F1(num_classes), torchmetrics.Accuracy(num_classes=10)]
+        )
+        trainer = Trainer(num_processes=2, distributed_backend="fork",
+                          max_epochs=4)
+        trainer.fit(pl_model, self.data_loader)
+        trainer.test(pl_model, self.data_loader)
+
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/python/nano/test/run-nano-pytorch-tests.sh
+++ b/python/nano/test/run-nano-pytorch-tests.sh
@@ -11,7 +11,8 @@ set -e
 # ipex is not installed here. Any tests needs ipex should be moved to next pytest command.
 echo "# Start testing"
 start=$(date "+%s")
-python -m pytest -s ${PYTORCH_NANO_TEST_DIR}/tests/ -k 'not ipex'
+python -m pytest -s ${PYTORCH_NANO_TEST_DIR}/tests/ -k 'not ipex and not fork'
+python -m pytest -s ${PYTORCH_NANO_TEST_DIR}/tests/test_plugin.py  # avoid issue pytorch/#41639
 
 now=$(date "+%s")
 time=$((now-start))


### PR DESCRIPTION
Since "fork" does not require any serialization, this might be a life-saver for our users who have
1. components that can not be serialized (e.g. `threading.Lock`)
2. closure (e.g. decorator)

I am not sure if current API design is the best.
Current:
```python
trainer = Trainer(distributed_backend="spawn", process_start_method="fork")
```
Is this confusing to our users? we may just create another backend called "fork" and make our users use it like:
```python
trainer = Trainer(distributed_backend="fork")
```
-------------------------
Update: 4/25: discussed with @yangw1234 
Will change this PR's implementation to 
```python
trainer = Trainer(distributed_backend="fork")
```
this design