### PR TITLE
Nano: support ipex and jit in nano's inference acceleration with consistent API

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
@@ -36,6 +36,15 @@ def ipex_device():
 
 def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
                         use_jit=False, channels_last=None):
+    '''
+    :param model: the model(nn.module) to be transform.
+    :param input_sample: torch tensor indicate the data sample to be used
+            for tracing.
+    :param use_ipex: if use ipex to optimize the model
+    :param use_jit: if use jit to accelerate the model
+    :param channels_last: if set model and data to be channels-last mode.
+            the parameter will be ignored if use_ipex is False.
+    '''
     from .ipex_inference_model import PytorchIPEXJITModel
     return PytorchIPEXJITModel(model, input_sample=input_sample, use_ipex=use_ipex,
                                use_jit=use_jit, channels_last=channels_last)

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
@@ -33,10 +33,13 @@ def ipex_device():
     from bigdl.nano.deps.ipex.version_1_9 import DEVICE
     return DEVICE
 
-def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False, use_jit=False, channels_last=None):
+
+def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
+                        use_jit=False, channels_last=None):
     from .ipex_inference_model import PytorchIPEXJITModel
     return PytorchIPEXJITModel(model, input_sample=input_sample, use_ipex=use_ipex,
                                use_jit=use_jit, channels_last=channels_last)
+
 
 def load_ipexjit_model(path, model):
     from .ipex_inference_model import PytorchIPEXJITModel

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
@@ -32,3 +32,12 @@ def ipex_optimize(*args, **kwargs):
 def ipex_device():
     from bigdl.nano.deps.ipex.version_1_9 import DEVICE
     return DEVICE
+
+def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False, use_jit=False, channels_last=None):
+    from .ipex_inference_model import PytorchIPEXJITModel
+    return PytorchIPEXJITModel(model, input_sample=input_sample, use_ipex=use_ipex,
+                               use_jit=use_jit, channels_last=channels_last)
+
+def load_ipexjit_model(path, model):
+    from .ipex_inference_model import PytorchIPEXJITModel
+    return PytorchIPEXJITModel._load(path, model)

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -31,7 +31,7 @@ class IPEXJITModel:
             self.model = model
             self.use_ipex = use_ipex
             self.use_jit = use_jit
-            self.channels_last=channels_last
+            self.channels_last = channels_last
             return
         self.channels_last = use_ipex if (channels_last is None or not use_ipex) else channels_last
         model.eval()

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -116,17 +116,16 @@ class PytorchIPEXJITModel(IPEXJITModel, AcceleratedLightningModule):
             model = torch.jit.load(checkpoint_path)
             model.eval()
             model = torch.jit.freeze(model)
+            from_load = True
         else:
             state_dict = torch.load(checkpoint_path)
             model.eval()
             model.load_state_dict(state_dict)
-            if status["channels_last"]:
-                model = model.to(memory_format=torch.channels_last)
-            model = ipex.optimize(model)
+            from_load = False
         return PytorchIPEXJITModel(model, use_ipex=status['use_ipex'],
                                    use_jit=status['use_jit'],
                                    channels_last=status['channels_last'],
-                                   from_load=True)
+                                   from_load=from_load)
 
     def _save_model(self, path):
         super()._save_model(path)

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -27,6 +27,17 @@ class IPEXJITModel:
                  use_jit=False,
                  channels_last=None,
                  from_load=False):
+        '''
+        :param model: the model(nn.module) to be transform if from_load is False
+               the accelerated model if from_load is True.
+        :param input_sample: torch tensor indicate the data sample to be used
+               for tracing.
+        :param use_ipex: if use ipex to optimize the model
+        :param use_jit: if use jit to accelerate the model
+        :param channels_last: if set model and data to be channels-last mode.
+               the parameter will be ignored if use_ipex is False.
+        :param from_load: this will only be set by _load method.
+        '''
         if from_load:
             self.model = model
             self.use_ipex = use_ipex
@@ -62,6 +73,22 @@ class IPEXJITModel:
 class PytorchIPEXJITModel(IPEXJITModel, AcceleratedLightningModule):
     def __init__(self, model, input_sample=None, use_ipex=False,
                  use_jit=False, channels_last=None, from_load=False):
