### PR TITLE
Add deepfm test to jenkins

### DIFF
--- a/python/friesian/dev/test/run-example-tests-tf2.6.0.sh
+++ b/python/friesian/dev/test/run-example-tests-tf2.6.0.sh
@@ -23,77 +23,77 @@ set -e
 mkdir -p result
 mkdir -p result/stats
 
-#echo "#1 start example test for two tower train"
-##timer
-#start=$(date "+%s")
-#if [ -d data/input_2tower ]; then
-#  echo "data/input_2tower already exists"
-#else
-#  wget -nv $FTP_URI/analytics-zoo-data/input_2tower.tar.gz -P data
-#  tar -xvzf data/input_2tower.tar.gz -C data
-#fi
-#
-#python ../../example/two_tower/train_2tower.py \
-#    --executor_cores 4 \
-#    --executor_memory 10g \
-#    --data_dir ./data/input_2tower \
-#    --model_dir ./result \
-#    --frequency_limit 2
-#
-#now=$(date "+%s")
-#time1=$((now - start))
-#
+echo "#1 start example test for two tower train"
+#timer
+start=$(date "+%s")
+if [ -d data/input_2tower ]; then
+  echo "data/input_2tower already exists"
+else
+  wget -nv $FTP_URI/analytics-zoo-data/input_2tower.tar.gz -P data
+  tar -xvzf data/input_2tower.tar.gz -C data
+fi
+
+python ../../example/two_tower/train_2tower.py \
+    --executor_cores 4 \
+    --executor_memory 10g \
+    --data_dir ./data/input_2tower \
+    --model_dir ./result \
+    --frequency_limit 2
+
+now=$(date "+%s")
+time1=$((now - start))
+
 if [ -d data/recsys_sample ]; then
   echo "data/recsys_sample already exists"
 else
   wget -nv $FTP_URI/analytics-zoo-data/recsys_sample.tar.gz -P data
   tar -xvzf data/recsys_sample.tar.gz -C data
 fi
-#
-#echo "#2 start example test for wnd train"
-##timer
-#start=$(date "+%s")
-#python ../../example/wnd/train/wnd_train_recsys.py \
-#    --executor_cores 4 \
-#    --executor_memory 10g \
-#    --data_dir ./data/recsys_sample \
-#    --model_dir ./result \
-#    -b 1600
-#
-#now=$(date "+%s")
-#time2=$((now - start))
-#
-#echo "#3 start example test for xgboost train"
-##timer
-#start=$(date "+%s")
-#sed -i "s/\[0.1, 0.15, 0.2, 0.25, 0.3\]/\[0.1\]/g" ../../example/xgb/xgb_train.py
-#sed -i "s/\[6, 8, 10, 12\]/\[6\]/g" ../../example/xgb/xgb_train.py
-#sed -i "s/\[200, 400, 600, 800, 1000\]/\[200\]/g" ../../example/xgb/xgb_train.py
-#python ../../example/xgb/xgb_train.py \
-#    --executor_cores 4 \
-#    --executor_memory 10g \
-#    --data_dir ./data/recsys_sample \
-#    --model_dir ./result/xgb_res
-#
-#now=$(date "+%s")
-#time3=$((now - start))
-#
-#echo "#4 start example test for ncf train"
-#start=$(date "+%s")
-#if [ -d data/movielens ]; then
-#  echo "data/movielens already exists"
-#else
-#  wget -nv $FTP_URI/analytics-zoo-data/movielens.tar.gz -P data
-#  tar -xvzf data/movielens.tar.gz -C data
-#fi
-#
-#python ../../example/ncf/ncf_train.py\
-#    --data_dir ./data/movielens \
-#    --model_dir ./result \
-#    --epochs 1
-#
-#now=$(date "+%s")
-#time4=$((now - start))
+
+echo "#2 start example test for wnd train"
+#timer
+start=$(date "+%s")
+python ../../example/wnd/train/wnd_train_recsys.py \
+    --executor_cores 4 \
+    --executor_memory 10g \
+    --data_dir ./data/recsys_sample \
+    --model_dir ./result \
+    -b 1600
+
+now=$(date "+%s")
+time2=$((now - start))
+
+echo "#3 start example test for xgboost train"
+#timer
+start=$(date "+%s")
+sed -i "s/\[0.1, 0.15, 0.2, 0.25, 0.3\]/\[0.1\]/g" ../../example/xgb/xgb_train.py
+sed -i "s/\[6, 8, 10, 12\]/\[6\]/g" ../../example/xgb/xgb_train.py
+sed -i "s/\[200, 400, 600, 800, 1000\]/\[200\]/g" ../../example/xgb/xgb_train.py
+python ../../example/xgb/xgb_train.py \
+    --executor_cores 4 \
+    --executor_memory 10g \
+    --data_dir ./data/recsys_sample \
+    --model_dir ./result/xgb_res
+
+now=$(date "+%s")
+time3=$((now - start))
+
+echo "#4 start example test for ncf train"
+start=$(date "+%s")
+if [ -d data/movielens ]; then
+  echo "data/movielens already exists"
+else
+  wget -nv $FTP_URI/analytics-zoo-data/movielens.tar.gz -P data
+  tar -xvzf data/movielens.tar.gz -C data
+fi
+
+python ../../example/ncf/ncf_train.py\
+    --data_dir ./data/movielens \
+    --model_dir ./result \
+    --epochs 1
+
+now=$(date "+%s")
+time4=$((now - start))
 
 echo "#5 start example test for deepfm train"
 start=$(date "+%s")
@@ -109,8 +109,8 @@ time5=$((now - start))
 rm -rf data
 rm -rf result
 
-#echo "#1 two tower train time used: $time1 seconds"
-#echo "#2 wnd train time used: $time2 seconds"
-#echo "#3 xgboost train time used: $time3 seconds"
-#echo "#4 ncf train time used: $time4 seconds"
+echo "#1 two tower train time used: $time1 seconds"
+echo "#2 wnd train time used: $time2 seconds"
+echo "#3 xgboost train time used: $time3 seconds"
+echo "#4 ncf train time used: $time4 seconds"
 echo "#5 deepfm train time used: $time5 seconds"

