### PR TITLE
Nano: Display Nano tensorflow APIs on website

### DIFF
--- a/docs/readthedocs/source/doc/PythonAPI/Nano/index.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Nano/index.rst
@@ -8,6 +8,12 @@ Nano API
 
 
 .. toctree::
+    :maxdepth: 2
+    
+    tensorflow.rst
+
+
+.. toctree::
     :maxdepth: 3
 
     hpo_api.rst

--- a/docs/readthedocs/source/doc/PythonAPI/Nano/tensorflow.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Nano/tensorflow.rst
@@ -1,0 +1,14 @@
+Nano Tensorflow API
+==================
+
+bigdl.nano.tf.keras
+---------------------------
+
+.. autoclass:: bigdl.nano.tf.keras.Model
+    :members: fit, quantize, trace
+    :undoc-members:
+
+.. autoclass:: bigdl.nano.tf.keras.Sequential
+    :members:
+    :undoc-members:
+    :inherited-members: Sequential

--- a/python/nano/src/bigdl/nano/tf/keras/Model.py
+++ b/python/nano/src/bigdl/nano/tf/keras/Model.py
@@ -21,4 +21,5 @@ from bigdl.nano.tf.keras.inheritance_utils import inject_function
 
 
 # override_method(Model, TFModel, f_wrapper)
+Model.__doc__ = 'A wrapper class for tf.keras.Model adding more functions for BigDL-Nano.'
 inject_function(Model, TrainingUtils, InferenceUtils)


### PR DESCRIPTION
Add tensorflow.rst and change bigdl.nano.tensorflow.keras.Model's docstring.
