### PR TITLE
Readthedoc: fix markdown version in doc

### DIFF
--- a/docs/readthedocs/requirements-doc.txt
+++ b/docs/readthedocs/requirements-doc.txt
@@ -4,6 +4,7 @@ sphinx-click
 sphinx-jsonschema
 sphinxemoji
 click
+markdown<3.4
 tensorflow==1.15.2
 bigdl==0.12.0
 cloudpickle

--- a/docs/readthedocs/requirements-rtd.txt
+++ b/docs/readthedocs/requirements-rtd.txt
@@ -7,6 +7,7 @@ alabaster>=0.7,<0.8,!=0.7.5
 commonmark==0.8.1
 recommonmark==0.5.0
 readthedocs-sphinx-ext<1.1
+markdown<3.4
 sphinx-book-theme
 sphinx_rtd_theme
 sphinx_markdown_tables


### PR DESCRIPTION
## Description

related to #5160 


document build pass: https://readthedocs.org/projects/bigdl-junweid/builds/17507311/