### PR TITLE
[PPML] Fix Occlum Log Level For Spark Executor

### DIFF
--- a/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/README.md
+++ b/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/README.md
@@ -145,5 +145,6 @@ Then run the script.
 ```
 
 ## How to debug
-Modify the `SGX_LOG_LEVEL` to one of `off, error, warn, debug, info, and trace` in `executor.yaml`.
+Modify the `--conf spark.kubernetes.sgx.log.level=off \` to one of `off, error, warn, debug, info, and trace` 
+in `run_spark_xx.sh`.
 

--- a/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/executor.yaml
+++ b/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/executor.yaml
@@ -28,8 +28,6 @@ spec:
       value: "512MB"
     - name: SGX_KERNEL_HEAP
       value: "1GB"
-    - name: SGX_LOG_LEVEL
-        value: "off"
   volumes:
   - name: sgx-enclave
     hostPath:

--- a/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/run_spark_gbt.sh
+++ b/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/run_spark_gbt.sh
@@ -13,6 +13,7 @@ ${SPARK_HOME}/bin/spark-submit \
     --conf spark.kubernetes.executor.deleteOnTermination=false \
     --conf spark.kubernetes.driver.podTemplateFile=./executor.yaml \
     --conf spark.kubernetes.executor.podTemplateFile=./executor.yaml \
+    --conf spark.kubernetes.sgx.log.level=off \
     --jars local:/opt/spark/examples/jars/scopt_2.12-3.7.1.jar \
     local:/opt/spark/examples/jars/spark-examples_2.12-3.1.2.jar \
     /opt/spark/data/mllib/sample_lda_libsvm_data.txt --algo regression

--- a/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/run_spark_lr.sh
+++ b/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/run_spark_lr.sh
@@ -13,6 +13,7 @@ ${SPARK_HOME}/bin/spark-submit \
     --conf spark.kubernetes.executor.deleteOnTermination=false \
     --conf spark.kubernetes.driver.podTemplateFile=./executor.yaml \
     --conf spark.kubernetes.executor.podTemplateFile=./executor.yaml \
+    --conf spark.kubernetes.sgx.log.level=off \
     --jars local:/opt/spark/examples/jars/scopt_2.12-3.7.1.jar \
     local:/opt/spark/examples/jars/spark-examples_2.12-3.1.2.jar \
     --regParam 0.3 --elasticNetParam 0.8 \

--- a/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/run_spark_pi.sh
+++ b/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/run_spark_pi.sh
@@ -12,4 +12,5 @@ ${SPARK_HOME}/bin/spark-submit \
     --conf spark.kubernetes.executor.deleteOnTermination=false \
     --conf spark.kubernetes.driver.podTemplateFile=./executor.yaml \
     --conf spark.kubernetes.executor.podTemplateFile=./executor.yaml \
+    --conf spark.kubernetes.sgx.log.level=off \
     local:/opt/spark/examples/jars/spark-examples_2.12-3.1.2.jar

--- a/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/run_spark_sql.sh
+++ b/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/run_spark_sql.sh
@@ -13,6 +13,7 @@ ${SPARK_HOME}/bin/spark-submit \
     --conf spark.kubernetes.executor.deleteOnTermination=false \
     --conf spark.kubernetes.driver.podTemplateFile=./executor.yaml \
     --conf spark.kubernetes.executor.podTemplateFile=./executor.yaml \
+    --conf spark.kubernetes.sgx.log.level=off \
     --jars local:/opt/spark/examples/jars/scopt_2.12-3.7.1.jar \
     local:/opt/spark/examples/jars/spark-examples_2.12-3.1.2.jar
 

--- a/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/run_spark_tpch.sh
+++ b/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/run_spark_tpch.sh
@@ -14,6 +14,7 @@ ${SPARK_HOME}/bin/spark-submit \
     --conf spark.kubernetes.executor.podTemplateFile=./executor.yaml \
     --conf spark.kubernetes.file.upload.path=file:///tmp \
     --conf spark.kubernetes.executor.podNamePrefix="sparktpch" \
+    --conf spark.kubernetes.sgx.log.level=off \
     --num-executors 1 \
     --executor-cores 8 \
     --executor-memory 16g \

--- a/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/run_spark_xgboost.sh
+++ b/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/run_spark_xgboost.sh
@@ -13,6 +13,7 @@ ${SPARK_HOME}/bin/spark-submit \
     --conf spark.kubernetes.driver.podTemplateFile=./executor.yaml \
     --conf spark.kubernetes.executor.podTemplateFile=./executor.yaml \
     --conf spark.kubernetes.file.upload.path=file:///tmp \
+    --conf spark.kubernetes.sgx.log.level=off \
     --conf spark.task.cpus=2 \
     --executor-cores 2 \
     --executor-memory 2g \


### PR DESCRIPTION
* Delete `SGX_LOG_LEVEL` in `executor.yaml`.
* Add `--conf spark.kubernetes.sgx.log.level=off ` to each scripts.
* Update `README.md`.