### PR TITLE
Chronos: Add `is_main_process` method for `BasepytorchForecaster`

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -341,6 +341,7 @@ class BasePytorchForecaster(Forecaster):
             # This error is only triggered when the python interpreter starts additional processes.
             # num_process=1 and subprocess will be safely started in the main process,
             # so this error will not be triggered.
+            from bigdl.nano.utils.log4Error import invalidInputError
             invalidInputError(is_main_process(),
                               "Make sure new Python interpreters can "
                               "safely import the main module. ",

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -305,6 +305,7 @@ class BasePytorchForecaster(Forecaster):
                                      batch_size=batch_size)
         else:
             from bigdl.chronos.pytorch import TSTrainer as Trainer
+            from bigdl.nano.utils.log4Error import invalidInputError
 
             # numpy data shape checking
             if isinstance(data, tuple):
@@ -341,7 +342,7 @@ class BasePytorchForecaster(Forecaster):
             # This error is only triggered when the python interpreter starts additional processes.
             # num_process=1 and subprocess will be safely started in the main process,
             # so this error will not be triggered.
-            from bigdl.nano.utils.log4Error import invalidInputError
+
             invalidInputError(is_main_process(),
                               "Make sure new Python interpreters can "
                               "safely import the main module. ",

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -20,6 +20,7 @@ from bigdl.chronos.metric.forecast_metrics import Evaluator
 
 import numpy as np
 import warnings
+# Filter out useless Userwarnings
 warnings.filterwarnings('ignore', category=UserWarning, module='pytorch_lightning')
 warnings.filterwarnings('ignore', category=UserWarning, module='torch')
 import torch
@@ -340,12 +341,11 @@ class BasePytorchForecaster(Forecaster):
             # This error is only triggered when the python interpreter starts additional processes.
             # num_process=1 and subprocess will be safely started in the main process,
             # so this error will not be triggered.
-            main_process = is_main_process()
-            if not main_process:
-                invalidInputError("Make sure new Python interpreters can "
-                                  "safely import the main module, "
-                                  "you should use if __name__ == '__main__':, "
-                                  "otherwise performance will be degraded.")
+            invalidInputError(is_main_process(),
+                              "Make sure new Python interpreters can "
+                              "safely import the main module. ",
+                              fixMsg="you should use if __name__ == '__main__':, "
+                              "otherwise performance will be degraded.")
 
             self.trainer.fit(self.internal, data)
             self.fitted = True

--- a/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
@@ -53,8 +53,7 @@ class LSTMForecaster(BasePytorchForecaster):
                  seed=None,
                  distributed=False,
                  workers_per_node=1,
-                 distributed_backend="ray",
-                 local_distributed_backend="subprocess"):
+                 distributed_backend="ray"):
         """
         Build a LSTM Forecast Model.
 
@@ -90,11 +89,7 @@ class LSTMForecaster(BasePytorchForecaster):
                The value defaults to 1. The param is only effective when
                distributed is set to True.
         :param distributed_backend: str, select from "ray" or
-               "horovod". The value defaults to "ray", the distributed backend
-               will be used in the cluster.
-        :param local_distributed_backend: str, "spawn" or "subprocess",
-               The value defaults to "subprocess", the distributed backend
-               will be used mode selection for local multiprocess.
+               "horovod". The value defaults to "ray".
         """
         # config setting
         self.data_config = {
@@ -129,7 +124,7 @@ class LSTMForecaster(BasePytorchForecaster):
         # distributed settings
         self.distributed = distributed
         self.remote_distributed_backend = distributed_backend
-        self.local_distributed_backend = local_distributed_backend
+        self.local_distributed_backend = "subprocess"
         self.workers_per_node = workers_per_node
 
         # other settings

--- a/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
@@ -53,7 +53,8 @@ class LSTMForecaster(BasePytorchForecaster):
                  seed=None,
                  distributed=False,
                  workers_per_node=1,
-                 distributed_backend="ray"):
+                 remote_distributed_backend="ray",
+                 local_distributed_backend="subprocess"):
         """
         Build a LSTM Forecast Model.
 
@@ -88,8 +89,12 @@ class LSTMForecaster(BasePytorchForecaster):
         :param workers_per_node: int, the number of worker you want to use.
                The value defaults to 1. The param is only effective when
                distributed is set to True.
-        :param distributed_backend: str, select from "ray" or
-               "horovod". The value defaults to "ray".
+        :param remote_distributed_backend: str, select from "ray" or
+               "horovod". The value defaults to "ray", the distributed backend
+               will be used in the cluster.
+        :param local_distributed_backend: str, "spawn" or "subprocess",
+               The value defaults to "subprocess", the distributed backend
+               will be used mode selection for local multiprocess.
         """
         # config setting
         self.data_config = {
@@ -123,7 +128,8 @@ class LSTMForecaster(BasePytorchForecaster):
 
         # distributed settings
         self.distributed = distributed
-        self.distributed_backend = distributed_backend
+        self.remote_distributed_backend = remote_distributed_backend
+        self.local_distributed_backend = local_distributed_backend
         self.workers_per_node = workers_per_node
 
         # other settings

--- a/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
@@ -53,7 +53,7 @@ class LSTMForecaster(BasePytorchForecaster):
                  seed=None,
                  distributed=False,
                  workers_per_node=1,
-                 remote_distributed_backend="ray",
+                 distributed_backend="ray",
                  local_distributed_backend="subprocess"):
         """
         Build a LSTM Forecast Model.
@@ -89,7 +89,7 @@ class LSTMForecaster(BasePytorchForecaster):
         :param workers_per_node: int, the number of worker you want to use.
                The value defaults to 1. The param is only effective when
                distributed is set to True.
-        :param remote_distributed_backend: str, select from "ray" or
+        :param distributed_backend: str, select from "ray" or
                "horovod". The value defaults to "ray", the distributed backend
                will be used in the cluster.
         :param local_distributed_backend: str, "spawn" or "subprocess",
@@ -128,7 +128,7 @@ class LSTMForecaster(BasePytorchForecaster):
 
         # distributed settings
         self.distributed = distributed
-        self.remote_distributed_backend = remote_distributed_backend
+        self.remote_distributed_backend = distributed_backend
         self.local_distributed_backend = local_distributed_backend
         self.workers_per_node = workers_per_node
 

--- a/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
@@ -50,7 +50,8 @@ class NBeatsForecaster(BasePytorchForecaster):
                  seed=None,
                  distributed=False,
                  workers_per_node=1,
-                 distributed_backend="ray"):
+                 remote_distributed_backend="ray",
+                 local_distributed_backend="subprocess"):
         """
         Build a NBeats Forecaster Model.
 
