### PR TITLE
Chronos: error message is added for tsdataset with less than 1 rolling sample

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -781,8 +781,9 @@ class TSDataset:
                 need_dflen = self.lookback + max(self.horizon)
             if len(self.df) < need_dflen:
                 invalidInputError(False,
-                                  "The length of the dataset must be larger than "
-                                  "'lookback' plus 'horizon'! ")
+                                  "The length of the dataset must be larger than the sum "
+                                  "of lookback and horizon, while get lookback+horizon="
+                                  f"{need_dflen} and the length of dataset is {len(self.df)}.")
 
             torch_dataset = RollDataset(self.df,
                                         dt_col=self.dt_col,

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -777,7 +777,8 @@ class TSDataset:
             
             if len(self.df) < self.lookback + self.horizon:
                 invalidInputError(False,
-                                  "The length of the dataset must be larger than 'lookback' plus 'horizon'! ")
+                                  "The length of the dataset must be larger than "
+                                  "'lookback' plus 'horizon'! ")
 
             torch_dataset = RollDataset(self.df,
                                         dt_col=self.dt_col,

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -774,6 +774,11 @@ class TSDataset:
             invalidInputError(not self._has_generate_agg_feature,
                               "Currently to_torch_data_loader does not support "
                               "'gen_global_feature' and 'gen_rolling_feature' methods.")
+            
+            if len(self.df) < self.lookback + self.horizon:
+                invalidInputError(False,
+                                  "The length of the dataset must be larger than 'lookback' plus 'horizon'! ")
+
             torch_dataset = RollDataset(self.df,
                                         dt_col=self.dt_col,
                                         freq=self._freq,

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -781,8 +781,8 @@ class TSDataset:
                 need_dflen = self.lookback + max(self.horizon)
             if len(self.df) < need_dflen:
                 invalidInputError(False,
-                                "The length of the dataset must be larger than "
-                                "'lookback' plus 'horizon'! ")
+                                  "The length of the dataset must be larger than "
+                                  "'lookback' plus 'horizon'! ")
 
             torch_dataset = RollDataset(self.df,
                                         dt_col=self.dt_col,

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -775,10 +775,14 @@ class TSDataset:
                               "Currently to_torch_data_loader does not support "
                               "'gen_global_feature' and 'gen_rolling_feature' methods.")
 
-            if len(self.df) < self.lookback + self.horizon:
+            if isinstance(self.horizon, int):
+                need_dflen = self.lookback + self.horizon
+            else:
+                need_dflen = self.lookback + max(self.horizon)
+            if len(self.df) < need_dflen:
                 invalidInputError(False,
-                                  "The length of the dataset must be larger than "
-                                  "'lookback' plus 'horizon'! ")
+                                "The length of the dataset must be larger than "
+                                "'lookback' plus 'horizon'! ")
 
             torch_dataset = RollDataset(self.df,
                                         dt_col=self.dt_col,

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -774,7 +774,7 @@ class TSDataset:
             invalidInputError(not self._has_generate_agg_feature,
                               "Currently to_torch_data_loader does not support "
                               "'gen_global_feature' and 'gen_rolling_feature' methods.")
-            
+
             if len(self.df) < self.lookback + self.horizon:
                 invalidInputError(False,
                                   "The length of the dataset must be larger than "

--- a/python/chronos/test/bigdl/chronos/data/test_tsdataset.py
+++ b/python/chronos/test/bigdl/chronos/data/test_tsdataset.py
@@ -503,6 +503,16 @@ class TestTSDataset(ZooTestCase):
             assert tuple(y_batch.size()) == (batch_size, horizon, 1)
             break
 
+    def test_tsdataset_to_torch_loader_lessthansample(self):
+        lookback = 96
+        horizon = 48
+        df = pd.DataFrame(np.random.randint(1, 10, size=(100, 1)), columns=["target"])
+        df.insert(0, "datetime", pd.date_range(start="2022-7-22", periods=100, freq="H"))
+        tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="target")
+        with pytest.raises(RuntimeError):
+            tsdata.to_torch_data_loader(roll=True, lookback=lookback, horizon=horizon)
+
+
     def test_tsdata_multi_unscale_numpy_torch_load(self):
         lookback = random.randint(1, 10)
         horizon = random.randint(1, 20)


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

A error message is added to .to_torch_data_loader()

(http://10.112.231.51:18889/view/BigDL-PR-Validation/job/BigDL-Chronos-PR-Validation/616/)