### PR TITLE
[PPML] Remove aesm in occlum image

### DIFF
--- a/ppml/trusted-big-data-ml/scala/docker-occlum/Dockerfile
+++ b/ppml/trusted-big-data-ml/scala/docker-occlum/Dockerfile
@@ -239,6 +239,7 @@ COPY ./entrypoint.sh /opt/
 
 RUN chmod a+x /opt/entrypoint.sh && \
     chmod a+x /opt/run_spark_on_occlum_glibc.sh && \
-    chmod a+x /root/demos/remote_attestation/init_ra_flow/run_attestation_server.sh
+    chmod a+x /root/demos/remote_attestation/init_ra_flow/run_attestation_server.sh && \
+    sed -i '/aesm/d' /root/.bashrc
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/ppml/trusted-big-data-ml/scala/docker-occlum/Dockerfile
+++ b/ppml/trusted-big-data-ml/scala/docker-occlum/Dockerfile
@@ -240,6 +240,7 @@ COPY ./entrypoint.sh /opt/
 RUN chmod a+x /opt/entrypoint.sh && \
     chmod a+x /opt/run_spark_on_occlum_glibc.sh && \
     chmod a+x /root/demos/remote_attestation/init_ra_flow/run_attestation_server.sh && \
-    sed -i '/aesm/d' /root/.bashrc
+    sed -i '/aesm/d' /root/.bashrc && \
+    rm -rf /var/run/aesmd
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]


### PR DESCRIPTION
## Description
Avoid aesm in occlum image to crash host aesm service
### 1. Why the change?
Occlum has aesm start command in bashrc which may crash aesm service when mount host aesm.
<!-- Provide the related github issue link if available -->

### 2. Summary of the change

Remove /var/run/aesmd
Remove aesm command in bashrc

### 3. How to test?
- [ ] Application test

