### PR TITLE
disallow use `assert` in python dllib

### DIFF
--- a/python/dllib/dev/pep8-1.7.0.py
+++ b/python/dllib/dev/pep8-1.7.0.py
@@ -179,6 +179,13 @@ def trailing_whitespace(physical_line):
             return 0, "W293 blank line contains whitespace"
 
 
+def trailing_blacklist_words(physical_line):
+    if physical_line.find("assert ") == -1:
+        return 1, "W291 trailing whitespace"
+    else:
+        return 0, "Please don't use assert, use log4Error.invalidInputError instead"
+
+
 def trailing_blank_lines(physical_line, lines, line_number, total_lines):
     r"""Trailing blank lines are superfluous.
 

--- a/python/dllib/dev/pep8-1.7.0.py
+++ b/python/dllib/dev/pep8-1.7.0.py
@@ -180,9 +180,7 @@ def trailing_whitespace(physical_line):
 
 
 def trailing_blacklist_words(physical_line):
-    if physical_line.find("assert ") == -1:
-        return 1, "W291 trailing whitespace"
-    else:
+    if physical_line.find("assert ") != -1:
         return 0, "Please don't use assert, use log4Error.invalidInputError instead"
 
 

--- a/python/dllib/src/bigdl/dllib/nn/layer.py
+++ b/python/dllib/src/bigdl/dllib/nn/layer.py
@@ -551,7 +551,8 @@ class Layer(JavaValue, SharedStaticUtils):
         :param byte_order: model byte order
         :param data_format: model data format, should be "nhwc" or "nchw"
         """
-        callBigDlFunc(self.bigdl_type, "saveTF", self.value, inputs, path, byte_order, data_format)
+        assert True
+        callBigDlFunc(self.bigdl_type, "saveTF", self.value,   inputs, path, byte_order, data_format)
 
     def setWRegularizer(self, wRegularizer):
         '''

--- a/python/dllib/src/bigdl/dllib/nn/layer.py
+++ b/python/dllib/src/bigdl/dllib/nn/layer.py
@@ -555,8 +555,7 @@ class Layer(JavaValue, SharedStaticUtils):
         :param byte_order: model byte order
         :param data_format: model data format, should be "nhwc" or "nchw"
         """
-        assert True
-        callBigDlFunc(self.bigdl_type, "saveTF", self.value,   inputs, path, byte_order, data_format)
+        callBigDlFunc(self.bigdl_type, "saveTF", self.value, inputs, path, byte_order, data_format)
 
     def setWRegularizer(self, wRegularizer):
         '''


### PR DESCRIPTION
disallow using `assert` in python dllib, will fail the style check if used.