### PR TITLE
Nano: Add automatically rescale learning rate

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
+++ b/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
@@ -449,7 +449,7 @@ class RayStrategy(DDPSpawnStrategy):
                 else _configure_schedulers_manual_opt(lr_schedulers)
             )
             _set_scheduler_opt_idx(self.optimizers, lr_scheduler_configs)
-            _validate_scheduler_api(lr_scheduler_configs, self.model)
+            _validate_scheduler_api(lr_scheduler_configs, self.lightning_module)
             self.lr_scheduler_configs = lr_scheduler_configs
 
     def training_step_end(self, output: _STEP_OUTPUT_TYPE) -> _STEP_OUTPUT_TYPE:

--- a/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
+++ b/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
@@ -40,6 +40,7 @@ from ray.util.ml_utils.util import find_free_port
 
 import torch
 from torch import Tensor
+from torch.optim.lr_scheduler import _LRScheduler
 import pytorch_lightning as pl
 from pytorch_lightning.core.datamodule import LightningDataModule
 from pytorch_lightning.trainer.states import TrainerFn
@@ -48,6 +49,10 @@ from pytorch_lightning.utilities.apply_func import move_data_to_device
 from pytorch_lightning.utilities.distributed import ReduceOp
 from pytorch_lightning.strategies.launchers import _SpawnLauncher
 from pytorch_lightning.strategies import DDPSpawnStrategy
+from pytorch_lightning.core.optimizer import _configure_schedulers_automatic_opt
+from pytorch_lightning.core.optimizer import _configure_schedulers_manual_opt
+from pytorch_lightning.core.optimizer import _set_scheduler_opt_idx, _validate_scheduler_api
+from pytorch_lightning.core.optimizer import LightningOptimizer
 
 from .ray_envbase import RayEnvironment
 from bigdl.nano.utils.log4Error import invalidInputError
@@ -173,6 +178,7 @@ class RayStrategy(DDPSpawnStrategy):
                  use_ipex: bool = False,
                  enable_bf16: bool = False,
                  init_hook: Callable = None,
+                 auto_lr: Union[bool, dict] = True,
                  **ddp_kwargs: Any):
         """Create a RayStrategy."""
         # Unset MKL setting as bigdl.nano would give default values when init env.
@@ -202,6 +208,7 @@ class RayStrategy(DDPSpawnStrategy):
         self.use_gpu = use_gpu
         self.use_ipex = use_ipex
         self.enable_bf16 = enable_bf16
+        self.auto_lr = auto_lr
 
         invalidInputError(not self.use_gpu or not self.use_ipex,
                           "You can not specify gpu and ipex at the same time.")
@@ -300,6 +307,26 @@ class RayStrategy(DDPSpawnStrategy):
             # so we need to set it to `False` manuallay
             self.model.eval()
 
+        if trainer.training and self.auto_lr:
+
+            def _unpack_lightning_optimizer(opt):
+                return opt._optimizer if isinstance(opt, LightningOptimizer) else opt
+
+            optimizers = self.optimizers
+            optimizers = [_unpack_lightning_optimizer(opt) for opt in optimizers]
+
+            for optimizer in optimizers:
+                for param_group in optimizer.param_groups:
+                    param_group["lr"] *= self.world_size
+
+            lr_scheduler_configs = self.lr_scheduler_configs
+            for config in lr_scheduler_configs:
+                scheduler = config.scheduler
+                if isinstance(scheduler, _LRScheduler):
+                    scheduler.base_lrs = [  # type: ignore
+                        lr * self.world_size for lr in scheduler.base_lrs  # type: ignore
+                    ]
+
         if self.use_ipex and not TORCH_VERSION_LESS_1_10:
             dtype = torch.bfloat16 if self.enable_bf16 else None
             num_optimizers = len(self.optimizers)
@@ -350,6 +377,80 @@ class RayStrategy(DDPSpawnStrategy):
             return super().reduce(tensor, group, reduce_op)
         except Exception as _e:
             return tensor
