### PR TITLE
Fix NanoHPO multiprocesses bug under PL1.6

### DIFF
--- a/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
@@ -219,5 +219,6 @@ class HPOSearcher:
         # Pytorch Lightning 1.6
         self.trainer.state.fn = TrainerFn.FITTING
         self.trainer.training = True
-        self.trainer._run(*args, **kwargs)
+        # self.trainer._run(*args, **kwargs)
+        self.trainer.fit(*args, **kwargs)
         self.trainer.tuning = True

--- a/python/nano/src/bigdl/nano/automl/pytorch/objective.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/objective.py
@@ -77,7 +77,6 @@ class Objective(object):
 
                 def compute(self):
                     # achieve the core logic of how to average latency
-                    # todo : is there should any diff in single and multi process?
                     self.times.sort()
                     count = len(self.times)
                     if count >= 3:
@@ -85,9 +84,7 @@ class Objective(object):
                         infer_times_mid = self.times[threshold:-threshold]
                     else:
                         infer_times_mid = self.times[:]
-                    print(self.times, infer_times_mid)
                     latency = sum(infer_times_mid) / len(infer_times_mid)
-                    print("latency : ", latency)
                     return latency
 
             class LatencyCallback(Callback):

--- a/python/nano/src/bigdl/nano/automl/pytorch/objective.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/objective.py
@@ -149,6 +149,7 @@ class Objective(object):
                 val_dataloaders=self.val_dataloaders,
                 datamodule=self.datamodule
             )
+            #  todo：多进程下可能需要别的修改？      
 
     def _post_train(self, model):
         pass

--- a/python/nano/src/bigdl/nano/automl/pytorch/objective.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/objective.py
@@ -148,7 +148,7 @@ class Objective(object):
                 train_dataloaders=self.train_dataloaders,
                 val_dataloaders=self.val_dataloaders,
                 datamodule=self.datamodule
-            ) 
+            )
 
     def _post_train(self, model):
         pass

--- a/python/nano/src/bigdl/nano/automl/pytorch/objective.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/objective.py
@@ -148,8 +148,7 @@ class Objective(object):
                 train_dataloaders=self.train_dataloaders,
                 val_dataloaders=self.val_dataloaders,
                 datamodule=self.datamodule
-            )
-            #  todo：多进程下可能需要别的修改？      
+            ) 
 
     def _post_train(self, model):
         pass

--- a/python/nano/test/automl/pytorch/test_multi_objective.py
+++ b/python/nano/test/automl/pytorch/test_multi_objective.py
@@ -157,6 +157,73 @@ class TestMOHPO(TestCase):
             n_trials=4,
             max_epochs=3,
         )
+    
+    def test_latency_hpo_multi_processes(self):
+    
+        @hpo.plmodel()
+        class CustomModel(BoringModel):
+            """Customized Model."""
+            def __init__(self,
+                        out_dim1,
+                        out_dim2,
+                        dropout_1,
+                        dropout_2,
+                        learning_rate=0.1,
+                        batch_size=16):
+                super().__init__()
+                layers = []
+                input_dim = 32
+                for out_dim, dropout in [(out_dim1, dropout_1),
+                                        (out_dim2,dropout_2)]:
+                    layers.append(torch.nn.Linear(input_dim, out_dim))
+                    layers.append(torch.nn.Tanh())
+                    layers.append(torch.nn.Dropout(dropout))
+                    input_dim = out_dim
+                layers.append(torch.nn.Linear(input_dim, 2))
+                self.layers: torch.nn.Module = torch.nn.Sequential(*layers)
+                self.save_hyperparameters()
+
+            def configure_optimizers(self):
+                # set learning rate in the optimizer
+                print("setting initial learning rate to",str(self.hparams.learning_rate))
+                self.optimizer = torch.optim.Adam(self.layers.parameters(),
+                                                  lr=self.hparams.learning_rate)
+                return [self.optimizer], []
+
+            def train_dataloader(self):
+                print("setting initial learning rate to",str(self.hparams.learning_rate))
+                return DataLoader(RandomDataset(32, 64),
+                                  batch_size=self.hparams.batch_size)
+
+            def val_dataloader(self):
+                return DataLoader(RandomDataset(32, 64),
+                                  batch_size=self.hparams.batch_size)
+
+        model = CustomModel(
+            out_dim1=space.Categorical(16,32),
+            out_dim2=space.Categorical(16,32),
+            dropout_1=space.Categorical(0.1, 0.2, 0.3, 0.4, 0.5),
+            dropout_2 = space.Categorical(0.1,0.2),
+            learning_rate = space.Real(0.001,0.01,log=True),
+            batch_size = space.Categorical(32,64)
+            )
+
+        trainer = Trainer(
+            logger=True,
+            checkpoint_callback=True,
+            max_epochs=2,
+            use_hpo=True,
+            num_processes=2,
+            distributed_backend="ray",
+        )
+        
+        best_trials = trainer.search(
+            model,
+            target_metric=['val_loss', 'latency'],
+            directions=['minimize', 'minimize'],
+            n_trials=4,
+            max_epochs=3,
+        )
 
     def test_invalid_input(self):
     

