### PR TITLE
[Nano HPO] global hpo configuration, enable/diable tf hpo

### DIFF
--- a/python/nano/src/bigdl/nano/automl/hpo/config.py
+++ b/python/nano/src/bigdl/nano/automl/hpo/config.py
@@ -1,0 +1,191 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import copy
+import warnings
+import importlib
+
+
+from bigdl.nano.automl.utils.register_modules import (
+    COMPONENT_TYPE,
+    register_module,
+    register_module_simple,
+    clean_modules_simple,
+    )
+
+
+TF_LAYER_MODULES = [
+        ("tensorflow.keras.layers", "keras.layers"),
+    ]
+NANO_DEFINED_TF_LAYERS = ['Embedding']
+
+TF_ACTIVATION_MODULE = [
+        ("tensorflow.keras.activations", "keras.activations")
+    ]
+TF_ACTIVATION_EXCLUDE = ['serialize','deserialize','get']
+
+TF_FUNCS = ['cast']
+TF_KERAS_FUNCS = ['Input']
+
+
+class HPOConfig(object):
+    """A global configuration object for HPO,
+    To access it, use "bigdl.nano.automl.hpo_config".
+    E.g., "use bigd.nano.automl.hpo_config.enable_hpo_tf() to enable tf hpo"
+    """
+    def __init__(self,
+                 hpo_tf=False,
+                 hpo_pytorch=False):
+        #configuraitons
+        self.hpo_tf_ = hpo_tf
+        self.hpo_pytorch_ = hpo_pytorch
+
+        self.torch_available = False
+        try:
+            import torch
+            self.torch_available = True
+        except:
+            pass
+        self.tf_available = False
+        try:
+            import tensorflow
+            self.tf_available = True
+        except:
+            pass
+
+        self.added_tf_activations = None
+        self.added_tf_layers = None
+        self.backup_tf_layers = None
+
+
+    def enable_hpo_tf(self):
+        self.hpo_tf_ = True if self.tf_available else False
+        if self.hpo_tf:
+            self._add_decorated_nano_tf_modules()
+
+    def enable_hpo_pytorch(self):
+        self.hpo_pytorch_ = True if self.torch_available else False
+        #TODO anything pytorch specific add here
+
+    def disable_hpo_tf(self):
+        # if self.hpo_tf:
+        #     self._clean_nano_tf_modules(self)
+        self._reload_modules()
+        self.hpo_tf_ = False
+
+    def disable_hpo_pytorch(self):
+        self.hpo_pytorch_ = False
+
+    @property
+    def hpo_tf(self):
+        return self.hpo_tf_
+
+    @property
+    def hpo_pytorch(self):
+        return self.hpo_pytorch_
+
+    def _backup_existing_components(self, symtab, subcomponents):
+        self.backup_tf_layers = self.backup_tf_layers or {}
+        for c in subcomponents:
+            self.backup_tf_layers[c] = symtab[c]
+
+    def _restore_existing_components(self, symtab):
+        self.backup_tf_layers = self.backup_tf_layers or {}
+        for c, component in self.backup_tf_layers.items():
+            symtab[c] = component
+
+    def _add_decorated_nano_tf_modules(self):
+        # register decorated activations
+        import bigdl.nano.tf.keras.activations as nano_activations
+        # self.backup_module_symtab(
+        #     vars(nano_activations),
+        #     self._backup_tf_activations)
+        self.added_tf_activations = register_module(
+            vars(nano_activations),
+            TF_ACTIVATION_MODULE,
+            include_types = COMPONENT_TYPE.FUNC,
+            exclude_names = TF_ACTIVATION_EXCLUDE)
+
+
+        # register decorated layers
+        import bigdl.nano.tf.keras.layers as nano_layers
+        # replace the nano defined layers with decorated layers,
+        # TODO auto detect the layers that's been defined in nano.tf.keras
+        # instead of using a fixed list NANO_DEFINED_TF_LAYERS
+        # register other nano layers defined in keras
+        self.added_tf_layers = register_module(
+            vars(nano_layers),
+            TF_LAYER_MODULES,
+            include_types = COMPONENT_TYPE.CLASS,
+            exclude_names = NANO_DEFINED_TF_LAYERS)
+        self._backup_existing_components(
+            vars(nano_layers),
+            subcomponents=NANO_DEFINED_TF_LAYERS)
+        register_module_simple(
+            vars(nano_layers),
+            subcomponents = NANO_DEFINED_TF_LAYERS,
+            component_type = COMPONENT_TYPE.CLASS,
+            module='bigdl.nano.tf.keras.layers'
+        )
+        self.added_tf_layers = self.added_tf_layers.extend(NANO_DEFINED_TF_LAYERS)
+
+        # register decorated tf.cast
+        import bigdl.nano.tf
+        register_module_simple(vars(bigdl.nano.tf),
+                               subcomponents = TF_FUNCS,
+                               component_type = COMPONENT_TYPE.FUNC,
+                               module='tensorflow')
+
+        # register decorated tf.keras.Input
+        import bigdl.nano.tf.keras
+        register_module_simple(vars(bigdl.nano.tf.keras),
+                               subcomponents=TF_KERAS_FUNCS,
+                               component_type = COMPONENT_TYPE.FUNC,
+                               module='tensorflow.keras')
+
+
+    def _reload_modules(self):
+        import bigdl.nano.tf.keras.layers
+        importlib.reload(bigdl.nano.tf.keras.layers)
+        import bigdl.nano.tf.keras.activations
+        importlib.reload(bigdl.nano.tf.keras.activations)
+        import bigdl.nano.tf.keras
+        importlib.reload(bigdl.nano.tf.keras)
+        import bigdl.nano.tf
+        importlib.reload(bigdl.nano.tf)
+
+    def _clean_nano_tf_modules(self):
+        # clean nano tf layers
+        import bigdl.nano.tf.keras.layers as nano_layers
+        clean_modules_simple(vars(nano_layers),
+                             subcomponents=self.added_tf_layers)
+        # restore non-decorated layers in nano, e.g. Embedding
+        self._restore_existing_components(vars(nano_layers))
+        # clean nano nano_activations
+        import bigdl.nano.tf.keras.activations as nano_activations
+        clean_modules_simple(vars(nano_activations))
+
+        # clean up decorated tf.cast
+        import bigdl.nano.tf
+        clean_modules_simple(vars(bigdl.nano.tf),
+                             subcomponents=TF_FUNCS)
+
+        # clean up tf.keras.Input
+        import bigdl.nano.tf.keras
+        clean_modules_simple(vars(bigdl.nano.tf.keras),
+                             subcomponents=TF_KERAS_FUNCS)
+
+

