### PR TITLE
Add optional validation_data in fit for Pytorch Estimator with ray backend

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -592,14 +592,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                 stats[stat_key] = worker_stats[0][stat_key]
         return stats
 
-    def _train_epochs(self, data_creator,
-                      epochs=1, batch_size=32,
-                      profile=False, info=None,
-                      callbacks=None):
-
-        params = dict(data_creator=data_creator, epochs=epochs,
-                      batch_size=batch_size, profile=profile, info=info,
-                      callbacks=callbacks)
+    def _train_epochs(self, **params):
         remote_worker_stats = []
         for i, w in enumerate(self.remote_workers):
             stats = w.train_epochs.remote(**params)

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -200,6 +200,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
             info=None,
             feature_cols=None,
             label_cols=None,
+            validation_data=None,
             callbacks=[]):
         """
         Trains a PyTorch model given training data for several epochs.
@@ -225,6 +226,8 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                train_epoch and train_batch.
         :param feature_cols: feature column names if data is Spark DataFrame or Ray Dataset.
         :param label_cols: label column names if data is Spark DataFrame or Ray Dataset.
+        :param validation_data: validation data. Validation data type should be the same
+               as train data.
         :param callbacks: A list for all callbacks.
 
         :return: A list of dictionary of metrics for every training epoch. If reduce_results is
@@ -233,60 +236,101 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                 You can also provide custom metrics by passing in a custom training_operator_cls
                 when creating the Estimator.
         """
+        params = dict(
+            epochs=epochs,
+            batch_size=batch_size,
+            profile=profile,
+            info=info,
+            wrap_dataloader=False,
+            callbacks=callbacks,
+        )
+
         from bigdl.orca.data import SparkXShards
         from ray.data import Dataset
 
-        data, _ = maybe_dataframe_to_xshards(data,
-                                             validation_data=None,
-                                             feature_cols=feature_cols,
-                                             label_cols=label_cols,
-                                             mode="fit",
-                                             num_workers=self.num_workers)
+        data, validation_data = maybe_dataframe_to_xshards(data,
+                                                           validation_data=validation_data,
+                                                           feature_cols=feature_cols,
+                                                           label_cols=label_cols,
+                                                           mode="fit",
+                                                           num_workers=self.num_workers)
 
         if isinstance(data, SparkXShards):
             if data._get_class_name() == 'pandas.core.frame.DataFrame':
-                data = process_xshards_of_pandas_dataframe(data, feature_cols, label_cols)
+                data, validation_data = process_xshards_of_pandas_dataframe(data, feature_cols,
+                                                                            label_cols,
+                                                                            validation_data, "fit")
             from bigdl.orca.data.utils import process_spark_xshards
             ray_xshards = process_spark_xshards(data, self.num_workers)
 
-            def transform_func(worker, partition_refs):
-                data_creator = partition_refs_to_creator(partition_refs)
-                # Should not wrap DistributedSampler on DataLoader for SparkXShards input.
-                return worker.train_epochs.remote(
-                    data_creator, epochs, batch_size, profile, info, False, callbacks)
+            if validation_data is None:
+                def transform_func(worker, partition_refs):
+                    data_creator = partition_refs_to_creator(partition_refs)
+                    params["data_creator"] = data_creator
+                    # Should not wrap DistributedSampler on DataLoader for SparkXShards input.
+                    return worker.train_epochs.remote(**params)
 
-            worker_stats = ray_xshards.reduce_partitions_for_actors(self.remote_workers,
-                                                                    transform_func)
+                worker_stats = ray_xshards.reduce_partitions_for_actors(self.remote_workers,
+                                                                        transform_func)
+            else:
+                val_ray_xshards = process_spark_xshards(validation_data, self.num_workers)
+
+                def zip_func(worker, this_partition_refs, that_partition_refs):
+                    params["data_creator"] = partition_refs_to_creator(this_partition_refs)
+                    params["validation_data_creator"] = \
+                        partition_refs_to_creator(that_partition_refs)
+                    return worker.train_epochs.remote(**params)
+
+                worker_stats = ray_xshards.zip_reduce_shards_with_actors(val_ray_xshards,
+                                                                         self.remote_workers,
+                                                                         zip_func)
         elif isinstance(data, Dataset):
