### PR TITLE
Enhance Pytorch Estimator Callbacks interface with logs input 

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/base.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/base.py
@@ -60,7 +60,10 @@ class Callback(object):
         Subclasses should override for any actions to run. This function should only
         be called during TRAIN mode.
         @param epoch:  Integer, index of epoch.
-        @param logs: Dict, metric results for this training epoch, and for the validation epoch if validation is performed. Validation result keys are prefixed with val_. For training epoch, the values of the Model's metrics are returned. Example : {'loss': 0.2, 'accuracy': 0.7}
+        @param logs: Dict, metric results for this training epoch, and for the validation epoch if
+            validation is performed. Validation result keys are prefixed with val_. For training
+            epoch, the values of the Model's metrics are returned.
+            Example : {'loss': 0.2, 'accuracy': 0.7}
         """
         pass
 
@@ -79,7 +82,8 @@ class Callback(object):
         """
         Called at the end of training.
         Subclasses should override for any actions to run.
-        :param logs: Dict. Currently the output of the last call to on_epoch_end() is passed to this argument for this method but that may change in the future.
+        :param logs: Dict. Currently the output of the last call to on_epoch_end() is passed to
+            this argument for this method but that may change in the future.
         """
         pass
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/base.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/base.py
@@ -32,11 +32,12 @@ class Callback(object):
         pass
 
     @abstractmethod
-    def on_batch_end(self, batch):
+    def on_batch_end(self, batch, logs=None):
         """
         Called at the end of a training batch in `fit` methods.
         Subclasses should override for any actions to run.
         @param batch: Integer, index of batch within the current epoch.
+        :param logs: Dict. Aggregated metric results up until this batch.
         """
         pass
 
@@ -73,10 +74,11 @@ class Callback(object):
         pass
 
     @abstractmethod
-    def on_train_end(self):
+    def on_train_end(self, logs=None):
         """
         Called at the end of training.
         Subclasses should override for any actions to run.
+        :param logs: Dict. Currently the output of the last call to on_epoch_end() is passed to this argument for this method but that may change in the future.
         """
         pass
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/base.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/base.py
@@ -32,7 +32,7 @@ class Callback(object):
         pass
 
     @abstractmethod
-    def on_batch_end(self, batch, logs=None):
+    def on_batch_end(self, batch):
         """
         Called at the end of a training batch in `fit` methods.
         Subclasses should override for any actions to run.
@@ -54,12 +54,13 @@ class Callback(object):
         pass
 
     @abstractmethod
-    def on_epoch_end(self, epoch):
+    def on_epoch_end(self, epoch, logs=None):
         """
         Called at the end of an epoch.
         Subclasses should override for any actions to run. This function should only
         be called during TRAIN mode.
         @param epoch:  Integer, index of epoch.
+        @param logs: Dict, metric results for this training epoch, and for the validation epoch if validation is performed. Validation result keys are prefixed with val_. For training epoch, the values of the Model's metrics are returned. Example : {'loss': 0.2, 'accuracy': 0.7}
         """
         pass
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/model_checkpoint.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/model_checkpoint.py
@@ -78,7 +78,7 @@ class ModelCheckpoint(Callback):
         """
         pass
 
-    def on_epoch_end(self, epoch):
+    def on_epoch_end(self, epoch, logs=None):
         """
         Called at the end of an epoch.
         Subclasses should override for any actions to run. This function should only
@@ -111,7 +111,7 @@ class ModelCheckpoint(Callback):
         else:
             fs.mkdirs(dirname)
 
