### PR TITLE
upgrade opencv 4 in serving

### DIFF
--- a/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/http/domains.scala
+++ b/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/http/domains.scala
@@ -175,7 +175,7 @@ case class Instances(instances: List[mutable.LinkedHashMap[String, Any]]) {
                       java.util.Base64.getDecoder.decode(value.toString)
                     }
                     val mat = timing("load byte buffer")() {
-                      OpenCVMethod.fromImageBytes(byteBuffer, Imgcodecs.CV_LOAD_IMAGE_UNCHANGED)
+                      OpenCVMethod.fromImageBytes(byteBuffer, Imgcodecs.IMREAD_UNCHANGED)
                     }
                     val (height, width, channel) = (mat.height(), mat.width(), mat.channels())
                     val arrayBuffer = new Array[Float](height * width * channel)

--- a/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/preprocessing/PreProcessing.scala
+++ b/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/preprocessing/PreProcessing.scala
@@ -121,7 +121,7 @@ class PreProcessing()
     } else {
       java.util.Base64.getDecoder.decode(s)
     }
-    val mat = OpenCVMethod.fromImageBytes(byteBuffer, Imgcodecs.CV_LOAD_IMAGE_UNCHANGED)
+    val mat = OpenCVMethod.fromImageBytes(byteBuffer, Imgcodecs.IMREAD_UNCHANGED)
     if (helper.imageResize != "") {
       val hw = helper.imageResize.split(",")
       Log4Error.invalidOperationError(hw.length == 2, "Image dim must be 2")

--- a/scala/serving/src/test/scala/com/intel/analytics/bigdl/serving/CorrectnessSpec.scala
+++ b/scala/serving/src/test/scala/com/intel/analytics/bigdl/serving/CorrectnessSpec.scala
@@ -64,7 +64,7 @@ class CorrectnessSpec extends FlatSpec with Matchers {
   def getBase64FromPath(path: String): String = {
 
     val b = FileUtils.readFileToByteArray(new File(path))
-    val img = OpenCVMethod.fromImageBytes(b, Imgcodecs.CV_LOAD_IMAGE_COLOR)
+    val img = OpenCVMethod.fromImageBytes(b, Imgcodecs.IMREAD_UNCHANGED)
     Imgproc.resize(img, img, new Size(224, 224))
     val matOfByte = new MatOfByte()
     Imgcodecs.imencode(".jpg", img, matOfByte)


### PR DESCRIPTION
## Description

Opencv 4 has different func typo with opencv 3

### 1. Why the change?
` /opt/work/jenkins/workspace/ZOO-PR-BigDL-Python-Spark-2.4-py37-ray/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/preprocessing/PreProcessing.scala:124: value CV_LOAD_IMAGE_UNCHANGED is not a member of object org.opencv.imgcodecs.Imgcodecs? serving module failed to compile
`
### 2. Summary of the change
Imgcodecs.CV_LOAD_IMAGE_UNCHANGED -> Imgcodecs.IMREAD_UNCHANGED

### 3. How to test?
Jenkins
