### PR TITLE
[DLlib] XGBoost Criteo example update

### DIFF
--- a/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/README.md
+++ b/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/README.md
@@ -168,7 +168,7 @@ Parameters:
 * -d means max_depth: Int.
 * -w means num_workers: Int.
 
-**Note: make sure num_threads is larger than spark.task.cpus.**
+**Note: make sure num_threads is no larger than spark.task.cpus.**
 
 #### Source code
 You can find source code [here](https://github.com/intel-analytics/BigDL/tree/main/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/nnframes/xgboost).

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/nnframes/xgboost/README.md
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/nnframes/xgboost/README.md
@@ -48,7 +48,7 @@ parameters:
 - num_round : Int 
 - path_to_model_to_be_saved : String
 
-**note: make sure num_threads is larger than spark.task.cpus.**
+**note: make sure num_threads is no larger than spark.task.cpus.**
 
 # XGBoostClassifier Predict Example
 ## Run:

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/nnframes/xgboost/xgbClassifierTrainingExampleOnCriteoClickLogsDataset.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/nnframes/xgboost/xgbClassifierTrainingExampleOnCriteoClickLogsDataset.scala
@@ -155,7 +155,7 @@ object xgbClassifierTrainingExampleOnCriteoClickLogsDataset {
     xgbClassificationModel.save(modelSavePath)
 
     val tAfterSave = System.nanoTime()
-    ealsped = (tAfterSave - tAfterTraining) / 1000000000.0f // second
+    elapsed = (tAfterSave - tAfterTraining) / 1000000000.0f // second
     log.info("--model save time is " + elapsed + "s")
  
     sc.stop()

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/nnframes/xgboost/xgbClassifierTrainingExampleOnCriteoClickLogsDataset.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/nnframes/xgboost/xgbClassifierTrainingExampleOnCriteoClickLogsDataset.scala
@@ -60,7 +60,6 @@ object xgbClassifierTrainingExampleOnCriteoClickLogsDataset {
   val feature_nums = 39
 
   def main(args: Array[String]): Unit = {
-    val tStart = System.nanoTime()
     val log: Logger = LoggerFactory.getLogger(this.getClass)
 
 
@@ -78,6 +77,7 @@ object xgbClassifierTrainingExampleOnCriteoClickLogsDataset {
     val spark = SQLContext.getOrCreate(sc)
     val task = new Task()
 
+    val tStart = System.nanoTime()
     // read csv files to dataframe
     var df = spark.read.option("header", "false").
       option("inferSchema", "true").option("delimiter", "\t").csv(trainingDataPath)
@@ -147,12 +147,17 @@ object xgbClassifierTrainingExampleOnCriteoClickLogsDataset {
 
     // start training model
     val xgbClassificationModel = xgbClassifier.fit(train)
-    xgbClassificationModel.save(modelSavePath)
 
     val tAfterTraining = System.nanoTime()
     elapsed = (tAfterTraining - tBeforeTraining) / 1000000000.0f // second
     log.info("--training time is " + elapsed + "s")
 
+    xgbClassificationModel.save(modelSavePath)
+
+    val tAfterSave = System.nanoTime()
+    ealsped = (tAfterSave - tAfterTraining) / 1000000000.0f // second
+    log.info("--model save time is " + elapsed + "s")
+ 
     sc.stop()
   }
 


### PR DESCRIPTION
## Description

1. Update timing in example 
2. Update XGBoost example README

### 1. Why the change?

1. For more accurate time breakdown between phases
2. `nthread` should be no larger than `spark.task.cpus` according to https://github.com/dmlc/xgboost/blob/34408a7fdcebc0e32142ed2f52156ea65d813400/jvm-packages/xgboost4j-spark/src/main/scala/ml/dmlc/xgboost4j/scala/spark/XGBoost.scala#L138

### 2. User API changes

None

### 3. Summary of the change 

Modify data read time and add model save time, modify README

### 4. How to test?
- [ ] Application test
- [ ] Document test
- [ ] ...

