### PR TITLE
fix ray test in nano

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
+++ b/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
@@ -244,7 +244,7 @@ class RayStrategy(DDPSpawnStrategy):
             # pytest will set this environment variable to the path of `nano` directory,
             # and subprocess will use it to initialize its `sys.path`,
             # so we can import `test` module in subprocess
-            ray.get(worker.set_env_var.remote("PYTHONPATH", envs[i]['PYTHONPATH']))
+            ray.get(worker.set_env_var.remote("PYTHONPATH", envs[i].get("PYTHONPATH", "")))
 
             workers.append(worker)
 

--- a/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
+++ b/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
@@ -241,6 +241,10 @@ class RayStrategy(DDPSpawnStrategy):
 
             ray.get(worker.set_env_var.remote("KMP_AFFINITY", envs[i]['KMP_AFFINITY']))
             ray.get(worker.set_env_var.remote("OMP_NUM_THREADS", envs[i]['OMP_NUM_THREADS']))
+            # pytest will set this environment variable to the path of `nano` directory,
+            # and subprocess will use it to initialize its `sys.path`,
+            # so we can import `test` module in subprocess
+            ray.get(worker.set_env_var.remote("PYTHONPATH", envs[i]['PYTHONPATH']))
 
             workers.append(worker)
 

--- a/python/nano/test/ray/test_ray_trainer.py
+++ b/python/nano/test/ray/test_ray_trainer.py
@@ -72,7 +72,7 @@ class TestTrainer(TestCase):
             resnet18, batch_size, num_workers, data_dir)
 
     def test_trainer_ray_compile(self):
-        trainer = Trainer(max_epochs=1, distributed_backend="ray")
+        trainer = Trainer(max_epochs=1, num_processes=2, distributed_backend="ray")
         pl_model = Trainer.compile(self.model, self.loss, self.optimizer)
         trainer.fit(pl_model, self.train_loader)
 

--- a/python/nano/test/ray/test_ray_trainer.py
+++ b/python/nano/test/ray/test_ray_trainer.py
@@ -65,6 +65,13 @@ class TestTrainer(TestCase):
     train_loader = create_data_loader(data_dir, batch_size, num_workers, data_transform)
     user_defined_pl_model = LitResNet18(10)
 
+    def setUp(self):
+        test_dir = os.path.dirname(__file__)
+        project_test_dir = os.path.abspath(
+            os.path.join(os.path.join(test_dir, ".."), "..")
+        )
+        os.environ['PYTHONPATH'] = project_test_dir
+
     def test_resnet18(self):
         resnet18 = vision.resnet18(
             pretrained=False, include_top=False, freeze=True)


### PR DESCRIPTION
## Description

the default value of `num_processes` argument of `Trainer` is 1, and the trainer won't use distributed backend when `num_processes==1`, so we need to set it

in addition, fix the bug that the test of ray backend doesn't set the `PYTHONPATH` environment variable and ray backend doesn't pass this environment variable to subprocesses