### PR TITLE
Enable automatically collect optimized latency in NanoHPO

### DIFF
--- a/python/chronos/dev/test/run-pytests-onnxrt16.sh
+++ b/python/chronos/dev/test/run-pytests-onnxrt16.sh
@@ -55,6 +55,9 @@ python -m pytest -v test/bigdl/chronos/autots/test_autotsestimator.py::TestAutoT
                     test/bigdl/chronos/forecaster/test_tcn_forecaster.py::TestChronosModelTCNForecaster::test_tcn_forecaster_distributed \
                     test/bigdl/chronos/forecaster/test_tcn_forecaster.py::TestChronosModelTCNForecaster::test_tcn_forecaster_fit_loader \
                     test/bigdl/chronos/forecaster/test_tcn_forecaster.py::TestChronosModelTCNForecaster::test_forecaster_from_tsdataset_data_loader_onnx \
+                    test/bigdl/chronos/forecaster/test_tcn_forecaster.py::TestChronosModelTCNForecaster::test_tcn_forecaster_multi_objective_tune_acceleration \
+                    test/bigdl/chronos/forecaster/test_tcn_forecaster.py::TestChronosModelTCNForecaster::test_tcn_forecaster_mo_tune_acceleration_fit_input \
+                    test/bigdl/chronos/forecaster/test_tcn_forecaster.py::TestChronosModelTCNForecaster::test_tcn_forecaster_mo_tune_acceleration_fit \
                     test/bigdl/chronos/forecaster/test_nbeats_forecaster.py::TestChronosNBeatsForecaster::test_nbeats_forecaster_onnx_methods \
                     test/bigdl/chronos/forecaster/test_nbeats_forecaster.py::TestChronosNBeatsForecaster::test_nbeats_forecaster_quantization_onnx \
                     test/bigdl/chronos/forecaster/test_nbeats_forecaster.py::TestChronosNBeatsForecaster::test_nbeats_forecaster_quantization_onnx_tuning \

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -256,8 +256,10 @@ class AutoformerForecaster(Forecaster):
             invalidInputError(False, "HPO only supports numpy train input data.")
 
         if input_sample is None:
-            input_sample = (torch.from_numpy(data[0][:1, :, :]), torch.from_numpy(data[1][:1, :, :]),
-                            torch.from_numpy(data[2][:1, :, :]), torch.from_numpy(data[3][:1, :, :]))
+            input_sample = (torch.from_numpy(data[0][:1, :, :]), 
+                            torch.from_numpy(data[1][:1, :, :]),
+                            torch.from_numpy(data[2][:1, :, :]), 
+                            torch.from_numpy(data[3][:1, :, :]))
 
         # prepare target metric
         if validation_data is not None:
@@ -338,7 +340,8 @@ class AutoformerForecaster(Forecaster):
             # check whether the user called the tune function
             invalidOperationError(hasattr(self, "trainer"), "There is no trainer, and you "
                                   "should call .tune() before .fit()")
-                        # build internal according to use_trail_id for multi-objective HPO
+            
+            # build internal according to use_trail_id for multi-objective HPO
             if self.trainer.hposearcher.objective.mo_hpo:
                 invalidOperationError(self.trainer.hposearcher.study,
                                       "You must tune before fit the model.")

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -280,16 +280,17 @@ class AutoformerForecaster(Forecaster):
             n_trials=n_trials,
             target_metric=formated_target_metric,
             direction=direction,
+            directions=directions,
             n_parallels=n_parallels,
             acceleration=acceleration,
             input_sample=input_sample,
             **kwargs)
 
-        if self.tune_trainer.hposearcher.objective.mo_hpo:
+        if self.trainer.hposearcher.objective.mo_hpo:
             return self.internal
         else:
             # reset train and validation datasets
-            self.tune_trainer.reset_train_val_dataloaders(self.internal)
+            self.trainer.reset_train_val_dataloaders(self.internal)
 
     def search_summary(self):
         # add tuning check

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -202,6 +202,7 @@ class AutoformerForecaster(Forecaster):
              validation_data,
              target_metric='mse',
              direction="minimize",
+             directions=None,
              n_trials=2,
              n_parallels=1,
              epochs=1,
@@ -257,18 +258,10 @@ class AutoformerForecaster(Forecaster):
         # build auto model
         self.tune_internal = self._build_automodel(data, validation_data, batch_size, epochs)
 
-        from pytorch_lightning.callbacks import Callback
-
-        # reset current epoch = 0 after each run
-        class ResetCallback(Callback):
-            def on_train_end(self, trainer, pl_module):
-                trainer.fit_loop.current_epoch = 0
-
         self.trainer = Trainer(logger=False, max_epochs=epochs,
                                checkpoint_callback=self.checkpoint_callback,
                                num_processes=self.num_processes, use_ipex=self.use_ipex,
-                               use_hpo=True,
-                               callbacks=[ResetCallback()] if self.num_processes == 1 else None)
+                               use_hpo=True)
 
         # run hyper parameter search
         self.internal = self.trainer.search(

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -207,6 +207,8 @@ class AutoformerForecaster(Forecaster):
              n_parallels=1,
              epochs=1,
              batch_size=32,
+             acceleration=False,
+             input_sample=None,
              **kwargs):
         """
         Search the hyper parameter.
@@ -225,6 +227,11 @@ class AutoformerForecaster(Forecaster):
                For more information, refer to Nano AutoML user guide.
         :param epochs: the number of epochs to run in each trial fit, defaults to 1
         :param batch_size: number of batch size for each trial fit, defaults to 32
+        :param acceleration: Whether to automatically consider the model after
+            inference acceleration in the search process. It will only take
+            effect if target_metric contains "latency". Default value is False.
+        :param input_sample: A set of inputs for trace, defaults to None if you have
+            trace before or model is a LightningModule with any dataloader attached.
         """
         invalidInputError(not self.distributed,
                           "HPO is not supported in distributed mode."
@@ -248,6 +255,10 @@ class AutoformerForecaster(Forecaster):
         else:
             invalidInputError(False, "HPO only supports numpy train input data.")
 
+        if input_sample is None:
+            input_sample = (torch.from_numpy(data[0][:1, :, :]), torch.from_numpy(data[1][:1, :, :]),
+                            torch.from_numpy(data[2][:1, :, :]), torch.from_numpy(data[3][:1, :, :]))
+
         # prepare target metric
         if validation_data is not None:
             formated_target_metric = _format_metric_str('val', target_metric)
@@ -270,17 +281,22 @@ class AutoformerForecaster(Forecaster):
             target_metric=formated_target_metric,
             direction=direction,
             n_parallels=n_parallels,
+            acceleration=acceleration,
+            input_sample=input_sample,
             **kwargs)
 
-        # reset train and validation datasets
-        self.trainer.reset_train_val_dataloaders(self.internal)
+        if self.tune_trainer.hposearcher.objective.mo_hpo:
+            return self.internal
+        else:
+            # reset train and validation datasets
+            self.tune_trainer.reset_train_val_dataloaders(self.internal)
 
     def search_summary(self):
         # add tuning check
         invalidOperationError(self.use_hpo, "No search summary when HPO is disabled.")
         return self.trainer.search_summary()
 
-    def fit(self, data, epochs=1, batch_size=32):
+    def fit(self, data, epochs=1, batch_size=32, use_trial_id=None):
         """
         Fit(Train) the forecaster.
 
@@ -295,6 +311,8 @@ class AutoformerForecaster(Forecaster):
         :param batch_size: Number of batch size you want to train. The value defaults to 32.
                if you input a pytorch dataloader for `data`, the batch_size will follow the
                batch_size setted in `data`.
+        :param use_trail_id: choose a internal according to trial_id, which is used only
+               in multi-objective search.
         """
         # distributed is not supported.
         if self.distributed:
@@ -319,6 +337,14 @@ class AutoformerForecaster(Forecaster):
             # check whether the user called the tune function
             invalidOperationError(hasattr(self, "trainer"), "There is no trainer, and you "
                                   "should call .tune() before .fit()")
+                        # build internal according to use_trail_id for multi-objective HPO
+            if self.trainer.hposearcher.objective.mo_hpo:
+                invalidOperationError(self.trainer.hposearcher.study,
+                                      "You must tune before fit the model.")
+                invalidInputError(use_trial_id is not None,
+                                  "For multibojective HPO, you must specify a trial id for fit.")
+                trial = self.trainer.hposearcher.study.trials[use_trial_id]
+                self.internal = self.tune_internal._model_build(trial)
 
         self.trainer.fit(self.internal, data)
 

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -256,9 +256,9 @@ class AutoformerForecaster(Forecaster):
             invalidInputError(False, "HPO only supports numpy train input data.")
 
         if input_sample is None:
