### PR TITLE
Chronos: fix bug in autoformer's `e_layers` parameter

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -44,7 +44,7 @@ class AutoformerForecaster(Forecaster):
                  n_head=8,
                  d_ff=256,
                  activation='gelu',
-                 e_layer=2,
+                 e_layers=2,
                  d_layers=1,
                  optimizer="Adam",
                  loss="mse",
@@ -116,7 +116,7 @@ class AutoformerForecaster(Forecaster):
             "n_head": n_head,
             "d_ff": d_ff,
             "activation": activation,
-            "e_layer": e_layer,
+            "e_layers": e_layers,
             "c_out": output_feature_num,
             "d_layers": d_layers
         }


### PR DESCRIPTION
## Description

Change parameter `e_layers`'s name to make it effective.

### 1. Why the change?

A parameter in AutoformerForecaster is mis-spelled and not effective due to the typo.

### 2. Summary of the change
No API changes.

### 3. How to test?
- [ ] N/A
- [x] Unit test - use original ut
- [ ] Application test
- [ ] Document test
- [ ] ...