--- a/python/friesian/dev/test/run-example-tests-tf2.6.0.sh
+++ b/python/friesian/dev/test/run-example-tests-tf2.6.0.sh
@@ -43,12 +43,12 @@ mkdir -p result/stats
 #now=$(date "+%s")
 #time1=$((now - start))
 #
-#if [ -d data/recsys_sample ]; then
-#  echo "data/recsys_sample already exists"
-#else
-#  wget -nv $FTP_URI/analytics-zoo-data/recsys_sample.tar.gz -P data
-#  tar -xvzf data/recsys_sample.tar.gz -C data
-#fi
+if [ -d data/recsys_sample ]; then
+  echo "data/recsys_sample already exists"
+else
+  wget -nv $FTP_URI/analytics-zoo-data/recsys_sample.tar.gz -P data
+  tar -xvzf data/recsys_sample.tar.gz -C data
+fi
 #
 #echo "#2 start example test for wnd train"
 ##timer
@@ -97,16 +97,11 @@ mkdir -p result/stats
 
 echo "#5 start example test for deepfm train"
 start=$(date "+%s")
-if [ -d data/input_deepFM ]; then
-  echo "data/input_deepFM already exists"
-else
-  wget -nv $FTP_URI/analytics-zoo-data/input_deepFM.tar.gz -P data
-  tar -xvzf data/input_deepFM.tar.gz -C data
-fi
 
 python ../../example/deep_fm/deepFM_train.py \
-    --data_dir ./data/input_deepFM \
-    --model_dir ./result/deepFM_model
+    --data_dir ./data/recsys_sample \
+    --model_dir ./result/deepFM_model \
+    --frequency_limit 1
 
 now=$(date "+%s")
 time5=$((now - start))

--- a/python/friesian/dev/test/run-example-tests-tf2.6.0.sh
+++ b/python/friesian/dev/test/run-example-tests-tf2.6.0.sh
@@ -23,82 +23,99 @@ set -e
 mkdir -p result
 mkdir -p result/stats
 
-echo "#1 start example test for two tower train"
-#timer
+#echo "#1 start example test for two tower train"
+##timer
+#start=$(date "+%s")
+#if [ -d data/input_2tower ]; then
+#  echo "data/input_2tower already exists"
+#else
+#  wget -nv $FTP_URI/analytics-zoo-data/input_2tower.tar.gz -P data
+#  tar -xvzf data/input_2tower.tar.gz -C data
+#fi
+#
+#python ../../example/two_tower/train_2tower.py \
+#    --executor_cores 4 \
+#    --executor_memory 10g \
+#    --data_dir ./data/input_2tower \
+#    --model_dir ./result \
+#    --frequency_limit 2
+#
+#now=$(date "+%s")
+#time1=$((now - start))
+#
+#if [ -d data/recsys_sample ]; then
+#  echo "data/recsys_sample already exists"
+#else
+#  wget -nv $FTP_URI/analytics-zoo-data/recsys_sample.tar.gz -P data
+#  tar -xvzf data/recsys_sample.tar.gz -C data
+#fi
+#
+#echo "#2 start example test for wnd train"
+##timer
+#start=$(date "+%s")
+#python ../../example/wnd/train/wnd_train_recsys.py \
+#    --executor_cores 4 \
+#    --executor_memory 10g \
+#    --data_dir ./data/recsys_sample \
+#    --model_dir ./result \
+#    -b 1600
+#
+#now=$(date "+%s")
+#time2=$((now - start))
+#
+#echo "#3 start example test for xgboost train"
+##timer
+#start=$(date "+%s")
+#sed -i "s/\[0.1, 0.15, 0.2, 0.25, 0.3\]/\[0.1\]/g" ../../example/xgb/xgb_train.py
+#sed -i "s/\[6, 8, 10, 12\]/\[6\]/g" ../../example/xgb/xgb_train.py
+#sed -i "s/\[200, 400, 600, 800, 1000\]/\[200\]/g" ../../example/xgb/xgb_train.py
+#python ../../example/xgb/xgb_train.py \
+#    --executor_cores 4 \
+#    --executor_memory 10g \
+#    --data_dir ./data/recsys_sample \
+#    --model_dir ./result/xgb_res
+#
+#now=$(date "+%s")
+#time3=$((now - start))
+#
+#echo "#4 start example test for ncf train"
+#start=$(date "+%s")
+#if [ -d data/movielens ]; then
+#  echo "data/movielens already exists"
+#else
+#  wget -nv $FTP_URI/analytics-zoo-data/movielens.tar.gz -P data
+#  tar -xvzf data/movielens.tar.gz -C data
+#fi
+#
+#python ../../example/ncf/ncf_train.py\
+#    --data_dir ./data/movielens \
+#    --model_dir ./result \
+#    --epochs 1
+#
+#now=$(date "+%s")
+#time4=$((now - start))
+
+echo "#5 start example test for deepfm train"
 start=$(date "+%s")
-if [ -d data/input_2tower ]; then
-  echo "data/input_2tower already exists"
+if [ -d data/input_deepFM ]; then
+  echo "data/input_deepFM already exists"
 else
-  wget -nv $FTP_URI/analytics-zoo-data/input_2tower.tar.gz -P data
-  tar -xvzf data/input_2tower.tar.gz -C data
+  wget -nv $FTP_URI/analytics-zoo-data/input_deepFM.tar.gz -P data
+  tar -xvzf data/input_deepFM.tar.gz -C data
 fi
 
-python ../../example/two_tower/train_2tower.py \
-    --executor_cores 4 \
-    --executor_memory 10g \
-    --data_dir ./data/input_2tower \
-    --model_dir ./result \
-    --frequency_limit 2
+python ../../example/deep_fm/deepFM_train.py \
+    --data_dir ./data/input_deepFM \
+    --model_dir ./result/deepFM_model
 
 now=$(date "+%s")
