### PR TITLE
Chronos: Build a new Jenkins environment  for `onnxrt` 1.6

### DIFF
--- a/python/chronos/dev/example/run-example-tests-pip-onnxrt1.6.sh
+++ b/python/chronos/dev/example/run-example-tests-pip-onnxrt1.6.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+clear_up () {
+    echo "Clearing up environment. Uninstalling bigdl"
+    pip uninstall -y bigdl-chronos
+    pip uninstall -y bigdl-orca
+    pip uninstall -y bigdl-dllib
+    pip uninstall -y pyspark
+}
+#if image exist this two dependency, remove below
+execute_ray_test(){
+    echo "start example $1"
+    start=$(date "+%s")
+    python $2
+    exit_status=$?
+    if [ $exit_status -ne 0 ];
+    then
+        clear_up
+        echo "$1 failed"
+        exit $exit_status
+    fi
+    now=$(date "+%s")
+    return $((now-start))
+}
+
+if [ ! -f ~/.chronos/dataset/nyc_taxi/nyc_taxi_data.csv ]; then
+  wget -nv $FTP_URI/analytics-zoo-data/apps/nyc-taxi/nyc_taxi.csv -P ~/.chronos/dataset/nyc_taxi/
+  mv ~/.chronos/dataset/nyc_taxi/nyc_taxi.csv ~/.chronos/dataset/nyc_taxi/nyc_taxi_data.csv
+fi
+
+execute_ray_test onnx_autotsestimator_nyc_taxi "${BIGDL_ROOT}/python/chronos/example/onnx/onnx_autotsestimator_nyc_taxi.py"
+time5=$?
+
+if [ ! -f ~/.chronos/dataset/network_traffic/network_traffic_data.csv ]; then
+  wget -nv $FTP_URI/analytics-zoo-data/network-traffic/data/data.csv -P ~/.chronos/dataset/network_traffic/
+  mv ~/.chronos/dataset/network_traffic/data.csv ~/.chronos/dataset/network_traffic/network_traffic_data.csv
+fi
+
+execute_ray_test onnx_forecaster_network_traffic "${BIGDL_ROOT}/python/chronos/example/onnx/onnx_forecaster_network_traffic.py"
+time6=$?
+
+if [ ! -f ~/.chronos/dataset/nyc_taxi/nyc_taxi_data.csv ]; then
+  wget -nv $FTP_URI/analytics-zoo-data/apps/nyc-taxi/nyc_taxi.csv -P ~/.chronos/dataset/nyc_taxi/
+  mv ~/.chronos/dataset/nyc_taxi/nyc_taxi.csv ~/.chronos/dataset/nyc_taxi/nyc_taxi_data.csv
+fi
+
+sed -i 's/epochs=10/epochs=1/' "${BIGDL_ROOT}/python/chronos/example/quantization/quantization_tcnforecaster_nyc_taxi.py"
+execute_ray_test quantization_tcnforecaster_nyc_taxi "${BIGDL_ROOT}/python/chronos/example/quantization/quantization_tcnforecaster_nyc_taxi.py"
+time7=$?
+
+echo "#5 onnx_autotsestimator_nyc_taxi time used:$time5 seconds"
+echo "#6 onnx_forecaster_network_traffic used:$time6 seconds"
+echo "#7 quantization_tcnforecaster_nyc_taxi used:$time7 seconds"

--- a/python/chronos/dev/example/run-example-tests-pip-ray.sh
+++ b/python/chronos/dev/example/run-example-tests-pip-ray.sh
@@ -57,37 +57,6 @@ if [ ! -f ~/.chronos/dataset/nyc_taxi/nyc_taxi_data.csv ]; then
   mv ~/.chronos/dataset/nyc_taxi/nyc_taxi.csv ~/.chronos/dataset/nyc_taxi/nyc_taxi_data.csv
 fi
 
