### PR TITLE
Chronos: add earlystop mode to forecasters' fit

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -331,8 +331,8 @@ class BasePytorchForecaster(Forecaster):
             early_stopping = EarlyStopping('val/loss', patience=earlystop_patience)
             callbacks = [early_stopping] if validation_mode == 'earlystop' else None
             # Trainer init
-            self.trainer = Trainer(logger=logger, max_epochs=epochs,
-                                   checkpoint_callback=self.checkpoint_callback, callbacks=callbacks,
+            self.trainer = Trainer(logger=logger, max_epochs=epochs, callbacks=callbacks,
+                                   checkpoint_callback=self.checkpoint_callback,
                                    num_processes=self.num_processes, use_ipex=self.use_ipex,
                                    flush_logs_every_n_steps=10, log_every_n_steps=10,
                                    distributed_backend="spawn")

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -250,8 +250,8 @@ class BasePytorchForecaster(Forecaster):
                If you input a pytorch dataloader for `data`, the batch_size will follow the
                batch_size setted in `data`.if the forecaster is distributed, the batch_size will be
                evenly distributed to all workers.
-        :param validation_mode: Operation mode while having 'validation_data'. Defaults to 'output'.
-               The validation_mode includes the following types:
+        :param validation_mode:  A str represent the operation mode while having 'validation_data'.
+               Defaults to 'output'. The validation_mode includes the following types:
 
                | 1. output:
                | If you choose 'output' for validation_mode, it will return a dict that records the

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -262,10 +262,8 @@ class BasePytorchForecaster(Forecaster):
 
         :param earlystop_patience: Number of checks with no improvement after which training will
                be stopped. It takes effect when 'validation_mode' is 'earlystop'. Under the default
-               configuration, one check happens after every training epoch. However, the frequency
-               of validation can be modified by setting various parameters on the Trainer, for
-               example check_val_every_n_epoch and val_check_interval.
-        :return: Validation loss if you input 'validation_data'.
+               configuration, one check happens after every training epoch.
+        :return: Validation loss if 'validation_data' is not None.
         """
         # input transform
         if isinstance(data, TSDataset):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -475,6 +475,27 @@ class TestChronosModelLSTMForecaster(TestCase):
         onnx_res = lstm.evaluate_with_onnx(test_loader)
         q_onnx_res = lstm.evaluate_with_onnx(test_loader, quantize=True)
 
+    def test_lstm_forecaster_fit_earlystop(self):
+        train_data, val_data, _ = create_data()
+        forecaster = LSTMForecaster(past_seq_len=24,
+                                    input_feature_num=2,
+                                    output_feature_num=2,
+                                    hidden_dim=[32, 16],
+                                    layer_num=2,
+                                    dropout=[0.1, 0.2],
+                                    loss="mae",
+                                    lr=0.01)
+        val_loss = forecaster.fit(train_data, val_data, validation_mode='earlystop', epochs=50)
 
-if __name__ == '__main__':
-    pytest.main([__file__])
+    def test_lstm_forecaster_fit_earlystop_patience(self):
+        train_data, val_data, _ = create_data()
+        forecaster = LSTMForecaster(past_seq_len=24,
+                                    input_feature_num=2,
+                                    output_feature_num=2,
+                                    hidden_dim=[32, 16],
+                                    layer_num=2,
+                                    dropout=[0.1, 0.2],
+                                    loss="mae",
+                                    lr=0.01)
+        val_loss = forecaster.fit(train_data, val_data, validation_mode='earlystop',
+                                  earlystop_patience=6, epochs=50)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -458,6 +458,27 @@ class TestChronosNBeatsForecaster(TestCase):
         onnx_res = nbeats.evaluate_with_onnx(test_loader)
         q_onnx_res = nbeats.evaluate_with_onnx(test_loader, quantize=True)
 
+    def test_nbeats_forecaster_fit_earlystop(self):
+        train_data, val_data, _ = create_data()
+        forecaster = NBeatsForecaster(past_seq_len=24,
+                                      future_seq_len=5,
+                                      stack_types=('generic', 'generic'),
+                                      nb_blocks_per_stack=3,
+                                      hidden_layer_units=256,
+                                      metrics=['mae'],
+                                      lr=0.01)
+        val_loss = forecaster.fit((train_data[0], train_data[1]), val_data,
+                                  validation_mode='earlystop', epochs=50)
 
-if __name__ == '__main__':
-    pytest.main([__file__])
+    def test_nbeats_forecaster_fit_earlystop_patience(self):
+        train_data, val_data, _ = create_data()
+        forecaster = NBeatsForecaster(past_seq_len=24,
+                                      future_seq_len=5,
+                                      stack_types=('generic', 'generic'),
+                                      nb_blocks_per_stack=3,
+                                      hidden_layer_units=256,
+                                      metrics=['mae'],
+                                      lr=0.01)
+        val_loss = forecaster.fit((train_data[0], train_data[1]), val_data,
+                                  validation_mode='earlystop', earlystop_patience=6,
+                                  epochs=50)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -410,6 +410,23 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
         res = s2s.evaluate(test_loader)
         onnx_res = s2s.evaluate_with_onnx(test_loader)
 
+    def test_s2s_forecaster_fit_earlystop(self):
+        train_data, val_data, _ = create_data()
+        forecaster = Seq2SeqForecaster(past_seq_len=24,
+                                       future_seq_len=5,
+                                       input_feature_num=1,
+                                       output_feature_num=1,
+                                       loss="mae",
+                                       lr=0.01)
+        val_loss = forecaster.fit(train_data, val_data, validation_mode='earlystop', epochs=50)
 
-if __name__ == '__main__':
-    pytest.main([__file__])
+    def test_s2s_forecaster_fit_earlystop_patience(self):
+        train_data, val_data, _ = create_data()
+        forecaster = Seq2SeqForecaster(past_seq_len=24,
+                                       future_seq_len=5,
+                                       input_feature_num=1,
+                                       output_feature_num=1,
+                                       loss="mae",
+                                       lr=0.01)
+        val_loss = forecaster.fit(train_data, val_data, validation_mode='earlystop',
+                                  earlystop_patience=6, epochs=50)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -534,6 +534,27 @@ class TestChronosModelTCNForecaster(TestCase):
         onnx_res = tcn.evaluate_with_onnx(test_loader)
         q_onnx_res = tcn.evaluate_with_onnx(test_loader, quantize=True)
 
+    def test_tcn_forecaster_fit_earlystop(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = TCNForecaster(past_seq_len=24,
+                                   future_seq_len=5,
+                                   input_feature_num=1,
+                                   output_feature_num=1,
+                                   kernel_size=4,
+                                   num_channels=[16, 16],
+                                   loss="mae",
+                                   lr=0.01)
+        train_loss = forecaster.fit(train_data, val_data, validation_mode='earlystop', epochs=50)
 
-if __name__ =='__main__':
-    pytest.main([__file__])
+    def test_tcn_forecaster_fit_earlystop_patience(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = TCNForecaster(past_seq_len=24,
+                                   future_seq_len=5,
+                                   input_feature_num=1,
+                                   output_feature_num=1,
+                                   kernel_size=4,
+                                   num_channels=[16, 16],
+                                   loss="mae",
+                                   lr=0.01)
+        train_loss = forecaster.fit(train_data, val_data, validation_mode='earlystop',
+                                    earlystop_patience=6, epochs=50)


### PR DESCRIPTION
## Description

### 1. Why the change?

To  add earlystop mode to forecasters' `fit`. Forecasters will monitor the validation_loss and stop training when it stops improving in this mode.
https://github.com/intel-analytics/BigDL/issues/4958

### 2. User API changes

Add a mode `earlystop` for `validation_mode`, and add a parameter `earlystop_patience` to set the number of checks with no improvement after which training will be stopped.

### 3. Summary of the change 

Change the file [python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py](https://github.com/intel-analytics/BigDL/pull/5178/files/d7e31ec44fc64337b5e9435440033798a3eebb64#diff-f90b2e349024be33300085266c59def4560dd7b81de6573ad6b93a51fd382fb0).

### 4. How to test?

Add  unit test in 
[python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py](https://github.com/intel-analytics/BigDL/pull/5178/files#diff-802bb8b90c18a761e7e0d4eb000cebddfde5366a48cb7201533a4ca4d0c295ce)
[python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py](https://github.com/intel-analytics/BigDL/pull/5178/files#diff-2d759068533e4a21b1b0e56c77e144731d37b63ff3ee83f7dd0721dce5c62458)
[python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py](https://github.com/intel-analytics/BigDL/pull/5178/files#diff-7f8329eefc66b1ba67d3c33380fff7e3d7134181812f20b197f53964616e3337)
[python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py](https://github.com/intel-analytics/BigDL/pull/5178/files#diff-779e0b1ffaba1d91d35970801d1c9c81958393d710ea1d6286913c421d76c2c7)

### 5. New dependencies
