### PR TITLE
NanoHPO : Enable grid search and automatic sampler_kwargs for categorial

### DIFF
--- a/python/nano/src/bigdl/nano/automl/hpo/decorator.py
+++ b/python/nano/src/bigdl/nano/automl/hpo/decorator.py
@@ -386,7 +386,6 @@ def obj(**kwvars):
                             # further add the sub_cs prefix onto the param
                             name = new_parameter.name
                             if hasattr(new_parameter, "choices"):
-                                print("enter choices")
                                 choices = tuple(new_parameter.choices)
                                 self.sampler_kwargs[name] = choices
                     elif isinstance(v, Space):

--- a/python/nano/src/bigdl/nano/automl/hpo/decorator.py
+++ b/python/nano/src/bigdl/nano/automl/hpo/decorator.py
@@ -351,6 +351,7 @@ def obj(**kwvars):
                 self._inited = False
                 self.kwspaces_ = OrderedDict()
                 self.kwvars = dict()
+                self.sampler_kwargs = dict()
                 self._update_kw()
                 self._callgraph = None  # keep a reference to the call graph
 
@@ -378,6 +379,17 @@ def obj(**kwvars):
                     if isinstance(v, NestedSpace):
                         self.kwspaces_[k] = v
                         self.kwargs[k] = v
+                        for hp in v.cs.get_hyperparameters():
+                            new_parameter = copy.deepcopy(hp)
+                            new_parameter.name = "{}{}{}".format(
+                                k, SPLITTER, new_parameter.name)
+                            # further add the sub_cs prefix onto the param
+                            name = new_parameter.name
+                            try:
+                                choices = tuple(new_parameter.choices)
+                                self.sampler_kwargs[name] = choices
+                            except:
+                                pass
                     elif isinstance(v, Space):
                         self.kwspaces_[k] = v
                         hp = v.get_hp(name=k)

--- a/python/nano/src/bigdl/nano/automl/hpo/decorator.py
+++ b/python/nano/src/bigdl/nano/automl/hpo/decorator.py
@@ -385,11 +385,10 @@ def obj(**kwvars):
                                 k, SPLITTER, new_parameter.name)
                             # further add the sub_cs prefix onto the param
                             name = new_parameter.name
-                            try:
+                            if hasattr(new_parameter, "choices"):
+                                print("enter choices")
                                 choices = tuple(new_parameter.choices)
                                 self.sampler_kwargs[name] = choices
-                            except:
-                                pass
                     elif isinstance(v, Space):
                         self.kwspaces_[k] = v
                         hp = v.get_hp(name=k)

--- a/python/nano/src/bigdl/nano/automl/hpo/search.py
+++ b/python/nano/src/bigdl/nano/automl/hpo/search.py
@@ -111,7 +111,7 @@ def _prepare_args(kwargs,
     # prepare sampler and pruner args
     sampler_type = create_kwargs.get('sampler', None)
     if sampler_type:
-        sampler_args = create_kwargs.get('sampler_kwargs', {})
+        sampler_args = create_kwargs.get('sampler_kwargs', None)
         sampler = backend.create_sampler(sampler_type, sampler_args)
         create_kwargs['sampler'] = sampler
         create_kwargs.pop('sampler_kwargs', None)

--- a/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
@@ -23,7 +23,7 @@ from pytorch_lightning.loops.epoch import TrainingEpochLoop
 from pytorch_lightning.loops.fit_loop import FitLoop
 from bigdl.nano.utils.log4Error import invalidInputError
 from bigdl.nano.pytorch.utils import LIGHTNING_VERSION_LESS_1_6
-from bigdl.nano.automl.hpo.backend import create_hpo_backend
+from bigdl.nano.automl.hpo.backend import create_hpo_backend, SamplerType
 from .objective import Objective
 from bigdl.nano.automl.utils.parallel import run_parallel
 from bigdl.nano.automl.hpo.search import (
@@ -132,7 +132,8 @@ class HPOSearcher:
         _sampler_kwargs = model._lazyobj.sampler_kwargs
         user_sampler_kwargs = kwargs.get("sampler_kwargs", {})
         _sampler_kwargs.update(user_sampler_kwargs)
-        search_kwargs["sampler_kwargs"] = _sampler_kwargs
+        if "sampler" in  kwargs and kwargs["sampler"] in [SamplerType.Grid]:
+            search_kwargs["sampler_kwargs"] = _sampler_kwargs
 
         (self.create_kwargs, self.run_kwargs, self.fit_kwargs) \
             = _prepare_args(search_kwargs,

--- a/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
@@ -128,7 +128,7 @@ class HPOSearcher:
                                    HPOSearcher.EXTRA_FIT_KEYS,
                                    HPOSearcher.TUNE_CREATE_KEYS,
                                    HPOSearcher.TUNE_RUN_KEYS])
-        
+
         _sampler_kwargs = model._lazyobj.sampler_kwargs
         user_sampler_kwargs = kwargs.get("sampler_kwargs", {})
         _sampler_kwargs.update(user_sampler_kwargs)

--- a/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
@@ -128,6 +128,11 @@ class HPOSearcher:
                                    HPOSearcher.EXTRA_FIT_KEYS,
                                    HPOSearcher.TUNE_CREATE_KEYS,
                                    HPOSearcher.TUNE_RUN_KEYS])