-            input_sample = (torch.from_numpy(data[0][:1, :, :]), 
+            input_sample = (torch.from_numpy(data[0][:1, :, :]),
                             torch.from_numpy(data[1][:1, :, :]),
-                            torch.from_numpy(data[2][:1, :, :]), 
+                            torch.from_numpy(data[2][:1, :, :]),
                             torch.from_numpy(data[3][:1, :, :]))
 
         # prepare target metric
@@ -340,7 +340,7 @@ class AutoformerForecaster(Forecaster):
             # check whether the user called the tune function
             invalidOperationError(hasattr(self, "trainer"), "There is no trainer, and you "
                                   "should call .tune() before .fit()")
-            
+
             # build internal according to use_trail_id for multi-objective HPO
             if self.trainer.hposearcher.objective.mo_hpo:
                 invalidOperationError(self.trainer.hposearcher.study,

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -211,7 +211,7 @@ class BasePytorchForecaster(Forecaster):
         invalidOperationError(self.use_hpo, "No search summary when HPO is disabled.")
         return self.trainer.search_summary()
 
-    def fit(self, data, validation_data=None, epochs=1, batch_size=32, validation_mode='output', 
+    def fit(self, data, validation_data=None, epochs=1, batch_size=32, validation_mode='output',
             earlystop_patience=1, use_trial_id=None):
         # TODO: give an option to close validation during fit to save time.
         """

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -365,7 +365,7 @@ class BasePytorchForecaster(Forecaster):
                               "otherwise performance will be degraded.")
 
             # build internal according to use_trail_id for multi-objective HPO
-            if self.tune_trainer.hposearcher.objective.mo_hpo:
+            if hasattr(self, "tune_trainer") and self.tune_trainer.hposearcher.objective.mo_hpo:
                 invalidOperationError(self.tune_trainer.hposearcher.study,
                                       "You must tune before fit the model.")
                 invalidInputError(use_trial_id is not None,

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -172,6 +172,9 @@ class BasePytorchForecaster(Forecaster):
         else:
             invalidInputError(False, "HPO only supports numpy train input data.")
 
+        if input_sample is None:
+            input_sample = torch.from_numpy(data[0][:1, :, :])
+
         # prepare target metric
         if validation_data is not None:
             formated_target_metric = _format_metric_str('val', target_metric)

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -206,6 +206,11 @@ class BasePytorchForecaster(Forecaster):
             # reset train and validation datasets
             self.tune_trainer.reset_train_val_dataloaders(self.internal)
 
+    def search_summary(self):
+        # add tuning check
+        invalidOperationError(self.use_hpo, "No search summary when HPO is disabled.")
+        return self.trainer.search_summary()
+
     def fit(self, data, validation_data=None, epochs=1, batch_size=32, validation_mode='output', use_trial_id=None):
         # TODO: give an option to close validation during fit to save time.
         """
@@ -272,6 +277,8 @@ class BasePytorchForecaster(Forecaster):
         :param earlystop_patience: Number of checks with no improvement after which training will
                be stopped. It takes effect when 'validation_mode' is 'earlystop'. Under the default
                configuration, one check happens after every training epoch.
+        :param use_trail_id: choose a internal according to trial_id, which is used only
+               in multi-objective search.
         :return: Validation loss if 'validation_data' is not None.
         """
         # input transform

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -199,7 +199,7 @@ class BasePytorchForecaster(Forecaster):
             acceleration=acceleration,
             input_sample=input_sample,
             **kwargs)
-        
+
         if self.tune_trainer.hposearcher.objective.mo_hpo:
             return self.internal
         else:

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -125,7 +125,7 @@ class BasePytorchForecaster(Forecaster):
              n_parallels=1,
              epochs=1,
              batch_size=32,
-             auto_optimize=False,
+             acceleration=False,
              input_sample=None,
              **kwargs):
         """
@@ -144,7 +144,11 @@ class BasePytorchForecaster(Forecaster):
                For more information, refer to Nano AutoML user guide.
         :param epochs: the number of epochs to run in each trial fit, defaults to 1
         :param batch_size: number of batch size for each trial fit, defaults to 32
-        to add !
+        :param acceleration: Whether to automatically consider the model after
+            inference acceleration in the search process. It will only take
+            effect if target_metric contains "latency". Default value is False.
+        :param input_sample: A set of inputs for trace, defaults to None if you have
+            trace before or model is a LightningModule with any dataloader attached.
         """
         invalidInputError(not self.distributed,
                           "HPO is not supported in distributed mode."
@@ -192,7 +196,7 @@ class BasePytorchForecaster(Forecaster):
             direction=direction,
             directions=directions,
             n_parallels=n_parallels,
-            auto_optimize=auto_optimize,
+            acceleration=acceleration,
             input_sample=input_sample,
             **kwargs)
         

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -211,7 +211,8 @@ class BasePytorchForecaster(Forecaster):
         invalidOperationError(self.use_hpo, "No search summary when HPO is disabled.")
         return self.trainer.search_summary()
 
-    def fit(self, data, validation_data=None, epochs=1, batch_size=32, validation_mode='output', use_trial_id=None):
+    def fit(self, data, validation_data=None, epochs=1, batch_size=32, validation_mode='output', 
+            earlystop_patience=1, use_trial_id=None):
         # TODO: give an option to close validation during fit to save time.
         """
         Fit(Train) the forecaster.

--- a/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
@@ -101,7 +101,8 @@ class LSTMForecaster(BasePytorchForecaster):
         self.model_config = {
             "hidden_dim": hidden_dim,
             "layer_num": layer_num,
-            "dropout": dropout
+            "dropout": dropout,
+            "seed": seed
         }
         self.loss_config = {
             "loss": loss

--- a/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
@@ -121,7 +121,8 @@ class NBeatsForecaster(BasePytorchForecaster):
             "thetas_dim": thetas_dim,
             "share_weights_in_stack": share_weights_in_stack,
             "hidden_layer_units": hidden_layer_units,
-            "nb_harmonics": nb_harmonics
+            "nb_harmonics": nb_harmonics,
+            "seed": seed,
         }
 
         self.loss_config = {

--- a/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
@@ -112,7 +112,8 @@ class TCNForecaster(BasePytorchForecaster):
             "num_channels": num_channels,
             "kernel_size": kernel_size,
             "repo_initialization": repo_initialization,
-            "dropout": dropout
+            "dropout": dropout,
+            "seed": seed
         }
         self.loss_config = {
             "loss": loss

--- a/python/chronos/src/bigdl/chronos/forecaster/utils.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/utils.py
@@ -21,6 +21,7 @@ import numpy
 from torch.utils.data import TensorDataset, DataLoader
 import numpy as np
 import multiprocessing as mp
+import warnings
 
 __all__ = ['loader_to_creator',
            'np_to_creator',

--- a/python/chronos/src/bigdl/chronos/forecaster/utils_hpo.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/utils_hpo.py
@@ -294,7 +294,7 @@ def _format_metric(prefix, metric, id=-1):
 
 def _format_metric_str(prefix, metric):
     """Format the string metric."""
-    if isinstance(metric, list) or isinstance(metric, tuple):
+    if isinstance(metric, (list, tuple)):
         metrics = []
         for target_metric in metric:
             if target_metric == "latency":

--- a/python/chronos/src/bigdl/chronos/forecaster/utils_hpo.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/utils_hpo.py
@@ -17,6 +17,7 @@
 from bigdl.nano.pytorch.lightning import LightningModule
 from bigdl.nano.utils.log4Error import invalidInputError
 from typing import List
+from numpy import append
 import pytorch_lightning as pl
 from torchmetrics.metric import Metric
 from torch.optim.lr_scheduler import _LRScheduler
@@ -294,6 +295,14 @@ def _format_metric(prefix, metric, id=-1):
 
 def _format_metric_str(prefix, metric):
     """Format the string metric."""
+    if isinstance(metric, list) or isinstance(metric, tuple):
+        metrics = []
+        for target_metric in metric:
+            if target_metric == "latency":
+                metrics.append(target_metric)
+            else:
+                metrics.append(_format_metric_str(prefix, target_metric))
+        return metrics
     if isinstance(metric, str):
         from bigdl.chronos.metric.forecast_metrics import TORCHMETRICS_REGRESSION_MAP
         metric_func = TORCHMETRICS_REGRESSION_MAP.get(metric, None)

--- a/python/chronos/src/bigdl/chronos/forecaster/utils_hpo.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/utils_hpo.py
@@ -17,7 +17,6 @@
 from bigdl.nano.pytorch.lightning import LightningModule
 from bigdl.nano.utils.log4Error import invalidInputError
 from typing import List
-from numpy import append
 import pytorch_lightning as pl
 from torchmetrics.metric import Metric
 from torch.optim.lr_scheduler import _LRScheduler

--- a/python/chronos/src/bigdl/chronos/model/Seq2Seq_pytorch.py
+++ b/python/chronos/src/bigdl/chronos/model/Seq2Seq_pytorch.py
@@ -19,6 +19,7 @@ import torch.nn as nn
 
 from .utils import PYTORCH_REGRESSION_LOSS_MAP
 import numpy as np
+from pytorch_lightning import seed_everything
 
 
 class LSTMSeq2Seq(nn.Module):
@@ -29,8 +30,10 @@ class LSTMSeq2Seq(nn.Module):
                  lstm_hidden_dim=128,
                  lstm_layer_num=2,
                  dropout=0.25,
-                 teacher_forcing=False):
+                 teacher_forcing=False,
+                 seed=None):
         super(LSTMSeq2Seq, self).__init__()
+        seed_everything(seed, workers=True)
         self.lstm_encoder = nn.LSTM(input_size=input_feature_num,
                                     hidden_size=lstm_hidden_dim,
                                     num_layers=lstm_layer_num,
@@ -73,7 +76,8 @@ def model_creator(config):
                        lstm_hidden_dim=config.get("lstm_hidden_dim", 128),
                        lstm_layer_num=config.get("lstm_layer_num", 2),
                        dropout=config.get("dropout", 0.25),
-                       teacher_forcing=config.get("teacher_forcing", False))
+                       teacher_forcing=config.get("teacher_forcing", False),
+                       seed=config.get("seed", None))
 
 
 def optimizer_creator(model, config):

--- a/python/chronos/src/bigdl/chronos/model/VanillaLSTM_pytorch.py
+++ b/python/chronos/src/bigdl/chronos/model/VanillaLSTM_pytorch.py
@@ -16,11 +16,13 @@
 
 import torch
 import torch.nn as nn
+from pytorch_lightning import seed_everything
 
 
 class LSTMModel(nn.Module):
-    def __init__(self, input_dim, hidden_dim, layer_num, dropout, output_dim):
+    def __init__(self, input_dim, hidden_dim, layer_num, dropout, output_dim, seed):
         super(LSTMModel, self).__init__()
+        seed_everything(seed, workers=True)
         self.hidden_dim = hidden_dim
         self.dropout = dropout
         self.layer_num = layer_num
@@ -70,7 +72,8 @@ def model_creator(config):
                      hidden_dim=hidden_dim,
                      layer_num=layer_num,
                      dropout=dropout,
-                     output_dim=config["output_feature_num"],)
+                     output_dim=config["output_feature_num"],
+                     seed=config["seed"])
 
 
 def optimizer_creator(model, config):

