### PR TITLE
fix: use -f as file test operator for file secured-argvs

### DIFF
--- a/ppml/trusted-big-data-ml/python/docker-graphene/init.sh
+++ b/ppml/trusted-big-data-ml/python/docker-graphene/init.sh
@@ -26,7 +26,7 @@ else
     echo "both /dev/sgx/provision /dev/sgx_provision are not ready, please check the kernel and driver"
 fi
 
-if [ -c "/ppml/trusted-big-data-ml/secured-argvs" ]; then
+if [ -f "/ppml/trusted-big-data-ml/secured-argvs" ]; then
     echo "/ppml/trusted-big-data-ml/secured-argvs is ready"
 else
     echo "/ppml/trusted-big-data-ml/secured-argvs is not ready, please generate it before init.sh"


### PR DESCRIPTION
In Linux Shell Script:
**if [ -c filename ]**: checks if file is a character special file
**if [ -f filename ]**: checks if file is an ordinary file as opposed to a directory or special file

In ppml/trusted-big-data-ml/python/docker-graphene/init.sh, /ppml/trusted-big-data-ml/secured-argvs is an ordinary file, so we should use operator **-f**.

