### PR TITLE
chronos: user guide python version note change

### DIFF
--- a/docs/readthedocs/source/doc/Chronos/Overview/chronos.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/chronos.md
@@ -48,7 +48,7 @@ pip install pyarrow=6.0.1
 .. note:: 
     **Supported Python Version**:
 
-     Chronos is thoroughly tested on Python3.6/3.7. Still, it is highly recommended to use python3.7.
+     Chronos only supports Python 3.7.2 ~ latest 3.7.x.
 ```
 ---
 ### **3. Run**


### PR DESCRIPTION
The Install section of the Chronos User Guide is updated about the Supported Python Version.

test document: https://binbin-testdoc.readthedocs.io/en/doc_update/doc/Chronos/Overview/chronos.html