--- a/python/chronos/src/bigdl/chronos/model/VanillaLSTM_pytorch.py
+++ b/python/chronos/src/bigdl/chronos/model/VanillaLSTM_pytorch.py
@@ -73,7 +73,7 @@ def model_creator(config):
                      layer_num=layer_num,
                      dropout=dropout,
                      output_dim=config["output_feature_num"],
-                     seed=config["seed"])
+                     seed=config.get("seed", None))
 
 
 def optimizer_creator(model, config):

--- a/python/chronos/src/bigdl/chronos/model/nbeats_pytorch.py
+++ b/python/chronos/src/bigdl/chronos/model/nbeats_pytorch.py
@@ -50,6 +50,7 @@ from torch.nn.functional import mse_loss, l1_loss, binary_cross_entropy, cross_e
 from torch.optim import Optimizer
 
 from .utils import PYTORCH_REGRESSION_LOSS_MAP
+from pytorch_lightning import seed_everything
 
 
 class NBeatsNet(nn.Module):
@@ -65,8 +66,10 @@ class NBeatsNet(nn.Module):
                  thetas_dim=(4, 8),
                  share_weights_in_stack=False,
                  hidden_layer_units=256,
-                 nb_harmonics=None):
+                 nb_harmonics=None,
+                 seed=None):
         super(NBeatsNet, self).__init__()
+        seed_everything(seed, workers=True)
         self.future_seq_len = future_seq_len
         self.past_seq_len = past_seq_len
         self.hidden_layer_units = hidden_layer_units

--- a/python/chronos/src/bigdl/chronos/model/tcn.py
+++ b/python/chronos/src/bigdl/chronos/model/tcn.py
@@ -45,6 +45,7 @@ import torch.nn as nn
 from .utils import PYTORCH_REGRESSION_LOSS_MAP
 from pytorch_lightning import seed_everything
 
+
 class Chomp1d(nn.Module):
     def __init__(self, chomp_size):
         super(Chomp1d, self).__init__()

--- a/python/chronos/src/bigdl/chronos/model/tcn.py
+++ b/python/chronos/src/bigdl/chronos/model/tcn.py
@@ -43,7 +43,7 @@ import warnings
 import torch
 import torch.nn as nn
 from .utils import PYTORCH_REGRESSION_LOSS_MAP
-
+from pytorch_lightning import seed_everything
 
 class Chomp1d(nn.Module):
     def __init__(self, chomp_size):
@@ -100,9 +100,10 @@ class TemporalConvNet(nn.Module):
                  num_channels,
                  kernel_size=3,
                  dropout=0.1,
-                 repo_initialization=True):
+                 repo_initialization=True,
+                 seed=None):
         super(TemporalConvNet, self).__init__()
-
+        seed_everything(seed, workers=True)
         num_channels.append(output_feature_num)
 
         layers = []
@@ -149,7 +150,8 @@ def model_creator(config):
                            num_channels=num_channels.copy(),
                            kernel_size=config.get("kernel_size", 7),
                            dropout=config.get("dropout", 0.2),
-                           repo_initialization=config.get("repo_initialization", True))
+                           repo_initialization=config.get("repo_initialization", True),
+                           seed=config.get("seed", None))
 
 
 def optimizer_creator(model, config):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
@@ -24,6 +24,7 @@ from bigdl.chronos.data import TSDataset
 from unittest import TestCase
 import pytest
 
