### PR TITLE
[Nano HPO] add decorator and proxy_methods utility

### DIFF
--- a/python/nano/src/bigdl/nano/automl/hpo/__init__.py
+++ b/python/nano/src/bigdl/nano/automl/hpo/__init__.py
@@ -15,3 +15,4 @@
 #
 
 from .space import *
+from .decorator import *

--- a/python/nano/src/bigdl/nano/automl/hpo/decorator.py
+++ b/python/nano/src/bigdl/nano/automl/hpo/decorator.py
@@ -1,0 +1,514 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This file is adapted from https://github.com/awslabs/autogluon/
+# blob/v0.3.1/core/src/autogluon/core/decorator.py
+# Copyright The AutoGluon project at https://github.com/awslabs/autogluon
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License at
+# https://github.com/awslabs/autogluon/blob/master/LICENSE
+
+
+import copy
+import logging
+import argparse
+import functools
+from collections import OrderedDict
+import numpy as np
+import multiprocessing as mp
+import ConfigSpace as CS
+
+from .backend import OptunaBackend
+
+from .space import *
+from .space import _add_hp, _add_cs, _rm_hp, _strip_config_space, SPLITTER
+from .callgraph import CallCache
+
+from bigdl.nano.automl.utils import EasyDict as ezdict
+from bigdl.nano.automl.utils import proxy_methods
+
+__all__ = ['args', 'obj', 'func', 'tfmodel', 'plmodel', 'sample_config']
+
+logger = logging.getLogger(__name__)
+
+
+def sample_config(args, config):
+    args = copy.deepcopy(args)
+    striped_keys = [k.split(SPLITTER)[0] for k in config.keys()]
+    if isinstance(args, (argparse.Namespace, argparse.ArgumentParser)):
+        args_dict = vars(args)
+    else:
+        args_dict = args
+    for k, v in args_dict.items():
+        # handle different type of configurations
+        if k in striped_keys:
+            if isinstance(v, NestedSpace):
+                sub_config = _strip_config_space(config, prefix=k)
+                args_dict[k] = v.sample(**sub_config)
+            else:
+                if SPLITTER in k:
+                    continue
+                args_dict[k] = config[k]
+        elif isinstance(v, AutoObject):
+            args_dict[k] = v.init()
+    return args
+
+
+class _automl_method(object):
+    SEED = mp.Value('i', 0)
+    LOCK = mp.Lock()
+
+    def __init__(self, f):
+        self.f = f
+        self.args = ezdict()
+        functools.update_wrapper(self, f)
+
+    def __call__(self, args, config={}, **kwargs):
+        new_config = copy.deepcopy(config)
+        self._rand_seed()
+        args = sample_config(args, new_config)
+        # from .reporter import FakeReporter
+        # if 'reporter' not in kwargs:
+        #    logger.debug('Creating FakeReporter for test purpose.')
+        #    kwargs['reporter'] = FakeReporter()
+
+        output = self.f(args, **kwargs)
+        # logger.debug('Reporter Done!')
+        # kwargs['reporter'](done=True)
+        return output
+
+    def register_args(self, default={}, **kwvars):
+        if isinstance(default, (argparse.Namespace, argparse.ArgumentParser)):
+            default = vars(default)
+        self.kwvars = {}
+        self.args = ezdict()
+        self.args.update(default)
+        self.update(**kwvars)
+
+    def update(self, **kwargs):
+        """For searcher support ConfigSpace
+        """
+        self.kwvars.update(kwargs)
+        for k, v in self.kwvars.items():
+            if isinstance(v, (NestedSpace)):
+                self.args.update({k: v})
+            elif isinstance(v, Space):
+                hp = v.get_hp(name=k)
+                self.args.update({k: hp.default_value})
+            else:
+                self.args.update({k: v})
+
+    @property
+    def cs(self):
+        cs = CS.ConfigurationSpace()
+        for k, v in self.kwvars.items():
+            if isinstance(v, NestedSpace):
+                _add_cs(cs, v.cs, k)
+            elif isinstance(v, Space):
+                hp = v.get_hp(name=k)
+                _add_hp(cs, hp)
+            else:
+                _rm_hp(cs, k)
+        return cs
+
+    @property
+    def kwspaces(self):
+        """For RL searcher/controller
+        """
+        kw_spaces = OrderedDict()
+        for k, v in self.kwvars.items():
+            if isinstance(v, NestedSpace):
+                if isinstance(v, Categorical):
+                    kw_spaces['{}{}choice'.format(k, SPLITTER)] = v
+                for sub_k, sub_v in v.kwspaces.items():
+                    new_k = '{}{}{}'.format(k, SPLITTER, sub_k)
+                    kw_spaces[new_k] = sub_v
+            elif isinstance(v, Space):
+                kw_spaces[k] = v
+        return kw_spaces
+
+    def _rand_seed(self):
+        _automl_method.SEED.value += 1
+        np.random.seed(_automl_method.SEED.value)
+
+    def __repr__(self):
+        return repr(self.f)
+
+
+def args(default=None, **kwvars):
+    """Decorator for a Python training script that
+       registers its arguments as hyperparameters.
+       Each hyperparameter takes fixed value or is a searchable space,
+       and the arguments may either be:
+       built-in Python objects (e.g. floats, strings, lists, etc.),
+       AutoObject (see :func:`hpo.obj`),
+       or hpo search spaces (see :class:`hpo.space.Int`,
+       :class:`hpo.space.Real`, etc.).
+
+    Examples
+    --------
+    >>>
+    """
+    if default is None:
+        default = dict()
+    kwvars['_default_config'] = default
+
+    def registered_func(func):
+        @_automl_method
+        @functools.wraps(func)
+        def wrapper_call(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        default = kwvars['_default_config']
+        wrapper_call.register_args(default=default, **kwvars)
+        return wrapper_call
+
+    return registered_func
+
+
+
+def func(**kwvars):
+    """Decorator for a function that registers its arguments as hyperparameters.
+       Each hyperparameter may take a fixed value or be a searchable space (hpo.space).
+
+    Returns
+    -------
+    Instance of :class:`hpo.space.AutoObject`:
+        A lazily initialized object, which allows for distributed training.
+
+    Examples
+    --------
+    >>>
+    """
+    from .callgraph import CallCache, CALLTYPE
+
+    # def _automl_kwargs_func(**kwvars):
+    #     def registered_func(func):
+    #         kwspaces = OrderedDict()
+
+    #         @functools.wraps(func)
+    #         def wrapper_call(*args, **kwargs):
+    #             _kwvars = copy.deepcopy(kwvars)
+    #             _kwvars.update(kwargs)
+    #             for k, v in _kwvars.items():
+    #                 if isinstance(v, NestedSpace):
+    #                     kwspaces[k] = v
+    #                     kwargs[k] = v
+    #                 elif isinstance(v, Space):
+    #                     kwspaces[k] = v
+    #                     hp = v.get_hp(name=k)
+    #                     kwargs[k] = hp.default_value
+    #                 else:
+    #                     kwargs[k] = v
+    #             return func(*args, **kwargs)
+    #         wrapper_call.kwspaces = kwspaces
+    #         return wrapper_call
+    #     return registered_func
+
+    def registered_func(func):
+        class AutoSlice(AutoObject):
+            def __init__(self, source, slice_arguments):
+                self.source = source
+                self.slice_arguments = slice_arguments
+                self._callgraph = CallCache.update(
+                    (self.source, self.slice_arguments),
+                    self,
+                    ctype=CALLTYPE.FUNC_SLICE)
+
+            def sample(self, **config):
+                slice_args, slice_kwargs = self.slice_arguments
+                return self.source.__getitem__(*slice_args, **slice_kwargs)
+
+            @property
+            def kwspaces(self):
+                return {}
+
+            def __repr__(self):
+                return 'AutoSlice -- [] ' + str(id(self))
+
+        class AutoFunc(AutoObject):
+            #@_automl_kwargs_func(**kwvars)
+            def __init__(self, *args, **kwargs):
+                self.func = func
+                self.args = args
+                self.kwargs = kwargs
+                self._inited = False
+
+                self.slice_args = None
+                self.slice_kwargs = None
+
+                self.kwspaces_ = OrderedDict()
+                self.kwvars = dict()
+                self._update_kw()
+
+                self._callgraph = None  # keep a reference to the call graph
+                self._callgraph = CallCache.update(
+                    (self.args, self.kwargs),
+                    self,
+                    ctype=CALLTYPE.FUNC_CALL)
+
+            def __getitem__(self, *args, **kwargs):
+                self.slice_args = args
+                self.slice_kwargs = kwargs
+                return AutoSlice(self, (self.slice_args, self.slice_kwargs))
+
+            def sample(self, **config):
+                kwargs = copy.deepcopy(self.kwargs)
+                #kwspaces = copy.deepcopy(AutoFunc.kwspaces)
+                kwspaces = copy.deepcopy(self.kwspaces_)
+                for k, v in kwargs.items():
+                    if k in kwspaces and isinstance(kwspaces[k], NestedSpace):
+                        sub_config = _strip_config_space(config, prefix=k)
+                        kwargs[k] = kwspaces[k].sample(**sub_config)
+                    elif k in config:
+                        kwargs[k] = config[k]
+
+                return self.func(*self.args, **kwargs)
+
+            @property
+            def kwspaces(self):
+                return self.kwspaces_
+
+            def _update_kw(self):
+                self.kwvars.update(self.kwargs)
+                for k, v in self.kwvars.items():
+                    if isinstance(v, NestedSpace):
+                        self.kwspaces_[k] = v
+                        self.kwargs[k] = v
+                    elif isinstance(v, Space):
+                        self.kwspaces_[k] = v
+                        hp = v.get_hp(name=k)
+                        self.kwargs[k] = hp.default_value
+                    else:
+                        self.kwargs[k] = v
+
+            def __repr__(self):
+                return 'AutoFunc -- ' + self.func.__name__ + ' ' + str(id(self))
+
+        @functools.wraps(func)
+        def wrapper_call(*args, **kwargs):
+            _kwvars = copy.deepcopy(kwvars)
+            _kwvars.update(kwargs)
+            autoobj = AutoFunc(*args, **kwargs)
+            autoobj.kwvars = _kwvars
+            return autoobj
+        return wrapper_call
+    return registered_func
+
+
+def obj(**kwvars):
+    """Decorator for a Python class that registers its arguments as hyperparameters.
+       Each hyperparameter may take a fixed value or be a searchable space (hpo.space).
+
+    Returns
+    -------
+    Instance of :class:`hpo.space.AutoObject`:
+        A lazily initialized object, which allows distributed training.
+
+    Examples
+    --------
+    >>>
+    """
+    # def _automl_kwargs_obj(**kwvars):
+    #     def registered_func(func):
+    #         kwspaces = OrderedDict()
+    #         @functools.wraps(func)
+    #         def wrapper_call(*args, **kwargs):
+    #             kwvars.update(kwargs)
+    #             for k, v in kwvars.items():
+    #                 if isinstance(v, NestedSpace):
+    #                     kwspaces[k] = v
+    #                     kwargs[k] = v
+    #                 elif isinstance(v, Space):
+    #                     kwspaces[k] = v
+    #                     hp = v.get_hp(name=k)
+    #                     kwargs[k] = hp.default_value
+    #                 else:
+    #                     kwargs[k] = v
+    #             return func(*args, **kwargs)
+    #         wrapper_call.kwspaces = kwspaces
+    #         wrapper_call.kwvars = kwvars
+    #         return wrapper_call
+    #     return registered_func
+
+    def registered_class(Cls):
+        class AutoCls(AutoObject):
+            #@_automl_kwargs_obj(**kwvars)
+            def __init__(self, *args, **kwargs):
+                self.args = args
+                self.kwargs = kwargs
+                self._inited = False
+                self.kwspaces_ = OrderedDict()
+                self.kwvars = dict()
+                self._update_kw()
+                self._callgraph = None  # keep a reference to the call graph
+
+            def sample(self, **config):
+                kwargs = copy.deepcopy(self.kwargs)
+                #kwspaces = copy.deepcopy(automlobject.kwspaces)
+                kwspaces = copy.deepcopy(self.kwspaces_)
+                for k, v in kwargs.items():
+                    if k in kwspaces and isinstance(kwspaces[k], NestedSpace):
+                        sub_config = _strip_config_space(config, prefix=k)
+                        kwargs[k] = kwspaces[k].sample(**sub_config)
+                    elif k in config:
+                        kwargs[k] = config[k]
+
+                args = self.args
+                return Cls(*args, **kwargs)
+
+            @property
+            def kwspaces(self):
+                return self.kwspaces_
+
+            def _update_kw(self):
+                self.kwvars.update(self.kwargs)
+                for k, v in self.kwvars.items():
+                    if isinstance(v, NestedSpace):
+                        self.kwspaces_[k] = v
+                        self.kwargs[k] = v
+                    elif isinstance(v, Space):
+                        self.kwspaces_[k] = v
+                        hp = v.get_hp(name=k)
+                        self.kwargs[k] = hp.default_value
+                    else:
+                        self.kwargs[k] = v
+
+            def __repr__(self):
+                return 'AutoCls -- ' + Cls.__name__ + str(id(self))
+
+            def __call__(self, *args, **kwargs):
+
+                #super.__call__(*args, **kwargs)
+                # this is to handle functional API of layers
+                self._call_args = args
+                self._call_kwargs = kwargs
+                # get the inputs tensor argument
+                if len(args) == 0:
+                    inputs = kwargs['inputs']
+                else:
+                    inputs = args[0]
+                self._callgraph = CallCache.update(inputs, self)
+                return self
+
+        #automlobject.kwvars = automlobject.__init__.kwvars
+        AutoCls.__doc__ = Cls.__doc__
+        AutoCls.__name__ = Cls.__name__
+        return AutoCls
+
+    return registered_class
+
+
+def tfmodel(**kwvars):
+    from bigdl.nano.automl.tf.mixin import HPOMixin
+    """Decorator for a custom model that registers its arguments as hyperparameters.
+       Each hyperparameter may take a fixed value or be a searchable space (hpo.space).
+
+    Returns
+    -------
+    Instance of :class:`hpo.space.AutomlModel`:
+        It contains a lazily initialized object.
+
+    Examples
+    --------
+    >>>
+    """
+    def registered_class(Cls):
+        objCls = obj(**kwvars)(Cls)
+
+        @proxy_methods
+        class TFAutoMdl(HPOMixin, Cls):
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self._lazyobj = objCls(**kwargs)
+                # generate a default config for the super class
+                default_config = self._lazyobj.cs.get_default_configuration().get_dictionary()
+                super_kwargs = copy.deepcopy(self.kwargs)
+                kwspaces = copy.deepcopy(self._lazyobj.kwspaces)
+                for k, v in super_kwargs.items():
+                    if k in kwspaces and isinstance(kwspaces[k], NestedSpace):
+                        sub_config = _strip_config_space(
+                            default_config, prefix=k)
+                        super_kwargs[k] = kwspaces[k].sample(**sub_config)
+                    elif k in default_config:
+                        super_kwargs[k] = default_config[k]
+                super().__init__(**super_kwargs)
+
+            def __repr__(self):
+                return 'TFAutoMdl -- ' + Cls.__name__
+
+            def _model_build(self, trial):
+                # override _model_build to build
+                # the model directly instead of using
+                # modeld_init and model_compile
+                model = OptunaBackend.instantiate(trial, self._lazyobj)
+                self._model_compile(model, trial)
+                return model
+
+        return TFAutoMdl
+
+    return registered_class
+
+def plmodel(**kwvars):
+    """Decorator for a custom model that registers its arguments as hyperparameters.
+       Each hyperparameter may take a fixed value or be a searchable space (hpo.space).
+
+    Returns
+    -------
+    Instance of :class:`hpo.space.AutomlModel`:
+        It contains a lazily initialized object.
+
+    Examples
+    --------
+    >>>
+    """
+    def registered_class(Cls):
+        objCls = obj(**kwvars)(Cls)
+
+        class PLAutoMdl(Cls):
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self._lazyobj = objCls(**kwargs)
+                # generate a default config for the super class
+                default_config = self._lazyobj.cs.get_default_configuration().get_dictionary()
+                super_kwargs = copy.deepcopy(self.kwargs)
+                kwspaces = copy.deepcopy(self._lazyobj.kwspaces)
+                for k, v in super_kwargs.items():
+                    if k in kwspaces and isinstance(kwspaces[k], NestedSpace):
+                        sub_config = _strip_config_space(
+                            default_config, prefix=k)
+                        super_kwargs[k] = kwspaces[k].sample(**sub_config)
+                    elif k in default_config:
+                        super_kwargs[k] = default_config[k]
+                super().__init__(**super_kwargs)
+
+            def __repr__(self):
+                return 'PlAutoMdl -- ' + Cls.__name__
+
+            def _model_build(self, trial):
+                # override _model_build to build
+                # the model directly instead of using
+                # modeld_init and model_compile
+                model = OptunaBackend.instantiate(trial, self._lazyobj)
+                # self._model_compile(model, trial)
+                return model
+
+        return PLAutoMdl
+
+    return registered_class
+
+
+

--- a/python/nano/src/bigdl/nano/automl/utils/proxy.py
+++ b/python/nano/src/bigdl/nano/automl/utils/proxy.py
@@ -14,5 +14,21 @@
 # limitations under the License.
 #
 
-from .edict import EasyDict
-from .proxy import proxy_methods
+import functools
+
+
+def proxy_method(cls, name):
+    # This unbound method will be pulled from the superclass.
+    assert(hasattr(cls, name))
+    proxyed = getattr(cls, name)
+
+    @functools.wraps(proxyed)
+    def wrapper(self, *args, **kwargs):
+        return self._proxy(name, proxyed.__get__(self, cls), *args, **kwargs)
+    return wrapper
+
+
+def proxy_methods(cls):
+    for name in cls.PROXYED_METHODS:
+        setattr(cls, name, proxy_method(cls, name))
+    return cls

--- a/python/nano/test/automl/common/test_decorator.py
+++ b/python/nano/test/automl/common/test_decorator.py
@@ -1,0 +1,54 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import pytest
+from unittest import TestCase
+from random import randrange
+from bigdl.nano.automl.hpo.decorator import *
+import bigdl.nano.automl.hpo.space as space
+
+class TestHPODecorator(TestCase):
+
+    def test_func(self):
+        @func()
+        def dummy_func(arg1=None, arg2=None):
+            return arg1, arg2
+
+        range_arg1 = (randrange(10,20), randrange(100,200))
+        range_arg2 = (randrange(10,20), randrange(100,200))
+        autofunc = dummy_func(arg1=space.Int(range_arg1[0], range_arg1[1]),
+                   arg2=space.Int(range_arg2[0], range_arg2[1]))
+        assert(autofunc)
+
+        arg1, arg2 = autofunc.sample()
+        assert(arg1 >= range_arg1[0] and arg1 <= range_arg1[1])
+        assert(arg2 >= range_arg2[0] and arg2 <= range_arg2[1])
+
+    def test_obj(self):
+        #TODO
+        pass
+
+    def test_tfmodel(self):
+        #TODO
+        pass
+
+    def test_plmodel(self):
+        #TODO
+        pass
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
This PR adds decorators and proxy_methods utlities. 

* **_decorator_** is used to turn tensorflow/pytorch objects into AutoObjects.
    *  decorators are used on tf.keras.layers, tf.keras.Sequential/Model, tf.keras.Input, tf.keras.activations (functions), and custom models defined by subclassing from tf.keras.Model, pl.LightningModule, etc.
    *  AutoObjects delay the instantiation of corresponding object until sample() is called in each trial. 
    * there're several types of autoobject decorators
        * func (tf.keras.Input, tf.keras.activations) 
        * obj(tf.keras.layers, tf.keras.Sequential, tf.keras.Model)
        * tfmodel (user defined keras models)
        * plmodel (user defined pytorch models)
* **_proxy_methods_** is used in tensorflow keras Model
   * a tf.keras.Model instance holds another tf.keras.Model instance and it is lazily instantiated until search is done
   * proxy_methods is a convinient utility which conveys method calls (e.g. fit, evalutate, etc.) to calls on internal model instance