### PR TITLE
Fix issues in kms-util image

### DIFF
--- a/ppml/services/kms-utils/docker/Dockerfile
+++ b/ppml/services/kms-utils/docker/Dockerfile
@@ -70,13 +70,13 @@ ENV PATH                ${JAVA_HOME}/bin:${SPARK_HOME}/bin:${PATH}
 # Step 1. Install requirement tools
 RUN apt-get update && apt-get install -y vim autoconf automake build-essential cmake curl debhelper git libcurl4-openssl-dev libprotobuf-dev libssl-dev libtool lsb-release ocaml ocamlbuild protobuf-compiler python wget libcurl4 libprotobuf17 libssl1.1 make kmod g++ libjsoncpp-dev uuid-dev openjdk-8-jdk && \
 # Step 2. Install Intel SGX SDK
-    mkdir /opt/intel && cd /opt/intel && \
-    wget https://download.01.org/intel-sgx/sgx-dcap/1.12.1/linux/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.15.101.1.bin && \
-    chmod 777 sgx_linux_x64_sdk_2.15.101.1.bin && \
-    sh -c 'echo yes | ./sgx_linux_x64_sdk_2.15.101.1.bin' && \
+    wget https://download.01.org/intel-sgx/sgx-dcap/1.13/linux/distro/ubuntu20.04-server/sgx_linux_x64_sdk_2.16.100.4.bin && \
+    chmod a+x ./sgx_linux_x64_sdk_2.16.100.4.bin && \
+    printf "no\n/opt/intel\n"|./sgx_linux_x64_sdk_2.16.100.4.bin && \
+    . /opt/intel/sgxsdk/environment && \
 # Step 3. Install DCAP packages and set PCCS
 # DCAP repository setup
-    wget https://download.01.org/intel-sgx/sgx-dcap/1.12.1/linux/distro/ubuntu18.04-server/sgx_debian_local_repo.tgz && \
+    wget https://download.01.org/intel-sgx/sgx-dcap/1.12.1/linux/distro/ubuntu20.04-server/sgx_debian_local_repo.tgz && \
     tar xzf sgx_debian_local_repo.tgz && \
     echo 'deb [trusted=yes arch=amd64] file:///opt/intel/sgx_debian_local_repo bionic main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
     wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - && \
@@ -84,7 +84,7 @@ RUN apt-get update && apt-get install -y vim autoconf automake build-essential c
     apt-get install -y libsgx-enclave-common-dev libsgx-ae-qe3 libsgx-ae-qve libsgx-urts libsgx-dcap-ql libsgx-dcap-default-qpl libsgx-dcap-quote-verify-dev libsgx-dcap-default-qpl-dev libsgx-quote-ex-dev libsgx-uae-service libsgx-ra-network libsgx-ra-uefi libsgx-dcap-ql-dev && \
 # Step 4. Build enroll app from source
     cd /home && \
-    git clone -b $EHSM_KMS_BRANCH_VERSION https://github.com/analytics-zoo/ehsm.git && cd ehsm && wget https://download.01.org/intel-sgx/sgx-linux/2.16/as.ld.objdump.r4.tar.gz && tar -zxf as.ld.objdump.r4.tar.gz && cp external/toolset/ubuntu18.04/* /usr/local/bin && make && cd out/ehsm-kms_enroll_app && ls ehsm-kms_enroll_app
+    git clone -b $EHSM_KMS_BRANCH_VERSION https://github.com/analytics-zoo/ehsm.git && cd ehsm && wget https://download.01.org/intel-sgx/sgx-linux/2.16/as.ld.objdump.r4.tar.gz && tar -zxf as.ld.objdump.r4.tar.gz && cp external/toolset/ubuntu20.04/* /usr/local/bin && make && cd out/ehsm-kms_enroll_app && ls ehsm-kms_enroll_app
 
 
 ADD ./entrypoint.sh /home/entrypoint.sh

--- a/ppml/services/kms-utils/docker/Dockerfile
+++ b/ppml/services/kms-utils/docker/Dockerfile
@@ -70,6 +70,7 @@ ENV PATH                ${JAVA_HOME}/bin:${SPARK_HOME}/bin:${PATH}
 # Step 1. Install requirement tools
 RUN apt-get update && apt-get install -y vim autoconf automake build-essential cmake curl debhelper git libcurl4-openssl-dev libprotobuf-dev libssl-dev libtool lsb-release ocaml ocamlbuild protobuf-compiler python wget libcurl4 libprotobuf17 libssl1.1 make kmod g++ libjsoncpp-dev uuid-dev openjdk-8-jdk && \
 # Step 2. Install Intel SGX SDK
+    mkdir /opt/intel && cd /opt/intel && \
     wget https://download.01.org/intel-sgx/sgx-dcap/1.13/linux/distro/ubuntu20.04-server/sgx_linux_x64_sdk_2.16.100.4.bin && \
     chmod a+x ./sgx_linux_x64_sdk_2.16.100.4.bin && \
     printf "no\n/opt/intel\n"|./sgx_linux_x64_sdk_2.16.100.4.bin && \

--- a/ppml/services/kms-utils/docker/Dockerfile
+++ b/ppml/services/kms-utils/docker/Dockerfile
@@ -4,24 +4,20 @@ ARG HTTPS_PROXY_HOST
 ARG HTTPS_PROXY_PORT
 ARG JDK_VERSION=8u192
 ARG SPARK_VERSION=3.1.2
-ARG SCALA_VERSION=2.12.10
 
-# stage.1 java & scala & spark
+# stage.1 java & spark
 FROM ubuntu:18.04 AS builder
 
 ARG SPARK_VERSION
-ARG SCALA_VERSION
 ARG JDK_VERSION
 ARG JDK_URL=your_jdk_url
 ARG SPARK_JAR_REPO_URL
 ENV JDK_VERSION         ${JDK_VERSION}
 ENV SPARK_VERSION       ${SPARK_VERSION}
-ENV SCALA_VERSION       ${SCALA_VERSION}
 
 ENV JAVA_HOME           /opt/jdk${JDK_VERSION}
-ENV SCALA_HOME          /opt/scala-${SCALA_VERSION}
 ENV SPARK_HOME          /opt/spark-${SPARK_VERSION}
-ENV PATH                ${JAVA_HOME}/bin:${SCALA_HOME}/bin:${SPARK_HOME}/bin:${PATH}
+ENV PATH                ${JAVA_HOME}/bin:${SPARK_HOME}/bin:${PATH}
 
 RUN apt-get update --fix-missing && \
     env DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y tzdata apt-utils wget unzip patch zip