+
 def get_ts_df():
     sample_num = np.random.randint(1000, 1500)
     train_df = pd.DataFrame({"datetime": pd.date_range('1/1/2019', periods=sample_num, freq="1s"),
@@ -161,7 +162,7 @@ class TestChronosModelAutoformerForecaster(TestCase):
         forecaster.tune(train_data, validation_data=val_data, 
                         target_metric=['mse', 'latency'],
                         directions=["minimize", "minimize"],
-                        acceleration=True, direction=None,
+                        direction=None,
                         n_trials=2)
         forecaster.fit(train_data, epochs=3, batch_size=32, use_trial_id=0)
         evaluate = forecaster.evaluate(val_data)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
@@ -199,6 +199,3 @@ class TestChronosModelAutoformerForecaster(TestCase):
             forecaster.load(ckpt_name)
             evaluate2 = forecaster.evaluate(val_loader)
         assert evaluate[0]['val_loss'] == evaluate2[0]['val_loss']
-
-auto = TestChronosModelAutoformerForecaster()
-auto.test_autoformer_forecaster_multi_objective_tune()

--- a/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
@@ -199,3 +199,6 @@ class TestChronosModelAutoformerForecaster(TestCase):
             forecaster.load(ckpt_name)
             evaluate2 = forecaster.evaluate(val_loader)
         assert evaluate[0]['val_loss'] == evaluate2[0]['val_loss']
+
+auto = TestChronosModelAutoformerForecaster()
+auto.test_autoformer_forecaster_multi_objective_tune()

--- a/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
@@ -127,7 +127,7 @@ class TestChronosModelAutoformerForecaster(TestCase):
         forecaster.tune(train_data, validation_data=val_data, n_trials=2)
         forecaster.fit(train_data, epochs=3, batch_size=32)
         evaluate = forecaster.evaluate(val_data)
-        
+
     def test_autoformer_forecaster_fit_without_tune(self):
         import bigdl.nano.automl.hpo.space as space
         train_data, val_data, test_data = create_data(loader=False)
@@ -145,6 +145,26 @@ class TestChronosModelAutoformerForecaster(TestCase):
         error_msg = e.value.args[0]
         assert error_msg == "There is no trainer, and you " \
                             "should call .tune() before .fit()"
+
+    def test_autoformer_forecaster_multi_objective_tune(self):
+        import bigdl.nano.automl.hpo.space as space
+        train_data, val_data, test_data = create_data(loader=False)
+        forecaster = AutoformerForecaster(past_seq_len=24,
+                                          future_seq_len=5,
+                                          input_feature_num=2,
+                                          output_feature_num=2,
+                                          label_len=12,
+                                          freq='s',
+                                          loss="mse",
+                                          metrics=['mae', 'mse', 'mape'],
+                                          lr=space.Real(0.001, 0.01, log=True))
+        forecaster.tune(train_data, validation_data=val_data, 
+                        target_metric=['mse', 'latency'],
+                        directions=["minimize", "minimize"],
+                        acceleration=True, direction=None,
+                        n_trials=2)
+        forecaster.fit(train_data, epochs=3, batch_size=32, use_trial_id=0)
+        evaluate = forecaster.evaluate(val_data)
 
     def test_autoformer_forecaster_seed(self):
         train_loader, val_loader, test_loader = create_data(loader=True)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -632,3 +632,8 @@ class TestChronosModelTCNForecaster(TestCase):
                                    lr=0.01)
         train_loss = forecaster.fit(train_data, val_data, validation_mode='earlystop',
                                     earlystop_patience=6, epochs=50)
+
+
+tcn = TestChronosModelTCNForecaster()
+tcn.test_tcn_forecaster_mo_tune_acceleration_fit_input()
+tcn.test_tcn_forecaster_mo_tune_acceleration_fit()

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -181,8 +181,7 @@ class TestChronosModelTCNForecaster(TestCase):
         forecaster.tune(train_data, validation_data=val_data,
                         n_trials=2, target_metric=['mse', 'latency'], 
                         directions=["minimize", "minimize"],
-                        acceleration=True, direction=None,
-                        input_sample=torch.from_numpy(train_data[0][:1,:,:]))
+                        acceleration=True, direction=None)
 
     @skip_onnxrt
     def test_tcn_forecaster_onnx_methods(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -632,8 +632,3 @@ class TestChronosModelTCNForecaster(TestCase):
                                    lr=0.01)
         train_loss = forecaster.fit(train_data, val_data, validation_mode='earlystop',
                                     earlystop_patience=6, epochs=50)
-
-
-tcn = TestChronosModelTCNForecaster()
-tcn.test_tcn_forecaster_mo_tune_acceleration_fit_input()
-tcn.test_tcn_forecaster_mo_tune_acceleration_fit()

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -160,11 +160,13 @@ class TestChronosModelTCNForecaster(TestCase):
                                 loss="mae",
                                 metrics=['mae', 'mse', 'mape'],
                                 lr=space.Real(0.001, 0.01, log=True))
+        forecaster.num_processes = 1
         forecaster.tune(train_data, validation_data=val_data,
                         n_trials=2, target_metric=['mse', 'latency'],
                         direction=None,
                         directions=["minimize", "minimize"])
 
+    @skip_onnxrt
     def test_tcn_forecaster_multi_objective_tune_acceleration(self):
         import bigdl.nano.automl.hpo.space as space
         train_data, val_data, _ = create_data(loader=False)
@@ -182,7 +184,8 @@ class TestChronosModelTCNForecaster(TestCase):
                         n_trials=2, target_metric=['mse', 'latency'], 
                         directions=["minimize", "minimize"],
                         acceleration=True, direction=None)
-    
+
+    @skip_onnxrt
     def test_tcn_forecaster_mo_tune_acceleration_fit_input(self):
         import bigdl.nano.automl.hpo.space as space
         train_data, val_data, _ = create_data(loader=False)
@@ -203,6 +206,7 @@ class TestChronosModelTCNForecaster(TestCase):
         with self.assertRaises(Exception):
             forecaster.fit(train_data, epochs=2)
 
+    @skip_onnxrt
     def test_tcn_forecaster_mo_tune_acceleration_fit(self):
         import bigdl.nano.automl.hpo.space as space
         train_data, val_data, _ = create_data(loader=False)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -182,6 +182,45 @@ class TestChronosModelTCNForecaster(TestCase):
                         n_trials=2, target_metric=['mse', 'latency'], 
                         directions=["minimize", "minimize"],
                         acceleration=True, direction=None)
+    
+    def test_tcn_forecaster_mo_tune_acceleration_fit_input(self):
+        import bigdl.nano.automl.hpo.space as space
+        train_data, val_data, _ = create_data(loader=False)
+        forecaster = TCNForecaster(past_seq_len=24,
+                                future_seq_len=5,
+                                input_feature_num=1,
+                                output_feature_num=1,
+                                kernel_size=4,
+                                num_channels=[16, 16],
+                                loss="mae",
+                                metrics=['mae', 'mse', 'mape'],
+                                lr=space.Real(0.001, 0.01, log=True))
+        forecaster.num_processes = 1
+        forecaster.tune(train_data, validation_data=val_data,
+                        n_trials=2, target_metric=['mse', 'latency'], 
+                        directions=["minimize", "minimize"],
+                        acceleration=True, direction=None)
+        with self.assertRaises(Exception):
+            forecaster.fit(train_data, epochs=2)
+
+    def test_tcn_forecaster_mo_tune_acceleration_fit(self):
+        import bigdl.nano.automl.hpo.space as space
+        train_data, val_data, _ = create_data(loader=False)
+        forecaster = TCNForecaster(past_seq_len=24,
+                                future_seq_len=5,
+                                input_feature_num=1,
+                                output_feature_num=1,
+                                kernel_size=4,
+                                num_channels=[16, 16],
+                                loss="mae",
+                                metrics=['mae', 'mse', 'mape'],
+                                lr=space.Real(0.001, 0.01, log=True))
+        forecaster.num_processes = 1
+        forecaster.tune(train_data, validation_data=val_data,
+                        n_trials=2, target_metric=['mse', 'latency'], 
+                        directions=["minimize", "minimize"],
+                        acceleration=True, direction=None)
+        forecaster.fit(train_data, epochs=2, use_trial_id=0)
 
     @skip_onnxrt
     def test_tcn_forecaster_onnx_methods(self):

--- a/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
@@ -112,3 +112,19 @@ class CustomEvaluationLoop(EvaluationLoop):
             self._print_results(logged_outputs, self.trainer.state.stage)
 
         return logged_outputs
+
+
+def _remove_metric_prefix(metric):
+    """Format the string metric to remove prefix."""
+    if isinstance(metric, (list, tuple)):
+        metrics = []
+        for target_metric in metric:
+            if target_metric == "latency":
+                metrics.append(target_metric)
+            else:
+                metrics.append(_remove_metric_prefix(target_metric))
+        return metrics
+    if isinstance(metric, str):
+        if '/' in metric:
+            metric = metric.split('/')[-1]
+        return metric