+
+    def on_train_start(self) -> None:
+        """Setup warmup lr_schedulers after resetting the train dataloaders."""
+        # LightnigModule.train_dataloader() generate the training dataloaders after setup,
+        # so config the warmup lr_schedulers in on_train_start hook to infer warmup_steps.
+        if not self.auto_lr:
+            return
+        if self.lr_scheduler_configs:
+            warnings.warn(f"Nano warmup currently only support no scheduler, "
+                          f"but got {len(self.lr_scheduler_configs)}. Skip warmup")
+        else:
+            trainer = self.lightning_module.trainer
+            lr_schedulers = []
+            warmup_params = {
+                'start_factor': 1.0 / self.world_size,
+                'end_factor': 1.0,
+                'warmup_epochs': trainer.max_epochs // 10,
+                'interval': 'epoch'
+            }
+            supported_keys = {'warmup_epochs'}
+            if isinstance(self.auto_lr, dict):
+                extra_keys = self.auto_lr.keys() - supported_keys
+                if extra_keys:
+                    warnings.warn(f"Found unsupported keys in the auto_lr dict: {extra_keys}")
+                if 'warmup_epochs' not in self.auto_lr:
+                    self.auto_lr = True
+                    warnings.warn("Not found \"warmup_epochs\" in the auto_lr dict"
+                                  " warmup_epochs is set by default")
+                else:
+                    invalidInputError(type(self.auto_lr['warmup_epochs']) is int,
+                                      f"\"warmup_epochs\" is {type(self.auto_lr['warmup_epochs'])}",
+                                      "expect \"warmup_epochs\" is a integer")
+                    warmup_params['warmup_epochs'] = self.auto_lr['warmup_epochs']
+            if type(self.auto_lr) is bool:
+                # Call scheduler.step() after each minibatch rather than epoch if max_epochs < 10
+                if warmup_params['warmup_epochs'] == 0:
+                    train_loader = trainer.train_dataloader
+                    max_steps = len(train_loader) * trainer.max_epochs
+                    warmup_params['warmup_epochs'] = max_steps // 10
+                    warmup_params['interval'] = 'step'
+            for opt_idx, opt in enumerate(self.optimizers):
+                from torch.optim.lr_scheduler import LambdaLR
+
+                def lr_func(epoch):
+                    current_epoch = trainer.current_epoch
+                    start_factor = warmup_params['start_factor']
+                    end_factor = warmup_params['end_factor']
+                    total_iters = warmup_params['warmup_epochs']
+                    if current_epoch > 0 and warmup_params['interval'] == 'step' \
+                            or epoch > total_iters:
+                        return 1.0
+                    if epoch == 0:
+                        return start_factor
+                    return (end_factor - start_factor) * epoch / total_iters \
+                        + start_factor
+                scheduler = LambdaLR(optimizer=opt,
+                                     lr_lambda=[lr_func] * len(opt.param_groups))
+                lr_scheduler = {
+                    'scheduler': scheduler,
+                    'opt_idx': opt_idx,
+                    'interval': warmup_params['interval']
+                }
+                lr_schedulers.append(lr_scheduler)
+
+            # validates the lr_scheduler_configs, adapted from lightning
+            # https://github.com/Lightning-AI/lightning/blob/1.6.4/pytorch_lightning/core/optimizer.py#L175
+            lr_scheduler_configs = (
+                _configure_schedulers_automatic_opt(lr_schedulers, None)
+                if self.lightning_module.automatic_optimization
+                else _configure_schedulers_manual_opt(lr_schedulers)
+            )
+            _set_scheduler_opt_idx(self.optimizers, lr_scheduler_configs)
+            _validate_scheduler_api(lr_scheduler_configs, self.model)
+            self.lr_scheduler_configs = lr_scheduler_configs
 
     def training_step_end(self, output: _STEP_OUTPUT_TYPE) -> _STEP_OUTPUT_TYPE:
         """

--- a/python/nano/src/bigdl/nano/pytorch/plugins/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/plugins/ddp_spawn.py
@@ -40,11 +40,9 @@ from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
 import torch
 from torch.nn.parallel.distributed import DistributedDataParallel
 from torch.multiprocessing.spawn import _wrap, ProcessContext
-from torch.optim.lr_scheduler import _LRScheduler
 
 import pytorch_lightning as pl
 from pytorch_lightning.overrides import LightningDistributedModule
-from pytorch_lightning.core.optimizer import LightningOptimizer
 from pytorch_lightning.plugins.environments.cluster_environment import ClusterEnvironment
 from pytorch_lightning.plugins.environments import LightningEnvironment
 from pytorch_lightning.utilities.distributed import rank_zero_only
@@ -119,7 +117,7 @@ class DDPSpawnPlugin(pl.plugins.DDPSpawnPlugin):
         num_processes: int = 1,
         cpu_for_each_process: Optional[List[List[int]]] = None,
         use_ipex=False,
-        enable_bf16=False
+        enable_bf16=False,
     ):
         """Create a DDPSpawnPlugin, adding a cpu_for_each_process parameter."""
         device = ipex_device() if use_ipex and TORCH_VERSION_LESS_1_10 else 'cpu'
@@ -132,7 +130,6 @@ class DDPSpawnPlugin(pl.plugins.DDPSpawnPlugin):
         self.is_distributed = True
         self.use_ipex = use_ipex
         self.enable_bf16 = enable_bf16
-
 
     @property
     def mp_spawn_kwargs(self):

--- a/python/nano/src/bigdl/nano/pytorch/plugins/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/plugins/ddp_spawn.py
@@ -145,7 +145,7 @@ class DDPSpawnPlugin(pl.plugins.DDPSpawnPlugin):
         }
 
     def pre_dispatch(self):
-        """Hook to config optimizers before training starts"""
+        """Hook to config optimizers before training starts."""
         if not self.lightning_module.trainer.training or not self.scale_lr:
             return
 

--- a/python/nano/src/bigdl/nano/pytorch/plugins/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/plugins/ddp_spawn.py
@@ -148,7 +148,7 @@ class DDPSpawnPlugin(pl.plugins.DDPSpawnPlugin):
         if not self.lightning_module.trainer.training or not self.scale_lr:
 
             return
-        
+
         def _unpack_lightning_optimizer(opt):
             return opt._optimizer if isinstance(opt, LightningOptimizer) else opt
 
@@ -164,7 +164,6 @@ class DDPSpawnPlugin(pl.plugins.DDPSpawnPlugin):
             scheduler = scheduler["scheduler"]
             if isinstance(scheduler, _LRScheduler):
                 scheduler.base_lrs = [lr * self.world_size for lr in scheduler.base_lrs]
-
 
     def start_training(self, trainer):
         """Setup start_training hook for the plugin."""

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -336,7 +336,7 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
                 else _configure_schedulers_manual_opt(lr_schedulers)
             )
             _set_scheduler_opt_idx(self.optimizers, lr_scheduler_configs)
-            _validate_scheduler_api(lr_scheduler_configs, self.model)
+            _validate_scheduler_api(lr_scheduler_configs, self.lightning_module)
             self.lr_scheduler_configs = lr_scheduler_configs
 
     def _setup_model(self, model: nn.Module) -> DistributedDataParallel:

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -245,7 +245,7 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
                 scheduler.base_lrs = [lr * self.world_size for lr in scheduler.base_lrs]
 
             if self.lr_scheduler_configs:
-                warnings.warn(f"Nano warmup currently only support none optimizers, "
+                warnings.warn(f"Nano warmup currently only support no scheduler, "
                               f"but got {len(self.lr_scheduler_configs)}. Skip warmup")
             else:
                 lr_schedulers = []
@@ -280,6 +280,9 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
                         'opt_idx': opt_idx
                     }
                     lr_schedulers.append(lr_scheduler)
+
+                # validates the lr_scheduler_configs, adapted from lightning
+                # https://github.com/Lightning-AI/lightning/blob/1.6.4/pytorch_lightning/core/optimizer.py#L175
                 lr_scheduler_configs = (
                     _configure_schedulers_automatic_opt(lr_schedulers, None)
                     if self.lightning_module.automatic_optimization

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -269,9 +269,6 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
         """Setup warmup lr_schedulers after resetting the train dataloaders."""
         # LightnigModule.train_dataloader() generate the training dataloaders after setup,
         # so config the warmup lr_schedulers in on_train_start hook to infer warmup_steps.
-        invalidInputError(isinstance(self.auto_lr, dict) or isinstance(self.auto_lr, bool),
-                          errMsg=f"auto_lr is {type(self.auto_lr)}",
-                          fixMsg="expect auto_lr is a bool or dict")
         if not self.auto_lr:
             return
         if self.lr_scheduler_configs:
@@ -294,7 +291,7 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
                 if 'warmup_epochs' not in self.auto_lr:
                     self.auto_lr = True
                     warnings.warn("Not found \"warmup_epochs\" in the auto_lr dict"
-                                  " warmup_epochs will be set by default")
+                                  " warmup_epochs is set by default")
                 else:
                     invalidInputError(type(self.auto_lr['warmup_epochs']) is int,
                                       f"\"warmup_epochs\" is {type(self.auto_lr['warmup_epochs'])}",

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -269,12 +269,12 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
                             if epoch == 0:
                                 return start_factor
                             if epoch < total_iters:
-                                return ((end_factor - start_factor) * epoch / total_iters +
-                                        start_factor)
+                                return ((end_factor - start_factor) * epoch / total_iters
+                                        + start_factor)
                             else:
                                 return 1.0
-                        scheduler = LambdaLR(optimizer=opt, lr_lambda=[lr_func] *
-                                             len(optimizer.param_groups))
+                        scheduler = LambdaLR(optimizer=opt, lr_lambda=[lr_func]
+                                             * len(optimizer.param_groups))
                     lr_scheduler = {
                         'scheduler': scheduler,
                         'opt_idx': opt_idx

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -40,13 +40,16 @@ from typing import Any, List, Optional, Callable, Union, Dict
 import torch
 from torch import nn
 from torch import Tensor
+from torch.optim.lr_scheduler import LinearLR
 from torch.multiprocessing.spawn import _wrap, ProcessContext
 from torch.nn.parallel.distributed import DistributedDataParallel
-from torch.optim.lr_scheduler import _LRScheduler
 
 import pytorch_lightning as pl
 from pytorch_lightning.trainer.states import TrainerFn
 from pytorch_lightning.core.optimizer import LightningOptimizer
+from pytorch_lightning.core.optimizer import _configure_schedulers_automatic_opt
+from pytorch_lightning.core.optimizer import _configure_schedulers_manual_opt
+from pytorch_lightning.core.optimizer import _set_scheduler_opt_idx, _validate_scheduler_api
 from pytorch_lightning.core.datamodule import LightningDataModule
 from pytorch_lightning.strategies.launchers import _SpawnLauncher
 from pytorch_lightning.strategies import DDPSpawnStrategy as _DDPSpawnStrategy
@@ -166,7 +169,7 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
         cpu_for_each_process: Optional[List[List[int]]] = None,
         use_ipex=False,
         enable_bf16=False,
-        scale_lr=False,
+        auto_lr=False,
         **kwargs: Any
     ):
         """Create a DDPSpawnStrategy, adding a cpu_for_each_process parameter."""
@@ -185,7 +188,7 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
         self.is_distributed = True
         self.use_ipex = use_ipex
         self.enable_bf16 = enable_bf16
-        self.scale_lr = scale_lr
+        self.auto_lr = auto_lr
 
     def _configure_launcher(self):
         self._launcher = _DDPSpawnLauncher(self)
@@ -225,7 +228,7 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
             # so we need to set it to `False` manuallay
             self.model.eval()
 
-        if trainer.training and self.scale_lr:
+        if trainer.training and self.auto_lr:
 
             def _unpack_lightning_optimizer(opt):
                 return opt._optimizer if isinstance(opt, LightningOptimizer) else opt
@@ -241,6 +244,34 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
             for config in lr_scheduler_configs:
                 scheduler = config.scheduler
                 scheduler.base_lrs = [lr * self.world_size for lr in scheduler.base_lrs]
+
+            if self.lr_scheduler_configs:
+                warnings.warn(f"Nano warmup currently only support none optimizers, "
+                              f"but got {len(self.lr_scheduler_configs)}. Skip warmup")
+            else:
+                lr_schedulers = []
+                for opt_idx, opt in enumerate(self.optimizers):
+                    if type(self.auto_lr) is bool:
+                        self.auto_lr = trainer.max_epochs // 5 + 1
+                    scheduler = LinearLR(optimizer=opt,
+                                            # set initial lr as user lr
+                                            start_factor= 1.0 / self.world_size,
+                                            end_factor=1.0,
+                                            total_iters=self.auto_lr)
+                    lr_scheduler = {
+                        'scheduler': scheduler,
+                        'opt_idx': opt_idx
+                    }
+                    lr_schedulers.append(lr_scheduler)
+                lr_scheduler_configs = (
+                    _configure_schedulers_automatic_opt(lr_schedulers, None)
+                        if self.lightning_module.automatic_optimization
+                        else _configure_schedulers_manual_opt(lr_schedulers)
+                )
+                _set_scheduler_opt_idx(self.optimizers, lr_scheduler_configs)
+                _validate_scheduler_api(lr_scheduler_configs, self.model)
+                self.lr_scheduler_configs = lr_scheduler_configs
+                
 
         if self.use_ipex and not TORCH_VERSION_LESS_1_10:
             dtype = torch.bfloat16 if self.enable_bf16 else None

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -244,80 +244,80 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
                 scheduler = config.scheduler
                 scheduler.base_lrs = [lr * self.world_size for lr in scheduler.base_lrs]
 
-            if self.lr_scheduler_configs:
-                warnings.warn(f"Nano warmup currently only support no scheduler, "
-                              f"but got {len(self.lr_scheduler_configs)}. Skip warmup")
-            else:
-                lr_schedulers = []
-                warmup_params = {
-                    'start_factor': 1.0 / self.world_size,
-                    'end_factor': 1.0,
-                    'warmup_epochs': trainer.max_epochs // 10,
-                    'interval': 'epoch'
-                }
-                supported_keys = {'warmup_epochs'}
-                if not isinstance(self.auto_lr, dict) and not isinstance(self.auto_lr, bool):
-                    raise TypeError("Except auto_lr to be a boolean or dict"
-                                    f" but got a {type(self.auto_lr)}")
-                if isinstance(self.auto_lr, dict):
-                    extra_keys = self.auto_lr.keys() - supported_keys
-                    if extra_keys:
-                        warnings.warn(f"Found unsupported keys in the auto_lr dict: {extra_keys}")
-                    if 'warmup_epochs' not in self.auto_lr:
-                        self.auto_lr = True
-                        warnings.warn("Not found \"warmup_epochs\" in the auto_lr dict"
-                                      " warmup_epochs will be set by default")
-                    elif type(self.auto_lr['warmup_epochs']) is not int:
-                        raise TypeError("Expect \"warmup_epochs\" to be an integer"
-                                        f" but got a {type(self.auto_lr['warmup_epochs'])}")
-                    else:
-                        warmup_params['warmup_epochs'] = self.auto_lr['warmup_epochs']
-                if type(self.auto_lr) is bool:
-                    train_loader = trainer._data_connector._train_dataloader_source.instance
-                    if isinstance(train_loader, pl.LightningModule):
-                        warnings.warn("It seems like train_dataloaders is None and max_epochs < 10."
-                                      " Inferring warmup_epochs failed"
-                                      "Hint: Set warmup_epochs manually")
-                    elif trainer.max_epochs < 10:
-                        train_dataset = train_loader.dataset
-                        batch_size = train_loader.batch_size
-                        max_steps = len(train_dataset) * trainer.max_epochs // batch_size
-                        warmup_params['warmup_epochs'] = max_steps // 10
-                        warmup_params['interval'] = 'step'
-                for opt_idx, opt in enumerate(self.optimizers):
-                    from torch.optim.lr_scheduler import LambdaLR
+            # if self.lr_scheduler_configs:
+            #     warnings.warn(f"Nano warmup currently only support no scheduler, "
+            #                   f"but got {len(self.lr_scheduler_configs)}. Skip warmup")
+            # else:
+            #     lr_schedulers = []
+            #     warmup_params = {
+            #         'start_factor': 1.0 / self.world_size,
+            #         'end_factor': 1.0,
+            #         'warmup_epochs': trainer.max_epochs // 10,
+            #         'interval': 'epoch'
+            #     }
+            #     supported_keys = {'warmup_epochs'}
+            #     if not isinstance(self.auto_lr, dict) and not isinstance(self.auto_lr, bool):
+            #         raise TypeError("Except auto_lr to be a boolean or dict"
+            #                         f" but got a {type(self.auto_lr)}")
+            #     if isinstance(self.auto_lr, dict):
+            #         extra_keys = self.auto_lr.keys() - supported_keys
+            #         if extra_keys:
+            #             warnings.warn(f"Found unsupported keys in the auto_lr dict: {extra_keys}")
+            #         if 'warmup_epochs' not in self.auto_lr:
+            #             self.auto_lr = True
+            #             warnings.warn("Not found \"warmup_epochs\" in the auto_lr dict"
+            #                           " warmup_epochs will be set by default")
+            #         elif type(self.auto_lr['warmup_epochs']) is not int:
+            #             raise TypeError("Expect \"warmup_epochs\" to be an integer"
+            #                             f" but got a {type(self.auto_lr['warmup_epochs'])}")
+            #         else:
+            #             warmup_params['warmup_epochs'] = self.auto_lr['warmup_epochs']
+            #     if type(self.auto_lr) is bool:
+            #         train_loader = trainer._data_connector._train_dataloader_source.instance
+            #         if isinstance(train_loader, pl.LightningModule):
+            #             warnings.warn("It seems like train_dataloaders is None and max_epochs < 10."
+            #                           " Inferring warmup_epochs failed"
+            #                           "Hint: Set warmup_epochs manually")
+            #         elif trainer.max_epochs < 10:
+            #             train_dataset = train_loader.dataset
+            #             batch_size = train_loader.batch_size
+            #             max_steps = len(train_dataset) * trainer.max_epochs // batch_size
+            #             warmup_params['warmup_epochs'] = max_steps // 10
+            #             warmup_params['interval'] = 'step'
+            #     for opt_idx, opt in enumerate(self.optimizers):
+            #         from torch.optim.lr_scheduler import LambdaLR
 
-                    def lr_func(epoch):
-                        current_epoch = self.lightning_module.current_epoch
-                        start_factor = warmup_params['start_factor']
-                        end_factor = warmup_params['end_factor']
-                        total_iters = warmup_params['warmup_epochs']
-                        if current_epoch > 0 and warmup_params['interval'] == 'step' \
-                           or epoch > total_iters:
-                            return 1.0
-                        if epoch == 0:
-                            return start_factor
-                        return (end_factor - start_factor) * epoch / total_iters \
-                            + start_factor
-                    scheduler = LambdaLR(optimizer=opt,
-                                         lr_lambda=[lr_func] * len(optimizer.param_groups))
-                    lr_scheduler = {
-                        'scheduler': scheduler,
-                        'opt_idx': opt_idx,
-                        'interval': warmup_params['interval']
-                    }
-                    lr_schedulers.append(lr_scheduler)
+            #         def lr_func(epoch):
+            #             current_epoch = self.lightning_module.current_epoch
+            #             start_factor = warmup_params['start_factor']
+            #             end_factor = warmup_params['end_factor']
+            #             total_iters = warmup_params['warmup_epochs']
+            #             if current_epoch > 0 and warmup_params['interval'] == 'step' \
+            #                or epoch > total_iters:
+            #                 return 1.0
+            #             if epoch == 0:
+            #                 return start_factor
+            #             return (end_factor - start_factor) * epoch / total_iters \
+            #                 + start_factor
+            #         scheduler = LambdaLR(optimizer=opt,
+            #                              lr_lambda=[lr_func] * len(optimizer.param_groups))
+            #         lr_scheduler = {
+            #             'scheduler': scheduler,
+            #             'opt_idx': opt_idx,
+            #             'interval': warmup_params['interval']
+            #         }
+            #         lr_schedulers.append(lr_scheduler)
 
-                # validates the lr_scheduler_configs, adapted from lightning
-                # https://github.com/Lightning-AI/lightning/blob/1.6.4/pytorch_lightning/core/optimizer.py#L175
-                lr_scheduler_configs = (
-                    _configure_schedulers_automatic_opt(lr_schedulers, None)
-                    if self.lightning_module.automatic_optimization
-                    else _configure_schedulers_manual_opt(lr_schedulers)
-                )
-                _set_scheduler_opt_idx(self.optimizers, lr_scheduler_configs)
-                _validate_scheduler_api(lr_scheduler_configs, self.model)
-                self.lr_scheduler_configs = lr_scheduler_configs
+            #     # validates the lr_scheduler_configs, adapted from lightning
+            #     # https://github.com/Lightning-AI/lightning/blob/1.6.4/pytorch_lightning/core/optimizer.py#L175
+            #     lr_scheduler_configs = (
+            #         _configure_schedulers_automatic_opt(lr_schedulers, None)
+            #         if self.lightning_module.automatic_optimization
+            #         else _configure_schedulers_manual_opt(lr_schedulers)
+            #     )
+            #     _set_scheduler_opt_idx(self.optimizers, lr_scheduler_configs)
+            #     _validate_scheduler_api(lr_scheduler_configs, self.model)
+            #     self.lr_scheduler_configs = lr_scheduler_configs
 
         if self.use_ipex and not TORCH_VERSION_LESS_1_10:
             dtype = torch.bfloat16 if self.enable_bf16 else None
@@ -335,6 +335,88 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
         # some operations in `configure_ddp` do not support XPU,
         # which is used by ipex==1.9, so we move this line here
         self.model_to_device()
+
+    def on_train_start(self):
+        """Setup warmup lr_schedulers after resetting the train dataloaders."""
+        if not self.auto_lr:
+            return
+        if self.lr_scheduler_configs:
+            warnings.warn(f"Nano warmup currently only support no scheduler, "
+                          f"but got {len(self.lr_scheduler_configs)}. Skip warmup")
+        else:
+            trainer = self.lightning_module.trainer
+            lr_schedulers = []
+            warmup_params = {
+                'start_factor': 1.0 / self.world_size,
+                'end_factor': 1.0,
+                'warmup_epochs': trainer.max_epochs // 10,
+                'interval': 'epoch'
+            }
+            supported_keys = {'warmup_epochs'}
+            if not isinstance(self.auto_lr, dict) and not isinstance(self.auto_lr, bool):
+                raise TypeError("Except auto_lr to be a boolean or dict"
+                                f" but got a {type(self.auto_lr)}")
+            if isinstance(self.auto_lr, dict):
+                extra_keys = self.auto_lr.keys() - supported_keys
+                if extra_keys:
+                    warnings.warn(f"Found unsupported keys in the auto_lr dict: {extra_keys}")
+                if 'warmup_epochs' not in self.auto_lr:
+                    self.auto_lr = True
+                    warnings.warn("Not found \"warmup_epochs\" in the auto_lr dict"
+                                  " warmup_epochs will be set by default")
+                elif type(self.auto_lr['warmup_epochs']) is not int:
+                    raise TypeError("Expect \"warmup_epochs\" to be an integer"
+                                    f" but got a {type(self.auto_lr['warmup_epochs'])}")
+                else:
+                    warmup_params['warmup_epochs'] = self.auto_lr['warmup_epochs']
+            if type(self.auto_lr) is bool:
+                train_loader = trainer.train_dataloader
+                if isinstance(train_loader, pl.LightningModule):
+                    # warnings.warn("It seems like train_dataloaders is None and max_epochs < 10."
+                    #               " Inferring warmup_epochs failed"
+                    #               "Hint: Set warmup_epochs manually")
+                    pass
+                elif trainer.max_epochs < 10:
+                    # train_dataset = train_loader.dataset
+                    # batch_size = train_loader.batch_size
+                    # max_steps = len(train_dataset) * trainer.max_epochs // batch_size
+                    max_steps = len(train_loader) * trainer.max_epochs
+                    warmup_params['warmup_epochs'] = max_steps // 10
+                    warmup_params['interval'] = 'step'
+            for opt_idx, opt in enumerate(self.optimizers):
+                from torch.optim.lr_scheduler import LambdaLR
+
+                def lr_func(epoch):
+                    current_epoch = trainer.current_epoch
+                    start_factor = warmup_params['start_factor']
+                    end_factor = warmup_params['end_factor']
+                    total_iters = warmup_params['warmup_epochs']
+                    if current_epoch > 0 and warmup_params['interval'] == 'step' \
+                            or epoch > total_iters:
+                        return 1.0
+                    if epoch == 0:
+                        return start_factor
+                    return (end_factor - start_factor) * epoch / total_iters \
+                        + start_factor
+                scheduler = LambdaLR(optimizer=opt,
+                                     lr_lambda=[lr_func] * len(opt.param_groups))
+                lr_scheduler = {
+                    'scheduler': scheduler,
+                    'opt_idx': opt_idx,
+                    'interval': warmup_params['interval']
+                }
+                lr_schedulers.append(lr_scheduler)
+
+            # validates the lr_scheduler_configs, adapted from lightning
+            # https://github.com/Lightning-AI/lightning/blob/1.6.4/pytorch_lightning/core/optimizer.py#L175
+            lr_scheduler_configs = (
+                _configure_schedulers_automatic_opt(lr_schedulers, None)
+                if self.lightning_module.automatic_optimization
+                else _configure_schedulers_manual_opt(lr_schedulers)
+            )
+            _set_scheduler_opt_idx(self.optimizers, lr_scheduler_configs)
+            _validate_scheduler_api(lr_scheduler_configs, self.model)
+            self.lr_scheduler_configs = lr_scheduler_configs
 
     def _setup_model(self, model: nn.Module) -> DistributedDataParallel:
         """Wraps the model into a 'DistributedDataParallel' module."""

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -273,12 +273,14 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
                     else:
                         warmup_params['warmup_epochs'] = self.auto_lr['warmup_epochs']
                 if type(self.auto_lr) is bool:
-                    if trainer.max_epochs < 10:
-                        train_dataset = (
-                            trainer._data_connector._train_dataloader_source.instance.dataset)
-                        batch_size = (
-                            trainer._data_connector._train_dataloader_source.instance.batch_size
-                        )
+                    train_loader = trainer._data_connector._train_dataloader_source.instance
+                    if isinstance(train_loader, pl.LightningModule):
+                        warnings.warn("It seems like train_dataloaders is None and max_epochs < 10."
+                                      "Inferring warmup_epochs failed"
+                                      "Hint: Set warmup_epochs manually")
+                    elif trainer.max_epochs < 10:
+                        train_dataset = train_loader.dataset
+                        batch_size = train_loader.batch_size
                         max_steps = len(train_dataset) * trainer.max_epochs // batch_size
                         warmup_params['warmup_epochs'] = max_steps // 10
                         warmup_params['interval'] = 'step'

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -244,81 +244,6 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
                 scheduler = config.scheduler
                 scheduler.base_lrs = [lr * self.world_size for lr in scheduler.base_lrs]
 
-            # if self.lr_scheduler_configs:
-            #     warnings.warn(f"Nano warmup currently only support no scheduler, "
-            #                   f"but got {len(self.lr_scheduler_configs)}. Skip warmup")
-            # else:
-            #     lr_schedulers = []
-            #     warmup_params = {
-            #         'start_factor': 1.0 / self.world_size,
-            #         'end_factor': 1.0,
-            #         'warmup_epochs': trainer.max_epochs // 10,
-            #         'interval': 'epoch'
-            #     }
-            #     supported_keys = {'warmup_epochs'}
-            #     if not isinstance(self.auto_lr, dict) and not isinstance(self.auto_lr, bool):
-            #         raise TypeError("Except auto_lr to be a boolean or dict"
-            #                         f" but got a {type(self.auto_lr)}")
-            #     if isinstance(self.auto_lr, dict):
-            #         extra_keys = self.auto_lr.keys() - supported_keys
-            #         if extra_keys:
-            #             warnings.warn(f"Found unsupported keys in the auto_lr dict: {extra_keys}")
-            #         if 'warmup_epochs' not in self.auto_lr:
-            #             self.auto_lr = True
-            #             warnings.warn("Not found \"warmup_epochs\" in the auto_lr dict"
-            #                           " warmup_epochs will be set by default")
-            #         elif type(self.auto_lr['warmup_epochs']) is not int:
-            #             raise TypeError("Expect \"warmup_epochs\" to be an integer"
-            #                             f" but got a {type(self.auto_lr['warmup_epochs'])}")
-            #         else:
-            #             warmup_params['warmup_epochs'] = self.auto_lr['warmup_epochs']
-            #     if type(self.auto_lr) is bool:
-            #         train_loader = trainer._data_connector._train_dataloader_source.instance
-            #         if isinstance(train_loader, pl.LightningModule):
-            #             warnings.warn("It seems like train_dataloaders is None and max_epochs < 10."
-            #                           " Inferring warmup_epochs failed"
-            #                           "Hint: Set warmup_epochs manually")
-            #         elif trainer.max_epochs < 10:
-            #             train_dataset = train_loader.dataset
-            #             batch_size = train_loader.batch_size
-            #             max_steps = len(train_dataset) * trainer.max_epochs // batch_size
-            #             warmup_params['warmup_epochs'] = max_steps // 10
-            #             warmup_params['interval'] = 'step'
-            #     for opt_idx, opt in enumerate(self.optimizers):
-            #         from torch.optim.lr_scheduler import LambdaLR
-
-            #         def lr_func(epoch):
-            #             current_epoch = self.lightning_module.current_epoch
-            #             start_factor = warmup_params['start_factor']
-            #             end_factor = warmup_params['end_factor']
-            #             total_iters = warmup_params['warmup_epochs']
-            #             if current_epoch > 0 and warmup_params['interval'] == 'step' \
-            #                or epoch > total_iters:
-            #                 return 1.0
-            #             if epoch == 0:
-            #                 return start_factor
-            #             return (end_factor - start_factor) * epoch / total_iters \
-            #                 + start_factor
-            #         scheduler = LambdaLR(optimizer=opt,
-            #                              lr_lambda=[lr_func] * len(optimizer.param_groups))
-            #         lr_scheduler = {
-            #             'scheduler': scheduler,
-            #             'opt_idx': opt_idx,
-            #             'interval': warmup_params['interval']
-            #         }
-            #         lr_schedulers.append(lr_scheduler)
-
-            #     # validates the lr_scheduler_configs, adapted from lightning
-            #     # https://github.com/Lightning-AI/lightning/blob/1.6.4/pytorch_lightning/core/optimizer.py#L175
-            #     lr_scheduler_configs = (
-            #         _configure_schedulers_automatic_opt(lr_schedulers, None)
-            #         if self.lightning_module.automatic_optimization
-            #         else _configure_schedulers_manual_opt(lr_schedulers)
-            #     )
-            #     _set_scheduler_opt_idx(self.optimizers, lr_scheduler_configs)
-            #     _validate_scheduler_api(lr_scheduler_configs, self.model)
-            #     self.lr_scheduler_configs = lr_scheduler_configs
-
         if self.use_ipex and not TORCH_VERSION_LESS_1_10:
             dtype = torch.bfloat16 if self.enable_bf16 else None
             num_optimizers = len(self.optimizers)
@@ -338,6 +263,8 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
 
     def on_train_start(self):
         """Setup warmup lr_schedulers after resetting the train dataloaders."""
+        # LightnigModule.train_dataloader() generate the training dataloaders after setup,
+        # so config the warmup lr_schedulers in on_train_start hook to infer warmup_steps.
         if not self.auto_lr:
             return
         if self.lr_scheduler_configs:
@@ -370,16 +297,9 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
                 else:
                     warmup_params['warmup_epochs'] = self.auto_lr['warmup_epochs']
             if type(self.auto_lr) is bool:
-                train_loader = trainer.train_dataloader
-                if isinstance(train_loader, pl.LightningModule):
-                    # warnings.warn("It seems like train_dataloaders is None and max_epochs < 10."
-                    #               " Inferring warmup_epochs failed"
-                    #               "Hint: Set warmup_epochs manually")
-                    pass
-                elif trainer.max_epochs < 10:
-                    # train_dataset = train_loader.dataset
-                    # batch_size = train_loader.batch_size
-                    # max_steps = len(train_dataset) * trainer.max_epochs // batch_size
+                # Call scheduler.step() after each minibatch rather than epoch if max_epochs < 10
+                if warmup_params['warmup_epochs'] == 0:
+                    train_loader = trainer.train_dataloader
                     max_steps = len(train_loader) * trainer.max_epochs
                     warmup_params['warmup_epochs'] = max_steps // 10
                     warmup_params['interval'] = 'step'

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -269,12 +269,12 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
                             if epoch == 0:
                                 return start_factor
                             if epoch < total_iters:
-                                return ((end_factor - start_factor) * epoch / total_iters
-                                        + start_factor)
+                                return (end_factor - start_factor) * epoch / total_iters \
+                                    + start_factor
                             else:
                                 return 1.0
-                        scheduler = LambdaLR(optimizer=opt, lr_lambda=[lr_func]
-                                             * len(optimizer.param_groups))
+                        scheduler = LambdaLR(optimizer=opt,
+                                             lr_lambda=[lr_func] * len(optimizer.param_groups))
                     lr_scheduler = {
                         'scheduler': scheduler,
                         'opt_idx': opt_idx

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -268,7 +268,7 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
     def on_train_start(self):
         """Setup warmup lr_schedulers after resetting the train dataloaders."""
         # LightnigModule.train_dataloader() generate the training dataloaders after setup,
-        # so config the warmup lr_schedulers in on_train_start hook to infer warmup_steps.
+        # so attach the warmup lr_schedulers in on_train_start hook to infer warmup_steps.
         if not self.auto_lr:
             return
         if self.lr_scheduler_configs:

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -282,17 +282,7 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
                         max_steps = len(train_dataset) * trainer.max_epochs // batch_size
                         warmup_params['warmup_epochs'] = max_steps // 10
                         warmup_params['interval'] = 'step'
-                # if type(self.auto_lr) is bool:
-                #     self.auto_lr = trainer.max_epochs // 5 + 1
                 for opt_idx, opt in enumerate(self.optimizers):
-                    # if not TORCH_VERSION_LESS_1_10:
-                    #     from torch.optim.lr_scheduler import LinearLR
-                    #     scheduler = LinearLR(optimizer=opt,
-                    #                          # set initial lr as user lr
-                    #                          start_factor=warmup_params['start_factor'],
-                    #                          end_factor=warmup_params['end_factor'],
-                    #                          total_iters=warmup_params['warmup_epochs'])
-                    # else:
                     from torch.optim.lr_scheduler import LambdaLR
 
                     def lr_func(epoch):

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -276,7 +276,7 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
                     train_loader = trainer._data_connector._train_dataloader_source.instance
                     if isinstance(train_loader, pl.LightningModule):
                         warnings.warn("It seems like train_dataloaders is None and max_epochs < 10."
-                                      "Inferring warmup_epochs failed"
+                                      " Inferring warmup_epochs failed"
                                       "Hint: Set warmup_epochs manually")
                     elif trainer.max_epochs < 10:
                         train_dataset = train_loader.dataset

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -62,7 +62,7 @@ class Trainer(pl.Trainer):
                  cpu_for_each_process: Optional[List[List[int]]] = None,
                  use_hpo=False,
                  channels_last: bool = False,
-                 scale_lr=False,
+                 auto_lr=False,
                  *args: Any, **kwargs: Any) -> None:
         """
         A pytorch lightning trainer that uses bigdl-nano optimization.