@@ -97,8 +98,12 @@ class NBeatsForecaster(BasePytorchForecaster):
         :param workers_per_node: int, the number of worker you want to use.
                The value defaults to 1. The param is only effective when
                distributed is set to True.
-        :param distributed_backend: str, select from "ray" or
-               "horovod". The value defaults to "ray".
+        :param remote_distributed_backend: str, select from "ray" or
+               "horovod". The value defaults to "ray", the distributed backend
+               will be used in the cluster.
+        :param local_distributed_backend: str, "spawn" or "subprocess",
+               The value defaults to "subprocess", the distributed backend
+               will be used mode selection for local multiprocess.
         """
         # ("generic", "generic") not support orca distributed.
         if stack_types[-1] == "generic" and distributed:
@@ -145,7 +150,8 @@ class NBeatsForecaster(BasePytorchForecaster):
 
         # distributed settings
         self.distributed = distributed
-        self.distributed_backend = distributed_backend
+        self.remote_distributed_backend = remote_distributed_backend
+        self.local_distributed_backend = local_distributed_backend
         self.workers_per_node = workers_per_node
 
         # other settings

--- a/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
@@ -50,7 +50,7 @@ class NBeatsForecaster(BasePytorchForecaster):
                  seed=None,
                  distributed=False,
                  workers_per_node=1,
-                 remote_distributed_backend="ray",
+                 distributed_backend="ray",
                  local_distributed_backend="subprocess"):
         """
         Build a NBeats Forecaster Model.
@@ -98,7 +98,7 @@ class NBeatsForecaster(BasePytorchForecaster):
         :param workers_per_node: int, the number of worker you want to use.
                The value defaults to 1. The param is only effective when
                distributed is set to True.
-        :param remote_distributed_backend: str, select from "ray" or
+        :param distributed_backend: str, select from "ray" or
                "horovod". The value defaults to "ray", the distributed backend
                will be used in the cluster.
         :param local_distributed_backend: str, "spawn" or "subprocess",
