### PR TITLE
Chronos: fix seed setting in autoformer

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -143,6 +143,10 @@ class AutoformerForecaster(Forecaster):
         self.quantize_available = False
         self.use_amp = False
 
+        # seed setting
+        from pytorch_lightning import seed_everything
+        seed_everything(seed=self.seed)
+
         self.model_creator = model_creator
         self.internal = model_creator(self.model_config)
 
@@ -162,10 +166,6 @@ class AutoformerForecaster(Forecaster):
                if you input a pytorch dataloader for `data`, the batch_size will follow the
                batch_size setted in `data`.
         """
-        # seed setting
-        from pytorch_lightning import seed_everything
-        seed_everything(seed=self.seed)
-
         # distributed is not supported.
         if self.distributed:
             invalidInputError(False, "distributed is not support in Autoformer")

--- a/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
@@ -68,6 +68,22 @@ class TestChronosModelTCNForecaster(TestCase):
         evaluate = forecaster.evaluate(self.val_loader)
         pred = forecaster.predict(self.test_loader)
 
+    def test_autoformer_forecaster_seed(self):
+        evaluate_list = []
+        for i in range(2):
+            forecaster = AutoformerForecaster(past_seq_len=24,
+                                            future_seq_len=5,
+                                            input_feature_num=2,
+                                            output_feature_num=2,
+                                            label_len=12,
+                                            freq='s',
+                                            seed=0)
+            forecaster.fit(self.train_loader, epochs=3, batch_size=32)
+            evaluate = forecaster.evaluate(self.val_loader)
+            pred = forecaster.predict(self.test_loader)
+            evaluate_list.append(evaluate)
+        assert evaluate_list[0][0]['val_loss'] == evaluate_list[1][0]['val_loss']
+
     def test_autoformer_forecaster_save_load(self):
         forecaster = AutoformerForecaster(past_seq_len=24,
                                           future_seq_len=5,


### PR DESCRIPTION
**1. What is the change?**
In this PR, seed is set before model's initialization, to make it effective.

**2. Why the change?**
seed parameter is not effective for autoformer model

**3. Summary of the change (interface and design)**
interface is not changed in this bug fix, it remains the same

**4. Link for the design**
Not Applied

**5. How to test?**
- [x] try test the seed in ut if possible