@@ -138,8 +138,7 @@ class Trainer(pl.Trainer):
                 strategy = DDPSubprocessStrategy(num_processes=num_processes,
                                                  cpu_for_each_process=cpu_for_each_process,
                                                  use_ipex=self.use_ipex,
-                                                 enable_bf16=enable_bf16,
-                                                 scale_lr=scale_lr)
+                                                 enable_bf16=enable_bf16)
                 elif distributed_backend == "ray":
                     # Import RayPlugins may entangle with openmp even if it has not been used,
                     # which leads to an unacceptably low performance.
@@ -159,14 +158,14 @@ class Trainer(pl.Trainer):
                                                 cpu_for_each_process=cpu_for_each_process,
                                                 use_ipex=self.use_ipex,
                                                 enable_bf16=enable_bf16,
-                                                scale_lr=scale_lr)
+                                                auto_lr=auto_lr)
                 elif distributed_backend == "subprocess":
                     from bigdl.nano.pytorch.strategies import DDPSubprocessStrategy
                     strategy = DDPSubprocessStrategy(num_processes=num_processes,
                                                      cpu_for_each_process=cpu_for_each_process,
                                                      use_ipex=self.use_ipex,
                                                      enable_bf16=enable_bf16,
-                                                     scale_lr=scale_lr)
+                                                     auto_lr=auto_lr)
                 elif distributed_backend == "ray":
                     from bigdl.nano.pytorch.strategies import create_RayStrategy
                     strategy = create_RayStrategy(num_workers=num_processes,

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -62,7 +62,7 @@ class Trainer(pl.Trainer):
                  cpu_for_each_process: Optional[List[List[int]]] = None,
                  use_hpo=False,
                  channels_last: bool = False,
-                 auto_lr=False,
+                 auto_lr=True,
                  *args: Any, **kwargs: Any) -> None:
         """
         A pytorch lightning trainer that uses bigdl-nano optimization.

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -16,7 +16,7 @@
 import copy
 from logging import warning
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 import pytorch_lightning as pl
 import torch
 from torch import nn
@@ -62,7 +62,7 @@ class Trainer(pl.Trainer):
                  cpu_for_each_process: Optional[List[List[int]]] = None,
                  use_hpo=False,
                  channels_last: bool = False,
-                 auto_lr=True,
+                 auto_lr: Union[int, bool] = True,
                  *args: Any, **kwargs: Any) -> None:
         """
         A pytorch lightning trainer that uses bigdl-nano optimization.
