### PR TITLE
[Orca] Rename RayContext in Orca to OrcaRayContext

### DIFF
--- a/python/orca/src/bigdl/orca/automl/search/ray_tune/ray_tune_search_engine.py
+++ b/python/orca/src/bigdl/orca/automl/search/ray_tune/ray_tune_search_engine.py
@@ -54,9 +54,9 @@ class RayTuneSearchEngine(SearchEngine):
 
     @staticmethod
     def get_default_remote_dir(name):
-        from bigdl.orca.ray import RayContext
+        from bigdl.orca.ray import OrcaRayContext
         from bigdl.orca.automl.search.utils import process
-        ray_ctx = RayContext.get()
+        ray_ctx = OrcaRayContext.get()
         if ray_ctx.is_local:
             return None
         else:

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -154,8 +154,8 @@ class OrcaContext(metaclass=OrcaContextMeta):
 
     @staticmethod
     def get_ray_context():
-        from bigdl.orca.ray import RayContext
-        return RayContext.get()
+        from bigdl.orca.ray import OrcaRayContext
+        return OrcaRayContext.get()
 
 
 def _check_python_micro_version():
@@ -171,7 +171,7 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=2, memory="2g", 
                       init_ray_on_spark=False, **kwargs):
     """
     Creates or gets a SparkContext for different Spark cluster modes (and launch Ray services
-    across the cluster if necessary) or a RayContext when the runtime is ray.
+    across the cluster if necessary) or an OrcaRayContext when the runtime is ray.
 
     :param runtime: The runtime for backend. One of "ray" and "spark". Default to be "spark".
     :param cluster_mode: The mode for the Spark cluster. One of "local", "yarn-client",
@@ -200,7 +200,7 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=2, memory="2g", 
     :param kwargs: The extra keyword arguments used for creating SparkContext and
            launching Ray if any.
 
-    :return: An instance of SparkContext or RayContext.
+    :return: An instance of SparkContext or OrcaRayContext.
     """
     print("Initializing orca context")
     import atexit
@@ -208,9 +208,9 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=2, memory="2g", 
     if runtime == "ray":
         assert cluster_mode is None, "Currently, cluster_mode is not supported for ray runtime " \
                                      "and you must connect to an exiting ray cluster."
-        from bigdl.orca.ray import RayContext
-        ray_ctx = RayContext(runtime="ray", cores=cores, num_nodes=num_nodes,
-                             **kwargs)
+        from bigdl.orca.ray import OrcaRayContext
+        ray_ctx = OrcaRayContext(runtime="ray", cores=cores, num_nodes=num_nodes,
+                                 **kwargs)
         assert "address" in kwargs, "ray_address must be specified if the runtime is ray."
         ray_ctx.init()
         return ray_ctx
@@ -317,9 +317,9 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=2, memory="2g", 
                     "system_config"]:
             if key in kwargs:
                 ray_args[key] = kwargs[key]
-        from bigdl.orca.ray import RayContext
-        ray_ctx = RayContext(runtime="spark", cores=cores, num_nodes=num_nodes,
-                             sc=sc, **ray_args)
+        from bigdl.orca.ray import OrcaRayContext
+        ray_ctx = OrcaRayContext(runtime="spark", cores=cores, num_nodes=num_nodes,
+                                 sc=sc, **ray_args)
         if init_ray_on_spark:
             driver_cores = 0  # This is the default value.
             ray_ctx.init(driver_cores=driver_cores)
@@ -331,28 +331,28 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=2, memory="2g", 
 def stop_orca_context():
     """
     Stop the SparkContext (and stop Ray services across the cluster if necessary) or
-    stop the RayContext.
+    stop the OrcaRayContext.
     """
     from pyspark import SparkContext
-    from bigdl.orca.ray import RayContext
+    from bigdl.orca.ray import OrcaRayContext
     # If users successfully call stop_orca_context after the program finishes,
     # namely when there is no active SparkContext, the registered exit function
     # should do nothing.
     if SparkContext._active_spark_context is not None:
         print("Stopping orca context")