+            # need to refactor to align with tf2 code
             shards = data.split(n=self.num_workers, locality_hints=self.remote_workers)
 
-            def data_creator(config, batch_size):
-                torch_datashard = shard.to_torch(label_column=label_cols,
-                                                 feature_columns=feature_cols,
-                                                 batch_size=batch_size)
-                return torch_datashard
+            def make_data_creator(shard, feature_cols, label_cols):
+                def data_creator(config, batch_size):
+                    torch_datashard = shard.to_torch(label_column=label_cols,
+                                                     feature_columns=feature_cols,
+                                                     batch_size=batch_size)
+                    return torch_datashard
+                return data_creator
 
             remote_worker_stats = []
-            for shard, worker in zip(shards, self.remote_workers):
-                stats = worker.train_epochs.remote(data_creator, epochs, batch_size, profile,
-                                                   info, False, callbacks)
-                remote_worker_stats.append(stats)
+            if validation_data is None:
+                for shard, worker in zip(shards, self.remote_workers):
+                    params["data_creator"] = make_data_creator(shard, feature_cols, label_cols)
+                    stats = worker.train_epochs.remote(**params)
+                    remote_worker_stats.append(stats)
+            else:
+                if not isinstance(validation_data, ray.data.Dataset):
+                    raise ValueError("Validation data type should be the same as train data, "
+                                     "but got type: {}".format(type(validation_data)))
+
+                val_shards = validation_data.split(n=self.num_workers,
+                                                   locality_hints=self.remote_workers)
+                for shard, val_shard, worker in zip(shards, val_shards, self.num_workers):
+                    params["data_creator"] = make_data_creator(shard, feature_cols, label_cols)
+
+                    params["validation_data_creator"] = make_data_creator(val_shard,
+                                                                          feature_cols,
+                                                                          label_cols)
+                    stats = worker.train_epochs.remote(**params)
+                    remote_worker_stats.append(stats)
+
             success = check_for_failure(remote_worker_stats)
             if success:
                 worker_stats = ray.get(remote_worker_stats)
             else:
                 worker_stats = None
         else:
-            assert isinstance(data, types.FunctionType), \
-                "data should be either an instance of SparkXShards, Ray Dataset " \
-                "or a callable function, but got type: {}".format(type(data))
+            if not isinstance(data, types.FunctionType):
+                raise ValueError("data should be either an instance of SparkXShards, Ray Dataset "
+                                 "or a callable function, but got type: {}".format(type(data)))
 
-            success, worker_stats = self._train_epochs(data,
-                                                       epochs=epochs,
-                                                       batch_size=batch_size,
-                                                       profile=profile,
-                                                       info=info,
-                                                       callbacks=callbacks)
+            params["data_creator"] = data
+            params["validation_data_creator"] = validation_data
+            success, worker_stats = self._train_epochs(**params)
 
         epoch_stats = list(map(list, zip(*worker_stats)))
         if reduce_results:
@@ -423,9 +467,9 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                 remote_worker_stats.append(stats)
             worker_stats = ray.get(remote_worker_stats)
         else:
-            assert isinstance(data, types.FunctionType), \
-                "data should be either an instance of SparkXShards or a callable function, but " \
-                "got type: {}".format(type(data))
+            if not isinstance(data, types.FunctionType):
+                raise ValueError("data should be either an instance of SparkXShards or a callable"
+                                 " function, but got type: {}".format(type(data)))
 
             params = dict(data_creator=data, batch_size=batch_size, num_steps=num_steps,
                           profile=profile, info=info)

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -275,8 +275,8 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                                                                         transform_func)
             else:
                 if self.backend == "horovod":
-                    raise ValueError("We don't support validation during fit with horovod backend" \
-                                     "for now.")
+                    raise ValueError("Currently, we don't support input validation_data for horovod"
+                                     " backend")
                 val_ray_xshards = process_spark_xshards(validation_data, self.num_workers)
 
                 def zip_func(worker, this_partition_refs, that_partition_refs):
@@ -308,8 +308,8 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                     remote_worker_stats.append(stats)
             else:
                 if self.backend == "horovod":
