### PR TITLE
[PPML] Fix Occlum docker container will start an aesm service

### DIFF
--- a/ppml/trusted-big-data-ml/scala/docker-occlum/run_spark_on_occlum_glibc.sh
+++ b/ppml/trusted-big-data-ml/scala/docker-occlum/run_spark_on_occlum_glibc.sh
@@ -39,7 +39,6 @@ init_instance() {
     # check if occlum_spark exists
     [[ -d occlum_spark ]] || mkdir occlum_spark
     cd occlum_spark
-    /opt/occlum/start_aesm.sh
     occlum init
     new_json="$(jq '.resource_limits.user_space_size = "SGX_MEM_SIZE" |
         .resource_limits.max_num_of_threads = "SGX_THREAD" |


### PR DESCRIPTION
## Description
Occlum docker container will start a new aesm service to crash other aesm.
<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-3 below and just provide a simple description here -->

### 1. Why the change?
avoiding crash other aesm service
<!-- Provide the related github issue link if available -->

### 2. Summary of the change
remove "/opt/occlum/start_aesm.sh" to fix
<!-- Provide the design for both API changes and the implementation; -->
<!-- alternatively, provide a link to the github issue link for the design -->

### 3. How to test?
- [x] Application test