-# When the thread of onnxruntime is None, "pthread_setaffinity_np failed" may appear.
-# sed -i '/onnx/d' ${BIGDL_ROOT}/python/chronos/example/onnx/onnx_autotsestimator_nyc_taxi.py
-
-execute_ray_test onnx_autotsestimator_nyc_taxi "${BIGDL_ROOT}/python/chronos/example/onnx/onnx_autotsestimator_nyc_taxi.py"
-time5=$?
-
-if [ ! -f ~/.chronos/dataset/network_traffic/network_traffic_data.csv ]; then
-  wget -nv $FTP_URI/analytics-zoo-data/network-traffic/data/data.csv -P ~/.chronos/dataset/network_traffic/
-  mv ~/.chronos/dataset/network_traffic/data.csv ~/.chronos/dataset/network_traffic/network_traffic_data.csv
-fi
-
-# When the thread of onnxruntime is None, "pthread_setaffinity_np failed" may appear.
-# sed -i '/onnx/d' ${BIGDL_ROOT}/python/chronos/example/onnx/onnx_forecaster_network_traffic.py
-
-execute_ray_test onnx_forecaster_network_traffic "${BIGDL_ROOT}/python/chronos/example/onnx/onnx_forecaster_network_traffic.py"
-time6=$?
-
-if [ ! -f ~/.chronos/dataset/nyc_taxi/nyc_taxi_data.csv ]; then
-  wget -nv $FTP_URI/analytics-zoo-data/apps/nyc-taxi/nyc_taxi.csv -P ~/.chronos/dataset/nyc_taxi/
-  mv ~/.chronos/dataset/nyc_taxi/nyc_taxi.csv ~/.chronos/dataset/nyc_taxi/nyc_taxi_data.csv
-fi
-
-sed -i 's/epochs=10/epochs=1/' "${BIGDL_ROOT}/python/chronos/example/quantization/quantization_tcnforecaster_nyc_taxi.py"
-execute_ray_test quantization_tcnforecaster_nyc_taxi "${BIGDL_ROOT}/python/chronos/example/quantization/quantization_tcnforecaster_nyc_taxi.py"
-time7=$?
-
-if [ ! -f ~/.chronos/dataset/nyc_taxi/nyc_taxi_data.csv ]; then
-  wget -nv $FTP_URI/analytics-zoo-data/apps/nyc-taxi/nyc_taxi.csv -P ~/.chronos/dataset/nyc_taxi/
-  mv ~/.chronos/dataset/nyc_taxi/nyc_taxi.csv ~/.chronos/dataset/nyc_taxi/nyc_taxi_data.csv
-fi
-
 execute_ray_test sparkdf_training_nyc_taxi.py "${BIGDL_ROOT}/python/chronos/example/distributed/sparkdf_training_nyc_taxi.py" --datadir ~/.chronos/dataset/nyc_taxi/nyc_taxi_data.csv
 time8=$?
 
@@ -95,9 +64,6 @@ echo "#1 autolstm_nyc_taxi time used:$time1 seconds"
 echo "#2 autoprophet_nyc_taxi time used:$time2 seconds"
 echo "#3 dpgansimulator_wwt time used:$time3 seconds"
 echo "#4 distributed_training_network_traffic time used:$time4 seconds"
-echo "#5 onnx_autotsestimator_nyc_taxi time used:$time5 seconds"
-echo "#6 onnx_forecaster_network_traffic used:$time6 seconds"
-echo "#7 quantization_tcnforecaster_nyc_taxi used:$time7 seconds"
 echo "#8 sparkdf_training_nyc_taxi used:$time8 seconds"
 
 clear_up

--- a/python/chronos/test/bigdl/chronos/autots/model/test_auto_lstm.py
+++ b/python/chronos/test/bigdl/chronos/autots/model/test_auto_lstm.py
@@ -20,6 +20,10 @@ import numpy as np
 from unittest import TestCase
 import pytest
 import tempfile
+import onnxruntime
+
+_onnxrt_ver = onnxruntime.__version__ != '1.6.0' #  Jenkins runtime requires version 1.6.0(chronos)
+onnxrt_whether_skip = pytest.mark.skipif(_onnxrt_ver, reason="Only runs when onnxrt is 1.6.0")
 
 from bigdl.chronos.autots.model.auto_lstm import AutoLSTM
 from bigdl.orca.automl import hp