--- a/python/nano/src/bigdl/nano/automl/utils/register_modules.py
+++ b/python/nano/src/bigdl/nano/automl/utils/register_modules.py
@@ -1,0 +1,115 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import importlib
+from bigdl.nano.automl.hpo import obj,func
+import inspect
+from enum import Enum
+import copy
+
+class COMPONENT_TYPE(Enum):
+    CLASS = 1
+    FUNC = 2
+
+def decorate_cls(module, name):
+    component = getattr(module, name)
+    derived = type(name, (component,), {})
+    decorated = obj()(derived)
+    return decorated
+
+def decorate_func(module, name):
+    component = getattr(module, name)
+    decorated = func()(component)
+    return decorated
+
+def register_module(target_symtab,
+                    modules,
+                    include_types,
+                    exclude_names):
+    '''register subcomponents in modules into target symtable,
+    return added components for later clean up'''
+    # get a component and return the auto counterpart
+
+    # filter the classes in a module
+    def filter(module,
+               prefix,
+               check_type,
+               exclude_set):
+        filtered = []
+        attrs= vars(module).items()
+        for name, attr in attrs:
+            if check_type(attr):
+                m = inspect.getmodule(attr)
+                if m.__name__.startswith(prefix) \
+                    and name not in exclude_set:
+                        filtered.append(name)
+        return filtered
+
+    if include_types == COMPONENT_TYPE.CLASS:
+        type_checker = lambda x: inspect.isclass(x)
+        decorator = decorate_cls
+    elif include_types == COMPONENT_TYPE.FUNC:
+        type_checker = lambda x: inspect.isfunction(x)
+        decorator = decorate_func
+    else:
+        raise ValueError("Unknown Component Type",
+                         "should be either class or function")
+
+    added_components = []
+    for m, prefix in modules:
+        module = importlib.import_module(m)
+        c_names = filter(module,
+                         prefix,
+                         check_type = type_checker,
+                         exclude_set=exclude_names)
+        # TODO check layers
+        for c_name in c_names:
+            new_c = decorator(module, c_name)
+            if target_symtab.get(c_name, None) is not None:
+                raise ValueError(
+                    "Fail to register decorated component to the target nano\
+                    module, as it is already defined in the target module.\
+                    Use register_module_simple instead."
+                )
+            target_symtab[c_name] = new_c
+            added_components.append(c_name)
+
+    return added_components
+
+
+def register_module_simple(target_symtab,
+                           subcomponents,
+                           component_type,
+                           module):
+    '''register subcomponents in a module to target symtable,
+    a simple version without many checks as in register_module.
+    subcomponents must be within the vars() of the module'''
+    if component_type == COMPONENT_TYPE.CLASS:
+        decorator = decorate_cls
+    elif component_type == COMPONENT_TYPE.FUNC:
+        decorator = decorate_func
+    m = importlib.import_module(module)
+    for c in subcomponents:
+        assert(c in vars(m).keys())
+        new_f = decorator(m, c)
+        target_symtab[c] = new_f
+
+
+def clean_modules_simple(target_symtab,
+                         subcomponents):
+    '''clean up the subcomponents in target symtab'''
+    for f in subcomponents:
+        target_symtab.pop(f, None)

