### PR TITLE
Chronos: add autoformer forecaster and corresponding tsdataset functions

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -639,8 +639,8 @@ class TSDataset:
             if is_predict:
                 pred_dates = pd.date_range(self.df[self.dt_col].values[-1],
                                            periods=horizon_time + 1, freq=self._freq)
-                df_stamp.loc[:, self.dt_col] = list(self.df[self.dt_col].values)\
-                                                + list(pred_dates[1:])
+                df_stamp.loc[:, self.dt_col] =\
+                    list(self.df[self.dt_col].values) + list(pred_dates[1:])
             else:
                 df_stamp.loc[:, self.dt_col] = list(self.df[self.dt_col].values)
             data_stamp = time_features(pd.to_datetime(df_stamp[self.dt_col].values),

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -637,11 +637,14 @@ class TSDataset:
         if time_enc:
             df_stamp = pd.DataFrame(columns=[self.dt_col])
             if is_predict:
-                pred_dates = pd.date_range(self.df[self.dt_col].values[-1], periods=horizon_time + 1, freq=self._freq)
-                df_stamp.loc[:, self.dt_col] = list(self.df[self.dt_col].values) + list(pred_dates[1:])
+                pred_dates = pd.date_range(self.df[self.dt_col].values[-1],
+                                           periods=horizon_time + 1, freq=self._freq)
+                df_stamp.loc[:, self.dt_col] = list(self.df[self.dt_col].values)\
+                                                + list(pred_dates[1:])
             else:
                 df_stamp.loc[:, self.dt_col] = list(self.df[self.dt_col].values)
-            data_stamp = time_features(pd.to_datetime(df_stamp[self.dt_col].values), freq=self._freq)
+            data_stamp = time_features(pd.to_datetime(df_stamp[self.dt_col].values),
+                                       freq=self._freq)
             self.data_stamp = data_stamp.transpose(1, 0)
             max_horizon = horizon_time if isinstance(horizon_time, int) else max(horizon_time)
             self.numpy_x_timeenc, _ = _roll_timeseries_ndarray(self.data_stamp[:-max_horizon],

--- a/python/chronos/src/bigdl/chronos/data/utils/roll.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/roll.py
@@ -56,7 +56,9 @@ def roll_timeseries_dataframe(df,
     invalidInputError(is_horizon_int or is_horizon_list,
                       "horizon is expected to be a list or int")
 
-    is_test = True if (is_horizon_int and horizon == 0) else False
+    # don't enter test mode if label_len!=0
+    # TODO: change to use is_predict.
+    is_test = True if (is_horizon_int and horizon == 0 and label_len==0) else False
     if not is_test:
         return _roll_timeseries_dataframe_train(df,
                                                 roll_feature_df,
@@ -114,7 +116,10 @@ def _roll_timeseries_dataframe_train(df,
         invalidInputError(False,
                           "horizon should be an integer if label_len is set to larger than 0.")
     max_horizon = horizon if isinstance(horizon, int) else max(horizon)
-    x = df[:-max_horizon].loc[:, target_col+feature_col].values.astype(np.float32)
+    if max_horizon > 0:
+        x = df[:-max_horizon].loc[:, target_col+feature_col].values.astype(np.float32)
+    else:
+        x = df.loc[:, target_col+feature_col].values.astype(np.float32)
     y = df.iloc[lookback-label_len:].loc[:, target_col].values.astype(np.float32)
 
     output_x, mask_x = _roll_timeseries_ndarray(x, lookback)

--- a/python/chronos/src/bigdl/chronos/data/utils/roll.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/roll.py
@@ -58,7 +58,7 @@ def roll_timeseries_dataframe(df,
 
     # don't enter test mode if label_len!=0
     # TODO: change to use is_predict.
-    is_test = True if (is_horizon_int and horizon == 0 and label_len==0) else False
+    is_test = True if (is_horizon_int and horizon == 0 and label_len == 0) else False
     if not is_test:
         return _roll_timeseries_dataframe_train(df,
                                                 roll_feature_df,

--- a/python/chronos/src/bigdl/chronos/data/utils/roll_dataset.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/roll_dataset.py
@@ -17,8 +17,10 @@
 import numpy as np
 from torch.utils.data import Dataset
 import torch
+import pandas as pd
 
 from bigdl.chronos.data.utils.utils import _check_cols_no_na, _to_list
+from bigdl.chronos.data.utils.time_feature import time_features
 
 
 def get_roll_start_idx(df, id_col, window_size):
@@ -34,13 +36,19 @@ def get_roll_start_idx(df, id_col, window_size):
 
 
 class RollDataset(Dataset):
-    def __init__(self, df, lookback, horizon, feature_col, target_col, id_col=None):
+    def __init__(self, df, dt_col, freq, lookback, horizon, feature_col, target_col,
+                 id_col=None, time_enc=False, label_len=0, is_predict=False):
         """
         A customized TorchDataset for rolling dataframe for time series applications.
 
         :param df: The dataframe to roll on. The dataframe could contain single id value or
             multiple id values. If the dataframe contains multiple ids, the rows of same id
             should be consecutive. And dataframe should have been ordered by timestamp for each id.
+        :param dt_col: a str indicates the col name of datetime column in the input data frame, the
+            dt_col must be sorted from past to latest respectively for each id.
+        :param freq: The freq(interval) of this dataset, it is normal if freq is None,
+            which means that we can not determine the frequency of this dataset. This parameter is
+            needed when time_enc is True(for autoformer).
         :param lookback: the length of the past sequence
         :param horizon: int or list,
            if `horizon` is an int, we will sample `horizon` step
@@ -49,11 +57,28 @@ class RollDataset(Dataset):
            to the input list. 1 means the timestamp just after the observed data.
         :param feature_col: list, indicate the feature col name.
         :param target_col: list, indicate the target col name.
-        :param id_col: (optional) a str indicates the col name of dataframe id
+        :param id_col: (optional) a str indicates the col name of dataframe id.
+        :param time_enc: bool,
+               This parameter should be set to True only when you are using Autoformer model. With
+               time_enc to be true, 2 additional numpy ndarray will be returned when you call
+               `.to_numpy()`. Be sure to have a time type for dt_col if you set time_enc to True.
+        :param label_len: int,
+               This parameter should be set to True only when you are using Autoformer model. This
+               indicates the length of overlap area of output(y) and input(x) on time axis.
+        :param is_predict: bool,
+               This parameter should be set to True only when you are using Autoformer model. This
+               indicates if the dataset will be sampled as a prediction dataset(without groud
+               truth).
 
         :return:
 
         """
+        # horizon_time is only for time_enc, the time_enc numpy ndarray won't have any
+        # shape change when the dataset is for prediction.
+        self.horizon_time = horizon
+        if is_predict:
+            horizon = 0
+
         df.reset_index(drop=True, inplace=True)
         feature_col = _to_list(feature_col, "feature_col")
         target_col = _to_list(target_col, "target_col")
@@ -69,23 +94,51 @@ class RollDataset(Dataset):
         self.horizon = horizon
         self.target_num = len(target_col)
 
+        # time_enc
+        self.time_enc = time_enc
+        self.label_len = label_len
+        if self.time_enc:
+            df_stamp = pd.DataFrame(columns=[dt_col])
+            if is_predict:
+                pred_dates = pd.date_range(df[dt_col].values[-1], periods=self.horizon_time + 1, freq=freq)
+                df_stamp.loc[:, dt_col] = list(df[dt_col].values) + list(pred_dates[1:])
+            else:
+                df_stamp.loc[:, dt_col] = list(df[dt_col].values)
+            data_stamp = time_features(pd.to_datetime(df_stamp[dt_col].values), freq=freq)
+            self.data_stamp_arr = data_stamp.transpose(1, 0)
+
     def __len__(self):
         return self.roll_start_idxes.size
 
     def __getitem__(self, idx):
         start_idx = self.roll_start_idxes[idx]
+
+        # cal x
         x = self.arr[start_idx: start_idx + self.lookback]
         x = torch.from_numpy(x).float()
-        if self.horizon == 0:
+        if self.horizon == 0 and not self.time_enc:
             return x
 
         # cal y
         arr_target_only = self.arr[:, :self.target_num]
         if isinstance(self.horizon, int):
-            y = arr_target_only[start_idx + self.lookback: start_idx + self.lookback + self.horizon]
+            y = arr_target_only[start_idx + self.lookback - self.label_len: start_idx + self.lookback + self.horizon]
         else:
             # horizon is a list of int
             horizons = np.array(self.horizon)
             y = np.take(arr_target_only, horizons + start_idx + self.lookback - 1, axis=0)
         y = torch.from_numpy(y).float()
-        return x, y
+
+        if self.time_enc:
+            # cal x_enc
+            x_enc = self.data_stamp_arr[start_idx: start_idx + self.lookback]
+            x_enc = torch.from_numpy(x_enc).float()
+            # cal y_enc
+            y_enc = self.data_stamp_arr[start_idx + self.lookback - self.label_len:
+                                        start_idx + self.lookback + self.horizon_time]
+            y_enc = torch.from_numpy(y_enc).float()
+
+        if self.time_enc:
+            return x, y, x_enc, y_enc
+        else:
+            return x, y

--- a/python/chronos/src/bigdl/chronos/data/utils/roll_dataset.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/roll_dataset.py
@@ -100,7 +100,8 @@ class RollDataset(Dataset):
         if self.time_enc:
             df_stamp = pd.DataFrame(columns=[dt_col])
             if is_predict:
-                pred_dates = pd.date_range(df[dt_col].values[-1], periods=self.horizon_time + 1, freq=freq)
+                pred_dates = pd.date_range(df[dt_col].values[-1], periods=self.horizon_time + 1,
+                                           freq=freq)
                 df_stamp.loc[:, dt_col] = list(df[dt_col].values) + list(pred_dates[1:])
             else:
                 df_stamp.loc[:, dt_col] = list(df[dt_col].values)
@@ -122,7 +123,8 @@ class RollDataset(Dataset):
         # cal y
         arr_target_only = self.arr[:, :self.target_num]
         if isinstance(self.horizon, int):
-            y = arr_target_only[start_idx + self.lookback - self.label_len: start_idx + self.lookback + self.horizon]
+            y = arr_target_only[start_idx + self.lookback - self.label_len:
+                                start_idx + self.lookback + self.horizon]
         else:
             # horizon is a list of int
             horizons = np.array(self.horizon)

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -130,7 +130,7 @@ class AutoformerForecaster(Forecaster):
 
         self.distributed = distributed
         self.seed = seed
-        self.checkpoint_callback = False
+        self.checkpoint_callback = True
 
         # disable multi-process training for now.
         # TODO: enable it in future.

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -54,7 +54,7 @@ class AutoformerForecaster(Forecaster):
                  distributed=False,
                  workers_per_node=1,
                  distributed_backend="ray"):
-        
+
         """
         Build a AutoformerForecaster Forecast Model.
 
@@ -173,8 +173,8 @@ class AutoformerForecaster(Forecaster):
                                             torch.from_numpy(data[1]),
                                             torch.from_numpy(data[2]),
                                             torch.from_numpy(data[3]),),
-                                batch_size=batch_size,
-                                shuffle=True)
+                              batch_size=batch_size,
+                              shuffle=True)
 
         # Trainer init and fitting
         self.trainer = Trainer(logger=False, max_epochs=epochs,
@@ -205,8 +205,8 @@ class AutoformerForecaster(Forecaster):
                                             torch.from_numpy(data[1]),
                                             torch.from_numpy(data[2]),
                                             torch.from_numpy(data[3]),),
-                                batch_size=batch_size,
-                                shuffle=False)
+                              batch_size=batch_size,
+                              shuffle=False)
 
         return self.trainer.predict(self.internal, data)
 
@@ -234,8 +234,8 @@ class AutoformerForecaster(Forecaster):
                                             torch.from_numpy(data[1]),
                                             torch.from_numpy(data[2]),
                                             torch.from_numpy(data[3]),),
-                                batch_size=batch_size,
-                                shuffle=False)
+                              batch_size=batch_size,
+                              shuffle=False)
 
         return self.trainer.validate(self.internal, data)
 

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -1,0 +1,260 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import torch
+from bigdl.chronos.forecaster.abstract import Forecaster
+from bigdl.chronos.model.autoformer import model_creator
+from torch.utils.data import TensorDataset, DataLoader
+from bigdl.chronos.model.autoformer.Autoformer import AutoFormer, _transform_config_to_namedtuple
+from bigdl.nano.utils.log4Error import invalidInputError
+from bigdl.chronos.pytorch import TSTrainer as Trainer
+import torch.nn as nn
+import numpy as np
+import os
+from collections import namedtuple
+
+
+class AutoformerForecaster(Forecaster):
+    def __init__(self,
+                 past_seq_len,
+                 future_seq_len,
+                 input_feature_num,
+                 output_feature_num,
+                 label_len,
+                 freq,
+                 output_attention=False,
+                 moving_avg=25,
+                 d_model=128,
+                 embed='timeF',
+                 dropout=0.05,
+                 factor=3,
+                 n_head=8,
+                 d_ff=256,
+                 activation='gelu',
+                 e_layer=2,
+                 d_layers=1,
+                 optimizer="Adam",
+                 loss="mse",
+                 lr=0.0001,
+                 metrics=["mse"],
+                 seed=None,
+                 distributed=False,
+                 workers_per_node=1,
+                 distributed_backend="ray"):
+        
+        """
+        Build a AutoformerForecaster Forecast Model.
+
+        :param past_seq_len: Specify the history time steps (i.e. lookback).
+        :param future_seq_len: Specify the output time steps (i.e. horizon).
+        :param input_feature_num: Specify the feature dimension.
+        :param output_feature_num: Specify the output dimension.
+        :param optimizer: Specify the optimizer used for training. This value
+               defaults to "Adam".
+        :param loss: str or pytorch loss instance, Specify the loss function
+               used for training. This value defaults to "mse". You can choose
+               from "mse", "mae", "huber_loss" or any customized loss instance
+               you want to use.
+        :param lr: Specify the learning rate. This value defaults to 0.001.
+        :param metrics: A list contains metrics for evaluating the quality of
+               forecasting. You may only choose from "mse" and "mae" for a
+               distributed forecaster. You may choose from "mse", "mae",
+               "rmse", "r2", "mape", "smape" or a callable function for a
+               non-distributed forecaster. If callable function, it signature
+               should be func(y_true, y_pred), where y_true and y_pred are numpy
+               ndarray.
+        :param seed: int, random seed for training. This value defaults to None.
+        :param distributed: bool, if init the forecaster in a distributed
+               fashion. If True, the internal model will use an Orca Estimator.
+               If False, the internal model will use a pytorch model. The value
+               defaults to False.
+        :param workers_per_node: int, the number of worker you want to use.
+               The value defaults to 1. The param is only effective when
+               distributed is set to True.
+        :param distributed_backend: str, select from "ray" or
+               "horovod". The value defaults to "ray".
+        :param kwargs: other hyperparameter please refer to
+               https://github.com/zhouhaoyi/Informer2020#usage
+        """
+
+        # config setting
+        self.data_config = {
+            "past_seq_len": past_seq_len,
+            "future_seq_len": future_seq_len,
+            "input_feature_num": input_feature_num,
+            "output_feature_num": output_feature_num
+        }
+        self.model_config = {
+            "seq_len": past_seq_len,
+            "label_len": label_len,
+            "pred_len": future_seq_len,
+            "output_attention": output_attention,
+            "moving_avg": moving_avg,
+            "enc_in": input_feature_num,
+            "d_model": d_model,
+            "embed": embed,
+            "freq": freq,
+            "dropout": dropout,
+            "dec_in": input_feature_num,
+            "factor": factor,
+            "n_head": n_head,
+            "d_ff": d_ff,
+            "activation": activation,
+            "e_layer": e_layer,
+            "c_out": output_feature_num,
+            "d_layers": d_layers
+        }
+        self.loss_config = {
+            "loss": loss
+        }
+        self.optim_config = {
+            "lr": lr,
+            "optim": optimizer
+        }
+
+        self.model_config.update(self.loss_config)
+        self.model_config.update(self.optim_config)
+
+        self.distributed = distributed
+        self.seed = seed
+        self.checkpoint_callback = False
+
+        # disable multi-process training for now.
+        # TODO: enable it in future.
+        self.num_processes = 1
+        self.use_ipex = False
+        self.onnx_available = False
+        self.quantize_available = False
+        self.use_amp = False
+
+        self.model_creator = model_creator
+        self.internal = model_creator(self.model_config)
+
+    def fit(self, data, epochs=1, batch_size=32):
+        """
+        Fit(Train) the forecaster.
+
+        :param data: The data support following formats:
+
+               | 1. numpy ndarrays: generate from `TSDataset.roll`,
+                    be sure to set label_len > 0 and time_enc = True
+               | 2. pytorch dataloader: generate from `TSDataset.to_torch_data_loader`,
+                    be sure to set label_len > 0 and time_enc = True
+
+        :param epochs: Number of epochs you want to train. The value defaults to 1.
+        :param batch_size: Number of batch size you want to train. The value defaults to 32.
+               if you input a pytorch dataloader for `data`, the batch_size will follow the
+               batch_size setted in `data`.
+        """
+        # seed setting
+        from pytorch_lightning import seed_everything
+        seed_everything(seed=self.seed)
+
+        # distributed is not supported.
+        if self.distributed:
+            invalidInputError(False, "distributed is not support in Autoformer")
+
+        # transform a tuple to dataloader.
+        if isinstance(data, tuple):
+            data = DataLoader(TensorDataset(torch.from_numpy(data[0]),
+                                            torch.from_numpy(data[1]),
+                                            torch.from_numpy(data[2]),
+                                            torch.from_numpy(data[3]),),
+                                batch_size=batch_size,
+                                shuffle=True)
+
+        # Trainer init and fitting
+        self.trainer = Trainer(logger=False, max_epochs=epochs,
+                               checkpoint_callback=self.checkpoint_callback, num_processes=1,
+                               use_ipex=self.use_ipex, distributed_backend="spawn")
+        self.trainer.fit(self.internal, data)
+
+    def predict(self, data, batch_size=32):
+        """
+        Predict using a trained forecaster.
+
+        :param data: The data support following formats:
+
+               | 1. numpy ndarrays: generate from `TSDataset.roll`,
+                    be sure to set label_len > 0 and time_enc = True
+               | 2. pytorch dataloader: generate from `TSDataset.to_torch_data_loader`,
+                    be sure to set label_len > 0, time_enc = True and is_predict = True
+
+        :param batch_size: predict batch size. The value will not affect predict
+               result but will affect resources cost(e.g. memory and time).
+
+        :return: A list of numpy ndarray
+        """
+        if self.distributed:
+            invalidInputError(False, "distributed is not support in Autoformer")
+        if isinstance(data, tuple):
+            data = DataLoader(TensorDataset(torch.from_numpy(data[0]),
+                                            torch.from_numpy(data[1]),
+                                            torch.from_numpy(data[2]),
+                                            torch.from_numpy(data[3]),),
+                                batch_size=batch_size,
+                                shuffle=False)
+
+        return self.trainer.predict(self.internal, data)
+
+    def evaluate(self, data, batch_size=32):
+        """
+        Predict using a trained forecaster.
+
+        :param data: The data support following formats:
+
+               | 1. numpy ndarrays: generate from `TSDataset.roll`,
+                    be sure to set label_len > 0 and time_enc = True
+               | 2. pytorch dataloader: generate from `TSDataset.to_torch_data_loader`,
+                    be sure to set label_len > 0 and time_enc = True
+
+        :param batch_size: predict batch size. The value will not affect predict
+               result but will affect resources cost(e.g. memory and time).
+
+        :return: A dict, currently returns the loss rather than metrics
+        """
+        # TODO: use metrics here
+        if self.distributed:
+            invalidInputError(False, "distributed is not support in Autoformer")
+        if isinstance(data, tuple):
+            data = DataLoader(TensorDataset(torch.from_numpy(data[0]),
+                                            torch.from_numpy(data[1]),
+                                            torch.from_numpy(data[2]),
+                                            torch.from_numpy(data[3]),),
+                                batch_size=batch_size,
+                                shuffle=False)
+
+        return self.trainer.validate(self.internal, data)
+
+    def load(self, checkpoint_file):
+        """
+        restore the forecaster.
+
+        :param checkpoint_file: The checkpoint file location you want to load the forecaster.
+        """
+        self.trainer = Trainer(logger=False, max_epochs=epochs,
+                               checkpoint_callback=self.checkpoint_callback, num_processes=1,
+                               use_ipex=self.use_ipex, distributed_backend="spawn")
+        args = _transform_config_to_namedtuple(self.model_config)
+        self.internal = AutoFormer.load_from_checkpoint(checkpoint_file, configs=args)
+
+    def save(self, checkpoint_file):
+        """
+        save the forecaster.
+
+        :param checkpoint_file: The checkpoint file location you want to load the forecaster.
+        """
+        self.trainer.save_checkpoint(checkpoint_file)

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -245,7 +245,7 @@ class AutoformerForecaster(Forecaster):
 
         :param checkpoint_file: The checkpoint file location you want to load the forecaster.
         """
-        self.trainer = Trainer(logger=False, max_epochs=epochs,
+        self.trainer = Trainer(logger=False, max_epochs=1,
                                checkpoint_callback=self.checkpoint_callback, num_processes=1,
                                use_ipex=self.use_ipex, distributed_backend="spawn")
         args = _transform_config_to_namedtuple(self.model_config)

--- a/python/chronos/src/bigdl/chronos/model/autoformer/layers/AutoCorrelation.py
+++ b/python/chronos/src/bigdl/chronos/model/autoformer/layers/AutoCorrelation.py
@@ -175,7 +175,6 @@ class AutoCorrelation(nn.Module):
             # change this to avoid the using of gather and improve the inference speed.
             V = self.time_delay_agg_training(values.permute(0, 2, 3, 1)
                                              .contiguous(), corr).permute(0, 3, 1, 2)
-            time_delay_agg_training
 
         if self.output_attention:
             return (V.contiguous(), corr.permute(0, 3, 1, 2))

--- a/python/chronos/src/bigdl/chronos/model/autoformer/layers/AutoCorrelation.py
+++ b/python/chronos/src/bigdl/chronos/model/autoformer/layers/AutoCorrelation.py
@@ -170,8 +170,12 @@ class AutoCorrelation(nn.Module):
             V = self.time_delay_agg_training(values.permute(0, 2, 3, 1)
                                              .contiguous(), corr).permute(0, 3, 1, 2)
         else:
-            V = self.time_delay_agg_inference(values.permute(0, 2, 3, 1)
-                                              .contiguous(), corr).permute(0, 3, 1, 2)
+            # V = self.time_delay_agg_inference(values.permute(0, 2, 3, 1)
+            #                                   .contiguous(), corr).permute(0, 3, 1, 2)
+            # change this to avoid the using of gather and improve the inference speed.
+            V = self.time_delay_agg_training(values.permute(0, 2, 3, 1)
+                                             .contiguous(), corr).permute(0, 3, 1, 2)
+            time_delay_agg_training
 
         if self.output_attention:
             return (V.contiguous(), corr.permute(0, 3, 1, 2))

--- a/python/chronos/test/bigdl/chronos/data/utils/test_roll_dataset.py
+++ b/python/chronos/test/bigdl/chronos/data/utils/test_roll_dataset.py
@@ -58,6 +58,8 @@ class TestRollDataset:
 
         # get results rolled by RollDataset
         roll_dataset = RollDataset(df=df,
+                                   dt_col="datetime",
+                                   freq=None,
                                    lookback=lookback,
                                    horizon=horizon,
                                    feature_col=tsdata.feature_col,
@@ -110,6 +112,8 @@ class TestRollDataset:
         df["value"][0] = np.nan
         with pytest.raises(RuntimeError):
             RollDataset(df=df,
+                        dt_col="datetime",
+                        freq=None,
                         lookback=2,
                         horizon=1,
                         feature_col=["extra feature"],

--- a/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
@@ -1,0 +1,85 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import numpy as np
+import pandas as pd
+import tempfile
+import os
+
+from bigdl.chronos.forecaster.autoformer_forecaster import AutoformerForecaster
+from bigdl.chronos.data import TSDataset
+from unittest import TestCase
+import pytest
+
+def get_ts_df():
+    sample_num = np.random.randint(1000, 1500)
+    train_df = pd.DataFrame({"datetime": pd.date_range('1/1/2019', periods=sample_num, freq="1s"),
+                             "value": np.random.randn(sample_num),
+                             "id": np.array(['00']*sample_num),
+                             "extra feature": np.random.randn(sample_num)})
+    return train_df
+
+
+def get_dataloader():
+    df = get_ts_df()
+    target = ["value", "extra feature"]
+    tsdata_train, tsdata_val, tsdata_test =\
+        TSDataset.from_pandas(df, dt_col="datetime", target_col=target,
+                              with_split=True, test_ratio=0.1, val_ratio=0.1)
+    train_loader = tsdata_train.to_torch_data_loader(roll=True, lookback=24, horizon=5,
+                                                     time_enc=True, label_len=12)
+    val_loader = tsdata_val.to_torch_data_loader(roll=True, lookback=24, horizon=5,
+                                                 time_enc=True, label_len=12, shuffle=False)
+    test_loader = tsdata_test.to_torch_data_loader(roll=True, lookback=24, horizon=5,
+                                                   time_enc=True, label_len=12, shuffle=False,
+                                                   is_predict=True)
+    return train_loader, val_loader, test_loader
+
+
+class TestChronosModelTCNForecaster(TestCase):
+
+    def setUp(self):
+        self.train_loader, self.val_loader, self.test_loader = get_dataloader()
+
+    def tearDown(self):
+        pass
+
+    def test_autoformer_forecaster_fit_eval_pred(self):
+        forecaster = AutoformerForecaster(past_seq_len=24,
+                                          future_seq_len=5,
+                                          input_feature_num=2,
+                                          output_feature_num=2,
+                                          label_len=12,
+                                          freq='s')
+        forecaster.fit(self.train_loader, epochs=3, batch_size=32)
+        evaluate = forecaster.evaluate(self.val_loader)
+        pred = forecaster.predict(self.test_loader)
+
+    def test_autoformer_forecaster_save_load(self):
+        forecaster = AutoformerForecaster(past_seq_len=24,
+                                          future_seq_len=5,
+                                          input_feature_num=2,
+                                          output_feature_num=2,
+                                          label_len=12,
+                                          freq='s')
+        forecaster.fit(self.train_loader, epochs=3, batch_size=32)
+        evaluate = forecaster.evaluate(self.val_loader)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            ckpt_name = os.path.join(tmp_dir_name, "af.ckpt")
+            forecaster.save(ckpt_name)
+            forecaster.load(ckpt_name)
+            evaluate2 = forecaster.evaluate(self.val_loader)
+        assert evaluate[0]['val_loss'] == evaluate2[0]['val_loss']


### PR DESCRIPTION
```python
tsdata_train = TSDataset.from_pandas(raw_df, dt_col="date", target_col=target)
train_loader = tsdata_train.to_torch_data_loader(roll=True, lookback=96, horizon=720,
                                                 time_enc=True, label_len=48)

forecaster = AutoformerForecaster(past_seq_len=96,
                                  future_seq_len=720,
                                  input_feature_num=32,
                                  output_feature_num=32,
                                  label_len=48,
                                  freq='h')
forecaster.fit(train_loader, epochs=5, batch_size=32)
evaluate = forecaster.evaluate(train_loader)

```