### PR TITLE
Fix pom for build on Spark3.2.1

### DIFF
--- a/scala/orca/src/main/scala/com/intel/analytics/bigdl/orca/utils/PythonInterpreter.scala
+++ b/scala/orca/src/main/scala/com/intel/analytics/bigdl/orca/utils/PythonInterpreter.scala
@@ -18,7 +18,6 @@ package com.intel.analytics.bigdl.orca.utils
 import java.util.concurrent.{ExecutorService, Executors, ThreadFactory}
 
 import jep.{JepConfig, JepException, NamingConventionClassEnquirer, SharedInterpreter}
-import org.apache.commons.lang.exception.ExceptionUtils
 import org.apache.logging.log4j.LogManager
 
 import scala.concurrent.{Await, ExecutionContext, Future}

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -122,7 +122,7 @@
         <maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>
         <maven-site-plugin.version>3.4</maven-site-plugin.version>
         <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
-        <maven-assembly-plugin.version>2.4</maven-assembly-plugin.version>
+        <maven-assembly-plugin.version>2.5</maven-assembly-plugin.version>
         <maven-dependency-plugin.version>2.8</maven-dependency-plugin.version>
         <maven-javadoc-plugin.version>2.10.1</maven-javadoc-plugin.version>
         <apache-rat-plugin.version>0.10</apache-rat-plugin.version>


### PR DESCRIPTION
1. assembly plugin 2.4 will have the following error:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.4:assembly (make-dist-all) on project bigdl-assembly-spark_3.2.1: Execution make-dist-all of goal org.apache.maven.plugins:maven-assembly-plugin:2.4:assembly failed: invalid entry size -> [Help 1]
```
2. `import org.apache.commons.lang.exception.ExceptionUtils` will throw import error for spark 3.2.1, but this import is unnecessary, just removed.

bash make_dist.sh -Dspark.version=3.2.1 -P spark_3.x