### PR TITLE
add model check for keras inc quantization

### DIFF
--- a/python/nano/src/bigdl/nano/tf/quantization.py
+++ b/python/nano/src/bigdl/nano/tf/quantization.py
@@ -68,6 +68,10 @@ def quantize(self,
     :return:           A TensorflowBaseModel for INC. If there is no model found, return None.
     """
     if backend == 'inc':
+        assert self.inputs is not None and self.outputs is not None,\
+            ("A keras.Model for quantization must include Input layers."
+             "Please create the model by keras.Model(inputs=.., outputs=..).")
+
         def get_tensors_name(tensors):
             return [tensor.name for tensor in tensors]
 

--- a/python/nano/src/bigdl/nano/tf/quantization.py
+++ b/python/nano/src/bigdl/nano/tf/quantization.py
@@ -72,10 +72,6 @@ def quantize(self,
                           "A keras.Model for quantization must include Input layers. "
                           "Please create the model by functional API keras.Model(inputs=.., outputs=..).\n"
                           "More details in https://keras.io/api/models/model/")
-        assert self.inputs is not None and self.outputs is not None,\
-            ("A keras.Model for quantization must include Input layers."
-             "Please create the model by functional API keras.Model(inputs=.., outputs=..).\n"
-             "More details in https://keras.io/api/models/model/")
 
         def get_tensors_name(tensors):
             return [tensor.name for tensor in tensors]

--- a/python/nano/src/bigdl/nano/tf/quantization.py
+++ b/python/nano/src/bigdl/nano/tf/quantization.py
@@ -68,6 +68,10 @@ def quantize(self,
     :return:           A TensorflowBaseModel for INC. If there is no model found, return None.
     """
     if backend == 'inc':
+        invalidInputError(self.inputs is not None and self.outputs is not None,
+                          "A keras.Model for quantization must include Input layers. "
+                          "Please create the model by functional API keras.Model(inputs=.., outputs=..).\n"
+                          "More details in https://keras.io/api/models/model/")
         assert self.inputs is not None and self.outputs is not None,\
             ("A keras.Model for quantization must include Input layers."
              "Please create the model by functional API keras.Model(inputs=.., outputs=..).\n"

--- a/python/nano/src/bigdl/nano/tf/quantization.py
+++ b/python/nano/src/bigdl/nano/tf/quantization.py
@@ -70,7 +70,8 @@ def quantize(self,
     if backend == 'inc':
         invalidInputError(self.inputs is not None and self.outputs is not None,
                           "A keras.Model for quantization must include Input layers. "
-                          "Please create the model by functional API keras.Model(inputs=.., outputs=..).\n"
+                          "Please create the model by functional API"
+                          " keras.Model(inputs=.., outputs=..).\n"
                           "More details in https://keras.io/api/models/model/")
 
         def get_tensors_name(tensors):

--- a/python/nano/src/bigdl/nano/tf/quantization.py
+++ b/python/nano/src/bigdl/nano/tf/quantization.py
@@ -70,7 +70,8 @@ def quantize(self,
     if backend == 'inc':
         assert self.inputs is not None and self.outputs is not None,\
             ("A keras.Model for quantization must include Input layers."
-             "Please create the model by keras.Model(inputs=.., outputs=..).")
+             "Please create the model by functional API keras.Model(inputs=.., outputs=..).\n"
+             "More details in https://keras.io/api/models/model/")
 
         def get_tensors_name(tensors):
             return [tensor.name for tensor in tensors]


### PR DESCRIPTION
`keras.Model` has two usage according to https://keras.io/api/models/model/.  
Raise error if the model for inc to quantize misses the Input layer.