--- a/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
@@ -70,7 +70,7 @@ class LatencyCallback(Callback):
         pl_module.log('latency', pl_module.time_avg)
 
     def on_validation_batch_start(self, trainer, pl_module, batch: Any,
-                                    batch_idx: int, dataloader_idx: int) -> None:
+                                  batch_idx: int, dataloader_idx: int) -> None:
         self.batch_latency = time.perf_counter()
 
     def on_validation_batch_end(self, trainer, pl_module, outputs, batch: Any,
@@ -82,7 +82,7 @@ class LatencyCallback(Callback):
 class CustomEvaluationLoop(EvaluationLoop):
     def __init__(self, verbose: bool = True) -> None:
         super().__init__()
-    
+
     def on_run_end(self):
         self.trainer._logger_connector.epoch_end_reached()
 

--- a/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
@@ -45,7 +45,6 @@ class LatencyAggregate(Metric):
 
     def compute(self):
         # achieve the core logic of how to average latency
-        # todo : is there should any diff in single and multi process?
         self.times.sort()
         count = len(self.times)
         if count >= 3:

--- a/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from typing import Any, Dict, Optional, Union
+from typing import Any
 import torch
 import time
 from bigdl.nano.pytorch.utils import LIGHTNING_VERSION_LESS_1_6

--- a/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
@@ -20,6 +20,7 @@ import time
 from bigdl.nano.pytorch.utils import LIGHTNING_VERSION_LESS_1_6
 from pytorch_lightning.callbacks import Callback
 from pytorch_lightning.loops.dataloader.evaluation_loop import EvaluationLoop
+from bigdl.nano.utils.log4Error import invalidInputError
 from collections import ChainMap
 from torchmetrics import Metric
 
@@ -81,7 +82,7 @@ class LatencyCallback(Callback):
 
 class CustomEvaluationLoop(EvaluationLoop):
     def __init__(self, verbose: bool = True) -> None:
-        super().__init__()
+        super().__init__(verbose=verbose)
 
     def on_run_end(self):
         self.trainer._logger_connector.epoch_end_reached()
@@ -108,7 +109,7 @@ class CustomEvaluationLoop(EvaluationLoop):
         self._on_evaluation_end()
 
         if self.verbose and self.trainer.is_global_zero:
-            assert self.trainer.state.stage is not None
+            invalidInputError(self.trainer.state.stage is not None, "stage is wrong")
             self._print_results(logged_outputs, self.trainer.state.stage)
 
         return logged_outputs

--- a/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
@@ -1,0 +1,114 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from typing import Any, Dict, Optional, Union
+import torch
+import time
+from bigdl.nano.pytorch.utils import LIGHTNING_VERSION_LESS_1_6
+from pytorch_lightning.callbacks import Callback
+from pytorch_lightning.loops.dataloader.evaluation_loop import EvaluationLoop
+from collections import ChainMap
+from torchmetrics import Metric
+
+
+class ResetCallback(Callback):
+    def on_train_end(self, trainer, pl_module) -> None:
+        # reset current epoch = 0 after each run
+        super().on_train_end(trainer, pl_module)
+        if LIGHTNING_VERSION_LESS_1_6:
+            trainer.fit_loop.current_epoch = 0
+        else:
+            trainer.fit_loop.epoch_progress.current.processed = 0
+
+
+class LatencyAggregate(Metric):
+    def __init__(self):
+        super().__init__(compute_on_step=False)
+        self.add_state("times", default=[])
+
+    def update(self, latency):
+        self.times.append(torch.Tensor([latency * 1000]).double())
+
+    def compute(self):
+        # achieve the core logic of how to average latency
+        # todo : is there should any diff in single and multi process?
+        self.times.sort()
+        count = len(self.times)
+        if count >= 3:
+            threshold = max(int(0.1 * count), 1)
+            infer_times_mid = self.times[threshold:-threshold]
+        else:
+            infer_times_mid = self.times[:]
+        latency = sum(infer_times_mid) / len(infer_times_mid)
+        return latency
+
+
+class LatencyCallback(Callback):
+    def __init__(self) -> None:
+        super().__init__()
+        self.time_avg = LatencyAggregate()
+
+    def on_validation_start(self, trainer, pl_module) -> None:
+        super().on_validation_start(trainer, pl_module)
+        if not hasattr(pl_module, "time_avg"):
+            pl_module.time_avg = self.time_avg
+
+    def on_validation_epoch_end(self, trainer, pl_module) -> None:
+        pl_module.log('latency', pl_module.time_avg)
+
+    def on_validation_batch_start(self, trainer, pl_module, batch: Any,
+                                    batch_idx: int, dataloader_idx: int) -> None:
+        self.batch_latency = time.perf_counter()
+
+    def on_validation_batch_end(self, trainer, pl_module, outputs, batch: Any,
+                                batch_idx: int, dataloader_idx: int) -> None:
+        batch_latency = time.perf_counter() - self.batch_latency
+        pl_module.time_avg(batch_latency)
+
+
+class CustomEvaluationLoop(EvaluationLoop):
+    def __init__(self, verbose: bool = True) -> None:
+        super().__init__()
+    
+    def on_run_end(self):
+        self.trainer._logger_connector.epoch_end_reached()
+
+        # hook
+        self._evaluation_epoch_end(self._outputs)
+        self._outputs = []  # free memory
+
+        # hook
+        self._on_evaluation_epoch_end()
+
+        logged_outputs, self._logged_outputs = self._logged_outputs, []  # free memory
+        # include any logged outputs on epoch_end
+        epoch_end_logged_outputs = self.trainer._logger_connector.update_eval_epoch_metrics()
+        all_logged_outputs = dict(ChainMap(*logged_outputs))  # list[dict] -> dict
+        all_logged_outputs.update(epoch_end_logged_outputs)
+        for dl_outputs in logged_outputs:
+            dl_outputs.update(epoch_end_logged_outputs)
+
+        # log metrics
+        self.trainer._logger_connector.log_eval_end_metrics(all_logged_outputs)
+
+        # hook
+        self._on_evaluation_end()
+
+        if self.verbose and self.trainer.is_global_zero:
+            assert self.trainer.state.stage is not None
+            self._print_results(logged_outputs, self.trainer.state.stage)
+
+        return logged_outputs

--- a/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
@@ -17,7 +17,6 @@
 from typing import Any
 import torch
 import time
-from bigdl.nano.pytorch.utils import LIGHTNING_VERSION_LESS_1_6
 from pytorch_lightning.callbacks import Callback
 from pytorch_lightning.loops.dataloader.evaluation_loop import EvaluationLoop
 from bigdl.nano.utils.log4Error import invalidInputError
@@ -29,10 +28,7 @@ class ResetCallback(Callback):
     def on_train_end(self, trainer, pl_module) -> None:
         # reset current epoch = 0 after each run
         super().on_train_end(trainer, pl_module)
-        if LIGHTNING_VERSION_LESS_1_6:
-            trainer.fit_loop.current_epoch = 0
-        else:
-            trainer.fit_loop.epoch_progress.current.processed = 0
+        trainer.fit_loop.epoch_progress.current.processed = 0
 
 
 class LatencyAggregate(Metric):

--- a/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
@@ -18,7 +18,6 @@ from typing import Any
 import pytorch_lightning as pl
 import copy
 import math
-from bigdl.nano.pytorch.utils import LIGHTNING_VERSION_LESS_1_6
 from pytorch_lightning.trainer.states import TrainerFn, TrainerStatus
 from bigdl.nano.utils.log4Error import invalidInputError
 from bigdl.nano.automl.hpo.backend import create_hpo_backend, SamplerType

--- a/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
@@ -68,7 +68,7 @@ class HPOSearcher:
         self.run_kwargs = None
         self.fit_kwargs = None
 
-    def _create_objective(self, model, target_metric, create_kwargs, auto_optimize, 
+    def _create_objective(self, model, target_metric, create_kwargs, auto_optimize,
                           input_sample, fit_kwargs):
         # target_metric = self._fix_target_metric(target_metric, search_kwargs)
         isprune = True if create_kwargs.get('pruner', None) else False
@@ -126,10 +126,11 @@ class HPOSearcher:
             defaults to False.
         :param target_metric: the object metric to optimize,
             defaults to None.
-        :param auto_optimize: Whether to automatically consider the model after 
-            inference acceleration in the search process. It will only take 
+        :param auto_optimize: Whether to automatically consider the model after
+            inference acceleration in the search process. It will only take
             effect if target_metric contains "latency". Default value is False.
-        :param input_sample: 
+        :param input_sample: A set of inputs for trace, defaults to None if you have
+            trace before or model is a LightningModule with any dataloader attached.
         :param return: the model with study meta info attached.
         """
         search_kwargs = kwargs or {}

--- a/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
@@ -14,16 +14,15 @@
 # limitations under the License.
 #
 
-from typing import Any, Dict, Optional, Union
+from typing import Any
 import pytorch_lightning as pl
 import copy
 import math
 from pytorch_lightning.trainer.states import TrainerFn, TrainerStatus
-from pytorch_lightning.loops.epoch import TrainingEpochLoop
-from pytorch_lightning.loops.fit_loop import FitLoop
 from bigdl.nano.utils.log4Error import invalidInputError
 from bigdl.nano.automl.hpo.backend import create_hpo_backend, SamplerType
 from .objective import Objective
+from ._helper import ResetCallback, CustomEvaluationLoop
 from bigdl.nano.automl.utils.parallel import run_parallel
 from bigdl.nano.automl.hpo.search import (
     _search_summary,
@@ -55,14 +54,6 @@ class HPOSearcher:
         self.trainer = trainer
         self.num_process = num_processes
         if num_processes == 1:
-            # reset current epoch = 0 after each run
-            from pytorch_lightning.callbacks import Callback
-
-            class ResetCallback(Callback):
-                def on_train_end(self, trainer, pl_module) -> None:
-                    super().on_train_end(trainer, pl_module)
-                    trainer.fit_loop.epoch_progress.current.processed = 0
-
             callbacks = self.trainer.callbacks or []
             callbacks.append(ResetCallback())
             self.trainer.callbacks = callbacks
@@ -77,7 +68,8 @@ class HPOSearcher:
         self.run_kwargs = None
         self.fit_kwargs = None
 
-    def _create_objective(self, model, target_metric, create_kwargs, fit_kwargs):
+    def _create_objective(self, model, target_metric, create_kwargs, auto_optimize, 
+                          input_sample, fit_kwargs):
         # target_metric = self._fix_target_metric(target_metric, search_kwargs)
         isprune = True if create_kwargs.get('pruner', None) else False
         self.objective = Objective(
@@ -85,6 +77,8 @@ class HPOSearcher:
             model=model._model_build,
             target_metric=target_metric,
             pruning=isprune,
+            auto_optimize=auto_optimize,
+            input_sample=input_sample,
             **fit_kwargs,
         )
 
@@ -121,6 +115,8 @@ class HPOSearcher:
                resume=False,
                target_metric=None,
                n_parallels=1,
+               auto_optimize=False,
+               input_sample=None,
                **kwargs):
         """
         Run HPO Searcher. It will be called in Trainer.search().
@@ -130,6 +126,10 @@ class HPOSearcher:
             defaults to False.
         :param target_metric: the object metric to optimize,
             defaults to None.
+        :param auto_optimize: Whether to automatically consider the model after 
+            inference acceleration in the search process. It will only take 
+            effect if target_metric contains "latency". Default value is False.
+        :param input_sample: 
         :param return: the model with study meta info attached.
         """
         search_kwargs = kwargs or {}
@@ -160,7 +160,8 @@ class HPOSearcher:
             self.study = _create_study(resume, self.create_kwargs, self.backend)
 
         if self.objective is None:
-            self._create_objective(model, self.target_metric, self.create_kwargs, self.fit_kwargs)
+            self._create_objective(model, self.target_metric, self.create_kwargs, auto_optimize,
+                                   input_sample, self.fit_kwargs)
 
         if n_parallels and n_parallels > 1:
             invalidInputError(self.create_kwargs.get('storage', "").strip() != "",
@@ -220,3 +221,12 @@ class HPOSearcher:
         else:
             self.trainer._run(*args, **kwargs)
         self.trainer.tuning = True
+
+    def _validate(self, *args: Any, **kwargs: Any) -> None:
+        """a wrapper to test optimization latency multiple times \
+        after training"""
+        self.trainer.validate_loop = CustomEvaluationLoop()
+        self.trainer.state.fn = TrainerFn.VALIDATING
+        self.trainer.training = False
+        self.trainer.testing = False
+        self.trainer.validate(*args, **kwargs)

--- a/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
@@ -224,8 +224,7 @@ class HPOSearcher:
         self.trainer.tuning = True
 
     def _validate(self, *args: Any, **kwargs: Any) -> None:
-        """a wrapper to test optimization latency multiple times \
-        after training"""
+        """A wrapper to test optimization latency multiple times after training"""
         self.trainer.validate_loop = CustomEvaluationLoop()
         self.trainer.state.fn = TrainerFn.VALIDATING
         self.trainer.training = False

--- a/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
@@ -18,6 +18,7 @@ from typing import Any
 import pytorch_lightning as pl
 import copy
 import math
+from bigdl.nano.pytorch.utils import LIGHTNING_VERSION_LESS_1_6
 from pytorch_lightning.trainer.states import TrainerFn, TrainerStatus
 from bigdl.nano.utils.log4Error import invalidInputError
 from bigdl.nano.automl.hpo.backend import create_hpo_backend, SamplerType

--- a/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
@@ -69,7 +69,7 @@ class HPOSearcher:
         self.run_kwargs = None
         self.fit_kwargs = None
 
-    def _create_objective(self, model, target_metric, create_kwargs, auto_optimize,
+    def _create_objective(self, model, target_metric, create_kwargs, acceleration,
                           input_sample, fit_kwargs):
         # target_metric = self._fix_target_metric(target_metric, search_kwargs)
         isprune = True if create_kwargs.get('pruner', None) else False
@@ -78,7 +78,7 @@ class HPOSearcher:
             model=model._model_build,
             target_metric=target_metric,
             pruning=isprune,
-            auto_optimize=auto_optimize,
+            acceleration=acceleration,
             input_sample=input_sample,
             **fit_kwargs,
         )
@@ -116,7 +116,7 @@ class HPOSearcher:
                resume=False,
                target_metric=None,
                n_parallels=1,
-               auto_optimize=False,
+               acceleration=False,
                input_sample=None,
                **kwargs):
         """
@@ -127,7 +127,7 @@ class HPOSearcher:
             defaults to False.
         :param target_metric: the object metric to optimize,
             defaults to None.
-        :param auto_optimize: Whether to automatically consider the model after
+        :param acceleration: Whether to automatically consider the model after
             inference acceleration in the search process. It will only take
             effect if target_metric contains "latency". Default value is False.
         :param input_sample: A set of inputs for trace, defaults to None if you have
@@ -162,7 +162,7 @@ class HPOSearcher:
             self.study = _create_study(resume, self.create_kwargs, self.backend)
 
         if self.objective is None:
-            self._create_objective(model, self.target_metric, self.create_kwargs, auto_optimize,
+            self._create_objective(model, self.target_metric, self.create_kwargs, acceleration,
                                    input_sample, self.fit_kwargs)
 
         if n_parallels and n_parallels > 1:

--- a/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
@@ -224,7 +224,7 @@ class HPOSearcher:
         self.trainer.tuning = True
 
     def _validate(self, *args: Any, **kwargs: Any) -> None:
-        """A wrapper to test optimization latency multiple times after training"""
+        """A wrapper to test optimization latency multiple times after training."""
         self.trainer.validate_loop = CustomEvaluationLoop()
         self.trainer.state.fn = TrainerFn.VALIDATING
         self.trainer.training = False

--- a/python/nano/src/bigdl/nano/automl/pytorch/objective.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/objective.py
@@ -173,13 +173,14 @@ class Objective(object):
             for metric in self.target_metric:
                 score = self.searcher.trainer.callback_metrics[metric].item()
                 optim_score.append(score)
-            # compare optim_scores with original scores to find a similar
-            # loss value with less latency
             optim_score = Score(*optim_score)
+            # Here, we use usable to represent whether the optimized model can get smaller latency
+            # with other performance indicators basically unchanged
             usable = True
             for metric in self.target_metric:
                 if metric != "latency":
-                    if abs(getattr(optim_score, metric) - getattr(best_score, metric)) >= 0.005:
+                    if abs(getattr(optim_score, metric) - getattr(best_score, metric)) >= \
+                        0.01 * getattr(best_score, metric):
                         usable = False
                         break
                 else:

--- a/python/nano/src/bigdl/nano/automl/pytorch/objective.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/objective.py
@@ -219,7 +219,7 @@ class Objective(object):
             scores = self.searcher.trainer.callback_metrics[self.target_metric].item()
         if self.auto_optimize:
             scores, optimization = self._auto_optimize(model, scores)
-            # via user_attr returns the choosed optimization corresponding 
+            # via user_attr returns the choosed optimization corresponding
             # to the minimum latency
             trial.set_user_attr("optimization", optimization)
         self._post_train(model)

--- a/python/nano/src/bigdl/nano/automl/pytorch/objective.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/objective.py
@@ -145,7 +145,7 @@ class Objective(object):
                               "or `val_dataloaders` to `trainer.search(datamodule=...)`")
         return train_dataloaders, val_dataloaders, datamodule
 
-    def _auto_optimize(self, model, score):
+    def _auto_optimize(self, model, scores):
         Score = namedtuple("Score", self.target_metric)
         original_score = Score(*scores)
         best_score = original_score
@@ -179,6 +179,8 @@ class Objective(object):
             usable = True
             for metric in self.target_metric:
                 if metric != "latency":
+                    # some bug for different direction like mse.
+                    # need more detailed design
                     if abs(getattr(optim_score, metric) - getattr(best_score, metric)) >= 0.005:
                         usable = False
                         break

--- a/python/nano/src/bigdl/nano/automl/pytorch/objective.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/objective.py
@@ -15,7 +15,6 @@
 #
 
 from collections import namedtuple
-from pickletools import optimize
 from typing import Optional, Tuple, Union
 
 import pytorch_lightning as pl
@@ -28,7 +27,6 @@ from pytorch_lightning.core.datamodule import LightningDataModule
 from bigdl.nano.pytorch.trainer import Trainer
 from bigdl.nano.automl.hpo.backend import create_pl_pruning_callback
 from bigdl.nano.utils.log4Error import invalidInputError
-from bigdl.nano.pytorch.utils import LIGHTNING_VERSION_LESS_1_6
 from ._helper import LatencyCallback, _remove_metric_prefix
 import inspect
 import copy
@@ -101,22 +99,12 @@ class Objective(object):
             self.searcher.trainer.callbacks = callbacks
 
         # links data to the trainer
-        if LIGHTNING_VERSION_LESS_1_6:
-            self.searcher.trainer.data_connector.attach_data(
-                model,
-                train_dataloaders=self.train_dataloaders,
-                val_dataloaders=self.val_dataloaders,
-                datamodule=self.datamodule
-            )
-        else:
-            self.searcher.trainer._data_connector.attach_data(  # type: ignore
-                model,
-                train_dataloaders=self.train_dataloaders,
-                val_dataloaders=self.val_dataloaders,
-                datamodule=self.datamodule
-            )
-        if self.val_dataloaders is None:
-            self.val_dataloaders = model.val_dataloader()
+        self.searcher.trainer._data_connector.attach_data(  # type: ignore
+            model,
+            train_dataloaders=self.train_dataloaders,
+            val_dataloaders=self.val_dataloaders,
+            datamodule=self.datamodule
+        )
 
     def _post_train(self, model):
         pass

--- a/python/nano/src/bigdl/nano/automl/pytorch/objective.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/objective.py
@@ -29,7 +29,6 @@ from bigdl.nano.pytorch.trainer import Trainer
 from bigdl.nano.automl.hpo.backend import create_pl_pruning_callback
 from bigdl.nano.utils.log4Error import invalidInputError
 from bigdl.nano.pytorch.utils import LIGHTNING_VERSION_LESS_1_6
-from sklearn.metrics import SCORERS
 from ._helper import LatencyCallback
 import inspect
 import copy
@@ -182,7 +181,7 @@ class Objective(object):
             for metric in self.target_metric:
                 if metric != "latency":
                     if abs(getattr(optim_score, metric) - getattr(best_score, metric)) >= \
-                        0.01 * getattr(best_score, metric):
+                            0.01 * getattr(best_score, metric):
                         usable = False
                         break
                 else:

--- a/python/nano/src/bigdl/nano/automl/pytorch/objective.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/objective.py
@@ -114,7 +114,7 @@ class Objective(object):
                 val_dataloaders=self.val_dataloaders,
                 datamodule=self.datamodule
             )
-        if self.val_dataloaders == None:
+        if self.val_dataloaders is None:
             self.val_dataloaders = model.val_dataloader()
 
     def _post_train(self, model):

--- a/python/nano/src/bigdl/nano/automl/pytorch/objective.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/objective.py
@@ -173,6 +173,7 @@ class Objective(object):
                 # some optimizations may fail, just skip and try next
                 continue
             model.model = optim_model
+            model.forward_args = optim_model.forward_args
             self.searcher._validate(model, self.val_dataloaders)
             optim_score = []
             for metric in self.target_metric:

--- a/python/nano/src/bigdl/nano/automl/pytorch/objective.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/objective.py
@@ -149,7 +149,6 @@ class Objective(object):
         :param: trial: a trial object which provides the hyperparameter combinition.
         :return: the target metric value.
         """
-
         if _is_creator(self.model):
             model = self.model(trial)
         else:

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -91,7 +91,9 @@ class PytorchIPEXJITModel(IPEXJITModel, AcceleratedLightningModule):
         '''
         AcceleratedLightningModule.__init__(self, None)
         IPEXJITModel.__init__(self, model, input_sample=input_sample,
-                              use_ipex=use_ipex, use_jit=use_jit, from_load=from_load)
+                              use_ipex=use_ipex, use_jit=use_jit,
+                              channels_last=channels_last,
+                              from_load=from_load)
 
     def on_forward_start(self, inputs):
         return inputs

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -57,10 +57,10 @@ class IPEXJITModel:
         if self.use_jit:
             self.model = torch.jit.trace(self.model, input_sample)
             self.model = torch.jit.freeze(self.model)
-    
+
     @property
     def forward_args(self):
-        return [input_value.debugName() for input_value in self.model.graph.inputs() 
+        return [input_value.debugName() for input_value in self.model.graph.inputs()
                 if not input_value.debugName().startswith('self')]
 
     def forward_step(self, *inputs):

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -57,6 +57,11 @@ class IPEXJITModel:
         if self.use_jit:
             self.model = torch.jit.trace(self.model, input_sample)
             self.model = torch.jit.freeze(self.model)
+    
+    @property
+    def forward_args(self):
+        return [input_value.debugName() for input_value in self.model.graph.inputs() 
+                if not input_value.debugName().startswith('self')]
 
     def forward_step(self, *inputs):
         if self.channels_last:

--- a/python/nano/src/bigdl/nano/pytorch/lightning.py
+++ b/python/nano/src/bigdl/nano/pytorch/lightning.py
@@ -58,8 +58,10 @@ class LightningModule(pl.LightningModule):
     def forward_args(self):  # noqa
         from bigdl.nano.deps.openvino.pytorch.model import PytorchOpenVINOModel
         from bigdl.nano.deps.ipex.ipex_inference_model import PytorchIPEXJITModel
-        from bigdl.nano.deps.onnxruntime.pytorch.pytorch_onnxruntime_model import PytorchONNXRuntimeModel
-        if isinstance(self.model, (PytorchOpenVINOModel, PytorchIPEXJITModel, PytorchONNXRuntimeModel)):
+        from bigdl.nano.deps.onnxruntime.pytorch.pytorch_onnxruntime_model \
+            import PytorchONNXRuntimeModel
+        if isinstance(self.model, (PytorchOpenVINOModel, PytorchIPEXJITModel, 
+                                   PytorchONNXRuntimeModel)):
             return self.model.forward_args
         return inspect.getfullargspec(self.model.forward).args[1:]
 

--- a/python/nano/src/bigdl/nano/pytorch/lightning.py
+++ b/python/nano/src/bigdl/nano/pytorch/lightning.py
@@ -60,7 +60,7 @@ class LightningModule(pl.LightningModule):
         if self._forward_args_ is None:
             self._forward_args_ = inspect.getfullargspec(self.model.forward).args[1:]
         return self._forward_args_
-    
+
     @forward_args.setter
     def forward_args(self, forward_args):
         self._forward_args_ = forward_args

--- a/python/nano/src/bigdl/nano/pytorch/lightning.py
+++ b/python/nano/src/bigdl/nano/pytorch/lightning.py
@@ -53,17 +53,17 @@ class LightningModule(pl.LightningModule):
         self.optimizer = optimizer
         self.scheduler = scheduler
         self.metrics = metrics
+        self._forward_args_ = None
 
     @property
     def forward_args(self):  # noqa
-        from bigdl.nano.deps.openvino.pytorch.model import PytorchOpenVINOModel
-        from bigdl.nano.deps.ipex.ipex_inference_model import PytorchIPEXJITModel
-        from bigdl.nano.deps.onnxruntime.pytorch.pytorch_onnxruntime_model \
-            import PytorchONNXRuntimeModel
-        if isinstance(self.model, (PytorchOpenVINOModel, PytorchIPEXJITModel,
-                                   PytorchONNXRuntimeModel)):
-            return self.model.forward_args
-        return inspect.getfullargspec(self.model.forward).args[1:]
+        if self._forward_args_ is None:
+            self._forward_args_ = inspect.getfullargspec(self.model.forward).args[1:]
+        return self._forward_args_
+    
+    @forward_args.setter
+    def forward_args(self, forward_args):
+        self._forward_args_ = forward_args
 
     @property
     def _nargs(self):

--- a/python/nano/src/bigdl/nano/pytorch/lightning.py
+++ b/python/nano/src/bigdl/nano/pytorch/lightning.py
@@ -56,6 +56,11 @@ class LightningModule(pl.LightningModule):
 
     @property
     def forward_args(self):  # noqa
+        from bigdl.nano.deps.openvino.pytorch.model import PytorchOpenVINOModel
+        from bigdl.nano.deps.ipex.ipex_inference_model import PytorchIPEXJITModel
+        from bigdl.nano.deps.onnxruntime.pytorch.pytorch_onnxruntime_model import PytorchONNXRuntimeModel
+        if isinstance(self.model, (PytorchOpenVINOModel, PytorchIPEXJITModel, PytorchONNXRuntimeModel)):
+            return self.model.forward_args
         return inspect.getfullargspec(self.model.forward).args[1:]
 
     @property

--- a/python/nano/src/bigdl/nano/pytorch/lightning.py
+++ b/python/nano/src/bigdl/nano/pytorch/lightning.py
@@ -60,7 +60,7 @@ class LightningModule(pl.LightningModule):
         from bigdl.nano.deps.ipex.ipex_inference_model import PytorchIPEXJITModel
         from bigdl.nano.deps.onnxruntime.pytorch.pytorch_onnxruntime_model \
             import PytorchONNXRuntimeModel
-        if isinstance(self.model, (PytorchOpenVINOModel, PytorchIPEXJITModel, 
+        if isinstance(self.model, (PytorchOpenVINOModel, PytorchIPEXJITModel,
                                    PytorchONNXRuntimeModel)):
             return self.model.forward_args
         return inspect.getfullargspec(self.model.forward).args[1:]

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -203,7 +203,7 @@ class Trainer(pl.Trainer):
                resume: bool = False,
                target_metric=None,
                n_parallels=1,
-               auto_optimize=False,
+               acceleration=False,
                input_sample=None,
                **kwargs):
         """
@@ -215,7 +215,7 @@ class Trainer(pl.Trainer):
         :param target_metric: the object metric to optimize,
             defaults to None.
         :param n_parallels: the number of parallel processes for running trials.
-        :param auto_optimize: Whether to automatically consider the model after
+        :param acceleration: Whether to automatically consider the model after
             inference acceleration in the search process. It will only take
             effect if target_metric contains "latency". Default value is False.
         :param input_sample: A set of inputs for trace, defaults to None if you have
@@ -230,7 +230,7 @@ class Trainer(pl.Trainer):
                                        resume=resume,
                                        target_metric=target_metric,
                                        n_parallels=n_parallels,
-                                       auto_optimize=auto_optimize,
+                                       acceleration=acceleration,
                                        input_sample=input_sample,
                                        **kwargs)
 

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -203,6 +203,8 @@ class Trainer(pl.Trainer):
                resume: bool = False,
                target_metric=None,
                n_parallels=1,