-time1=$((now - start))
-
-if [ -d data/recsys_sample ]; then
-  echo "data/recsys_sample already exists"
-else
-  wget -nv $FTP_URI/analytics-zoo-data/recsys_sample.tar.gz -P data
-  tar -xvzf data/recsys_sample.tar.gz -C data
-fi
-
-echo "#2 start example test for wnd train"
-#timer
-start=$(date "+%s")
-python ../../example/wnd/train/wnd_train_recsys.py \
-    --executor_cores 4 \
-    --executor_memory 10g \
-    --data_dir ./data/recsys_sample \
-    --model_dir ./result \
-    -b 1600
-
-now=$(date "+%s")
-time2=$((now - start))
-
-echo "#3 start example test for xgboost train"
-#timer
-start=$(date "+%s")
-sed -i "s/\[0.1, 0.15, 0.2, 0.25, 0.3\]/\[0.1\]/g" ../../example/xgb/xgb_train.py
-sed -i "s/\[6, 8, 10, 12\]/\[6\]/g" ../../example/xgb/xgb_train.py
-sed -i "s/\[200, 400, 600, 800, 1000\]/\[200\]/g" ../../example/xgb/xgb_train.py
-python ../../example/xgb/xgb_train.py \
-    --executor_cores 4 \
-    --executor_memory 10g \
-    --data_dir ./data/recsys_sample \
-    --model_dir ./result/xgb_res
-
-now=$(date "+%s")
-time3=$((now - start))
-
-echo "#4 start example test for ncf train"
-start=$(date "+%s")
-if [ -d data/movielens ]; then
-  echo "data/movielens already exists"
-else
-  wget -nv $FTP_URI/analytics-zoo-data/movielens.tar.gz -P data
-  tar -xvzf data/movielens.tar.gz -C data
-fi
-
-python ../../example/ncf/ncf_train.py\
-    --data_dir ./data/movielens \
-    --model_dir ./result \
-    --epochs 1
-
-now=$(date "+%s")
-time4=$((now - start))
+time5=$((now - start))
 
 rm -rf data
 rm -rf result
 
-echo "#1 two tower train time used: $time1 seconds"
-echo "#2 wnd train time used: $time2 seconds"
-echo "#3 xgboost train time used: $time3 seconds"
-echo "#4 ncf train time used: $time4 seconds"
+#echo "#1 two tower train time used: $time1 seconds"
+#echo "#2 wnd train time used: $time2 seconds"
+#echo "#3 xgboost train time used: $time3 seconds"
+#echo "#4 ncf train time used: $time4 seconds"
+echo "#5 deepfm train time used: $time5 seconds"

--- a/python/friesian/example/deep_fm/deepFM_train.py
+++ b/python/friesian/example/deep_fm/deepFM_train.py
@@ -37,6 +37,61 @@ spark_conf = {"spark.network.timeout": "10000000",
               "spark.executor.memoryOverhead": "120g"}
 
 
