### PR TITLE
Chronos: Add `from_tsdataset` method, BaseTF2Forecaster can input a tsdataset

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -832,6 +832,7 @@ class TSDataset:
                               "Please call 'roll' method "
                               "before transform a TSDataset to tf dataset!")
         data = tf.data.Dataset.from_tensor_slices((self.numpy_x, self.numpy_y))
+        batch_size = 32 if batch_size is None else batch_size
         if shuffle:
             data = data.cache().shuffle(self.numpy_x.shape[0]).batch(batch_size)
         else:

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/lstm_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/lstm_forecaster.py
@@ -126,3 +126,29 @@ class LSTMForecaster(BaseTF2Forecaster):
         # self.quantize_available = True
         # self.checkpoint_callback = False
         super(LSTMForecaster, self).__init__()
+
+    @classmethod
+    def from_tsdataset(cls, tsdataset, past_seq_len=None, **kwargs):
+        """
+        Build a LSTMForecaster Model
+
+        :param tsdataset: A bigdl.chronos.data.tsdataset.TSDataset instance.
+        :param past_seq_len: past_seq_len: Specify the history time steps (i.e. lookback).
+               Do not specify the 'past_seq_len' if your tsdataset has called
+               the 'TSDataset.roll' method.
+
+        :return: A LSTMForecaster Model
+        """
+        from bigdl.nano.utils.log4Error import invalidInputError
+        if tsdataset.numpy_x is not None:
+            past_seq_len = tsdataset.numpy_x.shape[1]
+        if all([tsdataset.numpy_x is None, past_seq_len is None]):
+            invalidInputError(False,
+                              "Forecaster needs 'past_seq_len' to specify "
+                              "the history time step of training.")
+        output_feature_num = len(tsdataset.target_col)
+        input_feature_num = output_feature_num + len(tsdataset.feature_col)
+        return cls(past_seq_len=past_seq_len,
+                   input_feature_num=input_feature_num,
+                   output_feature_num=output_feature_num,
+                   **kwargs)

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/lstm_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/lstm_forecaster.py
@@ -135,19 +135,45 @@ class LSTMForecaster(BaseTF2Forecaster):
         :param tsdataset: A bigdl.chronos.data.tsdataset.TSDataset instance.
         :param past_seq_len: past_seq_len: Specify the history time steps (i.e. lookback).
                Do not specify the 'past_seq_len' if your tsdataset has called
