### PR TITLE
Chronos: fix tsdataset.roll/to_torch_data_loader(time_enc=True) freq check bug

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/utils/time_feature.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/time_feature.py
@@ -121,30 +121,30 @@ def time_features_from_frequency_str(offset) -> List[TimeFeature]:
     """
 
     features_by_offsets = (
-        (Timedelta(seconds=1), [
+        (Timedelta(seconds=60), [
             SecondOfMinute,
             MinuteOfHour,
             HourOfDay,
             DayOfWeek,
             DayOfMonth,
             DayOfYear]),
-        (Timedelta(minutes=1), [
+        (Timedelta(minutes=60), [
             MinuteOfHour,
             HourOfDay,
             DayOfWeek,
             DayOfMonth,
             DayOfYear,
         ]),
-        (Timedelta(hours=1), [HourOfDay, DayOfWeek, DayOfMonth, DayOfYear]),
-        (Timedelta(days=1), [DayOfWeek, DayOfMonth, DayOfYear]),
-        (Timedelta(days=7), [DayOfMonth, WeekOfYear]),
-        (Timedelta(days=30), [MonthOfYear]),
-        (Timedelta(days=365), [])
+        (Timedelta(hours=24), [HourOfDay, DayOfWeek, DayOfMonth, DayOfYear]),
+        (Timedelta(days=7), [DayOfWeek, DayOfMonth, DayOfYear]),
+        (Timedelta(days=30), [DayOfMonth, WeekOfYear]),
+        (Timedelta(days=365), [MonthOfYear]),
     )
 
     for offset_type, feature_classes in features_by_offsets:
-        if offset <= offset_type:
+        if offset < offset_type:
             return [cls() for cls in feature_classes]
+    return []  # freq larger than 1 year
 
 
 def time_features(dates, freq='h'):

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -62,6 +62,9 @@ class AutoformerForecaster(Forecaster):
         :param future_seq_len: Specify the output time steps (i.e. horizon).
         :param input_feature_num: Specify the feature dimension.
         :param output_feature_num: Specify the output dimension.
+        :param label_len: Start token length of AutoFormer decoder.
+        :param freq: Freq for time features encoding. You may choose from "s",
+               "t","h","d","w","m" for second, minute, hour, day, week or month.
         :param optimizer: Specify the optimizer used for training. This value
                defaults to "Adam".
         :param loss: str or pytorch loss instance, Specify the loss function

--- a/python/chronos/test/bigdl/chronos/data/test_tsdataset.py
+++ b/python/chronos/test/bigdl/chronos/data/test_tsdataset.py
@@ -64,9 +64,9 @@ def get_ugly_ts_df():
     return df
 
 
-def get_int_target_df():
+def get_int_target_df(freq="D"):
     sample_num = np.random.randint(100, 200)
-    train_df = pd.DataFrame({"datetime": pd.date_range('1/1/2019', periods=sample_num),
+    train_df = pd.DataFrame({"datetime": pd.date_range('1/1/2019', periods=sample_num, freq=freq),
                              "value": np.array(sample_num),
                              "id": np.array(['00']*sample_num),
                              "extra feature": np.random.randn(sample_num)})
@@ -355,15 +355,16 @@ class TestTSDataset(ZooTestCase):
     def test_tsdata_roll_timeenc(self):
         horizon = random.randint(1, 9)
         lookback = random.randint(10, 20)
-        df = get_int_target_df()
-        tsdata = TSDataset.from_pandas(df, dt_col='datetime', target_col='value', id_col="id")
-        x, y, x_time, y_time =\
-            tsdata.roll(lookback=lookback, horizon=horizon,
-                        time_enc=True, label_len=lookback-horizon).to_numpy()
-        assert x.shape[1:] == (lookback, 1)
-        assert y.shape[1:] == (lookback, 1)
-        assert x_time.shape[1:] == (lookback, 3)
-        assert y_time.shape[1:] == (lookback, 3)
+        for freq in ["D", "2D"]:
+            df = get_int_target_df(freq=freq)
+            tsdata = TSDataset.from_pandas(df, dt_col='datetime', target_col='value', id_col="id")
+            x, y, x_time, y_time =\
+                tsdata.roll(lookback=lookback, horizon=horizon,
+                            time_enc=True, label_len=lookback-horizon).to_numpy()
+            assert x.shape[1:] == (lookback, 1)
+            assert y.shape[1:] == (lookback, 1)
+            assert x_time.shape[1:] == (lookback, 3)
+            assert y_time.shape[1:] == (lookback, 3)
 
     def test_tsdata_roll_timeenc_predict(self):
         horizon = 10


### PR DESCRIPTION
**1. What is the change?**
This pr changes the policy to generate time encoding features when users call `time_enc=True` in `tsdataset.roll` and `tsdataset.to_torch_data_loader`

**2. Why the change?**
Bug report from customer. We found that the original policy (generate time features "smaller or equal" to the frequency) has some issue when it comes to some specific frequencies.
e.g. when freq is 2h, the original policy will not generate "hour of day" feature, which is wrong.

**3. Summary of the change (interface and design)**
interface is not changed in this bug fix, it remains
```python
# tsdata is a TSDataset
dataloader = tsdata.to_torch_data_loader(..., time_enc=True, ...)
data = tsdata.roll(..., time_enc=True, ...)
```

**4. Link for the design**
Not Applied

**5. How to test?**
- [x] use data with different freq to test the time enc dim