### PR TITLE
[Nano]Make OpenVINOModel as public API

### DIFF
--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -26,8 +26,9 @@ from .utils import save
 
 
 class OpenVINOModel:
-    def __init__(self, ie_network: str):
+    def __init__(self, ie_network: str, device='CPU'):
         self._ie = Core()
+        self._device = device
         self.ie_network = ie_network
 
     def forward_step(self, *inputs):
@@ -43,7 +44,8 @@ class OpenVINOModel:
             self._ie_network = self._ie.read_model(model=str(model))
         else:
             self._ie_network = model
-        self._compiled_model = self._ie.compile_model(model=self.ie_network, device_name='CPU')
+        self._compiled_model = self._ie.compile_model(model=self.ie_network,
+                                                      device_name=self._device)
         self._infer_request = self._compiled_model.create_infer_request()
 
     def _save_model(self, path):

--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -48,3 +48,9 @@ def KerasOpenVINOModel(model, input_sample=None):
     """
     from .tf.model import KerasOpenVINOModel
     return KerasOpenVINOModel(model)
+
+
+def OpenVINOModel(model, device='CPU'):
+    from .core.model import OpenVINOModel
+    return OpenVINOModel(model, device)
+    

--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -53,4 +53,3 @@ def KerasOpenVINOModel(model, input_sample=None):
 def OpenVINOModel(model, device='CPU'):
     from .core.model import OpenVINOModel
     return OpenVINOModel(model, device)
-    

--- a/python/nano/src/bigdl/nano/openvino.py
+++ b/python/nano/src/bigdl/nano/openvino.py
@@ -1,0 +1,18 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# import public APIs of openvino
+from bigdl.nano.deps.openvino.openvino_api import *

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -36,7 +36,7 @@ from bigdl.nano.pytorch.plugins.ddp_subprocess import DDPSubprocessPlugin
 from bigdl.nano.deps.automl.hpo_api import create_hpo_searcher, check_hpo_status
 from bigdl.nano.deps.ray.ray_api import distributed_ray
 from bigdl.nano.deps.ipex.ipex_api import create_IPEXAccelerator, create_IPEXAccelerator_1_9
-from bigdl.nano.deps.openvino.openvino_api import PytorchOpenVINOModel, load_openvino_model
+from bigdl.nano.openvino import PytorchOpenVINOModel, load_openvino_model
 from bigdl.nano.deps.onnxruntime.onnxruntime_api import PytorchONNXRuntimeModel, \
     load_onnxruntime_model
 from bigdl.nano.deps.neural_compressor.inc_api import load_inc_model, quantize as inc_quantize


### PR DESCRIPTION
## Description

Allow users to use `deps/openvino` directly without Pytorch/Tensorflow. And add extra `device` option for users to specify the device.  If users want to load an openvino model without Pytorch/TF installed, current usage is like
```python
from bigdl.nano.deps.openvino.core.model import OpenVINOModel
ov_model = OpenVINOModel("model.xml")
```
From our previous design, `deps/xxx_api` is the only thing in the dependencies we expose to users. So we need to provide one 
`OpenVINOModel` api.

### 1. Why the change?

Mainly for the AI for workforce course.  
And after this change, users can load openvino model by `OpenVINOModel` without Pytorch/TF installed.

### 2. Summary of the change

-  make `OpenVINOModel` accessible to users
### Before
If users want to load an openvino model without Pytorch/TF installed, they may do this:
```python
from bigdl.nano.deps.openvino.core.model import OpenVINOModel
ov_model = OpenVINOModel("model.xml")
```
### After
```python
from bigdl.nano.openvino import OpenVINOModel
ov_model = OpenVINOModel("model.xml", device='cpu')
```
- add `device` option to `OpenVINOModel` in case the model is run on other type of devices

### 3. How to test?
- [x] N/A