### PR TITLE
AutoEstimator tf.keras spark dataframe input implemented with ray Dataset pipeline

### DIFF
--- a/python/orca/dev/test/run-pytests-horovod-tf.sh
+++ b/python/orca/dev/test/run-pytests-horovod-tf.sh
@@ -29,3 +29,4 @@ python -m pytest -v test/bigdl/orca/learn/ray/tf/ \
     --ignore=test/bigdl/orca/learn/ray/tf/test_ray_tf2estimator.py \
     --ignore=test/bigdl/orca/learn/ray/tf/test_tf2estimator_ray_dataset.py
 python -m pytest -v test/bigdl/orca/data/test_read_parquet_images.py
+python -m pytest -v test/bigdl/orca/automl/autoestimator/test_autoestimator_keras.py::TestTFKerasAutoEstimator::test_spark_df_single_input_model

--- a/python/orca/dev/test/run-pytests-ray
+++ b/python/orca/dev/test/run-pytests-ray
@@ -45,7 +45,8 @@ python -m pytest -v test/bigdl/orca/learn/ray \
       --ignore=test/bigdl/orca/learn/ray/pytorch/test_estimator_horovod_backend.py \
       --ignore=test/bigdl/orca/learn/ray/pytorch/test_ray_pytorch_estimator.py \
       --ignore=test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_dataset.py \
-      --ignore=test/bigdl/orca/learn/ray/tf/
+      --ignore=test/bigdl/orca/learn/ray/tf/ \
+      -k "not test_spark_df"
 exit_status_2=$?
 if [ $exit_status_2 -ne 0 ];
 then

--- a/python/orca/src/bigdl/orca/automl/auto_estimator.py
+++ b/python/orca/src/bigdl/orca/automl/auto_estimator.py
@@ -137,6 +137,7 @@ class AutoEstimator:
             scheduler_params=None,
             feature_cols=None,
             label_cols=None,
+            output_signature=None,
             ):
         """
         Automatically fit the model and search for the best hyperparameters.
@@ -203,7 +204,9 @@ class AutoEstimator:
                               scheduler=scheduler,
                               scheduler_params=scheduler_params,
                               feature_cols=feature_cols,
-                              label_cols=label_cols)
+                              label_cols=label_cols,
+                              output_signature=output_signature,
+                              )
         self.searcher.run()
         self._fitted = True
 

--- a/python/orca/src/bigdl/orca/automl/auto_estimator.py
+++ b/python/orca/src/bigdl/orca/automl/auto_estimator.py
@@ -146,7 +146,7 @@ class AutoEstimator:
             ndarrays or a PyTorch DataLoader or a function that takes a config dictionary as
             parameter and returns a PyTorch DataLoader.
             If the AutoEstimator is created with from_keras, data can be a tuple of
-            ndarrays or a function that takes a config dictionary as
+            ndarrays, Spark DataFrame, or a function that takes a config dictionary as
             parameter and returns a Tensorflow Dataset.
             If data is a tuple of ndarrays, it should be in the form of (x, y),
             where x is training input data and y is training target data.

--- a/python/orca/src/bigdl/orca/automl/model/base_keras_model.py
+++ b/python/orca/src/bigdl/orca/automl/model/base_keras_model.py
@@ -60,7 +60,7 @@ class KerasBaseModel(BaseModel):
                  metric_func=None, resources_per_trial=None,
                  **config):
         """
-        :param data: could be a tuple with numpy ndarray with form (x, y) or
+        :param data: could be a tuple with numpy ndarray with form (x, y) or a tensorflow Dataset
                a data creator takes a config dict as parameter and returns a tf.data.Dataset.
         :param validation_data: could be a tuple with numpy ndarray with form (x, y)
         fit_eval will build a model at the first time it is built
@@ -92,6 +92,10 @@ class KerasBaseModel(BaseModel):
                 validation_dataset = validation_data(self.config)
             else:
                 validation_dataset = validation_data
