### PR TITLE
fix stylecheck dllib

### DIFF
--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/image/ImageSet.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/image/ImageSet.scala
@@ -175,7 +175,7 @@ object ImageSet {
    *              By default is Imgcodecs.CV_LOAD_IMAGE_UNCHANGED
    */
   def array(data: Array[Array[Byte]], resizeH: Int = -1, resizeW: Int = -1,
-            imageCodec: Int = Imgcodecs.IMREAD_UNCHANGED ,
+            imageCodec: Int = Imgcodecs.IMREAD_UNCHANGED,
             labelMap: Map[String, Int] = null): ImageSet = {
     val images = data.map(ImageFeature(_))
     val imageSet = ImageSet.array(images, labelMap)
@@ -201,7 +201,7 @@ object ImageSet {
    *              By default is Imgcodecs.CV_LOAD_IMAGE_UNCHANGED
    */
   def rddBytes(data: RDD[Array[Byte]], resizeH: Int = -1, resizeW: Int = -1,
-               imageCodec: Int = Imgcodecs.IMREAD_UNCHANGED ,
+               imageCodec: Int = Imgcodecs.IMREAD_UNCHANGED,
                labelMap: Map[String, Int] = null): ImageSet = {
     val images = data.map(ImageFeature(_))
     val imageSet = ImageSet.rdd(images, labelMap)
@@ -236,7 +236,7 @@ object ImageSet {
    */
   def read(path: String, sc: SparkContext = null, minPartitions: Int = 1,
            resizeH: Int = -1, resizeW: Int = -1,
-           imageCodec: Int = Imgcodecs.IMREAD_UNCHANGED ,
+           imageCodec: Int = Imgcodecs.IMREAD_UNCHANGED,
            withLabel: Boolean = false, oneBasedLabel: Boolean = true): ImageSet = {
     val imageSet = if (null != sc) {
       readToDistributedImageSet(path, minPartitions, sc, withLabel, oneBasedLabel)


### PR DESCRIPTION
## Description

Fix scala stylecheck 
```
[INFO] --- scalastyle-maven-plugin:1.0.0:check (default) @ bigdl-dllib-spark_3.1.2 ---
error file=/var/jenkins_home/workspace/BigDL2.0-NB-Deploy-SCALA/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/image/ImageSet.scala message=Space before token , line=178 column=57
```