+        '''
+        This is the accelerated model for pytorch and ipex/jit.
+        All the external API is based on Trainer, so what we have here is
+        basically internal APIs and subject to change.
+
+        This PytorchIPEXJITModel will serve for fp32 and ipex>1.9 models.
+        :param model: the model(nn.module) to be transform if from_load is False
+               the accelerated model if from_load is True.
+        :param input_sample: torch tensor indicate the data sample to be used
+               for tracing.
+        :param use_ipex: if use ipex to optimize the model
+        :param use_jit: if use jit to accelerate the model
+        :param channels_last: if set model and data to be channels-last mode.
+               the parameter will be ignored if use_ipex is False.
+        :param from_load: this will only be set by _load method.
+        '''
         AcceleratedLightningModule.__init__(self, None)
         IPEXJITModel.__init__(self, model, input_sample=input_sample,
                               use_ipex=use_ipex, use_jit=use_jit, from_load=from_load)

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -1,0 +1,92 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from bigdl.nano.utils.inference.pytorch.model import AcceleratedLightningModule
+import intel_extension_for_pytorch as ipex
+import torch
+
+
+class IPEXJITModel:
+    def __init__(self,
+                 model,
+                 input_sample=None,
+                 use_ipex=False,
+                 use_jit=False,
+                 channels_last=None):
+        self.channels_last = use_ipex if (channels_last is None or not use_ipex) else channels_last
+        model.eval()
+        self.original_state_dict = model.state_dict()
+        self.model = model
+        self.use_ipex = use_ipex
+        self.use_jit = use_jit
+        if self.channels_last:
+            self.model = self.model.to(memory_format=torch.channels_last)
+        if self.use_ipex:
+            self.model = ipex.optimize(self.model)
+        if self.use_jit:
+            self.model = torch.jit.trace(self.model, input_sample)
+            self.model = torch.jit.freeze(self.model)
+
+    def forward_step(self, *inputs):
+        if self.channels_last:
+            inputs = tuple(map(lambda x:x.to(memory_format=torch.channels_last), inputs))
+        return self.model(*inputs)
+    
+    def _save_model(self, path):
+        if self.use_jit:
+            self.model.save(path / "ckpt.pth")
+        else:
+            torch.save(self.original_state_dict, path / "ckpt.pth")
+
+class PytorchIPEXJITModel(IPEXJITModel, AcceleratedLightningModule):
+    def __init__(self, model, input_sample=None, use_ipex=False, use_jit=False, channels_last=None):
+        AcceleratedLightningModule.__init__(self, None)
+        IPEXJITModel.__init__(self, model, input_sample=input_sample,
+                              use_ipex=use_ipex, use_jit=use_jit)
+    
+    def on_forward_start(self, inputs):
+        return inputs
+
+    def on_forward_end(self, outputs):
+        return outputs
+
+    @property
+    def status(self):
+        status = super().status
+        status.update({"use_ipex": self.use_ipex,
+                       "use_jit": self.use_jit,
+                       "channels_last": self.channels_last,
+                       "checkpoint": "ckpt.pth"})
+        return status
+
+    @staticmethod
+    def _load(path, model):
+        status = PytorchIPEXJITModel._load_status(path)
+        if status["use_jit"]:
+            checkpoint_path = path / status['checkpoint']
+            model = torch.jit.load(checkpoint_path)
+        else:
+            checkpoint_path = path / status['checkpoint']
+            state_dict = torch.load(checkpoint_path)
+            model.eval()
+            model.load_state_dict(state_dict)
+            if status["channels_last"]:
+                model = model.to(memory_format=torch.channels_last)
+            model = ipex.optimize(model)
+        return model
+
+    def _save_model(self, path):
+        super()._save_model(path)

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -424,7 +424,7 @@ class Trainer(pl.Trainer):
         :param input_sample: A set of inputs for trace, defaults to None if you have trace before or
                              model is a LightningModule with any dataloader attached.
         :param accelerator: The accelerator to use, defaults to None meaning staying in Pytorch
-                            backend. 'openvino' and 'onnxruntime' are supported for now.
+                            backend. 'openvino', 'onnxruntime' and 'jit' are supported for now.
         :param use_ipex: whether we use ipex as accelerator for inferencing. default: False.
         :param onnxruntime_session_options: The session option for onnxruntime, only valid when
                                             accelerator='onnxruntime', otherwise will be ignored.
@@ -459,8 +459,8 @@ class Trainer(pl.Trainer):
         """
         Save the model to local file.
 
-        :param model: Any model of torch.nn.Module, including PytorchOpenVINOModel,
-         PytorchONNXModel.
+        :param model: Any model of torch.nn.Module, including all models accelareted by
+               Trainer.trace/Trainer.quantize.
         :param path: Path to saved model. Path should be a directory.
         """
         path = Path(path)
@@ -485,8 +485,10 @@ class Trainer(pl.Trainer):
         Load a model from local.
 
         :param path: Path to model to be loaded. Path should be a directory.
