### PR TITLE
[PPML] add read/write json file in python api

### DIFF
--- a/python/ppml/src/bigdl/ppml/README.md
+++ b/python/ppml/src/bigdl/ppml/README.md
@@ -1,6 +1,6 @@
 # PPMLContext For PySpark
 
-This is a tutorial about how to use `PPMLContext` in python to read/write files in multiple formats(csv, parquet etc.). `PPMLContext` provide the ability to save DataFrame as encrypted files and read encrypted files as a plain DataFrame or RDD.
+This is a tutorial about how to use `PPMLContext` in python to read/write files in multiple formats(csv, parquet, json etc.). `PPMLContext` provide the ability to save DataFrame as encrypted files and read encrypted files as a plain DataFrame or RDD.
 
 ### 1.Create a PPMLContext
 
@@ -8,26 +8,11 @@ This is a tutorial about how to use `PPMLContext` in python to read/write files 
 
 So before you read/write files, you need to create a PPMLConext first. 
 
-#### 1.1 create with app_name
-
-if you don't need to read/write encrypted file, you can create a `PPMLContext`with just a `app_name`
-
-Example
-
-```python
-# import
-from bigdl.ppml.ppml_context import *
-
-sc = PPMLContext("MyApp")
-```
-
-if you need to read/write encrypted file, you can use the following 2 ways to create a `PPMLContext`.
-
-#### 1.2 create with app_name & ppml_args
+#### 1.1 create with app_name & ppml_args
 
 `ppml_args` is a dict, you need to provide the following parameters
 
-- `kms_type`: the `KeyManagementService` you use, it can be `SimpleKeyManagementService` or `EHSMKeyManagementService`
+- `kms_type`: the `KeyManagementService` you use, it can be `SimpleKeyManagementService` or `EHSMKeyManagementService`, the default `kms_type` is `SimpleKeyManagementService` 
 
 if the `kms_type` is `SimpleKeyManagementService`, then need
 
@@ -61,29 +46,6 @@ args = {"kms_type": "SimpleKeyManagementService",
        }
 
 sc = PPMLContext("MyApp", args)
-```
-
-#### 1.3 create with app_name & ppml_args & SparkConf
-
-Example
-
-```python
-# import
-from bigdl.ppml.ppml_context import *
-from pyspark import SparkConf
-
-args = {"kms_type": "SimpleKeyManagementService",
-        "simple_app_id": "123456",
-        "simple_app_key": "123456",
-        "primary_key_path": "/your/primary/key/path/primaryKey",
-        "data_key_path": "/your/data/key/path/dataKey"
-       }
-
-# create a SparkConf
-spark_conf = SparkConf()
-spark_conf.setMaster("local[4]")
-
-sc = PPMLContext("MyApp", args, spark_conf)
 ```
 
 ### 2.Read & Write Files
@@ -136,8 +98,8 @@ Example
 df1 = sc.read("plain_text").option("header", "true").csv(plain_csv_path)
 sc.write(df1, "plain_text")
 
-df2 = sc.read("AES_CBC_PKCS5PADDING").option("header", "true").csv(encrypted_csv_path)
-sc.write(df2, "AES_CBC_PKCS5PADDING")
+df2 = sc.read("AES/CBC/PKCS5Padding").option("header", "true").csv(encrypted_csv_path)
+sc.write(df2, "AES/CBC/PKCS5Padding")
 ```
 
 you can use Enum Class `CryptoMode` or just a string interchangeably. 