@@ -33,11 +29,6 @@ RUN wget $JDK_URL && \
     rm jdk-$JDK_VERSION-linux-x64.tar && \
     mv /opt/jdk* /opt/jdk$JDK_VERSION && \
     ln -s /opt/jdk$JDK_VERSION /opt/jdk
-
-# scala
-RUN cd / && wget -c https://downloads.lightbend.com/scala/${SCALA_VERSION}/scala-${SCALA_VERSION}.tgz && \
-    (cd / && gunzip < scala-${SCALA_VERSION}.tgz)|(cd /opt && tar -xvf -) && \
-    rm /scala-${SCALA_VERSION}.tgz
 
 # spark
 RUN cd /opt && \
@@ -57,13 +48,10 @@ RUN cd /home && \
 FROM ubuntu:18.04
 ARG EHSM_KMS_BRANCH_VERSION=main
 ARG SPARK_VERSION
-ARG SCALA_VERSION
 ENV SPARK_VERSION       ${SPARK_VERSION}
-ENV SCALA_VERSION       ${SCALA_VERSION}
 ENV JAVA_HOME           /opt/jdk8
-ENV SCALA_HOME          /opt/scala-${SCALA_VERSION}
 ENV SPARK_HOME          /opt/spark-${SPARK_VERSION}
-ENV PATH                ${JAVA_HOME}/bin:${SCALA_HOME}/bin:${SPARK_HOME}/bin:${PATH}
+ENV PATH                ${JAVA_HOME}/bin:${SPARK_HOME}/bin:${PATH}
 
 # Step 1. Install requirement tools
 RUN apt-get update && apt-get install -y vim autoconf automake build-essential cmake curl debhelper git libcurl4-openssl-dev libprotobuf-dev libssl-dev libtool lsb-release ocaml ocamlbuild protobuf-compiler python wget libcurl4 libprotobuf10 libssl1.1 make module-init-tools g++ libjsoncpp-dev uuid-dev openjdk-8-jdk && \
@@ -87,7 +75,6 @@ RUN apt-get update && apt-get install -y vim autoconf automake build-essential c
 
 ADD ./entrypoint.sh /home/entrypoint.sh
 COPY --from=builder /opt/jdk /opt/jdk8
-COPY --from=builder /opt/scala-${SCALA_VERSION} /opt/scala-${SCALA_VERSION}
 COPY --from=builder /opt/spark-${SPARK_VERSION} /opt/spark-${SPARK_VERSION}
 COPY --from=builder /home/spark-encrypt-io.jar /home/spark-encrypt-io.jar
 

--- a/ppml/services/kms-utils/docker/Dockerfile
+++ b/ppml/services/kms-utils/docker/Dockerfile
@@ -40,10 +40,6 @@ RUN cd /opt && \
     cp spark-${SPARK_VERSION}/conf/log4j.properties.template spark-${SPARK_VERSION}/conf/log4j.properties && \
     echo $'\nlog4j.logger.io.netty=ERROR' >> spark-${SPARK_VERSION}/conf/log4j.properties
 
-# spark-encrypt-io.jar
-RUN cd /home && \
-    wget $SPARK_JAR_REPO_URL/spark-encrypt-io-0.2-SNAPSHOT.jar -O spark-encrypt-io.jar
-
 
 # stage.2 bigdl
 FROM ubuntu:18.04 as bigdl
@@ -93,7 +89,6 @@ RUN apt-get update && apt-get install -y vim autoconf automake build-essential c
 ADD ./entrypoint.sh /home/entrypoint.sh
 COPY --from=builder /opt/jdk /opt/jdk8
 COPY --from=builder /opt/spark-${SPARK_VERSION} /opt/spark-${SPARK_VERSION}
-COPY --from=builder /home/spark-encrypt-io.jar /home/spark-encrypt-io.jar
 COPY --from=bigdl /bigdl-${BIGDL_VERSION} ${BIGDL_HOME}
 
 # python

--- a/ppml/services/kms-utils/docker/Dockerfile
+++ b/ppml/services/kms-utils/docker/Dockerfile
@@ -15,7 +15,6 @@ ARG JDK_URL=your_jdk_url
 ARG SPARK_JAR_REPO_URL
 ENV JDK_VERSION         ${JDK_VERSION}
 ENV SPARK_VERSION       ${SPARK_VERSION}
-
 ENV JAVA_HOME           /opt/jdk${JDK_VERSION}
 ENV SPARK_HOME          /opt/spark-${SPARK_VERSION}
 ENV PATH                ${JAVA_HOME}/bin:${SPARK_HOME}/bin:${PATH}
@@ -47,7 +46,7 @@ ARG BIGDL_VERSION
 ARG SPARK_VERSION
 ENV SPARK_VERSION               ${SPARK_VERSION}
 ENV BIGDL_VERSION               ${BIGDL_VERSION}
-ENV BIGDL_HOME                  /bigdl-${BIGDL_VERSION}
+ENV BIGDL_HOME                  /opt/bigdl-${BIGDL_VERSION}
 RUN apt-get update --fix-missing && \
     apt-get install -y apt-utils curl wget unzip git
 RUN wget https://raw.githubusercontent.com/intel-analytics/analytics-zoo/bigdl-2.0/docker/hyperzoo/download-bigdl.sh && \
@@ -60,6 +59,8 @@ RUN ./download-bigdl.sh && \
 FROM ubuntu:18.04
 ARG EHSM_KMS_BRANCH_VERSION=main
 ARG SPARK_VERSION
+ARG BIGDL_VERSION
+ENV BIGDL_VERSION       ${BIGDL_VERSION}
 ENV SPARK_VERSION       ${SPARK_VERSION}
 ENV JAVA_HOME           /opt/jdk8
 ENV SPARK_HOME          /opt/spark-${SPARK_VERSION}
@@ -89,7 +90,7 @@ RUN apt-get update && apt-get install -y vim autoconf automake build-essential c
 ADD ./entrypoint.sh /home/entrypoint.sh
 COPY --from=builder /opt/jdk /opt/jdk8
 COPY --from=builder /opt/spark-${SPARK_VERSION} /opt/spark-${SPARK_VERSION}
-COPY --from=bigdl /bigdl-${BIGDL_VERSION} ${BIGDL_HOME}
+COPY --from=bigdl   ${BIGDL_HOME} ${BIGDL_HOME}
 
 # python
 RUN apt-get install -y python3-minimal && \