+        
+        _sampler_kwargs = model._lazyobj.sampler_kwargs
+        user_sampler_kwargs = kwargs.get("sampler_kwargs", {})
+        _sampler_kwargs.update(user_sampler_kwargs)
+        search_kwargs["sampler_kwargs"] = _sampler_kwargs
 
         (self.create_kwargs, self.run_kwargs, self.fit_kwargs) \
             = _prepare_args(search_kwargs,

--- a/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
@@ -132,7 +132,7 @@ class HPOSearcher:
         _sampler_kwargs = model._lazyobj.sampler_kwargs
         user_sampler_kwargs = kwargs.get("sampler_kwargs", {})
         _sampler_kwargs.update(user_sampler_kwargs)
-        if "sampler" in  kwargs and kwargs["sampler"] in [SamplerType.Grid]:
+        if "sampler" in kwargs and kwargs["sampler"] in [SamplerType.Grid]:
             search_kwargs["sampler_kwargs"] = _sampler_kwargs
 
         (self.create_kwargs, self.run_kwargs, self.fit_kwargs) \

--- a/python/nano/src/bigdl/nano/deps/automl/optuna_backend.py
+++ b/python/nano/src/bigdl/nano/deps/automl/optuna_backend.py
@@ -155,7 +155,8 @@ class OptunaBackend(object):
     def create_sampler(sampler_type, kwargs):
         """Create a hyperparameter sampler by type."""
         sampler_class = OptunaBackend.sampler_map.get(sampler_type)
-        return sampler_class(**kwargs)
+        # return sampler_class(**kwargs)
+        return sampler_class(kwargs)
 
     @staticmethod
     def create_pruner(pruner_type, kwargs):

--- a/python/nano/src/bigdl/nano/deps/automl/optuna_backend.py
+++ b/python/nano/src/bigdl/nano/deps/automl/optuna_backend.py
@@ -155,7 +155,6 @@ class OptunaBackend(object):
     def create_sampler(sampler_type, kwargs):
         """Create a hyperparameter sampler by type."""
         sampler_class = OptunaBackend.sampler_map.get(sampler_type)
-        # return sampler_class(**kwargs)
         return sampler_class(kwargs)
 
     @staticmethod

--- a/python/nano/test/automl/pytorch/test_sampler.py
+++ b/python/nano/test/automl/pytorch/test_sampler.py
@@ -1,0 +1,132 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import pytest
+from unittest import TestCase
+
+import torch
+from bigdl.nano.pytorch import Trainer
+import bigdl.nano.automl.hpo.space as space
+from bigdl.nano.automl.hpo.backend import SamplerType
+from _helper import BoringModel
+import bigdl.nano.automl.hpo as hpo
+
+
+class TestHPOSearcher(TestCase):
+
+    def test_default_sampler(self):
+
+        @hpo.plmodel()
+        class CustomModel(BoringModel):
+            def __init__(self,
+                        out_dim1,
+                        out_dim2,
+                        dropout_1,
+                        dropout_2):
+
+                super().__init__()
+                layers = []
+                input_dim = 32
+                for out_dim, dropout in [(out_dim1, dropout_1),
+                                        (out_dim2,dropout_2)]:
+                    layers.append(torch.nn.Linear(input_dim, out_dim))
+                    layers.append(torch.nn.Tanh())
+                    layers.append(torch.nn.Dropout(dropout))
+                    input_dim = out_dim
+
+                layers.append(torch.nn.Linear(input_dim, 2))
+
+                self.layers: torch.nn.Module = torch.nn.Sequential(*layers)
+
+        model = CustomModel(
+            out_dim1=space.Categorical(16,32),
+            out_dim2=space.Categorical(16,32),
+            dropout_1=space.Real(0.1,0.5),
+            dropout_2 = 0.2)
+
+        trainer = Trainer(
+            logger=True,
+            checkpoint_callback=False,
+            max_epochs=3,
+            use_hpo=True,
+        )
+        
+        from bigdl.nano.automl.hpo.backend import SamplerType
+        trainer.search(
+            model,
+            target_metric='val_loss',
+            direction='minimize',
+            n_trials=3,
+            max_epochs=3,
+        )
+        study = trainer.search_summary()
+        assert(study)
+        assert(study.best_trial)
+
+    def test_grid_sampler(self):
+    
+        @hpo.plmodel()
+        class CustomModel(BoringModel):
+            def __init__(self,
+                        out_dim1,
+                        out_dim2,
+                        dropout_1,
+                        dropout_2):
+
+                super().__init__()
+                layers = []
+                input_dim = 32
+                for out_dim, dropout in [(out_dim1, dropout_1),
+                                        (out_dim2,dropout_2)]:
+                    layers.append(torch.nn.Linear(input_dim, out_dim))
+                    layers.append(torch.nn.Tanh())
+                    layers.append(torch.nn.Dropout(dropout))
+                    input_dim = out_dim
+
+                layers.append(torch.nn.Linear(input_dim, 2))
+
+                self.layers: torch.nn.Module = torch.nn.Sequential(*layers)
+
+        model = CustomModel(
+            out_dim1=space.Categorical(16,32),
+            out_dim2=space.Categorical(16,32),
+            dropout_1=space.Real(0.1,0.5),
+            dropout_2 = 0.2)
+
+        trainer = Trainer(
+            logger=True,
+            checkpoint_callback=False,
+            max_epochs=3,
+            use_hpo=True,
+        )
+        
+        trainer.search(
+            model,
+            target_metric='val_loss',
+            direction='minimize',
+            n_trials=12,
+            max_epochs=3,
+            sampler=SamplerType.Grid,
+            sampler_kwargs={"dropout_1" : (0.1,0.3,0.5)}
+        )
+        study = trainer.search_summary()
+        assert(study)
+        assert(study.best_trial)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
## Description
This PR fix kwargs bug in NanoHPO grid search and add automatic sampler_kwargs for space.categorial. Meanwhile, add three unittests for three samplers.

## Motivation and Context
Current NanoHPO can't run grid search.

## API Usage or Code Design
```
model = CustomModel(
            out_dim1=space.Categorical(16,32),
            out_dim2=space.Categorical(16,32),
            dropout_1=space.Real(0.1,0.5),
            dropout_2 = 0.2)

trainer = Trainer(
          logger=True,
          checkpoint_callback=False,
          max_epochs=3,
          use_hpo=True,
 )

 trainer.search(
          model,
          target_metric='val_loss',
          direction='minimize',
          n_trials=12,
          max_epochs=3,
          sampler=SamplerType.Grid,
          sampler_kwargs={"dropout_1" : (0.1,0.3,0.5)}
 )
```

## How was this PR tested?

unit tests

- [x] jenkins passed (please provide link):
http://10.112.231.51:18888/job/BigDL-NanoTests-PR-Validation/299/
http://10.112.231.51:18888/job/BigDL-PRVN-chronos-Python-Spark-2.4-py37-ray-part2/1156/