### PR TITLE
[Orca] Make RayContext init lighter

### DIFF
--- a/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
+++ b/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
@@ -541,7 +541,7 @@ class RayOnSparkContext(object):
         if self.initialized:
             print("The Ray cluster has been launched.")
         else:
-            self.activateRayOnSparkContext()
+            self.setupRayOnSparkContext()
             if self.is_local:
                 if self.env:
                     os.environ.update(self.env)

--- a/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
+++ b/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
@@ -402,7 +402,7 @@ class RayOnSparkContext(object):
         self.num_ray_nodes = num_ray_nodes
         RayOnSparkContext._active_ray_context = self
 
-    def setupRayOnSparkContext(self):
+    def setup(self):
         if self.is_local:
             self.num_ray_nodes = 1
             spark_cores = self._get_spark_local_cores()
@@ -541,7 +541,7 @@ class RayOnSparkContext(object):
         if self.initialized:
             print("The Ray cluster has been launched.")
         else:
-            self.setupRayOnSparkContext()
+            self.setup()
             if self.is_local:
                 if self.env:
                     os.environ.update(self.env)

--- a/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
+++ b/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
@@ -400,8 +400,9 @@ class RayOnSparkContext(object):
         self.redis_port = random.randint(10000, 65535) if not redis_port else int(redis_port)
         self.ray_node_cpu_cores = ray_node_cpu_cores
         self.num_ray_nodes = num_ray_nodes
+        RayOnSparkContext._active_ray_context = self
 
-    def activateRayOnSparkContext(self):
+    def setUpRayOnSparkContext(self):
         if self.is_local:
             self.num_ray_nodes = 1
             spark_cores = self._get_spark_local_cores()
@@ -469,7 +470,6 @@ class RayOnSparkContext(object):
                 include_webui=self.include_webui,
                 extra_params=self.extra_params,
                 system_config=self.system_config)
-        RayOnSparkContext._active_ray_context = self
         self.total_cores = self.num_ray_nodes * self.ray_node_cpu_cores
 
     @classmethod

--- a/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
+++ b/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
@@ -402,7 +402,7 @@ class RayOnSparkContext(object):
         self.num_ray_nodes = num_ray_nodes
         RayOnSparkContext._active_ray_context = self
 
-    def setUpRayOnSparkContext(self):
+    def setupRayOnSparkContext(self):
         if self.is_local:
             self.num_ray_nodes = 1
             spark_cores = self._get_spark_local_cores()

--- a/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
+++ b/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
@@ -402,7 +402,7 @@ class RayOnSparkContext(object):
         self.num_ray_nodes = num_ray_nodes
 
 
-    def initRayService(self):
+    def activateRayOnSparkContext(self):
         if self.is_local:
             self.num_ray_nodes = 1
             spark_cores = self._get_spark_local_cores()
@@ -542,7 +542,7 @@ class RayOnSparkContext(object):
         if self.initialized:
             print("The Ray cluster has been launched.")
         else:
-            self.initRayService()
+            self.activateRayOnSparkContext()
             if self.is_local:
                 if self.env:
                     os.environ.update(self.env)

--- a/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
+++ b/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
@@ -397,11 +397,17 @@ class RayOnSparkContext(object):
                 self.system_config = self.extra_params.pop("_system_config")
         self.include_webui = include_webui
         self._address_info = None
+        self.redis_port = random.randint(10000, 65535) if not redis_port else int(redis_port)
+        self.ray_node_cpu_cores = ray_node_cpu_cores
+        self.num_ray_nodes = num_ray_nodes
+
+
+    def initRayService(self):
         if self.is_local:
             self.num_ray_nodes = 1
             spark_cores = self._get_spark_local_cores()
-            if ray_node_cpu_cores:
-                ray_node_cpu_cores = int(ray_node_cpu_cores)
+            if self.ray_node_cpu_cores:
+                ray_node_cpu_cores = int(self.ray_node_cpu_cores)
                 if ray_node_cpu_cores > spark_cores:
                     warnings.warn("ray_node_cpu_cores is larger than available Spark cores, "
                                   "make sure there are enough resources on your machine")
