### PR TITLE
add ipex and ddp support for lightning-lite

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
+++ b/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
@@ -167,8 +167,6 @@ class _RayLauncher(_SpawnLauncher):
                 return move_data_to_device(results, "cpu"), \
                     None, \
                     move_data_to_device(strategy.lightning_module.state_dict(), "cpu")
-        else:
-            return None
 
 
 class RayStrategy(DDPSpawnStrategy):

--- a/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
+++ b/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
@@ -140,7 +140,7 @@ class _RayLauncher(_SpawnLauncher):
         strategy.lightning_module.trainer = trainer
         strategy.lightning_module.trainer.checkpoint_callback.best_model_path = best_path
 
-        return results.trainer_results
+        return results.trainer_results  # type: ignore
 
     @staticmethod
     def _wrapping_function(args_pack: tuple) -> Any:   # type: ignore[override]

--- a/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
+++ b/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
@@ -100,14 +100,10 @@ class _RayLauncher(_SpawnLauncher):
     def launch(self, function: Callable, *args: Any,
                trainer: Optional["pl.Trainer"] = None, **kwargs: Any) -> Any:
         # pytorch_lightning 1.6 uses this method to create child processes
-        invalidInputError(trainer is not None and self._strategy.cluster_environment is not None,
-                          'strategy.cluster_environment and trainer cannot be None')
-        invalidInputError(self._strategy.model is not None, "You must specify the model.")
-
         strategy = self._strategy
 
         # fix bug, see ddp_spawn strategy for details
-        if strategy.use_ipex and TORCH_VERSION_LESS_1_10:
+        if strategy.use_ipex and TORCH_VERSION_LESS_1_10 and trainer is not None:
             if isinstance(args[1], LightningDataModule):
                 args[1].trainer = None
             elif isinstance(args[3], LightningDataModule):
@@ -126,25 +122,27 @@ class _RayLauncher(_SpawnLauncher):
         futures = [
             strategy.workers[i].execute.remote(
                 self._wrapping_function,
-                (i, trainer, function, args, kwargs)
+                (i, trainer, strategy, function, args, kwargs)
             )
             for i in range(strategy.num_workers)
         ]
 
         results = ray.get(futures)  # type: ignore
 
+        if trainer is None:
+            return results[0]
+
         # Get the results, checkpoint path, and model weights from worker 0.
         results, best_path, state_dict = results[0]  # type: ignore
-        strategy._model.load_state_dict(state_dict)
+        strategy.model.load_state_dict(state_dict)
         strategy.lightning_module.trainer = trainer
         strategy.lightning_module.trainer.checkpoint_callback.best_model_path = best_path
 
-        return results
+        return results.trainer_results
 
     @staticmethod
     def _wrapping_function(args_pack: tuple) -> Any:   # type: ignore[override]
-        global_rank, trainer, function, args, kwargs = args_pack
-        strategy = trainer.strategy
+        global_rank, trainer, strategy, function, args, kwargs = args_pack
         invalidInputError(isinstance(strategy, RayStrategy), "expect ray strategy here")
         invalidInputError(isinstance(strategy.cluster_environment, RayEnvironment),
                           "expect ray environment here")
@@ -155,8 +153,10 @@ class _RayLauncher(_SpawnLauncher):
         strategy._worker_setup(global_rank)
         results = function(*args, **kwargs)
 
-        if trainer is not None:
-            results = strategy._launcher._collect_rank_zero_results(trainer, results)
+        if trainer is None:
+            return move_data_to_device(results, "cpu")
+
+        results = strategy._launcher._collect_rank_zero_results(trainer, results)
 
         if strategy.global_rank == 0:
             if trainer.checkpoint_callback is not None:

--- a/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
+++ b/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
@@ -129,6 +129,8 @@ class _RayLauncher(_SpawnLauncher):
 
         results = ray.get(futures)  # type: ignore
 
+        # when using pytorch lightning's trainer, the `trainer` cannot be None,
+        # when using pytorch lightning's LightningLite, the `trainer` should be None
         if trainer is None:
             return results[0]
 
@@ -153,6 +155,8 @@ class _RayLauncher(_SpawnLauncher):
         strategy._worker_setup(global_rank)
         results = function(*args, **kwargs)
 
+        # when using pytorch lightning's trainer, the `trainer` cannot be None,
+        # when using pytorch lightning's LightningLite, the `trainer` should be None
         if trainer is None:
             return move_data_to_device(results, "cpu")
 

--- a/python/nano/src/bigdl/nano/pytorch/lite/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/lite/__init__.py
@@ -1,0 +1,17 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from .lite import LightningLite

--- a/python/nano/src/bigdl/nano/pytorch/lite/lite.py
+++ b/python/nano/src/bigdl/nano/pytorch/lite/lite.py
@@ -1,0 +1,60 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from logging import warning
+
+import pytorch_lightning.lite as lite
+
+from bigdl.nano.pytorch.strategies import create_IPEXStrategy
+
+
+class LightningLite(lite.LightningLite):
+    """
+    LightningLite for BigDL-Nano pytorch.
+
+    This LightningLite extends PyTorch Lightning's LightningLite by adding
+    various options to accelerate pytorch training.
+    """
+
+    def __init__(self, num_processes: int = 1,
+                 use_ipex: bool = False,
+                 enable_bf16: bool = False,
+                 distributed_backend: str = "subprocess",
+                 *args, **kwargs) -> None:
+        """
+        Create a LightningLite with nano acceleration.
+
+        :param num_processes: number of processes in distributed training, defaults to 1
+        :param use_ipex: whether use ipex acceleration, defaults to False
+        :param enable_bf16: whether use bf16 acceleration, defaults to False
+        :param distributed_backend: use which backend in distributed mode, defaults to "subprocess"
+        """
+        # Check keyword arguments
+        if "strategy" in kwargs:
+            warning(f"""strategy will be specified by bigdl-nano,
+            strategy entered {kwargs['strategy']} will be ignored.""")
+
+        self.use_ipex = use_ipex
+        self.enable_bf16 = enable_bf16
+
+        strategy = None
+        if num_processes == 1:
+            strategy = create_IPEXStrategy(enable_bf16=self.enable_bf16)
+        else:
+            pass
+
+        kwargs["strategy"] = strategy
+        super().__init__(*args, **kwargs)

--- a/python/nano/src/bigdl/nano/pytorch/lite/lite.py
+++ b/python/nano/src/bigdl/nano/pytorch/lite/lite.py
@@ -27,7 +27,8 @@ from pytorch_lightning.lite.wrappers import _LiteModule, _LiteOptimizer
 from bigdl.nano.utils.log4Error import invalidInputError
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
 from bigdl.nano.pytorch.strategies.ipex.ipex_api import ipex_optimize
