### PR TITLE
Chronos: make multi-process training more robust

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -157,7 +157,8 @@ class BasePytorchForecaster(Forecaster):
             # Trainer init and fitting
             self.trainer = Trainer(logger=False, max_epochs=epochs,
                                    checkpoint_callback=self.checkpoint_callback,
-                                   num_processes=self.num_processes, use_ipex=self.use_ipex)
+                                   num_processes=self.num_processes, use_ipex=self.use_ipex,
+                                   distributed_backend="spawn")
             self.trainer.fit(self.internal, data)
             self.fitted = True
 

--- a/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
@@ -129,7 +129,10 @@ class LSTMForecaster(BasePytorchForecaster):
 
         # nano setting
         current_num_threads = torch.get_num_threads()
-        self.num_processes = max(1, current_num_threads//8)  # 8 is a magic num
+        if current_num_threads >= 24:
+            self.num_processes = max(1, current_num_threads//8)  # 8 is a magic num
+        else:
+            self.num_processes = 1
         self.use_ipex = False
         self.onnx_available = True
         self.quantize_available = True

--- a/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
@@ -152,7 +152,10 @@ class NBeatsForecaster(BasePytorchForecaster):
 
         # nano settings
         current_num_threads = torch.get_num_threads()
-        self.num_processes = max(1, current_num_threads//8)  # 8 is a magic num
+        if current_num_threads >= 24:
+            self.num_processes = max(1, current_num_threads//8)  # 8 is a magic num
+        else:
+            self.num_processes = 1
         self.use_ipex = False
         self.onnx_available = True
         self.quantize_available = True

--- a/python/chronos/src/bigdl/chronos/forecaster/seq2seq_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/seq2seq_forecaster.py
@@ -135,7 +135,10 @@ class Seq2SeqForecaster(BasePytorchForecaster):
 
         # nano setting
         current_num_threads = torch.get_num_threads()
-        self.num_processes = max(1, current_num_threads//8)  # 8 is a magic num
+        if current_num_threads >= 24:
+            self.num_processes = max(1, current_num_threads//8)  # 8 is a magic num
+        else:
+            self.num_processes = 1
         self.use_ipex = False  # S2S has worse performance on ipex
         self.onnx_available = True
         self.quantize_available = False

--- a/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
@@ -140,7 +140,10 @@ class TCNForecaster(BasePytorchForecaster):
 
         # nano setting
         current_num_threads = torch.get_num_threads()
-        self.num_processes = max(1, current_num_threads//8)  # 8 is a magic num
+        if current_num_threads >= 24:
+            self.num_processes = max(1, current_num_threads//8)  # 8 is a magic num
+        else:
+            self.num_processes = 1
         self.use_ipex = False  # TCN has worse performance on ipex
         self.onnx_available = True
         self.quantize_available = True


### PR DESCRIPTION
1. automatically use multi-process training when user has an environment larger or equal to 24 cores.
2. change distributed_backend to spawn.