### PR TITLE
Chronos: Extend the predict method

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
@@ -64,19 +64,19 @@ class BaseTF2Forecaster(Forecaster):
                 | should be the same as past_seq_len and input_feature_num.
 
         :params batch_size: predict batch size. The value will not affect evaluate
-                result but will affect resources cost(e.g. memory and time).
+                result but will affect resources cost(e.g. memory and time). The default to 32.
+                If set to None, the model will be used directly for inference.
+        :params training: Only takes effect when batch_size is None,
+                whether to update the weight value of the model, the default is False.
         """
         from bigdl.nano.utils.log4Error import invalidInputError
         if not self.fitted:
-<<<<<<< HEAD
             invalidInputError(False,
                               "You must call fit or restore first before calling predict!")
-        yhat = self.internal.predict(data, batch_size=batch_size)
-=======
-            raise RuntimeError("You must call fit or restore first before calling predict!")
-        # yhat = self.internal.predict(data, batch_size=batch_size)
-        yhat = self.internal(data, training=training).numpy()
->>>>>>> modify predict method
+        if batch_size:
+            yhat = self.internal.predict(data, batch_size=batch_size)
+        else:
+            yhat = self.internal(data, training=training)
         return yhat
 
     def evaluate(self, data, batch_size=32, multioutput="raw_values"):

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
@@ -68,6 +68,8 @@ class BaseTF2Forecaster(Forecaster):
                 If set to None, the model will be used directly for inference.
         :params training: Only takes effect when batch_size is None,
                 whether to update the weight value of the model, the default is False.
+        
+        :return: A numpy array with shape (num_samples, horizon, target_dim).
         """
         from bigdl.nano.utils.log4Error import invalidInputError
         if not self.fitted:
@@ -76,10 +78,10 @@ class BaseTF2Forecaster(Forecaster):
         if batch_size:
             yhat = self.internal.predict(data, batch_size=batch_size)
         else:
-            yhat = self.internal(data, training=training)
+            yhat = self.internal(data, training=training).numpy()
         return yhat
 
-    def evaluate(self, data, batch_size=32, multioutput="raw_values"):
+    def evaluate(self, data, batch_size=32, multioutput="raw_values", training=False):
         """
         Please note that evaluate result is calculated by scaled y and yhat. If you scaled
         your data (e.g. use .scale() on the TSDataset) please follow the following code
@@ -105,12 +107,16 @@ class BaseTF2Forecaster(Forecaster):
                 String in ['raw_values', 'uniform_average']. The value defaults to
                 'raw_values'.The param is only effective when the forecaster is a
                 non-distribtued version.
+        :params training: Only takes effect when batch_size is None,
+                whether to update the weight value of the model, the default is False.
+        
+        :return: A list of evaluation results. Each item represents a metric.
         """
         from bigdl.nano.utils.log4Error import invalidInputError
         if not self.fitted:
             invalidInputError(False,
                               "You must call fit or restore first before calling evaluate!")
-        yhat = self.internal.predict(data[0], batch_size=batch_size)
+        yhat = self.internal.predict(data[0], batch_size=batch_size, training=training)
 
         aggregate = 'mean' if multioutput == 'uniform_average' else None
         return Evaluator.evaluate(self.metrics, y_true=data[1], y_pred=yhat, aggregate=aggregate)

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
@@ -64,10 +64,11 @@ class BaseTF2Forecaster(Forecaster):
                 | should be the same as past_seq_len and input_feature_num.
 
         :params batch_size: predict batch size. The value will not affect evaluate
-                result but will affect resources cost(e.g. memory and time). The default to 32.
-                If set to None, the model will be used directly for inference.
+                result but will affect resources cost(e.g. memory and time).
+                The value default to 32. If set to None,
+                the model will be used directly for inference.
         :params training: Only takes effect when batch_size is None,
-                whether to update the weight value of the model, the default is False.
+                whether to update the weight value of the model, the value default is False.
         
         :return: A numpy array with shape (num_samples, horizon, target_dim).
         """
@@ -108,7 +109,7 @@ class BaseTF2Forecaster(Forecaster):
                 'raw_values'.The param is only effective when the forecaster is a
                 non-distribtued version.
         :params training: Only takes effect when batch_size is None,
-                whether to update the weight value of the model, the default is False.
+                whether to update the weight value of the model, the value default is False.
         
         :return: A list of evaluation results. Each item represents a metric.
         """

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
@@ -55,7 +55,7 @@ class BaseTF2Forecaster(Forecaster):
             self.internal.fit(x=data, epochs=epochs)
         self.fitted = True
 
-    def predict(self, data, batch_size=32):
+    def predict(self, data, batch_size=32, training=False):
         """
         :params data: The data support following formats:
 
@@ -68,9 +68,15 @@ class BaseTF2Forecaster(Forecaster):
         """
         from bigdl.nano.utils.log4Error import invalidInputError
         if not self.fitted:
+<<<<<<< HEAD
             invalidInputError(False,
                               "You must call fit or restore first before calling predict!")
         yhat = self.internal.predict(data, batch_size=batch_size)
+=======
+            raise RuntimeError("You must call fit or restore first before calling predict!")
+        # yhat = self.internal.predict(data, batch_size=batch_size)
+        yhat = self.internal(data, training=training).numpy()
+>>>>>>> modify predict method
         return yhat
 
     def evaluate(self, data, batch_size=32, multioutput="raw_values"):


### PR DESCRIPTION
About 4X speedup when `batch_size` is set to None, not recommended for large datasets.

Removed `training=False`, because normally the user does not update the weight matrix when predicting.