+               auto_optimize=False,
+               input_sample=None,
                **kwargs):
         """
         Run HPO search. It will be called in Trainer.search().
@@ -213,6 +215,11 @@ class Trainer(pl.Trainer):
         :param target_metric: the object metric to optimize,
             defaults to None.
         :param n_parallels: the number of parallel processes for running trials.
+        :param auto_optimize: Whether to automatically consider the model after
+            inference acceleration in the search process. It will only take
+            effect if target_metric contains "latency". Default value is False.
+        :param input_sample: A set of inputs for trace, defaults to None if you have
+            trace before or model is a LightningModule with any dataloader attached.
         :return: the model with study meta info attached.
         """
         if not check_hpo_status(self.hposearcher):
@@ -223,6 +230,8 @@ class Trainer(pl.Trainer):
                                        resume=resume,
                                        target_metric=target_metric,
                                        n_parallels=n_parallels,
+                                       auto_optimize=auto_optimize,
+                                       input_sample=input_sample,
                                        **kwargs)
 
     def search_summary(self):

--- a/python/nano/test/automl/pytorch/test_multi_objective.py
+++ b/python/nano/test/automl/pytorch/test_multi_objective.py
@@ -294,6 +294,72 @@ class TestMOHPO(TestCase):
         assert error_msg == "In multi-objective optimization, you must " \
                             "explicitly specify the direction for each metric"
 