-        ray_ctx = RayContext.get(initialize=False)
+        ray_ctx = OrcaRayContext.get(initialize=False)
         if ray_ctx.initialized:
             ray_ctx.stop()
         else:
-            RayContext._active_ray_context = None
+            OrcaRayContext._active_ray_context = None
         sc = SparkContext.getOrCreate()
         if sc.getConf().get("spark.master").startswith("spark://"):
             from bigdl.dllib.nncontext import stop_spark_standalone
             stop_spark_standalone()
         sc.stop()
     else:
-        if RayContext._active_ray_context is not None:
+        if OrcaRayContext._active_ray_context is not None:
             print("Stopping ray_orca context")
-            ray_ctx = RayContext.get(initialize=False)
+            ray_ctx = OrcaRayContext.get(initialize=False)
             if ray_ctx.initialized:
                 ray_ctx.stop()

--- a/python/orca/src/bigdl/orca/data/ray_xshards.py
+++ b/python/orca/src/bigdl/orca/data/ray_xshards.py
@@ -22,7 +22,7 @@ import random
 from packaging import version
 
 from bigdl.orca.data import XShards
-from bigdl.orca.ray import RayContext
+from bigdl.orca.ray import OrcaRayContext
 
 import logging
 logger = logging.getLogger(__name__)
@@ -177,7 +177,7 @@ class RayXShards(XShards):
 
     def to_spark_xshards(self):
         from bigdl.orca.data import SparkXShards
-        ray_ctx = RayContext.get()
+        ray_ctx = OrcaRayContext.get()
         sc = ray_ctx.sc
         address = ray_ctx.redis_address
         password = ray_ctx.redis_password
@@ -362,7 +362,7 @@ class RayXShards(XShards):
 
     @staticmethod
     def from_partition_refs(ip2part_id, part_id2ref, old_rdd):
-        ray_ctx = RayContext.get()
+        ray_ctx = OrcaRayContext.get()
         uuid_str = str(uuid.uuid4())
         id2store_name = {}
         partition_stores = {}
@@ -388,7 +388,7 @@ class RayXShards(XShards):
 
     @staticmethod
     def _from_spark_xshards_ray_api(spark_xshards):
-        ray_ctx = RayContext.get()
+        ray_ctx = OrcaRayContext.get()
         address = ray_ctx.redis_address
         password = ray_ctx.redis_password
         driver_ip = ray._private.services.get_node_ip_address()

--- a/python/orca/src/bigdl/orca/learn/mxnet/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/mxnet/estimator.py
@@ -22,7 +22,7 @@ import ray
 from dmlc_tracker.tracker import get_host_ip
 
 from bigdl.orca.data.utils import ray_partitions_get_data_label, process_spark_xshards
-from bigdl.orca.ray import RayContext
+from bigdl.orca.ray import OrcaRayContext
 from bigdl.orca.learn.mxnet.mxnet_runner import MXNetRunner
 from bigdl.orca.learn.mxnet.utils import find_free_port
 from bigdl.orca.learn.ray_estimator import Estimator as OrcaRayEstimator
@@ -97,7 +97,7 @@ class MXNetEstimator(OrcaRayEstimator):
     def __init__(self, config, model_creator, loss_creator=None,
                  eval_metrics_creator=None, validation_metrics_creator=None,
                  num_workers=None, num_servers=None, runner_cores=None):
-        ray_ctx = RayContext.get()
+        ray_ctx = OrcaRayContext.get()
         if not num_workers:
             num_workers = ray_ctx.num_ray_nodes
         self.config = {} if config is None else config

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -27,7 +27,7 @@ from bigdl.orca.learn.pytorch.pytorch_ray_worker import PytorchRayWorker
 from bigdl.orca.learn.utils import maybe_dataframe_to_xshards, dataframe_to_xshards, \
     convert_predict_xshards_to_dataframe, update_predict_xshards, \
     process_xshards_of_pandas_dataframe
