### PR TITLE
fix init_spark_on_k8s uploading jars & missing tf_lib path

### DIFF
--- a/python/dllib/src/bigdl/dllib/utils/spark.py
+++ b/python/dllib/src/bigdl/dllib/utils/spark.py
@@ -25,6 +25,7 @@ from bigdl.dllib.utils.utils import detect_python_location, pack_penv, get_node_
 from bigdl.dllib.utils.utils import get_executor_conda_zoo_classpath
 from bigdl.dllib.utils.utils import get_zoo_bigdl_classpath_on_driver
 from bigdl.dllib.utils.utils import get_bigdl_class_version
+from bigdl.dllib.utils.utils import get_bigdl_image_workdir
 from bigdl.dllib.utils.engine import get_bigdl_jars
 from bigdl.dllib.utils.log4Error import *
 
@@ -364,7 +365,8 @@ class SparkRunner:
             preload_so = executor_python_env + "/lib/libpython" + py_version + "m.so"
             ld_path = executor_python_env + "/lib:" + executor_python_env + "/lib/python" + \
                 py_version + "/lib-dynload"
-            tf_libs_path = "/opt/spark/work-dir/" + executor_python_env + "/lib/python" + \
+            image_workdir = get_bigdl_image_workdir()
+            tf_libs_path = image_workdir + executor_python_env + "/lib/python" + \
                 py_version + "/site-packages/bigdl/share/tflibs"
             if "spark.executor.extraLibraryPath" in conf:
                 ld_path = "{}:{}".format(ld_path, conf["spark.executor.extraLibraryPath"])

--- a/python/dllib/src/bigdl/dllib/utils/spark.py
+++ b/python/dllib/src/bigdl/dllib/utils/spark.py
@@ -355,6 +355,7 @@ class SparkRunner:
             submit_args = submit_args + gen_submit_args(
                 driver_cores, driver_memory, num_executors, executor_cores,
                 executor_memory, extra_python_lib, jars)
+            submit_args = submit_args + " --jars " + ",".join(get_bigdl_jars())
 
             conf = enrich_conf_for_spark(conf, driver_cores, driver_memory, num_executors,
                                          executor_cores, executor_memory,
@@ -363,10 +364,13 @@ class SparkRunner:
             preload_so = executor_python_env + "/lib/libpython" + py_version + "m.so"
             ld_path = executor_python_env + "/lib:" + executor_python_env + "/lib/python" + \
                 py_version + "/lib-dynload"
+            tf_libs_path = "/opt/spark/work-dir/" + executor_python_env + "/lib/python" + \
+                py_version + "/site-packages/bigdl/share/tflibs"
             if "spark.executor.extraLibraryPath" in conf:
                 ld_path = "{}:{}".format(ld_path, conf["spark.executor.extraLibraryPath"])
             conf.update({"spark.cores.max": num_executors * executor_cores,
                          "spark.executorEnv.PYTHONHOME": executor_python_env,
+                         "spark.executorEnv.TF_LIBS_PATH": tf_libs_path,
                          "spark.executor.extraLibraryPath": ld_path,
                          "spark.executorEnv.LD_PRELOAD": preload_so,
                          "spark.kubernetes.container.image": container_image})
@@ -374,13 +378,6 @@ class SparkRunner:
                 conf["spark.driver.host"] = get_node_ip()
             if "spark.driver.port" not in conf:
                 conf["spark.driver.port"] = random.randint(10000, 65535)
-            zoo_bigdl_path_on_executor = ":".join(
-                list(get_executor_conda_zoo_classpath(executor_python_env)))
-            if "spark.executor.extraClassPath" in conf:
-                conf["spark.executor.extraClassPath"] = "{}:{}".format(
-                    zoo_bigdl_path_on_executor, conf["spark.executor.extraClassPath"])
-            else:
-                conf["spark.executor.extraClassPath"] = zoo_bigdl_path_on_executor
 
             sc = self.create_sc(submit_args, conf)
         finally:

--- a/python/dllib/src/bigdl/dllib/utils/utils.py
+++ b/python/dllib/src/bigdl/dllib/utils/utils.py
@@ -178,7 +178,7 @@ def get_bigdl_class_version():
 
 
 def get_bigdl_image_workdir():
-    bigdl_image_workdir = "/opt/spark/work-dir" # WORKDIR defined in dockerfile
+    bigdl_image_workdir = "/opt/spark/work-dir"  # WORKDIR defined in dockerfile
     return bigdl_image_workdir
 
 

--- a/python/dllib/src/bigdl/dllib/utils/utils.py
+++ b/python/dllib/src/bigdl/dllib/utils/utils.py
@@ -177,6 +177,11 @@ def get_bigdl_class_version():
     return bigdl_class_version
 
 
+def get_bigdl_image_workdir():
+    bigdl_image_workdir = "/opt/spark/work-dir" # WORKDIR defined in dockerfile
+    return bigdl_image_workdir
+
+
 def _is_scalar_type(dtype, accept_str_col=False):
     import pyspark.sql.types as df_types
     if isinstance(dtype, df_types.FloatType):


### PR DESCRIPTION
delete this part since it can not set jars in executor classpath. Although it can be verified that jars in conda packed are uploaded in executor python "env", jars set by "spark.executor.extraClassPath" can not work. 
```
            zoo_bigdl_path_on_executor = ":".join(
                list(get_executor_conda_zoo_classpath(executor_python_env)))
            if "spark.executor.extraClassPath" in conf:
                conf["spark.executor.extraClassPath"] = "{}:{}".format(
                    zoo_bigdl_path_on_executor, conf["spark.executor.extraClassPath"])
            else:
                conf["spark.executor.extraClassPath"] = zoo_bigdl_path_on_executor
```

`java.lang.ClassCastException: cannot assign instance of java.lang.invoke.SerializedLambda to field org.apache.spark.rdd.MapPartitionsRDD.f of type scala.Function3 in instance of org.apache.spark.rdd.MapPartitionsRDD` is the error that jars in dirver and executor are not equal or jars are empty in excutors classpath.