--- a/python/nano/src/bigdl/nano/tf/keras/activations/__init__.py
+++ b/python/nano/src/bigdl/nano/tf/keras/activations/__init__.py
@@ -13,10 +13,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-#TODO extend to a class later for configuration
-
-from .hpo.config import HPOConfig
-
-hpo_config = HPOConfig()
-globals()['hpo_config'] = hpo_config

--- a/python/nano/test/automl/pytorch/test_global_config.py
+++ b/python/nano/test/automl/pytorch/test_global_config.py
@@ -14,9 +14,23 @@
 # limitations under the License.
 #
 
-#TODO extend to a class later for configuration
 
-from .hpo.config import HPOConfig
+import pytest
+from unittest import TestCase
 
-hpo_config = HPOConfig()
-globals()['hpo_config'] = hpo_config
+import bigdl.nano.automl as nano_automl
+
+class TestGlobalConfig(TestCase):
+
+    def test_disable_automl(self):
+        nano_automl.hpo_config.disable_hpo_pytorch()
+        pass
+
+    def test_enable_automl(self):
+        nano_automl.hpo_config.enable_hpo_pytorch()
+        pass
+
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/python/nano/test/automl/tf/test_global_config.py
+++ b/python/nano/test/automl/tf/test_global_config.py
@@ -1,0 +1,59 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import pytest
+from unittest import TestCase
+
+import bigdl.nano.automl as nano_automl
+
+class TestGlobalConfig(TestCase):
+
+    def test_enable_automl(self):
+        nano_automl.hpo_config.enable_hpo_tf()
+        try:
+            from bigdl.nano.tf.keras.activations import sigmoid, linear
+        except ImportError:
+            self.fail("nano.tf.automl should contain decorated activations")
+        try:
+            from bigdl.nano.tf.keras.layers import Dense, Embedding
+        except ImportError:
+            self.fail("nano.tf.automl should contain decorated layers")
+        try:
+            from bigdl.nano.tf import cast
+        except ImportError:
+            self.fail("nano.tf.automl should contain tensorflow functions like tf.cast")
+        try:
+            from bigdl.nano.tf.keras import Input
+        except ImportError:
+            self.fail("nano.tf.automl should contain keras.Input")
+
+    def test_disable_automl(self):
+        nano_automl.hpo_config.disable_hpo_tf()
+        with self.assertRaises(ImportError):
+            from bigdl.nano.tf.keras.activations import sigmoid, linear
+        with self.assertRaises(ImportError):
+            from bigdl.nano.tf.keras.layers import Dense, Embeddings
+        with self.assertRaises(ImportError):
+            from bigdl.nano.tf import cast
+        with self.assertRaises(ImportError):
+            from bigdl.nano.tf.keras import Input
+
+
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/python/nano/test/automl/tf/test_register_modules.py
+++ b/python/nano/test/automl/tf/test_register_modules.py
@@ -14,9 +14,24 @@
 # limitations under the License.
 #
 
-#TODO extend to a class later for configuration
 
-from .hpo.config import HPOConfig
+import pytest
+from unittest import TestCase
 
-hpo_config = HPOConfig()
-globals()['hpo_config'] = hpo_config
+import bigdl.nano.automl as automl
+
+class TestRegisterModules(TestCase):
+
+    def test_register_layers(self):
+        pass
+
+    def test_register_activations(self):
+        pass
+
+    def test_register_tf_funcs(self):
+        pass
+
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
* add global hpo configuration
* use global hpo configuration to disable/enable hpo for tf and pytorch respectively
* when tf hpo is enabled, decorated layers (e.g. tf.keras.layers), activations(tf.keras.activations), tf functions(i.e. tf.cast), tf.keras functions(i.e. tf.keras.Input) are added to corresonponding nano.tf modules. 