### PR TITLE
[Nano] avoid onnx model frequently save/load

### DIFF
--- a/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/pytorch/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/pytorch/quantization.py
@@ -58,9 +58,5 @@ class PytorchONNXRuntimeQuantization(BaseONNXRuntimeQuantization, PytorchQuantiz
         return model, calib_dataloader, metric
 
     def _post_execution(self, q_model):
-        # TODO Don't save, directly use q_model to create runtime
-        with TemporaryDirectory() as dir:
-            saved_onnx = Path(dir) / 'tmp.onnx'
-            q_model.save(saved_onnx)
-            return PytorchONNXRuntimeModel(str(saved_onnx),
-                                           onnxruntime_session_options=self.session_options)
+        return PytorchONNXRuntimeModel(q_model.model,
+                                       onnxruntime_session_options=self.session_options)

--- a/python/nano/test/pytorch/tests/test_lightning.py
+++ b/python/nano/test/pytorch/tests/test_lightning.py
@@ -49,7 +49,7 @@ loss = nn.CrossEntropyLoss()
 optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
 
 
-class TestLightningModuleFromTorch(TestCase):
+class TestLightningModule(TestCase):
 
     def test_resnet18(self):
         pl_model = LightningModule(


### PR DESCRIPTION
## Description

Definition of `bigdl.nano.deps.onnxruntime.core.onnxruntime_model.ONNXRuntimeModel` :

```python
class ONNXRuntimeModel:
    def __init__(self, onnx_filepath, session_options=None):
```
It is initialized with a local onnx file path of string type. This restricts us to have a saved onnx file everytime we want to create a ONNXRuntimeModel.

### 1. Why the change?

It's better to make `ONNXRuntimeModel` able to be created from:

- str, onnx path
- bytes
- ModelProto

So that we can avoid saving onnx models to local  and load them again.

### 2. User API changes

N/A

### 3. Summary of the change 

make `ONNXRuntimeModel` able to be created from:

- str, onnx path
- bytes
- ModelProto

by loading with different functions.

### 4. How to test?
- [ ] Unit test