@@ -145,7 +145,8 @@ class Trainer(pl.Trainer):
                 from bigdl.nano.pytorch.strategies import create_RayStrategy
                 strategy = create_RayStrategy(num_workers=num_processes,
                                               use_ipex=self.use_ipex,
-                                              enable_bf16=enable_bf16)
+                                              enable_bf16=enable_bf16,
+                                              auto_lr=auto_lr)
             kwargs["strategy"] = strategy
             super().__init__(*args, **kwargs)
 

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -132,47 +132,22 @@ class Trainer(pl.Trainer):
                 strategy = DDPSpawnStrategy(num_processes=num_processes,
                                             cpu_for_each_process=cpu_for_each_process,
                                             use_ipex=self.use_ipex,
-                                            enable_bf16=enable_bf16)
+                                            enable_bf16=enable_bf16,
+                                            auto_lr=auto_lr)
             elif distributed_backend == "subprocess":
                 from bigdl.nano.pytorch.strategies import DDPSubprocessStrategy
                 strategy = DDPSubprocessStrategy(num_processes=num_processes,
                                                  cpu_for_each_process=cpu_for_each_process,
                                                  use_ipex=self.use_ipex,
-                                                 enable_bf16=enable_bf16)
-                elif distributed_backend == "ray":
-                    # Import RayPlugins may entangle with openmp even if it has not been used,
-                    # which leads to an unacceptably low performance.
-                    # So we import when we need.
-                    plugin = distributed_ray(num_workers=num_processes,  # type: ignore
-                                             use_ipex=self.use_ipex,
-                                             enable_bf16=enable_bf16)
-                if self.use_ipex and TORCH_VERSION_LESS_1_10:
-                    accelerator = create_IPEXAccelerator_1_9(training_type_plugin=plugin,
-                                                             enable_bf16=enable_bf16)
-                super().__init__(accelerator=accelerator, plugins=[plugin],  # type: ignore
-                                 *args, **kwargs)
-            else:
-                if distributed_backend == "spawn":
-                    from bigdl.nano.pytorch.strategies import DDPSpawnStrategy
-                    strategy = DDPSpawnStrategy(num_processes=num_processes,
-                                                cpu_for_each_process=cpu_for_each_process,
-                                                use_ipex=self.use_ipex,
-                                                enable_bf16=enable_bf16,
-                                                auto_lr=auto_lr)
-                elif distributed_backend == "subprocess":
-                    from bigdl.nano.pytorch.strategies import DDPSubprocessStrategy
-                    strategy = DDPSubprocessStrategy(num_processes=num_processes,
-                                                     cpu_for_each_process=cpu_for_each_process,
-                                                     use_ipex=self.use_ipex,
-                                                     enable_bf16=enable_bf16,
-                                                     auto_lr=auto_lr)
-                elif distributed_backend == "ray":
-                    from bigdl.nano.pytorch.strategies import create_RayStrategy
-                    strategy = create_RayStrategy(num_workers=num_processes,
-                                                  use_ipex=self.use_ipex,
-                                                  enable_bf16=enable_bf16)
-                kwargs["strategy"] = strategy
-                super().__init__(*args, **kwargs)
+                                                 enable_bf16=enable_bf16,
+                                                 auto_lr=auto_lr)
+            elif distributed_backend == "ray":
+                from bigdl.nano.pytorch.strategies import create_RayStrategy
+                strategy = create_RayStrategy(num_workers=num_processes,
+                                              use_ipex=self.use_ipex,
+                                              enable_bf16=enable_bf16)
+            kwargs["strategy"] = strategy
+            super().__init__(*args, **kwargs)
 
         if use_hpo:
             self.hposearcher = create_hpo_searcher(trainer=self, num_processes=num_processes)

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -62,6 +62,7 @@ class Trainer(pl.Trainer):
                  cpu_for_each_process: Optional[List[List[int]]] = None,
                  use_hpo=False,
                  channels_last: bool = False,
