### PR TITLE
Fix #5153, change json4s version to 3.7.0-M5 in BigDL Serving module

### DIFF
--- a/scala/serving/pom.xml
+++ b/scala/serving/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.json4s</groupId>
             <artifactId>json4s-jackson_${scala.major.version}</artifactId>
-            <version>3.5.3</version>
+            <version>3.7.0-M5</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->
change the json4s dependency version in BigDL Serving module from 3.5.3 to 3.7.0-M5

### 1. Why the change?

<!-- Provide the related github issue link if available -->
related issue: https://github.com/intel-analytics/BigDL/issues/5153
the json4s version used in spark-3.1.2 is 3.7.0-M5, but in BigDL Serving module is 3.5.3, different version of jars may cause conflicts. 

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->
N/A
### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
change the json4s dependency version from 3.5.3 to 3.7.0-M5 in BigDL Serving module
### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...