### PR TITLE
Fix #5121, add  libgomp1 installation to Dockerfile

### DIFF
--- a/docker/bigdl-k8s/Dockerfile
+++ b/docker/bigdl-k8s/Dockerfile
@@ -128,7 +128,7 @@ COPY --from=spark /sbin/tini /sbin/tini
 RUN mkdir -p /opt/bigdl-examples/python && \
     mkdir -p /opt/bigdl-examples/scala && \
     apt-get update --fix-missing && \
-    apt-get install -y apt-utils vim curl nano wget unzip git && \
+    apt-get install -y apt-utils vim curl libgomp1 nano wget unzip git && \
     rm /bin/sh && \
     ln -sv /bin/bash /bin/sh && \
     echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \


### PR DESCRIPTION
## Description
Fix [issue#5121](https://github.com/intel-analytics/BigDL/issues/5121) , when I try to run xgboost on k8s using bigdl-k8s image, I run into this lack of lib libgomp1 .
So I add libgomp1 in bigdl-k8s 