@@ -150,7 +150,7 @@ class NBeatsForecaster(BasePytorchForecaster):
 
         # distributed settings
         self.distributed = distributed
-        self.remote_distributed_backend = remote_distributed_backend
+        self.remote_distributed_backend = distributed_backend
         self.local_distributed_backend = local_distributed_backend
         self.workers_per_node = workers_per_node
 

--- a/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
@@ -50,8 +50,7 @@ class NBeatsForecaster(BasePytorchForecaster):
                  seed=None,
                  distributed=False,
                  workers_per_node=1,
-                 distributed_backend="ray",
-                 local_distributed_backend="subprocess"):
+                 distributed_backend="ray"):
         """
         Build a NBeats Forecaster Model.
 
@@ -99,11 +98,7 @@ class NBeatsForecaster(BasePytorchForecaster):
                The value defaults to 1. The param is only effective when
                distributed is set to True.
         :param distributed_backend: str, select from "ray" or
-               "horovod". The value defaults to "ray", the distributed backend
-               will be used in the cluster.
-        :param local_distributed_backend: str, "spawn" or "subprocess",
-               The value defaults to "subprocess", the distributed backend
-               will be used mode selection for local multiprocess.
+               "horovod". The value defaults to "ray".
         """
         # ("generic", "generic") not support orca distributed.
         if stack_types[-1] == "generic" and distributed:
@@ -151,7 +146,7 @@ class NBeatsForecaster(BasePytorchForecaster):
         # distributed settings
         self.distributed = distributed
         self.remote_distributed_backend = distributed_backend
-        self.local_distributed_backend = local_distributed_backend
+        self.local_distributed_backend = "subprocess"
         self.workers_per_node = workers_per_node
 
         # other settings

--- a/python/chronos/src/bigdl/chronos/forecaster/seq2seq_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/seq2seq_forecaster.py
@@ -54,8 +54,7 @@ class Seq2SeqForecaster(BasePytorchForecaster):
                  seed=None,
                  distributed=False,
                  workers_per_node=1,
-                 distributed_backend="ray",
-                 local_distributed_backend="subprocess"):
+                 distributed_backend="ray"):
         """
         Build a Seq2Seq Forecast Model.
 
@@ -94,11 +93,7 @@ class Seq2SeqForecaster(BasePytorchForecaster):
                The value defaults to 1. The param is only effective when
                distributed is set to True.
         :param distributed_backend: str, select from "ray" or
-               "horovod". The value defaults to "ray", the distributed backend
-               will be used in the cluster.
-        :param local_distributed_backend: str, "spawn" or "subprocess",
-               The value defaults to "subprocess", the distributed backend
-               will be used mode selection for local multiprocess.
+               "horovod". The value defaults to "ray".
         """
         # config setting
         self.data_config = {
@@ -134,7 +129,7 @@ class Seq2SeqForecaster(BasePytorchForecaster):
         # distributed settings
         self.distributed = distributed
         self.remote_distributed_backend = distributed_backend
-        self.local_distributed_backend = local_distributed_backend
+        self.local_distributed_backend = "subprocess"
         self.workers_per_node = workers_per_node
 
         # other settings

--- a/python/chronos/src/bigdl/chronos/forecaster/seq2seq_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/seq2seq_forecaster.py
@@ -54,7 +54,8 @@ class Seq2SeqForecaster(BasePytorchForecaster):
                  seed=None,
                  distributed=False,
                  workers_per_node=1,
-                 distributed_backend="ray"):
+                 remote_distributed_backend="ray",
+                 local_distributed_backend="subprocess"):
         """
         Build a Seq2Seq Forecast Model.
 
@@ -92,8 +93,12 @@ class Seq2SeqForecaster(BasePytorchForecaster):
         :param workers_per_node: int, the number of worker you want to use.
                The value defaults to 1. The param is only effective when
                distributed is set to True.
-        :param distributed_backend: str, select from "ray" or
-               "horovod". The value defaults to "ray".
+        :param remote_distributed_backend: str, select from "ray" or
+               "horovod". The value defaults to "ray", the distributed backend
+               will be used in the cluster.
+        :param local_distributed_backend: str, "spawn" or "subprocess",
+               The value defaults to "subprocess", the distributed backend
+               will be used mode selection for local multiprocess.
         """
         # config setting
         self.data_config = {
@@ -128,7 +133,8 @@ class Seq2SeqForecaster(BasePytorchForecaster):
 
         # distributed settings
         self.distributed = distributed
-        self.distributed_backend = distributed_backend
+        self.remote_distributed_backend = remote_distributed_backend
+        self.local_distributed_backend = local_distributed_backend
         self.workers_per_node = workers_per_node
 
         # other settings

--- a/python/chronos/src/bigdl/chronos/forecaster/seq2seq_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/seq2seq_forecaster.py
@@ -54,7 +54,7 @@ class Seq2SeqForecaster(BasePytorchForecaster):
                  seed=None,
                  distributed=False,
                  workers_per_node=1,
-                 remote_distributed_backend="ray",
+                 distributed_backend="ray",
                  local_distributed_backend="subprocess"):
         """
         Build a Seq2Seq Forecast Model.
@@ -93,7 +93,7 @@ class Seq2SeqForecaster(BasePytorchForecaster):
         :param workers_per_node: int, the number of worker you want to use.
                The value defaults to 1. The param is only effective when
                distributed is set to True.
-        :param remote_distributed_backend: str, select from "ray" or
+        :param distributed_backend: str, select from "ray" or
                "horovod". The value defaults to "ray", the distributed backend
                will be used in the cluster.
         :param local_distributed_backend: str, "spawn" or "subprocess",
@@ -133,7 +133,7 @@ class Seq2SeqForecaster(BasePytorchForecaster):
 
         # distributed settings
         self.distributed = distributed
-        self.remote_distributed_backend = remote_distributed_backend
+        self.remote_distributed_backend = distributed_backend
         self.local_distributed_backend = local_distributed_backend
         self.workers_per_node = workers_per_node
 

--- a/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
@@ -55,8 +55,7 @@ class TCNForecaster(BasePytorchForecaster):
                  seed=None,
                  distributed=False,
                  workers_per_node=1,
-                 distributed_backend="ray",
-                 local_distributed_backend="subprocess"):
+                 distributed_backend="ray"):
         """
         Build a TCN Forecast Model.
 