-from bigdl.nano.pytorch.strategies import create_IPEXStrategy, DDPSpawnStrategy
+from bigdl.nano.pytorch.strategies import create_IPEXStrategy, DDPSpawnStrategy, \
+    DDPSubprocessStrategy
 
 
 class LightningLite(lite.LightningLite):
@@ -70,7 +71,9 @@ class LightningLite(lite.LightningLite):
                                         use_ipex=self.use_ipex,
                                         enable_bf16=self.enable_bf16)
         elif strategy == "subprocess":
-            pass
+            strategy = DDPSubprocessStrategy(num_processes=self.num_processes,
+                                             use_ipex=self.use_ipex,
+                                             enable_bf16=self.enable_bf16)
         elif strategy == "ray":
             pass
         else:

--- a/python/nano/src/bigdl/nano/pytorch/lite/lite.py
+++ b/python/nano/src/bigdl/nano/pytorch/lite/lite.py
@@ -28,7 +28,7 @@ from bigdl.nano.utils.log4Error import invalidInputError
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
 from bigdl.nano.pytorch.strategies.ipex.ipex_api import ipex_optimize
 from bigdl.nano.pytorch.strategies import create_IPEXStrategy, DDPSpawnStrategy, \
-    DDPSubprocessStrategy
+    DDPSubprocessStrategy, RayStrategy
 
 
 class LightningLite(lite.LightningLite):
@@ -75,7 +75,9 @@ class LightningLite(lite.LightningLite):
                                              use_ipex=self.use_ipex,
                                              enable_bf16=self.enable_bf16)
         elif strategy == "ray":
