### PR TITLE
dllib keras like model summary support returning string

### DIFF
--- a/python/dllib/src/bigdl/dllib/keras/engine/topology.py
+++ b/python/dllib/src/bigdl/dllib/keras/engine/topology.py
@@ -500,10 +500,12 @@ class KerasNet(ZooKerasLayer):
                    If the field has a larger length, the remaining part will be trimmed.
                    If the field has a smaller length, the remaining part will be white spaces.
         """
-        callZooFunc(self.bigdl_type, "zooKerasNetSummary",
+        res = callZooFunc(self.bigdl_type, "zooKerasNetSummary",
                     self.value,
                     line_length,
                     [float(p) for p in positions])
+        print(res)
+        return res
 
     def to_model(self):
         from bigdl.dllib.keras.models import Model

--- a/python/dllib/src/bigdl/dllib/keras/engine/topology.py
+++ b/python/dllib/src/bigdl/dllib/keras/engine/topology.py
@@ -501,9 +501,9 @@ class KerasNet(ZooKerasLayer):
                    If the field has a smaller length, the remaining part will be white spaces.
         """
         res = callZooFunc(self.bigdl_type, "zooKerasNetSummary",
-                    self.value,
-                    line_length,
-                    [float(p) for p in positions])
+                          self.value,
+                          line_length,
+                          [float(p) for p in positions])
         print(res)
         return res
 

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/Model.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/Model.scala
@@ -153,27 +153,36 @@ class Model[T: ClassTag] private (private val _inputs : Seq[ModuleNode[T]],
 
   override def summary(
                         lineLength: Int = 120,
-                        positions: Array[Double] = Array(.33, .55, .67, 1)): Unit = {
-    println("Model Summary:")
-    KerasUtils.printSplitLine('-', lineLength)
+                        positions: Array[Double] = Array(.33, .55, .67, 1),
+                        needPrint: Boolean = true): String = {
+    val summaryBuf = ArrayBuffer[String]()
+    summaryBuf.append("Model Summary:")
+    KerasUtils.printSplitLine('-', lineLength, summaryBuf)
 
     val toDisplay = Array("Layer (type)", "Output Shape", "Param #", "Connected to")
-    KerasUtils.printRow(toDisplay, lineLength, positions, splitChar = '=')
+    KerasUtils.printRow(toDisplay, lineLength, positions, splitChar = '=',
+      summaryBuf = summaryBuf)
     val nodes = labor.asInstanceOf[StaticGraph[T]].getSortedForwardExecutions()
     var totalParams = 0
     var trainableParams = 0
     for (node <- nodes) {
-      val (total, trainable) = KerasUtils.printNodeSummary(node, lineLength, positions)
+      val (total, trainable) = KerasUtils.printNodeSummary(node, lineLength, positions,
+        summaryBuf = summaryBuf)
       totalParams += total
       trainableParams += trainable
     }
     val msgTotal = "Total params: " + "%,d".format(totalParams)
-    println(msgTotal)
+    summaryBuf.append(msgTotal)
     val msgTrain = "Trainable params: " + "%,d".format(trainableParams)
-    println(msgTrain)
+    summaryBuf.append(msgTrain)
     val msgNonTrain = "Non-trainable params: " + "%,d".format(totalParams - trainableParams)
-    println(msgNonTrain)
-    KerasUtils.printSplitLine('-', lineLength)
+    summaryBuf.append(msgNonTrain)
+    KerasUtils.printSplitLine('-', lineLength, summaryBuf)
+    val res = summaryBuf.mkString("\n")
+    if (needPrint) {
+      InternalDistriOptimizer.logger.info(res)
+    }
+    return res
   }
 }
 

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/Sequential.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/Sequential.scala
@@ -175,9 +175,10 @@ class Sequential[T: ClassTag] private ()
 
   override def summary(
                         lineLength: Int = 120,
-                        positions: Array[Double] = Array(.33, .55, .67, 1)): Unit = {
+                        positions: Array[Double] = Array(.33, .55, .67, 1),
+                        needPrint: Boolean = true): String = {
     val graph = this.toModel()
-    graph.summary(lineLength, positions)
+    return graph.summary(lineLength, positions, needPrint)
   }
 
   override private[bigdl] def getKerasWeights(): Array[Tensor[Float]] = {

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/utils/KerasUtils.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/utils/KerasUtils.scala
@@ -396,8 +396,9 @@ object KerasUtils {
   def printNodeSummary[T: ClassTag](
       node: ModuleNode[T],
       lineLength: Int = 120,
-      positions: Array[Double] = Array(.33, .55, .67, 1)): (Int, Int) = {
-    printRow(getNodeSummary(node), lineLength, positions)
+      positions: Array[Double] = Array(.33, .55, .67, 1),
+      summaryBuf: ArrayBuffer[String] = null): (Int, Int) = {
+    printRow(getNodeSummary(node), lineLength, positions, summaryBuf = summaryBuf)
     countParams(node.element.asInstanceOf[KerasLayer[Activity, Activity, T]])
   }
 
@@ -422,7 +423,8 @@ object KerasUtils {
       lineLength: Int = 120,
       positions: Array[Double] = Array(.33, .55, .67, 1),
       includeSplitLine: Boolean = true,
-      splitChar: Char = '_'): Unit = {
+      splitChar: Char = '_',
+      summaryBuf: ArrayBuffer[String] = null): Unit = {
     val fieldLengths = ArrayBuffer[Int]()
     for (i <- positions.indices) {
       if (i > 0) {
@@ -455,22 +457,23 @@ object KerasUtils {
 
     }
 
-    println(line)
+    summaryBuf.append(line)
     // If there are multiple connected to nodes, print the remaining each in a separate line
     // without the split line.
     for (node <- nodes.slice(1, nodes.length)) {
-      printRow(Array("", "", "", node), lineLength, positions, includeSplitLine = false)
+      printRow(Array("", "", "", node), lineLength, positions, includeSplitLine = false,
+        summaryBuf = summaryBuf)
     }
-    if (includeSplitLine) printSplitLine(splitChar, lineLength)
+    if (includeSplitLine) printSplitLine(splitChar, lineLength, summaryBuf)
   }
 
   /**
    * Print a split line that repeats the 'char' for 'lineLength' times.
    */
-  def printSplitLine(char: Char, lineLength: Int = 120): Unit = {
+  def printSplitLine(char: Char, lineLength: Int = 120, summaryBuf: ArrayBuffer[String]): Unit = {
     val str = char.toString
     val message = str * lineLength
-    println(message)
+    summaryBuf.append(message)
   }
 
   /**

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/models/Topology.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/models/Topology.scala
@@ -785,7 +785,8 @@ abstract class KerasNet[T](implicit val tag: ClassTag[T], implicit val ev: Tenso
    */
   def summary(
       lineLength: Int = 120,
-      positions: Array[Double] = Array(.33, .55, .67, 1)): Unit
+      positions: Array[Double] = Array(.33, .55, .67, 1),
+      needPrint: Boolean = true): String
 }
 
 object InternalOptimizer {

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/python/PythonZooKeras.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/python/PythonZooKeras.scala
@@ -306,8 +306,8 @@ class PythonZooKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZ
   def zooKerasNetSummary(
       model: KerasNet[T],
       lineLength: Int = 120,
-      positions: JList[Double]): Unit = {
-    model.summary(lineLength, positions.asScala.toArray)
+      positions: JList[Double]): String = {
+    return model.summary(lineLength, positions.asScala.toArray, false)
   }
 
   def createZooKerasDense(

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/keras/models/TrainingSpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/keras/models/TrainingSpec.scala
@@ -115,6 +115,7 @@ class TrainingSpec extends ZooSpecHelper {
     model.add(Dense[Float](2, activation = "softmax"))
     model.compile(optimizer = "sgd", loss = "sparse_categorical_crossentropy",
       metrics = List("accuracy"))
+    model.summary()
     val tmpLogDir = createTmpDir()
     val tmpCheckpointDir = createTmpDir()
     model.setTensorBoard(tmpLogDir.getAbsolutePath, "TrainingSpec")


### PR DESCRIPTION
Fix https://github.com/intel-analytics/BigDL/issues/4318

1. scala `summary` will print model summary
2. python `summary` will print model summary on python side, no print on scala side
3. for both scala and python, `summary` will return string