--- a/ppml/services/kms-utils/docker/Dockerfile
+++ b/ppml/services/kms-utils/docker/Dockerfile
@@ -82,7 +82,7 @@ RUN apt-get update --fix-missing && \
 # DCAP repository setup
     wget https://download.01.org/intel-sgx/sgx-dcap/1.12.1/linux/distro/ubuntu20.04-server/sgx_debian_local_repo.tgz && \
     tar xzf sgx_debian_local_repo.tgz && \
-    echo 'deb [trusted=yes arch=amd64] file:///opt/intel/sgx_debian_local_repo bionic main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
+    echo 'deb [trusted=yes arch=amd64] file:///opt/intel/sgx_debian_local_repo focal main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
     wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - && \
     apt-get update --fix-missing && \
     apt-get install -y libsgx-enclave-common-dev libsgx-ae-qe3 libsgx-ae-qve libsgx-urts libsgx-dcap-ql libsgx-dcap-default-qpl libsgx-dcap-quote-verify-dev libsgx-dcap-default-qpl-dev libsgx-quote-ex-dev libsgx-uae-service libsgx-ra-network libsgx-ra-uefi libsgx-dcap-ql-dev && \

--- a/ppml/services/kms-utils/docker/Dockerfile
+++ b/ppml/services/kms-utils/docker/Dockerfile
@@ -1,23 +1,80 @@
-FROM ubuntu:20.04
-
-ARG EHSM_KMS_BRANCH_VERSION=main
-ARG SPARK_JAR_REPO_URL
 ARG HTTP_PROXY_HOST
 ARG HTTP_PROXY_PORT
 ARG HTTPS_PROXY_HOST
 ARG HTTPS_PROXY_PORT
+ARG JDK_VERSION=8u192
+ARG SPARK_VERSION=3.1.2
+ARG SCALA_VERSION=2.12.10
+
+# stage.1 java & scala & spark
+FROM ubuntu:18.04 AS builder
+
+ARG SPARK_VERSION
+ARG SCALA_VERSION
+ARG JDK_VERSION
+ARG JDK_URL=your_jdk_url
+ARG SPARK_JAR_REPO_URL
+ENV JDK_VERSION         ${JDK_VERSION}
+ENV SPARK_VERSION       ${SPARK_VERSION}
+ENV SCALA_VERSION       ${SCALA_VERSION}
+
+ENV JAVA_HOME           /opt/jdk${JDK_VERSION}
+ENV SCALA_HOME          /opt/scala-${SCALA_VERSION}
+ENV SPARK_HOME          /opt/spark-${SPARK_VERSION}
+ENV PATH                ${JAVA_HOME}/bin:${SCALA_HOME}/bin:${SPARK_HOME}/bin:${PATH}
+
+RUN apt-get update --fix-missing && \
+    env DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y tzdata apt-utils wget unzip patch zip
+
+# java
+RUN wget $JDK_URL && \
+    gunzip jdk-$JDK_VERSION-linux-x64.tar.gz && \
+    tar -xf jdk-$JDK_VERSION-linux-x64.tar -C /opt && \
+    rm jdk-$JDK_VERSION-linux-x64.tar && \
+    mv /opt/jdk* /opt/jdk$JDK_VERSION && \
+    ln -s /opt/jdk$JDK_VERSION /opt/jdk
+
+# scala
+RUN cd / && wget -c https://downloads.lightbend.com/scala/${SCALA_VERSION}/scala-${SCALA_VERSION}.tgz && \
+    (cd / && gunzip < scala-${SCALA_VERSION}.tgz)|(cd /opt && tar -xvf -) && \
+    rm /scala-${SCALA_VERSION}.tgz
+
+# spark
+RUN cd /opt && \
+    wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.2.tgz && \
+    tar -zxvf spark-${SPARK_VERSION}-bin-hadoop3.2.tgz && \
+    mv spark-${SPARK_VERSION}-bin-hadoop3.2 spark-${SPARK_VERSION} && \
+    rm spark-${SPARK_VERSION}-bin-hadoop3.2.tgz && \
+    cp spark-${SPARK_VERSION}/conf/log4j.properties.template spark-${SPARK_VERSION}/conf/log4j.properties && \
+    echo $'\nlog4j.logger.io.netty=ERROR' >> spark-${SPARK_VERSION}/conf/log4j.properties
+
+# spark-encrypt-io.jar
+RUN cd /home && \
+    wget $SPARK_JAR_REPO_URL/spark-encrypt-io-0.2-SNAPSHOT.jar -O spark-encrypt-io.jar
+
+
+# stage.2 kms-util
+FROM ubuntu:18.04
+ARG EHSM_KMS_BRANCH_VERSION=main
+ARG SPARK_VERSION
+ARG SCALA_VERSION
+ENV SPARK_VERSION       ${SPARK_VERSION}
+ENV SCALA_VERSION       ${SCALA_VERSION}
+ENV JAVA_HOME           /opt/jdk8
+ENV SCALA_HOME          /opt/scala-${SCALA_VERSION}
+ENV SPARK_HOME          /opt/spark-${SPARK_VERSION}
+ENV PATH                ${JAVA_HOME}/bin:${SCALA_HOME}/bin:${SPARK_HOME}/bin:${PATH}
 
 # Step 1. Install requirement tools
 RUN apt-get update && apt-get install -y vim autoconf automake build-essential cmake curl debhelper git libcurl4-openssl-dev libprotobuf-dev libssl-dev libtool lsb-release ocaml ocamlbuild protobuf-compiler python wget libcurl4 libprotobuf10 libssl1.1 make module-init-tools g++ libjsoncpp-dev uuid-dev openjdk-8-jdk && \
 # Step 2. Install Intel SGX SDK
     mkdir /opt/intel && cd /opt/intel && \
-    wget https://download.01.org/intel-sgx/sgx-dcap/1.13/linux/distro/ubuntu20.04-server/sgx_linux_x64_sdk_2.16.100.4.bin && \
-    chmod a+x ./sgx_linux_x64_sdk_2.16.100.4.bin && \
-    printf "no\n/opt/intel\n"|./sgx_linux_x64_sdk_2.16.100.4.bin && \
-    . /opt/intel/sgxsdk/environment && \
+    wget https://download.01.org/intel-sgx/sgx-dcap/1.12.1/linux/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.15.101.1.bin && \
+    chmod 777 sgx_linux_x64_sdk_2.15.101.1.bin && \
+    sh -c 'echo yes | ./sgx_linux_x64_sdk_2.15.101.1.bin' && \
 # Step 3. Install DCAP packages and set PCCS
 # DCAP repository setup