+from deepctr_torch.models.deepfm import *
+from deepctr_torch.models.basemodel import BaseModel
+from deepctr_torch.inputs import SparseFeat, DenseFeat, get_feature_names
+
+class DeepFM(BaseModel):
+    def __init__(self,
+                 linear_feature_columns, dnn_feature_columns, use_fm=True,
+                 dnn_hidden_units=(1024, 512, 128), l2_reg_linear=0.00001, l2_reg_embedding=0.00001,
+                 l2_reg_dnn=0, init_std=0.0001, seed=1024, dnn_dropout=0, dnn_activation='relu',
+                 dnn_use_bn=False, task='binary', device='cpu', gpus=None):
+        # print(linear_feature_columns)
+        # print(dnn_feature_columns)
+        super(DeepFM, self).__init__(linear_feature_columns, dnn_feature_columns,
+                                     l2_reg_linear=l2_reg_linear, l2_reg_embedding=l2_reg_embedding,
+                                     init_std=init_std, seed=seed, task=task,
+                                     device=device, gpus=gpus)
+
+        self.use_fm = use_fm
+        self.use_dnn = len(dnn_feature_columns) > 0 and len(dnn_hidden_units) > 0
+        if use_fm:
+            self.fm = FM()
+
+        if self.use_dnn:
+            self.dnn = DNN(self.compute_input_dim(dnn_feature_columns), dnn_hidden_units,
+                           activation=dnn_activation, l2_reg=l2_reg_dnn, dropout_rate=dnn_dropout,
+                           use_bn=dnn_use_bn, init_std=init_std, device=device)
+            self.dnn_linear = nn.Linear(dnn_hidden_units[-1], 1, bias=False).to(device)
+
+            self.add_regularization_weight(
+                filter(lambda x: 'weight' in x[0] and 'bn' not in x[0],
+                       self.dnn.named_parameters()), l2=l2_reg_dnn)
+            self.add_regularization_weight(self.dnn_linear.weight, l2=l2_reg_dnn)
+        self.to(device)
+
+    def forward(self, X):
+        sparse_embedding_list, dense_value_list = self\
+            .input_from_feature_columns(X, self.dnn_feature_columns, self.embedding_dict)
+        logit = self.linear_model(X)
+
+        if self.use_fm and len(sparse_embedding_list) > 0:
+            fm_input = torch.cat(sparse_embedding_list, dim=1)
+            logit += self.fm(fm_input)
+
+        if self.use_dnn:
+            dnn_input = combined_dnn_input(
+                sparse_embedding_list, dense_value_list)
+            dnn_output = self.dnn(dnn_input)
+            dnn_logit = self.dnn_linear(dnn_output)
+            logit += dnn_logit
+
+        y_pred = self.out(logit)
+
+        return y_pred
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Deep FM Training')
     parser.add_argument('--cluster_mode', type=str, default="local",
@@ -117,9 +172,7 @@ if __name__ == '__main__':
         .apply("label", "label", lambda x: [float(x)], dtype="array<float>")
     test.cache()
 
-    import torch
     def model_creator(config):
-        from model import DeepFM
         model = DeepFM(linear_feature_columns=config["linear_feature_columns"],
                        dnn_feature_columns=config["dnn_feature_columns"],
                        task='binary', l2_reg_embedding=1e-1)

--- a/python/friesian/example/deep_fm/deepFM_train.py
+++ b/python/friesian/example/deep_fm/deepFM_train.py
@@ -142,10 +142,6 @@ if __name__ == '__main__':
     train = FeatureTable.read_parquet(args.data_dir + "/train_parquet")
     test = FeatureTable.read_parquet(args.data_dir + "/test_parquet")
 
-    test_user_ids = test.select("engaged_with_user_id").cast("engaged_with_user_id", "str").\
-        to_list("engaged_with_user_id")
-    test_labels = test.select("label").to_list("label")
-
     full = train.concat(test)
     reindex_tbls = full.gen_reindex_mapping(embed_cols, freq_limit=args.frequency_limit)
     full, min_max_dict = full.min_max_scale(num_cols)

--- a/python/friesian/example/deep_fm/deepFM_train.py
+++ b/python/friesian/example/deep_fm/deepFM_train.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 #
 
-from deepctr_torch.inputs import SparseFeat, DenseFeat, get_feature_names
-from deepctr_torch.models.deepfm import *
-from deepctr_torch.models.basemodel import *
+# from deepctr_torch.inputs import SparseFeat, DenseFeat, get_feature_names
+# from deepctr_torch.models.deepfm import *
+# from deepctr_torch.models.basemodel import *
 from bigdl.friesian.feature import FeatureTable
 from bigdl.orca import init_orca_context, stop_orca_context
 from bigdl.orca.learn.pytorch import Estimator
@@ -40,54 +40,54 @@ spark_conf = {"spark.network.timeout": "10000000",
               "spark.executor.memoryOverhead": "120g"}
 
 
-class DeepFM(BaseModel):
-    def __init__(self,
-                 linear_feature_columns, dnn_feature_columns, use_fm=True,
-                 dnn_hidden_units=(1024, 512, 128), l2_reg_linear=0.00001, l2_reg_embedding=0.00001,
-                 l2_reg_dnn=0, init_std=0.0001, seed=1024, dnn_dropout=0, dnn_activation='relu',
-                 dnn_use_bn=False, task='binary', device='cpu', gpus=None):
-
-        super(DeepFM, self).__init__(linear_feature_columns, dnn_feature_columns,
-                                     l2_reg_linear=l2_reg_linear, l2_reg_embedding=l2_reg_embedding,
-                                     init_std=init_std, seed=seed, task=task,
-                                     device=device, gpus=gpus)
-
-        self.use_fm = use_fm
-        self.use_dnn = len(dnn_feature_columns) > 0 and len(dnn_hidden_units) > 0
-        if use_fm:
-            self.fm = FM()
-
-        if self.use_dnn:
-            self.dnn = DNN(self.compute_input_dim(dnn_feature_columns), dnn_hidden_units,
-                           activation=dnn_activation, l2_reg=l2_reg_dnn, dropout_rate=dnn_dropout,
-                           use_bn=dnn_use_bn, init_std=init_std, device=device)
-            self.dnn_linear = nn.Linear(dnn_hidden_units[-1], 1, bias=False).to(device)
-
-            self.add_regularization_weight(
-                filter(lambda x: 'weight' in x[0] and 'bn' not in x[0],
-                       self.dnn.named_parameters()), l2=l2_reg_dnn)
-            self.add_regularization_weight(self.dnn_linear.weight, l2=l2_reg_dnn)
-        self.to(device)
-
-    def forward(self, X):
-        sparse_embedding_list, dense_value_list = self\
-            .input_from_feature_columns(X, self.dnn_feature_columns, self.embedding_dict)
-        logit = self.linear_model(X)
-
-        if self.use_fm and len(sparse_embedding_list) > 0:
-            fm_input = torch.cat(sparse_embedding_list, dim=1)
-            logit += self.fm(fm_input)
-
-        if self.use_dnn:
-            dnn_input = combined_dnn_input(
-                sparse_embedding_list, dense_value_list)
-            dnn_output = self.dnn(dnn_input)
-            dnn_logit = self.dnn_linear(dnn_output)
-            logit += dnn_logit
-
-        y_pred = self.out(logit)
-
-        return y_pred
+# class DeepFM(BaseModel):
+#     def __init__(self,
+#                  linear_feature_columns, dnn_feature_columns, use_fm=True,
+#                  dnn_hidden_units=(1024, 512, 128), l2_reg_linear=0.00001, l2_reg_embedding=0.00001,
+#                  l2_reg_dnn=0, init_std=0.0001, seed=1024, dnn_dropout=0, dnn_activation='relu',
+#                  dnn_use_bn=False, task='binary', device='cpu', gpus=None):
+#
+#         super(DeepFM, self).__init__(linear_feature_columns, dnn_feature_columns,
+#                                      l2_reg_linear=l2_reg_linear, l2_reg_embedding=l2_reg_embedding,
+#                                      init_std=init_std, seed=seed, task=task,
+#                                      device=device, gpus=gpus)
+#
+#         self.use_fm = use_fm
+#         self.use_dnn = len(dnn_feature_columns) > 0 and len(dnn_hidden_units) > 0
+#         if use_fm:
+#             self.fm = FM()
+#
+#         if self.use_dnn:
+#             self.dnn = DNN(self.compute_input_dim(dnn_feature_columns), dnn_hidden_units,
+#                            activation=dnn_activation, l2_reg=l2_reg_dnn, dropout_rate=dnn_dropout,
+#                            use_bn=dnn_use_bn, init_std=init_std, device=device)
+#             self.dnn_linear = nn.Linear(dnn_hidden_units[-1], 1, bias=False).to(device)
+#
+#             self.add_regularization_weight(
+#                 filter(lambda x: 'weight' in x[0] and 'bn' not in x[0],
+#                        self.dnn.named_parameters()), l2=l2_reg_dnn)
+#             self.add_regularization_weight(self.dnn_linear.weight, l2=l2_reg_dnn)
+#         self.to(device)
+#
+#     def forward(self, X):
+#         sparse_embedding_list, dense_value_list = self\
+#             .input_from_feature_columns(X, self.dnn_feature_columns, self.embedding_dict)
+#         logit = self.linear_model(X)
+#
+#         if self.use_fm and len(sparse_embedding_list) > 0:
+#             fm_input = torch.cat(sparse_embedding_list, dim=1)
+#             logit += self.fm(fm_input)
+#
+#         if self.use_dnn:
+#             dnn_input = combined_dnn_input(
+#                 sparse_embedding_list, dense_value_list)
+#             dnn_output = self.dnn(dnn_input)
+#             dnn_logit = self.dnn_linear(dnn_output)
+#             logit += dnn_logit
+#
+#         y_pred = self.out(logit)
+#
+#         return y_pred
 
 
 if __name__ == '__main__':
@@ -152,6 +152,7 @@ if __name__ == '__main__':
     cat_dims = {col: max + 1 for col, max in cat_dims.items()}
     sparse_dims.update(cat_dims)
 
+    from deepctr_torch.inputs import SparseFeat, DenseFeat, get_feature_names
     feature_columns = [SparseFeat(feat, int(sparse_dims[feat]), 16) for feat in sparse_dims] + \
                       [DenseFeat(feat, 1) for feat in num_cols]
     feature_names = get_feature_names(feature_columns)
@@ -169,6 +170,7 @@ if __name__ == '__main__':
         .apply("label", "label", lambda x: [float(x)], dtype="array<float>")
     test.cache()
 
+    import torch
     def model_creator(config):
         model = DeepFM(linear_feature_columns=config["linear_feature_columns"],
                        dnn_feature_columns=config["dnn_feature_columns"],

--- a/python/friesian/example/deep_fm/deepFM_train.py
+++ b/python/friesian/example/deep_fm/deepFM_train.py
@@ -14,14 +14,11 @@
 # limitations under the License.
 #
 
-# from deepctr_torch.inputs import SparseFeat, DenseFeat, get_feature_names
-# from deepctr_torch.models.deepfm import *
-# from deepctr_torch.models.basemodel import *
-from bigdl.friesian.feature import FeatureTable
+import argparse
 from bigdl.orca import init_orca_context, stop_orca_context
 from bigdl.orca.learn.pytorch import Estimator
 from bigdl.orca.learn.metrics import Accuracy, AUC
-import argparse
+from bigdl.friesian.feature import FeatureTable
 
 spark_conf = {"spark.network.timeout": "10000000",
               "spark.sql.broadcastTimeout": "7200",
@@ -38,56 +35,6 @@ spark_conf = {"spark.network.timeout": "10000000",
               "spark.eventLog.enabled": "true",
               "spark.app.name": "recsys-2tower",
               "spark.executor.memoryOverhead": "120g"}
-
-
-# class DeepFM(BaseModel):
-#     def __init__(self,
-#                  linear_feature_columns, dnn_feature_columns, use_fm=True,
-#                  dnn_hidden_units=(1024, 512, 128), l2_reg_linear=0.00001, l2_reg_embedding=0.00001,
-#                  l2_reg_dnn=0, init_std=0.0001, seed=1024, dnn_dropout=0, dnn_activation='relu',
-#                  dnn_use_bn=False, task='binary', device='cpu', gpus=None):
-#
-#         super(DeepFM, self).__init__(linear_feature_columns, dnn_feature_columns,
-#                                      l2_reg_linear=l2_reg_linear, l2_reg_embedding=l2_reg_embedding,
-#                                      init_std=init_std, seed=seed, task=task,
-#                                      device=device, gpus=gpus)
-#
-#         self.use_fm = use_fm
-#         self.use_dnn = len(dnn_feature_columns) > 0 and len(dnn_hidden_units) > 0
-#         if use_fm:
-#             self.fm = FM()
-#
-#         if self.use_dnn:
-#             self.dnn = DNN(self.compute_input_dim(dnn_feature_columns), dnn_hidden_units,
-#                            activation=dnn_activation, l2_reg=l2_reg_dnn, dropout_rate=dnn_dropout,
-#                            use_bn=dnn_use_bn, init_std=init_std, device=device)
-#             self.dnn_linear = nn.Linear(dnn_hidden_units[-1], 1, bias=False).to(device)
-#
-#             self.add_regularization_weight(
-#                 filter(lambda x: 'weight' in x[0] and 'bn' not in x[0],
-#                        self.dnn.named_parameters()), l2=l2_reg_dnn)
-#             self.add_regularization_weight(self.dnn_linear.weight, l2=l2_reg_dnn)
-#         self.to(device)
-#
-#     def forward(self, X):
-#         sparse_embedding_list, dense_value_list = self\
-#             .input_from_feature_columns(X, self.dnn_feature_columns, self.embedding_dict)
-#         logit = self.linear_model(X)
-#
-#         if self.use_fm and len(sparse_embedding_list) > 0:
-#             fm_input = torch.cat(sparse_embedding_list, dim=1)
-#             logit += self.fm(fm_input)
-#
-#         if self.use_dnn:
-#             dnn_input = combined_dnn_input(
-#                 sparse_embedding_list, dense_value_list)
-#             dnn_output = self.dnn(dnn_input)
-#             dnn_logit = self.dnn_linear(dnn_output)
-#             logit += dnn_logit
-#
-#         y_pred = self.out(logit)
-#
-#         return y_pred
 
 
 if __name__ == '__main__':
@@ -116,13 +63,13 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.cluster_mode == "local":
-        sc = init_orca_context("local")
+        sc = init_orca_context("local", cores=args.executor_cores, memory=args.executor_memory)
     elif args.cluster_mode == "yarn":
         sc = init_orca_context("yarn-client", cores=args.executor_cores,
                                num_nodes=args.num_executor, memory=args.executor_memory,
                                driver_cores=args.driver_cores, driver_memory=args.driver_memory,
-                               conf=spark_conf, object_store_memory="40g", init_ray_on_spark=True,
-                               extra_python_lib="evaluation.py")
+                               conf=spark_conf, object_store_memory="40g",
+                               extra_python_lib="model.py,evaluation.py")
     elif args.cluster_mode == "spark-submit":
         sc = init_orca_context("spark-submit", object_store_memory="40g")
     else:
@@ -172,6 +119,7 @@ if __name__ == '__main__':
 
     import torch
     def model_creator(config):
+        from model import DeepFM
         model = DeepFM(linear_feature_columns=config["linear_feature_columns"],
                        dnn_feature_columns=config["dnn_feature_columns"],
                        task='binary', l2_reg_embedding=1e-1)

--- a/python/friesian/example/deep_fm/deepFM_train.py
+++ b/python/friesian/example/deep_fm/deepFM_train.py
@@ -63,13 +63,13 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.cluster_mode == "local":
-        sc = init_orca_context("local")
+        sc = init_orca_context("local", cores=args.executor_cores, memory=args.executor_memory)
     elif args.cluster_mode == "yarn":
         sc = init_orca_context("yarn-client", cores=args.executor_cores,
                                num_nodes=args.num_executor, memory=args.executor_memory,
                                driver_cores=args.driver_cores, driver_memory=args.driver_memory,
                                conf=spark_conf, object_store_memory="40g", init_ray_on_spark=True,
-                               extra_python_lib="evaluation.py")
+                               extra_python_lib="model.py,evaluation.py")
     elif args.cluster_mode == "spark-submit":
         sc = init_orca_context("spark-submit", object_store_memory="40g")
     else:

--- a/python/friesian/example/deep_fm/deepFM_train.py
+++ b/python/friesian/example/deep_fm/deepFM_train.py
@@ -37,61 +37,6 @@ spark_conf = {"spark.network.timeout": "10000000",
               "spark.executor.memoryOverhead": "120g"}
 
 
-from deepctr_torch.models.deepfm import *
-from deepctr_torch.models.basemodel import BaseModel
-from deepctr_torch.inputs import SparseFeat, DenseFeat, get_feature_names
-
-class DeepFM(BaseModel):
-    def __init__(self,
-                 linear_feature_columns, dnn_feature_columns, use_fm=True,
-                 dnn_hidden_units=(1024, 512, 128), l2_reg_linear=0.00001, l2_reg_embedding=0.00001,
-                 l2_reg_dnn=0, init_std=0.0001, seed=1024, dnn_dropout=0, dnn_activation='relu',
-                 dnn_use_bn=False, task='binary', device='cpu', gpus=None):
-        # print(linear_feature_columns)
-        # print(dnn_feature_columns)
-        super(DeepFM, self).__init__(linear_feature_columns, dnn_feature_columns,
-                                     l2_reg_linear=l2_reg_linear, l2_reg_embedding=l2_reg_embedding,
-                                     init_std=init_std, seed=seed, task=task,
-                                     device=device, gpus=gpus)
-
-        self.use_fm = use_fm
-        self.use_dnn = len(dnn_feature_columns) > 0 and len(dnn_hidden_units) > 0
-        if use_fm:
-            self.fm = FM()
-
-        if self.use_dnn:
-            self.dnn = DNN(self.compute_input_dim(dnn_feature_columns), dnn_hidden_units,
-                           activation=dnn_activation, l2_reg=l2_reg_dnn, dropout_rate=dnn_dropout,
-                           use_bn=dnn_use_bn, init_std=init_std, device=device)
-            self.dnn_linear = nn.Linear(dnn_hidden_units[-1], 1, bias=False).to(device)
-
-            self.add_regularization_weight(
-                filter(lambda x: 'weight' in x[0] and 'bn' not in x[0],
-                       self.dnn.named_parameters()), l2=l2_reg_dnn)
-            self.add_regularization_weight(self.dnn_linear.weight, l2=l2_reg_dnn)
-        self.to(device)
-
-    def forward(self, X):
-        sparse_embedding_list, dense_value_list = self\
-            .input_from_feature_columns(X, self.dnn_feature_columns, self.embedding_dict)
-        logit = self.linear_model(X)
-
-        if self.use_fm and len(sparse_embedding_list) > 0:
-            fm_input = torch.cat(sparse_embedding_list, dim=1)
-            logit += self.fm(fm_input)
-
-        if self.use_dnn:
-            dnn_input = combined_dnn_input(
-                sparse_embedding_list, dense_value_list)
-            dnn_output = self.dnn(dnn_input)
-            dnn_logit = self.dnn_linear(dnn_output)
-            logit += dnn_logit
-
-        y_pred = self.out(logit)
-
-        return y_pred
-
-
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Deep FM Training')
     parser.add_argument('--cluster_mode', type=str, default="local",
@@ -113,18 +58,18 @@ if __name__ == '__main__':
     parser.add_argument('--batch_size', default=8000, type=int, help='batch size')
     parser.add_argument('--model_dir', default='snapshot', type=str,
                         help='snapshot directory name (default: snapshot)')
-    parser.add_argument('--data_dir', type=str, help='data directory', required=True)
+    parser.add_argument('--data_dir', type=str, help='data directory')
     parser.add_argument('--frequency_limit', type=int, default=25, help='frequency limit')
     args = parser.parse_args()
 
     if args.cluster_mode == "local":
-        sc = init_orca_context("local", cores=args.executor_cores, memory=args.executor_memory)
+        sc = init_orca_context("local")
     elif args.cluster_mode == "yarn":
         sc = init_orca_context("yarn-client", cores=args.executor_cores,
                                num_nodes=args.num_executor, memory=args.executor_memory,
                                driver_cores=args.driver_cores, driver_memory=args.driver_memory,
-                               conf=spark_conf, object_store_memory="40g",
-                               extra_python_lib="model.py,evaluation.py")
+                               conf=spark_conf, object_store_memory="40g", init_ray_on_spark=True,
+                               extra_python_lib="evaluation.py")
     elif args.cluster_mode == "spark-submit":
         sc = init_orca_context("spark-submit", object_store_memory="40g")
     else:
@@ -139,9 +84,14 @@ if __name__ == '__main__':
                 "tweet_type", "language", 'present_media_language']
     embed_cols = ["enaging_user_id", "engaged_with_user_id", "hashtags", "present_links",
                   "present_domains"]
