### PR TITLE
Orca: set conf to None when using spark-submit

### DIFF
--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -252,7 +252,7 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=2, memory="2g", 
                 from bigdl.dllib.nncontext import init_nncontext
                 if "conf" in spark_args and spark_args["conf"] is not None:
                     warnings.warn("For spark-submit cluster_mode, all conf should be "
-                                  + "specified in the spark-submit command , but got "
+                                  + "specified in the spark-submit command, but got "
                                   + repr(spark_args["conf"]) + ", ignored", Warning)
                     spark_args["conf"] = None
                 sc = init_nncontext(**spark_args)

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -251,7 +251,8 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=2, memory="2g", 
             elif cluster_mode == "spark-submit":
                 from bigdl.dllib.nncontext import init_nncontext
                 if "conf" in spark_args and spark_args["conf"] is not None:
-                    warnings.warn("For Spark-submit mode, conf should be None, but got "
+                    warnings.warn("For spark-submit cluster_mode, all conf should be "
+                                  + "specified in the spark-submit command , but got "
                                   + repr(spark_args["conf"]) + ", ignored", Warning)
                     spark_args["conf"] = None
                 sc = init_nncontext(**spark_args)

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -252,7 +252,7 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=2, memory="2g", 
                 from bigdl.dllib.nncontext import init_nncontext
                 if "conf" in spark_args and spark_args["conf"] is not None:
                     warnings.warn("For Spark-submit mode, conf should be None, but got "
-                                  + repr(spark_args["conf"] + ", ignored", Warning)
+                                  + repr(spark_args["conf"]) + ", ignored", Warning)
                     spark_args["conf"] = None
                 sc = init_nncontext(**spark_args)
             elif cluster_mode.startswith("yarn"):  # yarn, yarn-client or yarn-cluster

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -250,7 +250,7 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=2, memory="2g", 
                 sc = init_spark_on_local(cores, **spark_args)
             elif cluster_mode == "spark-submit":
                 from bigdl.dllib.nncontext import init_nncontext
-                if "conf" in spark_args:
+                if "conf" in spark_args and spark_args["conf"] is not None:
                     warnings.warn("For Spark-submit mode, conf should be None, but got "
                                   + repr(spark_args["conf"] + ", ignored", Warning)
                     spark_args["conf"] = None

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -250,6 +250,10 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=2, memory="2g", 
                 sc = init_spark_on_local(cores, **spark_args)
             elif cluster_mode == "spark-submit":
                 from bigdl.dllib.nncontext import init_nncontext
+                if "conf" in spark_args:
+                    warnings.warn("For Spark-submit mode, conf should be None, but got "
+                                  + repr(spark_args["conf"] + ", ignored", Warning)
+                    spark_args["conf"] = None
                 sc = init_nncontext(**spark_args)
             elif cluster_mode.startswith("yarn"):  # yarn, yarn-client or yarn-cluster
                 hadoop_conf = os.environ.get("HADOOP_CONF_DIR")


### PR DESCRIPTION
## Description
This PR is to fix the issues report by customers when using spark-submit to submit tasks. If we use `conf` in `init_orca_context`, the `conf` will not be convert to `SparkConf` when using spark-submit and lead to exception. In this PR, we check the `conf`  before using it as `SparkConf` to avoid `no attribute 'getAll()'` exception.