-    wget https://download.01.org/intel-sgx/sgx-dcap/1.12.1/linux/distro/ubuntu20.04-server/sgx_debian_local_repo.tgz && \
+    wget https://download.01.org/intel-sgx/sgx-dcap/1.12.1/linux/distro/ubuntu18.04-server/sgx_debian_local_repo.tgz && \
     tar xzf sgx_debian_local_repo.tgz && \
     echo 'deb [trusted=yes arch=amd64] file:///opt/intel/sgx_debian_local_repo bionic main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
     wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - && \
@@ -25,21 +82,19 @@ RUN apt-get update && apt-get install -y vim autoconf automake build-essential c
     apt-get install -y libsgx-enclave-common-dev libsgx-ae-qe3 libsgx-ae-qve libsgx-urts libsgx-dcap-ql libsgx-dcap-default-qpl libsgx-dcap-quote-verify-dev libsgx-dcap-default-qpl-dev libsgx-quote-ex-dev libsgx-uae-service libsgx-ra-network libsgx-ra-uefi libsgx-dcap-ql-dev && \
 # Step 4. Build enroll app from source
     cd /home && \
-    git clone -b $EHSM_KMS_BRANCH_VERSION https://github.com/analytics-zoo/ehsm.git && cd ehsm && wget https://download.01.org/intel-sgx/sgx-linux/2.16/as.ld.objdump.r4.tar.gz && tar -zxf as.ld.objdump.r4.tar.gz && cp external/toolset/ubuntu20.04/* /usr/local/bin && make && cd out/ehsm-kms_enroll_app && ls ehsm-kms_enroll_app && \
-# Step 5. Prepare bigdl ppml e2e environment
-# scala
-    cd /home && \
-    wget $SPARK_JAR_REPO_URL/spark-encrypt-io-0.2-SNAPSHOT.jar && \
-    mv spark-encrypt-io-0.2-SNAPSHOT.jar spark-encrypt-io.jar
+    git clone -b $EHSM_KMS_BRANCH_VERSION https://github.com/analytics-zoo/ehsm.git && cd ehsm && wget https://download.01.org/intel-sgx/sgx-linux/2.16/as.ld.objdump.r4.tar.gz && tar -zxf as.ld.objdump.r4.tar.gz && cp external/toolset/ubuntu18.04/* /usr/local/bin && make && cd out/ehsm-kms_enroll_app && ls ehsm-kms_enroll_app
+
 
 ADD ./entrypoint.sh /home/entrypoint.sh
-ADD ./pyspark-encrypt-io /home/pyspark-encrypt-io
+COPY --from=builder /opt/jdk /opt/jdk8
+COPY --from=builder /opt/scala-${SCALA_VERSION} /opt/scala-${SCALA_VERSION}
+COPY --from=builder /opt/spark-${SPARK_VERSION} /opt/spark-${SPARK_VERSION}
+COPY --from=builder /home/spark-encrypt-io.jar /home/spark-encrypt-io.jar
 
 # python
 RUN apt-get install -y python3-minimal && \
     apt-get install -y build-essential python3 python3-setuptools python3-dev python3-pip && \
     pip3 install --upgrade pip && \
-    pip install setuptools==58.4.0 && \
-    pip install -r /home/pyspark-encrypt-io/src/bigdl/ppml/kms/requirement.yml
+    pip install setuptools==58.4.0
 
 CMD ["sh", "sleep 10s"]

--- a/ppml/services/kms-utils/docker/Dockerfile
+++ b/ppml/services/kms-utils/docker/Dockerfile
@@ -70,6 +70,7 @@ ENV PATH                ${JAVA_HOME}/bin:${SPARK_HOME}/bin:${PATH}
 
 # Step 1. Install requirement tools
 RUN apt-get update --fix-missing && \
+    env DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y tzdata && \
     apt-get install -y vim autoconf automake build-essential cmake curl debhelper git libcurl4-openssl-dev libprotobuf-dev libssl-dev libtool lsb-release ocaml ocamlbuild protobuf-compiler python wget libcurl4 libprotobuf17 libssl1.1 make kmod g++ libjsoncpp-dev uuid-dev openjdk-8-jdk && \
 # Step 2. Install Intel SGX SDK
     mkdir /opt/intel && cd /opt/intel && \

--- a/ppml/services/kms-utils/docker/Dockerfile
+++ b/ppml/services/kms-utils/docker/Dockerfile
@@ -20,7 +20,8 @@ ENV SPARK_HOME          /opt/spark-${SPARK_VERSION}
 ENV PATH                ${JAVA_HOME}/bin:${SPARK_HOME}/bin:${PATH}
 
 RUN apt-get update --fix-missing && \
-    env DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y tzdata apt-utils wget unzip patch zip
+    env DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y tzdata && \
+    apt-get install -y apt-utils wget unzip patch zip
 
 # java
 RUN wget $JDK_URL && \
@@ -68,7 +69,8 @@ ENV BIGDL_HOME          /opt/bigdl-${BIGDL_VERSION}
 ENV PATH                ${JAVA_HOME}/bin:${SPARK_HOME}/bin:${PATH}
 
 # Step 1. Install requirement tools
-RUN apt-get update && apt-get install -y vim autoconf automake build-essential cmake curl debhelper git libcurl4-openssl-dev libprotobuf-dev libssl-dev libtool lsb-release ocaml ocamlbuild protobuf-compiler python wget libcurl4 libprotobuf17 libssl1.1 make kmod g++ libjsoncpp-dev uuid-dev openjdk-8-jdk && \
+RUN apt-get update --fix-missing && \
+    apt-get install -y vim autoconf automake build-essential cmake curl debhelper git libcurl4-openssl-dev libprotobuf-dev libssl-dev libtool lsb-release ocaml ocamlbuild protobuf-compiler python wget libcurl4 libprotobuf17 libssl1.1 make kmod g++ libjsoncpp-dev uuid-dev openjdk-8-jdk && \
 # Step 2. Install Intel SGX SDK
     mkdir /opt/intel && cd /opt/intel && \
     wget https://download.01.org/intel-sgx/sgx-dcap/1.13/linux/distro/ubuntu20.04-server/sgx_linux_x64_sdk_2.16.100.4.bin && \
@@ -81,7 +83,7 @@ RUN apt-get update && apt-get install -y vim autoconf automake build-essential c
     tar xzf sgx_debian_local_repo.tgz && \
     echo 'deb [trusted=yes arch=amd64] file:///opt/intel/sgx_debian_local_repo bionic main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
     wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - && \
