### PR TITLE
Chronos: add "id" in xshardstsdatataset dict of numpy for scaling

### DIFF
--- a/python/chronos/example/distributed/sparkdf_training_nyc_taxi.py
+++ b/python/chronos/example/distributed/sparkdf_training_nyc_taxi.py
@@ -68,7 +68,7 @@ if __name__ == '__main__':
                         "You can change it depending on your own cluster setting.")
     parser.add_argument('--cluster_mode', type=str, default='local',
                         help="The mode for the Spark cluster.")
-    parser.add_argument('--num_workers', type=int, default=1,
+    parser.add_argument('--num_nodes', type=int, default=1,
                         help="The number of nodes to be used in the cluster"
                         "You can change it depending on your own cluster setting.")
 
@@ -85,7 +85,7 @@ if __name__ == '__main__':
                         help="Download link of dataset.")
 
     args = parser.parse_args()
-    num_nodes = 1 if args.cluster_mode == 'local' else args.num_workers
+    num_nodes = 1 if args.cluster_mode == 'local' else args.num_nodes
     init_orca_context(cluster_mode=args.cluster_mode, cores=args.cores,
                       memory=args.memory, num_nodes=num_nodes)
     dataset_path = get_csv(args)

--- a/python/chronos/src/bigdl/chronos/data/experimental/utils.py
+++ b/python/chronos/src/bigdl/chronos/data/experimental/utils.py
@@ -25,5 +25,8 @@ def add_row(df, name, const_num):
 
 def transform_to_dict(data):
     if data[1] is None:
-        return {"x": data[0].astype(np.float32)}
-    return {"x": data[0].astype(np.float32), "y": data[1].astype(np.float32)}
+        return {"x": data[0].astype(np.float32),
+                "id": data[2].astype(np.float32)}
+    return {"x": data[0].astype(np.float32),
+            "y": data[1].astype(np.float32),
+            "id": data[2].astype(np.float32)}

--- a/python/chronos/src/bigdl/chronos/data/experimental/xshards_tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/experimental/xshards_tsdataset.py
@@ -268,7 +268,8 @@ class XShardsTSDataset:
             else self.target_col
         self.numpy_shards = self.shards.transform_shard(roll_timeseries_dataframe,
                                                         None, lookback, horizon,
-                                                        feature_col, target_col)
+                                                        feature_col, target_col,
+                                                        self.id_col, 0, True)
         return self
 
     def scale(self, scaler, fit=True):
@@ -392,11 +393,13 @@ class XShardsTSDataset:
         self.shards = self.shards.transform_shard(df_reset_index)
         return self
 
-    def to_xshards(self):
+    def to_xshards(self, partition_num=1):
         '''
-        Export rolling result in form of a dict of numpy ndarray {'x': ..., 'y': ...}
+        Export rolling result in form of a dict of numpy ndarray {'x': ..., 'y': ..., 'id': ...}
 
-        :return: a 2-element dict xshard. each value is a 3d numpy ndarray. The ndarray
+        :param partition_num: how many partition you would like to split your data.
+
+        :return: a 3-element dict xshard. each value is a 3d numpy ndarray. The ndarray
                  is casted to float32.
         '''
         from bigdl.nano.utils.log4Error import invalidInputError
@@ -404,4 +407,4 @@ class XShardsTSDataset:
             invalidInputError(False,
                               "Please call 'roll' method "
                               "before transform a XshardsTSDataset to numpy ndarray!")
-        return self.numpy_shards.transform_shard(transform_to_dict)
+        return self.numpy_shards.transform_shard(transform_to_dict).repartition(partition_num)

--- a/python/chronos/src/bigdl/chronos/data/experimental/xshards_tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/experimental/xshards_tsdataset.py
@@ -393,18 +393,24 @@ class XShardsTSDataset:
         self.shards = self.shards.transform_shard(df_reset_index)
         return self
 