@@ -100,11 +99,7 @@ class TCNForecaster(BasePytorchForecaster):
                The value defaults to 1. The param is only effective when
                distributed is set to True.
         :param remote_distributed_backend: str, select from "ray" or
-               "horovod". The value defaults to "ray", the distributed backend
-               will be used in the cluster.
-        :param local_distributed_backend: str, "spawn" or "subprocess",
-               The value defaults to "subprocess", the distributed backend
-               will be used mode selection for local multiprocess.
+               "horovod". The value defaults to "ray".
         """
         # config setting
         self.data_config = {
@@ -140,7 +135,7 @@ class TCNForecaster(BasePytorchForecaster):
         # distributed settings
         self.distributed = distributed
         self.remote_distributed_backend = distributed_backend
-        self.local_distributed_backend = local_distributed_backend
+        self.local_distributed_backend = "subprocess"
         self.workers_per_node = workers_per_node
 
         # other settings

--- a/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
@@ -55,7 +55,7 @@ class TCNForecaster(BasePytorchForecaster):
                  seed=None,
                  distributed=False,
                  workers_per_node=1,
-                 remote_distributed_backend="ray",
+                 distributed_backend="ray",
                  local_distributed_backend="subprocess"):
         """
         Build a TCN Forecast Model.
@@ -139,7 +139,7 @@ class TCNForecaster(BasePytorchForecaster):
 
         # distributed settings
         self.distributed = distributed
-        self.remote_distributed_backend = remote_distributed_backend
+        self.remote_distributed_backend = distributed_backend
         self.local_distributed_backend = local_distributed_backend
         self.workers_per_node = workers_per_node
 

--- a/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
@@ -55,7 +55,8 @@ class TCNForecaster(BasePytorchForecaster):
                  seed=None,
                  distributed=False,
                  workers_per_node=1,