-    apt-get update && \
+    apt-get update --fix-missing && \
     apt-get install -y libsgx-enclave-common-dev libsgx-ae-qe3 libsgx-ae-qve libsgx-urts libsgx-dcap-ql libsgx-dcap-default-qpl libsgx-dcap-quote-verify-dev libsgx-dcap-default-qpl-dev libsgx-quote-ex-dev libsgx-uae-service libsgx-ra-network libsgx-ra-uefi libsgx-dcap-ql-dev && \
 # Step 4. Build enroll app from source
     cd /home && \

--- a/ppml/services/kms-utils/docker/Dockerfile
+++ b/ppml/services/kms-utils/docker/Dockerfile
@@ -7,7 +7,7 @@ ARG SPARK_VERSION=3.1.2
 ARG BIGDL_VERSION=2.1.0-SNAPSHOT
 
 # stage.1 java & spark
-FROM ubuntu:18.04 AS builder
+FROM ubuntu:20.04 AS builder
 
 ARG SPARK_VERSION
 ARG JDK_VERSION
@@ -41,7 +41,7 @@ RUN cd /opt && \
 
 
 # stage.2 bigdl
-FROM ubuntu:18.04 as bigdl
+FROM ubuntu:20.04 as bigdl
 ARG BIGDL_VERSION
 ARG SPARK_VERSION
 ENV SPARK_VERSION               ${SPARK_VERSION}
@@ -56,7 +56,7 @@ RUN ./download-bigdl.sh && \
 
 
 # stage.3 kms-util
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG EHSM_KMS_BRANCH_VERSION=main
 ARG SPARK_VERSION
 ARG BIGDL_VERSION
@@ -68,7 +68,7 @@ ENV BIGDL_HOME          /opt/bigdl-${BIGDL_VERSION}
 ENV PATH                ${JAVA_HOME}/bin:${SPARK_HOME}/bin:${PATH}
 
 # Step 1. Install requirement tools
-RUN apt-get update && apt-get install -y vim autoconf automake build-essential cmake curl debhelper git libcurl4-openssl-dev libprotobuf-dev libssl-dev libtool lsb-release ocaml ocamlbuild protobuf-compiler python wget libcurl4 libprotobuf10 libssl1.1 make module-init-tools g++ libjsoncpp-dev uuid-dev openjdk-8-jdk && \
+RUN apt-get update && apt-get install -y vim autoconf automake build-essential cmake curl debhelper git libcurl4-openssl-dev libprotobuf-dev libssl-dev libtool lsb-release ocaml ocamlbuild protobuf-compiler python wget libcurl4 libprotobuf17 libssl1.1 make kmod g++ libjsoncpp-dev uuid-dev openjdk-8-jdk && \
 # Step 2. Install Intel SGX SDK
     mkdir /opt/intel && cd /opt/intel && \
     wget https://download.01.org/intel-sgx/sgx-dcap/1.12.1/linux/distro/ubuntu18.04-server/sgx_linux_x64_sdk_2.15.101.1.bin && \

--- a/ppml/services/kms-utils/docker/Dockerfile
+++ b/ppml/services/kms-utils/docker/Dockerfile
@@ -47,6 +47,8 @@ RUN cd /opt && \
     wget -P ${SPARK_HOME}/jars/ https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.17.1/log4j-core-2.17.1.jar && \
     wget -P ${SPARK_HOME}/jars/ https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/2.17.1/log4j-slf4j-impl-2.17.1.jar
     
+ADD https://raw.githubusercontent.com/intel-analytics/BigDL/main/docker/bigdl-k8s/log4j2.xml ${SPARK_HOME}/conf/log4j2.xml
+
 
 # stage.2 bigdl
 FROM ubuntu:20.04 as bigdl

--- a/ppml/services/kms-utils/docker/Dockerfile
+++ b/ppml/services/kms-utils/docker/Dockerfile
@@ -4,6 +4,7 @@ ARG HTTPS_PROXY_HOST
 ARG HTTPS_PROXY_PORT
 ARG JDK_VERSION=8u192
 ARG SPARK_VERSION=3.1.2
+ARG BIGDL_VERSION=2.1.0-SNAPSHOT
 
 # stage.1 java & spark
 FROM ubuntu:18.04 AS builder
@@ -44,13 +45,29 @@ RUN cd /home && \
     wget $SPARK_JAR_REPO_URL/spark-encrypt-io-0.2-SNAPSHOT.jar -O spark-encrypt-io.jar
 
 
-# stage.2 kms-util
+# stage.2 bigdl
+FROM ubuntu:18.04 as bigdl
+ARG BIGDL_VERSION
+ARG SPARK_VERSION
+ENV SPARK_VERSION               ${SPARK_VERSION}
+ENV BIGDL_VERSION               ${BIGDL_VERSION}
+ENV BIGDL_HOME                  /bigdl-${BIGDL_VERSION}
+RUN apt-get update --fix-missing && \
+    apt-get install -y apt-utils curl wget unzip git
+RUN wget https://raw.githubusercontent.com/intel-analytics/analytics-zoo/bigdl-2.0/docker/hyperzoo/download-bigdl.sh && \
+    chmod a+x ./download-bigdl.sh
+RUN ./download-bigdl.sh && \
+    rm bigdl*.zip
+
+
+# stage.3 kms-util
 FROM ubuntu:18.04
 ARG EHSM_KMS_BRANCH_VERSION=main
 ARG SPARK_VERSION
 ENV SPARK_VERSION       ${SPARK_VERSION}
 ENV JAVA_HOME           /opt/jdk8
 ENV SPARK_HOME          /opt/spark-${SPARK_VERSION}
+ENV BIGDL_HOME          /opt/bigdl-${BIGDL_VERSION}
 ENV PATH                ${JAVA_HOME}/bin:${SPARK_HOME}/bin:${PATH}
 
 # Step 1. Install requirement tools
@@ -77,6 +94,7 @@ ADD ./entrypoint.sh /home/entrypoint.sh
 COPY --from=builder /opt/jdk /opt/jdk8
 COPY --from=builder /opt/spark-${SPARK_VERSION} /opt/spark-${SPARK_VERSION}
 COPY --from=builder /home/spark-encrypt-io.jar /home/spark-encrypt-io.jar
+COPY --from=bigdl /bigdl-${BIGDL_VERSION} ${BIGDL_HOME}
 
 # python
 RUN apt-get install -y python3-minimal && \

