### PR TITLE
[Nano HPO] fix nightly failure caused by error reporting changes 

### DIFF
--- a/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, Optional, Union
 import pytorch_lightning as pl
 
 from pytorch_lightning.trainer.states import TrainerFn, TrainerStatus
-
+from bigdl.nano.utils.log4Error import invalidInputError
 from bigdl.nano.automl.hpo.backend import create_hpo_backend
 from .objective import Objective
 from ..hpo.search import (

--- a/python/nano/test/automl/tf/test_usecases.py
+++ b/python/nano/test/automl/tf/test_usecases.py
@@ -252,7 +252,7 @@ class TestUseCases(TestCase):
         )
 
         # run fit
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             history = model.fit(x_train, y_train,
                     batch_size=128, epochs=2, validation_split=0.2)
 


### PR DESCRIPTION
1) Wrong type of error is raised for illegal usage. Did a hotfix to make nightly pass. We need to revisit it later to find a more elegant way to report invalid usage to user. 
2) add missing import of invalidInputError