### PR TITLE
[Orca] Replace Head Worker in PyTorch Ray Estimator 

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -90,6 +90,7 @@ def partition_refs_to_creator(partition_refs):
 
     return data_creator
 
+
 def get_node_ip():
     """Returns the IP address of the current node."""
     return ray._private.services.get_node_ip_address()

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -90,6 +90,10 @@ def partition_refs_to_creator(partition_refs):
 
     return data_creator
 
+def get_node_ip():
+    """Returns the IP address of the current node."""
+    return ray._private.services.get_node_ip_address()
+
 
 class PyTorchRayEstimator(OrcaRayEstimator):
     def __init__(
@@ -167,7 +171,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                 for i, worker in enumerate(self.remote_workers)
             ])
 
-            driver_ip = ray._private.services.get_node_ip_address()
+            driver_ip = get_node_ip()
             driver_tcp_store_port = find_free_port()
 
             _ = dist.TCPStore(driver_ip, driver_tcp_store_port, -1, True,

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -92,7 +92,11 @@ def partition_refs_to_creator(partition_refs):
 
 
 def get_driver_node_ip():
-    """Returns the IP address of the current node."""
+    """
+    Returns the IP address of the current node.
+
+    :return: the IP address of the current node.
+    """
     return ray._private.services.get_node_ip_address()
 
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -30,6 +30,7 @@ from bigdl.orca.learn.utils import maybe_dataframe_to_xshards, dataframe_to_xsha
 from bigdl.orca.ray import OrcaRayContext
 from bigdl.orca.learn.ray_estimator import Estimator as OrcaRayEstimator
 from bigdl.dllib.utils.file_utils import enable_multi_fs_load, enable_multi_fs_save
+from bigdl.orca.learn.pytorch.utils import find_free_port
 
 import ray
 from ray.exceptions import RayActorError
@@ -166,8 +167,8 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                 for i, worker in enumerate(self.remote_workers)
             ])
 
-            head_worker = self.remote_workers[0]
-            driver_ip, driver_tcp_store_port = ray.get(head_worker.get_node_ip_port.remote())
+            driver_ip = ray._private.services.get_node_ip_address()
+            driver_tcp_store_port = find_free_port()
 
             _ = dist.TCPStore(driver_ip, driver_tcp_store_port, -1, True,
                               dist.constants.default_pg_timeout)

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -91,7 +91,7 @@ def partition_refs_to_creator(partition_refs):
     return data_creator
 
 
-def get_node_ip():
+def get_driver_node_ip():
     """Returns the IP address of the current node."""
     return ray._private.services.get_node_ip_address()
 
@@ -172,7 +172,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                 for i, worker in enumerate(self.remote_workers)
             ])
 
-            driver_ip = get_node_ip()
+            driver_ip = get_driver_node_ip()
             driver_tcp_store_port = find_free_port()
 
             _ = dist.TCPStore(driver_ip, driver_tcp_store_port, -1, True,

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
@@ -29,6 +29,7 @@
 # limitations under the License.
 
 import ray
+from bigdl.orca.learn.pytorch.utils import find_free_port
 from bigdl.orca.learn.pytorch.torch_runner import TorchRunner
 import torch.nn as nn
 from torch.utils.data import IterableDataset
@@ -74,6 +75,15 @@ class PytorchRayWorker(TorchRunner):
         self.size = hvd.size()
         self.setup_components_horovod()
         self.setup_operator(self.models)
+
+    def get_node_ip_port(self):
+        ip = self.get_node_ip()
+        port = find_free_port()
+        return ip, port
+
+    def get_node_ip(self):
+        """Returns the IP address of the current node."""
+        return ray._private.services.get_node_ip_address()
 
     def setup_components_horovod(self):
         import horovod.torch as hvd

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
@@ -29,7 +29,6 @@
 # limitations under the License.
 
 import ray
-from bigdl.orca.learn.pytorch.utils import find_free_port
 from bigdl.orca.learn.pytorch.torch_runner import TorchRunner
 import torch.nn as nn
 from torch.utils.data import IterableDataset
@@ -75,15 +74,6 @@ class PytorchRayWorker(TorchRunner):
         self.size = hvd.size()
         self.setup_components_horovod()
         self.setup_operator(self.models)
-
-    def get_node_ip_port(self):
-        ip = self.get_node_ip()
-        port = find_free_port()
-        return ip, port
-
-    def get_node_ip(self):
-        """Returns the IP address of the current node."""
-        return ray._private.services.get_node_ip_address()
 
     def setup_components_horovod(self):
         import horovod.torch as hvd


### PR DESCRIPTION
## Description

Replace the head worker with the current client node.

### 1. Why the change?

To fix https://github.com/intel-analytics/BigDL/issues/5192. Users may get errors when there are existing ray clusters in Yarn cluster.

### 2. User API changes

N/A

### 3. Summary of the change 
1. Remove head worker processing in `pytorch_ray_worker`.
2. Use the `node_ip_address` and `free_port` in the client node (instead of the original head worker) to create TCPStore (server).  

### 4. How to test?
- [x] Unit test
- [x] Application test on Yarn Client / Cluster
- [x] Application test on K8s Client / Cluster.

