### PR TITLE
import pot locally

### DIFF
--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -18,10 +18,6 @@ from tempfile import TemporaryDirectory
 from openvino.runtime import Core
 from bigdl.nano.utils.log4Error import invalidInputError
 from openvino.runtime import Model
-from openvino.tools.pot.graph import load_model, save_model
-from openvino.tools.pot.engines.ie_engine import IEEngine
-from openvino.tools.pot.pipeline.initializer import create_pipeline
-from openvino.tools.pot.graph.model_utils import compress_model_weights
 from .utils import save
 
 
@@ -69,7 +65,10 @@ class OpenVINOModel:
             max_iter_num=1,
             n_requests=None,
             sample_size=300) -> Model:
-
+        from openvino.tools.pot.graph import load_model, save_model
+        from openvino.tools.pot.engines.ie_engine import IEEngine
+        from openvino.tools.pot.pipeline.initializer import create_pipeline
+        from openvino.tools.pot.graph.model_utils import compress_model_weights
         # set batch as 1 if it's dynaminc or larger than 1
         orig_shape = dict()
         static_shape = dict()


### PR DESCRIPTION
## Description

POT seems requires pytorch/tf installed. This will block some logging information in console.

### 1. Why the change?

By importing POT on the top level, if Pytorch/TF is not installed, there will be a warning, and all following logging information will be missing. An example from AI for workforce:
```shell
[ INFO ] Creating OpenVINO Runtime Core
[ INFO ] Reading the model: models/squeezenet1.1/FP32/squeezenet1.1.xml
[ INFO ] Loading the model to the plugin
None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used
```
If I make them locally import in `OpenVINOModel.pot(..)`,  the logging message will be complete:
```shell
[ INFO ] Creating OpenVINO Runtime Core
[ INFO ] Reading the model: models/squeezenet1.1/FP32/squeezenet1.1.xml
[ INFO ] Loading the model to the plugin
[ INFO ] Starting inference in synchronous mode
[ INFO ] Image path: [Dataset]_Module22_images/cat.jpeg
[ INFO ] Top 10 results: 
[ INFO ] class_id probability
[ INFO ] --------------------
[ INFO ] 283      0.7626219
[ INFO ] 281      0.1548642
[ INFO ] 282      0.0374082
[ INFO ] 287      0.0190066
[ INFO ] 285      0.0089489
[ INFO ] 186      0.0052443
[ INFO ] 277      0.0016707
[ INFO ] 876      0.0014718
[ INFO ] 185      0.0010728
[ INFO ] 284      0.0008468
[ INFO ] 
[ INFO ] This sample is an API example, for any performance measurements please use the dedicated benchmark_app tool
```


### 2. User API changes
N/A

### 3. Summary of the change 

Move POT import to `OpenVINOModel.pot(..)`

### 4. How to test?
- [ ] N/A