-from bigdl.orca.ray import RayContext
+from bigdl.orca.ray import OrcaRayContext
 from bigdl.orca.learn.ray_estimator import Estimator as OrcaRayEstimator
 from bigdl.dllib.utils.file_utils import enable_multi_fs_load, enable_multi_fs_save
 
@@ -111,7 +111,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                             " fit/evaluate/predict function of the estimator instead.")
 
         # todo remove ray_ctx to run on workers
-        ray_ctx = RayContext.get()
+        ray_ctx = OrcaRayContext.get()
         if not (isinstance(model_creator, types.FunctionType) and
                 isinstance(optimizer_creator, types.FunctionType)):  # Torch model is also callable.
             raise ValueError(

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -29,7 +29,7 @@ from bigdl.orca.learn.utils import maybe_dataframe_to_xshards, dataframe_to_xsha
     convert_predict_xshards_to_dataframe, update_predict_xshards, \
     process_xshards_of_pandas_dataframe, make_data_creator
 from bigdl.orca.data.utils import process_spark_xshards
-from bigdl.orca.ray import RayContext
+from bigdl.orca.ray import OrcaRayContext
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ class TensorFlow2Estimator(OrcaRayEstimator):
         self.config = {} if config is None else config
         self.verbose = verbose
 
-        ray_ctx = RayContext.get()
+        ray_ctx = OrcaRayContext.get()
         if "batch_size" in self.config:
             raise Exception("Please do not specify batch_size in config. Input batch_size in the"
                             " fit/evaluate function of the estimator instead.")

--- a/python/orca/src/bigdl/orca/ray/__init__.py
+++ b/python/orca/src/bigdl/orca/ray/__init__.py
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-from .raycontext import RayContext
+from .raycontext import OrcaRayContext
 from .ray_on_spark_context import RayOnSparkContext

--- a/python/orca/src/bigdl/orca/ray/raycontext.py
+++ b/python/orca/src/bigdl/orca/ray/raycontext.py
@@ -18,7 +18,7 @@
 from threading import Lock
 
 
-class RayContext(object):
+class OrcaRayContext(object):
 
     _active_ray_context = None
     _lock = Lock()
@@ -49,7 +49,7 @@ class RayContext(object):
             raise ValueError(f"Unsupported runtime: {runtime}. "
                              f"Runtime must be spark or ray")
 
-        RayContext._active_ray_context = self
+        OrcaRayContext._active_ray_context = self
 
     def init(self, driver_cores=0):
         if self.runtime == "ray":
@@ -72,13 +72,13 @@ class RayContext(object):
         import ray
         ray.shutdown()
         self.initialized = False
-        with RayContext._lock:
-            RayContext._active_ray_context = None
+        with OrcaRayContext._lock:
+            OrcaRayContext._active_ray_context = None
 
     @classmethod
     def get(cls, initialize=True):
-        if RayContext._active_ray_context:
-            ray_ctx = RayContext._active_ray_context
+        if OrcaRayContext._active_ray_context:
+            ray_ctx = OrcaRayContext._active_ray_context
             if initialize and not ray_ctx.initialized:
                 ray_ctx.init()
             return ray_ctx

--- a/python/orca/test/bigdl/orca/data/test_read_parquet_images.py
+++ b/python/orca/test/bigdl/orca/data/test_read_parquet_images.py
@@ -24,7 +24,7 @@ from bigdl.orca.data.image.parquet_dataset import ParquetDataset, read_parquet
 from bigdl.orca.data.image.utils import DType, FeatureType, SchemaField
 import tensorflow as tf
 
-from bigdl.orca.ray import RayContext
+from bigdl.orca.ray import OrcaRayContext
 
 resource_path = os.path.join(os.path.split(__file__)[0], "../resources")
 WIDTH, HEIGHT, NUM_CHANNELS = 224, 224, 3
@@ -124,7 +124,7 @@ class TestReadParquet(TestCase):
                 dataset = dataset.batch(batch_size)
                 return dataset
 
-            ray_ctx = RayContext.get()
+            ray_ctx = OrcaRayContext.get()
             trainer = Estimator.from_keras(model_creator=model_creator)
             trainer.fit(data=data_creator,
                         epochs=1,

--- a/python/orca/test/bigdl/orca/learn/ray/mxnet/test_mxnet_gluon.py
+++ b/python/orca/test/bigdl/orca/learn/ray/mxnet/test_mxnet_gluon.py
@@ -21,7 +21,7 @@ import pytest
 import mxnet as mx
 from mxnet import gluon
 from mxnet.gluon import nn
-from bigdl.orca.ray import RayContext
+from bigdl.orca.ray import OrcaRayContext
 from bigdl.orca.learn.mxnet import Estimator, create_config
 
 np.random.seed(1337)  # for reproducibility
@@ -70,7 +70,7 @@ def get_metrics(config):
 
 class TestMXNetGluon(TestCase):
     def test_gluon(self):
-        current_ray_ctx = RayContext.get()
+        current_ray_ctx = OrcaRayContext.get()
         address_info = current_ray_ctx.address_info
         assert "object_store_address" in address_info
         config = create_config(log_interval=2, optimizer="adam",

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
@@ -25,7 +25,7 @@ from bigdl.orca.data import XShards
 
 import bigdl.orca.data.pandas
 from bigdl.orca.learn.tf2 import Estimator
-from bigdl.orca.ray import RayContext
+from bigdl.orca.ray import OrcaRayContext
 import ray
 
 NUM_TRAIN_SAMPLES = 1000
@@ -167,7 +167,7 @@ class LRChecker(tf.keras.callbacks.Callback):
 class TestTFRayEstimator(TestCase):
     def impl_test_fit_and_evaluate(self, backend):
         import tensorflow as tf
-        ray_ctx = RayContext.get()
+        ray_ctx = OrcaRayContext.get()
         batch_size = 32
         global_batch_size = batch_size * ray_ctx.num_ray_nodes
 
@@ -233,7 +233,7 @@ class TestTFRayEstimator(TestCase):
         # the former case will return 0, and the latter
         # case will return non-zero.
 
-        ray_ctx = RayContext.get()
+        ray_ctx = OrcaRayContext.get()
         trainer = Estimator.from_keras(
             model_creator=auto_shard_model_creator,
             verbose=True,
@@ -251,7 +251,7 @@ class TestTFRayEstimator(TestCase):
         # the former case will return 0, and the latter
         # case will return non-zero.
 
-        ray_ctx = RayContext.get()
+        ray_ctx = OrcaRayContext.get()
         trainer = Estimator.from_keras(
             model_creator=create_auto_shard_model,
             compile_args_creator=create_auto_shard_compile_args,
@@ -270,7 +270,7 @@ class TestTFRayEstimator(TestCase):
         larger_patch = int(major) == 0 and int(minor) == 19 and int(patch) >= 2
 
         if larger_major or larger_minor or larger_patch:
-            ray_ctx = RayContext.get()
+            ray_ctx = OrcaRayContext.get()
             batch_size = 32
             workers_per_node = 4
             global_batch_size = batch_size * workers_per_node

--- a/python/orca/test/bigdl/orca/ray/integration/ray_on_yarn.py
+++ b/python/orca/test/bigdl/orca/ray/integration/ray_on_yarn.py
@@ -18,7 +18,7 @@
 import ray
 
 from bigdl.dllib.nncontext import init_spark_on_yarn
-from bigdl.orca.ray import RayContext
+from bigdl.orca.ray import OrcaRayContext
 
 slave_num = 2
 
@@ -33,11 +33,11 @@ sc = init_spark_on_yarn(
     extra_executor_memory_for_ray="30g",
     conf={"hello": "world"})
 
-ray_ctx = RayContext(sc=sc,
-                     object_store_memory="25g",
-                     extra_params={"temp-dir": "/tmp/hello/"},
-                     env={"http_proxy": "http://child-prc.intel.com:913",
-                          "http_proxys": "http://child-prc.intel.com:913"})
+ray_ctx = OrcaRayContext(sc=sc,
+                         object_store_memory="25g",
+                         extra_params={"temp-dir": "/tmp/hello/"},
+                         env={"http_proxy": "http://child-prc.intel.com:913",
+                              "http_proxys": "http://child-prc.intel.com:913"})
 ray_ctx.init()
 
 

--- a/python/orca/test/bigdl/orca/ray/integration/test_yarn_reinit_raycontext.py
+++ b/python/orca/test/bigdl/orca/ray/integration/test_yarn_reinit_raycontext.py
@@ -20,7 +20,7 @@ import numpy as np
 import ray
 
 from bigdl.dllib.nncontext import init_spark_on_yarn
-from bigdl.orca.ray import RayContext
+from bigdl.orca.ray import OrcaRayContext
 
 np.random.seed(1337)  # for reproducibility
 
@@ -42,13 +42,13 @@ sc = init_spark_on_yarn(
     driver_memory="2g",
     driver_cores=4,
     extra_executor_memory_for_ray="30g")
-ray_ctx = RayContext(sc=sc, object_store_memory="2g")
+ray_ctx = OrcaRayContext(sc=sc, object_store_memory="2g")
 ray_ctx.init()
 actors = [TestRay.remote() for i in range(0, node_num)]
 print(ray.get([actor.hostname.remote() for actor in actors]))
 ray_ctx.stop()
 # repeat
-ray_ctx = RayContext(sc=sc, object_store_memory="1g")
+ray_ctx = OrcaRayContext(sc=sc, object_store_memory="1g")
 ray_ctx.init()
 actors = [TestRay.remote() for i in range(0, node_num)]
 print(ray.get([actor.hostname.remote() for actor in actors]))

--- a/python/orca/test/bigdl/orca/ray/ray_cluster/test_rayctx_local.py
+++ b/python/orca/test/bigdl/orca/ray/ray_cluster/test_rayctx_local.py
@@ -13,7 +13,7 @@ import pytest
 import ray
 
 from bigdl.orca import stop_orca_context
-from bigdl.orca.ray import RayContext
+from bigdl.orca.ray import OrcaRayContext
 
 @ray.remote
 class TestRay():
@@ -23,7 +23,7 @@ class TestRay():
 
 class TestUtil(TestCase):
     def setUp(self):
-        self.ray_ctx = RayContext("ray", cores=2, num_nodes=1)
+        self.ray_ctx = OrcaRayContext("ray", cores=2, num_nodes=1)
     
     def tearDown(self):
         stop_orca_context()
@@ -31,7 +31,7 @@ class TestUtil(TestCase):
     def test_init(self):
         node_num = 4
         address_info = self.ray_ctx.init()
-        assert RayContext._active_ray_context, ("RayContext has not been initialized")
+        assert OrcaRayContext._active_ray_context, ("OrcaRayContext has not been initialized")
         assert "object_store_address" in address_info
         actors = [TestRay.remote() for i in range(0, node_num)]
         print(ray.get([actor.hostname.remote() for actor in actors]))

--- a/python/orca/test/bigdl/orca/ray/ray_cluster/test_rayctx_reinit.py
+++ b/python/orca/test/bigdl/orca/ray/ray_cluster/test_rayctx_reinit.py
@@ -20,7 +20,7 @@ import numpy as np
 import pytest
 import ray
 
-from bigdl.orca.ray import RayContext
+from bigdl.orca.ray import OrcaRayContext
 from bigdl.orca.common import stop_orca_context
 
 np.random.seed(1337)  # for reproducibility
@@ -35,7 +35,7 @@ class TestRay():
 
 class TestUtil(TestCase):
     def setUp(self):
-        self.ray_ctx = RayContext("ray", cores=2, num_nodes=1)
+        self.ray_ctx = OrcaRayContext("ray", cores=2, num_nodes=1)
         self.node_num = 4
     
     def tearDown(self):
@@ -51,8 +51,8 @@ class TestUtil(TestCase):
     
     def test_reinit(self):
         print("-------------------first repeat begin!------------------")
-        self.ray_ctx = RayContext("ray", cores=2, num_nodes=1)
-        assert RayContext._active_ray_context, ("Please create a RayContext First.")
+        self.ray_ctx = OrcaRayContext("ray", cores=2, num_nodes=1)
+        assert OrcaRayContext._active_ray_context, ("Please create an OrcaRayContext First.")
         assert not self.ray_ctx.initialized, ("The Ray cluster has not been launched.")
         self.ray_ctx.init()
         actors = [TestRay.remote() for i in range(0, self.node_num)]

--- a/python/orca/test/bigdl/orca/ray/test_ray_on_local.py
+++ b/python/orca/test/bigdl/orca/ray/test_ray_on_local.py
@@ -19,7 +19,7 @@ import pytest
 import ray
 
 from bigdl.dllib.nncontext import init_spark_on_local
-from bigdl.orca.ray import RayContext
+from bigdl.orca.ray import OrcaRayContext
 
 
 class TestRayLocal(TestCase):
@@ -34,8 +34,8 @@ class TestRayLocal(TestCase):
         sc = init_spark_on_local(cores=8)
         config = {"object_spilling_config":"{\"type\":\"filesystem\","
                                            "\"params\":{\"directory_path\":\"/tmp/spill\"}}"}
-        ray_ctx = RayContext(sc=sc, object_store_memory="1g", ray_node_cpu_cores=4,
-                             system_config=config)
+        ray_ctx = OrcaRayContext(sc=sc, object_store_memory="1g", ray_node_cpu_cores=4,
+                                 system_config=config)
         address_info = ray_ctx.init()
         assert "object_store_address" in address_info
         actors = [TestRay.remote() for i in range(0, 4)]

--- a/python/orca/test/bigdl/orca/ray/test_reinit_raycontext.py
+++ b/python/orca/test/bigdl/orca/ray/test_reinit_raycontext.py
@@ -22,7 +22,7 @@ import pytest
 import ray
 
 from bigdl.dllib.nncontext import init_spark_on_local
-from bigdl.orca.ray import RayContext
+from bigdl.orca.ray import OrcaRayContext
 
 np.random.seed(1337)  # for reproducibility
 
@@ -39,7 +39,7 @@ class TestUtil(TestCase):
         def test_local(self):
             node_num = 4
             sc = init_spark_on_local(cores=node_num)
-            ray_ctx = RayContext(sc=sc, object_store_memory="1g")
+            ray_ctx = OrcaRayContext(sc=sc, object_store_memory="1g")
             ray_ctx.init()
             actors = [TestRay.remote() for i in range(0, node_num)]
             print(ray.get([actor.hostname.remote() for actor in actors]))
@@ -47,7 +47,7 @@ class TestUtil(TestCase):
             time.sleep(3)
             # repeat
             print("-------------------first repeat begin!------------------")
-            ray_ctx = RayContext(sc=sc, object_store_memory="1g")
+            ray_ctx = OrcaRayContext(sc=sc, object_store_memory="1g")
             ray_ctx.init()
             actors = [TestRay.remote() for i in range(0, node_num)]
             print(ray.get([actor.hostname.remote() for actor in actors]))


### PR DESCRIPTION
Rename `RayContext` to `OrcaRayContext` to avoid the duplicate since `RayContext` has been added in `ray.worker` in the latest ray version. https://github.com/intel-analytics/BigDL/issues/4653