-    def on_train_end(self):
+    def on_train_end(self, logs=None):
         """
         Called at the end of training.
         Subclasses should override for any actions to run.

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -320,10 +320,10 @@ class TorchRunner:
             self.epochs_stats = stats
             if callbacks is not None:
                 for callback in callbacks:
-                    callback.on_epoch_end(epoch=self.epochs, logs=self.epoch_stats)
+                    callback.on_epoch_end(epoch=self.epochs, logs=self.epochs_stats)
         if callbacks is not None:
             for callback in callbacks:
-                callback.on_train_end(logs=self.epoch_stats)
+                callback.on_train_end(logs=self.epochs_stats)
         return stats_list
 
     def train_epoch(self,

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -320,10 +320,10 @@ class TorchRunner:
             self.epochs_stats = stats
             if callbacks is not None:
                 for callback in callbacks:
-                    callback.on_epoch_end(epoch=self.epochs)
+                    callback.on_epoch_end(epoch=self.epochs, logs=self.epoch_stats)
         if callbacks is not None:
             for callback in callbacks:
-                callback.on_train_end()
+                callback.on_train_end(logs=self.epoch_stats)
         return stats_list
 
     def train_epoch(self,

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
@@ -36,6 +36,8 @@ from bigdl.orca.data.image.utils import chunks
 import tempfile
 import shutil
 
+from bigdl.orca.learn.pytorch.callbacks.base import Callback
+
 np.random.seed(1337)  # for reproducibility
 resource_path = os.path.join(
     os.path.realpath(os.path.dirname(__file__)), "../../../resources")
@@ -127,6 +129,26 @@ class SimpleModel(nn.Module):
         x = self.fc(x)
         x = self.out_act(x).flatten()
         return x
+
+
+class CustomCallback(Callback):
+    def on_train_begin(self, logs=None):
+        keys = list(logs.keys())
+        print("Starting training; got log keys: {}".format(keys))
+
+    def on_train_end(self, logs=None):
+        keys = list(logs.keys())
+        # model = self.model
+        # weights = model.weights
+        print("Stop training; got log keys: {}".format(keys))
+
+    def on_epoch_begin(self, epoch, logs=None):
+        keys = list(logs.keys())
+        print("Start epoch {} of training; got log keys: {}".format(epoch, keys))
+
+    def on_epoch_end(self, epoch, logs=None):
+        keys = list(logs.keys())
+        print("End epoch {} of training; got log keys: {}".format(epoch, keys))
 
 
 def train_data_loader(config, batch_size):
@@ -577,6 +599,13 @@ class TestPyTorchEstimator(TestCase):
                 np.testing.assert_almost_equal(value, eval_after[name])
         finally:
             shutil.rmtree(temp_dir)
+
+    def test_custom_callback(self):
+        estimator = get_estimator(workers_per_node=2)
+        callbacks = [CustomCallback()]
+        train_stats = estimator.fit(train_data_loader, epochs=4, batch_size=128,
+                                    validation_data=val_data_loader, callbacks=callbacks)
+        print(train_stats)
 
 
 if __name__ == "__main__":

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
@@ -132,23 +132,16 @@ class SimpleModel(nn.Module):
 
 
 class CustomCallback(Callback):
-    def on_train_begin(self, logs=None):
-        keys = list(logs.keys())
-        print("Starting training; got log keys: {}".format(keys))
 
     def on_train_end(self, logs=None):
-        keys = list(logs.keys())
-        # model = self.model
-        # weights = model.weights
-        print("Stop training; got log keys: {}".format(keys))
-
-    def on_epoch_begin(self, epoch, logs=None):
-        keys = list(logs.keys())
-        print("Start epoch {} of training; got log keys: {}".format(epoch, keys))
+        assert "train_loss" in logs
+        assert "val_loss" in logs
+        assert self.model
 
     def on_epoch_end(self, epoch, logs=None):
-        keys = list(logs.keys())
-        print("End epoch {} of training; got log keys: {}".format(epoch, keys))
+        assert "train_loss" in logs 
+        assert "val_loss" in logs
+        assert self.model
 
 
 def train_data_loader(config, batch_size):
@@ -603,9 +596,8 @@ class TestPyTorchEstimator(TestCase):
     def test_custom_callback(self):
         estimator = get_estimator(workers_per_node=2)
         callbacks = [CustomCallback()]
-        train_stats = estimator.fit(train_data_loader, epochs=4, batch_size=128,
-                                    validation_data=val_data_loader, callbacks=callbacks)
-        print(train_stats)
+        estimator.fit(train_data_loader, epochs=4, batch_size=128, 
+                      validation_data=val_data_loader, callbacks=callbacks)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Issue #4586

### Interface change
This PR introduce `logs` in Pytorch Callbacks, as Tensorflow keras callback does, so that user could easily access the training status and evaluation results during the training process.

Specifically, this PR add `logs` support only for `on_epoch_end` and `on_train_end`.
For `on_xx_begin`, `logs` are not used. 
For `on_batch_end`, we may not support getting evaluation results via `logs` now,  since currently we only compute aggregated metrics after each training **epoch** ends, computing aggregated metrics on each **batch** ends would harm the overall performance. We could add support if requested by customers. 

```python

class CustomCallback(Callback):

    def on_train_end(self, logs=None):
        keys = list(logs.keys())
        model = self.model
        print("Stop training; got log keys: {}".format(keys))

    def on_epoch_end(self, epoch, logs=None):
        keys = list(logs.keys())
        print("End epoch {} of training; got log keys: {}".format(epoch, keys))
```