--- a/python/nano/test/automl/pytorch/test_multi_objective.py
+++ b/python/nano/test/automl/pytorch/test_multi_objective.py
@@ -214,7 +214,7 @@ class TestMOHPO(TestCase):
             max_epochs=2,
             use_hpo=True,
             num_processes=2,
-            distributed_backend="ray",
+            # distributed_backend="ray",
         )
         
         best_trials = trainer.search(

--- a/python/nano/test/automl/pytorch/test_searcher.py
+++ b/python/nano/test/automl/pytorch/test_searcher.py
@@ -17,14 +17,12 @@
 
 import pytest
 from unittest import TestCase
-
 import torch
 from bigdl.nano.pytorch import Trainer
 import bigdl.nano.automl.hpo.space as space
-
 from bigdl.nano.automl.pytorch import HPOSearcher
-from _helper import BoringModel
 import bigdl.nano.automl.hpo as hpo
+from _helper import BoringModel, RandomDataset
 
 
 class TestHPOSearcher(TestCase):
@@ -75,9 +73,55 @@ class TestHPOSearcher(TestCase):
         study = searcher.search_summary()
         assert(study)
         assert(study.best_trial)
-        # score = trainer.callback_metrics["val_loss"].item()
-        # print("final val_loss is:", score)
 
+    def test_simple_model_multi_processes(self):
+    
+        @hpo.plmodel()
+        class CustomModel(BoringModel):
+            def __init__(self,
+                        out_dim1,
+                        out_dim2,
+                        dropout_1,
+                        dropout_2):
+
+                super().__init__()
+                layers = []
+                input_dim = 32
+                for out_dim, dropout in [(out_dim1, dropout_1),
+                                        (out_dim2,dropout_2)]:
+                    layers.append(torch.nn.Linear(input_dim, out_dim))
+                    layers.append(torch.nn.Tanh())
+                    layers.append(torch.nn.Dropout(dropout))
+                    input_dim = out_dim
+
+                layers.append(torch.nn.Linear(input_dim, 2))
+
+                self.layers: torch.nn.Module = torch.nn.Sequential(*layers)
+
+        model = CustomModel(
+            out_dim1=space.Categorical(16,32),
+            out_dim2=space.Categorical(16,32),
+            dropout_1=space.Real(0.1,0.5),
+            dropout_2 = 0.2)
+
+        trainer = Trainer(
+            logger=True,
+            checkpoint_callback=True,
+            max_epochs=3,
+            num_processes=2,
+            distributed_backend="ray",
+        )
+        searcher = HPOSearcher(trainer, num_processes=2)
+        searcher.search(
+            model,
+            target_metric='val_loss',
+            direction='minimize',
+            n_trials=3,
+            max_epochs=3,
+        )
+        study = searcher.search_summary()
+        assert(study)
+        assert(study.best_trial)
 
 
 if __name__ == '__main__':

--- a/python/nano/test/automl/pytorch/test_searcher.py
+++ b/python/nano/test/automl/pytorch/test_searcher.py
@@ -109,7 +109,7 @@ class TestHPOSearcher(TestCase):
             checkpoint_callback=True,
             max_epochs=3,
             num_processes=2,
-            distributed_backend="ray",
+            # distributed_backend="ray",
         )
         searcher = HPOSearcher(trainer, num_processes=2)
         searcher.search(

--- a/python/nano/test/pytorch/tests/test_plugin.py
+++ b/python/nano/test/pytorch/tests/test_plugin.py
@@ -84,7 +84,7 @@ class TestPlugin(TestCase):
         from test_lightning import ResNet18
 
         model = ResNet18(pretrained=False, include_top=False, freeze=True)
-        pl_model = LightningModuleFromTorch(
+        pl_model = LightningModule(
             model, self.loss, self.optimizer,
             metrics=[torchmetrics.F1(num_classes), torchmetrics.Accuracy(num_classes=10)]
         )


### PR DESCRIPTION
## Description

This PR try to fix the problem of NanoHPO can't run in multiprocesses after upgrading to PytorchLightning1.6.4 .
Also delete some useless lines of code.
Add two unittests for multiprocesses.

### 4. How to test?
- [x] Unit test
- [x] jenkins
http://10.112.231.51:18888/job/BigDL-Chronos-PR-Validation/1162/
http://10.112.231.51:18888/job/BigDL-PRVN-chronos-Python-Spark-3.1-py37-ray-part1/1210/