### PR TITLE
[Nano] Remove redundant exposed apis and add basic openvino unit tests

### DIFF
--- a/.github/workflows/nano_unit_tests_basic.yml
+++ b/.github/workflows/nano_unit_tests_basic.yml
@@ -1,4 +1,4 @@
-name: Nano Unit Tests PyTorch
+name: Nano Unit Tests Basic
 
 # Controls when the action will run. 
 on:
@@ -78,6 +78,6 @@ jobs:
           source bigdl-nano-init
           bash python/nano/test/run-nano-basic-openvino-tests.sh
           source $CONDA/bin/deactivate
-          $CONDA/bin/conda remove -n openvino-pytorch --all
+          $CONDA/bin/conda remove -n openvino-basic --all
         env:
           ANALYTICS_ZOO_ROOT: ${{ github.workspace }}

--- a/.github/workflows/nano_unit_tests_basic.yml
+++ b/.github/workflows/nano_unit_tests_basic.yml
@@ -1,0 +1,80 @@
+name: Nano Unit Tests PyTorch
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'python/nano/**'
+      - '.github/workflows/nano_unit_tests_basic.yml'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  nano-unit-test-basic:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-20.04"]
+        python-version: ["3.7"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools==58.0.4
+          python -m pip install --upgrade wheel
+
+      - name: Run Nano-init test
+        shell: bash
+        run: |
+          $CONDA/bin/conda create -n bigdl-init -y python==3.7.10 setuptools==58.0.4
+          source $CONDA/bin/activate bigdl-init
+          $CONDA/bin/conda info
+          bash python/nano/dev/build_and_install.sh linux default false
+          source bigdl-nano-init
+          if [ 0"$LD_PRELOAD" = "0" ]; then
+            exit 1
+          else
+            echo "Set environment variable successfully."
+          fi
+          source $CONDA/bin/deactivate
+          if [ ! 0"$LD_PRELOAD" = "0" ]; then
+            exit 1
+          else
+            echo "Unset environment variable successfully while deactivating conda environment."
+          fi
+          source $CONDA/bin/activate bigdl-init
+          if [ 0"$LD_PRELOAD" = "0" ]; then
+            exit 1
+          else
+            echo "Setup environment variable successfully while activating conda environment."
+          fi
+          pip uninstall -y bigdl-nano
+          source $CONDA/bin/deactivate
+          $CONDA/bin/conda remove -n bigdl-init --all
+        env:
+          ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
+
+      - name: Run Basic unit tests (OpenVINO)
+        shell: bash
+        run: |
+          $CONDA/bin/conda create -n openvino-basic -y python==3.7.10 setuptools=58.0.4
+          source $CONDA/bin/activate openvino-basic
+          $CONDA/bin/conda info
+          bash python/nano/dev/build_and_install.sh linux default false
+          pip install pytest
+          pip install openvino-dev
+          source bigdl-nano-init
+          bash python/nano/test/run-nano-basic-openvino-tests.sh
+          source $CONDA/bin/deactivate
+          $CONDA/bin/conda remove -n openvino-pytorch --all
+        env:
+          ANALYTICS_ZOO_ROOT: ${{ github.workspace }}

--- a/.github/workflows/nano_unit_tests_basic.yml
+++ b/.github/workflows/nano_unit_tests_basic.yml
@@ -38,7 +38,9 @@ jobs:
           $CONDA/bin/conda create -n bigdl-init -y python==3.7.10 setuptools==58.0.4
           source $CONDA/bin/activate bigdl-init
           $CONDA/bin/conda info
-          bash python/nano/dev/build_and_install.sh linux default false
+          bash python/nano/dev/release_default_linux.sh default false
+          whl_name=`ls python/nano/dist`
+          pip install python/nano/dist/${whl_name}
           source bigdl-nano-init
           if [ 0"$LD_PRELOAD" = "0" ]; then
             exit 1
@@ -69,9 +71,10 @@ jobs:
           $CONDA/bin/conda create -n openvino-basic -y python==3.7.10 setuptools=58.0.4
           source $CONDA/bin/activate openvino-basic
           $CONDA/bin/conda info
-          bash python/nano/dev/build_and_install.sh linux default false
-          pip install pytest
-          pip install openvino-dev
+          bash python/nano/dev/release_default_linux.sh default false
+          whl_name=`ls python/nano/dist`
+          pip install python/nano/dist/${whl_name}
+          pip install pytest openvino-dev
           source bigdl-nano-init
           bash python/nano/test/run-nano-basic-openvino-tests.sh
           source $CONDA/bin/deactivate

--- a/python/nano/src/bigdl/nano/openvino.py
+++ b/python/nano/src/bigdl/nano/openvino.py
@@ -15,4 +15,4 @@
 #
 
 # import public APIs of openvino
-from bigdl.nano.deps.openvino.openvino_api import *
+from bigdl.nano.deps.openvino.openvino_api import OpenVINOModel

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -35,7 +35,7 @@ from bigdl.nano.pytorch.plugins.ddp_subprocess import DDPSubprocessPlugin
 
 from bigdl.nano.deps.automl.hpo_api import create_hpo_searcher, check_hpo_status
 from bigdl.nano.deps.ray.ray_api import distributed_ray
-from bigdl.nano.openvino import PytorchOpenVINOModel, load_openvino_model
+from bigdl.nano.deps.openvino.openvino_api import PytorchOpenVINOModel, load_openvino_model
 from bigdl.nano.deps.ipex.ipex_api import create_IPEXAccelerator, create_IPEXAccelerator_1_9, \
     PytorchIPEXJITModel, load_ipexjit_model
 from bigdl.nano.deps.onnxruntime.onnxruntime_api import PytorchONNXRuntimeModel, \

--- a/python/nano/test/openvino/basic/test_openvino.py
+++ b/python/nano/test/openvino/basic/test_openvino.py
@@ -1,0 +1,30 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+import os
+from bigdl.nano.openvino import OpenVINOModel
+import numpy as np
+
+
+class TestOpenVINO(TestCase):
+    def test_openvino_model(self):
+        os.system("omz_downloader --name resnet18-xnor-binary-onnx-0001")
+
+        openvino_model = OpenVINOModel("./intel/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.xml")
+        x = np.random.randn(1, 3, 224, 224)
+        y_hat = openvino_model.forward_step(x)
+        assert tuple(next(iter(y_hat)).shape) == (1, 1000)

--- a/python/nano/test/openvino/basic/test_openvino.py
+++ b/python/nano/test/openvino/basic/test_openvino.py
@@ -22,8 +22,6 @@ import numpy as np
 
 class TestOpenVINO(TestCase):
     def test_openvino_model(self):
-        os.system("omz_downloader --name resnet18-xnor-binary-onnx-0001")
-
         openvino_model = OpenVINOModel("./intel/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.xml")
         x = np.random.randn(1, 3, 224, 224)
         y_hat = openvino_model.forward_step(x)

--- a/python/nano/test/run-nano-basic-openvino-tests.sh
+++ b/python/nano/test/run-nano-basic-openvino-tests.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+export ANALYTICS_ZOO_ROOT=${ANALYTICS_ZOO_ROOT}
+export NANO_HOME=${ANALYTICS_ZOO_ROOT}/python/nano/src
+export OPENVINO_NANO_TEST_DIR=${ANALYTICS_ZOO_ROOT}/python/nano/test/openvino/basic
+
+# Download openvino model
+omz_downloader --name resnet18-xnor-binary-onnx-0001
+
+set -e
+
+# ipex is not installed here. Any tests needs ipex should be moved to next pytest command.
+echo "# Start testing"
+start=$(date "+%s")
+python -m pytest -s ${OPENVINO_NANO_TEST_DIR}
+
+now=$(date "+%s")
+time=$((now-start))
+
+echo "Bigdl-nano tests finished"
+echo "Time used:$time seconds"


### PR DESCRIPTION
## Description

This PR is to fix some unresolved issues in https://github.com/intel-analytics/BigDL/pull/5115

1. As mentioned in https://github.com/intel-analytics/BigDL/pull/5115, we should expose `bigdl.nano.openvino.OpenVINOModel` only for basic openvino usage.
2. Add basic unit tests w\o pytorch/tf installed.

### 1. Why the change?

1. expose Pytorch/TF APIs in `bigdl.nano.openvino` is not that reasonable.
2. We should have UTs to make sure openvino work fine w\o pytorch/tf.

### 2. User API changes

N/A

### 3. Summary of the change 

1. Only expose `OpenVINOModel` in `bigdl.nano.openvino`
2. Add UTs for `OpenVINOModel` usage

### 4. How to test?
- [x] Unit test
