### PR TITLE
add rules to disable throw exception

### DIFF
--- a/scala/scalastyle_config.xml
+++ b/scala/scalastyle_config.xml
@@ -206,5 +206,10 @@ You can also disable only one rule, by specifying its rule id, as specified in:
         <customMessage>require is not allowed to use, please use Log4Error api instead</customMessage>
     </check>
 
+    <check customId="throwexception" level="error" class="org.scalastyle.file.RegexChecker" enabled="true">
+        <parameters><parameter name="regex">throw new \w+Exception\(</parameter></parameters>
+        <customMessage>throw exception is not allowed to use, please use Log4Error api instead</customMessage>
+    </check>
+
 
 </scalastyle>


### PR DESCRIPTION
This PR is add rules to disallow using `throw new xxException` in scala code. Will merge this pr after all scala module has removed `throw new xxxException`