+
+        elif isinstance(data, tf.data.Dataset):
+            train_dataset = data
+            validation_dataset = validation_data
         else:
             if not isinstance(data, tuple):
                 raise ValueError(f"data/validation_data should be a tuple of numpy array "

--- a/python/orca/src/bigdl/orca/automl/model/base_keras_model.py
+++ b/python/orca/src/bigdl/orca/automl/model/base_keras_model.py
@@ -56,6 +56,19 @@ class KerasBaseModel(BaseModel):
         dataset = dataset.batch(batch_size)
         return dataset
 
+    @staticmethod
+    def _ray_dataset_ppl_to_tf_dataset(dataset, config):
+        label_cols = config["label_cols"]
+        if len(label_cols) > 1:
+            raise ValueError("We don't support model with multiple ouputs yet!")
+        label_col = label_cols[0]
+        dataset = dataset.to_tf(label_column=label_col,
+                                feature_columns=config["feature_cols"],
+                                output_signature=config["output_signature"],
+                                batch_size=int(config.get("batch_size", 32))
+                                )
+        return dataset
+
     def fit_eval(self, data, validation_data=None, mc=False, verbose=0, epochs=1, metric=None,
                  metric_func=None, resources_per_trial=None,
                  **config):
@@ -68,6 +81,8 @@ class KerasBaseModel(BaseModel):
         params be functional
         TODO: check the updated params and decide if the model is needed to be rebuilt
         """
+        from ray.data.dataset_pipeline import DatasetPipeline
+
         def update_config():
             if isinstance(data, tuple) and isinstance(data[0], np.ndarray):
                 x, y = data
@@ -85,17 +100,26 @@ class KerasBaseModel(BaseModel):
             self._check_config(**tmp_config)
             self.config.update(config)
 
+        validation_dataset = None
         # get train_dataset and validation_dataset
         if isinstance(data, types.FunctionType):
             train_dataset = data(self.config)
             if validation_data:
                 validation_dataset = validation_data(self.config)
-            else:
-                validation_dataset = validation_data
 
         elif isinstance(data, tf.data.Dataset):
             train_dataset = data
             validation_dataset = validation_data
+        elif isinstance(data, DatasetPipeline):
+            assert "feature_cols" in config, "'feature_cols' must be provided in config if input \
+                data is a Ray Dataset or DataPipeline."
+            assert "label_cols" in config, "'label_cols' must be provided in config if input \
+                data is a Ray Dataset or DataPipeline."
+            train_dataset = KerasBaseModel._ray_dataset_ppl_to_tf_dataset(data, self.config)
+            if validation_data:
+                validation_dataset = KerasBaseModel._ray_dataset_ppl_to_tf_dataset(validation_data,
+                                                                                   self.config)
+
         else:
             if not isinstance(data, tuple):
                 raise ValueError(f"data/validation_data should be a tuple of numpy array "
@@ -109,8 +133,6 @@ class KerasBaseModel(BaseModel):
             train_dataset = KerasBaseModel._np_to_dataset(data, batch_size=batch_size)
             if validation_data:
                 validation_dataset = KerasBaseModel._np_to_dataset(validation_data, batch_size)
-            else:
-                validation_dataset = validation_data
 
         hist = self.model.fit(train_dataset,
                               validation_data=validation_dataset,

--- a/python/orca/src/bigdl/orca/automl/search/ray_tune/ray_tune_search_engine.py
+++ b/python/orca/src/bigdl/orca/automl/search/ray_tune/ray_tune_search_engine.py
@@ -331,7 +331,6 @@ class RayTuneSearchEngine(SearchEngine):
                     val_data_iter = ray_val_data.iter_epochs()
                 else:
                     val_data_iter = None
-                #TODO: add check
                 assert feature_cols, "You must specify feature_cols for Spark DataFrame input"
                 assert label_cols, "You must specify label_cols for Spark DataFrame input"
                 assert output_signature, "You must specify output_signature for Spark DataFrame \

--- a/python/orca/test/bigdl/orca/automl/autoestimator/test_autoestimator_keras.py
+++ b/python/orca/test/bigdl/orca/automl/autoestimator/test_autoestimator_keras.py
@@ -332,7 +332,7 @@ class TestTFKerasAutoEstimator(TestCase):
     #     assert "lr" in best_config
     #     assert all(k in best_config.keys() for k in get_search_space_multi_inputs_outputs().keys())
 
-    def test_spark_df_single_inputs_model(self):
+    def test_spark_df_single_input_model(self):
         auto_est = AutoEstimator.from_keras(model_creator=single_input_model_creator,
                                         logs_dir="/tmp/zoo_automl_logs",
                                         resources_per_trial={"cpu": 2},

--- a/python/orca/test/bigdl/orca/automl/autoestimator/test_autoestimator_keras.py
+++ b/python/orca/test/bigdl/orca/automl/autoestimator/test_autoestimator_keras.py
@@ -129,6 +129,65 @@ def create_linear_search_space():
     }
 
 
+# for spark dataframe input and model of single input/output
+def simple_model(config):
+    import tensorflow as tf
+    model = tf.keras.models.Sequential([tf.keras.layers.Dense(config["dense"], input_shape=(1,)),
+                                        tf.keras.layers.Dense(1)])
+    return model
+
+
+def compile_args(config):
+    import tensorflow as tf
+    if "lr" in config:
+        lr = config["lr"]
+    else:
+        lr = 1e-3
+    args = {
+        "optimizer": tf.keras.optimizers.SGD(lr),
+        "loss": "mean_squared_error",
+        "metrics": ["mean_squared_error"]
+    }
+    return args
+
+
+def single_input_model_creator(config):
+    model = simple_model(config)
+    model.compile(**compile_args(config))
+    return model
+
+
+def get_search_space():
+    from bigdl.orca.automl import hp
+    return {
+        "dense": hp.choice([8, 16]),
+        "lr": hp.choice([0.001, 0.003, 0.01]),
+        "batch_size": hp.choice([32, 64])
+    }
+
+def get_spark_dataframes():
+    import tensorflow as tf
+    def get_df(size):
+        rdd = sc.range(0, size)
+        from pyspark.sql import SparkSession
+        spark = SparkSession(sc)
+        df = rdd.map(lambda x: (np.random.randn(1,).tolist(),
+                                int(np.random.randint(0, 1, size=())))).toDF(["feature", "label"])
+        return df
+
+    from pyspark.sql import SparkSession
+    from bigdl.orca import OrcaContext
+    sc = OrcaContext.get_spark_context()
+    spark = SparkSession(sc)
+    feature_cols = ["feature"]
+    label_cols = "label"
+    train_df = get_df(size=100)
+    val_df = get_df(size=30)
+    output_signature = (tf.TensorSpec(shape=(None, 1), dtype=tf.float32),
+                        tf.TensorSpec(shape=(None), dtype=tf.float32))
+    return train_df, val_df, feature_cols, label_cols, output_signature
+
+
 class TestTFKerasAutoEstimator(TestCase):
     def setUp(self) -> None:
         from bigdl.orca import init_orca_context
@@ -250,28 +309,52 @@ class TestTFKerasAutoEstimator(TestCase):
                      metric=pyrmsle,
                      metric_mode="min")
 
-    def test_multiple_inputs_model(self):
-        auto_est = AutoEstimator.from_keras(model_creator=model_creator_multi_inputs_outputs,
-                                            logs_dir="/tmp/zoo_automl_logs",
-                                            resources_per_trial={"cpu": 2},
-                                            name="test_fit")
+    # def test_multiple_inputs_model(self):
+    #     auto_est = AutoEstimator.from_keras(model_creator=model_creator_multi_inputs_outputs,
+    #                                         logs_dir="/tmp/zoo_automl_logs",
+    #                                         resources_per_trial={"cpu": 2},
+    #                                         name="test_fit")
 
-        data, validation_data, feature_cols, label_cols = get_multi_inputs_outputs_data()
+    #     data, validation_data, feature_cols, label_cols = get_multi_inputs_outputs_data()
+    #     auto_est.fit(data=data,
+    #                  validation_data=validation_data,
+    #                  search_space=get_search_space_multi_inputs_outputs(),
+    #                  n_sampling=2,
+    #                  epochs=5,
+    #                  metric='output_acc',
+    #                  metric_threshold=0.7,
+    #                  metric_mode="max",
+    #                  feature_cols=feature_cols,
+    #                  label_cols=label_cols,
+    #                  )
+    #     assert auto_est.get_best_model()
+    #     best_config = auto_est.get_best_config()
+    #     assert "lr" in best_config
+    #     assert all(k in best_config.keys() for k in get_search_space_multi_inputs_outputs().keys())
+
+    def test_spark_df_single_inputs_model(self):
+        auto_est = AutoEstimator.from_keras(model_creator=single_input_model_creator,
+                                        logs_dir="/tmp/zoo_automl_logs",
+                                        resources_per_trial={"cpu": 2},
+                                        name="test_fit")
+
+        data, validation_data, feature_cols, label_cols, output_signature = get_spark_dataframes()
         auto_est.fit(data=data,
                      validation_data=validation_data,
-                     search_space=get_search_space_multi_inputs_outputs(),
+                     search_space=get_search_space(),
                      n_sampling=2,
                      epochs=5,
-                     metric='output_acc',
-                     metric_threshold=0.7,
-                     metric_mode="max",
+                     metric="mean_squared_error",
+                     metric_threshold=0.01,
+                     metric_mode="min",
                      feature_cols=feature_cols,
                      label_cols=label_cols,
+                     output_signature=output_signature,
                      )
         assert auto_est.get_best_model()
         best_config = auto_est.get_best_config()
         assert "lr" in best_config
-        assert all(k in best_config.keys() for k in get_search_space_multi_inputs_outputs().keys())
+        assert all(k in best_config.keys() for k in get_search_space().keys())
 
 
 if __name__ == "__main__":

--- a/python/orca/test/bigdl/orca/automl/model/test_base_keras_model.py
+++ b/python/orca/test/bigdl/orca/automl/model/test_base_keras_model.py
@@ -39,6 +39,13 @@ def get_train_val_data():
     return data, validation_data
 
 
+def get_train_val_dataset():
+    config = {"batch_size": 32}
+    dataset = get_dataset(size=1000, config=config)
+    validation_dataset = get_dataset(size=400, config=config)
+    return dataset, validation_dataset
+
+
 def get_train_data_creator():
     def train_data_creator(config):
         return get_dataset(size=1000, config=config)
@@ -98,6 +105,19 @@ class TestBaseKerasModel(TestCase):
         })
         val_result = model.fit_eval(data=data_creator,
                                     validation_data=validation_data_creator,
+                                    metric="mse",
+                                    epochs=20)
+        assert val_result.get("mse")
+
+    def test_fit_eval_dataset(self):
+        dataset, validation_dataset = get_train_val_dataset()
+        modelBuilder_keras = KerasModelBuilder(model_creator_keras)
+        model = modelBuilder_keras.build(config={
+            "lr": 1e-2,
+            "batch_size": 32,
+        })
+        val_result = model.fit_eval(data=dataset,
+                                    validation_data=validation_dataset,
                                     metric="mse",
                                     epochs=20)
         assert val_result.get("mse")

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
@@ -328,7 +328,7 @@ class TestTFRayEstimator(TestCase):
         from pyspark.sql import SparkSession
         spark = SparkSession(sc)
         from pyspark.ml.linalg import DenseVector
-        df = rdd.map(lambda x: (DenseVector(np.random.randn(1,).astype(np.float)),
+        df = rdd.map(lambda x: (np.random.randn(1,).tolist(),
                                 int(np.random.randint(0, 1, size=())))).toDF(["feature", "label"])
 
         config = {


### PR DESCRIPTION
This PR aims at improving the memory efficiency for `AutoEstimator`. Specifically, it changes the tf.keras model input from ndarrays of the entire dataset to an iterable tensorflow dataset converted from Ray dataset pipeline. 

Note that temporarily,
1. users need to specify `output_signature`, which is of the same format as tf.dataset.from_generator() 
2. we only support models with single input output 

And new PRs will fix the aforementioned issues. Performance tests for memory efficiency will also be conducted after model with multiple inputs-outputs are supported.

 