### PR TITLE
fix jackson-databind Vulnerability

### DIFF
--- a/scala/dllib/pom.xml
+++ b/scala/dllib/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.11.4</version>
+            <version>2.12.6.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Cause: com.fasterxml.jackson.databind.JsonMappingException: Scala module 2.11.4 requires Jackson Databind version >= 2.11.0 and < 2.12.0
http://10.112.231.51:18888/job/BigDL-PRVN-scalatest-zoo-Spark-3.1/544/console

can not fix on spark2.4
close this pr