### PR TITLE
Chronos: TFT use-case inference optimization (with ipex)

### DIFF
--- a/python/chronos/src/bigdl/chronos/pytorch/trainer.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/trainer.py
@@ -14,4 +14,31 @@
 # limitations under the License.
 #
 
-from bigdl.nano.pytorch.trainer import Trainer as TSTrainer
+from bigdl.nano.pytorch.trainer import Trainer
+from bigdl.nano.utils.log4Error import invalidInputError
+from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
+
+
+class TSTrainer(Trainer):
+    @staticmethod
+    def optimize(model, accelerator="ipex"):
+        '''
+        This method helps users to transform their model
+        to a model optimized by Intel® Extension for PyTorch.
+        The returned model should only be used for inferencing.
+
+        :param model: the pytorch/pytorch-lightning model to be optimized.
+
+        :return: a model optimized by Intel® Extension for PyTorch.
+        '''
+
+        import intel_extension_for_pytorch as ipex
+
+        if TORCH_VERSION_LESS_1_10:
+            invalidInputError(False,
+                              f"`optimize` is only suitable for torch>1.10, ",
+                              f"please run `pip install --upgrade torch>=1.10.0` and "
+                              f"`pip install intel_extension_for_pytorch`")
+
+        model.eval()
+        return ipex.optimize(model)

--- a/python/chronos/use-case/pytorch-forecasting/TFT/README.md
+++ b/python/chronos/use-case/pytorch-forecasting/TFT/README.md
@@ -55,4 +55,5 @@ Then you may enjoy the accleration provided by `TSTrainer`
 best_tft = TSTrainer.optimize(best_tft)
 best_tft(x)
 ```
+### Results
 For an input of (128, 24, 7) and output of (128, 6, 7), the acceleration is ~1.5X on a single core.

--- a/python/chronos/use-case/pytorch-forecasting/TFT/README.md
+++ b/python/chronos/use-case/pytorch-forecasting/TFT/README.md
@@ -1,6 +1,8 @@
 # Use Chronos to help pytorch-forecasting improve the training/inference speed of TFT model
 Chronos can help a 3rd party time series lib to improve the performance (both training and inferencing) and accuracy. This use-case shows nano can easily help pytorch-forecasting speed up the training/inference of TFT (Temporal Fusion Transformers) model.
 
+More detailed information please refer to: https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/speed_up.html
+
 ## Prepare the environment
 We recommend you to use conda to prepare the environment, especially if you want to run on a yarn cluster:
 ```bash

--- a/python/chronos/use-case/pytorch-forecasting/TFT/README.md
+++ b/python/chronos/use-case/pytorch-forecasting/TFT/README.md
@@ -1,5 +1,5 @@
-# Use Nano to help pytorch-forecasting improve the training speed of TFT model
-Nano can help a 3rd party time series lib to improve the performance (both training and inferencing) and accuracy. This use-case shows nano can easily help pytorch-forecasting speed up the training of TFT (Temporal Fusion Transformers) model.
+# Use Chronos to help pytorch-forecasting improve the training/inference speed of TFT model
+Chronos can help a 3rd party time series lib to improve the performance (both training and inferencing) and accuracy. This use-case shows nano can easily help pytorch-forecasting speed up the training/inference of TFT (Temporal Fusion Transformers) model.
 
 ## Prepare the environment
 We recommend you to use conda to prepare the environment, especially if you want to run on a yarn cluster:
@@ -9,6 +9,7 @@ conda activate my_env
 pip install --pre --upgrade bigdl-chronos[all]
 pip install pytorch_forecasting
 pip install torch==1.11.0  # if your pytorch_forecasting version is 0.10.0 or above, you need to reinstall torch, otherwise you don't need this.
+pip install intel_extension_for_pytorch
 ```
 Please refer to [Chronos Install Guide](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install)
 
@@ -19,11 +20,39 @@ We are using the [Stallion dataset from Kaggle](https://www.kaggle.com/datasets/
 ```bash
 bigdl-nano-init python tft.py
 ```
-
-## Changes to use BigDL Nano
+## Training
+### Changes to use Chronos TSTrainer
 - Change `from pytorch_lightning import Trainer` to `from bigdl.chronos.pytorch import TSTrainer`
 - Set `gpus=0` in TSTrainer
 - Set `num_processes=8` in TSTrainer and set `batch_size = 128 // num_processes`
 
-## Results
+### Results
 In an experimental platform, the training speed of TFT model using nano Trainer is 3.5 times the speed of the training without nano Trainer. We can see that the training speed is significantly improved.
+
+## Inferencing
+**Currently inference speed-up is still on activate developing. Some definition in pytorch-forecasting's TFT needs to be changed.**
+
+### Changes to use Chronos TSTrainer
+Inside pytorch-forecasting's definition, we need to remove some code in `models/temporal_fusion_transformer/__init__.py`
+```python
+# comment all the `lengths` and `enforce_sorted` in code(2 in all)
+
+# run local encoder
+encoder_output, (hidden, cell) = self.lstm_encoder(
+    embeddings_varying_encoder, (input_hidden, input_cell)  #, lengths=encoder_lengths, enforce_sorted=False
+)
+
+# run local decoder
+decoder_output, _ = self.lstm_decoder(
+    embeddings_varying_decoder,
+    (hidden, cell),
+    #  lengths=decoder_lengths,
+    #  enforce_sorted=False,
+)
+```
+Then you may enjoy the accleration provided by `TSTrainer`
+```python
+best_tft = TSTrainer.optimize(best_tft)
+best_tft(x)
+```
+For an input of (128, 24, 7) and output of (128, 6, 7), the acceleration is ~1.5X.

--- a/python/chronos/use-case/pytorch-forecasting/TFT/README.md
+++ b/python/chronos/use-case/pytorch-forecasting/TFT/README.md
@@ -55,4 +55,4 @@ Then you may enjoy the accleration provided by `TSTrainer`
 best_tft = TSTrainer.optimize(best_tft)
 best_tft(x)
 ```
-For an input of (128, 24, 7) and output of (128, 6, 7), the acceleration is ~1.5X.
+For an input of (128, 24, 7) and output of (128, 6, 7), the acceleration is ~1.5X on a single core.


### PR DESCRIPTION
In this PR, I introduce a really "pre-alpha" ipex support in `TSTrainer` only for the usage of TFT use-case.

### Why I need this?
1. quantization and trace can not applied to TFT in pytorch-forecasting (will fail due to the complex API and model definition)
2. ipex will have a 50% improvement on TFT and same accuracy (with a little change on the model definition)
3. TFT need pytorch==1.11, which is suitable for latest ipex.

### Why this method is not "upstreamed" to `Trainer` in nano?
1. I only support ipex for inference in pytorch>=1.10
2. I am not sure if we need to put this optimization in another method(i.e. `optimize` or something) or existing method(i.e. `trace` and `quantize`)
3. need more investigation and experiments to understand its bkm

Usage is quite easy:
```python
from bigdl.chronos.pytorch import TSTrainer

model.eval()
opt_model = TSTrainer.optimize(model)
opt_model(x)
```