+    def test_auto_optimize(self):
+        @hpo.plmodel()
+        class CustomModel(BoringModel):
+            """Customized Model."""
+            def __init__(self,
+                        out_dim1,
+                        out_dim2,
+                        dropout_1,
+                        dropout_2,
+                        learning_rate=0.1,
+                        batch_size=16):
+                super().__init__()
+                layers = []
+                input_dim = 32
+                for out_dim, dropout in [(out_dim1, dropout_1),
+                                        (out_dim2,dropout_2)]:
+                    layers.append(torch.nn.Linear(input_dim, out_dim))
+                    layers.append(torch.nn.Tanh())
+                    layers.append(torch.nn.Dropout(dropout))
+                    input_dim = out_dim
+                layers.append(torch.nn.Linear(input_dim, 2))
+                self.model: torch.nn.Module = torch.nn.Sequential(*layers)
+                self.save_hyperparameters()
+
+            def configure_optimizers(self):
+                # set learning rate in the optimizer
+                print("setting initial learning rate to",str(self.hparams.learning_rate))
+                self.optimizer = torch.optim.Adam(self.model.parameters(),
+                                                  lr=self.hparams.learning_rate)
+                return [self.optimizer], []
+
+            def train_dataloader(self):
+                print("setting initial learning rate to",str(self.hparams.learning_rate))
+                return DataLoader(RandomDataset(32, 64),
+                                  batch_size=self.hparams.batch_size)
+
+            def val_dataloader(self):
+                return DataLoader(RandomDataset(32, 64),
+                                  batch_size=self.hparams.batch_size)
+
+        model = CustomModel(
+            out_dim1=space.Categorical(16,32),
+            out_dim2=space.Categorical(16,32),
+            dropout_1=space.Categorical(0.1, 0.2, 0.3, 0.4, 0.5),
+            dropout_2 = space.Categorical(0.1,0.2),
+            learning_rate = space.Real(0.001,0.01,log=True),
+            batch_size = space.Categorical(32,64)
+            )
+
+        trainer = Trainer(
+            logger=True,
+            checkpoint_callback=False,
+            max_epochs=2,
+            use_hpo=True,
+        )
+        
+        best_trials = trainer.search(
+            model,
+            target_metric=['val_loss', 'latency'],
+            directions=['minimize', 'minimize'],
+            n_trials=4,
+            max_epochs=3,
+            auto_optimize=True,
+            input_sample=torch.randn(1, 32),
+        )
+
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/python/nano/test/automl/pytorch/test_multi_objective.py
+++ b/python/nano/test/automl/pytorch/test_multi_objective.py
@@ -356,7 +356,7 @@ class TestMOHPO(TestCase):
             directions=['minimize', 'minimize'],
             n_trials=4,
             max_epochs=3,
