### PR TITLE
fix issues of `save_checkpoint` and test it more strictly

### DIFF
--- a/python/nano/notebooks/pytorch/cifar10/nano-trainer-example.ipynb
+++ b/python/nano/notebooks/pytorch/cifar10/nano-trainer-example.ipynb
@@ -1355,7 +1355,7 @@
    "source": [
     "model = LitResnet(learning_rate=0.05)\n",
     "model.datamodule = data_module\n",
-    "checkpoint_callback = ModelCheckpoint(dirpath=\"checkpoints/\", save_top_k=1, monitor=\"val_loss\", filename=\"renet18_single_ipex\", save_weights_only=True)\n",
+    "checkpoint_callback = ModelCheckpoint(dirpath=\"checkpoints/\", save_top_k=1, monitor=\"val_loss\", filename=\"renet18_single_ipex\", save_weights_only=False)\n",
     "single_ipex_trainer = Trainer(num_processes=1,\n",
     "                        use_ipex = True,\n",
     "                        distributed_backend=\"subprocess\",\n",
@@ -2160,7 +2160,7 @@
    "source": [
     "model = LitResnet(learning_rate=0.1, batch_size=64)\n",
     "model.datamodule = data_module\n",
-    "checkpoint_callback = ModelCheckpoint(dirpath=\"checkpoints/\", save_top_k=1, monitor=\"val_loss\", filename=\"renet18_multi_ipex\", save_weights_only=True)\n",
+    "checkpoint_callback = ModelCheckpoint(dirpath=\"checkpoints/\", save_top_k=1, monitor=\"val_loss\", filename=\"renet18_multi_ipex\", save_weights_only=False)\n",
     "multi_ipex_trainer = Trainer(num_processes=2,\n",
     "                       use_ipex=True,\n",
     "                       distributed_backend=\"subprocess\",\n",

--- a/python/nano/notebooks/pytorch/cifar10/nano-trainer-example.ipynb
+++ b/python/nano/notebooks/pytorch/cifar10/nano-trainer-example.ipynb
@@ -1355,7 +1355,7 @@
    "source": [
     "model = LitResnet(learning_rate=0.05)\n",
     "model.datamodule = data_module\n",
-    "checkpoint_callback = ModelCheckpoint(dirpath=\"checkpoints/\", save_top_k=1, monitor=\"val_loss\", filename=\"renet18_single_ipex\", save_weights_only=False)\n",
+    "checkpoint_callback = ModelCheckpoint(dirpath=\"checkpoints/\", save_top_k=1, monitor=\"val_loss\", filename=\"renet18_single_ipex\", save_weights_only=True)\n",
     "single_ipex_trainer = Trainer(num_processes=1,\n",
     "                        use_ipex = True,\n",
     "                        distributed_backend=\"subprocess\",\n",
@@ -2160,7 +2160,7 @@
    "source": [
     "model = LitResnet(learning_rate=0.1, batch_size=64)\n",
     "model.datamodule = data_module\n",
-    "checkpoint_callback = ModelCheckpoint(dirpath=\"checkpoints/\", save_top_k=1, monitor=\"val_loss\", filename=\"renet18_multi_ipex\", save_weights_only=False)\n",
+    "checkpoint_callback = ModelCheckpoint(dirpath=\"checkpoints/\", save_top_k=1, monitor=\"val_loss\", filename=\"renet18_multi_ipex\", save_weights_only=True)\n",
     "multi_ipex_trainer = Trainer(num_processes=2,\n",
     "                       use_ipex=True,\n",
     "                       distributed_backend=\"subprocess\",\n",

--- a/python/nano/src/bigdl/nano/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/pytorch/utils.py
@@ -19,3 +19,4 @@ from pytorch_lightning.utilities.imports import _compare_version
 
 TORCH_VERSION_LESS_1_10 = _compare_version("torch", operator.lt, "1.10")
 TORCH_VERSION_LESS_1_11 = _compare_version("torch", operator.lt, "1.11")
+LIGHTNING_VERSION_LESS_1_6 = _compare_version("pytorch_lightning", operator.lt, "1.6")

--- a/python/nano/test/pytorch/tests/test_trainer_ipex.py
+++ b/python/nano/test/pytorch/tests/test_trainer_ipex.py
@@ -1,0 +1,71 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import os
+from unittest import TestCase
+
+import pytest
+import torch
+from torch.optim.lr_scheduler import OneCycleLR
+from test.pytorch.utils._train_torch_lightning import create_data_loader, data_transform
+from torch import nn
+
+from bigdl.nano.pytorch import Trainer
+from bigdl.nano.pytorch.vision.models import vision
+
+batch_size = 256
+max_epochs = 2
+num_workers = 0
+data_dir = os.path.join(os.path.dirname(__file__), "../data")
+
+
+class ResNet18(nn.Module):
+    def __init__(self, num_classes, pretrained=True, include_top=False, freeze=True):
+        super().__init__()
+        backbone = vision.resnet18(pretrained=pretrained, include_top=include_top, freeze=freeze)
+        output_size = backbone.get_output_size()
+        head = nn.Linear(output_size, num_classes)
+        self.model = nn.Sequential(backbone, head)
+
+    def forward(self, x):
+        return self.model(x)
+
+
+class TestTrainer(TestCase):
+    model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
+    train_loader = create_data_loader(data_dir, batch_size, num_workers, data_transform)
+    loss = nn.CrossEntropyLoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+    scheduler_dict = {
+        "scheduler": OneCycleLR(
+                optimizer,
+                0.1,
+                epochs=max_epochs,
+                steps_per_epoch=len(train_loader),
+            ),
+        "interval": "step",
+    }
+
+    def test_trainer_save_checkpoint(self):
+        # `save_checkpoint` may report an error when using ipex 1.9 and custom lr_scheduler
+        trainer = Trainer(max_epochs=max_epochs, use_ipex=True)
+        pl_model = Trainer.compile(self.model, self.loss, self.optimizer, self.scheduler_dict)
+        trainer.fit(pl_model, self.train_loader)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
When using ipex==1.9 and custom lr_schedulers for training, if set `weights_only` to False,`save_checkpoint` method will report an error of 'Unsupport storage type' because the model is in 'xpu', so we temporarily move it to 'cpu', then move it back after `save_checkpoint`.