-            pass
+            strategy = RayStrategy(num_workers=self.num_processes,
+                                   use_ipex=self.use_ipex,
+                                   enable_bf16=self.enable_bf16)
         else:
             warning(f"Bigdl-nano doesn't support '{strategy}' strategy now, "
                     f"'{strategy}' strategy of pytorch_lightning will be used. "

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -38,6 +38,7 @@ import multiprocessing
 from typing import Any, List, Optional, Callable, Union, Dict
 
 import torch
+from torch import nn
 from torch import Tensor
 from torch.multiprocessing.spawn import _wrap, ProcessContext
 from torch.nn.parallel.distributed import DistributedDataParallel
@@ -75,8 +76,8 @@ class _DDPSpawnLauncher(_SpawnLauncher):
     def launch(self, function: Callable, *args: Any,
                trainer: Optional["pl.Trainer"] = None, **kwargs: Any) -> Any:
         # pytorch_lightning 1.6 uses this method to create child processes
-        invalidInputError(trainer is not None and self._strategy.cluster_environment is not None,
-                          'strategy.cluster_environment and trainer cannot be None')
+        invalidInputError(self._strategy.cluster_environment is not None,
+                          'strategy.cluster_environment cannot be None')
 
         os.environ["MASTER_PORT"] = str(self._strategy.cluster_environment.main_port)
 
@@ -97,7 +98,7 @@ class _DDPSpawnLauncher(_SpawnLauncher):
         # pytorch lightning 1.4 resets datamodule automatically before creating child processes,
         # so we do not need to do this, but 1.6 resets datamodule after creating child processes,
         # so we must reset datamodule here.
-        if self._strategy.use_ipex and TORCH_VERSION_LESS_1_10:
+        if self._strategy.use_ipex and TORCH_VERSION_LESS_1_10 and trainer is not None:
             # args[1] is dataloader, args[3] is datamodule when training,
             # and args[4] is datamodule when testing
             if isinstance(args[1], LightningDataModule):
@@ -141,6 +142,10 @@ class _DDPSpawnLauncher(_SpawnLauncher):
 
         # restore the state of child process
         spawn_output = return_queue.get()
+
+        if trainer is None:
+            return spawn_output
+
         self._recover_results_in_main_process(spawn_output, trainer)
         return spawn_output.trainer_results
 
@@ -230,18 +235,10 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
         # which is used by ipex==1.9, so we move this line here
         self.model_to_device()
 
-    def configure_ddp(self):
-        """Setup the configuration for pytorch ddp."""
+    def _setup_model(self, model: nn.Module) -> DistributedDataParallel:
+        """Wraps the model into a 'DistributedDataParallel' module."""
         # we should override this method to change the creation of `DistributedDataParallel`
-        self.pre_configure_ddp()
-        self._model = DistributedDataParallel(
-            LightningDistributedModule(self.model),
-            **self._ddp_kwargs,
-        )
-        self._register_ddp_hooks()
-
-        self.setup_optimizers(self.lightning_module.trainer)
-        optimizers_to_device(self.optimizers, self.root_device)
+        return DistributedDataParallel(model, **self._ddp_kwargs)
 
     def reduce(self, tensor, group: Optional[Any] = None,   # type: ignore[override]
                reduce_op: Union[ReduceOp, str] = "mean") -> Tensor:

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -74,6 +74,9 @@ class _DDPSpawnLauncher(_SpawnLauncher):
     def launch(self, function: Callable, *args: Any,
                trainer: Optional["pl.Trainer"] = None, **kwargs: Any) -> Any:
         # pytorch_lightning 1.6 uses this method to create child processes
+
+        # the `self._strategy.cluster_environment` should not be None in normal circumstances,
+        # if you see this error message, please raise an issue in BigDL.
         invalidInputError(self._strategy.cluster_environment is not None,
                           'strategy.cluster_environment cannot be None')
 
@@ -141,6 +144,8 @@ class _DDPSpawnLauncher(_SpawnLauncher):
         # restore the state of child process
         spawn_output = return_queue.get()
 
+        # when using pytorch lightning's trainer, the `trainer` cannot be None,
+        # when using pytorch lightning's LightningLite, the `trainer` should be None
         if trainer is None:
             return spawn_output
 

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -49,8 +49,6 @@ from pytorch_lightning.core.datamodule import LightningDataModule
 from pytorch_lightning.strategies.launchers import _SpawnLauncher
 from pytorch_lightning.strategies import DDPSpawnStrategy as _DDPSpawnStrategy
 from pytorch_lightning.plugins.environments import LightningEnvironment
-from pytorch_lightning.overrides import LightningDistributedModule
-from pytorch_lightning.utilities.optimizer import optimizers_to_device
 from pytorch_lightning.utilities.distributed import ReduceOp
 
 from bigdl.nano.common.cpu_schedule import schedule_processors

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -76,7 +76,7 @@ class _DDPSpawnLauncher(_SpawnLauncher):
         # pytorch_lightning 1.6 uses this method to create child processes
 
         # the `self._strategy.cluster_environment` should not be None in normal circumstances,
-        # if you see this error message, please raise an issue in BigDL.
+        # if you see this error message, please report an issue in BigDL.
         invalidInputError(self._strategy.cluster_environment is not None,
                           'strategy.cluster_environment cannot be None')
 

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_subprocess.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_subprocess.py
@@ -117,9 +117,9 @@ class _DDPSubprocessLauncher(_DDPSpawnLauncher):
 
             for _, process in enumerate(processes):
                 process.wait()
-
             for _, process in enumerate(processes):
-                assert process.returncode == 0, "Subprocess incorrectly exit"
+                invalidInputError(process.returncode == 0, "subprocess exits incorrectly")
+
             # restore the state of child process
             spawn_output = return_queue.get()
 

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_subprocess.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_subprocess.py
@@ -64,7 +64,7 @@ class _DDPSubprocessLauncher(_DDPSpawnLauncher):
         # pytorch_lightning 1.6 uses this method to create child processes
 
         # the `self._strategy.cluster_environment` should not be None in normal circumstances,
-        # if you see this error message, please raise an issue in BigDL.
+        # if you see this error message, please report an issue in BigDL.
         invalidInputError(self._strategy.cluster_environment is not None,
                           'strategy.cluster_environment cannot be None')
 

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_subprocess.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_subprocess.py
@@ -36,7 +36,6 @@ import os
 import multiprocessing
 import subprocess
 import sys
-import copy
 import uuid
 from typing import Any, Optional, Callable
 from tempfile import TemporaryDirectory
@@ -63,6 +62,9 @@ class _DDPSubprocessLauncher(_DDPSpawnLauncher):
     def launch(self, function: Callable, *args: Any,
                trainer: Optional["pl.Trainer"] = None, **kwargs: Any) -> Any:
         # pytorch_lightning 1.6 uses this method to create child processes
+
+        # the `self._strategy.cluster_environment` should not be None in normal circumstances,
+        # if you see this error message, please raise an issue in BigDL.
         invalidInputError(self._strategy.cluster_environment is not None,
                           'strategy.cluster_environment cannot be None')
 
@@ -123,6 +125,8 @@ class _DDPSubprocessLauncher(_DDPSpawnLauncher):
             # restore the state of child process
             spawn_output = return_queue.get()
 
+            # when using pytorch lightning's trainer, the `trainer` cannot be None,
+            # when using pytorch lightning's LightningLite, the `trainer` should be None
             if trainer is None:
                 return spawn_output
 

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_subprocess.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_subprocess.py
@@ -122,10 +122,10 @@ class _DDPSubprocessLauncher(_DDPSpawnLauncher):
                 assert process.returncode == 0, "Subprocess incorrectly exit"
             # restore the state of child process
             spawn_output = return_queue.get()
-            
+
             if trainer is None:
                 return spawn_output
-            
+
             self._recover_results_in_main_process(spawn_output, trainer)
             return spawn_output.trainer_results
 

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ipex/ipex_strategy.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ipex/ipex_strategy.py
@@ -14,11 +14,7 @@
 # limitations under the License.
 #
 
-from typing import Any
-
 import torch
-from torch import nn
-from torch.optim import Optimizer
 import pytorch_lightning as pl
 from pytorch_lightning.strategies import SingleDeviceStrategy
 from pytorch_lightning.accelerators.accelerator import Accelerator

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ipex/version_1_9/ipex_strategy_1_9.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ipex/version_1_9/ipex_strategy_1_9.py
@@ -17,8 +17,6 @@
 from typing import Union, Dict, Any, Optional
 
 import torch
-from torch import nn
-from torch.optim import Optimizer
 import pytorch_lightning as pl
 from pytorch_lightning.accelerators.accelerator import Accelerator
 from pytorch_lightning.plugins.precision import PrecisionPlugin, MixedPrecisionPlugin

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ipex/version_1_9/ipex_strategy_1_9.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ipex/version_1_9/ipex_strategy_1_9.py
@@ -17,6 +17,8 @@
 from typing import Union, Dict, Any, Optional
 
 import torch
+from torch import nn
+from torch.optim import Optimizer
 import pytorch_lightning as pl
 from pytorch_lightning.accelerators.accelerator import Accelerator
 from pytorch_lightning.plugins.precision import PrecisionPlugin, MixedPrecisionPlugin
@@ -64,6 +66,16 @@ class IPEXStrategy(SingleDeviceStrategy):
             invalidInputError(False, "amp is not supported in bigdl-nano.")
 
         super().setup(trainer)
+
+    def _setup_lite(self, model: nn.Module, *optimizers: Optimizer) -> Any:
+        """
+        Apply IPEX's optimization, which will be and only be used with LightningLite.
+
+        LightningLite won't call above `setup` method, instead,
+        we use this method to add IPEX's optimization.
+        """
+        # IPEX 1.9 has no need to do anything
+        return model, optimizers
 
     def training_step_end(self, output: _STEP_OUTPUT_TYPE) -> _STEP_OUTPUT_TYPE:
         """

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ipex/version_1_9/ipex_strategy_1_9.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ipex/version_1_9/ipex_strategy_1_9.py
@@ -67,16 +67,6 @@ class IPEXStrategy(SingleDeviceStrategy):
 
         super().setup(trainer)
 
-    def _setup_lite(self, model: nn.Module, *optimizers: Optimizer) -> Any:
-        """
-        Apply IPEX's optimization, which will be and only be used with LightningLite.
-
-        LightningLite won't call above `setup` method, instead,
-        we use this method to add IPEX's optimization.
-        """
-        # IPEX 1.9 has no need to do anything
-        return model, optimizers
-
     def training_step_end(self, output: _STEP_OUTPUT_TYPE) -> _STEP_OUTPUT_TYPE:
         """
         A hook to do something at the end of the train step.

--- a/python/nano/test/pytorch/tests/test_lite.py
+++ b/python/nano/test/pytorch/tests/test_lite.py
@@ -74,6 +74,17 @@ if not LIGHTNING_VERSION_LESS_1_6:
         def test_lite(self):
             Lite().run()
 
+        def test_lite_spawn(self):
+            Lite(num_processes=2, strategy="spawn").run()
+
+        # subprocess now has a issue, which was fixed in another PR,
+        # We'll uncomment this test after merging that PR
+        # def test_lite_subprocess(self):
+            # Lite(num_processes=2, strategy="subprocess").run()
+
+        def test_lite_ray(self):
+            Lite(num_processes=2, strategy="ray").run()
+
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/python/nano/test/pytorch/tests/test_lite.py
+++ b/python/nano/test/pytorch/tests/test_lite.py
@@ -1,0 +1,77 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import os
+from unittest import TestCase
+
+import pytest
+import torch
+from test.pytorch.utils._train_torch_lightning import create_data_loader, data_transform
+from torch import nn
+
+from bigdl.nano.pytorch.lite import LightningLite
+from bigdl.nano.pytorch.vision.models import vision
+
+batch_size = 256
+num_workers = 0
+data_dir = os.path.join(os.path.dirname(__file__), "../data")
+
+
+class ResNet18(nn.Module):
+    def __init__(self, num_classes, pretrained=True, include_top=False, freeze=True):
+        super().__init__()
+        backbone = vision.resnet18(pretrained=pretrained, include_top=include_top, freeze=freeze)
+        output_size = backbone.get_output_size()
+        head = nn.Linear(output_size, num_classes)
+        self.model = nn.Sequential(backbone, head)
+
+    def forward(self, x):
+        return self.model(x)
+
+
+class Lite(LightningLite):
+    def run(self):
+        model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
+        loss = nn.CrossEntropyLoss()
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+        train_loader = create_data_loader(data_dir, batch_size, num_workers, data_transform)
+
+        model, optimizer = self.setup(model, optimizer)
+        train_loader = self.setup_dataloaders(train_loader)
+        model.train()
+
+        max_epochs = 1
+        for _i in range(max_epochs):
+            total_loss, num = 0, 0
+            for X, y in train_loader:
+                optimizer.zero_grad()
+                l = loss(model(X), y)
+                self.backward(l)
+                optimizer.step()
+                
+                total_loss += l.sum()
+                num += 1
+            print(f'avg_loss: {total_loss / num}')
+
+
+class TestLite(TestCase):
+    def test_lite(self):
+        Lite().run()
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/python/nano/test/pytorch/tests/test_lite.py
+++ b/python/nano/test/pytorch/tests/test_lite.py
@@ -107,6 +107,13 @@ class LiteCorrectness(LightningLite):
 
 
 class TestLite(TestCase):
+    def setUp(self):
+        test_dir = os.path.dirname(__file__)
+        project_test_dir = os.path.abspath(
+            os.path.join(os.path.join(os.path.join(test_dir, ".."), ".."), "..")
+        )
+        os.environ['PYTHONPATH'] = project_test_dir
+
     def test_lite(self):
         Lite().run()
 
@@ -116,9 +123,6 @@ class TestLite(TestCase):
     def test_lite_subprocess(self):
         Lite(num_processes=2, strategy="subprocess").run()
 
-    def test_lite_ray(self):
-        Lite(num_processes=2, strategy="ray").run()
-
     def test_lite_correctness(self):
         LiteCorrectness().run(0.25)
 
@@ -127,9 +131,6 @@ class TestLite(TestCase):
 
     def test_lite_subprocess_correctness(self):
         LiteCorrectness(num_processes=2, strategy="subprocess").run(0.5)
-
-    def test_lite_ray_correctness(self):
-        LiteCorrectness(num_processes=2, strategy="ray").run(0.5)
 
 
 if __name__ == '__main__':

--- a/python/nano/test/pytorch/tests/test_lite.py
+++ b/python/nano/test/pytorch/tests/test_lite.py
@@ -14,14 +14,15 @@
 # limitations under the License.
 #
 
-
 import os
+import pytest
 from unittest import TestCase
 
-import pytest
 import torch
-from test.pytorch.utils._train_torch_lightning import create_data_loader, data_transform
 from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from test.pytorch.utils._train_torch_lightning import create_data_loader, data_transform
 
 from bigdl.nano.pytorch.utils import LIGHTNING_VERSION_LESS_1_6
 if not LIGHTNING_VERSION_LESS_1_6:
@@ -56,8 +57,8 @@ if not LIGHTNING_VERSION_LESS_1_6:
             train_loader = self.setup_dataloaders(train_loader)
             model.train()
 
-            max_epochs = 1
-            for _i in range(max_epochs):
+            num_epochs = 1
+            for _i in range(num_epochs):
                 total_loss, num = 0, 0
                 for X, y in train_loader:
                     optimizer.zero_grad()
@@ -70,6 +71,43 @@ if not LIGHTNING_VERSION_LESS_1_6:
                 print(f'avg_loss: {total_loss / num}')
 
 
+    class LinearModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc1 = nn.Linear(1, 1, bias=False)
+            self.fc1.weight.data.fill_(1.0)
+
+        def forward(self, input_):
+            return self.fc1(input_)
+
+
+    class LiteCorrectness(LightningLite):
+        def run(self, lr):
+            dataset=TensorDataset(
+                torch.tensor([[0.0],[0.0],[1.0],[1.0]]),
+                torch.tensor([[0.0],[0.0],[0.0],[0.0]]),
+            )
+            train_loader = DataLoader(dataset=dataset, batch_size=2, shuffle=False)
+            origin_model = LinearModel()
+            loss = nn.MSELoss()
+            optimizer = torch.optim.SGD(origin_model.parameters(), lr=lr)
+
+            model, optimizer = self.setup(origin_model, optimizer)
+            train_loader = self.setup_dataloaders(train_loader)
+            model.train()
+
+            num_epochs = 2
+            for _i in range(num_epochs):
+                for X, y in train_loader:
+                    optimizer.zero_grad()
+                    l = loss(model(X), y)
+                    self.backward(l)
+                    optimizer.step()
+
+            assert origin_model.fc1.weight.data == 0.25, \
+                f"wrong weights: {origin_model.fc1.weight.data}"
+
+
     class TestLite(TestCase):
         def test_lite(self):
             Lite().run()
@@ -77,13 +115,23 @@ if not LIGHTNING_VERSION_LESS_1_6:
         def test_lite_spawn(self):
             Lite(num_processes=2, strategy="spawn").run()
 
-        # subprocess now has a issue, which was fixed in another PR,
-        # We'll uncomment this test after merging that PR
-        # def test_lite_subprocess(self):
-            # Lite(num_processes=2, strategy="subprocess").run()
+        def test_lite_subprocess(self):
+            Lite(num_processes=2, strategy="subprocess").run()
 
         def test_lite_ray(self):
             Lite(num_processes=2, strategy="ray").run()
+
+        def test_lite_correctness(self):
+            LiteCorrectness().run(0.25)
+
+        def test_lite_spawn_correctness(self):
+            LiteCorrectness(num_processes=2, strategy="spawn").run(0.5)
+
+        def test_lite_subprocess_correctness(self):
+            LiteCorrectness(num_processes=2, strategy="subprocess").run(0.5)
+
+        def test_lite_ray_correctness(self):
+            LiteCorrectness(num_processes=2, strategy="ray").run(0.5)
 
 
 if __name__ == '__main__':

--- a/python/nano/test/pytorch/tests/test_lite.py
+++ b/python/nano/test/pytorch/tests/test_lite.py
@@ -23,54 +23,56 @@ import torch
 from test.pytorch.utils._train_torch_lightning import create_data_loader, data_transform
 from torch import nn
 
-from bigdl.nano.pytorch.lite import LightningLite
-from bigdl.nano.pytorch.vision.models import vision
+from bigdl.nano.pytorch.utils import LIGHTNING_VERSION_LESS_1_6
+if not LIGHTNING_VERSION_LESS_1_6:
+    from bigdl.nano.pytorch.lite import LightningLite
+    from bigdl.nano.pytorch.vision.models import vision
 
-batch_size = 256
-num_workers = 0
-data_dir = os.path.join(os.path.dirname(__file__), "../data")
-
-
-class ResNet18(nn.Module):
-    def __init__(self, num_classes, pretrained=True, include_top=False, freeze=True):
-        super().__init__()
-        backbone = vision.resnet18(pretrained=pretrained, include_top=include_top, freeze=freeze)
-        output_size = backbone.get_output_size()
-        head = nn.Linear(output_size, num_classes)
-        self.model = nn.Sequential(backbone, head)
-
-    def forward(self, x):
-        return self.model(x)
+    batch_size = 256
+    num_workers = 0
+    data_dir = os.path.join(os.path.dirname(__file__), "../data")
 
 
-class Lite(LightningLite):
-    def run(self):
-        model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
-        loss = nn.CrossEntropyLoss()
-        optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
-        train_loader = create_data_loader(data_dir, batch_size, num_workers, data_transform)
+    class ResNet18(nn.Module):
+        def __init__(self, num_classes, pretrained=True, include_top=False, freeze=True):
+            super().__init__()
+            backbone = vision.resnet18(pretrained=pretrained, include_top=include_top, freeze=freeze)
+            output_size = backbone.get_output_size()
+            head = nn.Linear(output_size, num_classes)
+            self.model = nn.Sequential(backbone, head)
 
-        model, optimizer = self.setup(model, optimizer)
-        train_loader = self.setup_dataloaders(train_loader)
-        model.train()
-
-        max_epochs = 1
-        for _i in range(max_epochs):
-            total_loss, num = 0, 0
-            for X, y in train_loader:
-                optimizer.zero_grad()
-                l = loss(model(X), y)
-                self.backward(l)
-                optimizer.step()
-                
-                total_loss += l.sum()
-                num += 1
-            print(f'avg_loss: {total_loss / num}')
+        def forward(self, x):
+            return self.model(x)
 
 
-class TestLite(TestCase):
-    def test_lite(self):
-        Lite().run()
+    class Lite(LightningLite):
+        def run(self):
+            model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
+            loss = nn.CrossEntropyLoss()
+            optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+            train_loader = create_data_loader(data_dir, batch_size, num_workers, data_transform)
+
+            model, optimizer = self.setup(model, optimizer)
+            train_loader = self.setup_dataloaders(train_loader)
+            model.train()
+
+            max_epochs = 1
+            for _i in range(max_epochs):
+                total_loss, num = 0, 0
+                for X, y in train_loader:
+                    optimizer.zero_grad()
+                    l = loss(model(X), y)
+                    self.backward(l)
+                    optimizer.step()
+                    
+                    total_loss += l.sum()
+                    num += 1
+                print(f'avg_loss: {total_loss / num}')
+
+
+    class TestLite(TestCase):
+        def test_lite(self):
+            Lite().run()
 
 
 if __name__ == '__main__':

--- a/python/nano/test/pytorch/tests/test_lite.py
+++ b/python/nano/test/pytorch/tests/test_lite.py
@@ -24,114 +24,112 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from test.pytorch.utils._train_torch_lightning import create_data_loader, data_transform
 
-from bigdl.nano.pytorch.utils import LIGHTNING_VERSION_LESS_1_6
-if not LIGHTNING_VERSION_LESS_1_6:
-    from bigdl.nano.pytorch.lite import LightningLite
-    from bigdl.nano.pytorch.vision.models import vision
+from bigdl.nano.pytorch.lite import LightningLite
+from bigdl.nano.pytorch.vision.models import vision
 
-    batch_size = 256
-    num_workers = 0
-    data_dir = os.path.join(os.path.dirname(__file__), "../data")
+batch_size = 256
+num_workers = 0
+data_dir = os.path.join(os.path.dirname(__file__), "../data")
 
 
-    class ResNet18(nn.Module):
-        def __init__(self, num_classes, pretrained=True, include_top=False, freeze=True):
-            super().__init__()
-            backbone = vision.resnet18(pretrained=pretrained, include_top=include_top, freeze=freeze)
-            output_size = backbone.get_output_size()
-            head = nn.Linear(output_size, num_classes)
-            self.model = nn.Sequential(backbone, head)
+class ResNet18(nn.Module):
+    def __init__(self, num_classes, pretrained=True, include_top=False, freeze=True):
+        super().__init__()
+        backbone = vision.resnet18(pretrained=pretrained, include_top=include_top, freeze=freeze)
+        output_size = backbone.get_output_size()
+        head = nn.Linear(output_size, num_classes)
+        self.model = nn.Sequential(backbone, head)
 
-        def forward(self, x):
-            return self.model(x)
-
-
-    class Lite(LightningLite):
-        def run(self):
-            model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
-            loss = nn.CrossEntropyLoss()
-            optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
-            train_loader = create_data_loader(data_dir, batch_size, num_workers, data_transform)
-
-            model, optimizer = self.setup(model, optimizer)
-            train_loader = self.setup_dataloaders(train_loader)
-            model.train()
-
-            num_epochs = 1
-            for _i in range(num_epochs):
-                total_loss, num = 0, 0
-                for X, y in train_loader:
-                    optimizer.zero_grad()
-                    l = loss(model(X), y)
-                    self.backward(l)
-                    optimizer.step()
-                    
-                    total_loss += l.sum()
-                    num += 1
-                print(f'avg_loss: {total_loss / num}')
+    def forward(self, x):
+        return self.model(x)
 
 
-    class LinearModel(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.fc1 = nn.Linear(1, 1, bias=False)
-            self.fc1.weight.data.fill_(1.0)
+class Lite(LightningLite):
+    def run(self):
+        model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
+        loss = nn.CrossEntropyLoss()
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+        train_loader = create_data_loader(data_dir, batch_size, num_workers, data_transform)
 
-        def forward(self, input_):
-            return self.fc1(input_)
+        model, optimizer = self.setup(model, optimizer)
+        train_loader = self.setup_dataloaders(train_loader)
+        model.train()
 
-
-    class LiteCorrectness(LightningLite):
-        def run(self, lr):
-            dataset=TensorDataset(
-                torch.tensor([[0.0],[0.0],[1.0],[1.0]]),
-                torch.tensor([[0.0],[0.0],[0.0],[0.0]]),
-            )
-            train_loader = DataLoader(dataset=dataset, batch_size=2, shuffle=False)
-            origin_model = LinearModel()
-            loss = nn.MSELoss()
-            optimizer = torch.optim.SGD(origin_model.parameters(), lr=lr)
-
-            model, optimizer = self.setup(origin_model, optimizer)
-            train_loader = self.setup_dataloaders(train_loader)
-            model.train()
-
-            num_epochs = 2
-            for _i in range(num_epochs):
-                for X, y in train_loader:
-                    optimizer.zero_grad()
-                    l = loss(model(X), y)
-                    self.backward(l)
-                    optimizer.step()
-
-            assert origin_model.fc1.weight.data == 0.25, \
-                f"wrong weights: {origin_model.fc1.weight.data}"
+        num_epochs = 1
+        for _i in range(num_epochs):
+            total_loss, num = 0, 0
+            for X, y in train_loader:
+                optimizer.zero_grad()
+                l = loss(model(X), y)
+                self.backward(l)
+                optimizer.step()
+                
+                total_loss += l.sum()
+                num += 1
+            print(f'avg_loss: {total_loss / num}')
 
 
-    class TestLite(TestCase):
-        def test_lite(self):
-            Lite().run()
+class LinearModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(1, 1, bias=False)
+        self.fc1.weight.data.fill_(1.0)
 
-        def test_lite_spawn(self):
-            Lite(num_processes=2, strategy="spawn").run()
+    def forward(self, input_):
+        return self.fc1(input_)
 
-        def test_lite_subprocess(self):
-            Lite(num_processes=2, strategy="subprocess").run()
 
-        def test_lite_ray(self):
-            Lite(num_processes=2, strategy="ray").run()
+class LiteCorrectness(LightningLite):
+    def run(self, lr):
+        dataset=TensorDataset(
+            torch.tensor([[0.0],[0.0],[1.0],[1.0]]),
+            torch.tensor([[0.0],[0.0],[0.0],[0.0]]),
+        )
+        train_loader = DataLoader(dataset=dataset, batch_size=2, shuffle=False)
+        origin_model = LinearModel()
+        loss = nn.MSELoss()
+        optimizer = torch.optim.SGD(origin_model.parameters(), lr=lr)
 
-        def test_lite_correctness(self):
-            LiteCorrectness().run(0.25)
+        model, optimizer = self.setup(origin_model, optimizer)
+        train_loader = self.setup_dataloaders(train_loader)
+        model.train()
 
-        def test_lite_spawn_correctness(self):
-            LiteCorrectness(num_processes=2, strategy="spawn").run(0.5)
+        num_epochs = 2
+        for _i in range(num_epochs):
+            for X, y in train_loader:
+                optimizer.zero_grad()
+                l = loss(model(X), y)
+                self.backward(l)
+                optimizer.step()
 
-        def test_lite_subprocess_correctness(self):
-            LiteCorrectness(num_processes=2, strategy="subprocess").run(0.5)
+        assert origin_model.fc1.weight.data == 0.25, \
+            f"wrong weights: {origin_model.fc1.weight.data}"
 
-        def test_lite_ray_correctness(self):
-            LiteCorrectness(num_processes=2, strategy="ray").run(0.5)
+
+class TestLite(TestCase):
+    def test_lite(self):
+        Lite().run()
+
+    def test_lite_spawn(self):
+        Lite(num_processes=2, strategy="spawn").run()
+
+    def test_lite_subprocess(self):
+        Lite(num_processes=2, strategy="subprocess").run()
+
+    def test_lite_ray(self):
+        Lite(num_processes=2, strategy="ray").run()
+
+    def test_lite_correctness(self):
+        LiteCorrectness().run(0.25)
+
+    def test_lite_spawn_correctness(self):
+        LiteCorrectness(num_processes=2, strategy="spawn").run(0.5)
+
+    def test_lite_subprocess_correctness(self):
+        LiteCorrectness(num_processes=2, strategy="subprocess").run(0.5)
+
+    def test_lite_ray_correctness(self):
+        LiteCorrectness(num_processes=2, strategy="ray").run(0.5)
 
 
 if __name__ == '__main__':

--- a/python/nano/test/pytorch/tests/test_lite_ipex.py
+++ b/python/nano/test/pytorch/tests/test_lite_ipex.py
@@ -24,114 +24,112 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from test.pytorch.utils._train_torch_lightning import create_data_loader, data_transform
 
-from bigdl.nano.pytorch.utils import LIGHTNING_VERSION_LESS_1_6
-if not LIGHTNING_VERSION_LESS_1_6:
-    from bigdl.nano.pytorch.lite import LightningLite
-    from bigdl.nano.pytorch.vision.models import vision
+from bigdl.nano.pytorch.lite import LightningLite
+from bigdl.nano.pytorch.vision.models import vision
 
-    batch_size = 256
-    num_workers = 0
-    data_dir = os.path.join(os.path.dirname(__file__), "../data")
+batch_size = 256
+num_workers = 0
+data_dir = os.path.join(os.path.dirname(__file__), "../data")
 
 
-    class ResNet18(nn.Module):
-        def __init__(self, num_classes, pretrained=True, include_top=False, freeze=True):
-            super().__init__()
-            backbone = vision.resnet18(pretrained=pretrained, include_top=include_top, freeze=freeze)
-            output_size = backbone.get_output_size()
-            head = nn.Linear(output_size, num_classes)
-            self.model = nn.Sequential(backbone, head)
+class ResNet18(nn.Module):
+    def __init__(self, num_classes, pretrained=True, include_top=False, freeze=True):
+        super().__init__()
+        backbone = vision.resnet18(pretrained=pretrained, include_top=include_top, freeze=freeze)
+        output_size = backbone.get_output_size()
+        head = nn.Linear(output_size, num_classes)
+        self.model = nn.Sequential(backbone, head)
 
-        def forward(self, x):
-            return self.model(x)
-
-
-    class Lite(LightningLite):
-        def run(self):
-            model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
-            loss = nn.CrossEntropyLoss()
-            optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
-            train_loader = create_data_loader(data_dir, batch_size, num_workers, data_transform)
-
-            model, optimizer = self.setup(model, optimizer)
-            train_loader = self.setup_dataloaders(train_loader)
-            model.train()
-
-            num_epochs = 1
-            for _i in range(num_epochs):
-                total_loss, num = 0, 0
-                for X, y in train_loader:
-                    optimizer.zero_grad()
-                    l = loss(model(X), y)
-                    self.backward(l)
-                    optimizer.step()
-                    
-                    total_loss += l.sum()
-                    num += 1
-                print(f'avg_loss: {total_loss / num}')
+    def forward(self, x):
+        return self.model(x)
 
 
-    class LinearModel(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.fc1 = nn.Linear(1, 1, bias=False)
-            self.fc1.weight.data.fill_(1.0)
+class Lite(LightningLite):
+    def run(self):
+        model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
+        loss = nn.CrossEntropyLoss()
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+        train_loader = create_data_loader(data_dir, batch_size, num_workers, data_transform)
 
-        def forward(self, input_):
-            return self.fc1(input_)
+        model, optimizer = self.setup(model, optimizer)
+        train_loader = self.setup_dataloaders(train_loader)
+        model.train()
 
-
-    class LiteCorrectness(LightningLite):
-        def run(self, lr):
-            dataset=TensorDataset(
-                torch.tensor([[0.0],[0.0],[1.0],[1.0]]),
-                torch.tensor([[0.0],[0.0],[0.0],[0.0]]),
-            )
-            train_loader = DataLoader(dataset=dataset, batch_size=2, shuffle=False)
-            origin_model = LinearModel()
-            loss = nn.MSELoss()
-            optimizer = torch.optim.SGD(origin_model.parameters(), lr=lr)
-
-            model, optimizer = self.setup(origin_model, optimizer)
-            train_loader = self.setup_dataloaders(train_loader)
-            model.train()
-
-            num_epochs = 2
-            for _i in range(num_epochs):
-                for X, y in train_loader:
-                    optimizer.zero_grad()
-                    l = loss(model(X), y)
-                    self.backward(l)
-                    optimizer.step()
-
-            assert origin_model.fc1.weight.data == 0.25, \
-                f"wrong weights: {origin_model.fc1.weight.data}"
+        num_epochs = 1
+        for _i in range(num_epochs):
+            total_loss, num = 0, 0
+            for X, y in train_loader:
+                optimizer.zero_grad()
+                l = loss(model(X), y)
+                self.backward(l)
+                optimizer.step()
+                
+                total_loss += l.sum()
+                num += 1
+            print(f'avg_loss: {total_loss / num}')
 
 
-    class TestLite(TestCase):
-        def test_lite(self):
-            Lite(use_ipex=True).run()
+class LinearModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(1, 1, bias=False)
+        self.fc1.weight.data.fill_(1.0)
 
-        def test_lite_spawn(self):
-            Lite(use_ipex=True, num_processes=2, strategy="spawn").run()
+    def forward(self, input_):
+        return self.fc1(input_)
 
-        def test_lite_subprocess(self):
-            Lite(use_ipex=True, num_processes=2, strategy="subprocess").run()
 
-        def test_lite_ray(self):
-            Lite(use_ipex=True, num_processes=2, strategy="ray").run()
+class LiteCorrectness(LightningLite):
+    def run(self, lr):
+        dataset=TensorDataset(
+            torch.tensor([[0.0],[0.0],[1.0],[1.0]]),
+            torch.tensor([[0.0],[0.0],[0.0],[0.0]]),
+        )
+        train_loader = DataLoader(dataset=dataset, batch_size=2, shuffle=False)
+        origin_model = LinearModel()
+        loss = nn.MSELoss()
+        optimizer = torch.optim.SGD(origin_model.parameters(), lr=lr)
 
-        def test_lite_correctness(self):
-            LiteCorrectness(use_ipex=True).run(0.25)
+        model, optimizer = self.setup(origin_model, optimizer)
+        train_loader = self.setup_dataloaders(train_loader)
+        model.train()
 
-        def test_lite_spawn_correctness(self):
-            LiteCorrectness(use_ipex=True, num_processes=2, strategy="spawn").run(0.5)
+        num_epochs = 2
+        for _i in range(num_epochs):
+            for X, y in train_loader:
+                optimizer.zero_grad()
+                l = loss(model(X), y)
+                self.backward(l)
+                optimizer.step()
 
-        def test_lite_subprocess_correctness(self):
-            LiteCorrectness(use_ipex=True, num_processes=2, strategy="subprocess").run(0.5)
+        assert origin_model.fc1.weight.data == 0.25, \
+            f"wrong weights: {origin_model.fc1.weight.data}"
 
-        def test_lite_ray_correctness(self):
-            LiteCorrectness(use_ipex=True, num_processes=2, strategy="ray").run(0.5)
+
+class TestLite(TestCase):
+    def test_lite(self):
+        Lite(use_ipex=True).run()
+
+    def test_lite_spawn(self):
+        Lite(use_ipex=True, num_processes=2, strategy="spawn").run()
+
+    def test_lite_subprocess(self):
+        Lite(use_ipex=True, num_processes=2, strategy="subprocess").run()
+
+    def test_lite_ray(self):
+        Lite(use_ipex=True, num_processes=2, strategy="ray").run()
+
+    def test_lite_correctness(self):
+        LiteCorrectness(use_ipex=True).run(0.25)
+
+    def test_lite_spawn_correctness(self):
+        LiteCorrectness(use_ipex=True, num_processes=2, strategy="spawn").run(0.5)
+
+    def test_lite_subprocess_correctness(self):
+        LiteCorrectness(use_ipex=True, num_processes=2, strategy="subprocess").run(0.5)
+
+    def test_lite_ray_correctness(self):
+        LiteCorrectness(use_ipex=True, num_processes=2, strategy="ray").run(0.5)
 
 
 if __name__ == '__main__':

--- a/python/nano/test/pytorch/tests/test_lite_ipex.py
+++ b/python/nano/test/pytorch/tests/test_lite_ipex.py
@@ -74,6 +74,17 @@ if not LIGHTNING_VERSION_LESS_1_6:
         def test_lite(self):
             Lite(use_ipex=True).run()
 
+        def test_lite_spawn(self):
+            Lite(use_ipex=True, num_processes=2, strategy="spawn").run()
+
+        # subprocess now has a issue, which was fixed in another PR,
+        # We'll uncomment this test after merging that PR
+        # def test_lite_subprocess(self):
+            # Lite(num_processes=2, strategy="subprocess").run()
+
+        def test_lite_ray(self):
+            Lite(use_ipex=True, num_processes=2, strategy="ray").run()
+
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/python/nano/test/pytorch/tests/test_lite_ipex.py
+++ b/python/nano/test/pytorch/tests/test_lite_ipex.py
@@ -23,54 +23,56 @@ import torch
 from test.pytorch.utils._train_torch_lightning import create_data_loader, data_transform
 from torch import nn
 
-from bigdl.nano.pytorch.lite import LightningLite
-from bigdl.nano.pytorch.vision.models import vision
+from bigdl.nano.pytorch.utils import LIGHTNING_VERSION_LESS_1_6
+if not LIGHTNING_VERSION_LESS_1_6:
+    from bigdl.nano.pytorch.lite import LightningLite
+    from bigdl.nano.pytorch.vision.models import vision
 
-batch_size = 256
-num_workers = 0
-data_dir = os.path.join(os.path.dirname(__file__), "../data")
-
-
-class ResNet18(nn.Module):
-    def __init__(self, num_classes, pretrained=True, include_top=False, freeze=True):
-        super().__init__()
-        backbone = vision.resnet18(pretrained=pretrained, include_top=include_top, freeze=freeze)
-        output_size = backbone.get_output_size()
-        head = nn.Linear(output_size, num_classes)
-        self.model = nn.Sequential(backbone, head)
-
-    def forward(self, x):
-        return self.model(x)
+    batch_size = 256
+    num_workers = 0
+    data_dir = os.path.join(os.path.dirname(__file__), "../data")
 
 
-class Lite(LightningLite):
-    def run(self):
-        model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
-        loss = nn.CrossEntropyLoss()
-        optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
-        train_loader = create_data_loader(data_dir, batch_size, num_workers, data_transform)
+    class ResNet18(nn.Module):
+        def __init__(self, num_classes, pretrained=True, include_top=False, freeze=True):
+            super().__init__()
+            backbone = vision.resnet18(pretrained=pretrained, include_top=include_top, freeze=freeze)
+            output_size = backbone.get_output_size()
+            head = nn.Linear(output_size, num_classes)
+            self.model = nn.Sequential(backbone, head)
 
-        model, optimizer = self.setup(model, optimizer)
-        train_loader = self.setup_dataloaders(train_loader)
-        model.train()
-
-        max_epochs = 1
-        for _i in range(max_epochs):
-            total_loss, num = 0, 0
-            for X, y in train_loader:
-                optimizer.zero_grad()
-                l = loss(model(X), y)
-                self.backward(l)
-                optimizer.step()
-                
-                total_loss += l.sum()
-                num += 1
-            print(f'avg_loss: {total_loss / num}')
+        def forward(self, x):
+            return self.model(x)
 
 
-class TestLite(TestCase):
-    def test_lite(self):
-        Lite(use_ipex=True).run()
+    class Lite(LightningLite):
+        def run(self):
+            model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
+            loss = nn.CrossEntropyLoss()
+            optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+            train_loader = create_data_loader(data_dir, batch_size, num_workers, data_transform)
+
+            model, optimizer = self.setup(model, optimizer)
+            train_loader = self.setup_dataloaders(train_loader)
+            model.train()
+
+            max_epochs = 1
+            for _i in range(max_epochs):
+                total_loss, num = 0, 0
+                for X, y in train_loader:
+                    optimizer.zero_grad()
+                    l = loss(model(X), y)
+                    self.backward(l)
+                    optimizer.step()
+                    
+                    total_loss += l.sum()
+                    num += 1
+                print(f'avg_loss: {total_loss / num}')
+
+
+    class TestLite(TestCase):
+        def test_lite(self):
+            Lite(use_ipex=True).run()
 
 
 if __name__ == '__main__':

--- a/python/nano/test/pytorch/tests/test_lite_ipex.py
+++ b/python/nano/test/pytorch/tests/test_lite_ipex.py
@@ -1,0 +1,77 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import os
+from unittest import TestCase
+
+import pytest
+import torch
+from test.pytorch.utils._train_torch_lightning import create_data_loader, data_transform
+from torch import nn
+
+from bigdl.nano.pytorch.lite import LightningLite
+from bigdl.nano.pytorch.vision.models import vision
+
+batch_size = 256
+num_workers = 0
+data_dir = os.path.join(os.path.dirname(__file__), "../data")
+
+
+class ResNet18(nn.Module):
+    def __init__(self, num_classes, pretrained=True, include_top=False, freeze=True):
+        super().__init__()
+        backbone = vision.resnet18(pretrained=pretrained, include_top=include_top, freeze=freeze)
+        output_size = backbone.get_output_size()
+        head = nn.Linear(output_size, num_classes)
+        self.model = nn.Sequential(backbone, head)
+
+    def forward(self, x):
+        return self.model(x)
+
+
+class Lite(LightningLite):
+    def run(self):
+        model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
+        loss = nn.CrossEntropyLoss()
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+        train_loader = create_data_loader(data_dir, batch_size, num_workers, data_transform)
+
+        model, optimizer = self.setup(model, optimizer)
+        train_loader = self.setup_dataloaders(train_loader)
+        model.train()
+
+        max_epochs = 1
+        for _i in range(max_epochs):
+            total_loss, num = 0, 0
+            for X, y in train_loader:
+                optimizer.zero_grad()
+                l = loss(model(X), y)
+                self.backward(l)
+                optimizer.step()
+                
+                total_loss += l.sum()
+                num += 1
+            print(f'avg_loss: {total_loss / num}')
+
+
+class TestLite(TestCase):
+    def test_lite(self):
+        Lite(use_ipex=True).run()
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/python/nano/test/pytorch/tests/test_lite_ipex.py
+++ b/python/nano/test/pytorch/tests/test_lite_ipex.py
@@ -107,6 +107,13 @@ class LiteCorrectness(LightningLite):
 
 
 class TestLite(TestCase):
+    def setUp(self):
+        test_dir = os.path.dirname(__file__)
+        project_test_dir = os.path.abspath(
+            os.path.join(os.path.join(os.path.join(test_dir, ".."), ".."), "..")
+        )
+        os.environ['PYTHONPATH'] = project_test_dir
+
     def test_lite(self):
         Lite(use_ipex=True).run()
 
@@ -116,9 +123,6 @@ class TestLite(TestCase):
     def test_lite_subprocess(self):
         Lite(use_ipex=True, num_processes=2, strategy="subprocess").run()
 
-    def test_lite_ray(self):
-        Lite(use_ipex=True, num_processes=2, strategy="ray").run()
-
     def test_lite_correctness(self):
         LiteCorrectness(use_ipex=True).run(0.25)
 
@@ -127,9 +131,6 @@ class TestLite(TestCase):
 
     def test_lite_subprocess_correctness(self):
         LiteCorrectness(use_ipex=True, num_processes=2, strategy="subprocess").run(0.5)
-
-    def test_lite_ray_correctness(self):
-        LiteCorrectness(use_ipex=True, num_processes=2, strategy="ray").run(0.5)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

This PR adds ipex, ddp and ray backend support for `LightningLite`.

## Motivation and Context

We want to support accelerating `LightningLite` with nano, so we should add ipex, ddp_spawn, ddp_subprocess and ray strategy support for `LightningLite`

## API Usage or Code Design

Add a nano's `LightningLite` to replace pytorch lightning's `LightningLite`.

See below for details.

## Related Link or Issue

analytics-zoo/nano#176

## How was this PR tested?

- [x] jenkins passed (please provide link): <http://10.112.231.51:18888/job/BigDL-NanoTests-PR-Validation/298/>

## License & Dependency
N/A