+    all_features = embed_cols + cat_cols + num_cols
 
     train = FeatureTable.read_parquet(args.data_dir + "/train_parquet")
     test = FeatureTable.read_parquet(args.data_dir + "/test_parquet")
+
+    test_user_ids = test.select("engaged_with_user_id").cast("engaged_with_user_id", "str").\
+        to_list("engaged_with_user_id")
+    test_labels = test.select("label").to_list("label")
 
     full = train.concat(test)
     reindex_tbls = full.gen_reindex_mapping(embed_cols, freq_limit=args.frequency_limit)
@@ -150,45 +100,43 @@ if __name__ == '__main__':
     sparse_dims = {}
     for i, c, in enumerate(embed_cols):
         sparse_dims[c] = max(reindex_tbls[i].df.agg({c+"_new": "max"}).collect()[0]) + 1
-    cat_dims = full.get_stats(cat_cols, "max")
-    cat_dims = {col: max + 1 for col, max in cat_dims.items()}
+    cat_dims = full.max(cat_cols).to_dict()
+    cat_dims = dict(zip(cat_dims['column'], [dim + 1 for dim in cat_dims['max']]))
     sparse_dims.update(cat_dims)
-
-    from deepctr_torch.inputs import SparseFeat, DenseFeat, get_feature_names
-    feature_columns = [SparseFeat(feat, int(sparse_dims[feat]), 16) for feat in sparse_dims] + \
-                      [DenseFeat(feat, 1) for feat in num_cols]
-    feature_names = get_feature_names(feature_columns)
 
     train = train.reindex(embed_cols, reindex_tbls)\
         .transform_min_max_scale(num_cols, min_max_dict)\