@@ -181,7 +143,36 @@ sc.write(df2, CryptoMode.AES_GCM_CTR_V1)
 .parquet(encrypted_output_path)
 ```
 
-#### 2.3 textfile
+#### 2.3 json
+
+Example
+
+```python
+# import
+from bigdl.ppml.ppml_context import *
+
+# read a plain json file and return a DataFrame
+plain_json_path = "/plain/json/path"
+df1 = sc.read(CryptoMode.PLAIN_TEXT).json(plain_json_path)
+
+# write a DataFrame as a plain json file
+plain_output_path = "/plain/output/path"
+sc.write(df1, CryptoMode.PLAIN_TEXT)
+.mode('overwrite')
+.json(plain_output_path)
+
+# read a encrypted json file and return a DataFrame
+encrypted_json_path = "/encrypted/parquet/path"
+df2 = sc.read(CryptoMode.AES_CBC_PKCS5PADDING).json(encrypted_json_path)
+
+# write a DataFrame as a encrypted parquet file
+encrypted_output_path = "/encrypted/output/path"
+sc.write(df2, CryptoMode.AES_CBC_PKCS5PADDING)
+.mode('overwrite')
+.json(encrypted_output_path)
+```
+
+#### 2.4 textfile
 
 Example
 

--- a/python/ppml/src/bigdl/ppml/ppml_context.py
+++ b/python/ppml/src/bigdl/ppml/ppml_context.py
@@ -97,6 +97,9 @@ class EncryptedDataFrameReader:
     def parquet(self, path):
         return callBigDlFunc(self.bigdl_type, "parquet", self.df_reader, path)
 
+    def json(self, path):
+        return callBigDlFunc(self.bigdl_type, "json", self.df_reader, path)
+
 
 class EncryptedDataFrameWriter:
     support_mode = {"overwrite", "append", "ignore", "error", "errorifexists"}
@@ -121,6 +124,9 @@ class EncryptedDataFrameWriter:
 
     def parquet(self, path):
         return callBigDlFunc(self.bigdl_type, "parquet", self.df_writer, path)
+
+    def json(self, path):
+        return callBigDlFunc(self.bigdl_type, "json", self.df_writer, path)
 
 
 class CryptoMode(Enum):

--- a/python/ppml/test/bigdl/ppml/test_ppml_context.py
+++ b/python/ppml/test/bigdl/ppml/test_ppml_context.py
@@ -168,6 +168,36 @@ class TestPPMLContext(unittest.TestCase):
         rdd_content = '\n'.join([line for line in rdd.collect()])
         self.assertEqual(rdd_content, "language,user\n" + self.data_content)
 
+    def test_write_and_read_plain_json(self):
+        json_path = os.path.join(resource_path, "json/plain-json")
+        # write as a json
+        self.sc.write(self.df, CryptoMode.PLAIN_TEXT) \
+            .mode('overwrite') \
+            .json(json_path)
+
+        # read from a json
+        df_from_json = self.sc.read(CryptoMode.PLAIN_TEXT) \
+            .json(json_path)
+
+        content = '\n'.join([str(v['language']) + "," + str(v['user'])
+                             for v in df_from_json.orderBy('language').collect()])
+        self.assertEqual(content, self.data_content)
+
+    def test_write_and_read_encrypted_json(self):
+        json_path = os.path.join(resource_path, "json/en-json")
+        # write as a json
+        self.sc.write(self.df, CryptoMode.AES_CBC_PKCS5PADDING) \
+            .mode('overwrite') \
+            .json(json_path)
+
+        # read from a json
+        df_from_json = self.sc.read(CryptoMode.AES_CBC_PKCS5PADDING) \
+            .json(json_path)
+
+        content = '\n'.join([str(v['language']) + "," + str(v['user'])
+                             for v in df_from_json.orderBy('language').collect()])
+        self.assertEqual(content, self.data_content)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/python/PPMLContextPython.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/python/PPMLContextPython.scala
@@ -83,6 +83,11 @@ class PPMLContextPython[T]() {
     encryptedDataFrameReader.parquet(path)
   }
 
+  def json(encryptedDataFrameReader: EncryptedDataFrameReader, path: String): DataFrame = {
+    logger.debug("read json file from path: " + path)
+    encryptedDataFrameReader.json(path)
+  }
+
   /**
    * EncryptedDataFrameWriter method
    */
@@ -108,6 +113,10 @@ class PPMLContextPython[T]() {
 
   def parquet(encryptedDataFrameWriter: EncryptedDataFrameWriter, path: String): Unit = {
     encryptedDataFrameWriter.parquet(path)
+  }
+
+  def json(encryptedDataFrameWriter: EncryptedDataFrameWriter, path: String): Unit = {
+    encryptedDataFrameWriter.json(path)
   }
 
   /**


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->
Add read/write json file function in PPMLContext's python api, and update the document. 

### 1. Why the change?

<!-- Provide the related github issue link if available -->
To support read/write plain or encrypted json file in PPMLContext's python api

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->
Example:

sc represent an initialized PPMLContext
```
from bigdl.ppml.ppml_context import *

# read a plain json file and return a DataFrame
plain_json_path = "/plain/json/path"
df = sc.read(CryptoMode.PLAIN_TEXT).json(plain_json_path)

# write a DataFrame as a plain json file
plain_output_path = "/plain/output/path"
sc.write(df, CryptoMode.PLAIN_TEXT)
.mode('overwrite')
.json(plain_output_path)
```



### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
Add read/write json file function in PPMLContext's python api, and update the document. 
### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...
