### PR TITLE
Nano: add `trainer.trace(accelerator="onnxruntime")`'s support

### DIFF
--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -76,9 +76,8 @@ def setup_package():
                         "torchmetrics==0.7.2",
                         "opencv-python-headless",
                         "PyTurboJPEG",
-                        "opencv-transforms",
-                        "onnx",
-                        "onnxruntime"]
+                        "opencv-transforms"]
+
     install_requires = ["intel-openmp", "cloudpickle"]
 
     package_data = [

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/__init__.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/__init__.py
@@ -13,9 +13,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-try:
-    import onnx
-    import onnxruntime as ort
-except ImportError:
-    raise ImportError("To enable onnxruntime inference, you need to install it by:\n"
-                      "\t\t pip install onnxruntime")

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/core/__init__.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/core/__init__.py
@@ -13,3 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+try:
+    import onnx
+    import onnxruntime as ort
+except ImportError:
+    raise ImportError("To enable onnxruntime inference, you need to install it by:\n"
+                      "\t\t pip install onnxruntime\n"
+                      "\t\t pip install onnx\n")

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/core/__init__.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/core/__init__.py
@@ -13,9 +13,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-try:
-    import onnx
-    import onnxruntime as ort
-except ImportError:
-    raise ImportError("To enable onnxruntime inference, you need to install it by:\n"
-                      "\t\t pip install onnxruntime")

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/core/onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/core/onnxruntime_model.py
@@ -1,0 +1,44 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import onnxruntime as ort
+import onnx
+
+
+class ONNXRuntimeModel:
+    def __init__(self, onnx_filepath):
+        self.onnx_filepath = onnx_filepath  # onnx filepath
+        self.onnx_model = None  # onnx model
+        self.ortsess = None  # onnxruntime session
+        self._build_ortsess()
+
+    def forward_step(self, *inputs):
+        '''
+            This function run through the onnxruntime forwarding step
+        '''
+        inputs = dict(zip(self._forward_args, inputs))
+        ort_outs = self.ortsess.run(None, inputs)
+        return ort_outs
+
+    def _build_ortsess(self,
+                       sess_options=None):
+        '''
+        Internal function to build a ortsess.
+
+        :param sess_options: ortsess options in ort.SessionOptions type
+        '''
+        self.onnx_model = onnx.load(self.onnx_filepath)
+        self.ortsess = ort.InferenceSession(self.onnx_filepath, sess_options=sess_options)
+        self._forward_args = list(map(lambda x: x.name, self.ortsess.get_inputs()))

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/core/onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/core/onnxruntime_model.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from pathlib import Path
 import onnxruntime as ort
 import onnx
 
@@ -42,3 +43,14 @@ class ONNXRuntimeModel:
         self.onnx_model = onnx.load(self.onnx_filepath)
         self.ortsess = ort.InferenceSession(self.onnx_filepath, sess_options=sess_options)
         self._forward_args = list(map(lambda x: x.name, self.ortsess.get_inputs()))
+
+    def _save_model(self, path):
+        """
+        Save ONNXRuntimeModel to local as an onnx file
+
+        :param path: Path to save the model.
+        """
+        path = Path(path)
+        assert self.onnx_model, "self.ie_network shouldn't be None."
+        assert path.suffix == ".onnx", "Path of onnx model must be with '.onnx' suffix."
+        onnx.save(self.onnx_model, str(path))

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
@@ -46,3 +46,7 @@ def PytorchONNXRuntimeModel(model, input_sample=None):
         """
     from .pytorch.pytorch_onnxruntime_model import PytorchONNXRuntimeModel
     return PytorchONNXRuntimeModel(model, input_sample)
+
+def load_onnxruntime_model(path):
+    from .pytorch.pytorch_onnxruntime_model import PytorchONNXRuntimeModel
+    return PytorchONNXRuntimeModel._load(path)

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
@@ -30,3 +30,19 @@ def bind_onnxrt_methods(pl_model: LightningModule, q_onnx_model=None, sess_optio
     pl_model.exit_onnx = partial(torch_funcs.exit_onnx, pl_model)
     pl_model.to_quantized_onnx = partial(torch_funcs.to_quantized_onnx, pl_model)
     return pl_model
+
+
+def PytorchONNXRuntimeModel(model, input_sample=None):
+    """
+        Create a ONNX Runtime model from pytorch.
+
+        :param model: 1. Pytorch model to be converted to ONNXRuntime for inference
+                      2. Path to ONNXRuntime saved model.
+        :param input_sample: A set of inputs for trace, defaults to None if you have trace before or
+                             model is a LightningModule with any dataloader attached,
+                             defaults to None.
+
+        :return: A PytorchONNXRuntimeModel instance
+        """
+    from .pytorch.pytorch_onnxruntime_model import PytorchONNXRuntimeModel
+    return PytorchONNXRuntimeModel(model, input_sample)

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
@@ -47,6 +47,7 @@ def PytorchONNXRuntimeModel(model, input_sample=None):
     from .pytorch.pytorch_onnxruntime_model import PytorchONNXRuntimeModel
     return PytorchONNXRuntimeModel(model, input_sample)
 
+
 def load_onnxruntime_model(path):
     from .pytorch.pytorch_onnxruntime_model import PytorchONNXRuntimeModel
     return PytorchONNXRuntimeModel._load(path)

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/__init__.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/__init__.py
@@ -13,9 +13,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-try:
-    import onnx
-    import onnxruntime as ort
-except ImportError:
-    raise ImportError("To enable onnxruntime inference, you need to install it by:\n"
-                      "\t\t pip install onnxruntime")

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -1,0 +1,76 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import torch
+import os
+from ..core.onnxruntime_model import ONNXRuntimeModel
+from bigdl.nano.utils.inference.pytorch.model import AcceleratedLightningModule
+from bigdl.nano.utils.inference.pytorch.model_utils import export_to_onnx, get_forward_args
+
+
+class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
+    '''
+        This is the accelerated model for pytorch and onnxruntime.
+        All the external API is based on Trainer, so what we have here is
+        basically internal APIs and subject to change.
+
+        This PytorchONNXRuntimeModel will serve for all precision models.
+    '''
+
+    def __init__(self, model, input_sample=None):
+        """
+        Create a ONNX Runtime model from pytorch.
+
+        :param model: 1. Pytorch model to be converted to ONNXRuntime for inference
+                      2. Path to ONNXRuntime saved model.
+        :param input_sample: A set of inputs for trace, defaults to None if you have trace before or
+                             model is a LightningModule with any dataloader attached,
+                             defaults to None.
+        """
+        # Typically, when model is int8, we use this path
+        # TODO: self._forward_args should be set externally
+        onnx_path = model
+        if isinstance(model, torch.nn.Module):
+            # Typically, when model is fp32, we use this path
+            # TODO: expose ONNX export parameters to users
+            export_to_onnx(model, input_sample=input_sample, onnx_path='tmp.onnx')
+            onnx_path = 'tmp.onnx'
+        AcceleratedLightningModule.__init__(self, None)
+        ONNXRuntimeModel.__init__(self, onnx_path)
+        if os.path.exists('tmp.onnx'):
+            os.remove('tmp.onnx')
+
+    def on_forward_start(self, inputs):
+        if self.ortsess is None:
+            raise RuntimeError(
+                "Please create an instance by PytorchONNXRuntimeModel()"
+            )
+        inputs = self.tensors_to_numpy(inputs)
+        return inputs
+
+    def on_forward_end(self, outputs):
+        outputs = self.numpy_to_tensors(outputs)
+        return outputs
+
+    @staticmethod
+    def load(path):
+        """
+        Load an OpenVINO model for inference.
+
+        :param path: Path to model to be loaded.
+        :return: PytorchOpenVINOModel model for OpenVINO inference.
+        """
+        assert path.split('.')[-1] == "onnx", "Path of onnx model must be with '.onnx' suffix."
+        return PytorchONNXRuntimeModel(path)

--- a/python/nano/src/bigdl/nano/pytorch/runtime_binding/base_inference.py
+++ b/python/nano/src/bigdl/nano/pytorch/runtime_binding/base_inference.py
@@ -16,7 +16,6 @@
 
 from pytorch_lightning import LightningModule
 import torch
-import onnxruntime as ort
 from functools import partial
 import warnings
 import math

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -35,7 +35,7 @@ from bigdl.nano.deps.ray.ray_api import distributed_ray
 from bigdl.nano.deps.ipex.ipex_api import create_IPEXAccelerator, ipex_device
 from bigdl.nano.deps.openvino.openvino_api import PytorchOpenVINOModel, load_openvino_model
 from bigdl.nano.deps.onnxruntime.onnxruntime_api import bind_onnxrt_methods,\
-    PytorchONNXRuntimeModel
+    PytorchONNXRuntimeModel, load_onnxruntime_model
 
 distributed_backends = ["spawn", "ray", "subprocess"]
 
@@ -365,7 +365,9 @@ class Trainer(pl.Trainer):
         if model_type == 'PytorchOpenVINOModel':
             assert model is None, "Argument 'model' must be None for OpenVINO loading."
             return load_openvino_model(path)
-        # if model_type == 'PytorchONNXModel':
+        if model_type == 'PytorchONNXRuntimeModel':
+            assert model is None, "Argument 'model' must be None for ONNX Runtime loading."
+            return load_onnxruntime_model(path)
         # if model_type == 'PytorchQuantizedModel':
         # ... to be implemented
         if isinstance(model, nn.Module):

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -34,7 +34,8 @@ from bigdl.nano.pytorch.plugins.ddp_spawn import DDPSpawnPlugin
 from bigdl.nano.deps.ray.ray_api import distributed_ray
 from bigdl.nano.deps.ipex.ipex_api import create_IPEXAccelerator, ipex_device
 from bigdl.nano.deps.openvino.openvino_api import PytorchOpenVINOModel, load_openvino_model
-from bigdl.nano.deps.onnxruntime.onnxruntime_api import bind_onnxrt_methods
+from bigdl.nano.deps.onnxruntime.onnxruntime_api import bind_onnxrt_methods,\
+    PytorchONNXRuntimeModel
 
 distributed_backends = ["spawn", "ray", "subprocess"]
 
@@ -309,11 +310,13 @@ class Trainer(pl.Trainer):
         :param input_sample: A set of inputs for trace, defaults to None if you have trace before or
                              model is a LightningModule with any dataloader attached.
         :param accelerator: The accelerator to use, defaults to None meaning staying in Pytorch
-                            backend. Only 'openvino' is supported for now.
+                            backend. 'openvino' and 'onnxruntime' are supported for now.
         :return: Model with different acceleration(OpenVINO/ONNX).
         """
         if accelerator == 'openvino':
             return PytorchOpenVINOModel(model, input_sample)
+        if accelerator == 'onnxruntime':
+            return PytorchONNXRuntimeModel(model, input_sample)
 
     @staticmethod
     def save(model: LightningModule, path):

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -292,10 +292,13 @@ class Trainer(pl.Trainer):
                     bind_base_inference_rt_methods
                 from bigdl.nano.pytorch.runtime_binding.quantization_inference import \
                     bind_quantize_methods
-                return bind_onnxrt_methods(
-                    bind_quantize_methods(
-                        bind_base_inference_rt_methods(pl_model), quantized_pytorch_model),
-                    quantized_onnx_model)
+                return_pl_model = bind_quantize_methods(
+                    bind_base_inference_rt_methods(pl_model), quantized_pytorch_model)
+                if quantized_onnx_model:
+                    return bind_onnxrt_methods(return_pl_model,
+                                               quantized_onnx_model)
+                else:
+                    return return_pl_model
         else:
             raise NotImplementedError("Backend {} is not implemented.".format(backend))
 

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -311,7 +311,7 @@ class Trainer(pl.Trainer):
                              model is a LightningModule with any dataloader attached.
         :param accelerator: The accelerator to use, defaults to None meaning staying in Pytorch
                             backend. 'openvino' and 'onnxruntime' are supported for now.
-        :return: Model with different acceleration(OpenVINO/ONNX).
+        :return: Model with different acceleration(OpenVINO/ONNX Runtime).
         """
         if accelerator == 'openvino':
             return PytorchOpenVINOModel(model, input_sample)
@@ -350,7 +350,7 @@ class Trainer(pl.Trainer):
 
         :param path: Path to model to be loaded. Path should be a directory.
         :param model: Required FP32 model to load pytorch model. Optional for ONNX/OpenVINO.
-        :return: Model with different acceleration(None/OpenVINO/ONNX) or
+        :return: Model with different acceleration(None/OpenVINO/ONNX Runtime) or
                  precision(FP32/FP16/BF16/INT8).
         """
         path = Path(path)

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
@@ -28,7 +28,7 @@ def get_forward_args(model):
     return forward_args
 
 
-def get_input_example(model: LightningModuleFromTorch, input_sample):
+def get_input_example(model, input_sample):
     if isinstance(input_sample, DataLoader):
         # TODO: This assumpe the last output is y
         input_sample = tuple(next(iter(input_sample))[:-1])


### PR DESCRIPTION
This PR implement `trainer.trace` only, skip save/load for now waiting for #4487 .
`trainer.quantize`'s support for onnxruntime and the removal of old `eval_onnx()` API will be carried out in following PRs.