### PR TITLE
Chronos: add an asymmetric loss for forecasting models

### DIFF
--- a/python/chronos/dev/test/run-pytests.sh
+++ b/python/chronos/dev/test/run-pytests.sh
@@ -46,6 +46,7 @@ echo "Running chronos tests Part 1"
 python -m pytest -v test/bigdl/chronos/model \
                     test/bigdl/chronos/forecaster \
                     test/bigdl/chronos/metric \
+                    test/bigdl/chronos/pytorch \
        -k "not test_forecast_tcmf_distributed"
 exit_status_0=$?
 if [ $exit_status_0 -ne 0 ];

--- a/python/chronos/src/bigdl/chronos/pytorch/loss/__init__.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/loss/__init__.py
@@ -1,0 +1,15 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/chronos/src/bigdl/chronos/pytorch/loss/linex.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/loss/linex.py
@@ -1,7 +1,23 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 import torch
 import torch.nn as nn
 
 from bigdl.nano.utils.log4Error import invalidInputError
+
 
 class LinexLoss(nn.Module):
     '''

--- a/python/chronos/src/bigdl/chronos/pytorch/loss/linex.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/loss/linex.py
@@ -1,0 +1,26 @@
+import torch
+import torch.nn as nn
+
+from bigdl.nano.utils.log4Error import invalidInputError
+
+class LinexLoss(nn.Module):
+    '''
+    LinexLoss is an asymmetric loss talked about in
+    https://www.scirp.org/journal/paperinformation.aspx?paperid=97986
+    
+    '''
+    def __init__(self, a=1):
+        '''
+        :param a: when a is set to ~0, this loss is similar to MSE.
+               when a is set to > 0, this loss panelize underestimate more.
+               when a is set to < 0, this loss panelize overestimate more.
+        '''
+        super().__init__()
+        invalidInputError(a!=0, "a should not be set to 0")
+        self.a = a
+        self.b = 2/(a**2)
+
+    def forward(self, y_hat, y):
+        delta = y - y_hat
+        loss = self.b * (torch.exp(self.a*delta) - self.a*delta - 1)
+        return torch.mean(loss)

--- a/python/chronos/src/bigdl/chronos/pytorch/loss/linex.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/loss/linex.py
@@ -23,7 +23,7 @@ class LinexLoss(nn.Module):
     '''
     LinexLoss is an asymmetric loss talked about in
     https://www.scirp.org/journal/paperinformation.aspx?paperid=97986
-    
+
     '''
     def __init__(self, a=1):
         '''
@@ -32,7 +32,7 @@ class LinexLoss(nn.Module):
                when a is set to < 0, this loss panelize overestimate more.
         '''
         super().__init__()
-        invalidInputError(a!=0, "a should not be set to 0")
+        invalidInputError(a != 0, "a should not be set to 0")
         self.a = a
         self.b = 2/(a**2)
 

--- a/python/chronos/test/bigdl/chronos/pytorch/__init__.py
+++ b/python/chronos/test/bigdl/chronos/pytorch/__init__.py
@@ -13,6 +13,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-
-from .linex import LinexLoss

--- a/python/chronos/test/bigdl/chronos/pytorch/loss/__init__.py
+++ b/python/chronos/test/bigdl/chronos/pytorch/loss/__init__.py
@@ -13,6 +13,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-
-from .linex import LinexLoss

--- a/python/chronos/test/bigdl/chronos/pytorch/loss/test_linex.py
+++ b/python/chronos/test/bigdl/chronos/pytorch/loss/test_linex.py
@@ -1,0 +1,42 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import torch
+
+from bigdl.chronos.pytorch.loss import LinexLoss
+from unittest import TestCase
+import pytest
+
+class TestChronosPytorchLoss(TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_linex_loss(self):
+        y = torch.rand(100, 10, 2)
+        yhat_high = y + 1
+        yhat_low = y - 1
+
+        # when a is set to > 0, this loss panelize underestimate more.
+        loss = LinexLoss(1)
+        assert loss(yhat_high, y) < loss(yhat_low, y)
+
+        # when a is set to < 0, this loss panelize overestimate more.
+        loss = LinexLoss(-1)
+        assert loss(yhat_high, y) > loss(yhat_low, y)


### PR DESCRIPTION
This is inspired by: https://www.datatrigger.org/post/asymmetric_loss/
same TCN model on nyc_taxi
```python
loss = LinexLoss(a=4)
```
<img width="727" alt="linex" src="https://user-images.githubusercontent.com/35031544/172323163-db017828-2065-40c9-ae57-723a3504f927.PNG">

```python
loss = MSELoss()
```

<img width="720" alt="mse" src="https://user-images.githubusercontent.com/35031544/172323207-9e5188ee-6c7a-48a7-be07-5cf74bded0b8.PNG">

