### PR TITLE
Chronos: thread num control for onnxruntime backend inference

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -756,6 +756,7 @@ class BasePytorchForecaster(Forecaster):
             sess_options = onnxruntime.SessionOptions()
             if thread_num is not None:
                 sess_options.intra_op_num_threads = thread_num
+                sess_options.inter_op_num_threads = thread_num
         if self.distributed:
             invalidInputError(False,
                               "build_onnx has not been supported for distributed "
@@ -819,7 +820,8 @@ class BasePytorchForecaster(Forecaster):
                  relative_drop=None,
                  absolute_drop=None,
                  timeout=0,
-                 max_trials=1):
+                 max_trials=1,
+                 sess_options=None):
         """
         Quantize the forecaster.
 
@@ -844,6 +846,9 @@ class BasePytorchForecaster(Forecaster):
         :param max_trials: Max tune times. Default to 1. Combine with timeout field to
                decide when to exit. "timeout=0, max_trials=1" means it will try quantization
                only once and return satisfying best model.
+        :param sess_options: The session option for onnxruntime, only valid when
+                             framework contains 'onnxrt_integerops' or 'onnxrt_qlinearops',
+                             otherwise will be ignored.
         """
         # check model support for quantization
         from bigdl.nano.utils.log4Error import invalidInputError
@@ -904,7 +909,8 @@ class BasePytorchForecaster(Forecaster):
                                             tuning_strategy=tuning_strategy,
                                             accuracy_criterion=accuracy_criterion,
                                             timeout=timeout,
-                                            max_trials=max_trials)
+                                            max_trials=max_trials,
+                                            onnxruntime_session_options=sess_options)
             if accelerator == 'onnxruntime':
                 self.onnxruntime_int8 = q_model
             if accelerator is None:

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
@@ -44,6 +44,7 @@ def quantize(model, dataloader=None, metric=None, **kwargs):
     }
     not_none_kwargs['approach'] = approach_map.get(kwargs['approach'], None)
     quantizer = None
+    onnxruntime_session_options = not_none_kwargs.pop('onnxruntime_session_options', None)
     if 'pytorch' in not_none_kwargs['framework']:
         from .pytorch.quantization import PytorchQuantization
         quantizer = PytorchQuantization(**not_none_kwargs)
@@ -51,7 +52,8 @@ def quantize(model, dataloader=None, metric=None, **kwargs):
         invalidInputError('torch' in str(type(dataloader)),
                           errMsg="ONNXRuntime quantization only support in Pytorch.")
         from .onnx.pytorch.quantization import PytorchONNXRuntimeQuantization
-        quantizer = PytorchONNXRuntimeQuantization(**not_none_kwargs)
+        quantizer = PytorchONNXRuntimeQuantization(onnxruntime_session_options=onnxruntime_session_options,
+                                                   **not_none_kwargs)
     if 'tensorflow' in not_none_kwargs['framework']:
         from .tensorflow.quantization import TensorflowQuantization
         quantizer = TensorflowQuantization(**not_none_kwargs)

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
@@ -52,8 +52,9 @@ def quantize(model, dataloader=None, metric=None, **kwargs):
         invalidInputError('torch' in str(type(dataloader)),
                           errMsg="ONNXRuntime quantization only support in Pytorch.")
         from .onnx.pytorch.quantization import PytorchONNXRuntimeQuantization
-        quantizer = PytorchONNXRuntimeQuantization(onnxruntime_session_options=onnxruntime_session_options,
-                                                   **not_none_kwargs)
+        quantizer =\
+            PytorchONNXRuntimeQuantization(onnxruntime_session_options=onnxruntime_session_options,
+                                           **not_none_kwargs)
     if 'tensorflow' in not_none_kwargs['framework']:
         from .tensorflow.quantization import TensorflowQuantization
         quantizer = TensorflowQuantization(**not_none_kwargs)

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/pytorch/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/pytorch/quantization.py
@@ -29,6 +29,7 @@ class PytorchONNXRuntimeQuantization(BaseONNXRuntimeQuantization, PytorchQuantiz
         Create a Intel Neural Compressor Quantization object for ONNXRuntime in Pytorch.
         """
         kwargs['framework'] = framework
+        self.session_options = kwargs.pop('onnxruntime_session_options', None)
         super().__init__(**kwargs)
         self._inc_metric_cls = PytorchONNXRuntimeINCMetic
 
@@ -61,4 +62,5 @@ class PytorchONNXRuntimeQuantization(BaseONNXRuntimeQuantization, PytorchQuantiz
         with TemporaryDirectory() as dir:
             saved_onnx = Path(dir) / 'tmp.onnx'
             q_model.save(saved_onnx)
-            return PytorchONNXRuntimeModel(str(saved_onnx))
+            return PytorchONNXRuntimeModel(str(saved_onnx),
+                                           onnxruntime_session_options=self.session_options)

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -348,7 +348,6 @@ class Trainer(pl.Trainer):
                             model,
                             input_sample=input_sample,
                             accelerator='onnxruntime',
-                            onnxruntime_session_options=onnxruntime_session_options,
                             **export_kwargs)
                 """
                 If accelerator==None, quantized model returned should be an object of PytorchModel
@@ -364,7 +363,8 @@ class Trainer(pl.Trainer):
                                     tuning_strategy=tuning_strategy,
                                     accuracy_criterion=accuracy_criterion,
                                     timeout=timeout,
-                                    max_trials=max_trials)
+                                    max_trials=max_trials,
+                                    onnxruntime_session_options=onnxruntime_session_options)
 
             elif accelerator == 'openvino':
                 model_type = type(model).__name__


### PR DESCRIPTION
## Description
### 1. Why the change?

Users report a strange performance when it comes to threadnum control of onnxruntime.

### 2. User API changes

add a new parameter called `sess_options` in `quantize` api

### 3. Summary of the change 
additionally set `sess_options.inter_op_num_threads` for fp32 models.
add a new parameter called `sess_options` in `quantize` api

### 4. How to test?
- [x] Unit test (use original ut) http://10.112.231.51:18889/view/BigDL-PR-Validation/job/BigDL-Chronos-PR-Validation/592/