### PR TITLE
delete servlet-api in dllib's pom

### DIFF
--- a/scala/dllib/pom.xml
+++ b/scala/dllib/pom.xml
@@ -110,12 +110,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.11.4</version>


### PR DESCRIPTION
BigDL's init commit by yiheng. We can delete the direct dependency in our pom.
Then it will be a dependency of spark-core.