+                 scale_lr=False,
                  *args: Any, **kwargs: Any) -> None:
         """
         A pytorch lightning trainer that uses bigdl-nano optimization.

--- a/python/nano/test/pytorch/tests/test_plugin.py
+++ b/python/nano/test/pytorch/tests/test_plugin.py
@@ -112,7 +112,8 @@ class TestPlugin(TestCase):
             loss=torch.nn.MSELoss(),
             metrics=[torchmetrics.MeanSquaredError()]
         )
-        trainer = Trainer(num_processes=2, distributed_backend="subprocess", max_epochs=2)
+        trainer = Trainer(num_processes=2, distributed_backend="subprocess", max_epochs=2,
+                          auto_lr=False)
         features = torch.tensor([[0.0],[0.0],[1.0],[1.0]])
         labels = torch.tensor([[0.0],[0.0],[0.0],[0.0]])
 
@@ -133,7 +134,7 @@ class TestPlugin(TestCase):
             loss=torch.nn.MSELoss(),
             metrics=[torchmetrics.MeanSquaredError()]
         )
-        trainer = Trainer(num_processes=2, distributed_backend="spawn", max_epochs=2)
+        trainer = Trainer(num_processes=2, distributed_backend="spawn", max_epochs=2, auto_lr=False)
         features = torch.tensor([[0.0],[0.0],[1.0],[1.0]])
         labels = torch.tensor([[0.0],[0.0],[0.0],[0.0]])
 

--- a/python/nano/test/pytorch/tests/test_scale_lr.py
+++ b/python/nano/test/pytorch/tests/test_scale_lr.py
@@ -1,0 +1,80 @@
+import os
+
+import pytest
+from unittest import TestCase
+
+from test.pytorch.utils._train_torch_lightning import create_data_loader, data_transform
+from test.pytorch.utils._train_torch_lightning import create_test_data_loader
+from bigdl.nano.pytorch.vision.models import vision
+from bigdl.nano.pytorch import Trainer
+import pytorch_lightning as pl
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+num_classes = 10
+batch_size = 32
+dataset_size = 256
+num_workers = 0
+data_dir = os.path.join(os.path.dirname(__file__), "../data")
+
+class Resnet_1_0(pl.LightningModule):
+    def __init__(self, learning_rate=0.01):
+        super().__init__()
+
+        self.save_hyperparameters()
+        self.backbone = vision.resnet18(pretrained=False, include_top=False, freeze=True)
+        output_size = self.backbone.get_output_size()
+        self.head = nn.Linear(output_size, num_classes)
+
+    def forward(self, x):
+        x = self.backbone(x)
+        x = self.head(x)
+        return F.log_softmax(x, dim=1)
+
+    def training_step(self, batch, batch_idx):
+        x, y = batch
+        logits = self(x)
+        loss = F.nll_loss(logits, y)
+        self.log("train_loss", loss)
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        x, y = batch
+        logits = self(x)
+        val_loss = F.nll_loss(logits, y)
+        self.log("val_loss", val_loss)
+
+    def test_step(self, batch, batch_idx):
+        x, y = batch
+        logits = self(x)
+        test_loss = F.nll_loss(logits, y)
+        self.log("test_loss", test_loss)
+
+    def configure_optimizers(self):
+        optimizer = torch.optim.SGD(
+            self.parameters(),
+            lr=self.hparams.learning_rate
+        )
+        return optimizer
+
+class TestScaleLr(TestCase):
+    data_loader = create_data_loader(data_dir, batch_size, num_workers,
+                                        data_transform, subset=dataset_size)
+    test_data_loader = create_test_data_loader(data_dir, batch_size, num_workers,
+                                                data_transform, subset=dataset_size)
+
+    def setUp(self):
+        test_dir = os.path.dirname(__file__)
+        project_test_dir = os.path.abspath(
+            os.path.join(os.path.join(os.path.join(test_dir, ".."), ".."), "..")
+        )
+        os.environ['PYTHONPATH'] = project_test_dir
+
+    def test_scale_lr_subprocess(self):
+        model = Resnet_1_0()
+        trainer = Trainer(num_processes=2, distributed_backend="subprocess",
+                          scale_lr=True, max_epochs=2)
+        trainer.fit(model, train_dataloaders=self.data_loader,
+                    val_dataloaders=self.test_data_loader)
+

--- a/python/nano/test/pytorch/tests/test_scale_lr.py
+++ b/python/nano/test/pytorch/tests/test_scale_lr.py
@@ -151,11 +151,6 @@ class CheckLinearLRScaleCallback(pl.Callback):
         self.world_size = num_processes
         self.lrs = lrs
 
-    def on_train_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule"):
-        # for lr, opt, sch in zip(self.lrs, pl_module.optimizers(), pl_module.lr_schedulers()):
-        #     assert sch.base_lrs[0] == lr * self.world_size
-        pass
-
     def on_train_epoch_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
         for lr, opt, sch in zip(self.lrs, pl_module.optimizers(), pl_module.lr_schedulers()):
             assert sch.base_lrs[0] == lr * self.world_size
@@ -234,8 +229,7 @@ class TestScaleLr(TestCase):
                           distributed_backend='subprocess',
                           auto_lr=True,
                           max_epochs=4,
-                          callbacks=[LearningRateMonitor(logging_interval='step'),
-                                     CheckWarmupCallback(2, [0.01, 0.05], 4, 4)])
+                          callbacks=[CheckWarmupCallback(2, [0.01, 0.05], 4, 4)])
         trainer.fit(model, train_dataloaders=self.data_loader,
                     val_dataloaders=self.test_data_loader)
 

--- a/python/nano/test/pytorch/tests/test_scale_lr.py
+++ b/python/nano/test/pytorch/tests/test_scale_lr.py
@@ -152,6 +152,11 @@ class CheckLinearLRScaleCallback(pl.Callback):
         self.lrs = lrs
 
     def on_train_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule"):
+        # for lr, opt, sch in zip(self.lrs, pl_module.optimizers(), pl_module.lr_schedulers()):
+        #     assert sch.base_lrs[0] == lr * self.world_size
+        pass
+
+    def on_train_epoch_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
         for lr, opt, sch in zip(self.lrs, pl_module.optimizers(), pl_module.lr_schedulers()):
             assert sch.base_lrs[0] == lr * self.world_size
 
@@ -230,7 +235,7 @@ class TestScaleLr(TestCase):
                           auto_lr=True,
                           max_epochs=4,
                           callbacks=[LearningRateMonitor(logging_interval='step'),
-                                     CheckWarmupCallback(2, [0.01, 0.05], 4, 5)])
+                                     CheckWarmupCallback(2, [0.01, 0.05], 4, 4)])
         trainer.fit(model, train_dataloaders=self.data_loader,
                     val_dataloaders=self.test_data_loader)
 
@@ -240,7 +245,7 @@ class TestScaleLr(TestCase):
                           distributed_backend='spawn',
                           auto_lr={'warmup_epochs': 4},
                           max_epochs=10,
-                          callbacks=[CheckWarmupCallback(4, [0.01, 0.05], 10, 5, 4)])
+                          callbacks=[CheckWarmupCallback(4, [0.01, 0.05], 10, 4, 4)])
         trainer.fit(model, train_dataloaders=self.data_loader,
                     val_dataloaders=self.test_data_loader)
 

--- a/python/nano/test/pytorch/tests/test_scale_lr.py
+++ b/python/nano/test/pytorch/tests/test_scale_lr.py
@@ -18,6 +18,7 @@
 import os
 
 import pytest
+import math
 from unittest import TestCase
 
 from test.pytorch.utils._train_torch_lightning import create_data_loader, data_transform
@@ -37,8 +38,8 @@ dataset_size = 256
 num_workers = 0
 data_dir = os.path.join(os.path.dirname(__file__), "../data")
 
-class Resnet_2_2(pl.LightningModule):
-    def __init__(self, learning_rate1=0.01, learning_rate2=0.02):
+class Resnet_2_0(pl.LightningModule):
+    def __init__(self, learning_rate1=0.01, learning_rate2=0.02) -> None:
         super().__init__()
 
         self.save_hyperparameters()
@@ -46,14 +47,19 @@ class Resnet_2_2(pl.LightningModule):
         output_size = self.backbone.get_output_size()
         self.head = nn.Linear(output_size, num_classes)
 
-    def on_train_start(self):
+    def on_train_epoch_start(self) -> None:
         world_size = self.trainer.strategy.world_size
-        for opt, lr_sch, lr in zip(self.trainer.optimizers, self.trainer.lr_schedulers, self.hparams):
-            lr_sch = lr_sch['scheduler']
-            if hasattr(lr_sch, 'start_factor'):
-                assert opt.param_groups[0]['lr'] == lr_sch.base_lrs[0] * lr_sch.start_factor
-                return
-            assert lr_sch.base_lrs[0] == self.hparams[lr] * world_size / 25
+        for lr_scheduler, lr in zip(self.lr_schedulers(), self.hparams):
+            if lr_scheduler.last_epoch > lr_scheduler.total_iters:
+                assert math.isclose(lr_scheduler.get_last_lr()[0], 
+                                    lr_scheduler.base_lrs[0])
+            else:
+                diff = lr_scheduler.base_lrs[0] * (lr_scheduler.end_factor - lr_scheduler.start_factor) / (lr_scheduler.total_iters)
+                assert lr_scheduler.base_lrs[0] == self.hparams[lr] * world_size
+                assert math.isclose(lr_scheduler.get_last_lr()[0], 
+                                    lr_scheduler.base_lrs[0] * lr_scheduler.start_factor + lr_scheduler.last_epoch * diff,
+                                    abs_tol=1e-7)
+        
 
     def forward(self, x):
         x = self.backbone(x)
@@ -88,18 +94,65 @@ class Resnet_2_2(pl.LightningModule):
             self.head.parameters(),
             lr=self.hparams.learning_rate2
         )
-        if TORCH_VERSION_LESS_1_10:
-            return [optimizer1, optimizer2]
-        # lr_scheduler1 = torch.optim.lr_scheduler.LinearLR(
-        #     optimizer1,
-        #     start_factor=0.25
-        # )
-        lr_scheduler1 = torch.optim.lr_scheduler.OneCycleLR(
-            optimizer1, max_lr=0.01, steps_per_epoch=7, epochs=2
+        return [optimizer1, optimizer2]
+
+class Resnet_2_2(pl.LightningModule):
+    def __init__(self, learning_rate1=0.01, learning_rate2=0.02):
+        super().__init__()
+
+        self.save_hyperparameters()
+        self.backbone = vision.resnet18(pretrained=False, include_top=False, freeze=False)
+        output_size = self.backbone.get_output_size()
+        self.head = nn.Linear(output_size, num_classes)
+
+    def on_train_start(self):
+        world_size = self.trainer.strategy.world_size
+        for opt, lr_sch, lr in zip(self.optimizers(), self.lr_schedulers(), self.hparams):
+            lr_sch = lr_sch['scheduler']
+            if hasattr(lr_sch, 'start_factor'):
+                assert opt.param_groups[0]['lr'] == lr_sch.base_lrs[0] * lr_sch.start_factor
+                return
+            assert lr_sch.base_lrs[0] == self.hparams[lr] * world_size
+
+    def forward(self, x):
+        x = self.backbone(x)
+        x = self.head(x)
+        return F.log_softmax(x, dim=1)
+
+    def training_step(self, batch, batch_idx, optimizer_idx):
+        x, y = batch
+        logits = self(x)
+        loss = F.nll_loss(logits, y)
+        self.log("train_loss", loss)
+        return loss
+
+    def validation_step(self, batch, batch_idx):
+        x, y = batch
+        logits = self(x)
+        val_loss = F.nll_loss(logits, y)
+        self.log("val_loss", val_loss)
+
+    def test_step(self, batch, batch_idx):
+        x, y = batch
+        logits = self(x)
+        test_loss = F.nll_loss(logits, y)
+        self.log("test_loss", test_loss)
+
+    def configure_optimizers(self):
+        optimizer1 = torch.optim.SGD(
+            self.backbone.parameters(),
+            lr=self.hparams.learning_rate1
+        )
+        optimizer2 = torch.optim.Adam(
+            self.head.parameters(),
+            lr=self.hparams.learning_rate2
+        )
+        lr_scheduler1 = torch.optim.lr_scheduler.StepLR(
+            optimizer1, step_size=1, gamma=0.5
         )
         if TORCH_VERSION_LESS_1_10:
             lr_scheduler2 = torch.optim.lr_scheduler.StepLR(
-                optimizer2, step_size=1, gamma=0.1, last_epoch=0
+                optimizer2, step_size=1, gamma=0.1
             )
         else:
             lr_scheduler2 = torch.optim.lr_scheduler.LinearLR(
@@ -127,7 +180,7 @@ class TestScaleLr(TestCase):
         model = Resnet_2_2()
         trainer = Trainer(num_processes=2,
                           distributed_backend="subprocess",
-                          scale_lr=True,
+                          auto_lr=True,
                           max_epochs=2,
                           callbacks=[LearningRateMonitor(logging_interval='epoch')])
         trainer.fit(model, train_dataloaders=self.data_loader,
@@ -137,10 +190,29 @@ class TestScaleLr(TestCase):
         model = Resnet_2_2()
         trainer = Trainer(num_processes=2,
                           distributed_backend='spawn',
-                          scale_lr=True,
+                          auto_lr=True,
                           max_epochs=2,
                           callbacks=[LearningRateMonitor(logging_interval='epoch')]
                           )
+        trainer.fit(model, train_dataloaders=self.data_loader,
+                    val_dataloaders=self.test_data_loader)
+
+    def test_warmup_subprocess(self):
+        model = Resnet_2_0()
+        trainer = Trainer(num_processes=2,
+                          distributed_backend='subprocess',
+                          auto_lr=3,
+                          max_epochs=4,
+                          callbacks=[LearningRateMonitor(logging_interval='epoch')])
+        trainer.fit(model, train_dataloaders=self.data_loader,
+                    val_dataloaders=self.test_data_loader)
+
+    def test_warmup_spawn(self):
+        model = Resnet_2_0()
+        trainer = Trainer(num_processes=4,
+                          distributed_backend='spawn',
+                          auto_lr=True,
+                          max_epochs=5)
         trainer.fit(model, train_dataloaders=self.data_loader,
                     val_dataloaders=self.test_data_loader)
 

--- a/python/nano/test/pytorch/tests/test_scale_lr.py
+++ b/python/nano/test/pytorch/tests/test_scale_lr.py
@@ -200,11 +200,11 @@ class TestScaleLr(TestCase):
 
     def test_scale_lr_ray(self):
         model = ResNetWithScheduler()
-        trainer = Trainer(num_processes=4,
+        trainer = Trainer(num_processes=2,
                           distributed_backend='ray',
                           auto_lr=True,
                           max_epochs=2,
-                          callbacks=[CheckLinearLRScaleCallback(4, [0.01, 0.02])])
+                          callbacks=[CheckLinearLRScaleCallback(2, [0.01, 0.02])])
         trainer.fit(model, train_dataloaders=self.data_loader,
                     val_dataloaders=self.test_data_loader)
 

--- a/python/nano/test/pytorch/tests/test_scale_lr.py
+++ b/python/nano/test/pytorch/tests/test_scale_lr.py
@@ -218,7 +218,7 @@ class TestScaleLr(TestCase):
                           distributed_backend='spawn',
                           auto_lr=True,
                           max_epochs=2,
-                          callbacks=[CheckLinearLRScaleCallback(2, [0.01, 0.02])]
+                          callbacks=[CheckLinearLRScaleCallback(4, [0.01, 0.02])]
                           )
         trainer.fit(model, train_dataloaders=self.data_loader,
                     val_dataloaders=self.test_data_loader)

--- a/python/nano/test/pytorch/tests/test_scale_lr.py
+++ b/python/nano/test/pytorch/tests/test_scale_lr.py
@@ -40,7 +40,7 @@ data_dir = os.path.join(os.path.dirname(__file__), "../data")
 
 
 class Resnet_2_0(pl.LightningModule):
-    def __init__(self, learning_rate1=0.01, learning_rate2=0.02) -> None:
+    def __init__(self, learning_rate1=0.01, learning_rate2=0.05) -> None:
         super().__init__()
 
         self.save_hyperparameters()

--- a/python/nano/test/pytorch/tests/test_scale_lr.py
+++ b/python/nano/test/pytorch/tests/test_scale_lr.py
@@ -1,3 +1,20 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
 import os
 
 import pytest
@@ -7,6 +24,7 @@ from test.pytorch.utils._train_torch_lightning import create_data_loader, data_t
 from test.pytorch.utils._train_torch_lightning import create_test_data_loader
 from bigdl.nano.pytorch.vision.models import vision
 from bigdl.nano.pytorch import Trainer
+from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks import LearningRateMonitor
 import torch
@@ -71,10 +89,16 @@ class Resnet_2_2(pl.LightningModule):
             self.head.parameters(),
             lr=self.hparams.learning_rate2
         )
-        lr_scheduler1 = torch.optim.lr_scheduler.LinearLR(
-            optimizer1,
-            start_factor=0.25
-        )
+        if not TORCH_VERSION_LESS_1_10:
+            lr_scheduler1 = torch.optim.lr_scheduler.LinearLR(
+                optimizer1,
+                start_factor=0.25
+            )
+        else:
+            lr_scheduler1 = torch.optim.lr_scheduler.ConstantLR(
+                optimizer1,
+                factor=0.25
+            )
         lr_scheduler2 = torch.optim.lr_scheduler.ConstantLR(
             optimizer2,
             factor=0.5

--- a/python/nano/test/pytorch/tests/test_scale_lr.py
+++ b/python/nano/test/pytorch/tests/test_scale_lr.py
@@ -8,6 +8,7 @@ from test.pytorch.utils._train_torch_lightning import create_test_data_loader
 from bigdl.nano.pytorch.vision.models import vision
 from bigdl.nano.pytorch import Trainer
 import pytorch_lightning as pl
+from pytorch_lightning.callbacks import LearningRateMonitor
 import torch
 from torch import nn
 import torch.nn.functional as F
@@ -18,21 +19,31 @@ dataset_size = 256
 num_workers = 0
 data_dir = os.path.join(os.path.dirname(__file__), "../data")
 
-class Resnet_1_0(pl.LightningModule):
-    def __init__(self, learning_rate=0.01):
+class Resnet_2_2(pl.LightningModule):
+    def __init__(self, learning_rate1=0.01, learning_rate2=0.02):
         super().__init__()
 
         self.save_hyperparameters()
-        self.backbone = vision.resnet18(pretrained=False, include_top=False, freeze=True)
+        self.backbone = vision.resnet18(pretrained=False, include_top=False, freeze=False)
         output_size = self.backbone.get_output_size()
         self.head = nn.Linear(output_size, num_classes)
+
+    def on_train_start(self):
+        world_size = self.trainer.strategy.world_size
+        for opt, lr_sch, lr in zip(self.trainer.optimizers, self.trainer.lr_schedulers, self.hparams):
+            lr_sch = lr_sch['scheduler']
+            assert lr_sch.base_lrs[0] == self.hparams[lr] * world_size
+            if hasattr(lr_sch, 'factor'):
+                assert opt.param_groups[0]['lr'] == lr_sch.base_lrs[0] * lr_sch.factor
+            else:
+                assert opt.param_groups[0]['lr'] == lr_sch.base_lrs[0] * lr_sch.start_factor
 
     def forward(self, x):
         x = self.backbone(x)
         x = self.head(x)
         return F.log_softmax(x, dim=1)
 
-    def training_step(self, batch, batch_idx):
+    def training_step(self, batch, batch_idx, optimizer_idx):
         x, y = batch
         logits = self(x)
         loss = F.nll_loss(logits, y)
@@ -52,11 +63,26 @@ class Resnet_1_0(pl.LightningModule):
         self.log("test_loss", test_loss)
 
     def configure_optimizers(self):
-        optimizer = torch.optim.SGD(
-            self.parameters(),
-            lr=self.hparams.learning_rate
+        optimizer1 = torch.optim.SGD(
+            self.backbone.parameters(),
+            lr=self.hparams.learning_rate1
         )
-        return optimizer
+        optimizer2 = torch.optim.Adam(
+            self.head.parameters(),
+            lr=self.hparams.learning_rate2
+        )
+        lr_scheduler1 = torch.optim.lr_scheduler.LinearLR(
+            optimizer1,
+            start_factor=0.25
+        )
+        lr_scheduler2 = torch.optim.lr_scheduler.ConstantLR(
+            optimizer2,
+            factor=0.5
+        )
+        return (
+            {"optimizer": optimizer1, "lr_scheduler": lr_scheduler1},
+            {"optimizer": optimizer2, "lr_scheduler": lr_scheduler2}
+        )
 
 class TestScaleLr(TestCase):
     data_loader = create_data_loader(data_dir, batch_size, num_workers,
@@ -72,9 +98,26 @@ class TestScaleLr(TestCase):
         os.environ['PYTHONPATH'] = project_test_dir
 
     def test_scale_lr_subprocess(self):
-        model = Resnet_1_0()
-        trainer = Trainer(num_processes=2, distributed_backend="subprocess",
-                          scale_lr=True, max_epochs=2)
+        model = Resnet_2_2()
+        trainer = Trainer(num_processes=2,
+                          distributed_backend="subprocess",
+                          scale_lr=True,
+                          max_epochs=2,
+                          callbacks=[LearningRateMonitor(logging_interval='epoch')])
         trainer.fit(model, train_dataloaders=self.data_loader,
                     val_dataloaders=self.test_data_loader)
+
+    def test_scale_lr_spawn(self):
+        model = Resnet_2_2()
+        trainer = Trainer(num_processes=2,
+                          distributed_backend='spawn',
+                          scale_lr=True,
+                          max_epochs=2,
+                          callbacks=[LearningRateMonitor(logging_interval='epoch')]
+                          )
+        trainer.fit(model, train_dataloaders=self.data_loader,
+                    val_dataloaders=self.test_data_loader)
+
+if __name__ == '__main__':
+    pytest.main([__file__])
 

--- a/python/nano/test/pytorch/tests/test_scale_lr.py
+++ b/python/nano/test/pytorch/tests/test_scale_lr.py
@@ -39,7 +39,7 @@ num_workers = 0
 data_dir = os.path.join(os.path.dirname(__file__), "../data")
 
 
-class Resnet_2_0(pl.LightningModule):
+class ResNetWith2Optimzers(pl.LightningModule):
     def __init__(self, learning_rate1=0.01, learning_rate2=0.05) -> None:
         super().__init__()
 
@@ -100,7 +100,7 @@ class Resnet_2_0(pl.LightningModule):
         return [optimizer1, optimizer2]
 
 
-class Resnet_2_2(pl.LightningModule):
+class ResNetWithScheduler(pl.LightningModule):
     def __init__(self, learning_rate1=0.01, learning_rate2=0.02):
         super().__init__()
 
@@ -181,7 +181,7 @@ class TestScaleLr(TestCase):
         os.environ['PYTHONPATH'] = project_test_dir
 
     def test_scale_lr_subprocess(self):
-        model = Resnet_2_2()
+        model = ResNetWithScheduler()
         trainer = Trainer(num_processes=2,
                           distributed_backend="subprocess",
                           auto_lr=True,
@@ -191,7 +191,7 @@ class TestScaleLr(TestCase):
                     val_dataloaders=self.test_data_loader)
 
     def test_scale_lr_spawn(self):
-        model = Resnet_2_2()
+        model = ResNetWithScheduler()
         trainer = Trainer(num_processes=2,
                           distributed_backend='spawn',
                           auto_lr=True,
@@ -202,7 +202,7 @@ class TestScaleLr(TestCase):
                     val_dataloaders=self.test_data_loader)
 
     def test_warmup_subprocess(self):
-        model = Resnet_2_0()
+        model = ResNetWith2Optimzers()
         trainer = Trainer(num_processes=2,
                           distributed_backend='subprocess',
                           auto_lr=3,
@@ -212,7 +212,7 @@ class TestScaleLr(TestCase):
                     val_dataloaders=self.test_data_loader)
 
     def test_warmup_spawn(self):
-        model = Resnet_2_0()
+        model = ResNetWith2Optimzers()
         trainer = Trainer(num_processes=4,
                           distributed_backend='spawn',
                           auto_lr=True,

--- a/python/nano/test/pytorch/tests/test_scale_lr.py
+++ b/python/nano/test/pytorch/tests/test_scale_lr.py
@@ -38,6 +38,7 @@ dataset_size = 256
 num_workers = 0
 data_dir = os.path.join(os.path.dirname(__file__), "../data")
 
+
 class Resnet_2_0(pl.LightningModule):
     def __init__(self, learning_rate1=0.01, learning_rate2=0.02) -> None:
         super().__init__()
@@ -54,12 +55,14 @@ class Resnet_2_0(pl.LightningModule):
                 assert math.isclose(lr_scheduler.get_last_lr()[0], 
                                     lr_scheduler.base_lrs[0])
             else:
-                diff = lr_scheduler.base_lrs[0] * (lr_scheduler.end_factor - lr_scheduler.start_factor) / (lr_scheduler.total_iters)
+                diff = lr_scheduler.base_lrs[0] * \
+                    (lr_scheduler.end_factor - lr_scheduler.start_factor) / \
+                    (lr_scheduler.total_iters)
                 assert lr_scheduler.base_lrs[0] == self.hparams[lr] * world_size
-                assert math.isclose(lr_scheduler.get_last_lr()[0], 
-                                    lr_scheduler.base_lrs[0] * lr_scheduler.start_factor + lr_scheduler.last_epoch * diff,
+                assert math.isclose(lr_scheduler.get_last_lr()[0],
+                                    lr_scheduler.base_lrs[0] * lr_scheduler.start_factor +
+                                    lr_scheduler.last_epoch * diff,
                                     abs_tol=1e-7)
-        
 
     def forward(self, x):
         x = self.backbone(x)
@@ -96,6 +99,7 @@ class Resnet_2_0(pl.LightningModule):
         )
         return [optimizer1, optimizer2]
 
+
 class Resnet_2_2(pl.LightningModule):
     def __init__(self, learning_rate1=0.01, learning_rate2=0.02):
         super().__init__()
@@ -108,7 +112,6 @@ class Resnet_2_2(pl.LightningModule):
     def on_train_start(self):
         world_size = self.trainer.strategy.world_size
         for opt, lr_sch, lr in zip(self.optimizers(), self.lr_schedulers(), self.hparams):
-            lr_sch = lr_sch['scheduler']
             if hasattr(lr_sch, 'start_factor'):
                 assert opt.param_groups[0]['lr'] == lr_sch.base_lrs[0] * lr_sch.start_factor
                 return
@@ -163,11 +166,12 @@ class Resnet_2_2(pl.LightningModule):
             {"optimizer": optimizer2, "lr_scheduler": lr_scheduler2}
         )
 
+
 class TestScaleLr(TestCase):
     data_loader = create_data_loader(data_dir, batch_size, num_workers,
-                                        data_transform, subset=dataset_size)
+                                     data_transform, subset=dataset_size)
     test_data_loader = create_test_data_loader(data_dir, batch_size, num_workers,
-                                                data_transform, subset=dataset_size)
+                                               data_transform, subset=dataset_size)
 
     def setUp(self):
         test_dir = os.path.dirname(__file__)
@@ -216,6 +220,6 @@ class TestScaleLr(TestCase):
         trainer.fit(model, train_dataloaders=self.data_loader,
                     val_dataloaders=self.test_data_loader)
 
+
 if __name__ == '__main__':
     pytest.main([__file__])
-

--- a/python/nano/test/run-nano-pytorch-ray-tests.sh
+++ b/python/nano/test/run-nano-pytorch-ray-tests.sh
@@ -11,6 +11,7 @@ set -e
 echo "# Start testing"
 start=$(date "+%s")
 python -m pytest -s ${NANO_RAY_TEST_DIR}/test_ray_trainer.py ${NANO_RAY_TEST_DIR}/test_torch_nano_ray.py
+python -m pytest -s ${ANALYTICS_ZOO_ROOT}/python/nano/test/pytorch/tests/test_scale_lr.py -k 'ray'
 
 now=$(date "+%s")
 time=$((now-start))

--- a/python/nano/test/run-nano-pytorch-tests.sh
+++ b/python/nano/test/run-nano-pytorch-tests.sh
@@ -11,7 +11,7 @@ set -e
 # ipex is not installed here. Any tests needs ipex should be moved to next pytest command.
 echo "# Start testing"
 start=$(date "+%s")
-python -m pytest -s ${PYTORCH_NANO_TEST_DIR}/tests/ -k 'not ipex'
+python -m pytest -s ${PYTORCH_NANO_TEST_DIR}/tests/ -k 'not ipex and not ray'
 
 now=$(date "+%s")
 time=$((now-start))


### PR DESCRIPTION
## Description
Add automatically learning rate configuration during multi-instance training. The strategy will scale the lr of optimizers' param_groups and base_lrs of lr_schedulers by the number of processes. Linear warmup will be applied on the optimizers if no other lr_schedulers is set.
- linear learning rate scaling: The lr of each optimizers' param_groups and base_lrs of each lr_scheduler will be scaled by the number of processes, for example:
```python
class Mymodel(pl.LightningModule):
...
def configure_optimizers(self):
    optimizer = SGD(
        self.parameters(),
        lr=0.05
    )
    lr_scheduler = LinearLR(
        optimizer,
        total_iters=2
    )
trainer = Trainer(num_processes=2, max_epochs=10)
model = Mymodel()
trainer.fit(model, train_dataloaders=train_loader)
```
The lr of optimizer's param_groups[0] will be scaled to 0.1 from 0.05, the same for lr_scheduler's base_lrs.
- Linear warmup strategy: The `start_lr` is the original learning rate, the `end_lr` is the scaled learning rate and the `warmup_epochs` is set to `max_epochs // 10` if `max_epochs >= 10` otherwise `max_steps //10` by default if the value isn't given in `auto_lr`. For the code above without lr_scheduler, start_lr=0.05, end_lr=0.1, warmup_epochs=1. The change of learning rate is shown in the figure below:
![image](https://user-images.githubusercontent.com/49382651/181143454-b9143515-edfb-4aa2-937d-c5d131dd2417.png)


<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?
Improve performance in multi-instance training.
related issue
https://github.com/intel-analytics/BigDL/issues/4855
<!-- Provide the related github issue link if available -->

### 2. User API changes
The flag `auto_lr` defaults to True. In multi-instance training, the above operations are preformed by default.
```python
from bigdl.nano.pytorch import Trainer
trainer = Trainer(num_processes=2,
                           distributed_backend='subprocess,
                           auto_lr=True,    # optionally
                           max_epochs=5)
trainer.fit(model, train_dataloaders = train_loader)
```
Meanwhile `auto_lr` can also accept an dict to control `warmup_epochs`, or it is set to max_epochs // 10 by default.
```python
from bigdl.nano.pytorch import Trainer
trainer = Trainer(num_processes=2,
                           distributed_backend='subprocess',
                           auto_lr={'warmup_epochs': 3},
                           max_epochs=10)
trainer.fit(model, train_dataloaders=train_loader)
```
<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. How to test?
- [x] Unit test
- [x] Jenkins