-               the 'TSDataset.roll' method.
+               the 'TSDataset.roll' method or 'TSDataset.to_torch_data_loader'.
+        :param kwargs: Specify parameters of Forecaster,
+               e.g. loss and optimizer, etc. More info, please refer to
+               LSTMForecaster.__init__ methods.
 
         :return: A LSTMForecaster Model
         """
         from bigdl.nano.utils.log4Error import invalidInputError
-        if tsdataset.numpy_x is not None:
-            past_seq_len = tsdataset.numpy_x.shape[1]
-        if all([tsdataset.numpy_x is None, past_seq_len is None]):
+
+        def check_time_steps(tsdataset, past_seq_len):
+            if tsdataset.lookback is not None and past_seq_len is not None:
+                return tsdataset.lookback == past_seq_len
+            return True
+
+        invalidInputError(not tsdataset._has_generate_agg_feature,
+                          "We will add support for 'gen_rolling_feature' method later.")
+
+        if tsdataset.lookback is not None:
+            past_seq_len = tsdataset.lookback
+            output_feature_num = len(tsdataset.roll_target)
+            input_feature_num = len(tsdataset.roll_feature) + output_feature_num
+        elif past_seq_len is not None:
+            past_seq_len = past_seq_len if isinstance(past_seq_len, int)\
+                else tsdataset.get_cycle_length()
+            output_feature_num = len(tsdataset.target_col)
+            input_feature_num = len(tsdataset.feature_col) + output_feature_num
+        else:
             invalidInputError(False,
                               "Forecaster needs 'past_seq_len' to specify "
                               "the history time step of training.")
-        output_feature_num = len(tsdataset.target_col)
-        input_feature_num = output_feature_num + len(tsdataset.feature_col)
+
+        invalidInputError(check_time_steps(tsdataset, past_seq_len),
+                          "tsdataset already has history time steps and "
+                          "differs from the given past_seq_len "
+                          f"Expected past_seq_len to be {tsdataset.lookback}, "
+                          f"but found {past_seq_len}.",
+                          fixMsg="Do not specify past_seq_len "
+                          "or call tsdataset.roll method again and specify time step.")
+
         return cls(past_seq_len=past_seq_len,
                    input_feature_num=input_feature_num,
                    output_feature_num=output_feature_num,

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/lstm_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/lstm_forecaster.py
@@ -135,7 +135,7 @@ class LSTMForecaster(BaseTF2Forecaster):
         :param tsdataset: A bigdl.chronos.data.tsdataset.TSDataset instance.
         :param past_seq_len: past_seq_len: Specify the history time steps (i.e. lookback).
                Do not specify the 'past_seq_len' if your tsdataset has called
-               the 'TSDataset.roll' method or 'TSDataset.to_torch_data_loader'.
+               the 'TSDataset.roll' method or 'TSDataset.to_tf_dataset'.
         :param kwargs: Specify parameters of Forecaster,
                e.g. loss and optimizer, etc. More info, please refer to
                LSTMForecaster.__init__ methods.
@@ -145,18 +145,18 @@ class LSTMForecaster(BaseTF2Forecaster):
         from bigdl.nano.utils.log4Error import invalidInputError
 
         def check_time_steps(tsdataset, past_seq_len):
-            if tsdataset.lookback is not None and past_seq_len is not None:
+            if tsdataset.lookback and past_seq_len:
                 return tsdataset.lookback == past_seq_len
             return True
 
         invalidInputError(not tsdataset._has_generate_agg_feature,
                           "We will add support for 'gen_rolling_feature' method later.")
 
-        if tsdataset.lookback is not None:
+        if tsdataset.lookback:
             past_seq_len = tsdataset.lookback
             output_feature_num = len(tsdataset.roll_target)
             input_feature_num = len(tsdataset.roll_feature) + output_feature_num
-        elif past_seq_len is not None:
+        elif past_seq_len:
             past_seq_len = past_seq_len if isinstance(past_seq_len, int)\
                 else tsdataset.get_cycle_length()
             output_feature_num = len(tsdataset.target_col)

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_lstm_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_lstm_keras_forecaster.py
@@ -18,6 +18,7 @@ import pytest
 import tempfile
 import os
 
+from bigdl.chronos.forecaster.tf.lstm_forecaster import LSTMForecaster
 from unittest import TestCase
 import numpy as np
 import tensorflow as tf
@@ -50,28 +51,48 @@ def create_data(tf_data=False, batch_size=32):
     return train_data, test_data
 
 
+def create_tsdataset(roll=True):
+    from bigdl.chronos.data import TSDataset
+    import pandas as pd
+    timeseries = pd.date_range(start='2020-01-01', freq='D', periods=1000)
+    df = pd.DataFrame(np.random.rand(1000, 2),
+                      columns=['value1', 'value2'],
+                      index=timeseries,
+                      dtype=np.float32)
+    df.reset_index(inplace=True)
+    df.rename(columns={'index': 'timeseries'}, inplace=True)
+    train, _, test = TSDataset.from_pandas(df=df,
+                                           dt_col='timeseries',
+                                           target_col=['value1', 'value2'],
+                                           with_split=True)
+    if roll:
+        for tsdata in [train, test]:
+            tsdata.roll(lookback=24, horizon=1)
+    return train, test
+
+
 @pytest.mark.skipif(tf.__version__ < '2.0.0', reason="Run only when tf > 2.0.0.")
 class TestLSTMForecaster(TestCase):
     def setUp(self):
         from bigdl.chronos.forecaster.tf.lstm_forecaster import LSTMForecaster
-        self. forecaster = LSTMForecaster(past_seq_len=10,
-                                          input_feature_num=10,
-                                          output_feature_num=2)
+        self.forecaster = LSTMForecaster(past_seq_len=10,
+                                         input_feature_num=10,
+                                         output_feature_num=2)
 
     def tearDown(self):
-        pass
+        del self.forecaster
 
     def test_lstm_forecaster_fit_predict_evaluate(self):
         train_data, test_data = create_data()
         self.forecaster.fit(train_data,
-                       epochs=2,
-                       batch_size=32)
+                            epochs=2,
+                            batch_size=32)
         yhat = self.forecaster.predict(test_data[0],
-                                  batch_size=32)
+                                       batch_size=32)
         assert yhat.shape == (400, 1, 2)
         mse = self.forecaster.evaluate(test_data,
-                                  batch_size=32,
-                                  multioutput="raw_values")
+                                       batch_size=32,
+                                       multioutput="raw_values")
         assert mse[0].shape == test_data[1].shape[1:]
 
     def test_lstm_forecaster_fit_tf_data(self):
@@ -120,6 +141,36 @@ class TestLSTMForecaster(TestCase):
         load_model_yhat = self.forecaster.predict(test_data)
         assert yhat.shape == (400, 1, 2)
         np.testing.assert_almost_equal(yhat, load_model_yhat, decimal=5)
+
+    def test_lstm_from_tsdataset(self):
+        train, test = create_tsdataset(roll=True)
+        lstm = LSTMForecaster.from_tsdataset(train,
+                                             hidden_dim=16,
+                                             layer_num=2)
+        lstm.fit(train,
+                 epochs=2,
+                 batch_size=32)
+        yhat = lstm.predict(test, batch_size=32)
+        test.roll(lookback=lstm.model_config['past_seq_len'],
+                  horizon=lstm.model_config['future_seq_len'])
+        _, y_test = test.to_numpy()
+        assert yhat.shape == y_test.shape
+
+        del lstm
+
+        train, test = create_tsdataset(roll=False)
+        lstm = LSTMForecaster.from_tsdataset(train,
+                                             past_seq_len=24,
+                                             hidden_dim=16,
+                                             layer_num=2)
+        lstm.fit(train,
+                 epochs=2,
+                 batch_size=32)
+        yhat = lstm.predict(test, batch_size=None)
+        test.roll(lookback=lstm.model_config['past_seq_len'],
+                  horizon=lstm.model_config['future_seq_len'])
+        _, y_test = test.to_numpy()
+        assert yhat.shape == y_test.shape
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
@@ -21,6 +21,7 @@ import os
 from unittest import TestCase
 import numpy as np
 import tensorflow as tf
+from bigdl.chronos.forecaster.tf.tcn_forecaster import TCNForecaster
 
 
 def create_data(tf_data=False, batch_size=32):
@@ -51,6 +52,26 @@ def create_data(tf_data=False, batch_size=32):
     return train_data, test_data
 
 
+def create_tsdataset(roll=True):
+    from bigdl.chronos.data import TSDataset
+    import pandas as pd
+    timeseries = pd.date_range(start='2020-01-01', freq='D', periods=1000)
+    df = pd.DataFrame(np.random.rand(1000, 2),
+                      columns=['value1', 'value2'],
+                      index=timeseries,
+                      dtype=np.float32)
+    df.reset_index(inplace=True)
+    df.rename(columns={'index': 'timeseries'}, inplace=True)
+    train, _, test = TSDataset.from_pandas(df=df,
+                                           dt_col='timeseries',
+                                           target_col=['value1', 'value2'],
+                                           with_split=True)
+    if roll:
+        for tsdata in [train, test]:
+            tsdata.roll(lookback=24, horizon=5)
+    return train, test
+
+
 @pytest.mark.skipif(tf.__version__ < '2.0.0', reason="Run only when tf > 2.0.0.")
 class TestTCNForecaster(TestCase):
     def setUp(self):
@@ -62,7 +83,7 @@ class TestTCNForecaster(TestCase):
                                         num_channels=[15]*7)
 
     def tearDown(self):
-        pass
+        del self.forecaster
 
     def test_tcn_forecaster_fit_predict_evaluate(self):
         train_data, test_data = create_data()
@@ -125,6 +146,37 @@ class TestTCNForecaster(TestCase):
         load_model_yhat = self.forecaster.predict(test_data)
         assert yhat.shape == (400, 2, 2)
         np.testing.assert_almost_equal(yhat, load_model_yhat, decimal=5)
+
+    def test_tcn_from_tsdataset(self):
+        train, test = create_tsdataset(roll=True)
+
+        tcn = TCNForecaster.from_tsdataset(train,
+                                            num_channels=[16]*2)
+        tcn.fit(train,
+                 epochs=2,
+                 batch_size=32)
+        yhat = tcn.predict(test, batch_size=32)
+        test.roll(lookback=tcn.model_config['past_seq_len'],
+                  horizon=tcn.model_config['future_seq_len'])
+        _, y_test = test.to_numpy()
+        assert yhat.shape == y_test.shape
+
+        del tcn
+
+        train, test = create_tsdataset(roll=False)
+        tcn = TCNForecaster.from_tsdataset(train,
+                                            past_seq_len=24,
+                                            future_seq_len=5,
+                                            num_channels=[16]*2)
+        tcn.fit(train,
+                 epochs=2,
+                 batch_size=32)
+        yhat = tcn.predict(test, batch_size=None)
+        test.roll(lookback=tcn.model_config['past_seq_len'],
+                  horizon=tcn.model_config['future_seq_len'])
+        _, y_test = test.to_numpy()
+        assert yhat.shape == y_test.shape
+
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
#### 1. Why we need this?
Sync with `BasepytorchForecaster`.

#### 2. What is the change?
 1. support input `tfdataset` and `tsdataset` directly.
 2. add from_tsdataset method(like load)

#### 3. How to test?
run-pytests.sh with jenkins

#### TODO:
 - [ ] doc 