@@ -416,8 +422,8 @@ class RayOnSparkContext(object):
                 executor_cores = int(self.sc.getConf().get("spark.executor.cores"))
             else:
                 executor_cores = None
-            if ray_node_cpu_cores:
-                ray_node_cpu_cores = int(ray_node_cpu_cores)
+            if self.ray_node_cpu_cores:
+                ray_node_cpu_cores = int(self.ray_node_cpu_cores)
                 if executor_cores and ray_node_cpu_cores > executor_cores:
                     warnings.warn("ray_node_cpu_cores is larger than Spark executor cores, "
                                   "make sure there are enough resources on your cluster")
@@ -437,8 +443,8 @@ class RayOnSparkContext(object):
                     int(self.sc.getConf().get("spark.cores.max")) / self.ray_node_cpu_cores)
             else:
                 num_executors = None
-            if num_ray_nodes:
-                num_ray_nodes = int(num_ray_nodes)
+            if self.num_ray_nodes:
+                num_ray_nodes = int(self.num_ray_nodes)
                 if num_executors and num_ray_nodes > num_executors:
                     warnings.warn("num_ray_nodes is larger than the number of Spark executors, "
                                   "make sure there are enough resources on your cluster")
@@ -453,7 +459,6 @@ class RayOnSparkContext(object):
 
             from bigdl.dllib.utils.utils import detect_python_location
             self.python_loc = os.environ.get("PYSPARK_PYTHON", detect_python_location())
-            self.redis_port = random.randint(10000, 65535) if not redis_port else int(redis_port)
             self.ray_service = RayServiceFuncGenerator(
                 python_loc=self.python_loc,
                 redis_port=self.redis_port,
@@ -537,6 +542,7 @@ class RayOnSparkContext(object):
         if self.initialized:
             print("The Ray cluster has been launched.")
         else:
+            self.initRayService()
             if self.is_local:
                 if self.env:
                     os.environ.update(self.env)

--- a/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
+++ b/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
@@ -401,7 +401,6 @@ class RayOnSparkContext(object):
         self.ray_node_cpu_cores = ray_node_cpu_cores
         self.num_ray_nodes = num_ray_nodes
 
-
     def activateRayOnSparkContext(self):
         if self.is_local:
             self.num_ray_nodes = 1

--- a/python/orca/src/bigdl/orca/ray/raycontext.py
+++ b/python/orca/src/bigdl/orca/ray/raycontext.py
@@ -38,8 +38,6 @@ class OrcaRayContext(object):
             from bigdl.orca.ray import RayOnSparkContext
             self._ray_on_spark_context = RayOnSparkContext(**kwargs)
             self.is_local = self._ray_on_spark_context.is_local
-            self.num_ray_nodes = self._ray_on_spark_context.num_ray_nodes
-            self.ray_node_cpu_cores = self._ray_on_spark_context.ray_node_cpu_cores
 
         elif runtime == "ray":
             self.is_local = False
@@ -60,6 +58,8 @@ class OrcaRayContext(object):
             results = ray.init(**self.ray_args)
         else:
             results = self._ray_on_spark_context.init(driver_cores=driver_cores)
+            self.num_ray_nodes = self._ray_on_spark_context.num_ray_nodes
+            self.ray_node_cpu_cores = self._ray_on_spark_context.ray_node_cpu_cores
             self.address_info = self._ray_on_spark_context.address_info
             self.redis_address = self._ray_on_spark_context.redis_address
             self.redis_password = self._ray_on_spark_context.redis_password


### PR DESCRIPTION
## Description
This PR is to solve #5090. In order to have a lighter RayContext initialization, we do not set up the RayOnSparkContext Instance when init OrcaRayContext in init_orca_context, instead we set up it when set up ray cluster. Thus, the init process of RayContext in init_orca_context become lighter for users who do not use the ray cluster.
<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->
