### PR TITLE
speed up dropout

### DIFF
--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/Dropout.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/Dropout.scala
@@ -74,61 +74,15 @@ class Dropout[T: ClassTag](
     }
     if (train) {
       noise.resizeAs(input)
-      if (input.isContiguous()) {
-        if (isResampling) {
-          val noiseData = noise.storage().array()
-          var taskSize = noise.nElement() / Engine.model.getPoolSize
-          var extraTask = noise.nElement() % Engine.model.getPoolSize
-          var allocated = 0
-          val offset = this.output.storageOffset() - 1
-          val data = this.output.storage.array()
-          var i = 0
-          while (allocated < noise.nElement()) {
-            val start = allocated
-            allocated += taskSize
-            if (extraTask > 0) {
-              allocated += 1
-              extraTask -= 1
-            }
-            val end = allocated
-            results(i) = Engine.model.invoke(() => {
-              var k = start
-              while (k < end) {
-                noiseData(k) = if (RNG.bernoulli(1 - p)) {
-                  if (scale) {
-                    data(offset + k) = ev.divide(data(offset + k), ev.fromType[Double](1 - p))
-                    ev.fromType[Double](1.0 / (1 - p))
-                  } else {
-                    ev.fromType[Int](1)
-                  }
-                } else {
-                  data(offset + k) = ev.fromType[Int](0)
-                  ev.fromType[Int](0)
-                }
+      if (isResampling) {
+        noise.bernoulli(1 - p)
 
-                k += 1
-              }
-            })
-            i += 1
-
-          }
-
-          Engine.model.sync(results)
-        } else {
-          this.output.cmul(noise)
+        if (scale) {
+          noise.div(ev.fromType[Double](1 - p))
         }
-        this.output
-      } else {
-        if (isResampling) {
-          noise.bernoulli(1 - p)
-
-          if (scale) {
-            noise.div(ev.fromType[Double](1 - p))
-          }
-        }
-
-        this.output.cmul(noise)
       }
+
+      this.output.cmul(noise)
     } else if (!scale) {
       this.output.mul(ev.fromType[Double](1 - p))
     } else {
@@ -147,39 +101,7 @@ class Dropout[T: ClassTag](
         this.gradInput.resizeAs(gradOutput).copy(gradOutput)
       }
 
-      if (gradInput.isContiguous()) {
-        val noiseData = noise.storage().array()
-        var taskSize = noise.nElement() / Engine.model.getPoolSize
-        var extraTask = noise.nElement() % Engine.model.getPoolSize
-        val gradInputData = gradInput.storage().array()
-        val gradInputOffset = gradInput.storageOffset() - 1
-        var allocated = 0
-        var i = 0
-        while (allocated < noise.nElement()) {
-          val start = allocated
-          allocated += taskSize
-          if (extraTask > 0) {
-            allocated += 1
-            extraTask -= 1
-          }
-          val end = allocated
-          results(i) = Engine.model.invoke(() => {
-            var k = start
-            while (k < end) {
-              gradInputData(gradInputOffset + k) =
-                ev.times(gradInputData(gradInputOffset + k), noiseData(k))
-              k += 1
-            }
-          })
-          i += 1
-        }
-
-        Engine.model.sync(results)
-
-        this.gradInput
-      } else {
-        this.gradInput.cmul(noise)
-      }
+      this.gradInput.cmul(noise)
     } else {
       Log4Error.invalidOperationError(false, "Dropout: backprop only defined while training")
     }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/DenseTensor.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/DenseTensor.scala
@@ -17,7 +17,6 @@
 package com.intel.analytics.bigdl.dllib.tensor
 
 import java.util.Comparator
-
 import breeze.linalg.{DenseMatrix => BrzDenseMatrix, DenseVector => BrzDenseVector}
 import com.intel.analytics.bigdl.mkl.MKL
 import com.intel.analytics.bigdl.dllib.tensor.TensorNumericMath.TensorNumeric
@@ -25,6 +24,7 @@ import com.intel.analytics.bigdl.dllib.utils.RandomGenerator._
 import com.intel.analytics.bigdl.dllib.utils.{File, Log4Error, Table}
 import org.apache.spark.mllib.linalg.{DenseMatrix, DenseVector, Matrix, Vector}
 
+import java.util.concurrent.ThreadLocalRandom
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 import scala.collection.JavaConverters._
@@ -313,19 +313,42 @@ private[tensor] class DenseTensor[@specialized T: ClassTag](
   }
 
   override def bernoulli(p: Double): Tensor[T] = {
-
     if (this.isContiguous()) {
       var i = 0
+      val floatP = p.toFloat
       val total = this.nElement()
       val data = this.storage().array()
       val offset = this.storageOffset() - 1
-      while (i < total) {
-        data(offset + i) = if (RNG.bernoulli(p)) {
-          ev.fromType[Int](1)
-        } else {
-          ev.fromType[Int](0)
-        }
-        i += 1
+      this.getType() match {
+        case FloatType =>
+          val floatData = data.asInstanceOf[Array[Float]]
+          while (i < total) {
+            floatData(offset + i) = if (ThreadLocalRandom.current().nextFloat() <= floatP) {
+              1
+            } else {
+              0
+            }
+            i += 1
+          }
+        case DoubleType =>
+          val doubleData = data.asInstanceOf[Array[Double]]
+          while (i < total) {
+            doubleData(offset + i) = if (ThreadLocalRandom.current().nextFloat() <= p) {
+              1
+            } else {
+              0
+            }
+            i += 1
+          }
+        case _ =>
+          while (i < total) {
+            data(offset + i) = if (RNG.bernoulli(p)) {
+              ev.fromType[Int](1)
+            } else {
+              ev.fromType[Int](0)
+            }
+            i += 1
+          }
       }
     } else {
       val func = new TensorFunc2[T] {

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/DenseTensor.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/DenseTensor.scala
@@ -315,7 +315,6 @@ private[tensor] class DenseTensor[@specialized T: ClassTag](
   override def bernoulli(p: Double): Tensor[T] = {
     if (this.isContiguous()) {
       var i = 0
-      val floatP = p.toFloat
       val total = this.nElement()
       val data = this.storage().array()
       val offset = this.storageOffset() - 1
@@ -323,7 +322,7 @@ private[tensor] class DenseTensor[@specialized T: ClassTag](
         case FloatType =>
           val floatData = data.asInstanceOf[Array[Float]]
           while (i < total) {
-            floatData(offset + i) = if (ThreadLocalRandom.current().nextFloat() <= floatP) {
+            floatData(offset + i) = if (ThreadLocalRandom.current().nextFloat() <= p) {
               1
             } else {
               0

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/integration/torch/DropoutSpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/integration/torch/DropoutSpec.scala
@@ -84,4 +84,15 @@ class DropoutSpec extends TorchSpec {
 
     println("Test case : Dropout, Torch : " + luaTime + " s, Scala : " + scalaTime / 1e9 + " s")
   }
-}
+
+  "Dropout performance" should "work" in {
+    val module = new Dropout[Float](0.7, true, false)
+    val input = Tensor[Float](1, 12, 512, 512)
+    val seed = 100
+    input.rand()
+    val start = System.nanoTime()
+    val output = module.forward(input)
+//    val d = input.bernoulli(0.7)
+    println((System.nanoTime() - start) / 1e9)
+  }
+  }


### PR DESCRIPTION
The forward time of dropout (input size (1, 12, 512, 512)) reduce from 0.15s to 0.06s. 
1. use ThreadLocalRandom instead of RandomGenerator. (- 0.03s)
2. move ev.fromType when generating bernoulli data. (- 0.06s)

TODO: 
1. Maybe break the compare test VS torch test.
2. Run the training of ImageNet.