### PR TITLE
Nano: relax dataloader check in quantization

### DIFF
--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantization.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 from typing import Callable
+from collections import Iterable
 from bigdl.nano.utils.log4Error import invalidInputError
 from ..core import BaseQuantization
 from .utils import _check_loader
@@ -44,8 +45,8 @@ class PytorchQuantization(BaseQuantization):
                           "model should be an instance of torch.nn.Module.")
         if calib_dataloader:
             _check_loader(model=model, loader=calib_dataloader, metric=metric)
-            invalidInputError(isinstance(calib_dataloader, torch.utils.data.DataLoader),
-                              "Only torch dataloader is supported for onnx quantization.")
+            invalidInputError(isinstance(calib_dataloader, Iterable),
+                              "Only iterable class is supported.")
         if metric:
             invalidInputError(
                 isinstance(metric, Metric) or isinstance(metric, Callable),

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/utils.py
@@ -32,22 +32,22 @@ def _check_loader(model, loader, metric=None):
     sample = next(iter(loader))
     try:
         if metric is not None:
-            # only check the type when tunning
+            # only check the data when tunning
             # TODO: not only check type, but also if metric(y, yhat)
             # can return a valid result.
             # Each one must be of torch.Tensor
             _check_data_type(sample)
-        if len(sample) == 2:
-            x, y = sample
-            if isinstance(x, torch.Tensor):
-                model(x)
+            if len(sample) == 2:
+                x, y = sample
+                if isinstance(x, torch.Tensor):
+                    model(x)
+                else:
+                    model(*x)
             else:
-                model(*x)
-        else:
-            # If sample is not tuple of length 2, then it should be (x1, x2, x3, ...).
-            # check if datalader yields data complied with what model requires
-            # TypeError will throw if it fails
-            model(*sample)
+                # If sample is not tuple of length 2, then it should be (x1, x2, x3, ...).
+                # check if datalader yields data complied with what model requires
+                # TypeError will throw if it fails
+                model(*sample)
     except (ValueError, TypeError):
         invalidInputError(False,
                           "Dataloader for quantization should yield data in format below:\n"

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/utils.py
@@ -46,7 +46,7 @@ def _check_loader(model, loader, metric=None):
             else:
                 # If sample is not tuple of length 2, then it should be (x1, x2, x3, ...).
                 # check if datalader yields data complied with what model requires
-                # TypeError will throw if it fails
+                # TypeError will throw if it fails.
                 model(*sample)
     except (ValueError, TypeError):
         invalidInputError(False,

--- a/python/nano/test/neural-compressor/pytorch/test_dataloader.py
+++ b/python/nano/test/neural-compressor/pytorch/test_dataloader.py
@@ -105,8 +105,8 @@ class TestDataloader(TestCase):
         model = ModelWithMultipleInputs()
 
         with pytest.raises(RuntimeError, match="Dataloader for quantization should yield data *"):
-            trainer.quantize(model, calib_dataloader=dataloader)
-    
+            trainer.quantize(model, calib_dataloader=dataloader, metric=torchmetrics.F1(10))
+
     def test_no_output_check(self):
         # dataloader 1: torch.Tensor, numpy.ndarray
         dataset = TensorDataset(torch.ones(10, 3), torch.ones(10))


### PR DESCRIPTION
This is a quick fix for demo.
1. change the check from strictly pytorch dataloader to an Iterable
2. remove all the check under non-tunning quantization