-            auto_optimize=True,
+            acceleration=True,
             input_sample=torch.randn(1, 32),
         )
 


### PR DESCRIPTION
## Description
This PR want to enable automatic latency collection for different accelerated model (e.g. ONNXRuntime, OpenVINO, JIT_IPEX) in NanoHPO and return the accelerated minimum latency to user.

### 1. Why the change?

Help user get the accelerated minimum latency when using NanoHPO.

### 2. User API changes
In NanoHPO
```
trials = trainer.search(
            model,
            target_metric=['val_loss', 'latency'],  # latency is a built-in metric
            directions=['minimize', 'minimize'],
            n_trials=4,
            max_epochs=3,
            acceleration=True,
            input_sample=input_sample
        )
```
Muti-Objective HPO in BaseForecaster of Chronos
```
trials = forecaster.tune(data=train_data, validation_data=val_data,
                target_metric=['mse','latency'],
                direction=None,
                directions=['minimize', 'minimize'],
                epochs=3,
                acceleration=True)
```
in which `acceleration` and `input_sample` are new parameters.
### 3. Summary of the change 
- add _help.py to refactor code
- fix a bug of PytorchIPEXJITModel and add forward_args property for IPEXJITModel
- add _auto_optimize func for Objective to enable automatic latency collection for different accelerated model on the end of each trial (e.g. ONNXRuntime, OpenVINO, JIT_IPEX) 
- add unittest in NanoHPO for acceleration option
- Migrated multi-target search and built-in acceleration to BaseForecaster in Chronos, fixed some bugs in the migration process
- Migrated multi-target search and built-in acceleration to AutoformerForecaster in Chronos, fixed some bugs in the migration process
- Support seed search in BaseForecaster
- add unittest in TCNForecaster for multi-target search and acceleration option
- add unittest in AutoformerForecaster for multi-target search and acceleration option

### 4. How to test?
- [x] Unit test
- [x] Jenkins
http://10.112.231.51:18888/job/BigDL-NanoTests-PR-Validation/342/
http://10.112.231.51:18889/job/BigDL-Chronos-PR-Validation/650/