-                    raise ValueError("We don't support validation during fit with horovod backend" \
-                                     "for now.")
+                    raise ValueError("Currently, we don't support input validation_data for horovod"
+                                     " backend")
                 if not isinstance(validation_data, ray.data.Dataset):
                     raise ValueError("Validation data type should be the same as train data, "
                                      "but got type: {}".format(type(validation_data)))

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -334,7 +334,7 @@ class TorchRunner:
                 validation_stats = {}
                 for name, value in validation_results.items():
                     if not name.startswith("val_"):
-                        name = "val_" + name
+                        name = "val_" + name.lower()
                     validation_stats[name] = value
 
         else:

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -323,7 +323,7 @@ class TorchRunner:
         with self.timers.record("train_epoch"):
             data_loader = iter(data_loader)
             train_stats = self.training_operator.train_epoch(data_loader, info, callbacks)
-    
+
         if val_loader:
             with self.timers.record("validation"):
                 info = info or {}

--- a/python/orca/src/bigdl/orca/learn/pytorch/training_operator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/training_operator.py
@@ -297,7 +297,7 @@ class TrainingOperator:
 
         return {"train_loss": loss.item(), NUM_SAMPLES: features[0].size(0)}
 
-    def validate(self, val_iterator, info, metrics):
+    def validate(self, val_iterator, info, metrics, num_steps=None):
         """Runs one standard validation pass over the val_iterator.
 
         This will call ``model.eval()`` and ``torch.no_grad`` when iterating
@@ -327,6 +327,8 @@ class TrainingOperator:
         total_samples = 0
         with torch.no_grad():
             for batch_idx, batch in enumerate(val_iterator):
+                if num_steps and batch_idx == num_steps:
+                    break
                 batch_info = {"batch_idx": batch_idx}
                 batch_info.update(info)
                 output, target, loss = self.forward_batch(batch, batch_info)

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
@@ -151,12 +151,14 @@ def get_model(config):
     torch.manual_seed(0)
     return Net()
 
+
 def get_optimizer(model, config):
     return torch.optim.SGD(model.parameters(), lr=config.get("lr", 1e-2))
 
 
 def get_zero_optimizer(model, config):
     return torch.optim.SGD(model.parameters(), lr=0.0)
+
 
 def get_estimator(workers_per_node=1, model_fn=get_model, sync_stats=False,
                   log_level=logging.INFO, loss=nn.BCELoss(), optimizer=get_optimizer):
@@ -178,8 +180,9 @@ class TestPyTorchEstimator(TestCase):
         start_val_stats = estimator.evaluate(val_data_loader, batch_size=64)
         print(start_val_stats)
         train_stats = estimator.fit(train_data_loader, epochs=4, batch_size=128,
-                                    validation_data=train_data_loader)
+                                    validation_data=val_data_loader)
         print(train_stats)
+        assert "val_loss" in train_stats[0]
         end_val_stats = estimator.evaluate(val_data_loader, batch_size=64)
         print(end_val_stats)
         assert 0 < end_val_stats["Accuracy"] < 1
@@ -216,7 +219,9 @@ class TestPyTorchEstimator(TestCase):
         train_rdd, val_rdd = rdd.randomSplit([0.9, 0.1])
         train_xshards = SparkXShards(train_rdd)
         val_xshards = SparkXShards(val_rdd)
-        train_stats = estimator.fit(train_xshards, batch_size=256, epochs=2)
+        train_stats = estimator.fit(train_xshards, validation_data=val_xshards,
+                                    batch_size=256, epochs=2)
+        assert "val_loss" in train_stats[0]
         print(train_stats)
         val_stats = estimator.evaluate(val_xshards, batch_size=128)
         print(val_stats)
@@ -230,8 +235,14 @@ class TestPyTorchEstimator(TestCase):
                                 [int(np.random.randint(0, 2, size=()))])
                      ).toDF(["feature", "label"])
 
+        val_rdd = sc.range(0, 40)
+        val_df = val_rdd.map(lambda x: (np.random.randn(50).astype(np.float).tolist(),
+                             [int(np.random.randint(0, 2, size=()))])
+                            ).toDF(["feature", "label"])
+
         estimator = get_estimator(workers_per_node=2)
         estimator.fit(df, batch_size=4, epochs=2,
+                      validation_data=df,
                       feature_cols=["feature"],
                       label_cols=["label"])
         estimator.evaluate(df, batch_size=4,

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
@@ -242,7 +242,7 @@ class TestPyTorchEstimator(TestCase):
 
         estimator = get_estimator(workers_per_node=2)
         estimator.fit(df, batch_size=4, epochs=2,
-                      validation_data=df,
+                      validation_data=val_df,
                       feature_cols=["feature"],
                       label_cols=["label"])
         estimator.evaluate(df, batch_size=4,
@@ -277,6 +277,7 @@ class TestPyTorchEstimator(TestCase):
         assert df.rdd.getNumPartitions() < estimator.num_workers
 
         estimator.fit(df, batch_size=4, epochs=2,
+                      validation_data=df,
                       feature_cols=["feature"],
                       label_cols=["label"])
         estimator.evaluate(df, batch_size=4,
@@ -323,6 +324,7 @@ class TestPyTorchEstimator(TestCase):
 
         estimator = get_estimator(model_fn=lambda config: SimpleModel())
         estimator.fit(data_shard, batch_size=2, epochs=2,
+                      validation_data=data_shard,
                       feature_cols=["user", "item"],
                       label_cols=["label"])
 
@@ -345,6 +347,7 @@ class TestPyTorchEstimator(TestCase):
         estimator = get_estimator(workers_per_node=2,
                                   model_fn=lambda config: MultiInputNet())
         estimator.fit(df, batch_size=4, epochs=2,
+                      validation_data=df,
                       feature_cols=["f1", "f2"],
                       label_cols=["label"])
         estimator.evaluate(df, batch_size=4,
@@ -367,6 +370,7 @@ class TestPyTorchEstimator(TestCase):
                                   model_fn=lambda config: LinearModel(),
                                   loss=nn.MSELoss())
         stats = estimator.fit(df, batch_size=4, epochs=2,
+                              validation_data=df,
                               feature_cols=["feature"],
                               label_cols=["label"])
         estimator.evaluate(df, batch_size=4,

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
@@ -177,7 +177,8 @@ class TestPyTorchEstimator(TestCase):
         estimator = get_estimator(workers_per_node=2)
         start_val_stats = estimator.evaluate(val_data_loader, batch_size=64)
         print(start_val_stats)
-        train_stats = estimator.fit(train_data_loader, epochs=4, batch_size=128)
+        train_stats = estimator.fit(train_data_loader, epochs=4, batch_size=128,
+                                    validation_data=train_data_loader)
         print(train_stats)
         end_val_stats = estimator.evaluate(val_data_loader, batch_size=64)
         print(end_val_stats)


### PR DESCRIPTION
Related to issue #4584

### What does this PR for?
This PR introduces an optional `validation_data` input in Orca Pytorch Estimator with Ray backend.
If users input `validation_data` in `fit`, we will automatedly validate at each training epoch ends. The return value of `fit` will also include validation metric results, with prefix of `val_`.
```python
from bigdl.orca.learn.pytorch import Estimator

est = Estimator.from_torch(model, backend="ray")
stats = est.fit(data, validation_data)
# stats like [{'num_samples': 1000, 'epoch': 1, 'batch_count': 4, 'train_loss': 0.6919452295303344, 'last_train_loss': 0.6783539056777954, 'val_accuracy': tensor(0.6050), 'val_loss': 0.686676161289215, 'val_num_samples': 200}]
```
### What does this PR include? 
- [x] Add `validation_data` option in `estimator.fit`
- [x] Introduce `val_step` in `training_operator`. Notes that we truncate the `validation_steps` during training, since unevenly distributed validation data will cause error `op.preamble.length <= op.nbytes` in the next epoch of training.
- [x] Some refactor in `fit` 
- [x] Styles

### How is the function tested? 

- [x] In UT, all input data types has been tested, including Spark DataFrame, SparkXShards, Pandas DataFrame, Data Creator Function.
- [x] In UT, the return value has been checked with validation metric results
- [x] Manually check, validation loss decreases and accuracy increases during training 

### Remain issues (todos)
- [ ] Horovod backend support. 
- [ ] Refactor the data processing part, since it is very similar to that of  `TF2Estimator`

Notes for `horovod` backend support
 The reason that we haven't supported `horovod` yet is that we need to add `all_reduce_min` in `horovod` backend, however 
1. Horovod doesn't provide `allreduce` with MIN op, and we should implement it with its `allgather`. 
2. The behavior of `allreduce` function for horovod and pytorch differs, pytorch modifies the input tensor in place while horovod doesn't.