@@ -140,6 +144,7 @@ class TestAutoLSTM(TestCase):
         auto_lstm.predict(test_data_x)
         auto_lstm.evaluate((test_data_x, test_data_y))
 
+    @onnxrt_whether_skip
     def test_onnx_methods(self):
         auto_lstm = get_auto_estimator()
         auto_lstm.fit(data=train_dataloader_creator(config={"batch_size": 64}),

--- a/python/chronos/test/bigdl/chronos/autots/model/test_auto_lstm.py
+++ b/python/chronos/test/bigdl/chronos/autots/model/test_auto_lstm.py
@@ -22,7 +22,7 @@ import pytest
 import tempfile
 import onnxruntime
 
-_onnxrt_ver = onnxruntime.__version__ != '1.6.0' #  Jenkins runtime requires version 1.6.0(chronos)
+_onnxrt_ver = onnxruntime.__version__ != '1.6.0' #  Jenkins requires 1.6.0(chronos)
 onnxrt_whether_skip = pytest.mark.skipif(_onnxrt_ver, reason="Only runs when onnxrt is 1.6.0")
 
 from bigdl.chronos.autots.model.auto_lstm import AutoLSTM

--- a/python/chronos/test/bigdl/chronos/autots/model/test_auto_seq2seq.py
+++ b/python/chronos/test/bigdl/chronos/autots/model/test_auto_seq2seq.py
@@ -22,7 +22,7 @@ import pytest
 import tempfile
 import onnxruntime
 
-_onnxrt_ver = onnxruntime.__version != '1.6.0'
+_onnxrt_ver = onnxruntime.__version__ != '1.6.0' #  Jenkins requires 1.6.0(chronos)
 onnxrt_whether_skip = pytest.mark.skipif(_onnxrt_ver, reason="Only runs when onnxrt is 1.6.0")
 
 from bigdl.chronos.autots.model.auto_seq2seq import AutoSeq2Seq

--- a/python/chronos/test/bigdl/chronos/autots/model/test_auto_seq2seq.py
+++ b/python/chronos/test/bigdl/chronos/autots/model/test_auto_seq2seq.py
@@ -20,6 +20,10 @@ import numpy as np
 from unittest import TestCase
 import pytest
 import tempfile
+import onnxruntime
+
+_onnxrt_ver = onnxruntime.__version != '1.6.0'
+onnxrt_whether_skip = pytest.mark.skipif(_onnxrt_ver, reason="Only runs when onnxrt is 1.6.0")
 
 from bigdl.chronos.autots.model.auto_seq2seq import AutoSeq2Seq
 from bigdl.orca.automl import hp
@@ -148,6 +152,7 @@ class TestAutoSeq2Seq(TestCase):
         auto_seq2seq.predict(test_data_x)
         auto_seq2seq.evaluate((test_data_x, test_data_y))
 
+    @onnxrt_whether_skip
     def test_onnx_methods(self):
         auto_seq2seq = get_auto_estimator()
         auto_seq2seq.fit(data=train_dataloader_creator(config={"batch_size": 64}),

--- a/python/chronos/test/bigdl/chronos/autots/model/test_auto_tcn.py
+++ b/python/chronos/test/bigdl/chronos/autots/model/test_auto_tcn.py
@@ -19,6 +19,10 @@ import numpy as np
 from unittest import TestCase
 import pytest
 import tempfile
+import onnxruntime
+
+_onnxrt_ver = onnxruntime.__version__ != '1.6.0' #  Jenkins runtime requires version 1.6.0(chronos)
+onnxrt_whether_skip = pytest.mark.skipif(_onnxrt_ver, reason="Only runs when onnxrt is 1.6.0")
 
 from bigdl.chronos.autots.model.auto_tcn import AutoTCN
 from bigdl.orca.automl import hp
@@ -165,6 +169,7 @@ class TestAutoTCN(TestCase):
         auto_tcn.predict(test_data_x)
         auto_tcn.evaluate((test_data_x, test_data_y))
 
+    @onnxrt_whether_skip
     def test_onnx_methods(self):
         auto_tcn = get_auto_estimator()
         auto_tcn.fit(data=train_dataloader_creator(config={"batch_size": 64}),

--- a/python/chronos/test/bigdl/chronos/autots/model/test_auto_tcn.py
+++ b/python/chronos/test/bigdl/chronos/autots/model/test_auto_tcn.py
@@ -21,7 +21,7 @@ import pytest
 import tempfile
 import onnxruntime
 
-_onnxrt_ver = onnxruntime.__version__ != '1.6.0' #  Jenkins runtime requires version 1.6.0(chronos)
+_onnxrt_ver = onnxruntime.__version__ != '1.6.0' #  Jenkins requires 1.6.0(chronos)
 onnxrt_whether_skip = pytest.mark.skipif(_onnxrt_ver, reason="Only runs when onnxrt is 1.6.0")
 
 from bigdl.chronos.autots.model.auto_tcn import AutoTCN

--- a/python/chronos/test/bigdl/chronos/autots/test_autotsestimator.py
+++ b/python/chronos/test/bigdl/chronos/autots/test_autotsestimator.py
@@ -26,6 +26,10 @@ from bigdl.chronos.data import TSDataset
 from bigdl.orca.automl import hp
 import pandas as pd
 import tensorflow as tf
+import onnxruntime
+
+_onnxrt_ver = onnxruntime.__version__ != '1.6.0' #  Jenkins runtime requires version 1.6.0(chronos)
+onnxrt_whether_skip = pytest.mark.skipif(_onnxrt_ver, reason="Only runs when onnxrt is 1.6.0")
 
 
 def get_ts_df():
@@ -307,6 +311,7 @@ class TestAutoTrainer(TestCase):
         best_model = auto_estimator._get_best_automl_model()
         assert 4 <= best_config["past_seq_len"] <= 6
 
+    @onnxrt_whether_skip
     def test_fit_lstm_feature(self):
         from sklearn.preprocessing import StandardScaler
         scaler = StandardScaler()
@@ -373,6 +378,7 @@ class TestAutoTrainer(TestCase):
         # use tspipeline to incrementally train
         new_ts_pipeline.fit(tsdata_valid)
 
+    @onnxrt_whether_skip
     def test_fit_tcn_feature(self):
         from sklearn.preprocessing import StandardScaler
         scaler = StandardScaler()
@@ -440,6 +446,7 @@ class TestAutoTrainer(TestCase):
         # use tspipeline to incrementally train
         new_ts_pipeline.fit(tsdata_valid)
 
+    @onnxrt_whether_skip
     def test_fit_seq2seq_feature(self):
         from sklearn.preprocessing import StandardScaler
         scaler = StandardScaler()

--- a/python/chronos/test/bigdl/chronos/autots/test_autotsestimator.py
+++ b/python/chronos/test/bigdl/chronos/autots/test_autotsestimator.py
@@ -28,7 +28,7 @@ import pandas as pd
 import tensorflow as tf
 import onnxruntime
 
-_onnxrt_ver = onnxruntime.__version__ != '1.6.0' #  Jenkins runtime requires version 1.6.0(chronos)
+_onnxrt_ver = onnxruntime.__version__ != '1.6.0' #  Jenkins requires 1.6.0(chronos)
 onnxrt_whether_skip = pytest.mark.skipif(_onnxrt_ver, reason="Only runs when onnxrt is 1.6.0")
 
 

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -22,6 +22,10 @@ import torch
 from bigdl.chronos.forecaster.lstm_forecaster import LSTMForecaster
 from unittest import TestCase
 import pytest
+import onnxruntime
+
+_onnxrt_ver = onnxruntime.__version__ != '1.6.0' #  Jenkins runtime requires version 1.6.0(chronos)
+onnxrt_whether_skip = pytest.mark.skipif(_onnxrt_ver, reason="Only runs when onnxrt is 1.6.0")
 
 
 def create_data(loader=False):
@@ -92,6 +96,7 @@ class TestChronosModelLSTMForecaster(TestCase):
                                     lr=0.01)
         train_loss = forecaster.fit(train_loader, epochs=2)
 
+    @onnxrt_whether_skip
     def test_lstm_forecaster_onnx_methods(self):
         train_data, val_data, test_data = create_data()
         forecaster = LSTMForecaster(past_seq_len=24,

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -24,7 +24,7 @@ from unittest import TestCase
 import pytest
 import onnxruntime
 
-_onnxrt_ver = onnxruntime.__version__ != '1.6.0' #  Jenkins runtime requires version 1.6.0(chronos)
+_onnxrt_ver = onnxruntime.__version__ != '1.6.0' #  Jenkins requires 1.6.0(chronos)
 onnxrt_whether_skip = pytest.mark.skipif(_onnxrt_ver, reason="Only runs when onnxrt is 1.6.0")
 
 

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -22,6 +22,10 @@ import torch
 from bigdl.chronos.forecaster.seq2seq_forecaster import Seq2SeqForecaster
 from unittest import TestCase
 import pytest
+import onnxruntime
+
+_onnxrt_ver = onnxruntime.__version__ != '1.6.0' #  Jenkins runtime requires version 1.6.0(chronos)
+onnxrt_whether_skip = pytest.mark.skipif(_onnxrt_ver, reason="Only runs when onnxrt is 1.6.0")
 
 
 def create_data(loader=False):
@@ -88,6 +92,7 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
                                        lr=0.01)
         train_loss = forecaster.fit(train_loader, epochs=2)
 
+    @onnxrt_whether_skip
     def test_s2s_forecaster_onnx_methods(self):
         train_data, val_data, test_data = create_data()
         forecaster = Seq2SeqForecaster(past_seq_len=24,

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -24,7 +24,7 @@ from unittest import TestCase
 import pytest
 import onnxruntime
 
-_onnxrt_ver = onnxruntime.__version__ != '1.6.0' #  Jenkins runtime requires version 1.6.0(chronos)
+_onnxrt_ver = onnxruntime.__version__ != '1.6.0' #  Jenkins requires 1.6.0(chronos)
 onnxrt_whether_skip = pytest.mark.skipif(_onnxrt_ver, reason="Only runs when onnxrt is 1.6.0")
 
 

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -22,6 +22,10 @@ import torch
 from bigdl.chronos.forecaster.tcn_forecaster import TCNForecaster
 from unittest import TestCase
 import pytest
+import onnxruntime
+
+_onnxrt_ver = onnxruntime.__version__ != '1.6.0' #  Jenkins runtime requires version 1.6.0(chronos)
+onnxrt_whether_skip = pytest.mark.skipif(_onnxrt_ver, reason="Only runs when onnxrt is 1.6.0")
 
 
 def create_data(loader=False):
@@ -112,7 +116,7 @@ class TestChronosModelTCNForecaster(TestCase):
         train_loss = forecaster.trainer.callback_metrics['train/loss']
         assert train_loss > 10
 
-
+    @onnxrt_whether_skip
     def test_tcn_forecaster_onnx_methods(self):
         train_data, val_data, test_data = create_data()
         forecaster = TCNForecaster(past_seq_len=24,

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -24,7 +24,7 @@ from unittest import TestCase
 import pytest
 import onnxruntime
 
-_onnxrt_ver = onnxruntime.__version__ != '1.6.0' #  Jenkins runtime requires version 1.6.0(chronos)
+_onnxrt_ver = onnxruntime.__version__ != '1.6.0' #  Jenkins requires 1.6.0(chronos)
 onnxrt_whether_skip = pytest.mark.skipif(_onnxrt_ver, reason="Only runs when onnxrt is 1.6.0")
 
 


### PR DESCRIPTION
Because `nano` upgrades the `pytorch` version, the `onnxrt` version higher than 1.6 is required, so split the running environment of onnxrt.