--- a/ppml/services/kms-utils/docker/Dockerfile
+++ b/ppml/services/kms-utils/docker/Dockerfile
@@ -37,9 +37,16 @@ RUN cd /opt && \
     tar -zxvf spark-${SPARK_VERSION}-bin-hadoop3.2.tgz && \
     mv spark-${SPARK_VERSION}-bin-hadoop3.2 spark-${SPARK_VERSION} && \
     rm spark-${SPARK_VERSION}-bin-hadoop3.2.tgz && \
-    cp spark-${SPARK_VERSION}/conf/log4j.properties.template spark-${SPARK_VERSION}/conf/log4j.properties && \
-    echo $'\nlog4j.logger.io.netty=ERROR' >> spark-${SPARK_VERSION}/conf/log4j.properties
-
+    # remove log4j 1.x jars
+    rm -f ${SPARK_HOME}/jars/log4j-1.2.17.jar && \
+    rm -f ${SPARK_HOME}/jars/slf4j-log4j12-1.7.16.jar && \
+    rm -f ${SPARK_HOME}/jars/apache-log4j-extras-1.2.17.jar && \
+    wget -P ${SPARK_HOME}/jars/ https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-1.2-api/2.17.1/log4j-1.2-api-2.17.1.jar && \
+    wget -P ${SPARK_HOME}/jars/ https://repo1.maven.org/maven2/org/slf4j/slf4j-reload4j/1.7.35/slf4j-reload4j-1.7.35.jar && \
+    wget -P ${SPARK_HOME}/jars/ https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.17.1/log4j-api-2.17.1.jar && \
+    wget -P ${SPARK_HOME}/jars/ https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.17.1/log4j-core-2.17.1.jar && \
+    wget -P ${SPARK_HOME}/jars/ https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/2.17.1/log4j-slf4j-impl-2.17.1.jar
+    
 
 # stage.2 bigdl
 FROM ubuntu:20.04 as bigdl

--- a/ppml/services/kms-utils/docker/build-docker-image.sh
+++ b/ppml/services/kms-utils/docker/build-docker-image.sh
@@ -7,7 +7,6 @@ export SPARK_JAR_REPO_URL=your_spark_jar_repo_url
 export ENROLL_IMAGE_VERSION=latest
 export ENROLL_IMAGE_NAME=bigdl-ppml-e2e-enroll
 
-cp -r ../../pyspark-encrypt-io/ ./
 
 sudo docker build \
     --no-cache=true \
@@ -19,5 +18,3 @@ sudo docker build \
     --build-arg HTTPS_PROXY_PORT=${HTTPS_PROXY_PORT} \
     --build-arg SPARK_JAR_REPO_URL=${SPARK_JAR_REPO_URL} \
     -t $ENROLL_IMAGE_NAME:$ENROLL_IMAGE_VERSION -f ./Dockerfile .
-
-rm -r ./pyspark-encrypt-io

--- a/ppml/services/kms-utils/docker/entrypoint.sh
+++ b/ppml/services/kms-utils/docker/entrypoint.sh
@@ -89,7 +89,7 @@ elif [ "$action" = "encrypt" ]; then
                 --primaryKeyPath /home/key/simple_encrypted_primary_key \
                 --dataKeyPath /home/key/simple_encrypted_data_key \
                 --kmsType AzureKeyManagementService \
-		        --vaultName $keyVaultName
+		--vaultName $keyVaultName
 	else
 		echo "Wrong KMS_TYPE! KMS_TYPE can be (1) ehsm, (2) simple, (3) azure"
                 return -1
@@ -157,8 +157,8 @@ elif [ "$action" = "decrypt" ]; then
 		--inputPath $input_path \
 		--inputPartitionNum 8 \
 		--outputPartitionNum 8 \
-		--inputCryptoModeValue AES/CBC/PKCS5Padding \
-		--outputCryptoModeValue plain_text \
+		--inputEncryptModeValue AES/CBC/PKCS5Padding \
+		--outputEncryptModeValue plain_text \
 		--primaryKeyPath /home/key/ehsm_encrypted_primary_key \
 		--dataKeyPath /home/key/ehsm_encrypted_data_key \
 		--kmsType EHSMKeyManagementService \
@@ -175,8 +175,8 @@ elif [ "$action" = "decrypt" ]; then
                 --inputPath $input_path \
                 --inputPartitionNum 8 \
                 --outputPartitionNum 8 \
-                --inputCryptoModeValue AES/CBC/PKCS5Padding \
-                --outputCryptoModeValue plain_text \
+                --inputEncryptModeValue AES/CBC/PKCS5Padding \
+                --outputEncryptModeValue plain_text \
                 --primaryKeyPath /home/key/simple_encrypted_primary_key \
                 --dataKeyPath /home/key/simple_encrypted_data_key \
                 --kmsType SimpleKeyManagementService \
@@ -190,8 +190,8 @@ elif [ "$action" = "decrypt" ]; then
                 --inputPath $input_path \
                 --inputPartitionNum 8 \
                 --outputPartitionNum 8 \
-                --inputCryptoModeValue AES/CBC/PKCS5Padding \
-                --outputCryptoModeValue plain_text \
+                --inputEncryptModeValue AES/CBC/PKCS5Padding \
+                --outputEncryptModeValue plain_text \
                 --primaryKeyPath /home/key/simple_encrypted_primary_key \
                 --dataKeyPath /home/key/simple_encrypted_data_key \
                 --kmsType AzureKeyManagementService \

--- a/ppml/services/kms-utils/docker/entrypoint.sh
+++ b/ppml/services/kms-utils/docker/entrypoint.sh
@@ -22,7 +22,7 @@ elif [ "$action" = "generatekeys" ]; then
 	if [ "$KMS_TYPE" = "ehsm" ]; then
 	    appid=$2
 	    appkey=$3