-    def to_xshards(self, partition_num=1):
+    def to_xshards(self, partition_num=None):
         '''
-        Export rolling result in form of a dict of numpy ndarray {'x': ..., 'y': ..., 'id': ...}
+        Export rolling result in form of a dict of numpy ndarray {'x': ..., 'y': ..., 'id': ...},
+        where value for 'x' and 'y' are 3-dim numpy ndarray and value for 'id' is 2-dim ndarray
+        with shape (batch_size, 1)
 
         :param partition_num: how many partition you would like to split your data.
 
         :return: a 3-element dict xshard. each value is a 3d numpy ndarray. The ndarray
-                 is casted to float32.
+                 is casted to float32. Default to None which will partition according
+                 to id.
         '''
         from bigdl.nano.utils.log4Error import invalidInputError
         if self.numpy_shards is None:
             invalidInputError(False,
                               "Please call 'roll' method "
                               "before transform a XshardsTSDataset to numpy ndarray!")
-        return self.numpy_shards.transform_shard(transform_to_dict).repartition(partition_num)
+        if partition_num is None:
+            return self.numpy_shards.transform_shard(transform_to_dict)
+        else:
+            return self.numpy_shards.transform_shard(transform_to_dict).repartition(partition_num)

--- a/python/chronos/test/bigdl/chronos/data/experimental/test_xshardstsdataset.py
+++ b/python/chronos/test/bigdl/chronos/data/experimental/test_xshardstsdataset.py
@@ -273,13 +273,13 @@ class TestXShardsTSDataset(TestCase):
                                                target_col="feature",
                                                id_col="id")
         tsdata.roll(lookback=4, horizon=2)
-        data = tsdata.to_xshards(partition_num=4)
+        data = tsdata.to_xshards(partition_num=5)
         data_collected = data.collect()
         assert data_collected[0]['x'].shape[1] == 4
         assert data_collected[0]['x'].shape[2] == 1
         assert data_collected[0]['y'].shape[1] == 2
         assert data_collected[0]['y'].shape[2] == 1
-        assert data.num_partitions() == 4
+        assert data.num_partitions() == 5
         assert "id" in data.collect()[0].keys()
         assert tsdata.shards.num_partitions() == 2
 

--- a/python/chronos/test/bigdl/chronos/data/experimental/test_xshardstsdataset.py
+++ b/python/chronos/test/bigdl/chronos/data/experimental/test_xshardstsdataset.py
@@ -273,11 +273,14 @@ class TestXShardsTSDataset(TestCase):
                                                target_col="feature",
                                                id_col="id")
         tsdata.roll(lookback=4, horizon=2)
-        data = tsdata.to_xshards().collect()
-        assert data[0]['x'].shape[1] == 4
-        assert data[0]['x'].shape[2] == 1
-        assert data[0]['y'].shape[1] == 2
-        assert data[0]['y'].shape[2] == 1
+        data = tsdata.to_xshards(partition_num=4)
+        data_collected = data.collect()
+        assert data_collected[0]['x'].shape[1] == 4
+        assert data_collected[0]['x'].shape[2] == 1
+        assert data_collected[0]['y'].shape[1] == 2
+        assert data_collected[0]['y'].shape[2] == 1
+        assert data.num_partitions() == 4
+        assert "id" in data.collect()[0].keys()
         assert tsdata.shards.num_partitions() == 2
 
         # with only 1 id


### PR DESCRIPTION
**working on the description**

## Description

### 1. Why the change?

We are supporting this workflow in distributed style
```python
# create xshardstsdata
xtsdata_train, xtsdata_test = XShardsTSDataset.from_sparkdf(df, ...)

# preprocessing
for xtsdata in [xtsdata_train, xtsdata_test]:
    xtsdata_train.scale(scalers, fit=xtsdata is xtsdata_train)\
                 .roll(lookback=10, horizon=1)
data_train = xtsdata_train.to_xshards(partition_num=4)
data_test = xtsdata_test.to_xshards(partition_num=4)

# train
forecaster.fit(data_train)

# predict
yhat_xshard = forecaster.predict(data_test)

# post process
yhat_xshard_unscale = xtsdata_test.unscale_xshards(yhat_xshard)
```

### 2. Summary of the change

1. add a "id" key in `xtsdata.to_xshards()`, this means that we have the information about which id is this partition sampled from. This will help us choose the correct scaler
2. add a `partition_num` parameter to `xtsdata.to_xshards()`, so that users can change the partition_num to any value they want.

### 3. How to test?
- [x] Unit test http://10.112.231.51:18889/view/BigDL-PR-Validation/job/BigDL-Chronos-PR-Validation/560/

