### PR TITLE
Chronos: add missing API document for ProphetForecaster and MTNetForecaster

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/prophet_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/prophet_forecaster.py
@@ -105,7 +105,7 @@ class ProphetForecaster(Forecaster):
 
         :return: A pandas DataFrame of length horizon,
                  including "trend" and "seasonality" and inference values, etc.
-                 where the last column is the inference value.
+                 where the "yhat" column is the inference value.
         """
         if self.internal.model is None:
             raise RuntimeError(

--- a/python/chronos/src/bigdl/chronos/forecaster/prophet_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/prophet_forecaster.py
@@ -78,6 +78,8 @@ class ProphetForecaster(Forecaster):
             and 2 columns, with column 'ds' indicating date and column 'y' indicating value
             and Td is the time dimension
         :param validation_data: evaluation data, should be the same type as data
+
+        :return: the evaluation metric value
         """
         self._check_data(data, validation_data)
         return self.internal.fit_eval(data=data,
@@ -100,6 +102,10 @@ class ProphetForecaster(Forecaster):
                the frequency can be anything from the pandas list of frequency strings here:
                https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#timeseries-offset-aliases
         :param ds_data: a dataframe that has 1 column 'ds' indicating date.
+
+        :return: A pandas DataFrame of length horizon,
+                 including "trend" and "seasonality" and inference values, etc.
+                 where the last column is the inference value.
         """
         if self.internal.model is None:
             raise RuntimeError(
@@ -114,6 +120,8 @@ class ProphetForecaster(Forecaster):
             and 2 columns, with column 'ds' indicating date and column 'y' indicating value
             and Td is the time dimension
         :param metrics: A list contains metrics for test/valid data.
+
+        :return: A list of evaluation results. Calculation results for each metrics.
         """
         if data is None:
             raise ValueError("Input invalid data of None")

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/mtnet_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/mtnet_forecaster.py
@@ -120,6 +120,8 @@ class MTNetForecaster(Forecaster):
 
         :param batch_size: predict batch size. The value will not affect evaluate
                result but will affect resources cost(e.g. memory and time).
+
+        :return: A numpy.ndarray with shape of (num_samples, feature_dum).
         """
         if not self._fitted:
             raise RuntimeError("You must call fit or restore first before calling predict!")
@@ -140,6 +142,8 @@ class MTNetForecaster(Forecaster):
         :param multioutput: Defines aggregating of multiple output values.
                String in ['raw_values', 'uniform_average']. The value defaults to
                'raw_values'.
+        
+        :return: A list of evaluation results. Calculation results for each metrics.
         """
         if not self._fitted:
             raise RuntimeError("You must call fit or restore first before calling evaluate!")

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/mtnet_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/mtnet_forecaster.py
@@ -142,7 +142,7 @@ class MTNetForecaster(Forecaster):
         :param multioutput: Defines aggregating of multiple output values.
                String in ['raw_values', 'uniform_average']. The value defaults to
                'raw_values'.
-        
+
         :return: A list of evaluation results. Calculation results for each metrics.
         """
         if not self._fitted:


### PR DESCRIPTION
Related doc: https://smalldl.readthedocs.io/en/missing_doc_api/doc/PythonAPI/Chronos/forecasters.html#prophetforecaster