-		java -cp /home/spark-encrypt-io.jar \
+		java -cp $BIGDL_HOME/jars/bigdl-ppml-spark_3.1.2-2.1.0-SNAPSHOT.jar:$SPARK_HOME/jars/*:$SPARK_HOME/examples/jars/*:$BIGDL_HOME/jars/* \
 		com.intel.analytics.bigdl.ppml.examples.GenerateKeys \
 		--primaryKeyPath /home/key/ehsm_encrypted_primary_key \
 		--dataKeyPath /home/key/ehsm_encrypted_data_key \
@@ -34,7 +34,7 @@ elif [ "$action" = "generatekeys" ]; then
 	elif [ "$KMS_TYPE" = "simple" ]; then
 	    appid=$2
 	    appkey=$3
-		java -cp /home/spark-encrypt-io.jar \
+		java -cp $BIGDL_HOME/jars/bigdl-ppml-spark_3.1.2-2.1.0-SNAPSHOT.jar:$SPARK_HOME/jars/*:$SPARK_HOME/examples/jars/*:$BIGDL_HOME/jars/* \
 		com.intel.analytics.bigdl.ppml.examples.GenerateKeys \
 		--primaryKeyPath /home/key/simple_encrypted_primary_key \
 		--dataKeyPath /home/key/simple_encrypted_data_key \
@@ -43,7 +43,7 @@ elif [ "$action" = "generatekeys" ]; then
 		--simpleAPPKEY $appkey
 	elif [ "$KMS_TYPE" = "azure" ]; then
 	    keyVaultName=$2
-		java -cp /home/spark-encrypt-io.jar \
+		java -cp $BIGDL_HOME/jars/bigdl-ppml-spark_3.1.2-2.1.0-SNAPSHOT.jar:$SPARK_HOME/jars/*:$SPARK_HOME/examples/jars/*:$BIGDL_HOME/jars/* \
 		com.intel.analytics.bigdl.ppml.examples.GenerateKeys \
 		--primaryKeyPath /home/key/simple_encrypted_primary_key \
 		--dataKeyPath /home/key/simple_encrypted_data_key \
@@ -60,7 +60,7 @@ elif [ "$action" = "encrypt" ]; then
 	if [ "$KMS_TYPE" = "ehsm" ]; then
 	    appid=$2
 	    appkey=$3
-		java -cp /home/spark-encrypt-io.jar \
+		java -cp $BIGDL_HOME/jars/bigdl-ppml-spark_3.1.2-2.1.0-SNAPSHOT.jar:$SPARK_HOME/jars/*:$SPARK_HOME/examples/jars/*:$BIGDL_HOME/jars/* \
 		com.intel.analytics.bigdl.ppml.examples.Encrypt \
 		--inputPath $input_path \
 		--primaryKeyPath /home/key/ehsm_encrypted_primary_key \
@@ -73,7 +73,7 @@ elif [ "$action" = "encrypt" ]; then
 	elif [ "$KMS_TYPE" = "simple" ]; then
 	    appid=$2
 	    appkey=$3
-		java -cp /home/spark-encrypt-io.jar \
+		java -cp $BIGDL_HOME/jars/bigdl-ppml-spark_3.1.2-2.1.0-SNAPSHOT.jar:$SPARK_HOME/jars/*:$SPARK_HOME/examples/jars/*:$BIGDL_HOME/jars/* \
 		com.intel.analytics.bigdl.ppml.examples.Encrypt \
                 --inputPath $input_path \
                 --primaryKeyPath /home/key/simple_encrypted_primary_key \
@@ -83,7 +83,7 @@ elif [ "$action" = "encrypt" ]; then
                 --simpleAPPKEY $appkey
     elif [ "$KMS_TYPE" = "azure" ]; then
         keyVaultName=$2
-		java -cp /home/spark-encrypt-io.jar \
+		java -cp $BIGDL_HOME/jars/bigdl-ppml-spark_3.1.2-2.1.0-SNAPSHOT.jar:$SPARK_HOME/jars/*:$SPARK_HOME/examples/jars/*:$BIGDL_HOME/jars/* \
 		com.intel.analytics.bigdl.ppml.examples.Encrypt \
                 --inputPath $input_path \
                 --primaryKeyPath /home/key/simple_encrypted_primary_key \
@@ -100,7 +100,7 @@ elif [ "$action" = "splitandencrypt" ]; then
             appkey=$3
 	    input_path=$4
 	    output_path=$input_path.encrypted
-		java -cp /home/spark-encrypt-io.jar \
+		java -cp $BIGDL_HOME/jars/bigdl-ppml-spark_3.1.2-2.1.0-SNAPSHOT.jar:$SPARK_HOME/jars/*:$SPARK_HOME/examples/jars/*:$BIGDL_HOME/jars/* \
 		com.intel.analytics.bigdl.ppml.examples.SplitAndEncrypt   \
 		--inputPath $input_path \
 		--outputPath $output_path \
@@ -118,7 +118,7 @@ elif [ "$action" = "splitandencrypt" ]; then
         appkey=$3
 	    input_path=$4
 	    output_path=$input_path.encrypted
-		java -cp /home/spark-encrypt-io.jar \
+		java -cp $BIGDL_HOME/jars/bigdl-ppml-spark_3.1.2-2.1.0-SNAPSHOT.jar:$SPARK_HOME/jars/*:$SPARK_HOME/examples/jars/*:$BIGDL_HOME/jars/* \
 		com.intel.analytics.bigdl.ppml.examples.SplitAndEncrypt   \
 		--inputPath $input_path \
                 --outputPath $output_path \
@@ -133,7 +133,7 @@ elif [ "$action" = "splitandencrypt" ]; then
         keyVaultName=$2
         input_path=$3
 	    output_path=$input_path.encrypted
-		java -cp /home/spark-encrypt-io.jar \
+		java -cp $BIGDL_HOME/jars/bigdl-ppml-spark_3.1.2-2.1.0-SNAPSHOT.jar:$SPARK_HOME/jars/*:$SPARK_HOME/examples/jars/*:$BIGDL_HOME/jars/* \
 		com.intel.analytics.bigdl.ppml.examples.SplitAndEncrypt   \
 		--inputPath $input_path \
                 --outputPath $output_path \
@@ -152,7 +152,7 @@ elif [ "$action" = "decrypt" ]; then
 	appid=$2
         appkey=$3
         input_path=$4
-		java -cp /home/spark-encrypt-io.jar \
+		java -cp $BIGDL_HOME/jars/bigdl-ppml-spark_3.1.2-2.1.0-SNAPSHOT.jar:$SPARK_HOME/jars/*:$SPARK_HOME/examples/jars/*:$BIGDL_HOME/jars/* \
 		com.intel.analytics.bigdl.ppml.examples.Decrypt \
 		--inputPath $input_path \
 		--inputPartitionNum 8 \
@@ -170,7 +170,7 @@ elif [ "$action" = "decrypt" ]; then
 	appid=$2
         appkey=$3
         input_path=$4
-		java -cp /home/spark-encrypt-io.jar \
+		java -cp $BIGDL_HOME/jars/bigdl-ppml-spark_3.1.2-2.1.0-SNAPSHOT.jar:$SPARK_HOME/jars/*:$SPARK_HOME/examples/jars/*:$BIGDL_HOME/jars/* \
 		com.intel.analytics.bigdl.ppml.examples.Decrypt \
                 --inputPath $input_path \
                 --inputPartitionNum 8 \
@@ -185,7 +185,7 @@ elif [ "$action" = "decrypt" ]; then
     elif [ "$KMS_TYPE" = "azure" ]; then
         keyVaultName=$2
         input_path=$3
-		java -cp /home/spark-encrypt-io.jar \
+		java -cp $BIGDL_HOME/jars/bigdl-ppml-spark_3.1.2-2.1.0-SNAPSHOT.jar:$SPARK_HOME/jars/*:$SPARK_HOME/examples/jars/*:$BIGDL_HOME/jars/* \
 		com.intel.analytics.bigdl.ppml.examples.Decrypt \
                 --inputPath $input_path \
                 --inputPartitionNum 8 \

--- a/ppml/services/kms-utils/docker/entrypoint.sh
+++ b/ppml/services/kms-utils/docker/entrypoint.sh
@@ -94,59 +94,6 @@ elif [ "$action" = "encrypt" ]; then
 		echo "Wrong KMS_TYPE! KMS_TYPE can be (1) ehsm, (2) simple, (3) azure"
                 return -1
         fi
-elif [ "$action" = "splitandencrypt" ]; then
-	if [ "$KMS_TYPE" = "ehsm" ]; then
-	    appid=$2
-            appkey=$3
-	    input_path=$4
-	    output_path=$input_path.encrypted
-		java -cp $BIGDL_HOME/jars/bigdl-ppml-spark_3.1.2-2.1.0-SNAPSHOT.jar:$SPARK_HOME/jars/*:$SPARK_HOME/examples/jars/*:$BIGDL_HOME/jars/* \
-		com.intel.analytics.bigdl.ppml.examples.SplitAndEncrypt   \
-		--inputPath $input_path \
-		--outputPath $output_path \
-		--outputPartitionNum 4 \
-		--outputCryptoModeValue AES/CBC/PKCS5Padding \
-		--primaryKeyPath /home/key/ehsm_encrypted_primary_key \
-		--dataKeyPath /home/key/ehsm_encrypted_data_key \
-		--kmsType EHSMKeyManagementService \
-		--kmsServerIP $EHSM_KMS_IP \
-                --kmsServerPort $EHSM_KMS_PORT \
-                --ehsmAPPID $appid \
-                --ehsmAPPKEY $appkey
-	elif [ "$KMS_TYPE" = "simple" ]; then
-	    appid=$2
-        appkey=$3
-	    input_path=$4
-	    output_path=$input_path.encrypted
-		java -cp $BIGDL_HOME/jars/bigdl-ppml-spark_3.1.2-2.1.0-SNAPSHOT.jar:$SPARK_HOME/jars/*:$SPARK_HOME/examples/jars/*:$BIGDL_HOME/jars/* \
-		com.intel.analytics.bigdl.ppml.examples.SplitAndEncrypt   \
-		--inputPath $input_path \
-                --outputPath $output_path \
-                --outputPartitionNum 4 \
-                --outputCryptoModeValue AES/CBC/PKCS5Padding \
-                --primaryKeyPath /home/key/simple_encrypted_primary_key \
-                --dataKeyPath /home/key/simple_encrypted_data_key \
-		--kmsType SimpleKeyManagementService \
-                --simpleAPPID $appid \
-                --simpleAPPKEY $appkey
-    elif [ "$KMS_TYPE" = "azure" ]; then
-        keyVaultName=$2
-        input_path=$3
-	    output_path=$input_path.encrypted
-		java -cp $BIGDL_HOME/jars/bigdl-ppml-spark_3.1.2-2.1.0-SNAPSHOT.jar:$SPARK_HOME/jars/*:$SPARK_HOME/examples/jars/*:$BIGDL_HOME/jars/* \
-		com.intel.analytics.bigdl.ppml.examples.SplitAndEncrypt   \
-		--inputPath $input_path \
-                --outputPath $output_path \
-                --outputPartitionNum 4 \
-                --outputCryptoModeValue AES/CBC/PKCS5Padding \
-                --primaryKeyPath /home/key/simple_encrypted_primary_key \
-                --dataKeyPath /home/key/simple_encrypted_data_key \
-		--kmsType AzureKeyManagementService \
-                --vaultName $keyVaultName
-	else
-                echo "Wrong KMS_TYPE! KMS_TYPE can be (1) ehsm, (2) simple, (3) azure"
-                return -1
-        fi
 elif [ "$action" = "decrypt" ]; then
 	if [ "$KMS_TYPE" = "ehsm" ]; then
 	appid=$2
@@ -201,5 +148,5 @@ elif [ "$action" = "decrypt" ]; then
                 return -1
         fi
 else
-	echo "Wrong action! Action can be (1) enroll, (2) generatekeys, (3) encrypt, (4) decrypt, and (5) splitandencrypt."
+	echo "Wrong action! Action can be (1) enroll, (2) generatekeys, (3) encrypt, (4) decrypt."
 fi

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/utils/HTTPUtil.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/utils/HTTPUtil.scala
@@ -27,7 +27,7 @@ object HTTPUtil {
   def postRequest(url: String, postString: String): JSONObject = {
     val response: String = retrieveResponse(url, postString)
     val jsonObj: JSONObject = new JSONObject(response)
-    val result: JSONObject = new JSONObject(jsonObj.getString("result"))
+    val result: JSONObject = jsonObj.getJSONObject("result")
     result
   }
 


### PR DESCRIPTION
This submission 
- install Java and Spark and bigdl in kms-util image so that ppml jar can be invoked to generate keys and encrypt/decrypt.
- remove pyspark-encrypt-io and spark-encrypt-io.jar from kms-util image
- update java classpath in ppml/services/kms-utils/docker/entrypoint.sh
- replace package module-init-tools with kmod, [kmod](https://launchpad.net/ubuntu/focal/amd64/kmod) replaces module-init-tools in Focal (20.04)
- replace package libprotobuf10 with libprotobuf17 since [libprotobuf10](https://packages.ubuntu.com/bionic/libprotobuf10) is only available in bionic (18.04LTS), [libprotobuf17](https://packages.ubuntu.com/focal/libprotobuf17) is for focal (20.04LTS)

Testing
- I build a new kms-util image and start a docker container. Enroll, key generation and encrypt/decrypt are tested in kms-util container.
- The new kms-util image is already pushed to 10.239.45.10/arda/intelanalytics/kms-utils:0.3.0