-                 distributed_backend="ray"):
+                 remote_distributed_backend="ray",
+                 local_distributed_backend="subprocess"):
         """
         Build a TCN Forecast Model.
 
@@ -98,8 +99,12 @@ class TCNForecaster(BasePytorchForecaster):
         :param workers_per_node: int, the number of worker you want to use.
                The value defaults to 1. The param is only effective when
                distributed is set to True.
-        :param distributed_backend: str, select from "ray" or
-               "horovod". The value defaults to "ray".
+        :param remote_distributed_backend: str, select from "ray" or
+               "horovod". The value defaults to "ray", the distributed backend
+               will be used in the cluster.
+        :param local_distributed_backend: str, "spawn" or "subprocess",
+               The value defaults to "subprocess", the distributed backend
+               will be used mode selection for local multiprocess.
         """
         # config setting
         self.data_config = {
@@ -134,7 +139,8 @@ class TCNForecaster(BasePytorchForecaster):
 
         # distributed settings
         self.distributed = distributed
-        self.distributed_backend = distributed_backend
+        self.remote_distributed_backend = remote_distributed_backend
+        self.local_distributed_backend = local_distributed_backend
         self.workers_per_node = workers_per_node
 
         # other settings

--- a/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
@@ -98,7 +98,7 @@ class TCNForecaster(BasePytorchForecaster):
         :param workers_per_node: int, the number of worker you want to use.
                The value defaults to 1. The param is only effective when
                distributed is set to True.
-        :param remote_distributed_backend: str, select from "ray" or
+        :param distributed_backend: str, select from "ray" or
                "horovod". The value defaults to "ray".
         """
         # config setting

--- a/python/chronos/src/bigdl/chronos/forecaster/utils.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/utils.py
@@ -15,10 +15,12 @@
 #
 
 import torch
+import warnings
 import random
 import numpy
 from torch.utils.data import TensorDataset, DataLoader
 import numpy as np
+import multiprocessing as mp
 
 __all__ = ['loader_to_creator',
            'np_to_creator',
@@ -28,7 +30,8 @@ __all__ = ['loader_to_creator',
            'check_data',
            'np_to_dataloader',
            'read_csv',
-           'delete_folder']
+           'delete_folder',
+           'is_main_process']
 
 
 def loader_to_creator(loader):
@@ -132,7 +135,6 @@ def check_transformer_data(x, y, x_enc, y_enc, data_config):
                       "y_enc input shape of {}.".format(data_config["future_seq_len"] +
                                                         data_config["label_len"], y_enc.shape[-2]))
 
-
 def np_to_dataloader(data, batch_size, num_processes):
     if batch_size % num_processes != 0:
         warnings.warn("'batch_size' cannot be divided with no remainder by "
@@ -159,3 +161,6 @@ def read_csv(filename):
 def delete_folder(path):
     import shutil
     shutil.rmtree(path)
+
+def is_main_process():
+    return mp.current_process().name == "MainProcess"

--- a/python/chronos/src/bigdl/chronos/forecaster/utils.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/utils.py
@@ -135,6 +135,7 @@ def check_transformer_data(x, y, x_enc, y_enc, data_config):
                       "y_enc input shape of {}.".format(data_config["future_seq_len"] +
                                                         data_config["label_len"], y_enc.shape[-2]))
 
+
 def np_to_dataloader(data, batch_size, num_processes):
     if batch_size % num_processes != 0:
         warnings.warn("'batch_size' cannot be divided with no remainder by "
@@ -161,6 +162,7 @@ def read_csv(filename):
 def delete_folder(path):
     import shutil
     shutil.rmtree(path)
+
 
 def is_main_process():
     return mp.current_process().name == "MainProcess"


### PR DESCRIPTION
#### 1. Why we need this?
Launching additional subprocesses can cause performance degradation when our user use multiprocessing and use `spawn` as backend, e.g. not using __name__ == '__main__': ,

#### 2. What is the change?
 * In this PR, check if additional subprocesses are started and print some warnings.
 * Filter out some Userwarnings from torch and pl, they are mostly useless.
 * Set backend default to "subprocess".

#### 3. How to test?
I don't think testing is necessary since interface is not changed.

#### 4. TODO:
- [ ] find_unused_parameters
- [x] `prophetforecaster` will print unexpected warnings when importing other forecasters.


#### 4. Example
##### Spawn
1. closed all warnings and set find_unused_parameters to False.
```python
Global seed set to 2300593249
GPU available: False, used: False
TPU available: False, using: 0 TPU cores
IPU available: False, using: 0 IPUs
Importing plotly failed. Interactive plots will not work.
Importing plotly failed. Interactive plots will not work.
Global seed set to 2300593249
Global seed set to 2300593249
initializing ddp: GLOBAL_RANK: 1, MEMBER: 2/2
initializing ddp: GLOBAL_RANK: 0, MEMBER: 1/2
----------------------------------------------------------------------------------------------------
distributed_backend=gloo
All DDP processes registered. Starting ddp with 2 processes
----------------------------------------------------------------------------------------------------

Global seed set to 2300593249              
Global seed set to 2300593249
Epoch 4: 100%|███████████████| 290/290 [00:01<00:00, 179.13it/s, loss=2.87e+08]
13.799668788909912
```
2. Currenctly
```python
Importing plotly failed. Interactive plots will not work.
/home/liangs/miniconda3/envs/chronos-deps/lib/python3.7/site-packages/pytorch_lightning/utilities/seed.py:57: UserWarning: No correct seed found, seed set to 4060706980
  rank_zero_warn(f"No correct seed found, seed set to {seed}")
Global seed set to 4060706980
/home/liangs/miniconda3/envs/chronos-deps/lib/python3.7/site-packages/torch/nn/modules/rnn.py:65: UserWarning: dropout option adds dropout after all but last recurrent layer, so non-zero dropout expects num_layers greater than 1, but got dropout=0.1 and num_layers=1
  "num_layers={}".format(dropout, num_layers))
GPU available: False, used: False
TPU available: False, using: 0 TPU cores
IPU available: False, using: 0 IPUs
/home/liangs/miniconda3/envs/chronos-deps/lib/python3.7/site-packages/pytorch_lightning/trainer/configuration_validator.py:101: UserWarning: you defined a validation_step but have no val_dataloader. Skipping val loop
  rank_zero_warn(f"you defined a {step_name} but have no {loader_name}. Skipping {stage} loop")
Importing plotly failed. Interactive plots will not work.
Importing plotly failed. Interactive plots will not work.
Global seed set to 4060706980
Global seed set to 4060706980
initializing ddp: GLOBAL_RANK: 1, MEMBER: 2/2
initializing ddp: GLOBAL_RANK: 0, MEMBER: 1/2
----------------------------------------------------------------------------------------------------
distributed_backend=gloo
All DDP processes registered. Starting ddp with 2 processes
----------------------------------------------------------------------------------------------------

Global seed set to 4060706980
Global seed set to 4060706980              
/home/liangs/miniconda3/envs/chronos-deps/lib/python3.7/site-packages/pytorch_lightning/trainer/data_loading.py:106: UserWarning: The dataloader, train dataloader, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 20 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.
  f"The dataloader, {name}, does not have many workers which may be a bottleneck."
Epoch 0:   0%|                                                                                                                                                                                      | 0/290 [00:00<00:00, 3248.88it/s][W reducer.cpp:1289] Warning: find_unused_parameters=True was specified in DDP constructor, but did not find any unused parameters in the forward pass. This flag results in an extra traversal of the autograd graph every iteration,  which can adversely affect performance. If your model indeed never has any unused parameters in the forward pass, consider turning this flag off. Note that this warning may be a false positive if your model has flow control causing later iterations to have unused parameters. (function operator())
[W reducer.cpp:1289] Warning: find_unused_parameters=True was specified in DDP constructor, but did not find any unused parameters in the forward pass. This flag results in an extra traversal of the autograd graph every iteration,  which can adversely affect performance. If your model indeed never has any unused parameters in the forward pass, consider turning this flag off. Note that this warning may be a false positive if your model has flow control causing later iterations to have unused parameters. (function operator())
Epoch 4: 100%|██████████████| 290/290 [00:01<00:00, 154.00it/s, loss=2.81e+08]
/home/liangs/miniconda3/envs/chronos-deps/lib/python3.7/site-packages/pytorch_lightning/plugins/training_type/ddp_spawn.py:288: UserWarning: cleaning up ddp environment...
  rank_zero_warn("cleaning up ddp environment...")
```

##### Subprocess
1. closed all warnings and set find_unused_parameters to False.
```python
Importing plotly failed. Interactive plots will not work.
Global seed set to 1165311946
GPU available: False, used: False
TPU available: False, using: 0 TPU cores
IPU available: False, using: 0 IPUs
Global seed set to 1165311946
initializing ddp: GLOBAL_RANK: 0, MEMBER: 1/2
Global seed set to 1165311946
initializing ddp: GLOBAL_RANK: 1, MEMBER: 2/2
----------------------------------------------------------------------------------------------------
distributed_backend=gloo
All DDP processes registered. Starting ddp with 2 processes
----------------------------------------------------------------------------------------------------

Global seed set to 1165311946
Global seed set to 1165311946              
/home/liangs/miniconda3/envs/chronos-deps/lib/python3.7/site-packages/pytorch_lightning/trainer/data_loading.py:106: UserWarning: The dataloader, train dataloader, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 20 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.
  f"The dataloader, {name}, does not have many workers which may be a bottleneck."
Epoch 4: 100%|██████████████| 290/290 [00:01<00:00, 161.49it/s, loss=2.73e+08]
/home/liangs/miniconda3/envs/chronos-deps/lib/python3.7/site-packages/pytorch_lightning/plugins/training_type/ddp_spawn.py:288: UserWarning: cleaning up ddp environment...
  rank_zero_warn("cleaning up ddp environment...")
```

2. currenctly
```python
Importing plotly failed. Interactive plots will not work.
/home/liangs/miniconda3/envs/chronos-deps/lib/python3.7/site-packages/pytorch_lightning/utilities/seed.py:57: UserWarning: No correct seed found, seed set to 1246913139
  rank_zero_warn(f"No correct seed found, seed set to {seed}")
Global seed set to 1246913139
/home/liangs/miniconda3/envs/chronos-deps/lib/python3.7/site-packages/torch/nn/modules/rnn.py:65: UserWarning: dropout option adds dropout after all but last recurrent layer, so non-zero dropout expects num_layers greater than 1, but got dropout=0.1 and num_layers=1
  "num_layers={}".format(dropout, num_layers))
GPU available: False, used: False
TPU available: False, using: 0 TPU cores
IPU available: False, using: 0 IPUs
/home/liangs/miniconda3/envs/chronos-deps/lib/python3.7/site-packages/pytorch_lightning/trainer/configuration_validator.py:101: UserWarning: you defined a validation_step but have no val_dataloader. Skipping val loop
  rank_zero_warn(f"you defined a {step_name} but have no {loader_name}. Skipping {stage} loop")
Global seed set to 1246913139
initializing ddp: GLOBAL_RANK: 0, MEMBER: 1/2
Global seed set to 1246913139
initializing ddp: GLOBAL_RANK: 1, MEMBER: 2/2
----------------------------------------------------------------------------------------------------
distributed_backend=gloo
All DDP processes registered. Starting ddp with 2 processes
----------------------------------------------------------------------------------------------------

Validation sanity check: 0it [00:00, ?it/s]Global seed set to 1246913139
Global seed set to 1246913139              
/home/liangs/miniconda3/envs/chronos-deps/lib/python3.7/site-packages/pytorch_lightning/trainer/data_loading.py:106: UserWarning: The dataloader, train dataloader, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 20 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.
  f"The dataloader, {name}, does not have many workers which may be a bottleneck."
Epoch 0:   0%|                                                                                                                                                                                      | 0/290 [00:00<00:00, 3026.19it/s][W reducer.cpp:1289] Warning: find_unused_parameters=True was specified in DDP constructor, but did not find any unused parameters in the forward pass. This flag results in an extra traversal of the autograd graph every iteration,  which can adversely affect performance. If your model indeed never has any unused parameters in the forward pass, consider turning this flag off. Note that this warning may be a false positive if your model has flow control causing later iterations to have unused parameters. (function operator())
[W reducer.cpp:1289] Warning: find_unused_parameters=True was specified in DDP constructor, but did not find any unused parameters in the forward pass. This flag results in an extra traversal of the autograd graph every iteration,  which can adversely affect performance. If your model indeed never has any unused parameters in the forward pass, consider turning this flag off. Note that this warning may be a false positive if your model has flow control causing later iterations to have unused parameters. (function operator())
Epoch 4: 100%|██████████████| 290/290 [00:01<00:00, 157.79it/s, loss=2.85e+08]
/home/liangs/miniconda3/envs/chronos-deps/lib/python3.7/site-packages/pytorch_lightning/plugins/training_type/ddp_spawn.py:288: UserWarning: cleaning up ddp environment...
  rank_zero_warn("cleaning up ddp environment...")
```