-        .merge_cols(feature_names, "feature") \
+        .merge_cols(all_features, "feature") \
         .select(["label", "feature"])\
         .apply("label", "label", lambda x: [float(x)], dtype="array<float>")
 
     test = test.reindex(embed_cols, reindex_tbls) \
         .transform_min_max_scale(num_cols, min_max_dict) \
-        .merge_cols(feature_names, "feature") \
+        .merge_cols(all_features, "feature") \
         .select(["label", "feature"]) \
         .apply("label", "label", lambda x: [float(x)], dtype="array<float>")
     test.cache()
 
     def model_creator(config):
-        model = DeepFM(linear_feature_columns=config["linear_feature_columns"],
-                       dnn_feature_columns=config["dnn_feature_columns"],
+        from deepctr_torch.inputs import SparseFeat, DenseFeat
+        from model import DeepFM
+
+        feature_columns = [SparseFeat(feat, int(dim), 16) for feat, dim in config["sparse_dims"].items()] + \
+                          [DenseFeat(feat, 1) for feat in config["num_cols"]]
+        model = DeepFM(linear_feature_columns=feature_columns,
+                       dnn_feature_columns=feature_columns,
                        task='binary', l2_reg_embedding=1e-1)
         model.float()
         print(model)
         return model
 
+    import torch
     def optim_creator(model, config):
         return torch.optim.Adam(model.parameters(), config['lr'])
 
     criterion = torch.nn.BCELoss()
 
-    config = {'linear_feature_columns': feature_columns,
-              'dnn_feature_columns': feature_columns,
-              'feature_names': feature_names,
-              'lr': args.lr}
+    config = {'sparse_dims': sparse_dims, 'num_cols': num_cols, 'lr': args.lr}
 
     est = Estimator.from_torch(model=model_creator, optimizer=optim_creator, loss=criterion,
                                metrics=[Accuracy(), AUC()], use_tqdm=True, backend="ray",

--- a/python/friesian/example/deep_fm/deepFM_train.py
+++ b/python/friesian/example/deep_fm/deepFM_train.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
     parser.add_argument('--batch_size', default=8000, type=int, help='batch size')
     parser.add_argument('--model_dir', default='snapshot', type=str,
                         help='snapshot directory name (default: snapshot)')
-    parser.add_argument('--data_dir', type=str, help='data directory')
+    parser.add_argument('--data_dir', type=str, help='data directory', required=True)
     parser.add_argument('--frequency_limit', type=int, default=25, help='frequency limit')
     args = parser.parse_args()
 

--- a/python/friesian/example/deep_fm/deepFM_train.py
+++ b/python/friesian/example/deep_fm/deepFM_train.py
@@ -121,8 +121,9 @@ if __name__ == '__main__':
         from deepctr_torch.inputs import SparseFeat, DenseFeat
         from model import DeepFM
 
-        feature_columns = [SparseFeat(feat, int(dim), 16) for feat, dim in config["sparse_dims"].items()] + \
-                          [DenseFeat(feat, 1) for feat in config["num_cols"]]
+        feature_columns = \
+            [SparseFeat(feat, int(dim), 16) for feat, dim in config["sparse_dims"].items()] + \
+            [DenseFeat(feat, 1) for feat in config["num_cols"]]
         model = DeepFM(linear_feature_columns=feature_columns,
                        dnn_feature_columns=feature_columns,
                        task='binary', l2_reg_embedding=1e-1)
@@ -131,6 +132,7 @@ if __name__ == '__main__':
         return model
 
     import torch
+
     def optim_creator(model, config):
         return torch.optim.Adam(model.parameters(), config['lr'])
 

--- a/python/friesian/example/deep_fm/deepFM_train.py
+++ b/python/friesian/example/deep_fm/deepFM_train.py
@@ -17,7 +17,6 @@
 from deepctr_torch.inputs import SparseFeat, DenseFeat, get_feature_names
 from deepctr_torch.models.deepfm import *
 from deepctr_torch.models.basemodel import *
-from evaluation import uAUC
 from bigdl.friesian.feature import FeatureTable
 from bigdl.orca import init_orca_context, stop_orca_context
 from bigdl.orca.learn.pytorch import Estimator
@@ -112,7 +111,7 @@ if __name__ == '__main__':
     parser.add_argument('--batch_size', default=8000, type=int, help='batch size')
     parser.add_argument('--model_dir', default='snapshot', type=str,
                         help='snapshot directory name (default: snapshot)')
-    parser.add_argument('--data_dir', type=str, help='data directory')
+    parser.add_argument('--data_dir', type=str, help='data directory', required=True)
     parser.add_argument('--frequency_limit', type=int, default=25, help='frequency limit')
     args = parser.parse_args()
 
@@ -149,8 +148,8 @@ if __name__ == '__main__':
     sparse_dims = {}
     for i, c, in enumerate(embed_cols):
         sparse_dims[c] = max(reindex_tbls[i].df.agg({c+"_new": "max"}).collect()[0]) + 1
-    cat_dims = full.max(cat_cols).to_dict()
-    cat_dims = dict(zip(cat_dims['column'], [dim + 1 for dim in cat_dims['max']]))
+    cat_dims = full.get_stats(cat_cols, "max")
+    cat_dims = {col: max + 1 for col, max in cat_dims.items()}
     sparse_dims.update(cat_dims)
 
     feature_columns = [SparseFeat(feat, int(sparse_dims[feat]), 16) for feat in sparse_dims] + \

--- a/python/friesian/example/deep_fm/model.py
+++ b/python/friesian/example/deep_fm/model.py
@@ -1,0 +1,66 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from deepctr_torch.models.deepfm import *
+from deepctr_torch.models.basemodel import BaseModel
+
+class DeepFM(BaseModel):
+    def __init__(self,
+                 linear_feature_columns, dnn_feature_columns, use_fm=True,
+                 dnn_hidden_units=(1024, 512, 128), l2_reg_linear=0.00001, l2_reg_embedding=0.00001,
+                 l2_reg_dnn=0, init_std=0.0001, seed=1024, dnn_dropout=0, dnn_activation='relu',
+                 dnn_use_bn=False, task='binary', device='cpu', gpus=None):
+        super(DeepFM, self).__init__(linear_feature_columns, dnn_feature_columns,
+                                     l2_reg_linear=l2_reg_linear, l2_reg_embedding=l2_reg_embedding,
+                                     init_std=init_std, seed=seed, task=task,
+                                     device=device, gpus=gpus)
+
+        self.use_fm = use_fm
+        self.use_dnn = len(dnn_feature_columns) > 0 and len(dnn_hidden_units) > 0
+        if use_fm:
+            self.fm = FM()
+
+        if self.use_dnn:
+            self.dnn = DNN(self.compute_input_dim(dnn_feature_columns), dnn_hidden_units,
+                           activation=dnn_activation, l2_reg=l2_reg_dnn, dropout_rate=dnn_dropout,
+                           use_bn=dnn_use_bn, init_std=init_std, device=device)
+            self.dnn_linear = nn.Linear(dnn_hidden_units[-1], 1, bias=False).to(device)
+
+            self.add_regularization_weight(
+                filter(lambda x: 'weight' in x[0] and 'bn' not in x[0],
+                       self.dnn.named_parameters()), l2=l2_reg_dnn)
+            self.add_regularization_weight(self.dnn_linear.weight, l2=l2_reg_dnn)
+        self.to(device)
+
+    def forward(self, X):
+        sparse_embedding_list, dense_value_list = self\
+            .input_from_feature_columns(X, self.dnn_feature_columns, self.embedding_dict)
+        logit = self.linear_model(X)
+
+        if self.use_fm and len(sparse_embedding_list) > 0:
+            fm_input = torch.cat(sparse_embedding_list, dim=1)
+            logit += self.fm(fm_input)
+
+        if self.use_dnn:
+            dnn_input = combined_dnn_input(
+                sparse_embedding_list, dense_value_list)
+            dnn_output = self.dnn(dnn_input)
+            dnn_logit = self.dnn_linear(dnn_output)
+            logit += dnn_logit
+
+        y_pred = self.out(logit)
+
+        return y_pred

--- a/python/friesian/example/deep_fm/model.py
+++ b/python/friesian/example/deep_fm/model.py
@@ -17,6 +17,7 @@
 from deepctr_torch.models.deepfm import *
 from deepctr_torch.models.basemodel import BaseModel
 
+
 class DeepFM(BaseModel):
     def __init__(self,
                  linear_feature_columns, dnn_feature_columns, use_fm=True,


### PR DESCRIPTION
http://10.112.231.51:18888/job/BigDL-PRVN-Python-Friesian-ExampleTest-Spark-3.1-tf2/335/console spark3.1 has the same error as ncf https://github.com/intel-analytics/BigDL/pull/4509

It is also caused by `import deepctr` at the beginning of the model.

In this example, since DeepFM extends BaseModel, which can't be lazily imported? Thus put model into a separate file and import it in the creator function.

Also, `from deepctr_torch.inputs import SparseFeat, DenseFeat` should import at the very beginning, otherwise seems SparseFeat and DenseFeat will have serialize problems (don't know why...) and thus to make things easy, modified to create them in model_creator.

Since the error only happens on Jenkins with Spark3, not producible on my laptop, this is just a workaround and has no impact to the original implementation.