### PR TITLE
Chronos: support unscale_xshards in XShardsTSDataset

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/experimental/xshards_tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/experimental/xshards_tsdataset.py
@@ -22,6 +22,7 @@ from bigdl.chronos.data.utils.roll import roll_timeseries_dataframe
 from bigdl.chronos.data.utils.impute import impute_timeseries_dataframe
 from bigdl.chronos.data.utils.split import split_timeseries_dataframe
 from bigdl.chronos.data.experimental.utils import add_row, transform_to_dict
+from bigdl.chronos.data.utils.scale import unscale_timeseries_numpy
 
 
 _DEFAULT_ID_COL_NAME = "id"

--- a/python/chronos/src/bigdl/chronos/data/experimental/xshards_tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/experimental/xshards_tsdataset.py
@@ -368,13 +368,14 @@ class XShardsTSDataset:
                                                   self.target_col)
         return self
 
-    def unscale_xshards(self, data, key='y'):
+    def unscale_xshards(self, data, key=None):
         '''
         Unscale the time series forecaster's numpy prediction result/ground truth.
 
         :param data: xshards same with self.numpy_xshards.
         :param key: str, 'y' or 'prediction', default to 'y'. if no "prediction"
-        or "y" return an error and require our users to input a key.
+        or "y" return an error and require our users to input a key. if key is
+        None, key will be set 'prediction'.
 
         :return: the unscaled xshardtsdataset instance.
         '''
@@ -392,6 +393,8 @@ class XShardsTSDataset:
 
             return unscale_timeseries_numpy(data[key], scaler_for_this_id, scaler_index)
 
+        if key is None:
+            key = 'prediction'
         invalidInputError(key in {'y', 'prediction'}, "key is not in {'y', 'prediction'}, "
                           "please input the correct key.")
 

--- a/python/chronos/src/bigdl/chronos/data/experimental/xshards_tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/experimental/xshards_tsdataset.py
@@ -383,6 +383,7 @@ class XShardsTSDataset:
                               "you need to set fit=True.")
 
             return unscale_timeseries_numpy(data['y'], scaler_for_this_id, scaler_index)
+
         def _get_features(df):
             return df.columns
 

--- a/python/chronos/src/bigdl/chronos/data/experimental/xshards_tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/experimental/xshards_tsdataset.py
@@ -363,7 +363,7 @@ class XShardsTSDataset:
                                                   self.scaler_dict, self.feature_col,
                                                   self.target_col)
         return self
-    
+
     def unscale_xshards(self, data):
         '''
         Unscale the time series forecaster's numpy prediction result/ground truth.
@@ -385,6 +385,7 @@ class XShardsTSDataset:
             return unscale_timeseries_numpy(data['y'], scaler_for_this_id, scaler_index)
         def _get_features(df):
             return df.columns
+
         cols = self.shards.transform_shard(_get_features).collect()[0]
         scaler_index = [cols.get_loc(col) + 1 for col in self.target_col]
         return data.transform_shard(_inverse_transform, self.scaler_dict, scaler_index)

--- a/python/chronos/test/bigdl/chronos/data/experimental/test_xshardstsdataset.py
+++ b/python/chronos/test/bigdl/chronos/data/experimental/test_xshardstsdataset.py
@@ -272,7 +272,7 @@ class TestXShardsTSDataset(TestCase):
             tsdata.roll(horizon=horizon, lookback=lookback)
 
             scale_arr = tsdata.to_xshards()
-            numpy_tsdata = tsdata.unscale_xshards(scale_arr)
+            numpy_tsdata = tsdata.unscale_xshards(scale_arr, 'y')
             numpy_tsdata = numpy_tsdata.collect()
             y = np.concatenate(numpy_tsdata, axis=0)
             assert_array_almost_equal(ori_y, y)

--- a/python/chronos/test/bigdl/chronos/data/experimental/test_xshardstsdataset.py
+++ b/python/chronos/test/bigdl/chronos/data/experimental/test_xshardstsdataset.py
@@ -262,8 +262,8 @@ class TestXShardsTSDataset(TestCase):
             ori_tsdata = XShardsTSDataset.from_xshards(shards_multiple, dt_col="datetime",
                                                    target_col="value",
                                                    extra_feature_col=["extra feature"], id_col="id")
-            horizon = 1
-            lookback = 1
+            horizon = random.randint(1, 10)
+            lookback = random.randint(1, 20)
             ori_tsdata.roll(horizon=horizon, lookback=lookback)
             ori_arr_shards = ori_tsdata.to_xshards().collect()
             ori_arr_shards = [arr['y'] for arr in ori_arr_shards]

--- a/python/chronos/test/bigdl/chronos/data/experimental/test_xshardstsdataset.py
+++ b/python/chronos/test/bigdl/chronos/data/experimental/test_xshardstsdataset.py
@@ -245,6 +245,37 @@ class TestXShardsTSDataset(TestCase):
             tsdata.unscale()
             df_train_unscale = get_local_df(tsdata)
             assert_frame_equal(df_train_unscale, df)
+            
+    def test_xshardstsdataset_unscale_numpy(self):
+        from sklearn.preprocessing import  StandardScaler, MaxAbsScaler, MinMaxScaler, RobustScaler
+        scalers = [{0: StandardScaler(), 1: StandardScaler()}, 
+                   {0: MaxAbsScaler(), 1: MaxAbsScaler()},
+                   {0: MinMaxScaler(), 1: MinMaxScaler()},
+                   {0: RobustScaler(), 1: RobustScaler()}]
+        for scaler in scalers:
+            shards_multiple = read_csv(os.path.join(self.resource_path, "multiple.csv"))
+
+            tsdata = XShardsTSDataset.from_xshards(shards_multiple, dt_col="datetime",
+                                                   target_col="value",
+                                                   extra_feature_col=["extra feature"], id_col="id")
+
+            ori_tsdata = XShardsTSDataset.from_xshards(shards_multiple, dt_col="datetime",
+                                                   target_col="value",
+                                                   extra_feature_col=["extra feature"], id_col="id")
+            horizon = 1
+            lookback = 1
+            ori_tsdata.roll(horizon=horizon, lookback=lookback)
+            ori_arr_shards = ori_tsdata.to_xshards().collect()
+            ori_arr_shards = [arr['y'] for arr in ori_arr_shards]
+            ori_y = np.concatenate(ori_arr_shards, axis=0)
+            tsdata.scale(scaler)
+            tsdata.roll(horizon=horizon, lookback=lookback)
+
+            scale_arr = tsdata.to_xshards()
+            numpy_tsdata = tsdata.unscale_xshards(scale_arr)
+            numpy_tsdata = numpy_tsdata.collect()
+            y = np.concatenate(numpy_tsdata, axis=0)
+            assert_array_almost_equal(ori_y, y)
 
     def test_xshardstsdataset_impute(self):
         from tempfile import TemporaryDirectory


### PR DESCRIPTION
## Description

add `xshards.unscale_xshards` and test function `tests.test_xshardstsdataset_unscale_numpy`.
initialize scaler_index and update scaler_index in xshards.roll.

### 1. Why the change?

help user unscale the xshards data containing numpy array.

### 2. Summary of the change

add `xshards.unscale_xshards` and test function `tests.test_xshardstsdataset_unscale_numpy`.
initialize scaler_index and update scaler_index in `xshards.roll`.
change the order of [feature_col, target_col] in `xshards.scale` and `xshards.unscale`.

### 3. How to test?
- [x] Unit test http://10.112.231.51:18889/job/BigDL-Chronos-PR-Validation/581/
