### PR TITLE
fix: parsing jsonObject error

### DIFF
--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/utils/HTTPUtil.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/utils/HTTPUtil.scala
@@ -27,7 +27,7 @@ object HTTPUtil {
   def postRequest(url: String, postString: String): JSONObject = {
     val response: String = retrieveResponse(url, postString)
     val jsonObj: JSONObject = new JSONObject(response)
-    val result: JSONObject = new JSONObject(jsonObj.getString("result"))
+    val result: JSONObject = jsonObj.getJSONObject("result")
     result
   }
 


### PR DESCRIPTION
This submission is to fix the error `JSONObject["result"] is not a string.`
<img width="1086" alt="Annotation 2022-06-30 090027" src="https://user-images.githubusercontent.com/61072813/176621898-c66d3d56-ead8-4f87-ae2b-3a2e6f8de3e1.png">
