### PR TITLE
Add ray backend for pytorch_lightning 1.6

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/strategies/ray/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ray/__init__.py
@@ -14,7 +14,4 @@
 # limitations under the License.
 #
 
-from .ipex.ipex_api import create_IPEXStrategy
-from .ddp_spawn import DDPSpawnStrategy
-from .ddp_subprocess import DDPSubprocessStrategy
-from .ray import RayStrategy
+from .ray_distributed import RayStrategy

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ray/ray_distributed.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ray/ray_distributed.py
@@ -1,0 +1,410 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This file is adapted from ray_lightning. https://github.com/ray-project/ray_lightning
+# Copyright 2021 Ray Lightning Author
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from shutil import move
+import warnings
+from typing import Callable, Dict, List, Union, Any, Optional
+from collections import defaultdict
+
+import ray
+from ray.util.ml_utils.util import find_free_port
+
+import torch
+from torch import Tensor
+import pytorch_lightning as pl
+from pytorch_lightning.core.datamodule import LightningDataModule
+from pytorch_lightning.trainer.states import TrainerFn
+from pytorch_lightning.utilities import rank_zero_only
+from pytorch_lightning.utilities.apply_func import move_data_to_device
+from pytorch_lightning.utilities.distributed import ReduceOp
+from pytorch_lightning.strategies.launchers import _SpawnLauncher
+from pytorch_lightning.strategies import DDPSpawnStrategy
+
+from .ray_envbase import RayEnvironment
+from bigdl.nano.utils.log4Error import invalidInputError
+from bigdl.nano.pytorch.strategies.ipex.ipex_api import ipex_device, ipex_optimize, \
+    create_IPEXAccelerator, to_cpu
+from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
+
+_STEP_OUTPUT_TYPE = Union[torch.Tensor, Dict[str, Any]]
+
+
+@ray.remote     # type: ignore
+class RayExecutor:
+    """A class to execute any arbitrary function remotely."""
+
+    def set_env_var(self, key: str, value: str):
+        """Set an environment variable with the provided values."""
+        if value is not None:
+            value = str(value)
+            os.environ[key] = value
+
+    def set_env_vars(self, keys: List[str], values: List[str]):
+        """Sets multiple env vars with the provided values."""
+        invalidInputError(len(keys) == len(values),
+                          "keys length doesn't mathcc values length")
+        for key, value in zip(keys, values):
+            self.set_env_var(key, value)
+
+    def get_env_vars(self, key: str):
+        """Return the specified environment variable."""
+        return os.environ[key]
+
+    def get_node_ip(self):
+        """Returns the IP address of the node that this Ray actor is on."""
+        return ray.util.get_node_ip_address()
+
+    def execute(self, fn: Callable, *args, **kwargs):
+        """Execute the provided function and return the result."""
+        return fn(*args, **kwargs)
+
+
+class _RayLauncher(_SpawnLauncher):
+
+    def __init__(self, strategy: 'RayStrategy') -> None:
+        self._strategy: RayStrategy = strategy
+
+    @property
+    def is_interactive_compatible(self) -> bool:
+        return False
+
+    def launch(self, function: Callable, *args: Any,
+               trainer: Optional["pl.Trainer"] = None, **kwargs: Any) -> Any:
+        # pytorch_lightning 1.6 uses this method to create child processes
+        invalidInputError(trainer is not None and self._strategy.cluster_environment is not None,
+                          'strategy.cluster_environment and trainer cannot be None')
+        invalidInputError(self._strategy.model is not None, "You must specify the model.")
+
+        strategy = self._strategy
+
+        # fix bug
+        # args[1] is dataloader, args[3] and args[4] is datamodule
+        if strategy.use_ipex and TORCH_VERSION_LESS_1_10:
+            if isinstance(args[1], LightningDataModule):
+                args[1].trainer = None
+            elif isinstance(args[3], LightningDataModule):
+                args[3].trainer = None
+            elif isinstance(args[4], LightningDataModule):
+                args[4].trainer = None
+
+        strategy._setup_env_vars()
+        strategy.global_to_local = strategy.get_local_ranks()   # type: ignore
+
+        torch_backend = os.getenv("PL_TORCH_DISTRIBUTED_BACKEND")
+        if torch_backend is None:
+            torch_backend = "nccl" if strategy.use_gpu else "gloo"
+        strategy._process_group_backend = torch_backend
+
+        futures = [
+            strategy.workers[i].execute.remote(
+                self._wrapping_function,
+                (i, trainer, function, args, kwargs)
+            )
+            for i in range(strategy.num_workers)
+        ]
+
+        results = ray.get(futures)  # type: ignore
+
+        # Get the results, checkpoint path, and model weights from worker 0.
+        results, best_path, state_dict = results[0]  # type: ignore
+        strategy._model.load_state_dict(state_dict)
+        strategy.lightning_module.trainer = trainer
+        strategy.lightning_module.trainer.checkpoint_callback.best_model_path = best_path
+
+        return results
+
+    @staticmethod
+    def _wrapping_function(args_pack: tuple) -> Any:   # type: ignore[override]
+        global_rank, trainer, function, args, kwargs = args_pack
+        strategy = trainer.strategy
+        invalidInputError(isinstance(strategy, RayStrategy), "expect ray strategy here")
+        invalidInputError(isinstance(strategy.cluster_environment, RayEnvironment),
+                          "expect ray environment here")
+
+        strategy.cluster_environment.set_global_rank(global_rank)
+        strategy.cluster_environment.set_remote_execution(True)
+
+        strategy._worker_setup(global_rank)
+        results = function(*args, **kwargs)
+
+        if trainer is not None:
+            results = strategy._launcher._collect_rank_zero_results(trainer, results)
+
+        if strategy.global_rank == 0:
+            if trainer.checkpoint_callback is not None:
+                return move_data_to_device(results, "cpu"), \
+                    trainer.checkpoint_callback.best_model_path, \
+                    move_data_to_device(strategy.lightning_module.state_dict(), "cpu")
+            else:
+                return move_data_to_device(results, "cpu"), \
+                    None, \
+                    move_data_to_device(strategy.lightning_module.state_dict(), "cpu")
+        else:
+            return None
+
+
+class RayStrategy(DDPSpawnStrategy):
+    """A DDP Strategy which uses ray as backend."""
+
+    strategy_name = "ray"
+
+    def __init__(self,
+                 num_workers: int = 1,
+                 num_cpus_per_worker: int = 1,
+                 use_gpu: bool = False,
+                 use_ipex: bool = False,
+                 enable_bf16: bool = False,
+                 init_hook: Callable = None,
+                 **ddp_kwargs: Any):
+        """Create a RayStrategy."""
+        # Unset MKL setting as bigdl.nano would give default values when init env.
+        # Running different programs may need different configurations.
+        # refer to https://analytics-zoo-doc.readthedocs.io/en/master/zoo.ray.html#
+        # zoo.ray.raycontext.RayServiceFuncGenerator
+        # Also KMP_AFFINITY may entangle something doing with ray._raylet.CoreWorker,
+        # which is invoked by ray.init and leads to stocking.
+        os.environ.pop("KMP_AFFINITY", None)
+        os.environ.pop("OMP_NUM_THREADS", None)
+
+        if not ray.is_initialized():    # type: ignore
+            print(ray.init())   # type: ignore
+
+        if use_ipex and TORCH_VERSION_LESS_1_10 and 'accelerator' not in ddp_kwargs:
+            super().__init__(accelerator=create_IPEXAccelerator(),
+                             parallel_devices=[],
+                             cluster_environment=RayEnvironment(world_size=num_workers),
+                             **ddp_kwargs)
+        else:
+            super().__init__(parallel_devices=[],
+                             cluster_environment=RayEnvironment(world_size=num_workers),
+                             **ddp_kwargs)
+
+        self.num_workers = num_workers
+        self.num_cpus_per_worker = num_cpus_per_worker
+        self.use_gpu = use_gpu
+        self.use_ipex = use_ipex
+        self.enable_bf16 = enable_bf16
+
+        invalidInputError(not self.use_gpu or not self.use_ipex,
+                          "You can not specify gpu and ipex at the same time.")
+
+        self.workers = self._create_worker()
+        self.init_hook = init_hook
+        self._local_rank = 0
+
+        if self.init_hook:
+            ray.get([w.execute.remote(self.init_hook) for w in self.workers])   # type: ignore
+
+    def _configure_launcher(self):
+        self._launcher = _RayLauncher(self)
+
+    def _create_worker(self):
+        """Creates Ray actor."""
+        from bigdl.nano.common.cpu_schedule import schedule_workers
+
+        cpu_procs = schedule_workers(self.num_workers)
+
+        workers = []
+        for i in range(self.num_workers):
+            worker = RayExecutor.options(
+                num_cpus=self.num_cpus_per_worker,
+                num_gpus=int(self.use_gpu)
+            ).remote()
+
+            KMP_AFFINITY_vars = f"granularity=fine,proclist"\
+                f"=[{','.join([str(i) for i in cpu_procs[i]])}],explicit"
+            ray.get(worker.set_env_var.remote("KMP_AFFINITY", KMP_AFFINITY_vars))
+            ray.get(worker.set_env_var.remote("OMP_NUM_THREADS", str(len(cpu_procs[i]))))
+
+            workers.append(worker)
+
+        return workers
+
+    def _setup_env_vars(self):
+        # Get rank 0 worker address and port for DDP connection.
+        os.environ["MASTER_ADDR"] = ray.get(
+            self.workers[0].get_node_ip.remote())
+        os.environ["MASTER_PORT"] = str(
+            ray.get(self.workers[0].execute.remote(find_free_port)))
+
+        # Set environment variables for remote workers.
+        keys = [
+            "PL_GLOBAL_SEED", "PL_TORCH_DISTRIBUTED_BACKEND",
+            "MASTER_ADDR", "MASTER_PORT"
+        ]
+        values = [os.getenv(k) for k in keys]
+        ray.get([w.set_env_vars.remote(keys, values) for w in self.workers])
+
+    def get_local_ranks(self):
+        """Creates a mapping of global ranks to local ranks."""
+        # Get the local ranks for all the workers and store as a dict.
+        # First get the IP address of each remote worker.
+        node_ips = ray.get([w.get_node_ip.remote() for w in self.workers])
+        rank_counter_dict = defaultdict(int)  # type: ignore
+        global_to_local = [None] * self.num_workers
+        for global_rank in range(self.num_workers):
+            ip = node_ips[global_rank]
+            global_to_local[global_rank] = rank_counter_dict[ip]
+            rank_counter_dict[ip] += 1
+        return global_to_local
+
+    def set_world_ranks(self, process_idx: int = 0):
+        """Set the appropriate rank attribues for the trainer."""
+        invalidInputError(self.cluster_environment is not None and isinstance(
+            self.cluster_environment, RayEnvironment), "expect ray environment here")
+        if self.cluster_environment.is_remote():    # type: ignore
+            self._local_rank = self.global_to_local[self.global_rank]   # type: ignore
+            self.cluster_environment.set_global_rank(self.global_rank)
+            self.cluster_environment.set_world_size(self.num_workers)
+            rank_zero_only.rank = self.cluster_environment.global_rank()  # type: ignore
+
+    def setup(self, trainer: "pl.Trainer") -> None:
+        """Setup the distributed environment of ray executor, we add ipex optimization here."""
+        self.accelerator.setup(trainer)
+
+        trainer_fn = trainer.state.fn
+        if trainer_fn == TrainerFn.FITTING:
+            if self._layer_sync:
+                self.model = self._layer_sync.apply(self.model)
+
+        self.setup_precision_plugin()
+
+        # `configure_ddp` will create a `DistributedDataParallel`, which has no
+        # `test_step` method in pytorch_lightning 1.6, which causes error when
+        # calling `trainer.test()`, so we call `configure_ddp` only when fitting
+        if trainer_fn == TrainerFn.FITTING:
+            self.configure_ddp()
+        else:
+            # when calling `trainer.test()`, the `model.training` won't be set to `False`,
+            # then the following `ipex_optimize()` will report an error,
+            # so we need to set it to `False` manuallay
+            self.model.training = False
+
+        if self.use_ipex and not TORCH_VERSION_LESS_1_10:
+            dtype = torch.bfloat16 if self.enable_bf16 else None
+            num_optimizers = len(self.optimizers)
+
+            if num_optimizers == 1:
+                optimizer = self.optimizers[0]
+                ipex_optimize(self.model, optimizer=optimizer, inplace=True, dtype=dtype)
+            elif num_optimizers == 0:
+                ipex_optimize(self.model, inplace=True, dtype=dtype)
+            else:
+                warnings.warn(f"IPEX currently only support single optimizers, "
+                              f"but got {num_optimizers}. Skip IPEX")
+
+        # some operations in `configure_ddp` do not support XPU,
+        # which is used by ipex==1.9, so we move this line here
+        self.model_to_device()
+
+    @property
+    def root_device(self):
+        """Return the root device."""
+        if self.use_ipex and TORCH_VERSION_LESS_1_10:
+            # Add ipex option.
+            return torch.device(ipex_device())
+        else:
+            return torch.device("cpu")
+
+    def determine_ddp_device_ids(self):
+        """Return the index of root device."""
+        # For ipex case, we also should not return any optional device id.
+        if self.root_device.type == "cpu" or self.root_device.type == "xpu":
+            return None
+        return [self.root_device.index]
+
+    @property
+    def distributed_sampler_kwargs(self):
+        """Returns the args to use for torch.data.DistributedSampler."""
+        distributed_sampler_kwargs = dict(
+            num_replicas=self.num_workers, rank=self.global_rank)
+        return distributed_sampler_kwargs
+
+    def reduce(self, tensor, group: Optional[Any] = None,   # type: ignore[override]
+               reduce_op: Union[ReduceOp, str] = "mean") -> Tensor:
+        """Reduces a tensor from several distributed processes to one aggregated tensor."""
+        # some operations in `super.reduce()` method do not support XPU,
+        # which will cause error when using ipex==1.9, however, these operations
+        # seems not necessary, so we just ignore these errors
+        try:
+            return super().reduce(tensor, group, reduce_op)
+        except Exception as _e:
+            return tensor
+
+    def training_step_end(self, output: _STEP_OUTPUT_TYPE) -> _STEP_OUTPUT_TYPE:
+        """
+        A hook to do something at the end of the train step.
+
+        For ipex xpu tensor do not support `tensor.storage()` right now,
+        which is a required operation by pytorch_lightning,
+        so just move output to cpu to store it, and move it back when doing backward.
+        """
+        if self.use_ipex and TORCH_VERSION_LESS_1_10:
+            output = to_cpu(output)
+
+        return super().training_step_end(output)
+
+    def test_step_end(self, output: Optional[_STEP_OUTPUT_TYPE]) -> \
+            Optional[_STEP_OUTPUT_TYPE]:
+        """
+        A hook to do something at the end of the test step.
+
+        :param output: the output of the test step
+        """
+        if self.use_ipex and TORCH_VERSION_LESS_1_10:
+            output = to_cpu(output)
+
+        return super().test_step_end(output)
+
+    def validation_step_end(self, output: Optional[_STEP_OUTPUT_TYPE]) -> \
+            Optional[_STEP_OUTPUT_TYPE]:
+        """
+        A hook to do something at the end of the validation step.
+
+        :param output: the output of the validation step
+        """
+        if self.use_ipex and TORCH_VERSION_LESS_1_10:
+            output = to_cpu(output)
+
+        return super().validation_step_end(output)
+
+    def backward(self,  # type: ignore
+                 closure_loss: torch.Tensor,
+                 *args,
+                 **kwargs) -> torch.Tensor:
+        """Moving back loss to xpu device."""
+        closure_loss = closure_loss.to(self.root_device)
+        return super().backward(
+            closure_loss,
+            *args,
+            **kwargs,
+        )

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ray/ray_envbase.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ray/ray_envbase.py
@@ -1,0 +1,102 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This file is adapted from ray_lightning. https://github.com/ray-project/ray_lightning
+# Copyright 2021 Ray Lightning Author
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from pytorch_lightning.plugins.environments import ClusterEnvironment
+from pytorch_lightning.utilities import rank_zero_only
+
+
+class RayEnvironment(ClusterEnvironment):
+    """Environment for PTL training on a Ray cluster."""
+
+    def __init__(self, world_size):
+        """Create a Ray environment."""
+        self.set_world_size(world_size)
+        self._global_rank = 0
+        self._is_remote = False
+        self._main_port = -1
+
+    @property
+    def creates_processes_externally(self) -> bool:
+        """Whether the environment creates the subprocesses or not."""
+        return False
+
+    @property
+    def main_address(self) -> str:
+        """The main address through which all processes connect and communicate."""
+        return os.environ.get("MASTER_ADDR", "127.0.0.1")
+
+    @property
+    def main_port(self) -> int:
+        """An open and configured port in the main node through which all processes communicate."""
+        if self._main_port == -1:
+            self._main_port = int(os.environ.get("MASTER_PORT", 0))
+        return self._main_port
+
+    @staticmethod
+    def detect() -> bool:
+        """Detects the environment settings and returns `True` if they match."""
+        return True
+
+    def world_size(self) -> int:
+        """The number of processes across all devices and nodes."""
+        return self._world_size
+
+    def set_world_size(self, size: int) -> None:
+        """Set world size."""
+        self._world_size = size
+
+    def global_rank(self) -> int:
+        """The rank (index) of the currently running process across all nodes and devices."""
+        return self._global_rank
+
+    def set_global_rank(self, rank: int) -> None:
+        """Set global rank."""
+        self._global_rank = rank
+        rank_zero_only.rank = rank  # type: ignore
+
+    def set_remote_execution(self, is_remote: bool) -> None:
+        """Set remote or not."""
+        self._is_remote = is_remote
+
+    def is_remote(self) -> bool:
+        """Whether execute the codes remotely."""
+        return self._is_remote
+
+    def local_rank(self) -> int:
+        """The rank (index) of the currently running process inside of the current node."""
+        return int(os.environ.get("LOCAL_RANK", 0))
+
+    def node_rank(self) -> int:
+        """The rank (index) of the node on which the current process runs."""
+        group_rank = os.environ.get("GROUP_RANK", 0)
+        return int(os.environ.get("NODE_RANK", group_rank))

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -160,6 +160,11 @@ class Trainer(pl.Trainer):
                                                      cpu_for_each_process=cpu_for_each_process,
                                                      use_ipex=self.use_ipex,
                                                      enable_bf16=enable_bf16)
+                elif distributed_backend == "ray":
+                    from bigdl.nano.pytorch.strategies import RayStrategy
+                    strategy = RayStrategy(num_workers=num_processes,
+                                           use_ipex=self.use_ipex,
+                                           enable_bf16=enable_bf16)
                 super().__init__(strategy=strategy, *args, **kwargs)
 
     @staticmethod


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `RayStrategy` for pytorch_lightning 1.6.4

## Why are the changes needed?

The api of pytorch_lihgtning 1.6 has changed a lot, we need to make these changes to keep the code working

## Please briefly describe the changes such as API changes and code design.

Add `RayStrategy` and `RayEnvironment`, which will be used when using pytorch_lightning 1.6 and ray backend

## Design Link

#4813 

## How was this patch tested?

unit tests and manual tests