-        :param model: Required FP32 model to load pytorch model. Optional for ONNX/OpenVINO.
-        :return: Model with different acceleration(None/OpenVINO/ONNX Runtime) or
+        :param model: Required FP32 model to load pytorch model, it is needed if you accelerated
+               the model with accelerator=None by Trainer.trace/Trainer.quantize. model
+               should be set to None if you choose accelerator="onnxruntime"/"openvino"/"jit".
+        :return: Model with different acceleration(None/OpenVINO/ONNX Runtime/JIT) or
                  precision(FP32/FP16/BF16/INT8).
         """
         path = Path(path)

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -447,6 +447,9 @@ class Trainer(pl.Trainer):
             return PytorchONNXRuntimeModel(model, input_sample, onnxruntime_session_options,
                                            **export_kwargs)
         if accelerator == 'jit' or use_ipex:
+            if use_ipex:
+                invalidInputError(not TORCH_VERSION_LESS_1_10,
+                                  "torch version should >=1.10 to use ipex")
             use_jit = (accelerator == "jit")
             channels_last = export_kwargs["channels_last"]\
                 if "channels_last" in export_kwargs else None

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -428,8 +428,12 @@ class Trainer(pl.Trainer):
         :param use_ipex: whether we use ipex as accelerator for inferencing. default: False.
         :param onnxruntime_session_options: The session option for onnxruntime, only valid when
                                             accelerator='onnxruntime', otherwise will be ignored.
-        :param **export_kwargs: will be passed to torch.onnx.export function, only valid when
-                                accelerator='onnxruntime'/'openvino', otherwise will be ignored.
+        :param **kwargs: other extra advanced settings include
+                         1. those be passed to torch.onnx.export function, only valid when
+                         accelerator='onnxruntime'/'openvino', otherwise will be ignored.
+                         2. if channels_last is set and use_ipex=True, we will transform the
+                         data to be channels last according to the setting. Defaultly, channels_last
+                         will be set to True if use_ipex=True.
         :return: Model with different acceleration.
         """
         invalidInputError(

--- a/python/nano/test/pytorch/tests/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/test_ipex_jit_inference.py
@@ -1,0 +1,95 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import os
+from unittest import TestCase
+
+import pytest
+import torch
+from test.pytorch.utils._train_torch_lightning import create_data_loader, data_transform
+from torch import nn
+
+from bigdl.nano.pytorch import Trainer
+from bigdl.nano.pytorch.vision.models import vision
+from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
+import tempfile
+
+batch_size = 256
+num_workers = 0
+data_dir = os.path.join(os.path.dirname(__file__), "../data")
+
+
+class ResNet18(nn.Module):
+    def __init__(self, num_classes, pretrained=True, include_top=False, freeze=True):
+        super().__init__()
+        backbone = vision.resnet18(pretrained=pretrained, include_top=include_top, freeze=freeze)
+        output_size = backbone.get_output_size()
+        head = nn.Linear(output_size, num_classes)
+        self.model = nn.Sequential(backbone, head)
+
+    def forward(self, x):
+        return self.model(x)
+
+
+class IPEXJITInference_gt_1_10:
+    model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
+    data_loader = create_data_loader(data_dir, batch_size, num_workers, data_transform)
+    data_sample = next(iter(data_loader))[0]
+
+    def test_ipex_inference(self):
+        model = Trainer.trace(self.model, accelerator=None, use_ipex=True)
+        model(self.data_sample)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            Trainer.save(model, tmp_dir_name)
+            new_model = Trainer.load(tmp_dir_name, self.model)
+        new_model(self.data_sample)
+
+    def test_jit_inference(self):
+        model = Trainer.trace(self.model, accelerator="jit",
+                              use_ipex=False, input_sample=self.data_sample)
+        model(self.data_sample)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            Trainer.save(model, tmp_dir_name)
+            new_model = Trainer.load(tmp_dir_name)
+        new_model(self.data_sample)
+
+    def test_ipex_jit_inference(self):
+        model = Trainer.trace(self.model, accelerator="jit",
+                              use_ipex=True, input_sample=self.data_sample)
+        model(self.data_sample)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            Trainer.save(model, tmp_dir_name)
+            new_model = Trainer.load(tmp_dir_name)
+        new_model(self.data_sample)
+
+
+class IPEXJITInference_lt_1_10:
+    def test_placeholder(self):
+        pass
+
+
+TORCH_VERSION_CLS = IPEXJITInference_gt_1_10
+if TORCH_VERSION_LESS_1_10:
+    TORCH_VERSION_CLS = IPEXJITInference_lt_1_10
+
+
+class TestIPEXJITInference(TORCH_VERSION_CLS, TestCase):
+    pass
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
## Description

### 1. Why the change?

Since we find for some models(e.g. Autoformer in Chronos), JIT and ipex brings some improvement on inference latency while Onnxruntime and OpenVINO can not work properly (e.g. lack of operators).
related to #5131

### 2. User API changes
```python
# ipex
model_ipex = Trainer.trace(model, accelerator=None, use_ipex=True...)
model_ipex(*args)

# jit
model_jit = Trainer.trace(model, accelerator="jit", input_sample=input_sample, use_ipex=False...)
model_jit(*args)

# jit + ipex
model_jit_ipex = Trainer.trace(model, accelerator="jit", input_sample=input_sample, use_ipex=True...)
model_jit_ipex(*args)
```
For save/load
```python
# jit / jit+ipex
Trainer.save(model_accelerated , path="ckpt")
load_model = Trainer.load(path="ckpt")

# ipex
Trainer.save(model_accelerated , path="ckpt")
load_model = Trainer.load(path="ckpt", model)
```

### 3. Summary of the change 
Add a new class called `PytorchIPEXJITModel`, which is quite similar to `PytorchONNXRuntimeModel`.
TODO: support torch==1.9 in future. This PR only support torch>1.9.

### 4. How to test?
- [x] Unit test
http://10.112.231.51:18888/job/ZOO-PR-nano-pytorch-ipex-test/280/
http://10.112.231.51:18889/job/BigDL-Chronos-PR-Validation/587/
