### PR TITLE
[Nano] Integrate ipynb files into ReadtheDocs

### DIFF
--- a/docs/readthedocs/requirements-doc.txt
+++ b/docs/readthedocs/requirements-doc.txt
@@ -11,7 +11,7 @@ cloudpickle==2.1.0
 ray[tune]==1.9.2
 ray==1.9.2
 torch==1.9.0
-Pygments==2.3.1
+Pygments==2.6.1
 setuptools==41.0.1
 docutils==0.17
 mock==1.0.1
@@ -37,3 +37,4 @@ optuna==2.10.0
 ConfigSpace==0.5.0
 sphinx-design==0.2.0
 sphinx-external-toc==0.3.0
+nbsphinx==0.8.9

--- a/docs/readthedocs/source/conf.py
+++ b/docs/readthedocs/source/conf.py
@@ -92,6 +92,7 @@ extensions = [
     'sphinx_tabs.tabs',
     'sphinx_design',
     'sphinx_external_toc',
+    'nbsphinx'
 ]
 
 

--- a/docs/readthedocs/source/conf.py
+++ b/docs/readthedocs/source/conf.py
@@ -245,3 +245,6 @@ def setup(app):
         'enable_auto_doc_ref': True,
     }, True)
     app.add_transform(AutoStructify)
+
+# disable notebook execution
+nbsphinx_execute = 'never'

--- a/docs/readthedocs/source/doc/Nano/QuickStart/index.md
+++ b/docs/readthedocs/source/doc/Nano/QuickStart/index.md
@@ -48,9 +48,7 @@
 
 ---------------------------
 
-
-- [**BigDL-Nano Hyperparameter Tuning (Tensorflow Sequential/Functional API) Quickstart**](./pytorch_quantization_openvino.html)
-
+- [**BigDL-Nano Hyperparameter Tuning (Tensorflow Sequential/Functional API) Quickstart**](../Tutorials/seq_and_func.html)
 
     > ![](../../../../image/colab_logo_32px.png)[Run in Google Colab][Nano_hpo_tf_seq_func_colab] &nbsp;![](../../../../image/GitHub-Mark-32px.png)[View source on GitHub][Nano_hpo_tf_seq_func]
 
@@ -60,7 +58,7 @@
 
 ---------------------------
 
-- [**BigDL-Nano Hyperparameter Tuning (Tensorflow Subclassing Model) Quickstart**](./pytorch_quantization_openvino.html)
+- [**BigDL-Nano Hyperparameter Tuning (Tensorflow Subclassing Model) Quickstart**](../Tutorials/custom.html)
 
     > ![](../../../../image/colab_logo_32px.png)[Run in Google Colab][Nano_hpo_tf_subclassing_colab] &nbsp;![](../../../../image/GitHub-Mark-32px.png)[View source on GitHub][Nano_hpo_tf_subclassing]
 

--- a/docs/readthedocs/source/doc/Nano/Tutorials/custom.ipynb
+++ b/docs/readthedocs/source/doc/Nano/Tutorials/custom.ipynb
@@ -24,7 +24,7 @@
         "id": "rICdZgjQBfUl"
       },
       "source": [
-        "# Introduction\n",
+        "# BigDL-Nano Hyperparameter Tuning (Tensorflow Subclassing Model) Quickstart\n",
         "In this notebook we demonstrates how to use Nano HPO to tune the hyperparameters in tensorflow training. The model is built by subclassing tensorflow.keras.Model.\n"
       ]
     },
@@ -34,7 +34,7 @@
         "id": "XZHU5E3ABfUm"
       },
       "source": [
-        "# Step0: Prepare Environment\n",
+        "## Step 0: Prepare Environment\n",
         "You can install the latest pre-release version with nano support using below commands.\n",
         "\n",
         "We recommend to run below commands, especially `source bigdl-nano-init` before jupyter kernel is started, or some of the optimizations may not take effect."
@@ -82,7 +82,7 @@
         "id": "xKKCHTU9BfUn"
       },
       "source": [
-        "# Step1: Init Nano AutoML\n",
+        "## Step 1: Init Nano AutoML\n",
         "We need to enable Nano HPO before we use it for tensorflow training."
       ]
     },
@@ -109,7 +109,7 @@
         "id": "3InpJGOuBfUp"
       },
       "source": [
-        "# Step2: Prepare data\n",
+        "## Step 2: Prepare data\n",
         "We use fashion MNIST dataset for demonstration."
       ]
     },
@@ -141,7 +141,7 @@
         "id": "hwrtVD9yBfUq"
       },
       "source": [
-        "# Step3: Build model and specify search spaces\n",
+        "## Step 3: Build model and specify search spaces\n",
         "We now create our model. \n",
         "\n",
         "Decorate the model class with hpo.tfmodel, and you will be able to specify search spaces in init arguments when creating the model, as shown below. For more details, refer to [user doc](https://bigdl.readthedocs.io/en/latest/doc/Nano/QuickStart/hpo.html).\n"
@@ -211,7 +211,7 @@
         "id": "msSa9fyeGHTU"
       },
       "source": [
-        "# Step4: Compile model\n",
+        "## Step 4: Compile model\n",
         "We now compile our model with loss function, optimizer and metrics. If you want to tune learning rate and batch size, refer to [user guide](https://bigdl.readthedocs.io/en/latest/doc/Nano/QuickStart/hpo.html#search-the-learning-rate)."
       ]
     },
@@ -237,7 +237,7 @@
         "id": "tuZXTIjXBfUs"
       },
       "source": [
-        "# Step5: Run hyperparameter search\n",
+        "## Step 5: Run hyperparameter search\n",
         "Run hyperparameter search by calling `model.search`. Set the `target_metric` and `direction` so that HPO optimizes the `target_metric` in the specified `direction`. Each trial will use a different set of hyperparameters in the search space range. Use `n_parallels` to set the nubmer of parallel processes to run trials. After search completes, you can use `search_summary` to retrive the search results for analysis. For more details, refer to [user doc](https://bigdl.readthedocs.io/en/latest/doc/Nano/QuickStart/hpo.html)."
       ]
     },
@@ -308,7 +308,7 @@
         "id": "NVDG1hl-BfUt"
       },
       "source": [
-        "# Step 6: fit with the best hyperparameters\n",
+        "## Step 6: fit with the best hyperparameters\n",
         "After search, `model.fit` will autotmatically use the best hyperparmeters found in search to fit the model."
       ]
     },
@@ -354,6 +354,13 @@
       "outputs": [],
       "source": [
         "print(model.summary())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "You can find the running output from [here](https://github.com/intel-analytics/BigDL/blob/main/python/nano/notebooks/hpo/custom.ipynb), or run the notebook by yourself in [Google Colab](https://colab.research.google.com/github/intel-analytics/BigDL/blob/main/python/nano/notebooks/hpo/custom.ipynb)."
       ]
     }
   ],

--- a/docs/readthedocs/source/doc/Nano/Tutorials/custom.ipynb
+++ b/docs/readthedocs/source/doc/Nano/Tutorials/custom.ipynb
@@ -50,84 +50,7 @@
         "id": "3UyXJWA4Cjx2",
         "outputId": "4518ce08-cfc8-4f6c-c40c-01006ffabc81"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
-            "Requirement already satisfied: bigdl-nano[tensorflow] in /usr/local/lib/python3.7/dist-packages (2.1.0b20220613)\n",
-            "Requirement already satisfied: cloudpickle in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (1.3.0)\n",
-            "Requirement already satisfied: intel-openmp in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (2022.1.0)\n",
-            "Requirement already satisfied: protobuf==3.20.1 in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (3.20.1)\n",
-            "Requirement already satisfied: keras==2.7.0 in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (2.7.0)\n",
-            "Requirement already satisfied: intel-tensorflow==2.7.0 in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (2.7.0)\n",
-            "Requirement already satisfied: tensorflow-estimator==2.7.0 in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (2.7.0)\n",
-            "Requirement already satisfied: keras-preprocessing>=1.1.1 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.1.2)\n",
-            "Requirement already satisfied: tensorflow-io-gcs-filesystem>=0.21.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.26.0)\n",
-            "Requirement already satisfied: tensorboard~=2.6 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2.8.0)\n",
-            "Requirement already satisfied: six>=1.12.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.15.0)\n",
-            "Requirement already satisfied: typing-extensions>=3.6.6 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (4.2.0)\n",
-            "Requirement already satisfied: termcolor>=1.1.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.1.0)\n",
-            "Requirement already satisfied: astunparse>=1.6.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.6.3)\n",
-            "Requirement already satisfied: wheel<1.0,>=0.32.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.37.1)\n",
-            "Requirement already satisfied: libclang>=9.0.1 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (14.0.1)\n",
-            "Requirement already satisfied: h5py>=2.9.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.1.0)\n",
-            "Requirement already satisfied: gast<0.5.0,>=0.2.1 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.4.0)\n",
-            "Requirement already satisfied: google-pasta>=0.1.1 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.2.0)\n",
-            "Requirement already satisfied: wrapt>=1.11.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.14.1)\n",
-            "Requirement already satisfied: absl-py>=0.4.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.1.0)\n",
-            "Requirement already satisfied: numpy>=1.14.5 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.21.6)\n",
-            "Requirement already satisfied: opt-einsum>=2.3.2 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.3.0)\n",
-            "Requirement already satisfied: flatbuffers<3.0,>=1.12 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2.0)\n",
-            "Requirement already satisfied: grpcio<2.0,>=1.24.3 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.46.3)\n",
-            "Requirement already satisfied: cached-property in /usr/local/lib/python3.7/dist-packages (from h5py>=2.9.0->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.5.2)\n",
-            "Requirement already satisfied: setuptools>=41.0.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (58.0.4)\n",
-            "Requirement already satisfied: markdown>=2.6.8 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.3.7)\n",
-            "Requirement already satisfied: tensorboard-plugin-wit>=1.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.8.1)\n",
-            "Requirement already satisfied: google-auth<3,>=1.6.3 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.35.0)\n",
-            "Requirement already satisfied: tensorboard-data-server<0.7.0,>=0.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.6.1)\n",
-            "Requirement already satisfied: requests<3,>=2.21.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2.23.0)\n",
-            "Requirement already satisfied: werkzeug>=0.11.15 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.0.1)\n",
-            "Requirement already satisfied: google-auth-oauthlib<0.5,>=0.4.1 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.4.6)\n",
-            "Requirement already satisfied: rsa<5,>=3.1.4 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (4.8)\n",
-            "Requirement already satisfied: cachetools<5.0,>=2.0.0 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (4.2.4)\n",
-            "Requirement already satisfied: pyasn1-modules>=0.2.1 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.2.8)\n",
-            "Requirement already satisfied: requests-oauthlib>=0.7.0 in /usr/local/lib/python3.7/dist-packages (from google-auth-oauthlib<0.5,>=0.4.1->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.3.1)\n",
-            "Requirement already satisfied: importlib-metadata>=4.4 in /usr/local/lib/python3.7/dist-packages (from markdown>=2.6.8->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (4.11.4)\n",
-            "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata>=4.4->markdown>=2.6.8->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.8.0)\n",
-            "Requirement already satisfied: pyasn1<0.5.0,>=0.4.6 in /usr/local/lib/python3.7/dist-packages (from pyasn1-modules>=0.2.1->google-auth<3,>=1.6.3->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.4.8)\n",
-            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2022.5.18.1)\n",
-            "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.24.3)\n",
-            "Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2.10)\n",
-            "Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.0.4)\n",
-            "Requirement already satisfied: oauthlib>=3.0.0 in /usr/local/lib/python3.7/dist-packages (from requests-oauthlib>=0.7.0->google-auth-oauthlib<0.5,>=0.4.1->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.2.0)\n",
-            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
-            "Requirement already satisfied: setuptools==58.0.4 in /usr/local/lib/python3.7/dist-packages (58.0.4)\n",
-            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
-            "Requirement already satisfied: protobuf==3.20.1 in /usr/local/lib/python3.7/dist-packages (3.20.1)\n",
-            "conda dir found: /usr/local/bin/..\n",
-            "OpenMP library found...\n",
-            "Setting OMP_NUM_THREADS...\n",
-            "Setting OMP_NUM_THREADS specified for pytorch...\n",
-            "Setting KMP_AFFINITY...\n",
-            "Setting KMP_BLOCKTIME...\n",
-            "Setting MALLOC_CONF...\n",
-            "Not in a conda env\n",
-            "+++++ Env Variables +++++\n",
-            "LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4\n",
-            "MALLOC_CONF=\n",
-            "OMP_NUM_THREADS=1\n",
-            "KMP_AFFINITY=granularity=fine,compact,1,0\n",
-            "KMP_BLOCKTIME=1\n",
-            "TF_ENABLE_ONEDNN_OPTS=1\n",
-            "ENABLE_TF_OPTS=1\n",
-            "NANO_TF_INTER_OP=1\n",
-            "+++++++++++++++++++++++++\n",
-            "Complete.\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "# Install latest pre-release version of bigdl-nano\n",
         "!pip install --pre bigdl-nano[tensorflow]\n",
@@ -146,77 +69,7 @@
         "id": "phw-whHaCnpR",
         "outputId": "b517e45c-c98a-4b12-820b-a1a8009fc5aa"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
-            "Collecting ConfigSpace\n",
-            "  Downloading ConfigSpace-0.5.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (4.7 MB)\n",
-            "\u001b[K     |████████████████████████████████| 4.7 MB 4.2 MB/s \n",
-            "\u001b[?25hRequirement already satisfied: scipy in /usr/local/lib/python3.7/dist-packages (from ConfigSpace) (1.4.1)\n",
-            "Requirement already satisfied: cython in /usr/local/lib/python3.7/dist-packages (from ConfigSpace) (0.29.30)\n",
-            "Requirement already satisfied: pyparsing in /usr/local/lib/python3.7/dist-packages (from ConfigSpace) (3.0.9)\n",
-            "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from ConfigSpace) (1.21.6)\n",
-            "Installing collected packages: ConfigSpace\n",
-            "Successfully installed ConfigSpace-0.5.0\n",
-            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
-            "Collecting optuna\n",
-            "  Downloading optuna-2.10.1-py3-none-any.whl (308 kB)\n",
-            "\u001b[K     |████████████████████████████████| 308 kB 5.2 MB/s \n",
-            "\u001b[?25hRequirement already satisfied: sqlalchemy>=1.1.0 in /usr/local/lib/python3.7/dist-packages (from optuna) (1.4.37)\n",
-            "Requirement already satisfied: scipy!=1.4.0 in /usr/local/lib/python3.7/dist-packages (from optuna) (1.4.1)\n",
-            "Collecting cmaes>=0.8.2\n",
-            "  Downloading cmaes-0.8.2-py3-none-any.whl (15 kB)\n",
-            "Collecting alembic\n",
-            "  Downloading alembic-1.8.0-py3-none-any.whl (209 kB)\n",
-            "\u001b[K     |████████████████████████████████| 209 kB 15.7 MB/s \n",
-            "\u001b[?25hRequirement already satisfied: packaging>=20.0 in /usr/local/lib/python3.7/dist-packages (from optuna) (21.3)\n",
-            "Collecting colorlog\n",
-            "  Downloading colorlog-6.6.0-py2.py3-none-any.whl (11 kB)\n",
-            "Collecting cliff\n",
-            "  Downloading cliff-3.10.1-py3-none-any.whl (81 kB)\n",
-            "\u001b[K     |████████████████████████████████| 81 kB 8.4 MB/s \n",
-            "\u001b[?25hRequirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from optuna) (1.21.6)\n",
-            "Requirement already satisfied: PyYAML in /usr/local/lib/python3.7/dist-packages (from optuna) (3.13)\n",
-            "Requirement already satisfied: tqdm in /usr/local/lib/python3.7/dist-packages (from optuna) (4.64.0)\n",
-            "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /usr/local/lib/python3.7/dist-packages (from packaging>=20.0->optuna) (3.0.9)\n",
-            "Requirement already satisfied: greenlet!=0.4.17 in /usr/local/lib/python3.7/dist-packages (from sqlalchemy>=1.1.0->optuna) (1.1.2)\n",
-            "Requirement already satisfied: importlib-metadata in /usr/local/lib/python3.7/dist-packages (from sqlalchemy>=1.1.0->optuna) (4.11.4)\n",
-            "Collecting Mako\n",
-            "  Downloading Mako-1.2.0-py3-none-any.whl (78 kB)\n",
-            "\u001b[K     |████████████████████████████████| 78 kB 6.7 MB/s \n",
-            "\u001b[?25hRequirement already satisfied: importlib-resources in /usr/local/lib/python3.7/dist-packages (from alembic->optuna) (5.7.1)\n",
-            "Requirement already satisfied: PrettyTable>=0.7.2 in /usr/local/lib/python3.7/dist-packages (from cliff->optuna) (3.3.0)\n",
-            "Collecting cmd2>=1.0.0\n",
-            "  Downloading cmd2-2.4.1-py3-none-any.whl (146 kB)\n",
-            "\u001b[K     |████████████████████████████████| 146 kB 39.7 MB/s \n",
-            "\u001b[?25hCollecting pbr!=2.1.0,>=2.0.0\n",
-            "  Downloading pbr-5.9.0-py2.py3-none-any.whl (112 kB)\n",
-            "\u001b[K     |████████████████████████████████| 112 kB 41.2 MB/s \n",
-            "\u001b[?25hCollecting stevedore>=2.0.1\n",
-            "  Downloading stevedore-3.5.0-py3-none-any.whl (49 kB)\n",
-            "\u001b[K     |████████████████████████████████| 49 kB 3.1 MB/s \n",
-            "\u001b[?25hCollecting autopage>=0.4.0\n",
-            "  Downloading autopage-0.5.1-py3-none-any.whl (29 kB)\n",
-            "Requirement already satisfied: attrs>=16.3.0 in /usr/local/lib/python3.7/dist-packages (from cmd2>=1.0.0->cliff->optuna) (21.4.0)\n",
-            "Requirement already satisfied: wcwidth>=0.1.7 in /usr/local/lib/python3.7/dist-packages (from cmd2>=1.0.0->cliff->optuna) (0.2.5)\n",
-            "Collecting pyperclip>=1.6\n",
-            "  Downloading pyperclip-1.8.2.tar.gz (20 kB)\n",
-            "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.7/dist-packages (from cmd2>=1.0.0->cliff->optuna) (4.2.0)\n",
-            "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata->sqlalchemy>=1.1.0->optuna) (3.8.0)\n",
-            "Requirement already satisfied: MarkupSafe>=0.9.2 in /usr/local/lib/python3.7/dist-packages (from Mako->alembic->optuna) (2.0.1)\n",
-            "Building wheels for collected packages: pyperclip\n",
-            "  Building wheel for pyperclip (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
-            "  Created wheel for pyperclip: filename=pyperclip-1.8.2-py3-none-any.whl size=11137 sha256=0a54c6970643d24a9797d28c73e10b1865935286e27caf04e9aec71f751622fb\n",
-            "  Stored in directory: /root/.cache/pip/wheels/9f/18/84/8f69f8b08169c7bae2dde6bd7daf0c19fca8c8e500ee620a28\n",
-            "Successfully built pyperclip\n",
-            "Installing collected packages: pyperclip, pbr, stevedore, Mako, cmd2, autopage, colorlog, cmaes, cliff, alembic, optuna\n",
-            "Successfully installed Mako-1.2.0 alembic-1.8.0 autopage-0.5.1 cliff-3.10.1 cmaes-0.8.2 cmd2-2.4.1 colorlog-6.6.0 optuna-2.10.1 pbr-5.9.0 pyperclip-1.8.2 stevedore-3.5.0\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "# Install other dependecies for Nano HPO\n",
         "!pip install ConfigSpace\n",
@@ -237,24 +90,13 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "gF1XGVtuBfUn",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "gF1XGVtuBfUn",
         "outputId": "c610c446-328d-43e4-e701-51fe180aef1f"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.7/dist-packages/bigdl/nano/tf/__init__.py:24: UserWarning: NANO_TF_INTER_OP not found the in os.environ, please run `source bigdl-nano-init`\n",
-            "  warnings.warn(\"NANO_TF_INTER_OP not found the in os.environ, \"\n",
-            "/usr/local/lib/python3.7/dist-packages/bigdl/nano/tf/__init__.py:30: UserWarning: OMP_NUM_THREADS not found the in os.environ, please run `source bigdl-nano-init`\n",
-            "  warnings.warn(\"OMP_NUM_THREADS not found the in os.environ, \"\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "import bigdl.nano.automl as automl\n",
         "import bigdl.nano.automl.hpo as hpo\n",
@@ -275,31 +117,13 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "A4AjqFBTBfUp",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "A4AjqFBTBfUp",
         "outputId": "d80596f1-98e4-4358-a583-706e24c3da0c"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/train-labels-idx1-ubyte.gz\n",
-            "32768/29515 [=================================] - 0s 0us/step\n",
-            "40960/29515 [=========================================] - 0s 0us/step\n",
-            "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/train-images-idx3-ubyte.gz\n",
-            "26427392/26421880 [==============================] - 0s 0us/step\n",
-            "26435584/26421880 [==============================] - 0s 0us/step\n",
-            "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/t10k-labels-idx1-ubyte.gz\n",
-            "16384/5148 [===============================================================================================] - 0s 0us/step\n",
-            "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/t10k-images-idx3-ubyte.gz\n",
-            "4423680/4422102 [==============================] - 0s 0us/step\n",
-            "4431872/4422102 [==============================] - 0s 0us/step\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "from tensorflow import keras\n",
         "(x_train, y_train), (x_test, y_test) = keras.datasets.fashion_mnist.load_data()\n",
@@ -427,136 +251,7 @@
         "id": "hfBS_1JLBfUs",
         "outputId": "897ac4d1-5766-44f2-d6fb-ed7b2a437b9e"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "\u001b[32m[I 2022-06-14 07:51:36,119]\u001b[0m A new study created in memory with name: no-name-0cbf0f2d-5fc7-4245-b792-924ec2e250b3\u001b[0m\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Starting a new tuning\n",
-            "Epoch 1/5\n",
-            "375/375 - 8s - loss: 0.6107 - accuracy: 0.7830 - val_loss: 0.4149 - val_accuracy: 0.8488 - 8s/epoch - 21ms/step\n",
-            "Epoch 2/5\n",
-            "375/375 - 7s - loss: 0.4329 - accuracy: 0.8438 - val_loss: 0.3630 - val_accuracy: 0.8681 - 7s/epoch - 20ms/step\n",
-            "Epoch 3/5\n",
-            "375/375 - 7s - loss: 0.3931 - accuracy: 0.8575 - val_loss: 0.3471 - val_accuracy: 0.8729 - 7s/epoch - 19ms/step\n",
-            "Epoch 4/5\n",
-            "375/375 - 7s - loss: 0.3746 - accuracy: 0.8635 - val_loss: 0.3524 - val_accuracy: 0.8694 - 7s/epoch - 20ms/step\n",
-            "Epoch 5/5\n",
-            "375/375 - 7s - loss: 0.3621 - accuracy: 0.8695 - val_loss: 0.3197 - val_accuracy: 0.8828 - 7s/epoch - 20ms/step\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "\u001b[32m[I 2022-06-14 07:52:13,425]\u001b[0m Trial 0 finished with value: 0.8828333616256714 and parameters: {'activation▁choice': 1, 'filters▁choice': 0, 'kernel_size▁choice': 0, 'strides▁choice': 1}. Best is trial 0 with value: 0.8828333616256714.\u001b[0m\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 1/5\n",
-            "375/375 - 20s - loss: 0.5215 - accuracy: 0.8151 - val_loss: 0.3636 - val_accuracy: 0.8669 - 20s/epoch - 54ms/step\n",
-            "Epoch 2/5\n",
-            "375/375 - 19s - loss: 0.3665 - accuracy: 0.8678 - val_loss: 0.3334 - val_accuracy: 0.8804 - 19s/epoch - 51ms/step\n",
-            "Epoch 3/5\n",
-            "375/375 - 21s - loss: 0.3218 - accuracy: 0.8844 - val_loss: 0.3105 - val_accuracy: 0.8883 - 21s/epoch - 56ms/step\n",
-            "Epoch 4/5\n",
-            "375/375 - 20s - loss: 0.2968 - accuracy: 0.8934 - val_loss: 0.2860 - val_accuracy: 0.8981 - 20s/epoch - 53ms/step\n",
-            "Epoch 5/5\n",
-            "375/375 - 20s - loss: 0.2775 - accuracy: 0.9004 - val_loss: 0.2837 - val_accuracy: 0.8985 - 20s/epoch - 52ms/step\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "\u001b[32m[I 2022-06-14 07:54:35,924]\u001b[0m Trial 1 finished with value: 0.8985000252723694 and parameters: {'activation▁choice': 1, 'filters▁choice': 0, 'kernel_size▁choice': 1, 'strides▁choice': 0}. Best is trial 1 with value: 0.8985000252723694.\u001b[0m\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 1/5\n",
-            "375/375 - 48s - loss: 0.5305 - accuracy: 0.8119 - val_loss: 0.3556 - val_accuracy: 0.8729 - 48s/epoch - 129ms/step\n",
-            "Epoch 2/5\n",
-            "375/375 - 47s - loss: 0.3542 - accuracy: 0.8737 - val_loss: 0.3045 - val_accuracy: 0.8907 - 47s/epoch - 126ms/step\n",
-            "Epoch 3/5\n",
-            "375/375 - 46s - loss: 0.3124 - accuracy: 0.8877 - val_loss: 0.3179 - val_accuracy: 0.8847 - 46s/epoch - 124ms/step\n",
-            "Epoch 4/5\n",
-            "375/375 - 49s - loss: 0.2881 - accuracy: 0.8961 - val_loss: 0.2718 - val_accuracy: 0.9040 - 49s/epoch - 131ms/step\n",
-            "Epoch 5/5\n",
-            "375/375 - 49s - loss: 0.2751 - accuracy: 0.9022 - val_loss: 0.2714 - val_accuracy: 0.9026 - 49s/epoch - 130ms/step\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "\u001b[32m[I 2022-06-14 07:58:58,425]\u001b[0m Trial 2 finished with value: 0.9039999842643738 and parameters: {'activation▁choice': 0, 'filters▁choice': 1, 'kernel_size▁choice': 0, 'strides▁choice': 0}. Best is trial 2 with value: 0.9039999842643738.\u001b[0m\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 1/5\n",
-            "375/375 - 8s - loss: 0.6889 - accuracy: 0.7514 - val_loss: 0.4607 - val_accuracy: 0.8334 - 8s/epoch - 22ms/step\n",
-            "Epoch 2/5\n",
-            "375/375 - 8s - loss: 0.4777 - accuracy: 0.8277 - val_loss: 0.4082 - val_accuracy: 0.8466 - 8s/epoch - 21ms/step\n",
-            "Epoch 3/5\n",
-            "375/375 - 8s - loss: 0.4279 - accuracy: 0.8452 - val_loss: 0.3585 - val_accuracy: 0.8677 - 8s/epoch - 21ms/step\n",
-            "Epoch 4/5\n",
-            "375/375 - 8s - loss: 0.3988 - accuracy: 0.8556 - val_loss: 0.3470 - val_accuracy: 0.8720 - 8s/epoch - 22ms/step\n",
-            "Epoch 5/5\n",
-            "375/375 - 8s - loss: 0.3828 - accuracy: 0.8623 - val_loss: 0.3363 - val_accuracy: 0.8742 - 8s/epoch - 23ms/step\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "\u001b[32m[I 2022-06-14 07:59:39,921]\u001b[0m Trial 3 finished with value: 0.8741666674613953 and parameters: {'activation▁choice': 0, 'filters▁choice': 0, 'kernel_size▁choice': 0, 'strides▁choice': 1}. Best is trial 2 with value: 0.9039999842643738.\u001b[0m\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 1/5\n",
-            "375/375 - 7s - loss: 0.6287 - accuracy: 0.7717 - val_loss: 0.4239 - val_accuracy: 0.8471 - 7s/epoch - 18ms/step\n",
-            "Epoch 2/5\n",
-            "375/375 - 6s - loss: 0.4369 - accuracy: 0.8427 - val_loss: 0.3693 - val_accuracy: 0.8633 - 6s/epoch - 17ms/step\n",
-            "Epoch 3/5\n",
-            "375/375 - 6s - loss: 0.3940 - accuracy: 0.8570 - val_loss: 0.3435 - val_accuracy: 0.8772 - 6s/epoch - 16ms/step\n",
-            "Epoch 4/5\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "\u001b[32m[I 2022-06-14 08:00:05,357]\u001b[0m Trial 4 pruned. Trial was pruned at epoch 3.\u001b[0m\n"
-          ]
-        },
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "CPU times: user 10min 38s, sys: 3min 45s, total: 14min 23s\n",
-            "Wall time: 8min 29s\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "%%time\n",
         "from bigdl.nano.automl.hpo.backend import PrunerType\n",
@@ -585,23 +280,7 @@
         "id": "jeK1hT42HCD5",
         "outputId": "204acc43-94db-4cb8-f058-46c02e43c6ab"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Number of finished trials: 5\n",
-            "Best trial:\n",
-            "  Value: 0.9039999842643738\n",
-            "  Params: \n",
-            "    activation▁choice: 0\n",
-            "    filters▁choice: 1\n",
-            "    kernel_size▁choice: 0\n",
-            "    strides▁choice: 0\n",
-            "<optuna.study.study.Study object at 0x7f82ae603a90>\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "print(model.search_summary())"
       ]
@@ -617,206 +296,7 @@
         "id": "n_vwMwJVLaCc",
         "outputId": "8996e8ac-5ced-4cfb-c454-de4df5860012"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Number of finished trials: 5\n",
-            "Best trial:\n",
-            "  Value: 0.9039999842643738\n",
-            "  Params: \n",
-            "    activation▁choice: 0\n",
-            "    filters▁choice: 1\n",
-            "    kernel_size▁choice: 0\n",
-            "    strides▁choice: 0\n"
-          ]
-        },
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "   number     value  params_activation▁choice  params_filters▁choice  \\\n",
-              "0       0  0.882833                         1                      0   \n",
-              "1       1  0.898500                         1                      0   \n",
-              "2       2  0.904000                         0                      1   \n",
-              "3       3  0.874167                         0                      0   \n",
-              "4       4  0.876833                         1                      0   \n",
-              "\n",
-              "   params_kernel_size▁choice  params_strides▁choice     state  \n",
-              "0                          0                      1  COMPLETE  \n",
-              "1                          1                      0  COMPLETE  \n",
-              "2                          0                      0  COMPLETE  \n",
-              "3                          0                      1  COMPLETE  \n",
-              "4                          1                      1    PRUNED  "
-            ],
-            "text/html": [
-              "\n",
-              "  <div id=\"df-a8488958-932e-4400-ba28-9cf8d867650e\">\n",
-              "    <div class=\"colab-df-container\">\n",
-              "      <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>number</th>\n",
-              "      <th>value</th>\n",
-              "      <th>params_activation▁choice</th>\n",
-              "      <th>params_filters▁choice</th>\n",
-              "      <th>params_kernel_size▁choice</th>\n",
-              "      <th>params_strides▁choice</th>\n",
-              "      <th>state</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>0</td>\n",
-              "      <td>0.882833</td>\n",
-              "      <td>1</td>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>1</td>\n",
-              "      <td>COMPLETE</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>1</td>\n",
-              "      <td>0.898500</td>\n",
-              "      <td>1</td>\n",
-              "      <td>0</td>\n",
-              "      <td>1</td>\n",
-              "      <td>0</td>\n",
-              "      <td>COMPLETE</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>2</td>\n",
-              "      <td>0.904000</td>\n",
-              "      <td>0</td>\n",
-              "      <td>1</td>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>COMPLETE</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>3</th>\n",
-              "      <td>3</td>\n",
-              "      <td>0.874167</td>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>1</td>\n",
-              "      <td>COMPLETE</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>4</th>\n",
-              "      <td>4</td>\n",
-              "      <td>0.876833</td>\n",
-              "      <td>1</td>\n",
-              "      <td>0</td>\n",
-              "      <td>1</td>\n",
-              "      <td>1</td>\n",
-              "      <td>PRUNED</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n",
-              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-a8488958-932e-4400-ba28-9cf8d867650e')\"\n",
-              "              title=\"Convert this dataframe to an interactive table.\"\n",
-              "              style=\"display:none;\">\n",
-              "        \n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "       width=\"24px\">\n",
-              "    <path d=\"M0 0h24v24H0V0z\" fill=\"none\"/>\n",
-              "    <path d=\"M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z\"/><path d=\"M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z\"/>\n",
-              "  </svg>\n",
-              "      </button>\n",
-              "      \n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      flex-wrap:wrap;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "      <script>\n",
-              "        const buttonEl =\n",
-              "          document.querySelector('#df-a8488958-932e-4400-ba28-9cf8d867650e button.colab-df-convert');\n",
-              "        buttonEl.style.display =\n",
-              "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "        async function convertToInteractive(key) {\n",
-              "          const element = document.querySelector('#df-a8488958-932e-4400-ba28-9cf8d867650e');\n",
-              "          const dataTable =\n",
-              "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                     [key], {});\n",
-              "          if (!dataTable) return;\n",
-              "\n",
-              "          const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "            '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "            + ' to learn more about interactive tables.';\n",
-              "          element.innerHTML = '';\n",
-              "          dataTable['output_type'] = 'display_data';\n",
-              "          await google.colab.output.renderOutput(dataTable, element);\n",
-              "          const docLink = document.createElement('div');\n",
-              "          docLink.innerHTML = docLinkHtml;\n",
-              "          element.appendChild(docLink);\n",
-              "        }\n",
-              "      </script>\n",
-              "    </div>\n",
-              "  </div>\n",
-              "  "
-            ]
-          },
-          "metadata": {},
-          "execution_count": 10
-        }
-      ],
+      "outputs": [],
       "source": [
         "study = model.search_summary()\n",
         "study.trials_dataframe(attrs=(\"number\", \"value\", \"params\", \"state\"))"
@@ -842,27 +322,7 @@
         "id": "aAet3uX5BfUt",
         "outputId": "2401cd38-09a6-4251-b459-c97e64d89cc9"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Epoch 1/5\n",
-            "375/375 [==============================] - 53s 140ms/step - loss: 0.5348 - accuracy: 0.8099 - val_loss: 0.3566 - val_accuracy: 0.8759\n",
-            "Epoch 2/5\n",
-            "375/375 [==============================] - 51s 136ms/step - loss: 0.3535 - accuracy: 0.8741 - val_loss: 0.3114 - val_accuracy: 0.8878\n",
-            "Epoch 3/5\n",
-            "375/375 [==============================] - 51s 137ms/step - loss: 0.3144 - accuracy: 0.8880 - val_loss: 0.2905 - val_accuracy: 0.8950\n",
-            "Epoch 4/5\n",
-            "375/375 [==============================] - 53s 140ms/step - loss: 0.2916 - accuracy: 0.8949 - val_loss: 0.2910 - val_accuracy: 0.8966\n",
-            "Epoch 5/5\n",
-            "375/375 [==============================] - 52s 138ms/step - loss: 0.2762 - accuracy: 0.9020 - val_loss: 0.2787 - val_accuracy: 0.8998\n",
-            "313/313 - 3s - loss: 0.2913 - accuracy: 0.8927 - 3s/epoch - 8ms/step\n",
-            "Test loss: 0.2913445234298706\n",
-            "Test accuracy: 0.8927000164985657\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "history = model.fit(x_train, y_train,\n",
         "                    batch_size=128, epochs=5, validation_split=0.2)\n",
@@ -891,39 +351,7 @@
         "id": "d8O_cz4DBfUu",
         "outputId": "dd7d6add-a32c-4618-dc88-d19bec8e4c3e"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Model: \"my_model_1\"\n",
-            "_________________________________________________________________\n",
-            " Layer (type)                Output Shape              Param #   \n",
-            "=================================================================\n",
-            " conv2d_1 (Conv2D)           multiple                  320       \n",
-            "                                                                 \n",
-            " max_pooling2d_1 (MaxPooling  multiple                 0         \n",
-            " 2D)                                                             \n",
-            "                                                                 \n",
-            " dropout_2 (Dropout)         multiple                  0         \n",
-            "                                                                 \n",
-            " flatten_1 (Flatten)         multiple                  0         \n",
-            "                                                                 \n",
-            " dense_2 (Dense)             multiple                  2769152   \n",
-            "                                                                 \n",
-            " dropout_3 (Dropout)         multiple                  0         \n",
-            "                                                                 \n",
-            " dense_3 (Dense)             multiple                  2570      \n",
-            "                                                                 \n",
-            "=================================================================\n",
-            "Total params: 2,772,042\n",
-            "Trainable params: 2,772,042\n",
-            "Non-trainable params: 0\n",
-            "_________________________________________________________________\n",
-            "None\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "print(model.summary())"
       ]

--- a/docs/readthedocs/source/doc/Nano/Tutorials/custom.ipynb
+++ b/docs/readthedocs/source/doc/Nano/Tutorials/custom.ipynb
@@ -1,0 +1,958 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "yzsDlbsUBsuF"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/intel-analytics/BigDL/blob/main/python/nano/notebooks/hpo/custom.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "zcHLkcVjB7Jg"
+      },
+      "source": [
+        "![image.png](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJsAAABHCAMAAAAnQ8XqAAAACXBIWXMAAA7DAAAOwwHHb6hkAAADAFBMVEVHcEyAgYR+gYU0OD85OTuOkZSChYk5OTs5OTs5OTuAgYR/gYM5OTuAgYSAgYSBgoWAgoU5OTs+NTg5OTs4ODs5OTsAccQ1NTk3Nzo4ODuBg4U4ODs5OTs4ODs5OTuRlJY6OjwAccM4ODs5OTs3Nzo4ODuBgoQ3Nzo4OTo3NzqSlJc5OTsBccOAgYSRlJeRk5Y5OTs5OTs5OTs4ODuPkpQ4ODo4ODs5OTs5OTs4ODuRlJeSlJeJio4BccM5OTsDbrw4ODuPkpU4ODuVmJs4ODsBccOTlpk2Njo3OTwBccOSlZiUmJo5OTs5OTs5OTyPkZSRk5eTlpk5OTw4ODs5OTw2Njk5OTuRlJeUl5pzi6EAccM5OTsBcMM4ODs4ODs4ODs4ODs4ODs5OTs4ODuAgYSAgYM4ODs4ODuTl5kBccM4ODo4ODs4ODs5OTs4ODs5OTs5OTuSlJc4ODs4ODs5OTs4ODuAgYSRk5aFh4o4ODucn6I4ODs4ODv7/P4BccM5OTuAgoVDQ0c4ODsBccM4ODtFf7ABcMM5OTuTlZh/goM4ODqAgYSFhomnrK4jTnCDhYeAgYUCb744OTyChIc4ODsAcMI5OTsBccM5OTt/gYSChIeFh4paW15/gYOChIcDbrs5OTv///+AgYT+/v6IiYw6OjyBgoX9/f47Oz09PT99foF+f4KDhIc5OTw8PD88PD73+Pj9/v6Oj5KCg4Z/gIMBccOJio1/gYTq6us7Oz56e3719fU6Oj2AgYV8fYCAgoR4eXzm5ud7fH/7+/s9PUDs7Ozh4uLi4uOCg4W2triJio6RkpTq6+s+PkCOj5F5en2RkpXs7O2HiIz8/P2Gh4qDhIgBdMj09PX5+fn29vaPkJP29/cBcsW1treKi46XmJvT1NV3eHs4ODqEhYh8fIDf3+Dp6emjpKYBccTb29zOz9A/P0HDw8WdnqCUlZjz8/O+v8Hv7/Dx8fGysrSvr7F9foJzdHiqq60Bdcv+/v/HyMm2t7nGxsien6Hj4+S3t7nLBRsYAAAAoHRSTlMA+wMC/QEC/vz7nyP6+nL7oAIBBFHrAQovQgQZ1xA/PAP+OvIHYnISoA438Pz+KDPv+d+EDBR/pveBMCUFI+c+Sg+tByH9HAicJCsi2S3+CRYSHCklOEo/Ggb02xjUorKptvFb/J0xZSD6dJErwpXkbkJHactLmEcjRAvQiQMZ0qkMV/I0DiG8TiId+NMuBMn7E5u0efzF5LlkvllplbYvkV0hXwAADA1JREFUaN7MmXtUFNcdx6867OyY9dTl4QPFRYNH3FjeKoLaoIgK8oqgMa2KWo3G+k7qqWliEnPS1qbtSWPb056ednZwhtmF3W1lhYC7LCIx+ABSwdpo1CiN2hiNzyRt/2jvvTM7O6996Dnafs/CDDNz3I/f3/397u/eAeB/qRgs8H8lJdDcgqp1o3T0mE2S/Tlz2cxn80vS0pdaLemzacqo1eMPW05FRUWxNc8CofLW5xflLCsHcQk86VSLpR+XS+W7youK0/Ks1nRLcXpxUWVluezm6wksQWr1iF2KqSwqKsmzQJcseSVF6ysSDYbgPZE/FrJ5CVqrR2LS3IKCyvz0NKt1qTU9Py+/MidnZshEEHx7JGyJiYmBrywvLy9Ky0+zbrNuy1uanl9UVJE4eLBwL9YwU1CiSgYppo/It1de2fVsSVHx+vySosqKuQ/xDzwKthhQMXz48N+9/fYv/vDuu6+tXbv2+1BDhw4dHqWGvvZbEPMwbCMMIwIK9YgBPHG8qal/YGCgv79//wVBTcebjsNPE/o0NQknslPxvAk9dOrD18DgSGyxgh7ct58MGzTsu1CDoIY9sH7avxYYovbNHGcOnL66cNZCpFkL3xocku0JxvdNphGqC/90oV9cI8dxjEJcoyj0WPDyoP1DRTY+JFtc0mSsIQIfCih45zfXNkxB2jDvubfAiJBsjK+5Ham3vV089va2djgYf6OMr7Vdutve69Fh0/dt4vJNm8auzkB6avevV04bB0AyYnv1uY8PCrr2q4Xh2Dz9d4+dP3b+PPo5duzY3XtfXb1x8WxDW3sr0xWw7d5/8H381N0GBOeLhi37Ou/mWUG8227nl4+Dzo0A39lzbd54pHkHN8wKw8Y5ztba1Ko9d/vTz284WruQdz5Pwx3ZvSP766P1bZo910iIMhopytjCTwTJiO3j8di28QenhGFr5up7Dtn66pQSKD642osI/EzDFemJPtsX++s50biIbN0mp3AKD2QZTVKssxT8PFo26NuBc7ZarerqoJ23OhjI4Wk4aasLXLcdEtiY6NgUF0ja5N4EhkTP1obYtFFFeLW2W72Y7T1bXeA6ZHNEw3ZZh40lSSMPE0LLZk5OjtUdb3psGAO6dKOV45pVbNA3z4P4RpI0ZSLQARpn34jZhFwYL+SCUPfM8BBrRnXaHGuWxVSGU4uZhL/qbJ+2cT4cU+mJM/vr/dHGtFP0jbR3wydIeGJs2Q1L756DU+YhTRmP2GBdKd2+vRAXGPmcpWTDJzK42tp/XuzgGAVbcLz55Gx6vaXIRpLs5n1ZuDyTBJswBryz5+u/Cvr62iyYG6NfNrrcuTWQLnvVHKSVqfMBYruv8K3v9hfYPpGtzna3vdGjjanGN6MWrUxiI/gqUIp9g5zedSD2j9+StCwWxHtbyiiK7ly9OC632+1yudyd9CTMVq9g+8vAqat3gn/X2T6/1OhR++YXSm+QLSNQYWXyXpaxvQnAi24jjYNaDYYoRv2kDN4EhyKZ6c5ag6ogRZnojCSgHW8nGc+X92x14oXaPttnlxqYSL6ZJ4wep9bo6t9LuUDw6wBYaacwm3siSMlO/eUCQal7wQv2TEhWRtJGNhd7S5Psk3ps73Nc28XAeEO+fdKqjalPxabfsf5M5htcq64S2CjX8+D1LddddixXZykyFBGh0uwkhcALbH7O0aNkY9pu2mxBtn+0qWrIGa1vMP3VSgY7c2Rs1ZDNJbGNXM5mUlgmZ9X8DJhIqC6TLE+UqdgOqNk+PCJdgEXE4Q+Vp8ygU6F8M4D0PCCxoTjKfRs5ljcKtYX07i2FFRmfO3N3s4qYNuuwnZCzHfVwzac1uRAxpjnbYPVUsom+uXdAtpYAGz/mB52U8FDLDlDjpshw441xKHw7CrsO9XiLgs2C1tYSmwuyrXSJubBE7hs/ZrRd5MndC/a5IrEpfPvAo5lP6xlVDdHO02n5aJETyFPMhmsILHtsqS4bwcK6sSYCm1853g77GE19i5inBRZ8gL6Rglc7QLyTJC+TNMFnzQfz5TGV2J6aBLYr2Joj+XaYYZofuIZYcvBhRmCud24Z62RRMhK517NBbEqQzatgeykCG6fyjWMizln6EQVgn+Ab+jKexHXC270pBYAU3ZhCtqcjxJRT5imMKaMdb2F9y7EIaCCeJ4Q5lCaMZbhVyppmhh2RjM0bhk3rm08z3nTy1IfTIUR92xnY/4oXKj7uyVFXTj8JcyIujG9LlL51aecF1XjzMRHnBUXVteaJtoH4lgCb2Max3uXVsEuL0jcm0rxw2K/1LWwulG+TTuN5oxRTEve9Rrf3aZQLIdiWPGAN4ZjmELng12GLCeSowjfS62ZxU05ntuAaEhWbp1E73tQ1JPR8qmEzgPy04CXJNzbrRQrCwZnTabLDPuThYnpSE1N17Q0/3nYFclTmG55PS7cITTllXxnRN4JdPVlgi5QLTKhc4DRsiogq2cAcYT6FE8OQuEgxpel1+mwObX2LMqaw6qbJbFOyZQs9EpzTnwGRai/JToiq9sKVfYhcaNb4lmNRBFiHDbZp9JtgUbRsPZHm02h7JFVEQ7DR5Ch9NtiHIDYWT8CIrbnr/oGI4+10VDE1gGKr0kaJzSVng2Npkd54Wz016Btm82vyVFNDfJ4ofZu7U1WGlb65RDaiVMEW6HtpulrqQ8SYNkbukaKb62OAtSAsm+ib0f0S+HaQ7ZnqFkLMzQkq3zzc/Qhzlg4bJ/a935CxxYCSYhATmY02da6RsxXuzWTJAPM0e9g89XGR2XR9K7doGhJd30ydbyjYxuQ68cRG8C/PyOBJOmwN6bhZq1hnaedTv0/DBiNaqbZNmrMoezZsgnV9YxeDLF5YnxJeOyuunUOx+TqC63rM5lflQpOH44Rd/iAbjqghhG+0qXszAKmib5Rd7hv7PbQZIQw4ghL6gcB40/PtqrQfgtbO9ZyS7cxAq6PNAcXJfdOJaDCmps6NIF4MnaqGwFXXVrwfgiufkQ7rW0PDl/8O7tXgPQflXP/RxZ4TJ86ePdEj8w1W3YLQbLCvSFjkFbcP4QX5vAB9mzybN6HFIW0k3bRivPnlbH+2vdd76cIVicSG9mpUvtX+CemjuqP1Uv8Gq266XnMe7N94niDE76VNVXK2xQBsZ3kTEs9nz8b/gxC+nfvXJ4ekvUFxj0vOFtziPFwf9K38x7qLezEXULQI0ikMJcK7JU7Wh0C2ODA6AW8qJbwBxN1Ncbw1yudT4aRWvsd1S71vKW7xy9gMwFIBYsLEVL5koFyr5P0bYksBSc8vWJC6NQnEKdnUe9HovYKEBhG+6lWwBYMtscWA9Xn6S+hSwSsZGUln2rfK+14U0+CbwtgAG46pcg2oecdg+1uPQ5ELOmxg5tIQ24OFQrkSw4pEZLqzUsB8af+NclYlrZg+fXpNTc2c1MmgcLU43pzVGt9UaLYjts/aG5nwvulWXZGNokySEImRtdPb4Tpry3W3y4U+7u7Cwha7C+9gOpNAFYU3+mH/OUZYy/TovpdBrvXZ7lxwcEwo33CeJoaMKABVnXaZ3C43n/GjUXB9GvfDOdNF1UydnODE3JneGVM34gEK82X2SNG3Q7Y6PUHg9292NKJ3Rlc0b+P6Ar6BZUtDvteemhrUio07XlgzYSoAZvVTu4XVP0nzTl44oewrYPbid0Z1Nn3dvjXw90YPZDt9W+fuSZEtZER1ZTar9oeTwWY7LL1OXGcIPCxp6r9bHwZx2+p7L/8dQwXHj7188Ofu3zUHtoBqzWXbNz84eOw4Kjh28NXqRROWCDDoyeMeKmcQRgYKCgqCmEsKFBgkd3Kyg+e6wCQoKx9xYhACzxnp6h7ahQHO7zr/cNeWzUBJMDi06xA62HVIV5dxSSpDB6WrU4QYZhyxAI9IrIUMTwCzsimDECtDJ2MKIyM/LsAIAzhku6/M1XNjoHBtniBDV/7ZBTyQCWoOTp6lZ6ODgKEJDLclhMAlPFKXzvV744lRoh1nOsnwyPo9oEn9netWKmdrQiYEHfnU+EAIBKAUH7KAGp+aGpoAisrZ1FhzBMwewVPajUTt7OyqzQu6sGTlAQRCoHBSMQUCcO6AZRgmygAblVwnqCAIYwjRJTgAjNdLil1g3K4AAAAASUVORK5CYII=)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "rICdZgjQBfUl"
+      },
+      "source": [
+        "# Introduction\n",
+        "In this notebook we demonstrates how to use Nano HPO to tune the hyperparameters in tensorflow training. The model is built by subclassing tensorflow.keras.Model.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "XZHU5E3ABfUm"
+      },
+      "source": [
+        "# Step0: Prepare Environment\n",
+        "You can install the latest pre-release version with nano support using below commands.\n",
+        "\n",
+        "We recommend to run below commands, especially `source bigdl-nano-init` before jupyter kernel is started, or some of the optimizations may not take effect."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "3UyXJWA4Cjx2",
+        "outputId": "4518ce08-cfc8-4f6c-c40c-01006ffabc81"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
+            "Requirement already satisfied: bigdl-nano[tensorflow] in /usr/local/lib/python3.7/dist-packages (2.1.0b20220613)\n",
+            "Requirement already satisfied: cloudpickle in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (1.3.0)\n",
+            "Requirement already satisfied: intel-openmp in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (2022.1.0)\n",
+            "Requirement already satisfied: protobuf==3.20.1 in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (3.20.1)\n",
+            "Requirement already satisfied: keras==2.7.0 in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (2.7.0)\n",
+            "Requirement already satisfied: intel-tensorflow==2.7.0 in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (2.7.0)\n",
+            "Requirement already satisfied: tensorflow-estimator==2.7.0 in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (2.7.0)\n",
+            "Requirement already satisfied: keras-preprocessing>=1.1.1 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.1.2)\n",
+            "Requirement already satisfied: tensorflow-io-gcs-filesystem>=0.21.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.26.0)\n",
+            "Requirement already satisfied: tensorboard~=2.6 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2.8.0)\n",
+            "Requirement already satisfied: six>=1.12.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.15.0)\n",
+            "Requirement already satisfied: typing-extensions>=3.6.6 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (4.2.0)\n",
+            "Requirement already satisfied: termcolor>=1.1.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.1.0)\n",
+            "Requirement already satisfied: astunparse>=1.6.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.6.3)\n",
+            "Requirement already satisfied: wheel<1.0,>=0.32.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.37.1)\n",
+            "Requirement already satisfied: libclang>=9.0.1 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (14.0.1)\n",
+            "Requirement already satisfied: h5py>=2.9.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.1.0)\n",
+            "Requirement already satisfied: gast<0.5.0,>=0.2.1 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.4.0)\n",
+            "Requirement already satisfied: google-pasta>=0.1.1 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.2.0)\n",
+            "Requirement already satisfied: wrapt>=1.11.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.14.1)\n",
+            "Requirement already satisfied: absl-py>=0.4.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.1.0)\n",
+            "Requirement already satisfied: numpy>=1.14.5 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.21.6)\n",
+            "Requirement already satisfied: opt-einsum>=2.3.2 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.3.0)\n",
+            "Requirement already satisfied: flatbuffers<3.0,>=1.12 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2.0)\n",
+            "Requirement already satisfied: grpcio<2.0,>=1.24.3 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.46.3)\n",
+            "Requirement already satisfied: cached-property in /usr/local/lib/python3.7/dist-packages (from h5py>=2.9.0->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.5.2)\n",
+            "Requirement already satisfied: setuptools>=41.0.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (58.0.4)\n",
+            "Requirement already satisfied: markdown>=2.6.8 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.3.7)\n",
+            "Requirement already satisfied: tensorboard-plugin-wit>=1.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.8.1)\n",
+            "Requirement already satisfied: google-auth<3,>=1.6.3 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.35.0)\n",
+            "Requirement already satisfied: tensorboard-data-server<0.7.0,>=0.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.6.1)\n",
+            "Requirement already satisfied: requests<3,>=2.21.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2.23.0)\n",
+            "Requirement already satisfied: werkzeug>=0.11.15 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.0.1)\n",
+            "Requirement already satisfied: google-auth-oauthlib<0.5,>=0.4.1 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.4.6)\n",
+            "Requirement already satisfied: rsa<5,>=3.1.4 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (4.8)\n",
+            "Requirement already satisfied: cachetools<5.0,>=2.0.0 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (4.2.4)\n",
+            "Requirement already satisfied: pyasn1-modules>=0.2.1 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.2.8)\n",
+            "Requirement already satisfied: requests-oauthlib>=0.7.0 in /usr/local/lib/python3.7/dist-packages (from google-auth-oauthlib<0.5,>=0.4.1->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.3.1)\n",
+            "Requirement already satisfied: importlib-metadata>=4.4 in /usr/local/lib/python3.7/dist-packages (from markdown>=2.6.8->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (4.11.4)\n",
+            "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata>=4.4->markdown>=2.6.8->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.8.0)\n",
+            "Requirement already satisfied: pyasn1<0.5.0,>=0.4.6 in /usr/local/lib/python3.7/dist-packages (from pyasn1-modules>=0.2.1->google-auth<3,>=1.6.3->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.4.8)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2022.5.18.1)\n",
+            "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.24.3)\n",
+            "Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2.10)\n",
+            "Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.0.4)\n",
+            "Requirement already satisfied: oauthlib>=3.0.0 in /usr/local/lib/python3.7/dist-packages (from requests-oauthlib>=0.7.0->google-auth-oauthlib<0.5,>=0.4.1->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.2.0)\n",
+            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
+            "Requirement already satisfied: setuptools==58.0.4 in /usr/local/lib/python3.7/dist-packages (58.0.4)\n",
+            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
+            "Requirement already satisfied: protobuf==3.20.1 in /usr/local/lib/python3.7/dist-packages (3.20.1)\n",
+            "conda dir found: /usr/local/bin/..\n",
+            "OpenMP library found...\n",
+            "Setting OMP_NUM_THREADS...\n",
+            "Setting OMP_NUM_THREADS specified for pytorch...\n",
+            "Setting KMP_AFFINITY...\n",
+            "Setting KMP_BLOCKTIME...\n",
+            "Setting MALLOC_CONF...\n",
+            "Not in a conda env\n",
+            "+++++ Env Variables +++++\n",
+            "LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4\n",
+            "MALLOC_CONF=\n",
+            "OMP_NUM_THREADS=1\n",
+            "KMP_AFFINITY=granularity=fine,compact,1,0\n",
+            "KMP_BLOCKTIME=1\n",
+            "TF_ENABLE_ONEDNN_OPTS=1\n",
+            "ENABLE_TF_OPTS=1\n",
+            "NANO_TF_INTER_OP=1\n",
+            "+++++++++++++++++++++++++\n",
+            "Complete.\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Install latest pre-release version of bigdl-nano\n",
+        "!pip install --pre bigdl-nano[tensorflow]\n",
+        "!pip install setuptools==58.0.4\n",
+        "!pip install protobuf==3.20.1\n",
+        "!source bigdl-nano-init"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "phw-whHaCnpR",
+        "outputId": "b517e45c-c98a-4b12-820b-a1a8009fc5aa"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
+            "Collecting ConfigSpace\n",
+            "  Downloading ConfigSpace-0.5.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (4.7 MB)\n",
+            "\u001b[K     |████████████████████████████████| 4.7 MB 4.2 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: scipy in /usr/local/lib/python3.7/dist-packages (from ConfigSpace) (1.4.1)\n",
+            "Requirement already satisfied: cython in /usr/local/lib/python3.7/dist-packages (from ConfigSpace) (0.29.30)\n",
+            "Requirement already satisfied: pyparsing in /usr/local/lib/python3.7/dist-packages (from ConfigSpace) (3.0.9)\n",
+            "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from ConfigSpace) (1.21.6)\n",
+            "Installing collected packages: ConfigSpace\n",
+            "Successfully installed ConfigSpace-0.5.0\n",
+            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
+            "Collecting optuna\n",
+            "  Downloading optuna-2.10.1-py3-none-any.whl (308 kB)\n",
+            "\u001b[K     |████████████████████████████████| 308 kB 5.2 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: sqlalchemy>=1.1.0 in /usr/local/lib/python3.7/dist-packages (from optuna) (1.4.37)\n",
+            "Requirement already satisfied: scipy!=1.4.0 in /usr/local/lib/python3.7/dist-packages (from optuna) (1.4.1)\n",
+            "Collecting cmaes>=0.8.2\n",
+            "  Downloading cmaes-0.8.2-py3-none-any.whl (15 kB)\n",
+            "Collecting alembic\n",
+            "  Downloading alembic-1.8.0-py3-none-any.whl (209 kB)\n",
+            "\u001b[K     |████████████████████████████████| 209 kB 15.7 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: packaging>=20.0 in /usr/local/lib/python3.7/dist-packages (from optuna) (21.3)\n",
+            "Collecting colorlog\n",
+            "  Downloading colorlog-6.6.0-py2.py3-none-any.whl (11 kB)\n",
+            "Collecting cliff\n",
+            "  Downloading cliff-3.10.1-py3-none-any.whl (81 kB)\n",
+            "\u001b[K     |████████████████████████████████| 81 kB 8.4 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from optuna) (1.21.6)\n",
+            "Requirement already satisfied: PyYAML in /usr/local/lib/python3.7/dist-packages (from optuna) (3.13)\n",
+            "Requirement already satisfied: tqdm in /usr/local/lib/python3.7/dist-packages (from optuna) (4.64.0)\n",
+            "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /usr/local/lib/python3.7/dist-packages (from packaging>=20.0->optuna) (3.0.9)\n",
+            "Requirement already satisfied: greenlet!=0.4.17 in /usr/local/lib/python3.7/dist-packages (from sqlalchemy>=1.1.0->optuna) (1.1.2)\n",
+            "Requirement already satisfied: importlib-metadata in /usr/local/lib/python3.7/dist-packages (from sqlalchemy>=1.1.0->optuna) (4.11.4)\n",
+            "Collecting Mako\n",
+            "  Downloading Mako-1.2.0-py3-none-any.whl (78 kB)\n",
+            "\u001b[K     |████████████████████████████████| 78 kB 6.7 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: importlib-resources in /usr/local/lib/python3.7/dist-packages (from alembic->optuna) (5.7.1)\n",
+            "Requirement already satisfied: PrettyTable>=0.7.2 in /usr/local/lib/python3.7/dist-packages (from cliff->optuna) (3.3.0)\n",
+            "Collecting cmd2>=1.0.0\n",
+            "  Downloading cmd2-2.4.1-py3-none-any.whl (146 kB)\n",
+            "\u001b[K     |████████████████████████████████| 146 kB 39.7 MB/s \n",
+            "\u001b[?25hCollecting pbr!=2.1.0,>=2.0.0\n",
+            "  Downloading pbr-5.9.0-py2.py3-none-any.whl (112 kB)\n",
+            "\u001b[K     |████████████████████████████████| 112 kB 41.2 MB/s \n",
+            "\u001b[?25hCollecting stevedore>=2.0.1\n",
+            "  Downloading stevedore-3.5.0-py3-none-any.whl (49 kB)\n",
+            "\u001b[K     |████████████████████████████████| 49 kB 3.1 MB/s \n",
+            "\u001b[?25hCollecting autopage>=0.4.0\n",
+            "  Downloading autopage-0.5.1-py3-none-any.whl (29 kB)\n",
+            "Requirement already satisfied: attrs>=16.3.0 in /usr/local/lib/python3.7/dist-packages (from cmd2>=1.0.0->cliff->optuna) (21.4.0)\n",
+            "Requirement already satisfied: wcwidth>=0.1.7 in /usr/local/lib/python3.7/dist-packages (from cmd2>=1.0.0->cliff->optuna) (0.2.5)\n",
+            "Collecting pyperclip>=1.6\n",
+            "  Downloading pyperclip-1.8.2.tar.gz (20 kB)\n",
+            "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.7/dist-packages (from cmd2>=1.0.0->cliff->optuna) (4.2.0)\n",
+            "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata->sqlalchemy>=1.1.0->optuna) (3.8.0)\n",
+            "Requirement already satisfied: MarkupSafe>=0.9.2 in /usr/local/lib/python3.7/dist-packages (from Mako->alembic->optuna) (2.0.1)\n",
+            "Building wheels for collected packages: pyperclip\n",
+            "  Building wheel for pyperclip (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for pyperclip: filename=pyperclip-1.8.2-py3-none-any.whl size=11137 sha256=0a54c6970643d24a9797d28c73e10b1865935286e27caf04e9aec71f751622fb\n",
+            "  Stored in directory: /root/.cache/pip/wheels/9f/18/84/8f69f8b08169c7bae2dde6bd7daf0c19fca8c8e500ee620a28\n",
+            "Successfully built pyperclip\n",
+            "Installing collected packages: pyperclip, pbr, stevedore, Mako, cmd2, autopage, colorlog, cmaes, cliff, alembic, optuna\n",
+            "Successfully installed Mako-1.2.0 alembic-1.8.0 autopage-0.5.1 cliff-3.10.1 cmaes-0.8.2 cmd2-2.4.1 colorlog-6.6.0 optuna-2.10.1 pbr-5.9.0 pyperclip-1.8.2 stevedore-3.5.0\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Install other dependecies for Nano HPO\n",
+        "!pip install ConfigSpace\n",
+        "!pip install optuna"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xKKCHTU9BfUn"
+      },
+      "source": [
+        "# Step1: Init Nano AutoML\n",
+        "We need to enable Nano HPO before we use it for tensorflow training."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "gF1XGVtuBfUn",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "c610c446-328d-43e4-e701-51fe180aef1f"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/bigdl/nano/tf/__init__.py:24: UserWarning: NANO_TF_INTER_OP not found the in os.environ, please run `source bigdl-nano-init`\n",
+            "  warnings.warn(\"NANO_TF_INTER_OP not found the in os.environ, \"\n",
+            "/usr/local/lib/python3.7/dist-packages/bigdl/nano/tf/__init__.py:30: UserWarning: OMP_NUM_THREADS not found the in os.environ, please run `source bigdl-nano-init`\n",
+            "  warnings.warn(\"OMP_NUM_THREADS not found the in os.environ, \"\n"
+          ]
+        }
+      ],
+      "source": [
+        "import bigdl.nano.automl as automl\n",
+        "import bigdl.nano.automl.hpo as hpo\n",
+        "automl.hpo_config.enable_hpo_tf()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3InpJGOuBfUp"
+      },
+      "source": [
+        "# Step2: Prepare data\n",
+        "We use fashion MNIST dataset for demonstration."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "A4AjqFBTBfUp",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "d80596f1-98e4-4358-a583-706e24c3da0c"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/train-labels-idx1-ubyte.gz\n",
+            "32768/29515 [=================================] - 0s 0us/step\n",
+            "40960/29515 [=========================================] - 0s 0us/step\n",
+            "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/train-images-idx3-ubyte.gz\n",
+            "26427392/26421880 [==============================] - 0s 0us/step\n",
+            "26435584/26421880 [==============================] - 0s 0us/step\n",
+            "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/t10k-labels-idx1-ubyte.gz\n",
+            "16384/5148 [===============================================================================================] - 0s 0us/step\n",
+            "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/t10k-images-idx3-ubyte.gz\n",
+            "4423680/4422102 [==============================] - 0s 0us/step\n",
+            "4431872/4422102 [==============================] - 0s 0us/step\n"
+          ]
+        }
+      ],
+      "source": [
+        "from tensorflow import keras\n",
+        "(x_train, y_train), (x_test, y_test) = keras.datasets.fashion_mnist.load_data()\n",
+        "\n",
+        "CLASSES = 10\n",
+        "\n",
+        "img_x, img_y = x_train.shape[1], x_train.shape[2]\n",
+        "x_train = x_train.reshape(-1, img_x, img_y,1).astype(\"float32\") / 255\n",
+        "x_test = x_test.reshape(-1, img_x, img_y,1).astype(\"float32\") / 255"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "hwrtVD9yBfUq"
+      },
+      "source": [
+        "# Step3: Build model and specify search spaces\n",
+        "We now create our model. \n",
+        "\n",
+        "Decorate the model class with hpo.tfmodel, and you will be able to specify search spaces in init arguments when creating the model, as shown below. For more details, refer to [user doc](https://bigdl.readthedocs.io/en/latest/doc/Nano/QuickStart/hpo.html).\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "uRFIRllGr0xu"
+      },
+      "outputs": [],
+      "source": [
+        "import tensorflow as tf\n",
+        "from tensorflow.keras.datasets import mnist\n",
+        "from tensorflow.keras.layers import Conv2D, Dropout, MaxPooling2D\n",
+        "from tensorflow.keras.layers import Dense\n",
+        "from tensorflow.keras.layers import Flatten"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "SNmZHFMMBfUr"
+      },
+      "outputs": [],
+      "source": [
+        "import tensorflow as tf\n",
+        "@hpo.tfmodel()\n",
+        "class MyModel(tf.keras.Model):\n",
+        "\n",
+        "    def __init__(self, filters, kernel_size, strides, activation):\n",
+        "        super().__init__()\n",
+        "        self.conv1 = Conv2D(\n",
+        "            filters=filters,\n",
+        "            kernel_size=kernel_size,\n",
+        "            strides=strides,\n",
+        "            activation=activation)\n",
+        "        self.pool1 = MaxPooling2D(pool_size=2)\n",
+        "        self.drop1 = Dropout(0.3)\n",
+        "        self.flat = Flatten()\n",
+        "        self.dense1 = Dense(256, activation='relu')\n",
+        "        self.drop3 = Dropout(0.5)\n",
+        "        self.dense2 = Dense(CLASSES, activation=\"softmax\")\n",
+        "\n",
+        "    def call(self, inputs):\n",
+        "        x = self.conv1(inputs)\n",
+        "        x = self.pool1(x)\n",
+        "        x = self.drop1(x)\n",
+        "        x = self.flat(x)\n",
+        "        x = self.dense1(x)\n",
+        "        x = self.drop3(x)\n",
+        "        x = self.dense2(x)\n",
+        "        return x\n",
+        "model = MyModel(\n",
+        "    filters=hpo.space.Categorical(32, 64),\n",
+        "    kernel_size=hpo.space.Categorical(2, 4),\n",
+        "    strides=hpo.space.Categorical(1, 2),\n",
+        "    activation=hpo.space.Categorical(\"relu\", \"linear\")\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "msSa9fyeGHTU"
+      },
+      "source": [
+        "# Step4: Compile model\n",
+        "We now compile our model with loss function, optimizer and metrics. If you want to tune learning rate and batch size, refer to [user guide](https://bigdl.readthedocs.io/en/latest/doc/Nano/QuickStart/hpo.html#search-the-learning-rate)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "PfeBIEmoGHxA"
+      },
+      "outputs": [],
+      "source": [
+        "from tensorflow.keras.optimizers import RMSprop\n",
+        "model.compile(\n",
+        "    loss=\"sparse_categorical_crossentropy\",\n",
+        "    optimizer=RMSprop(learning_rate=0.001),\n",
+        "    metrics=[\"accuracy\"],\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tuZXTIjXBfUs"
+      },
+      "source": [
+        "# Step5: Run hyperparameter search\n",
+        "Run hyperparameter search by calling `model.search`. Set the `target_metric` and `direction` so that HPO optimizes the `target_metric` in the specified `direction`. Each trial will use a different set of hyperparameters in the search space range. Use `n_parallels` to set the nubmer of parallel processes to run trials. After search completes, you can use `search_summary` to retrive the search results for analysis. For more details, refer to [user doc](https://bigdl.readthedocs.io/en/latest/doc/Nano/QuickStart/hpo.html)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "hfBS_1JLBfUs",
+        "outputId": "897ac4d1-5766-44f2-d6fb-ed7b2a437b9e"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "\u001b[32m[I 2022-06-14 07:51:36,119]\u001b[0m A new study created in memory with name: no-name-0cbf0f2d-5fc7-4245-b792-924ec2e250b3\u001b[0m\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Starting a new tuning\n",
+            "Epoch 1/5\n",
+            "375/375 - 8s - loss: 0.6107 - accuracy: 0.7830 - val_loss: 0.4149 - val_accuracy: 0.8488 - 8s/epoch - 21ms/step\n",
+            "Epoch 2/5\n",
+            "375/375 - 7s - loss: 0.4329 - accuracy: 0.8438 - val_loss: 0.3630 - val_accuracy: 0.8681 - 7s/epoch - 20ms/step\n",
+            "Epoch 3/5\n",
+            "375/375 - 7s - loss: 0.3931 - accuracy: 0.8575 - val_loss: 0.3471 - val_accuracy: 0.8729 - 7s/epoch - 19ms/step\n",
+            "Epoch 4/5\n",
+            "375/375 - 7s - loss: 0.3746 - accuracy: 0.8635 - val_loss: 0.3524 - val_accuracy: 0.8694 - 7s/epoch - 20ms/step\n",
+            "Epoch 5/5\n",
+            "375/375 - 7s - loss: 0.3621 - accuracy: 0.8695 - val_loss: 0.3197 - val_accuracy: 0.8828 - 7s/epoch - 20ms/step\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "\u001b[32m[I 2022-06-14 07:52:13,425]\u001b[0m Trial 0 finished with value: 0.8828333616256714 and parameters: {'activation▁choice': 1, 'filters▁choice': 0, 'kernel_size▁choice': 0, 'strides▁choice': 1}. Best is trial 0 with value: 0.8828333616256714.\u001b[0m\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Epoch 1/5\n",
+            "375/375 - 20s - loss: 0.5215 - accuracy: 0.8151 - val_loss: 0.3636 - val_accuracy: 0.8669 - 20s/epoch - 54ms/step\n",
+            "Epoch 2/5\n",
+            "375/375 - 19s - loss: 0.3665 - accuracy: 0.8678 - val_loss: 0.3334 - val_accuracy: 0.8804 - 19s/epoch - 51ms/step\n",
+            "Epoch 3/5\n",
+            "375/375 - 21s - loss: 0.3218 - accuracy: 0.8844 - val_loss: 0.3105 - val_accuracy: 0.8883 - 21s/epoch - 56ms/step\n",
+            "Epoch 4/5\n",
+            "375/375 - 20s - loss: 0.2968 - accuracy: 0.8934 - val_loss: 0.2860 - val_accuracy: 0.8981 - 20s/epoch - 53ms/step\n",
+            "Epoch 5/5\n",
+            "375/375 - 20s - loss: 0.2775 - accuracy: 0.9004 - val_loss: 0.2837 - val_accuracy: 0.8985 - 20s/epoch - 52ms/step\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "\u001b[32m[I 2022-06-14 07:54:35,924]\u001b[0m Trial 1 finished with value: 0.8985000252723694 and parameters: {'activation▁choice': 1, 'filters▁choice': 0, 'kernel_size▁choice': 1, 'strides▁choice': 0}. Best is trial 1 with value: 0.8985000252723694.\u001b[0m\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Epoch 1/5\n",
+            "375/375 - 48s - loss: 0.5305 - accuracy: 0.8119 - val_loss: 0.3556 - val_accuracy: 0.8729 - 48s/epoch - 129ms/step\n",
+            "Epoch 2/5\n",
+            "375/375 - 47s - loss: 0.3542 - accuracy: 0.8737 - val_loss: 0.3045 - val_accuracy: 0.8907 - 47s/epoch - 126ms/step\n",
+            "Epoch 3/5\n",
+            "375/375 - 46s - loss: 0.3124 - accuracy: 0.8877 - val_loss: 0.3179 - val_accuracy: 0.8847 - 46s/epoch - 124ms/step\n",
+            "Epoch 4/5\n",
+            "375/375 - 49s - loss: 0.2881 - accuracy: 0.8961 - val_loss: 0.2718 - val_accuracy: 0.9040 - 49s/epoch - 131ms/step\n",
+            "Epoch 5/5\n",
+            "375/375 - 49s - loss: 0.2751 - accuracy: 0.9022 - val_loss: 0.2714 - val_accuracy: 0.9026 - 49s/epoch - 130ms/step\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "\u001b[32m[I 2022-06-14 07:58:58,425]\u001b[0m Trial 2 finished with value: 0.9039999842643738 and parameters: {'activation▁choice': 0, 'filters▁choice': 1, 'kernel_size▁choice': 0, 'strides▁choice': 0}. Best is trial 2 with value: 0.9039999842643738.\u001b[0m\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Epoch 1/5\n",
+            "375/375 - 8s - loss: 0.6889 - accuracy: 0.7514 - val_loss: 0.4607 - val_accuracy: 0.8334 - 8s/epoch - 22ms/step\n",
+            "Epoch 2/5\n",
+            "375/375 - 8s - loss: 0.4777 - accuracy: 0.8277 - val_loss: 0.4082 - val_accuracy: 0.8466 - 8s/epoch - 21ms/step\n",
+            "Epoch 3/5\n",
+            "375/375 - 8s - loss: 0.4279 - accuracy: 0.8452 - val_loss: 0.3585 - val_accuracy: 0.8677 - 8s/epoch - 21ms/step\n",
+            "Epoch 4/5\n",
+            "375/375 - 8s - loss: 0.3988 - accuracy: 0.8556 - val_loss: 0.3470 - val_accuracy: 0.8720 - 8s/epoch - 22ms/step\n",
+            "Epoch 5/5\n",
+            "375/375 - 8s - loss: 0.3828 - accuracy: 0.8623 - val_loss: 0.3363 - val_accuracy: 0.8742 - 8s/epoch - 23ms/step\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "\u001b[32m[I 2022-06-14 07:59:39,921]\u001b[0m Trial 3 finished with value: 0.8741666674613953 and parameters: {'activation▁choice': 0, 'filters▁choice': 0, 'kernel_size▁choice': 0, 'strides▁choice': 1}. Best is trial 2 with value: 0.9039999842643738.\u001b[0m\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Epoch 1/5\n",
+            "375/375 - 7s - loss: 0.6287 - accuracy: 0.7717 - val_loss: 0.4239 - val_accuracy: 0.8471 - 7s/epoch - 18ms/step\n",
+            "Epoch 2/5\n",
+            "375/375 - 6s - loss: 0.4369 - accuracy: 0.8427 - val_loss: 0.3693 - val_accuracy: 0.8633 - 6s/epoch - 17ms/step\n",
+            "Epoch 3/5\n",
+            "375/375 - 6s - loss: 0.3940 - accuracy: 0.8570 - val_loss: 0.3435 - val_accuracy: 0.8772 - 6s/epoch - 16ms/step\n",
+            "Epoch 4/5\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "\u001b[32m[I 2022-06-14 08:00:05,357]\u001b[0m Trial 4 pruned. Trial was pruned at epoch 3.\u001b[0m\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "CPU times: user 10min 38s, sys: 3min 45s, total: 14min 23s\n",
+            "Wall time: 8min 29s\n"
+          ]
+        }
+      ],
+      "source": [
+        "%%time\n",
+        "from bigdl.nano.automl.hpo.backend import PrunerType\n",
+        "model.search(\n",
+        "    n_trials=5,\n",
+        "    target_metric='val_accuracy',\n",
+        "    direction=\"maximize\",\n",
+        "    pruner=PrunerType.HyperBand,\n",
+        "    pruner_kwargs={'min_resource':1, 'max_resource':100, 'reduction_factor':3},\n",
+        "    x=x_train,\n",
+        "    y=y_train,\n",
+        "    batch_size=128,\n",
+        "    epochs=5,\n",
+        "    validation_split=0.2,\n",
+        "    verbose=False,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "jeK1hT42HCD5",
+        "outputId": "204acc43-94db-4cb8-f058-46c02e43c6ab"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Number of finished trials: 5\n",
+            "Best trial:\n",
+            "  Value: 0.9039999842643738\n",
+            "  Params: \n",
+            "    activation▁choice: 0\n",
+            "    filters▁choice: 1\n",
+            "    kernel_size▁choice: 0\n",
+            "    strides▁choice: 0\n",
+            "<optuna.study.study.Study object at 0x7f82ae603a90>\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(model.search_summary())"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 345
+        },
+        "id": "n_vwMwJVLaCc",
+        "outputId": "8996e8ac-5ced-4cfb-c454-de4df5860012"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Number of finished trials: 5\n",
+            "Best trial:\n",
+            "  Value: 0.9039999842643738\n",
+            "  Params: \n",
+            "    activation▁choice: 0\n",
+            "    filters▁choice: 1\n",
+            "    kernel_size▁choice: 0\n",
+            "    strides▁choice: 0\n"
+          ]
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "   number     value  params_activation▁choice  params_filters▁choice  \\\n",
+              "0       0  0.882833                         1                      0   \n",
+              "1       1  0.898500                         1                      0   \n",
+              "2       2  0.904000                         0                      1   \n",
+              "3       3  0.874167                         0                      0   \n",
+              "4       4  0.876833                         1                      0   \n",
+              "\n",
+              "   params_kernel_size▁choice  params_strides▁choice     state  \n",
+              "0                          0                      1  COMPLETE  \n",
+              "1                          1                      0  COMPLETE  \n",
+              "2                          0                      0  COMPLETE  \n",
+              "3                          0                      1  COMPLETE  \n",
+              "4                          1                      1    PRUNED  "
+            ],
+            "text/html": [
+              "\n",
+              "  <div id=\"df-a8488958-932e-4400-ba28-9cf8d867650e\">\n",
+              "    <div class=\"colab-df-container\">\n",
+              "      <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>number</th>\n",
+              "      <th>value</th>\n",
+              "      <th>params_activation▁choice</th>\n",
+              "      <th>params_filters▁choice</th>\n",
+              "      <th>params_kernel_size▁choice</th>\n",
+              "      <th>params_strides▁choice</th>\n",
+              "      <th>state</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>0</td>\n",
+              "      <td>0.882833</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>COMPLETE</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>1</td>\n",
+              "      <td>0.898500</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>COMPLETE</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>2</td>\n",
+              "      <td>0.904000</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>COMPLETE</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>3</td>\n",
+              "      <td>0.874167</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>COMPLETE</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>4</td>\n",
+              "      <td>0.876833</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>PRUNED</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>\n",
+              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-a8488958-932e-4400-ba28-9cf8d867650e')\"\n",
+              "              title=\"Convert this dataframe to an interactive table.\"\n",
+              "              style=\"display:none;\">\n",
+              "        \n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "       width=\"24px\">\n",
+              "    <path d=\"M0 0h24v24H0V0z\" fill=\"none\"/>\n",
+              "    <path d=\"M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z\"/><path d=\"M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z\"/>\n",
+              "  </svg>\n",
+              "      </button>\n",
+              "      \n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      flex-wrap:wrap;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "      <script>\n",
+              "        const buttonEl =\n",
+              "          document.querySelector('#df-a8488958-932e-4400-ba28-9cf8d867650e button.colab-df-convert');\n",
+              "        buttonEl.style.display =\n",
+              "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "        async function convertToInteractive(key) {\n",
+              "          const element = document.querySelector('#df-a8488958-932e-4400-ba28-9cf8d867650e');\n",
+              "          const dataTable =\n",
+              "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                     [key], {});\n",
+              "          if (!dataTable) return;\n",
+              "\n",
+              "          const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "            '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "            + ' to learn more about interactive tables.';\n",
+              "          element.innerHTML = '';\n",
+              "          dataTable['output_type'] = 'display_data';\n",
+              "          await google.colab.output.renderOutput(dataTable, element);\n",
+              "          const docLink = document.createElement('div');\n",
+              "          docLink.innerHTML = docLinkHtml;\n",
+              "          element.appendChild(docLink);\n",
+              "        }\n",
+              "      </script>\n",
+              "    </div>\n",
+              "  </div>\n",
+              "  "
+            ]
+          },
+          "metadata": {},
+          "execution_count": 10
+        }
+      ],
+      "source": [
+        "study = model.search_summary()\n",
+        "study.trials_dataframe(attrs=(\"number\", \"value\", \"params\", \"state\"))"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "NVDG1hl-BfUt"
+      },
+      "source": [
+        "# Step 6: fit with the best hyperparameters\n",
+        "After search, `model.fit` will autotmatically use the best hyperparmeters found in search to fit the model."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "aAet3uX5BfUt",
+        "outputId": "2401cd38-09a6-4251-b459-c97e64d89cc9"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Epoch 1/5\n",
+            "375/375 [==============================] - 53s 140ms/step - loss: 0.5348 - accuracy: 0.8099 - val_loss: 0.3566 - val_accuracy: 0.8759\n",
+            "Epoch 2/5\n",
+            "375/375 [==============================] - 51s 136ms/step - loss: 0.3535 - accuracy: 0.8741 - val_loss: 0.3114 - val_accuracy: 0.8878\n",
+            "Epoch 3/5\n",
+            "375/375 [==============================] - 51s 137ms/step - loss: 0.3144 - accuracy: 0.8880 - val_loss: 0.2905 - val_accuracy: 0.8950\n",
+            "Epoch 4/5\n",
+            "375/375 [==============================] - 53s 140ms/step - loss: 0.2916 - accuracy: 0.8949 - val_loss: 0.2910 - val_accuracy: 0.8966\n",
+            "Epoch 5/5\n",
+            "375/375 [==============================] - 52s 138ms/step - loss: 0.2762 - accuracy: 0.9020 - val_loss: 0.2787 - val_accuracy: 0.8998\n",
+            "313/313 - 3s - loss: 0.2913 - accuracy: 0.8927 - 3s/epoch - 8ms/step\n",
+            "Test loss: 0.2913445234298706\n",
+            "Test accuracy: 0.8927000164985657\n"
+          ]
+        }
+      ],
+      "source": [
+        "history = model.fit(x_train, y_train,\n",
+        "                    batch_size=128, epochs=5, validation_split=0.2)\n",
+        "\n",
+        "test_scores = model.evaluate(x_test, y_test, verbose=2)\n",
+        "print(\"Test loss:\", test_scores[0])\n",
+        "print(\"Test accuracy:\", test_scores[1])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "9JKTKAGQBfUt"
+      },
+      "source": [
+        "Check out the summary of the model. The model has already been built with the best hyperparameters found by nano hpo."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "d8O_cz4DBfUu",
+        "outputId": "dd7d6add-a32c-4618-dc88-d19bec8e4c3e"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Model: \"my_model_1\"\n",
+            "_________________________________________________________________\n",
+            " Layer (type)                Output Shape              Param #   \n",
+            "=================================================================\n",
+            " conv2d_1 (Conv2D)           multiple                  320       \n",
+            "                                                                 \n",
+            " max_pooling2d_1 (MaxPooling  multiple                 0         \n",
+            " 2D)                                                             \n",
+            "                                                                 \n",
+            " dropout_2 (Dropout)         multiple                  0         \n",
+            "                                                                 \n",
+            " flatten_1 (Flatten)         multiple                  0         \n",
+            "                                                                 \n",
+            " dense_2 (Dense)             multiple                  2769152   \n",
+            "                                                                 \n",
+            " dropout_3 (Dropout)         multiple                  0         \n",
+            "                                                                 \n",
+            " dense_3 (Dense)             multiple                  2570      \n",
+            "                                                                 \n",
+            "=================================================================\n",
+            "Total params: 2,772,042\n",
+            "Trainable params: 2,772,042\n",
+            "Non-trainable params: 0\n",
+            "_________________________________________________________________\n",
+            "None\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(model.summary())"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [],
+      "name": "custom.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.7.13"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/docs/readthedocs/source/doc/Nano/Tutorials/seq_and_func.ipynb
+++ b/docs/readthedocs/source/doc/Nano/Tutorials/seq_and_func.ipynb
@@ -1,0 +1,1604 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "pDIKqAcwmexW"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/intel-analytics/BigDL/blob/main/python/nano/notebooks/hpo/seq_and_func.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "SQRh9TDkmexb"
+      },
+      "source": [
+        "![image.png](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJsAAABHCAMAAAAnQ8XqAAAACXBIWXMAAA7DAAAOwwHHb6hkAAADAFBMVEVHcEyAgYR+gYU0OD85OTuOkZSChYk5OTs5OTs5OTuAgYR/gYM5OTuAgYSAgYSBgoWAgoU5OTs+NTg5OTs4ODs5OTsAccQ1NTk3Nzo4ODuBg4U4ODs5OTs4ODs5OTuRlJY6OjwAccM4ODs5OTs3Nzo4ODuBgoQ3Nzo4OTo3NzqSlJc5OTsBccOAgYSRlJeRk5Y5OTs5OTs5OTs4ODuPkpQ4ODo4ODs5OTs5OTs4ODuRlJeSlJeJio4BccM5OTsDbrw4ODuPkpU4ODuVmJs4ODsBccOTlpk2Njo3OTwBccOSlZiUmJo5OTs5OTs5OTyPkZSRk5eTlpk5OTw4ODs5OTw2Njk5OTuRlJeUl5pzi6EAccM5OTsBcMM4ODs4ODs4ODs4ODs4ODs5OTs4ODuAgYSAgYM4ODs4ODuTl5kBccM4ODo4ODs4ODs5OTs4ODs5OTs5OTuSlJc4ODs4ODs5OTs4ODuAgYSRk5aFh4o4ODucn6I4ODs4ODv7/P4BccM5OTuAgoVDQ0c4ODsBccM4ODtFf7ABcMM5OTuTlZh/goM4ODqAgYSFhomnrK4jTnCDhYeAgYUCb744OTyChIc4ODsAcMI5OTsBccM5OTt/gYSChIeFh4paW15/gYOChIcDbrs5OTv///+AgYT+/v6IiYw6OjyBgoX9/f47Oz09PT99foF+f4KDhIc5OTw8PD88PD73+Pj9/v6Oj5KCg4Z/gIMBccOJio1/gYTq6us7Oz56e3719fU6Oj2AgYV8fYCAgoR4eXzm5ud7fH/7+/s9PUDs7Ozh4uLi4uOCg4W2triJio6RkpTq6+s+PkCOj5F5en2RkpXs7O2HiIz8/P2Gh4qDhIgBdMj09PX5+fn29vaPkJP29/cBcsW1treKi46XmJvT1NV3eHs4ODqEhYh8fIDf3+Dp6emjpKYBccTb29zOz9A/P0HDw8WdnqCUlZjz8/O+v8Hv7/Dx8fGysrSvr7F9foJzdHiqq60Bdcv+/v/HyMm2t7nGxsien6Hj4+S3t7nLBRsYAAAAoHRSTlMA+wMC/QEC/vz7nyP6+nL7oAIBBFHrAQovQgQZ1xA/PAP+OvIHYnISoA438Pz+KDPv+d+EDBR/pveBMCUFI+c+Sg+tByH9HAicJCsi2S3+CRYSHCklOEo/Ggb02xjUorKptvFb/J0xZSD6dJErwpXkbkJHactLmEcjRAvQiQMZ0qkMV/I0DiG8TiId+NMuBMn7E5u0efzF5LlkvllplbYvkV0hXwAADA1JREFUaN7MmXtUFNcdx6867OyY9dTl4QPFRYNH3FjeKoLaoIgK8oqgMa2KWo3G+k7qqWliEnPS1qbtSWPb056ednZwhtmF3W1lhYC7LCIx+ABSwdpo1CiN2hiNzyRt/2jvvTM7O6996Dnafs/CDDNz3I/f3/397u/eAeB/qRgs8H8lJdDcgqp1o3T0mE2S/Tlz2cxn80vS0pdaLemzacqo1eMPW05FRUWxNc8CofLW5xflLCsHcQk86VSLpR+XS+W7youK0/Ks1nRLcXpxUWVluezm6wksQWr1iF2KqSwqKsmzQJcseSVF6ysSDYbgPZE/FrJ5CVqrR2LS3IKCyvz0NKt1qTU9Py+/MidnZshEEHx7JGyJiYmBrywvLy9Ky0+zbrNuy1uanl9UVJE4eLBwL9YwU1CiSgYppo/It1de2fVsSVHx+vySosqKuQ/xDzwKthhQMXz48N+9/fYv/vDuu6+tXbv2+1BDhw4dHqWGvvZbEPMwbCMMIwIK9YgBPHG8qal/YGCgv79//wVBTcebjsNPE/o0NQknslPxvAk9dOrD18DgSGyxgh7ct58MGzTsu1CDoIY9sH7avxYYovbNHGcOnL66cNZCpFkL3xocku0JxvdNphGqC/90oV9cI8dxjEJcoyj0WPDyoP1DRTY+JFtc0mSsIQIfCih45zfXNkxB2jDvubfAiJBsjK+5Ham3vV089va2djgYf6OMr7Vdutve69Fh0/dt4vJNm8auzkB6avevV04bB0AyYnv1uY8PCrr2q4Xh2Dz9d4+dP3b+PPo5duzY3XtfXb1x8WxDW3sr0xWw7d5/8H381N0GBOeLhi37Ou/mWUG8227nl4+Dzo0A39lzbd54pHkHN8wKw8Y5ztba1Ko9d/vTz284WruQdz5Pwx3ZvSP766P1bZo910iIMhopytjCTwTJiO3j8di28QenhGFr5up7Dtn66pQSKD642osI/EzDFemJPtsX++s50biIbN0mp3AKD2QZTVKssxT8PFo26NuBc7ZarerqoJ23OhjI4Wk4aasLXLcdEtiY6NgUF0ja5N4EhkTP1obYtFFFeLW2W72Y7T1bXeA6ZHNEw3ZZh40lSSMPE0LLZk5OjtUdb3psGAO6dKOV45pVbNA3z4P4RpI0ZSLQARpn34jZhFwYL+SCUPfM8BBrRnXaHGuWxVSGU4uZhL/qbJ+2cT4cU+mJM/vr/dHGtFP0jbR3wydIeGJs2Q1L756DU+YhTRmP2GBdKd2+vRAXGPmcpWTDJzK42tp/XuzgGAVbcLz55Gx6vaXIRpLs5n1ZuDyTBJswBryz5+u/Cvr62iyYG6NfNrrcuTWQLnvVHKSVqfMBYruv8K3v9hfYPpGtzna3vdGjjanGN6MWrUxiI/gqUIp9g5zedSD2j9+StCwWxHtbyiiK7ly9OC632+1yudyd9CTMVq9g+8vAqat3gn/X2T6/1OhR++YXSm+QLSNQYWXyXpaxvQnAi24jjYNaDYYoRv2kDN4EhyKZ6c5ag6ogRZnojCSgHW8nGc+X92x14oXaPttnlxqYSL6ZJ4wep9bo6t9LuUDw6wBYaacwm3siSMlO/eUCQal7wQv2TEhWRtJGNhd7S5Psk3ps73Nc28XAeEO+fdKqjalPxabfsf5M5htcq64S2CjX8+D1LddddixXZykyFBGh0uwkhcALbH7O0aNkY9pu2mxBtn+0qWrIGa1vMP3VSgY7c2Rs1ZDNJbGNXM5mUlgmZ9X8DJhIqC6TLE+UqdgOqNk+PCJdgEXE4Q+Vp8ygU6F8M4D0PCCxoTjKfRs5ljcKtYX07i2FFRmfO3N3s4qYNuuwnZCzHfVwzac1uRAxpjnbYPVUsom+uXdAtpYAGz/mB52U8FDLDlDjpshw441xKHw7CrsO9XiLgs2C1tYSmwuyrXSJubBE7hs/ZrRd5MndC/a5IrEpfPvAo5lP6xlVDdHO02n5aJETyFPMhmsILHtsqS4bwcK6sSYCm1853g77GE19i5inBRZ8gL6Rglc7QLyTJC+TNMFnzQfz5TGV2J6aBLYr2Joj+XaYYZofuIZYcvBhRmCud24Z62RRMhK517NBbEqQzatgeykCG6fyjWMizln6EQVgn+Ab+jKexHXC270pBYAU3ZhCtqcjxJRT5imMKaMdb2F9y7EIaCCeJ4Q5lCaMZbhVyppmhh2RjM0bhk3rm08z3nTy1IfTIUR92xnY/4oXKj7uyVFXTj8JcyIujG9LlL51aecF1XjzMRHnBUXVteaJtoH4lgCb2Max3uXVsEuL0jcm0rxw2K/1LWwulG+TTuN5oxRTEve9Rrf3aZQLIdiWPGAN4ZjmELng12GLCeSowjfS62ZxU05ntuAaEhWbp1E73tQ1JPR8qmEzgPy04CXJNzbrRQrCwZnTabLDPuThYnpSE1N17Q0/3nYFclTmG55PS7cITTllXxnRN4JdPVlgi5QLTKhc4DRsiogq2cAcYT6FE8OQuEgxpel1+mwObX2LMqaw6qbJbFOyZQs9EpzTnwGRai/JToiq9sKVfYhcaNb4lmNRBFiHDbZp9JtgUbRsPZHm02h7JFVEQ7DR5Ch9NtiHIDYWT8CIrbnr/oGI4+10VDE1gGKr0kaJzSVng2Npkd54Wz016Btm82vyVFNDfJ4ofZu7U1WGlb65RDaiVMEW6HtpulrqQ8SYNkbukaKb62OAtSAsm+ib0f0S+HaQ7ZnqFkLMzQkq3zzc/Qhzlg4bJ/a935CxxYCSYhATmY02da6RsxXuzWTJAPM0e9g89XGR2XR9K7doGhJd30ydbyjYxuQ68cRG8C/PyOBJOmwN6bhZq1hnaedTv0/DBiNaqbZNmrMoezZsgnV9YxeDLF5YnxJeOyuunUOx+TqC63rM5lflQpOH44Rd/iAbjqghhG+0qXszAKmib5Rd7hv7PbQZIQw4ghL6gcB40/PtqrQfgtbO9ZyS7cxAq6PNAcXJfdOJaDCmps6NIF4MnaqGwFXXVrwfgiufkQ7rW0PDl/8O7tXgPQflXP/RxZ4TJ86ePdEj8w1W3YLQbLCvSFjkFbcP4QX5vAB9mzybN6HFIW0k3bRivPnlbH+2vdd76cIVicSG9mpUvtX+CemjuqP1Uv8Gq266XnMe7N94niDE76VNVXK2xQBsZ3kTEs9nz8b/gxC+nfvXJ4ekvUFxj0vOFtziPFwf9K38x7qLezEXULQI0ikMJcK7JU7Wh0C2ODA6AW8qJbwBxN1Ncbw1yudT4aRWvsd1S71vKW7xy9gMwFIBYsLEVL5koFyr5P0bYksBSc8vWJC6NQnEKdnUe9HovYKEBhG+6lWwBYMtscWA9Xn6S+hSwSsZGUln2rfK+14U0+CbwtgAG46pcg2oecdg+1uPQ5ELOmxg5tIQ24OFQrkSw4pEZLqzUsB8af+NclYlrZg+fXpNTc2c1MmgcLU43pzVGt9UaLYjts/aG5nwvulWXZGNokySEImRtdPb4Tpry3W3y4U+7u7Cwha7C+9gOpNAFYU3+mH/OUZYy/TovpdBrvXZ7lxwcEwo33CeJoaMKABVnXaZ3C43n/GjUXB9GvfDOdNF1UydnODE3JneGVM34gEK82X2SNG3Q7Y6PUHg9292NKJ3Rlc0b+P6Ar6BZUtDvteemhrUio07XlgzYSoAZvVTu4XVP0nzTl44oewrYPbid0Z1Nn3dvjXw90YPZDt9W+fuSZEtZER1ZTar9oeTwWY7LL1OXGcIPCxp6r9bHwZx2+p7L/8dQwXHj7188Ofu3zUHtoBqzWXbNz84eOw4Kjh28NXqRROWCDDoyeMeKmcQRgYKCgqCmEsKFBgkd3Kyg+e6wCQoKx9xYhACzxnp6h7ahQHO7zr/cNeWzUBJMDi06xA62HVIV5dxSSpDB6WrU4QYZhyxAI9IrIUMTwCzsimDECtDJ2MKIyM/LsAIAzhku6/M1XNjoHBtniBDV/7ZBTyQCWoOTp6lZ6ODgKEJDLclhMAlPFKXzvV744lRoh1nOsnwyPo9oEn9netWKmdrQiYEHfnU+EAIBKAUH7KAGp+aGpoAisrZ1FhzBMwewVPajUTt7OyqzQu6sGTlAQRCoHBSMQUCcO6AZRgmygAblVwnqCAIYwjRJTgAjNdLil1g3K4AAAAASUVORK5CYII=)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "onZXfhnkmexc"
+      },
+      "source": [
+        "# Introduction\n",
+        "In this notebook we demonstrates how to use Nano HPO to tune the hyperparameters in tensorflow training. The model is built using either tensorflow keras sequential API or functional API.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "i8kjsyL4mexd"
+      },
+      "source": [
+        "# Step0: Prepare Environment\n",
+        "You can install the latest pre-release version with nano support using below commands.\n",
+        "\n",
+        "We recommend to run below commands, especially `source bigdl-nano-init` before jupyter kernel is started, or some of the optimizations may not take effect.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "collapsed": true,
+        "id": "NC4pcIizmexe",
+        "outputId": "d266f123-ba84-422c-82c3-cb12c2768776"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
+            "Requirement already satisfied: bigdl-nano[tensorflow] in /usr/local/lib/python3.7/dist-packages (2.1.0b20220613)\n",
+            "Requirement already satisfied: protobuf==3.20.1 in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (3.20.1)\n",
+            "Requirement already satisfied: cloudpickle in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (1.3.0)\n",
+            "Requirement already satisfied: intel-openmp in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (2022.1.0)\n",
+            "Requirement already satisfied: tensorflow-estimator==2.7.0 in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (2.7.0)\n",
+            "Requirement already satisfied: intel-tensorflow==2.7.0 in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (2.7.0)\n",
+            "Requirement already satisfied: keras==2.7.0 in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (2.7.0)\n",
+            "Requirement already satisfied: libclang>=9.0.1 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (14.0.1)\n",
+            "Requirement already satisfied: keras-preprocessing>=1.1.1 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.1.2)\n",
+            "Requirement already satisfied: wheel<1.0,>=0.32.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.37.1)\n",
+            "Requirement already satisfied: numpy>=1.14.5 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.21.6)\n",
+            "Requirement already satisfied: tensorboard~=2.6 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2.8.0)\n",
+            "Requirement already satisfied: tensorflow-io-gcs-filesystem>=0.21.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.26.0)\n",
+            "Requirement already satisfied: opt-einsum>=2.3.2 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.3.0)\n",
+            "Requirement already satisfied: gast<0.5.0,>=0.2.1 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.4.0)\n",
+            "Requirement already satisfied: google-pasta>=0.1.1 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.2.0)\n",
+            "Requirement already satisfied: wrapt>=1.11.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.14.1)\n",
+            "Requirement already satisfied: grpcio<2.0,>=1.24.3 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.46.3)\n",
+            "Requirement already satisfied: flatbuffers<3.0,>=1.12 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2.0)\n",
+            "Requirement already satisfied: astunparse>=1.6.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.6.3)\n",
+            "Requirement already satisfied: typing-extensions>=3.6.6 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (4.2.0)\n",
+            "Requirement already satisfied: termcolor>=1.1.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.1.0)\n",
+            "Requirement already satisfied: h5py>=2.9.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.1.0)\n",
+            "Requirement already satisfied: six>=1.12.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.15.0)\n",
+            "Requirement already satisfied: absl-py>=0.4.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.1.0)\n",
+            "Requirement already satisfied: cached-property in /usr/local/lib/python3.7/dist-packages (from h5py>=2.9.0->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.5.2)\n",
+            "Requirement already satisfied: requests<3,>=2.21.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2.23.0)\n",
+            "Requirement already satisfied: google-auth<3,>=1.6.3 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.35.0)\n",
+            "Requirement already satisfied: tensorboard-data-server<0.7.0,>=0.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.6.1)\n",
+            "Requirement already satisfied: markdown>=2.6.8 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.3.7)\n",
+            "Requirement already satisfied: setuptools>=41.0.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (58.0.4)\n",
+            "Requirement already satisfied: tensorboard-plugin-wit>=1.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.8.1)\n",
+            "Requirement already satisfied: werkzeug>=0.11.15 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.0.1)\n",
+            "Requirement already satisfied: google-auth-oauthlib<0.5,>=0.4.1 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.4.6)\n",
+            "Requirement already satisfied: rsa<5,>=3.1.4 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (4.8)\n",
+            "Requirement already satisfied: pyasn1-modules>=0.2.1 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.2.8)\n",
+            "Requirement already satisfied: cachetools<5.0,>=2.0.0 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (4.2.4)\n",
+            "Requirement already satisfied: requests-oauthlib>=0.7.0 in /usr/local/lib/python3.7/dist-packages (from google-auth-oauthlib<0.5,>=0.4.1->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.3.1)\n",
+            "Requirement already satisfied: importlib-metadata>=4.4 in /usr/local/lib/python3.7/dist-packages (from markdown>=2.6.8->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (4.11.4)\n",
+            "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata>=4.4->markdown>=2.6.8->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.8.0)\n",
+            "Requirement already satisfied: pyasn1<0.5.0,>=0.4.6 in /usr/local/lib/python3.7/dist-packages (from pyasn1-modules>=0.2.1->google-auth<3,>=1.6.3->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.4.8)\n",
+            "Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2.10)\n",
+            "Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.0.4)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2022.5.18.1)\n",
+            "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.24.3)\n",
+            "Requirement already satisfied: oauthlib>=3.0.0 in /usr/local/lib/python3.7/dist-packages (from requests-oauthlib>=0.7.0->google-auth-oauthlib<0.5,>=0.4.1->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.2.0)\n",
+            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
+            "Requirement already satisfied: setuptools==58.0.4 in /usr/local/lib/python3.7/dist-packages (58.0.4)\n",
+            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
+            "Requirement already satisfied: protobuf==3.20.1 in /usr/local/lib/python3.7/dist-packages (3.20.1)\n",
+            "conda dir found: /usr/local/bin/..\n",
+            "OpenMP library found...\n",
+            "Setting OMP_NUM_THREADS...\n",
+            "Setting OMP_NUM_THREADS specified for pytorch...\n",
+            "Setting KMP_AFFINITY...\n",
+            "Setting KMP_BLOCKTIME...\n",
+            "Setting MALLOC_CONF...\n",
+            "Not in a conda env\n",
+            "+++++ Env Variables +++++\n",
+            "LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4\n",
+            "MALLOC_CONF=\n",
+            "OMP_NUM_THREADS=1\n",
+            "KMP_AFFINITY=granularity=fine,compact,1,0\n",
+            "KMP_BLOCKTIME=1\n",
+            "TF_ENABLE_ONEDNN_OPTS=1\n",
+            "ENABLE_TF_OPTS=1\n",
+            "NANO_TF_INTER_OP=1\n",
+            "+++++++++++++++++++++++++\n",
+            "Complete.\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Install latest pre-release version of bigdl-nano\n",
+        "!pip install --pre bigdl-nano[tensorflow]\n",
+        "!pip install setuptools==58.0.4\n",
+        "!pip install protobuf==3.20.1\n",
+        "!source bigdl-nano-init"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "collapsed": true,
+        "id": "Y8mUaHScU61U",
+        "outputId": "5cb15a29-a5e4-4ffd-90ac-50ff8427ab87"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
+            "Collecting ConfigSpace\n",
+            "  Downloading ConfigSpace-0.5.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (4.7 MB)\n",
+            "\u001b[K     |████████████████████████████████| 4.7 MB 7.4 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: cython in /usr/local/lib/python3.7/dist-packages (from ConfigSpace) (0.29.30)\n",
+            "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from ConfigSpace) (1.21.6)\n",
+            "Requirement already satisfied: scipy in /usr/local/lib/python3.7/dist-packages (from ConfigSpace) (1.4.1)\n",
+            "Requirement already satisfied: pyparsing in /usr/local/lib/python3.7/dist-packages (from ConfigSpace) (3.0.9)\n",
+            "Installing collected packages: ConfigSpace\n",
+            "Successfully installed ConfigSpace-0.5.0\n",
+            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
+            "Collecting optuna\n",
+            "  Downloading optuna-2.10.1-py3-none-any.whl (308 kB)\n",
+            "\u001b[K     |████████████████████████████████| 308 kB 7.7 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from optuna) (1.21.6)\n",
+            "Requirement already satisfied: sqlalchemy>=1.1.0 in /usr/local/lib/python3.7/dist-packages (from optuna) (1.4.37)\n",
+            "Collecting alembic\n",
+            "  Downloading alembic-1.8.0-py3-none-any.whl (209 kB)\n",
+            "\u001b[K     |████████████████████████████████| 209 kB 55.4 MB/s \n",
+            "\u001b[?25hCollecting cmaes>=0.8.2\n",
+            "  Downloading cmaes-0.8.2-py3-none-any.whl (15 kB)\n",
+            "Collecting colorlog\n",
+            "  Downloading colorlog-6.6.0-py2.py3-none-any.whl (11 kB)\n",
+            "Requirement already satisfied: scipy!=1.4.0 in /usr/local/lib/python3.7/dist-packages (from optuna) (1.4.1)\n",
+            "Requirement already satisfied: PyYAML in /usr/local/lib/python3.7/dist-packages (from optuna) (3.13)\n",
+            "Requirement already satisfied: packaging>=20.0 in /usr/local/lib/python3.7/dist-packages (from optuna) (21.3)\n",
+            "Collecting cliff\n",
+            "  Downloading cliff-3.10.1-py3-none-any.whl (81 kB)\n",
+            "\u001b[K     |████████████████████████████████| 81 kB 8.0 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: tqdm in /usr/local/lib/python3.7/dist-packages (from optuna) (4.64.0)\n",
+            "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /usr/local/lib/python3.7/dist-packages (from packaging>=20.0->optuna) (3.0.9)\n",
+            "Requirement already satisfied: importlib-metadata in /usr/local/lib/python3.7/dist-packages (from sqlalchemy>=1.1.0->optuna) (4.11.4)\n",
+            "Requirement already satisfied: greenlet!=0.4.17 in /usr/local/lib/python3.7/dist-packages (from sqlalchemy>=1.1.0->optuna) (1.1.2)\n",
+            "Collecting Mako\n",
+            "  Downloading Mako-1.2.0-py3-none-any.whl (78 kB)\n",
+            "\u001b[K     |████████████████████████████████| 78 kB 5.9 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: importlib-resources in /usr/local/lib/python3.7/dist-packages (from alembic->optuna) (5.7.1)\n",
+            "Collecting pbr!=2.1.0,>=2.0.0\n",
+            "  Downloading pbr-5.9.0-py2.py3-none-any.whl (112 kB)\n",
+            "\u001b[K     |████████████████████████████████| 112 kB 49.2 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: PrettyTable>=0.7.2 in /usr/local/lib/python3.7/dist-packages (from cliff->optuna) (3.3.0)\n",
+            "Collecting stevedore>=2.0.1\n",
+            "  Downloading stevedore-3.5.0-py3-none-any.whl (49 kB)\n",
+            "\u001b[K     |████████████████████████████████| 49 kB 5.7 MB/s \n",
+            "\u001b[?25hCollecting autopage>=0.4.0\n",
+            "  Downloading autopage-0.5.1-py3-none-any.whl (29 kB)\n",
+            "Collecting cmd2>=1.0.0\n",
+            "  Downloading cmd2-2.4.1-py3-none-any.whl (146 kB)\n",
+            "\u001b[K     |████████████████████████████████| 146 kB 49.9 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: typing-extensions in /usr/local/lib/python3.7/dist-packages (from cmd2>=1.0.0->cliff->optuna) (4.2.0)\n",
+            "Requirement already satisfied: attrs>=16.3.0 in /usr/local/lib/python3.7/dist-packages (from cmd2>=1.0.0->cliff->optuna) (21.4.0)\n",
+            "Collecting pyperclip>=1.6\n",
+            "  Downloading pyperclip-1.8.2.tar.gz (20 kB)\n",
+            "Requirement already satisfied: wcwidth>=0.1.7 in /usr/local/lib/python3.7/dist-packages (from cmd2>=1.0.0->cliff->optuna) (0.2.5)\n",
+            "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata->sqlalchemy>=1.1.0->optuna) (3.8.0)\n",
+            "Requirement already satisfied: MarkupSafe>=0.9.2 in /usr/local/lib/python3.7/dist-packages (from Mako->alembic->optuna) (2.0.1)\n",
+            "Building wheels for collected packages: pyperclip\n",
+            "  Building wheel for pyperclip (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for pyperclip: filename=pyperclip-1.8.2-py3-none-any.whl size=11137 sha256=50f3f2456ea704b7882c94a258550d46ac88cc02884fdeaf4c92e4b400ce35c1\n",
+            "  Stored in directory: /root/.cache/pip/wheels/9f/18/84/8f69f8b08169c7bae2dde6bd7daf0c19fca8c8e500ee620a28\n",
+            "Successfully built pyperclip\n",
+            "Installing collected packages: pyperclip, pbr, stevedore, Mako, cmd2, autopage, colorlog, cmaes, cliff, alembic, optuna\n",
+            "Successfully installed Mako-1.2.0 alembic-1.8.0 autopage-0.5.1 cliff-3.10.1 cmaes-0.8.2 cmd2-2.4.1 colorlog-6.6.0 optuna-2.10.1 pbr-5.9.0 pyperclip-1.8.2 stevedore-3.5.0\n"
+          ]
+        }
+      ],
+      "source": [
+        "# Install other dependecies for Nano HPO\n",
+        "!pip install ConfigSpace\n",
+        "!pip install optuna"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "IswBKf39mexg"
+      },
+      "source": [
+        "# Step1: Init Nano AutoML\n",
+        "We need to enable Nano HPO before we use it for tensorflow training."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "yc34x9dcmexg",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "bba44274-e6d0-408a-bf9b-32d549fe1ea9"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/bigdl/nano/tf/__init__.py:24: UserWarning: NANO_TF_INTER_OP not found the in os.environ, please run `source bigdl-nano-init`\n",
+            "  warnings.warn(\"NANO_TF_INTER_OP not found the in os.environ, \"\n",
+            "/usr/local/lib/python3.7/dist-packages/bigdl/nano/tf/__init__.py:30: UserWarning: OMP_NUM_THREADS not found the in os.environ, please run `source bigdl-nano-init`\n",
+            "  warnings.warn(\"OMP_NUM_THREADS not found the in os.environ, \"\n"
+          ]
+        }
+      ],
+      "source": [
+        "import bigdl.nano.automl as automl\n",
+        "automl.hpo_config.enable_hpo_tf()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ZiolCDSmmexj"
+      },
+      "source": [
+        "# Step2: Prepare data\n",
+        "We use MNIST dataset for demonstration."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "o7jWojYNmexk",
+        "outputId": "eb4cc68f-4d38-410d-b007-c507da30b97f"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist.npz\n",
+            "11493376/11490434 [==============================] - 0s 0us/step\n",
+            "11501568/11490434 [==============================] - 0s 0us/step\n"
+          ]
+        }
+      ],
+      "source": [
+        "from tensorflow import keras\n",
+        "\n",
+        "(x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()\n",
+        "\n",
+        "CLASSES = 10\n",
+        "img_x, img_y = x_train.shape[1], x_train.shape[2]\n",
+        "input_shape = (img_x, img_y, 1)\n",
+        "x_train = x_train.reshape(-1, img_x, img_y,1).astype(\"float32\") / 255\n",
+        "x_test = x_test.reshape(-1, img_x, img_y,1).astype(\"float32\") / 255"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Pxvb3gKcmexk"
+      },
+      "source": [
+        "# Step3: Build model and specify search spaces"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "9liaVsdhBwDF"
+      },
+      "source": [
+        "We now create our model. \n",
+        "\n",
+        "Change the imports from tensorflow.keras to bigdl.nano as below, and you will be able to specify search spaces as you define the model. For how to specify search space, refer to [user doc](https://bigdl.readthedocs.io/en/latest/doc/Nano/QuickStart/hpo.html)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Mv1R2_SWS0rn"
+      },
+      "outputs": [],
+      "source": [
+        "from bigdl.nano.automl.tf.keras import Sequential\n",
+        "from bigdl.nano.tf.keras.layers import Dense, Flatten, Conv2D\n",
+        "from bigdl.nano.tf.keras import Input\n",
+        "from bigdl.nano.automl.tf.keras import Model\n",
+        "import bigdl.nano.automl.hpo.space as space"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "YgXu2BvLBuAo"
+      },
+      "source": [
+        "Below two cells show how to define the model with search spaces using either sequential or functional API respectively. You can choose one of them to run."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "XgIpL38-mexl"
+      },
+      "outputs": [],
+      "source": [
+        "model = Sequential()\n",
+        "model.add(Conv2D(\n",
+        "    filters=space.Categorical(32, 64),\n",
+        "    kernel_size=space.Categorical(3, 5),\n",
+        "    strides=space.Categorical(1, 2),\n",
+        "    activation=space.Categorical(\"relu\", \"linear\"),\n",
+        "    input_shape=input_shape))\n",
+        "model.add(Flatten())\n",
+        "model.add(Dense(CLASSES, activation=\"softmax\"))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Gn95Gp2Rmexl"
+      },
+      "outputs": [],
+      "source": [
+        "inputs = Input(shape=(28,28,1))\n",
+        "x = Conv2D(\n",
+        "    filters=space.Categorical(32, 64),\n",
+        "    kernel_size=space.Categorical(3, 5),\n",
+        "    strides=space.Categorical(1, 2),\n",
+        "    activation=space.Categorical(\"relu\", \"linear\"),\n",
+        "    input_shape=input_shape)(inputs)\n",
+        "x = Flatten()(x)\n",
+        "outputs = Dense(CLASSES, activation=\"softmax\")(x)\n",
+        "model = Model(inputs=inputs, outputs=outputs, name=\"mnist_model\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "O5SBRAawmexm"
+      },
+      "source": [
+        "# Step4: Compile model\n",
+        "We now compile our model with loss function, optimizer and metrics. If you want to tune learning rate and batch size, refer to [user guide](https://bigdl.readthedocs.io/en/latest/doc/Nano/QuickStart/hpo.html#search-the-learning-rate)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "U9HXvfIlmexm"
+      },
+      "outputs": [],
+      "source": [
+        "from tensorflow.keras.optimizers import RMSprop\n",
+        "model.compile(\n",
+        "    loss=\"sparse_categorical_crossentropy\",\n",
+        "    optimizer=RMSprop(learning_rate=0.001),\n",
+        "    metrics=[\"accuracy\"]\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "fW1b_B9Kmexn"
+      },
+      "source": [
+        "# Step5: Run hyperparameter search\n",
+        "Run hyperparameter search by calling `model.search`. Set `n_trials` to the number of trialials you want to run, and set the `target_metric` and `direction` so that HPO optimizes the `target_metric` in the specified `direction`. Each trial will use a different set of hyperparameters in the search space range. After search completes, you can use `search_summary` to retrive the search results for analysis. For more details, refer to [user doc](https://bigdl.readthedocs.io/en/latest/doc/Nano/QuickStart/hpo.html)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "FKdwjvMJmexn",
+        "outputId": "9faa9254-c148-4a40-baef-3f39bf89e6e0",
+        "scrolled": true
+      },
+      "outputs": [
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "\u001b[32m[I 2022-06-10 07:06:31,890]\u001b[0m A new study created in memory with name: no-name-b1869d33-f7ad-404a-b5a8-734c0784052c\u001b[0m\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Starting a new tuning\n",
+            "Epoch 1/5\n",
+            "375/375 - 3s - loss: 0.4179 - accuracy: 0.8872 - val_loss: 0.2395 - val_accuracy: 0.9335 - 3s/epoch - 9ms/step\n",
+            "Epoch 2/5\n",
+            "375/375 - 3s - loss: 0.2149 - accuracy: 0.9376 - val_loss: 0.1784 - val_accuracy: 0.9524 - 3s/epoch - 9ms/step\n",
+            "Epoch 3/5\n",
+            "375/375 - 3s - loss: 0.1523 - accuracy: 0.9570 - val_loss: 0.1315 - val_accuracy: 0.9670 - 3s/epoch - 7ms/step\n",
+            "Epoch 4/5\n",
+            "375/375 - 3s - loss: 0.1167 - accuracy: 0.9669 - val_loss: 0.1095 - val_accuracy: 0.9720 - 3s/epoch - 9ms/step\n",
+            "Epoch 5/5\n",
+            "375/375 - 3s - loss: 0.0957 - accuracy: 0.9724 - val_loss: 0.0992 - val_accuracy: 0.9730 - 3s/epoch - 7ms/step\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "\u001b[32m[I 2022-06-10 07:06:47,295]\u001b[0m Trial 0 finished with value: 0.9729999899864197 and parameters: {'activation▁choice': 0, 'filters▁choice': 0, 'kernel_size▁choice': 0, 'strides▁choice': 1}. Best is trial 0 with value: 0.9729999899864197.\u001b[0m\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Epoch 1/5\n",
+            "375/375 - 9s - loss: 0.3837 - accuracy: 0.8881 - val_loss: 0.3021 - val_accuracy: 0.9144 - 9s/epoch - 24ms/step\n",
+            "Epoch 2/5\n",
+            "375/375 - 7s - loss: 0.3129 - accuracy: 0.9114 - val_loss: 0.2998 - val_accuracy: 0.9165 - 7s/epoch - 19ms/step\n",
+            "Epoch 3/5\n",
+            "375/375 - 8s - loss: 0.2973 - accuracy: 0.9162 - val_loss: 0.2974 - val_accuracy: 0.9142 - 8s/epoch - 22ms/step\n",
+            "Epoch 4/5\n",
+            "375/375 - 9s - loss: 0.2888 - accuracy: 0.9177 - val_loss: 0.2929 - val_accuracy: 0.9197 - 9s/epoch - 24ms/step\n",
+            "Epoch 5/5\n",
+            "375/375 - 8s - loss: 0.2822 - accuracy: 0.9218 - val_loss: 0.2906 - val_accuracy: 0.9210 - 8s/epoch - 20ms/step\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "\u001b[32m[I 2022-06-10 07:07:28,702]\u001b[0m Trial 1 finished with value: 0.9210000038146973 and parameters: {'activation▁choice': 1, 'filters▁choice': 0, 'kernel_size▁choice': 1, 'strides▁choice': 0}. Best is trial 0 with value: 0.9729999899864197.\u001b[0m\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Epoch 1/5\n",
+            "375/375 - 9s - loss: 0.3831 - accuracy: 0.8902 - val_loss: 0.3052 - val_accuracy: 0.9143 - 9s/epoch - 23ms/step\n",
+            "Epoch 2/5\n",
+            "375/375 - 8s - loss: 0.3129 - accuracy: 0.9112 - val_loss: 0.2855 - val_accuracy: 0.9205 - 8s/epoch - 22ms/step\n",
+            "Epoch 3/5\n",
+            "375/375 - 8s - loss: 0.2978 - accuracy: 0.9164 - val_loss: 0.2807 - val_accuracy: 0.9240 - 8s/epoch - 22ms/step\n",
+            "Epoch 4/5\n",
+            "375/375 - 8s - loss: 0.2881 - accuracy: 0.9190 - val_loss: 0.2823 - val_accuracy: 0.9225 - 8s/epoch - 22ms/step\n",
+            "Epoch 5/5\n",
+            "375/375 - 9s - loss: 0.2827 - accuracy: 0.9199 - val_loss: 0.2884 - val_accuracy: 0.9216 - 9s/epoch - 23ms/step\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "\u001b[32m[I 2022-06-10 07:08:10,866]\u001b[0m Trial 2 finished with value: 0.9240000247955322 and parameters: {'activation▁choice': 1, 'filters▁choice': 0, 'kernel_size▁choice': 1, 'strides▁choice': 0}. Best is trial 0 with value: 0.9729999899864197.\u001b[0m\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Epoch 1/5\n",
+            "375/375 - 3s - loss: 0.3833 - accuracy: 0.8935 - val_loss: 0.2027 - val_accuracy: 0.9457 - 3s/epoch - 9ms/step\n",
+            "Epoch 2/5\n",
+            "375/375 - 3s - loss: 0.1661 - accuracy: 0.9529 - val_loss: 0.1239 - val_accuracy: 0.9661 - 3s/epoch - 8ms/step\n",
+            "Epoch 3/5\n",
+            "375/375 - 4s - loss: 0.1056 - accuracy: 0.9697 - val_loss: 0.0900 - val_accuracy: 0.9750 - 4s/epoch - 10ms/step\n",
+            "Epoch 4/5\n",
+            "375/375 - 3s - loss: 0.0806 - accuracy: 0.9769 - val_loss: 0.0808 - val_accuracy: 0.9773 - 3s/epoch - 9ms/step\n",
+            "Epoch 5/5\n",
+            "375/375 - 3s - loss: 0.0663 - accuracy: 0.9807 - val_loss: 0.0728 - val_accuracy: 0.9793 - 3s/epoch - 8ms/step\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "\u001b[32m[I 2022-06-10 07:08:27,356]\u001b[0m Trial 3 finished with value: 0.9792500138282776 and parameters: {'activation▁choice': 0, 'filters▁choice': 0, 'kernel_size▁choice': 1, 'strides▁choice': 1}. Best is trial 3 with value: 0.9792500138282776.\u001b[0m\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Epoch 1/5\n",
+            "375/375 - 3s - loss: 0.4181 - accuracy: 0.8856 - val_loss: 0.2939 - val_accuracy: 0.9190 - 3s/epoch - 7ms/step\n",
+            "Epoch 2/5\n",
+            "375/375 - 2s - loss: 0.3041 - accuracy: 0.9133 - val_loss: 0.2788 - val_accuracy: 0.9234 - 2s/epoch - 6ms/step\n",
+            "Epoch 3/5\n",
+            "375/375 - 3s - loss: 0.2919 - accuracy: 0.9182 - val_loss: 0.2723 - val_accuracy: 0.9254 - 3s/epoch - 7ms/step\n",
+            "Epoch 4/5\n",
+            "375/375 - 3s - loss: 0.2842 - accuracy: 0.9194 - val_loss: 0.2826 - val_accuracy: 0.9222 - 3s/epoch - 7ms/step\n",
+            "Epoch 5/5\n",
+            "375/375 - 2s - loss: 0.2782 - accuracy: 0.9217 - val_loss: 0.2737 - val_accuracy: 0.9254 - 2s/epoch - 6ms/step\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "\u001b[32m[I 2022-06-10 07:08:39,673]\u001b[0m Trial 4 finished with value: 0.9254166483879089 and parameters: {'activation▁choice': 1, 'filters▁choice': 0, 'kernel_size▁choice': 0, 'strides▁choice': 1}. Best is trial 3 with value: 0.9792500138282776.\u001b[0m\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Epoch 1/5\n",
+            "375/375 - 12s - loss: 0.2912 - accuracy: 0.9173 - val_loss: 0.1453 - val_accuracy: 0.9599 - 12s/epoch - 31ms/step\n",
+            "Epoch 2/5\n",
+            "375/375 - 10s - loss: 0.1099 - accuracy: 0.9686 - val_loss: 0.0921 - val_accuracy: 0.9750 - 10s/epoch - 26ms/step\n",
+            "Epoch 3/5\n",
+            "375/375 - 9s - loss: 0.0757 - accuracy: 0.9781 - val_loss: 0.0920 - val_accuracy: 0.9751 - 9s/epoch - 25ms/step\n",
+            "Epoch 4/5\n",
+            "375/375 - 10s - loss: 0.0602 - accuracy: 0.9830 - val_loss: 0.0773 - val_accuracy: 0.9784 - 10s/epoch - 27ms/step\n",
+            "Epoch 5/5\n",
+            "375/375 - 10s - loss: 0.0498 - accuracy: 0.9861 - val_loss: 0.0771 - val_accuracy: 0.9793 - 10s/epoch - 26ms/step\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "\u001b[32m[I 2022-06-10 07:09:30,500]\u001b[0m Trial 5 finished with value: 0.9793333411216736 and parameters: {'activation▁choice': 0, 'filters▁choice': 0, 'kernel_size▁choice': 0, 'strides▁choice': 0}. Best is trial 5 with value: 0.9793333411216736.\u001b[0m\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Epoch 1/5\n",
+            "375/375 - 12s - loss: 0.2349 - accuracy: 0.9321 - val_loss: 0.0939 - val_accuracy: 0.9733 - 12s/epoch - 32ms/step\n",
+            "Epoch 2/5\n",
+            "375/375 - 10s - loss: 0.0783 - accuracy: 0.9773 - val_loss: 0.0768 - val_accuracy: 0.9776 - 10s/epoch - 27ms/step\n",
+            "Epoch 3/5\n",
+            "375/375 - 10s - loss: 0.0549 - accuracy: 0.9838 - val_loss: 0.0628 - val_accuracy: 0.9824 - 10s/epoch - 27ms/step\n",
+            "Epoch 4/5\n",
+            "375/375 - 10s - loss: 0.0432 - accuracy: 0.9872 - val_loss: 0.0573 - val_accuracy: 0.9841 - 10s/epoch - 27ms/step\n",
+            "Epoch 5/5\n",
+            "375/375 - 10s - loss: 0.0358 - accuracy: 0.9890 - val_loss: 0.0611 - val_accuracy: 0.9834 - 10s/epoch - 28ms/step\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "\u001b[32m[I 2022-06-10 07:10:23,197]\u001b[0m Trial 6 finished with value: 0.984083354473114 and parameters: {'activation▁choice': 0, 'filters▁choice': 0, 'kernel_size▁choice': 1, 'strides▁choice': 0}. Best is trial 6 with value: 0.984083354473114.\u001b[0m\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Epoch 1/5\n",
+            "375/375 - 21s - loss: 0.2005 - accuracy: 0.9410 - val_loss: 0.0953 - val_accuracy: 0.9722 - 21s/epoch - 55ms/step\n",
+            "Epoch 2/5\n",
+            "375/375 - 20s - loss: 0.0687 - accuracy: 0.9792 - val_loss: 0.0628 - val_accuracy: 0.9820 - 20s/epoch - 53ms/step\n",
+            "Epoch 3/5\n",
+            "375/375 - 19s - loss: 0.0473 - accuracy: 0.9860 - val_loss: 0.0634 - val_accuracy: 0.9815 - 19s/epoch - 50ms/step\n",
+            "Epoch 4/5\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "\u001b[32m[I 2022-06-10 07:11:42,902]\u001b[0m Trial 7 pruned. Trial was pruned at epoch 3.\u001b[0m\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "CPU times: user 7min 20s, sys: 2min 40s, total: 10min\n",
+            "Wall time: 5min 11s\n"
+          ]
+        }
+      ],
+      "source": [
+        "%%time\n",
+        "from bigdl.nano.automl.hpo.backend import PrunerType\n",
+        "model.search(\n",
+        "    n_trials=8,\n",
+        "    target_metric='val_accuracy',\n",
+        "    direction=\"maximize\",\n",
+        "    pruner=PrunerType.HyperBand,\n",
+        "    pruner_kwargs={'min_resource':1, 'max_resource':100, 'reduction_factor':3},\n",
+        "    x=x_train,\n",
+        "    y=y_train,\n",
+        "    batch_size=128,\n",
+        "    epochs=5,\n",
+        "    validation_split=0.2,\n",
+        "    verbose=False\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "MpFgoN4TwZHk",
+        "outputId": "e157fe1d-5628-4795-d3b9-40db199ae9b3"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Number of finished trials: 8\n",
+            "Best trial:\n",
+            "  Value: 0.984083354473114\n",
+            "  Params: \n",
+            "    activation▁choice: 0\n",
+            "    filters▁choice: 0\n",
+            "    kernel_size▁choice: 1\n",
+            "    strides▁choice: 0\n",
+            "<optuna.study.study.Study object at 0x7fe562357f10>\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(model.search_summary())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xU_PnDXnmexo"
+      },
+      "source": [
+        "# Step6: (Optional) Resume training from memory\n",
+        "You can resume the previous search when a search completes by setting `resume=True`. Refer to [user doc](https://bigdl.readthedocs.io/en/latest/doc/Nano/QuickStart/hpo.html) for more details."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "mvHyvEDomexo",
+        "outputId": "350caead-932c-4b69-a9b6-4592dc12da72"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Epoch 1/5\n",
+            "375/375 - 6s - loss: 0.3255 - accuracy: 0.9053 - val_loss: 0.1474 - val_accuracy: 0.9602 - 6s/epoch - 16ms/step\n",
+            "Epoch 2/5\n",
+            "375/375 - 6s - loss: 0.1183 - accuracy: 0.9667 - val_loss: 0.0970 - val_accuracy: 0.9728 - 6s/epoch - 15ms/step\n",
+            "Epoch 3/5\n",
+            "375/375 - 6s - loss: 0.0796 - accuracy: 0.9777 - val_loss: 0.0795 - val_accuracy: 0.9772 - 6s/epoch - 15ms/step\n",
+            "Epoch 4/5\n",
+            "375/375 - 5s - loss: 0.0626 - accuracy: 0.9821 - val_loss: 0.0690 - val_accuracy: 0.9803 - 5s/epoch - 14ms/step\n",
+            "Epoch 5/5\n",
+            "375/375 - 6s - loss: 0.0523 - accuracy: 0.9846 - val_loss: 0.0638 - val_accuracy: 0.9818 - 6s/epoch - 15ms/step\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "\u001b[32m[I 2022-06-10 07:12:27,503]\u001b[0m Trial 8 finished with value: 0.9818333387374878 and parameters: {'activation▁choice': 0, 'filters▁choice': 1, 'kernel_size▁choice': 1, 'strides▁choice': 1}. Best is trial 6 with value: 0.984083354473114.\u001b[0m\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Epoch 1/5\n",
+            "375/375 - 18s - loss: 0.3843 - accuracy: 0.8866 - val_loss: 0.3061 - val_accuracy: 0.9155 - 18s/epoch - 49ms/step\n",
+            "Epoch 2/5\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "\u001b[32m[I 2022-06-10 07:13:03,941]\u001b[0m Trial 9 pruned. Trial was pruned at epoch 1.\u001b[0m\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Epoch 1/5\n",
+            "375/375 - 4s - loss: 0.4129 - accuracy: 0.8843 - val_loss: 0.3053 - val_accuracy: 0.9132 - 4s/epoch - 9ms/step\n",
+            "Epoch 2/5\n",
+            "375/375 - 3s - loss: 0.3095 - accuracy: 0.9117 - val_loss: 0.2873 - val_accuracy: 0.9205 - 3s/epoch - 7ms/step\n",
+            "Epoch 3/5\n",
+            "375/375 - 3s - loss: 0.2971 - accuracy: 0.9163 - val_loss: 0.2818 - val_accuracy: 0.9208 - 3s/epoch - 8ms/step\n",
+            "Epoch 4/5\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "\u001b[32m[I 2022-06-10 07:13:15,216]\u001b[0m Trial 10 pruned. Trial was pruned at epoch 3.\u001b[0m\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Epoch 1/5\n",
+            "375/375 - 6s - loss: 0.3945 - accuracy: 0.8856 - val_loss: 0.2878 - val_accuracy: 0.9193 - 6s/epoch - 16ms/step\n",
+            "Epoch 2/5\n"
+          ]
+        },
+        {
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "\u001b[32m[I 2022-06-10 07:13:35,444]\u001b[0m Trial 11 pruned. Trial was pruned at epoch 1.\u001b[0m\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "CPU times: user 1min 59s, sys: 48.6 s, total: 2min 48s\n",
+            "Wall time: 1min 52s\n"
+          ]
+        }
+      ],
+      "source": [
+        "%%time\n",
+        "model.search(\n",
+        "    n_trials=4,\n",
+        "    target_metric='val_accuracy',\n",
+        "    direction=\"maximize\",\n",
+        "    pruner=PrunerType.HyperBand,\n",
+        "    pruner_kwargs={'min_resource':1, 'max_resource':100, 'reduction_factor':3},\n",
+        "    x=x_train,\n",
+        "    y=y_train,\n",
+        "    batch_size=128,\n",
+        "    epochs=5,\n",
+        "    validation_split=0.2,\n",
+        "    verbose=False,\n",
+        "    resume = True\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "xQEDtjj1mexx",
+        "outputId": "11040b63-a3fc-4570-d2a9-02c681900cca"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Number of finished trials: 12\n",
+            "Best trial:\n",
+            "  Value: 0.984083354473114\n",
+            "  Params: \n",
+            "    activation▁choice: 0\n",
+            "    filters▁choice: 0\n",
+            "    kernel_size▁choice: 1\n",
+            "    strides▁choice: 0\n",
+            "<optuna.study.study.Study object at 0x7fe562357f10>\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(model.search_summary())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "uI05vzTgmexy"
+      },
+      "source": [
+        "# Step 7: fit with the best hyperparameters\n",
+        "After search, `model.fit` will autotmatically use the best hyperparmeters found in search to fit the model."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "jTJ8FGnAmexy",
+        "outputId": "86d9215e-b20f-45b7-c171-8c4b31fe466f",
+        "scrolled": true
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Epoch 1/5\n",
+            "375/375 [==============================] - 13s 33ms/step - loss: 0.2448 - accuracy: 0.9281 - val_loss: 0.1068 - val_accuracy: 0.9715\n",
+            "Epoch 2/5\n",
+            "375/375 [==============================] - 12s 33ms/step - loss: 0.0794 - accuracy: 0.9768 - val_loss: 0.0684 - val_accuracy: 0.9813\n",
+            "Epoch 3/5\n",
+            "375/375 [==============================] - 12s 31ms/step - loss: 0.0556 - accuracy: 0.9834 - val_loss: 0.0658 - val_accuracy: 0.9814\n",
+            "Epoch 4/5\n",
+            "375/375 [==============================] - 12s 32ms/step - loss: 0.0441 - accuracy: 0.9871 - val_loss: 0.0619 - val_accuracy: 0.9825\n",
+            "Epoch 5/5\n",
+            "375/375 [==============================] - 14s 38ms/step - loss: 0.0357 - accuracy: 0.9900 - val_loss: 0.0613 - val_accuracy: 0.9837\n",
+            "313/313 - 1s - loss: 0.0502 - accuracy: 0.9837 - 1s/epoch - 5ms/step\n",
+            "Test loss: 0.050218481570482254\n",
+            "Test accuracy: 0.9836999773979187\n"
+          ]
+        }
+      ],
+      "source": [
+        "history = model.fit(x_train, y_train,\n",
+        "                    batch_size=128, epochs=5, validation_split=0.2)\n",
+        "\n",
+        "test_scores = model.evaluate(x_test, y_test, verbose=2)\n",
+        "print(\"Test loss:\", test_scores[0])\n",
+        "print(\"Test accuracy:\", test_scores[1])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xYhKbOjYDzMv"
+      },
+      "source": [
+        "# Step 8: HPO Result Analysis and Visualization\n",
+        "Check out the summary of the model. The model has already been built with the best hyperparameters found by nano hpo."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "wQDqKt8Emexz",
+        "outputId": "7e33c852-cea8-4204-f2fa-f1f265759426",
+        "scrolled": true
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Model: \"sequential_1\"\n",
+            "_________________________________________________________________\n",
+            " Layer (type)                Output Shape              Param #   \n",
+            "=================================================================\n",
+            " conv2d_1 (Conv2D)           (None, 24, 24, 32)        832       \n",
+            "                                                                 \n",
+            " flatten_1 (Flatten)         (None, 18432)             0         \n",
+            "                                                                 \n",
+            " dense_1 (Dense)             (None, 10)                184330    \n",
+            "                                                                 \n",
+            "=================================================================\n",
+            "Total params: 185,162\n",
+            "Trainable params: 185,162\n",
+            "Non-trainable params: 0\n",
+            "_________________________________________________________________\n",
+            "None\n",
+            "Number of finished trials: 12\n",
+            "Best trial:\n",
+            "  Value: 0.984083354473114\n",
+            "  Params: \n",
+            "    activation▁choice: 0\n",
+            "    filters▁choice: 0\n",
+            "    kernel_size▁choice: 1\n",
+            "    strides▁choice: 0\n"
+          ]
+        }
+      ],
+      "source": [
+        "print(model.summary())\n",
+        "study = model.search_summary()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 426
+        },
+        "id": "EZZZgiWeNfuN",
+        "outputId": "b99dade8-1838-4b19-c4c3-2afbffd801f5"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "\n",
+              "  <div id=\"df-640cd69f-9fb1-41ed-af4e-6520ff30e15c\">\n",
+              "    <div class=\"colab-df-container\">\n",
+              "      <div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>number</th>\n",
+              "      <th>value</th>\n",
+              "      <th>params_activation▁choice</th>\n",
+              "      <th>params_filters▁choice</th>\n",
+              "      <th>params_kernel_size▁choice</th>\n",
+              "      <th>params_strides▁choice</th>\n",
+              "      <th>state</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>0</td>\n",
+              "      <td>0.973000</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>COMPLETE</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>1</td>\n",
+              "      <td>0.921000</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>COMPLETE</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>2</td>\n",
+              "      <td>0.924000</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>COMPLETE</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>3</td>\n",
+              "      <td>0.979250</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>COMPLETE</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>4</td>\n",
+              "      <td>0.925417</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>COMPLETE</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>5</th>\n",
+              "      <td>5</td>\n",
+              "      <td>0.979333</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>COMPLETE</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>6</th>\n",
+              "      <td>6</td>\n",
+              "      <td>0.984083</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>COMPLETE</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>7</th>\n",
+              "      <td>7</td>\n",
+              "      <td>0.982917</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>PRUNED</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>8</th>\n",
+              "      <td>8</td>\n",
+              "      <td>0.981833</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>COMPLETE</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>9</th>\n",
+              "      <td>9</td>\n",
+              "      <td>0.913500</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>PRUNED</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>10</th>\n",
+              "      <td>10</td>\n",
+              "      <td>0.920917</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>PRUNED</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>11</th>\n",
+              "      <td>11</td>\n",
+              "      <td>0.919750</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>PRUNED</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>\n",
+              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-640cd69f-9fb1-41ed-af4e-6520ff30e15c')\"\n",
+              "              title=\"Convert this dataframe to an interactive table.\"\n",
+              "              style=\"display:none;\">\n",
+              "        \n",
+              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
+              "       width=\"24px\">\n",
+              "    <path d=\"M0 0h24v24H0V0z\" fill=\"none\"/>\n",
+              "    <path d=\"M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z\"/><path d=\"M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z\"/>\n",
+              "  </svg>\n",
+              "      </button>\n",
+              "      \n",
+              "  <style>\n",
+              "    .colab-df-container {\n",
+              "      display:flex;\n",
+              "      flex-wrap:wrap;\n",
+              "      gap: 12px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert {\n",
+              "      background-color: #E8F0FE;\n",
+              "      border: none;\n",
+              "      border-radius: 50%;\n",
+              "      cursor: pointer;\n",
+              "      display: none;\n",
+              "      fill: #1967D2;\n",
+              "      height: 32px;\n",
+              "      padding: 0 0 0 0;\n",
+              "      width: 32px;\n",
+              "    }\n",
+              "\n",
+              "    .colab-df-convert:hover {\n",
+              "      background-color: #E2EBFA;\n",
+              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
+              "      fill: #174EA6;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert {\n",
+              "      background-color: #3B4455;\n",
+              "      fill: #D2E3FC;\n",
+              "    }\n",
+              "\n",
+              "    [theme=dark] .colab-df-convert:hover {\n",
+              "      background-color: #434B5C;\n",
+              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
+              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
+              "      fill: #FFFFFF;\n",
+              "    }\n",
+              "  </style>\n",
+              "\n",
+              "      <script>\n",
+              "        const buttonEl =\n",
+              "          document.querySelector('#df-640cd69f-9fb1-41ed-af4e-6520ff30e15c button.colab-df-convert');\n",
+              "        buttonEl.style.display =\n",
+              "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
+              "\n",
+              "        async function convertToInteractive(key) {\n",
+              "          const element = document.querySelector('#df-640cd69f-9fb1-41ed-af4e-6520ff30e15c');\n",
+              "          const dataTable =\n",
+              "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
+              "                                                     [key], {});\n",
+              "          if (!dataTable) return;\n",
+              "\n",
+              "          const docLinkHtml = 'Like what you see? Visit the ' +\n",
+              "            '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
+              "            + ' to learn more about interactive tables.';\n",
+              "          element.innerHTML = '';\n",
+              "          dataTable['output_type'] = 'display_data';\n",
+              "          await google.colab.output.renderOutput(dataTable, element);\n",
+              "          const docLink = document.createElement('div');\n",
+              "          docLink.innerHTML = docLinkHtml;\n",
+              "          element.appendChild(docLink);\n",
+              "        }\n",
+              "      </script>\n",
+              "    </div>\n",
+              "  </div>\n",
+              "  "
+            ],
+            "text/plain": [
+              "    number     value  params_activation▁choice  params_filters▁choice  \\\n",
+              "0        0  0.973000                         0                      0   \n",
+              "1        1  0.921000                         1                      0   \n",
+              "2        2  0.924000                         1                      0   \n",
+              "3        3  0.979250                         0                      0   \n",
+              "4        4  0.925417                         1                      0   \n",
+              "5        5  0.979333                         0                      0   \n",
+              "6        6  0.984083                         0                      0   \n",
+              "7        7  0.982917                         0                      1   \n",
+              "8        8  0.981833                         0                      1   \n",
+              "9        9  0.913500                         1                      1   \n",
+              "10      10  0.920917                         1                      0   \n",
+              "11      11  0.919750                         1                      1   \n",
+              "\n",
+              "    params_kernel_size▁choice  params_strides▁choice     state  \n",
+              "0                           0                      1  COMPLETE  \n",
+              "1                           1                      0  COMPLETE  \n",
+              "2                           1                      0  COMPLETE  \n",
+              "3                           1                      1  COMPLETE  \n",
+              "4                           0                      1  COMPLETE  \n",
+              "5                           0                      0  COMPLETE  \n",
+              "6                           1                      0  COMPLETE  \n",
+              "7                           1                      0    PRUNED  \n",
+              "8                           1                      1  COMPLETE  \n",
+              "9                           1                      0    PRUNED  \n",
+              "10                          1                      1    PRUNED  \n",
+              "11                          1                      1    PRUNED  "
+            ]
+          },
+          "execution_count": 15,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "study.trials_dataframe(attrs=(\"number\", \"value\", \"params\", \"state\"))"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 542
+        },
+        "id": "mukvET_7mexz",
+        "outputId": "b80a13a5-3cf0-40b0-c33c-b9b83de43c1a",
+        "scrolled": false
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<html>\n",
+              "<head><meta charset=\"utf-8\" /></head>\n",
+              "<body>\n",
+              "    <div>            <script src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG\"></script><script type=\"text/javascript\">if (window.MathJax) {MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}</script>                <script type=\"text/javascript\">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
+              "        <script src=\"https://cdn.plot.ly/plotly-2.8.3.min.js\"></script>                <div id=\"a3dbb9aa-a8c6-4a7e-b8c8-4ed350afc379\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"a3dbb9aa-a8c6-4a7e-b8c8-4ed350afc379\")) {                    Plotly.newPlot(                        \"a3dbb9aa-a8c6-4a7e-b8c8-4ed350afc379\",                        [{\"mode\":\"markers\",\"name\":\"Objective Value\",\"x\":[0,1,2,3,4,5,6,8],\"y\":[0.9729999899864197,0.9210000038146973,0.9240000247955322,0.9792500138282776,0.9254166483879089,0.9793333411216736,0.984083354473114,0.9818333387374878],\"type\":\"scatter\"},{\"name\":\"Best Value\",\"x\":[0,1,2,3,4,5,6,8],\"y\":[0.9729999899864197,0.9729999899864197,0.9729999899864197,0.9792500138282776,0.9792500138282776,0.9793333411216736,0.984083354473114,0.984083354473114],\"type\":\"scatter\"}],                        {\"title\":{\"text\":\"Optimization History Plot\"},\"xaxis\":{\"title\":{\"text\":\"#Trials\"}},\"yaxis\":{\"title\":{\"text\":\"Objective Value\"}},\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}}},                        {\"responsive\": true}                    ).then(function(){\n",
+              "                            \n",
+              "var gd = document.getElementById('a3dbb9aa-a8c6-4a7e-b8c8-4ed350afc379');\n",
+              "var x = new MutationObserver(function (mutations, observer) {{\n",
+              "        var display = window.getComputedStyle(gd).display;\n",
+              "        if (!display || display === 'none') {{\n",
+              "            console.log([gd, 'removed!']);\n",
+              "            Plotly.purge(gd);\n",
+              "            observer.disconnect();\n",
+              "        }}\n",
+              "}});\n",
+              "\n",
+              "// Listen for the removal of the full notebook cells\n",
+              "var notebookContainer = gd.closest('#notebook-container');\n",
+              "if (notebookContainer) {{\n",
+              "    x.observe(notebookContainer, {childList: true});\n",
+              "}}\n",
+              "\n",
+              "// Listen for the clearing of the current output cell\n",
+              "var outputEl = gd.closest('.output');\n",
+              "if (outputEl) {{\n",
+              "    x.observe(outputEl, {childList: true});\n",
+              "}}\n",
+              "\n",
+              "                        })                };                            </script>        </div>\n",
+              "</body>\n",
+              "</html>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "from bigdl.nano.automl.hpo.visualization import plot_optimization_history\n",
+        "plot_optimization_history(study)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 542
+        },
+        "id": "QdZhgElEmexz",
+        "outputId": "3da0abb3-bc1b-4412-8834-0e995ea27857"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<html>\n",
+              "<head><meta charset=\"utf-8\" /></head>\n",
+              "<body>\n",
+              "    <div>            <script src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG\"></script><script type=\"text/javascript\">if (window.MathJax) {MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}</script>                <script type=\"text/javascript\">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
+              "        <script src=\"https://cdn.plot.ly/plotly-2.8.3.min.js\"></script>                <div id=\"7c87d5b5-4588-45b4-9ee9-cd56cbeff5e1\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"7c87d5b5-4588-45b4-9ee9-cd56cbeff5e1\")) {                    Plotly.newPlot(                        \"7c87d5b5-4588-45b4-9ee9-cd56cbeff5e1\",                        [{\"dimensions\":[{\"label\":\"Objective Value\",\"range\":[0.9210000038146973,0.984083354473114],\"values\":[0.9793333411216736,0.9729999899864197,0.984083354473114,0.9792500138282776,0.9818333387374878,0.9254166483879089,0.9210000038146973,0.9240000247955322]},{\"label\":\"activation\\u2581choice\",\"range\":[0,1],\"ticktext\":[0,1],\"tickvals\":[0,1],\"values\":[0,0,0,0,0,1,1,1]},{\"label\":\"filters\\u2581choice\",\"range\":[0,1],\"ticktext\":[0,1],\"tickvals\":[0,1],\"values\":[0,0,0,0,1,0,0,0]},{\"label\":\"kernel_size\\u2581choice\",\"range\":[0,1],\"ticktext\":[0,1],\"tickvals\":[0,1],\"values\":[0,0,1,1,1,0,1,1]},{\"label\":\"strides\\u2581choice\",\"range\":[0,1],\"ticktext\":[0,1],\"tickvals\":[0,1],\"values\":[0,1,0,1,1,1,0,0]}],\"labelangle\":30,\"labelside\":\"bottom\",\"line\":{\"color\":[0.9793333411216736,0.9729999899864197,0.984083354473114,0.9792500138282776,0.9818333387374878,0.9254166483879089,0.9210000038146973,0.9240000247955322],\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0.0,\"rgb(247,251,255)\"],[0.125,\"rgb(222,235,247)\"],[0.25,\"rgb(198,219,239)\"],[0.375,\"rgb(158,202,225)\"],[0.5,\"rgb(107,174,214)\"],[0.625,\"rgb(66,146,198)\"],[0.75,\"rgb(33,113,181)\"],[0.875,\"rgb(8,81,156)\"],[1.0,\"rgb(8,48,107)\"]],\"reversescale\":false,\"showscale\":true},\"type\":\"parcoords\"}],                        {\"title\":{\"text\":\"Parallel Coordinate Plot\"},\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}}},                        {\"responsive\": true}                    ).then(function(){\n",
+              "                            \n",
+              "var gd = document.getElementById('7c87d5b5-4588-45b4-9ee9-cd56cbeff5e1');\n",
+              "var x = new MutationObserver(function (mutations, observer) {{\n",
+              "        var display = window.getComputedStyle(gd).display;\n",
+              "        if (!display || display === 'none') {{\n",
+              "            console.log([gd, 'removed!']);\n",
+              "            Plotly.purge(gd);\n",
+              "            observer.disconnect();\n",
+              "        }}\n",
+              "}});\n",
+              "\n",
+              "// Listen for the removal of the full notebook cells\n",
+              "var notebookContainer = gd.closest('#notebook-container');\n",
+              "if (notebookContainer) {{\n",
+              "    x.observe(notebookContainer, {childList: true});\n",
+              "}}\n",
+              "\n",
+              "// Listen for the clearing of the current output cell\n",
+              "var outputEl = gd.closest('.output');\n",
+              "if (outputEl) {{\n",
+              "    x.observe(outputEl, {childList: true});\n",
+              "}}\n",
+              "\n",
+              "                        })                };                            </script>        </div>\n",
+              "</body>\n",
+              "</html>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "from bigdl.nano.automl.hpo.visualization import plot_parallel_coordinate\n",
+        "plot_parallel_coordinate(study)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 542
+        },
+        "id": "rL8-6vGYmex0",
+        "outputId": "c7ac5ec6-2af9-4b9d-9815-e98b4466d732"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<html>\n",
+              "<head><meta charset=\"utf-8\" /></head>\n",
+              "<body>\n",
+              "    <div>            <script src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG\"></script><script type=\"text/javascript\">if (window.MathJax) {MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}</script>                <script type=\"text/javascript\">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
+              "        <script src=\"https://cdn.plot.ly/plotly-2.8.3.min.js\"></script>                <div id=\"e89c6280-813a-478f-bba0-49a4d2ca7875\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"e89c6280-813a-478f-bba0-49a4d2ca7875\")) {                    Plotly.newPlot(                        \"e89c6280-813a-478f-bba0-49a4d2ca7875\",                        [{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial0\",\"x\":[0,1,2,3,4],\"y\":[0.9334999918937683,0.9524166584014893,0.9670000076293945,0.972000002861023,0.9729999899864197],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial1\",\"x\":[0,1,2,3,4],\"y\":[0.9144166707992554,0.9164999723434448,0.9141666889190674,0.9196666479110718,0.9210000038146973],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial2\",\"x\":[0,1,2,3,4],\"y\":[0.9143333435058594,0.9204999804496765,0.9240000247955322,0.9225000143051147,0.921583354473114],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial3\",\"x\":[0,1,2,3,4],\"y\":[0.9457499980926514,0.9660833477973938,0.9750000238418579,0.9773333072662354,0.9792500138282776],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial4\",\"x\":[0,1,2,3,4],\"y\":[0.9190000295639038,0.9234166741371155,0.9254166483879089,0.922249972820282,0.9254166483879089],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial5\",\"x\":[0,1,2,3,4],\"y\":[0.9599166512489319,0.9750000238418579,0.9750833511352539,0.9784166812896729,0.9793333411216736],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial6\",\"x\":[0,1,2,3,4],\"y\":[0.9733333587646484,0.9775833487510681,0.9824166893959045,0.984083354473114,0.9834166765213013],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial7\",\"x\":[0,1,2,3],\"y\":[0.9722499847412109,0.9819999933242798,0.9815000295639038,0.9829166531562805],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial8\",\"x\":[0,1,2,3,4],\"y\":[0.9601666927337646,0.9727500081062317,0.9771666526794434,0.9803333282470703,0.9818333387374878],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial9\",\"x\":[0,1],\"y\":[0.9154999852180481,0.9135000109672546],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial10\",\"x\":[0,1,2,3],\"y\":[0.9131666421890259,0.9204999804496765,0.9208333492279053,0.9209166765213013],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial11\",\"x\":[0,1],\"y\":[0.9193333387374878,0.9197499752044678],\"type\":\"scatter\"}],                        {\"showlegend\":false,\"title\":{\"text\":\"Intermediate Values Plot\"},\"xaxis\":{\"title\":{\"text\":\"Step\"}},\"yaxis\":{\"title\":{\"text\":\"Intermediate Value\"}},\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}}},                        {\"responsive\": true}                    ).then(function(){\n",
+              "                            \n",
+              "var gd = document.getElementById('e89c6280-813a-478f-bba0-49a4d2ca7875');\n",
+              "var x = new MutationObserver(function (mutations, observer) {{\n",
+              "        var display = window.getComputedStyle(gd).display;\n",
+              "        if (!display || display === 'none') {{\n",
+              "            console.log([gd, 'removed!']);\n",
+              "            Plotly.purge(gd);\n",
+              "            observer.disconnect();\n",
+              "        }}\n",
+              "}});\n",
+              "\n",
+              "// Listen for the removal of the full notebook cells\n",
+              "var notebookContainer = gd.closest('#notebook-container');\n",
+              "if (notebookContainer) {{\n",
+              "    x.observe(notebookContainer, {childList: true});\n",
+              "}}\n",
+              "\n",
+              "// Listen for the clearing of the current output cell\n",
+              "var outputEl = gd.closest('.output');\n",
+              "if (outputEl) {{\n",
+              "    x.observe(outputEl, {childList: true});\n",
+              "}}\n",
+              "\n",
+              "                        })                };                            </script>        </div>\n",
+              "</body>\n",
+              "</html>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "from bigdl.nano.automl.hpo.visualization import plot_intermediate_values\n",
+        "plot_intermediate_values(study)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 542
+        },
+        "id": "A5mqqXg8mex0",
+        "outputId": "325accdc-c371-48d1-d9e2-ce332759d9bb"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<html>\n",
+              "<head><meta charset=\"utf-8\" /></head>\n",
+              "<body>\n",
+              "    <div>            <script src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG\"></script><script type=\"text/javascript\">if (window.MathJax) {MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}</script>                <script type=\"text/javascript\">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
+              "        <script src=\"https://cdn.plot.ly/plotly-2.8.3.min.js\"></script>                <div id=\"4fa75e5b-111d-4d78-936c-357b16d5bb13\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"4fa75e5b-111d-4d78-936c-357b16d5bb13\")) {                    Plotly.newPlot(                        \"4fa75e5b-111d-4d78-936c-357b16d5bb13\",                        [{\"type\":\"scatter\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":true,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.984083354473114,0.9254166483879089,null],[null,0.9818333387374878,null,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x5\",\"yaxis\":\"y5\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[0,1,1,0,1,0,0,0],\"y\":[0,0,0,0,0,0,0,1],\"type\":\"scatter\",\"xaxis\":\"x5\",\"yaxis\":\"y5\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.9793333411216736,0.9254166483879089,null],[null,0.9818333387374878,0.9240000247955322,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x9\",\"yaxis\":\"y9\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[0,1,1,0,1,0,0,0],\"y\":[0,1,1,1,0,0,1,1],\"type\":\"scatter\",\"xaxis\":\"x9\",\"yaxis\":\"y9\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.984083354473114,0.9240000247955322,null],[null,0.9818333387374878,0.9254166483879089,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x13\",\"yaxis\":\"y13\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[0,1,1,0,1,0,0,0],\"y\":[1,0,0,1,1,0,0,1],\"type\":\"scatter\",\"xaxis\":\"x13\",\"yaxis\":\"y13\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.984083354473114,0.9818333387374878,null],[null,0.9254166483879089,null,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[0,0,0,0,0,0,0,1],\"y\":[0,1,1,0,1,0,0,0],\"type\":\"scatter\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"},{\"type\":\"scatter\",\"xaxis\":\"x6\",\"yaxis\":\"y6\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.9793333411216736,null,null],[null,0.984083354473114,0.9818333387374878,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x10\",\"yaxis\":\"y10\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[0,0,0,0,0,0,0,1],\"y\":[0,1,1,1,0,0,1,1],\"type\":\"scatter\",\"xaxis\":\"x10\",\"yaxis\":\"y10\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.984083354473114,null,null],[null,0.9254166483879089,0.9818333387374878,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x14\",\"yaxis\":\"y14\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[0,0,0,0,0,0,0,1],\"y\":[1,0,0,1,1,0,0,1],\"type\":\"scatter\",\"xaxis\":\"x14\",\"yaxis\":\"y14\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.9793333411216736,0.9818333387374878,null],[null,0.9254166483879089,0.9240000247955322,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x3\",\"yaxis\":\"y3\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[0,1,1,1,0,0,1,1],\"y\":[0,1,1,0,1,0,0,0],\"type\":\"scatter\",\"xaxis\":\"x3\",\"yaxis\":\"y3\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.9793333411216736,0.984083354473114,null],[null,null,0.9818333387374878,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x7\",\"yaxis\":\"y7\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[0,1,1,1,0,0,1,1],\"y\":[0,0,0,0,0,0,0,1],\"type\":\"scatter\",\"xaxis\":\"x7\",\"yaxis\":\"y7\"},{\"type\":\"scatter\",\"xaxis\":\"x11\",\"yaxis\":\"y11\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.9793333411216736,0.984083354473114,null],[null,0.9254166483879089,0.9818333387374878,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x15\",\"yaxis\":\"y15\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[0,1,1,1,0,0,1,1],\"y\":[1,0,0,1,1,0,0,1],\"type\":\"scatter\",\"xaxis\":\"x15\",\"yaxis\":\"y15\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.984083354473114,0.9818333387374878,null],[null,0.9240000247955322,0.9254166483879089,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x4\",\"yaxis\":\"y4\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[1,0,0,1,1,0,0,1],\"y\":[0,1,1,0,1,0,0,0],\"type\":\"scatter\",\"xaxis\":\"x4\",\"yaxis\":\"y4\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.984083354473114,0.9254166483879089,null],[null,null,0.9818333387374878,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x8\",\"yaxis\":\"y8\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[1,0,0,1,1,0,0,1],\"y\":[0,0,0,0,0,0,0,1],\"type\":\"scatter\",\"xaxis\":\"x8\",\"yaxis\":\"y8\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.9793333411216736,0.9254166483879089,null],[null,0.984083354473114,0.9818333387374878,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x12\",\"yaxis\":\"y12\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[1,0,0,1,1,0,0,1],\"y\":[0,1,1,1,0,0,1,1],\"type\":\"scatter\",\"xaxis\":\"x12\",\"yaxis\":\"y12\"},{\"type\":\"scatter\",\"xaxis\":\"x16\",\"yaxis\":\"y16\"}],                        {\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,0.2125],\"matches\":\"x13\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.80625,1.0],\"range\":[-0.05,1.05],\"title\":{\"text\":\"activation\\u2581choice\"}},\"xaxis2\":{\"anchor\":\"y2\",\"domain\":[0.2625,0.475],\"matches\":\"x14\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis2\":{\"anchor\":\"x2\",\"domain\":[0.80625,1.0],\"matches\":\"y\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis3\":{\"anchor\":\"y3\",\"domain\":[0.525,0.7375],\"matches\":\"x15\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis3\":{\"anchor\":\"x3\",\"domain\":[0.80625,1.0],\"matches\":\"y\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis4\":{\"anchor\":\"y4\",\"domain\":[0.7875,1.0],\"matches\":\"x16\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis4\":{\"anchor\":\"x4\",\"domain\":[0.80625,1.0],\"matches\":\"y\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis5\":{\"anchor\":\"y5\",\"domain\":[0.0,0.2125],\"matches\":\"x13\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis5\":{\"anchor\":\"x5\",\"domain\":[0.5375,0.73125],\"range\":[-0.05,1.05],\"title\":{\"text\":\"filters\\u2581choice\"}},\"xaxis6\":{\"anchor\":\"y6\",\"domain\":[0.2625,0.475],\"matches\":\"x14\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis6\":{\"anchor\":\"x6\",\"domain\":[0.5375,0.73125],\"matches\":\"y5\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis7\":{\"anchor\":\"y7\",\"domain\":[0.525,0.7375],\"matches\":\"x15\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis7\":{\"anchor\":\"x7\",\"domain\":[0.5375,0.73125],\"matches\":\"y5\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis8\":{\"anchor\":\"y8\",\"domain\":[0.7875,1.0],\"matches\":\"x16\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis8\":{\"anchor\":\"x8\",\"domain\":[0.5375,0.73125],\"matches\":\"y5\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis9\":{\"anchor\":\"y9\",\"domain\":[0.0,0.2125],\"matches\":\"x13\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis9\":{\"anchor\":\"x9\",\"domain\":[0.26875,0.4625],\"range\":[-0.05,1.05],\"title\":{\"text\":\"kernel_size\\u2581choice\"}},\"xaxis10\":{\"anchor\":\"y10\",\"domain\":[0.2625,0.475],\"matches\":\"x14\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis10\":{\"anchor\":\"x10\",\"domain\":[0.26875,0.4625],\"matches\":\"y9\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis11\":{\"anchor\":\"y11\",\"domain\":[0.525,0.7375],\"matches\":\"x15\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis11\":{\"anchor\":\"x11\",\"domain\":[0.26875,0.4625],\"matches\":\"y9\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis12\":{\"anchor\":\"y12\",\"domain\":[0.7875,1.0],\"matches\":\"x16\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis12\":{\"anchor\":\"x12\",\"domain\":[0.26875,0.4625],\"matches\":\"y9\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis13\":{\"anchor\":\"y13\",\"domain\":[0.0,0.2125],\"range\":[-0.05,1.05],\"title\":{\"text\":\"activation\\u2581choice\"}},\"yaxis13\":{\"anchor\":\"x13\",\"domain\":[0.0,0.19375],\"range\":[-0.05,1.05],\"title\":{\"text\":\"strides\\u2581choice\"}},\"xaxis14\":{\"anchor\":\"y14\",\"domain\":[0.2625,0.475],\"range\":[-0.05,1.05],\"title\":{\"text\":\"filters\\u2581choice\"}},\"yaxis14\":{\"anchor\":\"x14\",\"domain\":[0.0,0.19375],\"matches\":\"y13\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis15\":{\"anchor\":\"y15\",\"domain\":[0.525,0.7375],\"range\":[-0.05,1.05],\"title\":{\"text\":\"kernel_size\\u2581choice\"}},\"yaxis15\":{\"anchor\":\"x15\",\"domain\":[0.0,0.19375],\"matches\":\"y13\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis16\":{\"anchor\":\"y16\",\"domain\":[0.7875,1.0],\"range\":[-0.05,1.05],\"title\":{\"text\":\"strides\\u2581choice\"}},\"yaxis16\":{\"anchor\":\"x16\",\"domain\":[0.0,0.19375],\"matches\":\"y13\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"title\":{\"text\":\"Contour Plot\"}},                        {\"responsive\": true}                    ).then(function(){\n",
+              "                            \n",
+              "var gd = document.getElementById('4fa75e5b-111d-4d78-936c-357b16d5bb13');\n",
+              "var x = new MutationObserver(function (mutations, observer) {{\n",
+              "        var display = window.getComputedStyle(gd).display;\n",
+              "        if (!display || display === 'none') {{\n",
+              "            console.log([gd, 'removed!']);\n",
+              "            Plotly.purge(gd);\n",
+              "            observer.disconnect();\n",
+              "        }}\n",
+              "}});\n",
+              "\n",
+              "// Listen for the removal of the full notebook cells\n",
+              "var notebookContainer = gd.closest('#notebook-container');\n",
+              "if (notebookContainer) {{\n",
+              "    x.observe(notebookContainer, {childList: true});\n",
+              "}}\n",
+              "\n",
+              "// Listen for the clearing of the current output cell\n",
+              "var outputEl = gd.closest('.output');\n",
+              "if (outputEl) {{\n",
+              "    x.observe(outputEl, {childList: true});\n",
+              "}}\n",
+              "\n",
+              "                        })                };                            </script>        </div>\n",
+              "</body>\n",
+              "</html>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "from bigdl.nano.automl.hpo.visualization import plot_contour\n",
+        "plot_contour(study)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 542
+        },
+        "id": "MUmsUyAfmex0",
+        "outputId": "ea74030c-309f-468f-80e6-718956a44cc2"
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<html>\n",
+              "<head><meta charset=\"utf-8\" /></head>\n",
+              "<body>\n",
+              "    <div>            <script src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG\"></script><script type=\"text/javascript\">if (window.MathJax) {MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}</script>                <script type=\"text/javascript\">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
+              "        <script src=\"https://cdn.plot.ly/plotly-2.8.3.min.js\"></script>                <div id=\"6bf43d00-f567-4b01-b4b5-670ffbaf37b6\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"6bf43d00-f567-4b01-b4b5-670ffbaf37b6\")) {                    Plotly.newPlot(                        \"6bf43d00-f567-4b01-b4b5-670ffbaf37b6\",                        [{\"cliponaxis\":false,\"hovertemplate\":[\"filters\\u2581choice (CategoricalDistribution): 0.0018418691140907294<extra></extra>\",\"kernel_size\\u2581choice (CategoricalDistribution): 0.008168059594574145<extra></extra>\",\"strides\\u2581choice (CategoricalDistribution): 0.017955841523344354<extra></extra>\",\"activation\\u2581choice (CategoricalDistribution): 0.9720342297679908<extra></extra>\"],\"marker\":{\"color\":\"rgb(66,146,198)\"},\"orientation\":\"h\",\"text\":[\"0.0018418691140907294\",\"0.008168059594574145\",\"0.017955841523344354\",\"0.9720342297679908\"],\"textposition\":\"outside\",\"texttemplate\":\"%{text:.2f}\",\"x\":[0.0018418691140907294,0.008168059594574145,0.017955841523344354,0.9720342297679908],\"y\":[\"filters\\u2581choice\",\"kernel_size\\u2581choice\",\"strides\\u2581choice\",\"activation\\u2581choice\"],\"type\":\"bar\"}],                        {\"showlegend\":false,\"title\":{\"text\":\"Hyperparameter Importances\"},\"xaxis\":{\"title\":{\"text\":\"Importance for Objective Value\"}},\"yaxis\":{\"title\":{\"text\":\"Hyperparameter\"}},\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}}},                        {\"responsive\": true}                    ).then(function(){\n",
+              "                            \n",
+              "var gd = document.getElementById('6bf43d00-f567-4b01-b4b5-670ffbaf37b6');\n",
+              "var x = new MutationObserver(function (mutations, observer) {{\n",
+              "        var display = window.getComputedStyle(gd).display;\n",
+              "        if (!display || display === 'none') {{\n",
+              "            console.log([gd, 'removed!']);\n",
+              "            Plotly.purge(gd);\n",
+              "            observer.disconnect();\n",
+              "        }}\n",
+              "}});\n",
+              "\n",
+              "// Listen for the removal of the full notebook cells\n",
+              "var notebookContainer = gd.closest('#notebook-container');\n",
+              "if (notebookContainer) {{\n",
+              "    x.observe(notebookContainer, {childList: true});\n",
+              "}}\n",
+              "\n",
+              "// Listen for the clearing of the current output cell\n",
+              "var outputEl = gd.closest('.output');\n",
+              "if (outputEl) {{\n",
+              "    x.observe(outputEl, {childList: true});\n",
+              "}}\n",
+              "\n",
+              "                        })                };                            </script>        </div>\n",
+              "</body>\n",
+              "</html>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "from bigdl.nano.automl.hpo.visualization import plot_param_importances\n",
+        "plot_param_importances(study)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 542
+        },
+        "id": "Y-oXajiTmex1",
+        "outputId": "e678b912-7946-41c1-e431-8e61e9a28dca",
+        "scrolled": true
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<html>\n",
+              "<head><meta charset=\"utf-8\" /></head>\n",
+              "<body>\n",
+              "    <div>            <script src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG\"></script><script type=\"text/javascript\">if (window.MathJax) {MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}</script>                <script type=\"text/javascript\">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
+              "        <script src=\"https://cdn.plot.ly/plotly-2.8.3.min.js\"></script>                <div id=\"e288ca9b-ca81-4788-9870-988a60bd95b5\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"e288ca9b-ca81-4788-9870-988a60bd95b5\")) {                    Plotly.newPlot(                        \"e288ca9b-ca81-4788-9870-988a60bd95b5\",                        [{\"cliponaxis\":false,\"hovertemplate\":[\"activation\\u2581choice (CategoricalDistribution): 0.031071014437459847<extra></extra>\",\"filters\\u2581choice (CategoricalDistribution): 0.1548635182874492<extra></extra>\",\"kernel_size\\u2581choice (CategoricalDistribution): 0.30958575140327604<extra></extra>\",\"strides\\u2581choice (CategoricalDistribution): 0.5044797158718148<extra></extra>\"],\"marker\":{\"color\":\"rgb(66,146,198)\"},\"orientation\":\"h\",\"text\":[\"0.031071014437459847\",\"0.1548635182874492\",\"0.30958575140327604\",\"0.5044797158718148\"],\"textposition\":\"outside\",\"texttemplate\":\"%{text:.2f}\",\"x\":[0.031071014437459847,0.1548635182874492,0.30958575140327604,0.5044797158718148],\"y\":[\"activation\\u2581choice\",\"filters\\u2581choice\",\"kernel_size\\u2581choice\",\"strides\\u2581choice\"],\"type\":\"bar\"}],                        {\"showlegend\":false,\"title\":{\"text\":\"Hyperparameter Importances\"},\"xaxis\":{\"title\":{\"text\":\"Importance for duration\"}},\"yaxis\":{\"title\":{\"text\":\"Hyperparameter\"}},\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}}},                        {\"responsive\": true}                    ).then(function(){\n",
+              "                            \n",
+              "var gd = document.getElementById('e288ca9b-ca81-4788-9870-988a60bd95b5');\n",
+              "var x = new MutationObserver(function (mutations, observer) {{\n",
+              "        var display = window.getComputedStyle(gd).display;\n",
+              "        if (!display || display === 'none') {{\n",
+              "            console.log([gd, 'removed!']);\n",
+              "            Plotly.purge(gd);\n",
+              "            observer.disconnect();\n",
+              "        }}\n",
+              "}});\n",
+              "\n",
+              "// Listen for the removal of the full notebook cells\n",
+              "var notebookContainer = gd.closest('#notebook-container');\n",
+              "if (notebookContainer) {{\n",
+              "    x.observe(notebookContainer, {childList: true});\n",
+              "}}\n",
+              "\n",
+              "// Listen for the clearing of the current output cell\n",
+              "var outputEl = gd.closest('.output');\n",
+              "if (outputEl) {{\n",
+              "    x.observe(outputEl, {childList: true});\n",
+              "}}\n",
+              "\n",
+              "                        })                };                            </script>        </div>\n",
+              "</body>\n",
+              "</html>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "source": [
+        "plot_param_importances(study, target=lambda t: t.duration.total_seconds(), target_name=\"duration\")"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [],
+      "name": "seq_and_func.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3 (ipykernel)",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.7.13"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/docs/readthedocs/source/doc/Nano/Tutorials/seq_and_func.ipynb
+++ b/docs/readthedocs/source/doc/Nano/Tutorials/seq_and_func.ipynb
@@ -51,84 +51,7 @@
         "id": "NC4pcIizmexe",
         "outputId": "d266f123-ba84-422c-82c3-cb12c2768776"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
-            "Requirement already satisfied: bigdl-nano[tensorflow] in /usr/local/lib/python3.7/dist-packages (2.1.0b20220613)\n",
-            "Requirement already satisfied: protobuf==3.20.1 in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (3.20.1)\n",
-            "Requirement already satisfied: cloudpickle in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (1.3.0)\n",
-            "Requirement already satisfied: intel-openmp in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (2022.1.0)\n",
-            "Requirement already satisfied: tensorflow-estimator==2.7.0 in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (2.7.0)\n",
-            "Requirement already satisfied: intel-tensorflow==2.7.0 in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (2.7.0)\n",
-            "Requirement already satisfied: keras==2.7.0 in /usr/local/lib/python3.7/dist-packages (from bigdl-nano[tensorflow]) (2.7.0)\n",
-            "Requirement already satisfied: libclang>=9.0.1 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (14.0.1)\n",
-            "Requirement already satisfied: keras-preprocessing>=1.1.1 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.1.2)\n",
-            "Requirement already satisfied: wheel<1.0,>=0.32.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.37.1)\n",
-            "Requirement already satisfied: numpy>=1.14.5 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.21.6)\n",
-            "Requirement already satisfied: tensorboard~=2.6 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2.8.0)\n",
-            "Requirement already satisfied: tensorflow-io-gcs-filesystem>=0.21.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.26.0)\n",
-            "Requirement already satisfied: opt-einsum>=2.3.2 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.3.0)\n",
-            "Requirement already satisfied: gast<0.5.0,>=0.2.1 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.4.0)\n",
-            "Requirement already satisfied: google-pasta>=0.1.1 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.2.0)\n",
-            "Requirement already satisfied: wrapt>=1.11.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.14.1)\n",
-            "Requirement already satisfied: grpcio<2.0,>=1.24.3 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.46.3)\n",
-            "Requirement already satisfied: flatbuffers<3.0,>=1.12 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2.0)\n",
-            "Requirement already satisfied: astunparse>=1.6.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.6.3)\n",
-            "Requirement already satisfied: typing-extensions>=3.6.6 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (4.2.0)\n",
-            "Requirement already satisfied: termcolor>=1.1.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.1.0)\n",
-            "Requirement already satisfied: h5py>=2.9.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.1.0)\n",
-            "Requirement already satisfied: six>=1.12.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.15.0)\n",
-            "Requirement already satisfied: absl-py>=0.4.0 in /usr/local/lib/python3.7/dist-packages (from intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.1.0)\n",
-            "Requirement already satisfied: cached-property in /usr/local/lib/python3.7/dist-packages (from h5py>=2.9.0->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.5.2)\n",
-            "Requirement already satisfied: requests<3,>=2.21.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2.23.0)\n",
-            "Requirement already satisfied: google-auth<3,>=1.6.3 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.35.0)\n",
-            "Requirement already satisfied: tensorboard-data-server<0.7.0,>=0.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.6.1)\n",
-            "Requirement already satisfied: markdown>=2.6.8 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.3.7)\n",
-            "Requirement already satisfied: setuptools>=41.0.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (58.0.4)\n",
-            "Requirement already satisfied: tensorboard-plugin-wit>=1.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.8.1)\n",
-            "Requirement already satisfied: werkzeug>=0.11.15 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.0.1)\n",
-            "Requirement already satisfied: google-auth-oauthlib<0.5,>=0.4.1 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.4.6)\n",
-            "Requirement already satisfied: rsa<5,>=3.1.4 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (4.8)\n",
-            "Requirement already satisfied: pyasn1-modules>=0.2.1 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.2.8)\n",
-            "Requirement already satisfied: cachetools<5.0,>=2.0.0 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (4.2.4)\n",
-            "Requirement already satisfied: requests-oauthlib>=0.7.0 in /usr/local/lib/python3.7/dist-packages (from google-auth-oauthlib<0.5,>=0.4.1->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.3.1)\n",
-            "Requirement already satisfied: importlib-metadata>=4.4 in /usr/local/lib/python3.7/dist-packages (from markdown>=2.6.8->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (4.11.4)\n",
-            "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata>=4.4->markdown>=2.6.8->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.8.0)\n",
-            "Requirement already satisfied: pyasn1<0.5.0,>=0.4.6 in /usr/local/lib/python3.7/dist-packages (from pyasn1-modules>=0.2.1->google-auth<3,>=1.6.3->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (0.4.8)\n",
-            "Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2.10)\n",
-            "Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.0.4)\n",
-            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (2022.5.18.1)\n",
-            "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (1.24.3)\n",
-            "Requirement already satisfied: oauthlib>=3.0.0 in /usr/local/lib/python3.7/dist-packages (from requests-oauthlib>=0.7.0->google-auth-oauthlib<0.5,>=0.4.1->tensorboard~=2.6->intel-tensorflow==2.7.0->bigdl-nano[tensorflow]) (3.2.0)\n",
-            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
-            "Requirement already satisfied: setuptools==58.0.4 in /usr/local/lib/python3.7/dist-packages (58.0.4)\n",
-            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
-            "Requirement already satisfied: protobuf==3.20.1 in /usr/local/lib/python3.7/dist-packages (3.20.1)\n",
-            "conda dir found: /usr/local/bin/..\n",
-            "OpenMP library found...\n",
-            "Setting OMP_NUM_THREADS...\n",
-            "Setting OMP_NUM_THREADS specified for pytorch...\n",
-            "Setting KMP_AFFINITY...\n",
-            "Setting KMP_BLOCKTIME...\n",
-            "Setting MALLOC_CONF...\n",
-            "Not in a conda env\n",
-            "+++++ Env Variables +++++\n",
-            "LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4\n",
-            "MALLOC_CONF=\n",
-            "OMP_NUM_THREADS=1\n",
-            "KMP_AFFINITY=granularity=fine,compact,1,0\n",
-            "KMP_BLOCKTIME=1\n",
-            "TF_ENABLE_ONEDNN_OPTS=1\n",
-            "ENABLE_TF_OPTS=1\n",
-            "NANO_TF_INTER_OP=1\n",
-            "+++++++++++++++++++++++++\n",
-            "Complete.\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "# Install latest pre-release version of bigdl-nano\n",
         "!pip install --pre bigdl-nano[tensorflow]\n",
@@ -148,77 +71,7 @@
         "id": "Y8mUaHScU61U",
         "outputId": "5cb15a29-a5e4-4ffd-90ac-50ff8427ab87"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
-            "Collecting ConfigSpace\n",
-            "  Downloading ConfigSpace-0.5.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (4.7 MB)\n",
-            "\u001b[K     |████████████████████████████████| 4.7 MB 7.4 MB/s \n",
-            "\u001b[?25hRequirement already satisfied: cython in /usr/local/lib/python3.7/dist-packages (from ConfigSpace) (0.29.30)\n",
-            "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from ConfigSpace) (1.21.6)\n",
-            "Requirement already satisfied: scipy in /usr/local/lib/python3.7/dist-packages (from ConfigSpace) (1.4.1)\n",
-            "Requirement already satisfied: pyparsing in /usr/local/lib/python3.7/dist-packages (from ConfigSpace) (3.0.9)\n",
-            "Installing collected packages: ConfigSpace\n",
-            "Successfully installed ConfigSpace-0.5.0\n",
-            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
-            "Collecting optuna\n",
-            "  Downloading optuna-2.10.1-py3-none-any.whl (308 kB)\n",
-            "\u001b[K     |████████████████████████████████| 308 kB 7.7 MB/s \n",
-            "\u001b[?25hRequirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (from optuna) (1.21.6)\n",
-            "Requirement already satisfied: sqlalchemy>=1.1.0 in /usr/local/lib/python3.7/dist-packages (from optuna) (1.4.37)\n",
-            "Collecting alembic\n",
-            "  Downloading alembic-1.8.0-py3-none-any.whl (209 kB)\n",
-            "\u001b[K     |████████████████████████████████| 209 kB 55.4 MB/s \n",
-            "\u001b[?25hCollecting cmaes>=0.8.2\n",
-            "  Downloading cmaes-0.8.2-py3-none-any.whl (15 kB)\n",
-            "Collecting colorlog\n",
-            "  Downloading colorlog-6.6.0-py2.py3-none-any.whl (11 kB)\n",
-            "Requirement already satisfied: scipy!=1.4.0 in /usr/local/lib/python3.7/dist-packages (from optuna) (1.4.1)\n",
-            "Requirement already satisfied: PyYAML in /usr/local/lib/python3.7/dist-packages (from optuna) (3.13)\n",
-            "Requirement already satisfied: packaging>=20.0 in /usr/local/lib/python3.7/dist-packages (from optuna) (21.3)\n",
-            "Collecting cliff\n",
-            "  Downloading cliff-3.10.1-py3-none-any.whl (81 kB)\n",
-            "\u001b[K     |████████████████████████████████| 81 kB 8.0 MB/s \n",
-            "\u001b[?25hRequirement already satisfied: tqdm in /usr/local/lib/python3.7/dist-packages (from optuna) (4.64.0)\n",
-            "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in /usr/local/lib/python3.7/dist-packages (from packaging>=20.0->optuna) (3.0.9)\n",
-            "Requirement already satisfied: importlib-metadata in /usr/local/lib/python3.7/dist-packages (from sqlalchemy>=1.1.0->optuna) (4.11.4)\n",
-            "Requirement already satisfied: greenlet!=0.4.17 in /usr/local/lib/python3.7/dist-packages (from sqlalchemy>=1.1.0->optuna) (1.1.2)\n",
-            "Collecting Mako\n",
-            "  Downloading Mako-1.2.0-py3-none-any.whl (78 kB)\n",
-            "\u001b[K     |████████████████████████████████| 78 kB 5.9 MB/s \n",
-            "\u001b[?25hRequirement already satisfied: importlib-resources in /usr/local/lib/python3.7/dist-packages (from alembic->optuna) (5.7.1)\n",
-            "Collecting pbr!=2.1.0,>=2.0.0\n",
-            "  Downloading pbr-5.9.0-py2.py3-none-any.whl (112 kB)\n",
-            "\u001b[K     |████████████████████████████████| 112 kB 49.2 MB/s \n",
-            "\u001b[?25hRequirement already satisfied: PrettyTable>=0.7.2 in /usr/local/lib/python3.7/dist-packages (from cliff->optuna) (3.3.0)\n",
-            "Collecting stevedore>=2.0.1\n",
-            "  Downloading stevedore-3.5.0-py3-none-any.whl (49 kB)\n",
-            "\u001b[K     |████████████████████████████████| 49 kB 5.7 MB/s \n",
-            "\u001b[?25hCollecting autopage>=0.4.0\n",
-            "  Downloading autopage-0.5.1-py3-none-any.whl (29 kB)\n",
-            "Collecting cmd2>=1.0.0\n",
-            "  Downloading cmd2-2.4.1-py3-none-any.whl (146 kB)\n",
-            "\u001b[K     |████████████████████████████████| 146 kB 49.9 MB/s \n",
-            "\u001b[?25hRequirement already satisfied: typing-extensions in /usr/local/lib/python3.7/dist-packages (from cmd2>=1.0.0->cliff->optuna) (4.2.0)\n",
-            "Requirement already satisfied: attrs>=16.3.0 in /usr/local/lib/python3.7/dist-packages (from cmd2>=1.0.0->cliff->optuna) (21.4.0)\n",
-            "Collecting pyperclip>=1.6\n",
-            "  Downloading pyperclip-1.8.2.tar.gz (20 kB)\n",
-            "Requirement already satisfied: wcwidth>=0.1.7 in /usr/local/lib/python3.7/dist-packages (from cmd2>=1.0.0->cliff->optuna) (0.2.5)\n",
-            "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata->sqlalchemy>=1.1.0->optuna) (3.8.0)\n",
-            "Requirement already satisfied: MarkupSafe>=0.9.2 in /usr/local/lib/python3.7/dist-packages (from Mako->alembic->optuna) (2.0.1)\n",
-            "Building wheels for collected packages: pyperclip\n",
-            "  Building wheel for pyperclip (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
-            "  Created wheel for pyperclip: filename=pyperclip-1.8.2-py3-none-any.whl size=11137 sha256=50f3f2456ea704b7882c94a258550d46ac88cc02884fdeaf4c92e4b400ce35c1\n",
-            "  Stored in directory: /root/.cache/pip/wheels/9f/18/84/8f69f8b08169c7bae2dde6bd7daf0c19fca8c8e500ee620a28\n",
-            "Successfully built pyperclip\n",
-            "Installing collected packages: pyperclip, pbr, stevedore, Mako, cmd2, autopage, colorlog, cmaes, cliff, alembic, optuna\n",
-            "Successfully installed Mako-1.2.0 alembic-1.8.0 autopage-0.5.1 cliff-3.10.1 cmaes-0.8.2 cmd2-2.4.1 colorlog-6.6.0 optuna-2.10.1 pbr-5.9.0 pyperclip-1.8.2 stevedore-3.5.0\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "# Install other dependecies for Nano HPO\n",
         "!pip install ConfigSpace\n",
@@ -239,24 +92,13 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "yc34x9dcmexg",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
+        "id": "yc34x9dcmexg",
         "outputId": "bba44274-e6d0-408a-bf9b-32d549fe1ea9"
       },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stderr",
-          "text": [
-            "/usr/local/lib/python3.7/dist-packages/bigdl/nano/tf/__init__.py:24: UserWarning: NANO_TF_INTER_OP not found the in os.environ, please run `source bigdl-nano-init`\n",
-            "  warnings.warn(\"NANO_TF_INTER_OP not found the in os.environ, \"\n",
-            "/usr/local/lib/python3.7/dist-packages/bigdl/nano/tf/__init__.py:30: UserWarning: OMP_NUM_THREADS not found the in os.environ, please run `source bigdl-nano-init`\n",
-            "  warnings.warn(\"OMP_NUM_THREADS not found the in os.environ, \"\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "import bigdl.nano.automl as automl\n",
         "automl.hpo_config.enable_hpo_tf()"
@@ -282,17 +124,7 @@
         "id": "o7jWojYNmexk",
         "outputId": "eb4cc68f-4d38-410d-b007-c507da30b97f"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist.npz\n",
-            "11493376/11490434 [==============================] - 0s 0us/step\n",
-            "11501568/11490434 [==============================] - 0s 0us/step\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "from tensorflow import keras\n",
         "\n",
@@ -435,205 +267,7 @@
         "outputId": "9faa9254-c148-4a40-baef-3f39bf89e6e0",
         "scrolled": true
       },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[32m[I 2022-06-10 07:06:31,890]\u001b[0m A new study created in memory with name: no-name-b1869d33-f7ad-404a-b5a8-734c0784052c\u001b[0m\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Starting a new tuning\n",
-            "Epoch 1/5\n",
-            "375/375 - 3s - loss: 0.4179 - accuracy: 0.8872 - val_loss: 0.2395 - val_accuracy: 0.9335 - 3s/epoch - 9ms/step\n",
-            "Epoch 2/5\n",
-            "375/375 - 3s - loss: 0.2149 - accuracy: 0.9376 - val_loss: 0.1784 - val_accuracy: 0.9524 - 3s/epoch - 9ms/step\n",
-            "Epoch 3/5\n",
-            "375/375 - 3s - loss: 0.1523 - accuracy: 0.9570 - val_loss: 0.1315 - val_accuracy: 0.9670 - 3s/epoch - 7ms/step\n",
-            "Epoch 4/5\n",
-            "375/375 - 3s - loss: 0.1167 - accuracy: 0.9669 - val_loss: 0.1095 - val_accuracy: 0.9720 - 3s/epoch - 9ms/step\n",
-            "Epoch 5/5\n",
-            "375/375 - 3s - loss: 0.0957 - accuracy: 0.9724 - val_loss: 0.0992 - val_accuracy: 0.9730 - 3s/epoch - 7ms/step\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[32m[I 2022-06-10 07:06:47,295]\u001b[0m Trial 0 finished with value: 0.9729999899864197 and parameters: {'activation▁choice': 0, 'filters▁choice': 0, 'kernel_size▁choice': 0, 'strides▁choice': 1}. Best is trial 0 with value: 0.9729999899864197.\u001b[0m\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 1/5\n",
-            "375/375 - 9s - loss: 0.3837 - accuracy: 0.8881 - val_loss: 0.3021 - val_accuracy: 0.9144 - 9s/epoch - 24ms/step\n",
-            "Epoch 2/5\n",
-            "375/375 - 7s - loss: 0.3129 - accuracy: 0.9114 - val_loss: 0.2998 - val_accuracy: 0.9165 - 7s/epoch - 19ms/step\n",
-            "Epoch 3/5\n",
-            "375/375 - 8s - loss: 0.2973 - accuracy: 0.9162 - val_loss: 0.2974 - val_accuracy: 0.9142 - 8s/epoch - 22ms/step\n",
-            "Epoch 4/5\n",
-            "375/375 - 9s - loss: 0.2888 - accuracy: 0.9177 - val_loss: 0.2929 - val_accuracy: 0.9197 - 9s/epoch - 24ms/step\n",
-            "Epoch 5/5\n",
-            "375/375 - 8s - loss: 0.2822 - accuracy: 0.9218 - val_loss: 0.2906 - val_accuracy: 0.9210 - 8s/epoch - 20ms/step\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[32m[I 2022-06-10 07:07:28,702]\u001b[0m Trial 1 finished with value: 0.9210000038146973 and parameters: {'activation▁choice': 1, 'filters▁choice': 0, 'kernel_size▁choice': 1, 'strides▁choice': 0}. Best is trial 0 with value: 0.9729999899864197.\u001b[0m\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 1/5\n",
-            "375/375 - 9s - loss: 0.3831 - accuracy: 0.8902 - val_loss: 0.3052 - val_accuracy: 0.9143 - 9s/epoch - 23ms/step\n",
-            "Epoch 2/5\n",
-            "375/375 - 8s - loss: 0.3129 - accuracy: 0.9112 - val_loss: 0.2855 - val_accuracy: 0.9205 - 8s/epoch - 22ms/step\n",
-            "Epoch 3/5\n",
-            "375/375 - 8s - loss: 0.2978 - accuracy: 0.9164 - val_loss: 0.2807 - val_accuracy: 0.9240 - 8s/epoch - 22ms/step\n",
-            "Epoch 4/5\n",
-            "375/375 - 8s - loss: 0.2881 - accuracy: 0.9190 - val_loss: 0.2823 - val_accuracy: 0.9225 - 8s/epoch - 22ms/step\n",
-            "Epoch 5/5\n",
-            "375/375 - 9s - loss: 0.2827 - accuracy: 0.9199 - val_loss: 0.2884 - val_accuracy: 0.9216 - 9s/epoch - 23ms/step\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[32m[I 2022-06-10 07:08:10,866]\u001b[0m Trial 2 finished with value: 0.9240000247955322 and parameters: {'activation▁choice': 1, 'filters▁choice': 0, 'kernel_size▁choice': 1, 'strides▁choice': 0}. Best is trial 0 with value: 0.9729999899864197.\u001b[0m\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 1/5\n",
-            "375/375 - 3s - loss: 0.3833 - accuracy: 0.8935 - val_loss: 0.2027 - val_accuracy: 0.9457 - 3s/epoch - 9ms/step\n",
-            "Epoch 2/5\n",
-            "375/375 - 3s - loss: 0.1661 - accuracy: 0.9529 - val_loss: 0.1239 - val_accuracy: 0.9661 - 3s/epoch - 8ms/step\n",
-            "Epoch 3/5\n",
-            "375/375 - 4s - loss: 0.1056 - accuracy: 0.9697 - val_loss: 0.0900 - val_accuracy: 0.9750 - 4s/epoch - 10ms/step\n",
-            "Epoch 4/5\n",
-            "375/375 - 3s - loss: 0.0806 - accuracy: 0.9769 - val_loss: 0.0808 - val_accuracy: 0.9773 - 3s/epoch - 9ms/step\n",
-            "Epoch 5/5\n",
-            "375/375 - 3s - loss: 0.0663 - accuracy: 0.9807 - val_loss: 0.0728 - val_accuracy: 0.9793 - 3s/epoch - 8ms/step\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[32m[I 2022-06-10 07:08:27,356]\u001b[0m Trial 3 finished with value: 0.9792500138282776 and parameters: {'activation▁choice': 0, 'filters▁choice': 0, 'kernel_size▁choice': 1, 'strides▁choice': 1}. Best is trial 3 with value: 0.9792500138282776.\u001b[0m\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 1/5\n",
-            "375/375 - 3s - loss: 0.4181 - accuracy: 0.8856 - val_loss: 0.2939 - val_accuracy: 0.9190 - 3s/epoch - 7ms/step\n",
-            "Epoch 2/5\n",
-            "375/375 - 2s - loss: 0.3041 - accuracy: 0.9133 - val_loss: 0.2788 - val_accuracy: 0.9234 - 2s/epoch - 6ms/step\n",
-            "Epoch 3/5\n",
-            "375/375 - 3s - loss: 0.2919 - accuracy: 0.9182 - val_loss: 0.2723 - val_accuracy: 0.9254 - 3s/epoch - 7ms/step\n",
-            "Epoch 4/5\n",
-            "375/375 - 3s - loss: 0.2842 - accuracy: 0.9194 - val_loss: 0.2826 - val_accuracy: 0.9222 - 3s/epoch - 7ms/step\n",
-            "Epoch 5/5\n",
-            "375/375 - 2s - loss: 0.2782 - accuracy: 0.9217 - val_loss: 0.2737 - val_accuracy: 0.9254 - 2s/epoch - 6ms/step\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[32m[I 2022-06-10 07:08:39,673]\u001b[0m Trial 4 finished with value: 0.9254166483879089 and parameters: {'activation▁choice': 1, 'filters▁choice': 0, 'kernel_size▁choice': 0, 'strides▁choice': 1}. Best is trial 3 with value: 0.9792500138282776.\u001b[0m\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 1/5\n",
-            "375/375 - 12s - loss: 0.2912 - accuracy: 0.9173 - val_loss: 0.1453 - val_accuracy: 0.9599 - 12s/epoch - 31ms/step\n",
-            "Epoch 2/5\n",
-            "375/375 - 10s - loss: 0.1099 - accuracy: 0.9686 - val_loss: 0.0921 - val_accuracy: 0.9750 - 10s/epoch - 26ms/step\n",
-            "Epoch 3/5\n",
-            "375/375 - 9s - loss: 0.0757 - accuracy: 0.9781 - val_loss: 0.0920 - val_accuracy: 0.9751 - 9s/epoch - 25ms/step\n",
-            "Epoch 4/5\n",
-            "375/375 - 10s - loss: 0.0602 - accuracy: 0.9830 - val_loss: 0.0773 - val_accuracy: 0.9784 - 10s/epoch - 27ms/step\n",
-            "Epoch 5/5\n",
-            "375/375 - 10s - loss: 0.0498 - accuracy: 0.9861 - val_loss: 0.0771 - val_accuracy: 0.9793 - 10s/epoch - 26ms/step\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[32m[I 2022-06-10 07:09:30,500]\u001b[0m Trial 5 finished with value: 0.9793333411216736 and parameters: {'activation▁choice': 0, 'filters▁choice': 0, 'kernel_size▁choice': 0, 'strides▁choice': 0}. Best is trial 5 with value: 0.9793333411216736.\u001b[0m\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 1/5\n",
-            "375/375 - 12s - loss: 0.2349 - accuracy: 0.9321 - val_loss: 0.0939 - val_accuracy: 0.9733 - 12s/epoch - 32ms/step\n",
-            "Epoch 2/5\n",
-            "375/375 - 10s - loss: 0.0783 - accuracy: 0.9773 - val_loss: 0.0768 - val_accuracy: 0.9776 - 10s/epoch - 27ms/step\n",
-            "Epoch 3/5\n",
-            "375/375 - 10s - loss: 0.0549 - accuracy: 0.9838 - val_loss: 0.0628 - val_accuracy: 0.9824 - 10s/epoch - 27ms/step\n",
-            "Epoch 4/5\n",
-            "375/375 - 10s - loss: 0.0432 - accuracy: 0.9872 - val_loss: 0.0573 - val_accuracy: 0.9841 - 10s/epoch - 27ms/step\n",
-            "Epoch 5/5\n",
-            "375/375 - 10s - loss: 0.0358 - accuracy: 0.9890 - val_loss: 0.0611 - val_accuracy: 0.9834 - 10s/epoch - 28ms/step\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[32m[I 2022-06-10 07:10:23,197]\u001b[0m Trial 6 finished with value: 0.984083354473114 and parameters: {'activation▁choice': 0, 'filters▁choice': 0, 'kernel_size▁choice': 1, 'strides▁choice': 0}. Best is trial 6 with value: 0.984083354473114.\u001b[0m\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 1/5\n",
-            "375/375 - 21s - loss: 0.2005 - accuracy: 0.9410 - val_loss: 0.0953 - val_accuracy: 0.9722 - 21s/epoch - 55ms/step\n",
-            "Epoch 2/5\n",
-            "375/375 - 20s - loss: 0.0687 - accuracy: 0.9792 - val_loss: 0.0628 - val_accuracy: 0.9820 - 20s/epoch - 53ms/step\n",
-            "Epoch 3/5\n",
-            "375/375 - 19s - loss: 0.0473 - accuracy: 0.9860 - val_loss: 0.0634 - val_accuracy: 0.9815 - 19s/epoch - 50ms/step\n",
-            "Epoch 4/5\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[32m[I 2022-06-10 07:11:42,902]\u001b[0m Trial 7 pruned. Trial was pruned at epoch 3.\u001b[0m\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 7min 20s, sys: 2min 40s, total: 10min\n",
-            "Wall time: 5min 11s\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "%%time\n",
         "from bigdl.nano.automl.hpo.backend import PrunerType\n",
@@ -662,23 +296,7 @@
         "id": "MpFgoN4TwZHk",
         "outputId": "e157fe1d-5628-4795-d3b9-40db199ae9b3"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Number of finished trials: 8\n",
-            "Best trial:\n",
-            "  Value: 0.984083354473114\n",
-            "  Params: \n",
-            "    activation▁choice: 0\n",
-            "    filters▁choice: 0\n",
-            "    kernel_size▁choice: 1\n",
-            "    strides▁choice: 0\n",
-            "<optuna.study.study.Study object at 0x7fe562357f10>\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "print(model.search_summary())"
       ]
@@ -703,91 +321,7 @@
         "id": "mvHyvEDomexo",
         "outputId": "350caead-932c-4b69-a9b6-4592dc12da72"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 1/5\n",
-            "375/375 - 6s - loss: 0.3255 - accuracy: 0.9053 - val_loss: 0.1474 - val_accuracy: 0.9602 - 6s/epoch - 16ms/step\n",
-            "Epoch 2/5\n",
-            "375/375 - 6s - loss: 0.1183 - accuracy: 0.9667 - val_loss: 0.0970 - val_accuracy: 0.9728 - 6s/epoch - 15ms/step\n",
-            "Epoch 3/5\n",
-            "375/375 - 6s - loss: 0.0796 - accuracy: 0.9777 - val_loss: 0.0795 - val_accuracy: 0.9772 - 6s/epoch - 15ms/step\n",
-            "Epoch 4/5\n",
-            "375/375 - 5s - loss: 0.0626 - accuracy: 0.9821 - val_loss: 0.0690 - val_accuracy: 0.9803 - 5s/epoch - 14ms/step\n",
-            "Epoch 5/5\n",
-            "375/375 - 6s - loss: 0.0523 - accuracy: 0.9846 - val_loss: 0.0638 - val_accuracy: 0.9818 - 6s/epoch - 15ms/step\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[32m[I 2022-06-10 07:12:27,503]\u001b[0m Trial 8 finished with value: 0.9818333387374878 and parameters: {'activation▁choice': 0, 'filters▁choice': 1, 'kernel_size▁choice': 1, 'strides▁choice': 1}. Best is trial 6 with value: 0.984083354473114.\u001b[0m\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 1/5\n",
-            "375/375 - 18s - loss: 0.3843 - accuracy: 0.8866 - val_loss: 0.3061 - val_accuracy: 0.9155 - 18s/epoch - 49ms/step\n",
-            "Epoch 2/5\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[32m[I 2022-06-10 07:13:03,941]\u001b[0m Trial 9 pruned. Trial was pruned at epoch 1.\u001b[0m\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 1/5\n",
-            "375/375 - 4s - loss: 0.4129 - accuracy: 0.8843 - val_loss: 0.3053 - val_accuracy: 0.9132 - 4s/epoch - 9ms/step\n",
-            "Epoch 2/5\n",
-            "375/375 - 3s - loss: 0.3095 - accuracy: 0.9117 - val_loss: 0.2873 - val_accuracy: 0.9205 - 3s/epoch - 7ms/step\n",
-            "Epoch 3/5\n",
-            "375/375 - 3s - loss: 0.2971 - accuracy: 0.9163 - val_loss: 0.2818 - val_accuracy: 0.9208 - 3s/epoch - 8ms/step\n",
-            "Epoch 4/5\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[32m[I 2022-06-10 07:13:15,216]\u001b[0m Trial 10 pruned. Trial was pruned at epoch 3.\u001b[0m\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 1/5\n",
-            "375/375 - 6s - loss: 0.3945 - accuracy: 0.8856 - val_loss: 0.2878 - val_accuracy: 0.9193 - 6s/epoch - 16ms/step\n",
-            "Epoch 2/5\n"
-          ]
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "\u001b[32m[I 2022-06-10 07:13:35,444]\u001b[0m Trial 11 pruned. Trial was pruned at epoch 1.\u001b[0m\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "CPU times: user 1min 59s, sys: 48.6 s, total: 2min 48s\n",
-            "Wall time: 1min 52s\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "%%time\n",
         "model.search(\n",
@@ -816,23 +350,7 @@
         "id": "xQEDtjj1mexx",
         "outputId": "11040b63-a3fc-4570-d2a9-02c681900cca"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Number of finished trials: 12\n",
-            "Best trial:\n",
-            "  Value: 0.984083354473114\n",
-            "  Params: \n",
-            "    activation▁choice: 0\n",
-            "    filters▁choice: 0\n",
-            "    kernel_size▁choice: 1\n",
-            "    strides▁choice: 0\n",
-            "<optuna.study.study.Study object at 0x7fe562357f10>\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "print(model.search_summary())"
       ]
@@ -858,27 +376,7 @@
         "outputId": "86d9215e-b20f-45b7-c171-8c4b31fe466f",
         "scrolled": true
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Epoch 1/5\n",
-            "375/375 [==============================] - 13s 33ms/step - loss: 0.2448 - accuracy: 0.9281 - val_loss: 0.1068 - val_accuracy: 0.9715\n",
-            "Epoch 2/5\n",
-            "375/375 [==============================] - 12s 33ms/step - loss: 0.0794 - accuracy: 0.9768 - val_loss: 0.0684 - val_accuracy: 0.9813\n",
-            "Epoch 3/5\n",
-            "375/375 [==============================] - 12s 31ms/step - loss: 0.0556 - accuracy: 0.9834 - val_loss: 0.0658 - val_accuracy: 0.9814\n",
-            "Epoch 4/5\n",
-            "375/375 [==============================] - 12s 32ms/step - loss: 0.0441 - accuracy: 0.9871 - val_loss: 0.0619 - val_accuracy: 0.9825\n",
-            "Epoch 5/5\n",
-            "375/375 [==============================] - 14s 38ms/step - loss: 0.0357 - accuracy: 0.9900 - val_loss: 0.0613 - val_accuracy: 0.9837\n",
-            "313/313 - 1s - loss: 0.0502 - accuracy: 0.9837 - 1s/epoch - 5ms/step\n",
-            "Test loss: 0.050218481570482254\n",
-            "Test accuracy: 0.9836999773979187\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "history = model.fit(x_train, y_train,\n",
         "                    batch_size=128, epochs=5, validation_split=0.2)\n",
@@ -909,38 +407,7 @@
         "outputId": "7e33c852-cea8-4204-f2fa-f1f265759426",
         "scrolled": true
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "Model: \"sequential_1\"\n",
-            "_________________________________________________________________\n",
-            " Layer (type)                Output Shape              Param #   \n",
-            "=================================================================\n",
-            " conv2d_1 (Conv2D)           (None, 24, 24, 32)        832       \n",
-            "                                                                 \n",
-            " flatten_1 (Flatten)         (None, 18432)             0         \n",
-            "                                                                 \n",
-            " dense_1 (Dense)             (None, 10)                184330    \n",
-            "                                                                 \n",
-            "=================================================================\n",
-            "Total params: 185,162\n",
-            "Trainable params: 185,162\n",
-            "Non-trainable params: 0\n",
-            "_________________________________________________________________\n",
-            "None\n",
-            "Number of finished trials: 12\n",
-            "Best trial:\n",
-            "  Value: 0.984083354473114\n",
-            "  Params: \n",
-            "    activation▁choice: 0\n",
-            "    filters▁choice: 0\n",
-            "    kernel_size▁choice: 1\n",
-            "    strides▁choice: 0\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "print(model.summary())\n",
         "study = model.search_summary()"
@@ -957,276 +424,7 @@
         "id": "EZZZgiWeNfuN",
         "outputId": "b99dade8-1838-4b19-c4c3-2afbffd801f5"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "\n",
-              "  <div id=\"df-640cd69f-9fb1-41ed-af4e-6520ff30e15c\">\n",
-              "    <div class=\"colab-df-container\">\n",
-              "      <div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>number</th>\n",
-              "      <th>value</th>\n",
-              "      <th>params_activation▁choice</th>\n",
-              "      <th>params_filters▁choice</th>\n",
-              "      <th>params_kernel_size▁choice</th>\n",
-              "      <th>params_strides▁choice</th>\n",
-              "      <th>state</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>0</td>\n",
-              "      <td>0.973000</td>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>1</td>\n",
-              "      <td>COMPLETE</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>1</td>\n",
-              "      <td>0.921000</td>\n",
-              "      <td>1</td>\n",
-              "      <td>0</td>\n",
-              "      <td>1</td>\n",
-              "      <td>0</td>\n",
-              "      <td>COMPLETE</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>2</td>\n",
-              "      <td>0.924000</td>\n",
-              "      <td>1</td>\n",
-              "      <td>0</td>\n",
-              "      <td>1</td>\n",
-              "      <td>0</td>\n",
-              "      <td>COMPLETE</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>3</th>\n",
-              "      <td>3</td>\n",
-              "      <td>0.979250</td>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>1</td>\n",
-              "      <td>1</td>\n",
-              "      <td>COMPLETE</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>4</th>\n",
-              "      <td>4</td>\n",
-              "      <td>0.925417</td>\n",
-              "      <td>1</td>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>1</td>\n",
-              "      <td>COMPLETE</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>5</th>\n",
-              "      <td>5</td>\n",
-              "      <td>0.979333</td>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>COMPLETE</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>6</th>\n",
-              "      <td>6</td>\n",
-              "      <td>0.984083</td>\n",
-              "      <td>0</td>\n",
-              "      <td>0</td>\n",
-              "      <td>1</td>\n",
-              "      <td>0</td>\n",
-              "      <td>COMPLETE</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>7</th>\n",
-              "      <td>7</td>\n",
-              "      <td>0.982917</td>\n",
-              "      <td>0</td>\n",
-              "      <td>1</td>\n",
-              "      <td>1</td>\n",
-              "      <td>0</td>\n",
-              "      <td>PRUNED</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>8</th>\n",
-              "      <td>8</td>\n",
-              "      <td>0.981833</td>\n",
-              "      <td>0</td>\n",
-              "      <td>1</td>\n",
-              "      <td>1</td>\n",
-              "      <td>1</td>\n",
-              "      <td>COMPLETE</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>9</th>\n",
-              "      <td>9</td>\n",
-              "      <td>0.913500</td>\n",
-              "      <td>1</td>\n",
-              "      <td>1</td>\n",
-              "      <td>1</td>\n",
-              "      <td>0</td>\n",
-              "      <td>PRUNED</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>10</th>\n",
-              "      <td>10</td>\n",
-              "      <td>0.920917</td>\n",
-              "      <td>1</td>\n",
-              "      <td>0</td>\n",
-              "      <td>1</td>\n",
-              "      <td>1</td>\n",
-              "      <td>PRUNED</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>11</th>\n",
-              "      <td>11</td>\n",
-              "      <td>0.919750</td>\n",
-              "      <td>1</td>\n",
-              "      <td>1</td>\n",
-              "      <td>1</td>\n",
-              "      <td>1</td>\n",
-              "      <td>PRUNED</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>\n",
-              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-640cd69f-9fb1-41ed-af4e-6520ff30e15c')\"\n",
-              "              title=\"Convert this dataframe to an interactive table.\"\n",
-              "              style=\"display:none;\">\n",
-              "        \n",
-              "  <svg xmlns=\"http://www.w3.org/2000/svg\" height=\"24px\"viewBox=\"0 0 24 24\"\n",
-              "       width=\"24px\">\n",
-              "    <path d=\"M0 0h24v24H0V0z\" fill=\"none\"/>\n",
-              "    <path d=\"M18.56 5.44l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94zm-11 1L8.5 8.5l.94-2.06 2.06-.94-2.06-.94L8.5 2.5l-.94 2.06-2.06.94zm10 10l.94 2.06.94-2.06 2.06-.94-2.06-.94-.94-2.06-.94 2.06-2.06.94z\"/><path d=\"M17.41 7.96l-1.37-1.37c-.4-.4-.92-.59-1.43-.59-.52 0-1.04.2-1.43.59L10.3 9.45l-7.72 7.72c-.78.78-.78 2.05 0 2.83L4 21.41c.39.39.9.59 1.41.59.51 0 1.02-.2 1.41-.59l7.78-7.78 2.81-2.81c.8-.78.8-2.07 0-2.86zM5.41 20L4 18.59l7.72-7.72 1.47 1.35L5.41 20z\"/>\n",
-              "  </svg>\n",
-              "      </button>\n",
-              "      \n",
-              "  <style>\n",
-              "    .colab-df-container {\n",
-              "      display:flex;\n",
-              "      flex-wrap:wrap;\n",
-              "      gap: 12px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert {\n",
-              "      background-color: #E8F0FE;\n",
-              "      border: none;\n",
-              "      border-radius: 50%;\n",
-              "      cursor: pointer;\n",
-              "      display: none;\n",
-              "      fill: #1967D2;\n",
-              "      height: 32px;\n",
-              "      padding: 0 0 0 0;\n",
-              "      width: 32px;\n",
-              "    }\n",
-              "\n",
-              "    .colab-df-convert:hover {\n",
-              "      background-color: #E2EBFA;\n",
-              "      box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 1px 3px 1px rgba(60, 64, 67, 0.15);\n",
-              "      fill: #174EA6;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert {\n",
-              "      background-color: #3B4455;\n",
-              "      fill: #D2E3FC;\n",
-              "    }\n",
-              "\n",
-              "    [theme=dark] .colab-df-convert:hover {\n",
-              "      background-color: #434B5C;\n",
-              "      box-shadow: 0px 1px 3px 1px rgba(0, 0, 0, 0.15);\n",
-              "      filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.3));\n",
-              "      fill: #FFFFFF;\n",
-              "    }\n",
-              "  </style>\n",
-              "\n",
-              "      <script>\n",
-              "        const buttonEl =\n",
-              "          document.querySelector('#df-640cd69f-9fb1-41ed-af4e-6520ff30e15c button.colab-df-convert');\n",
-              "        buttonEl.style.display =\n",
-              "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
-              "\n",
-              "        async function convertToInteractive(key) {\n",
-              "          const element = document.querySelector('#df-640cd69f-9fb1-41ed-af4e-6520ff30e15c');\n",
-              "          const dataTable =\n",
-              "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
-              "                                                     [key], {});\n",
-              "          if (!dataTable) return;\n",
-              "\n",
-              "          const docLinkHtml = 'Like what you see? Visit the ' +\n",
-              "            '<a target=\"_blank\" href=https://colab.research.google.com/notebooks/data_table.ipynb>data table notebook</a>'\n",
-              "            + ' to learn more about interactive tables.';\n",
-              "          element.innerHTML = '';\n",
-              "          dataTable['output_type'] = 'display_data';\n",
-              "          await google.colab.output.renderOutput(dataTable, element);\n",
-              "          const docLink = document.createElement('div');\n",
-              "          docLink.innerHTML = docLinkHtml;\n",
-              "          element.appendChild(docLink);\n",
-              "        }\n",
-              "      </script>\n",
-              "    </div>\n",
-              "  </div>\n",
-              "  "
-            ],
-            "text/plain": [
-              "    number     value  params_activation▁choice  params_filters▁choice  \\\n",
-              "0        0  0.973000                         0                      0   \n",
-              "1        1  0.921000                         1                      0   \n",
-              "2        2  0.924000                         1                      0   \n",
-              "3        3  0.979250                         0                      0   \n",
-              "4        4  0.925417                         1                      0   \n",
-              "5        5  0.979333                         0                      0   \n",
-              "6        6  0.984083                         0                      0   \n",
-              "7        7  0.982917                         0                      1   \n",
-              "8        8  0.981833                         0                      1   \n",
-              "9        9  0.913500                         1                      1   \n",
-              "10      10  0.920917                         1                      0   \n",
-              "11      11  0.919750                         1                      1   \n",
-              "\n",
-              "    params_kernel_size▁choice  params_strides▁choice     state  \n",
-              "0                           0                      1  COMPLETE  \n",
-              "1                           1                      0  COMPLETE  \n",
-              "2                           1                      0  COMPLETE  \n",
-              "3                           1                      1  COMPLETE  \n",
-              "4                           0                      1  COMPLETE  \n",
-              "5                           0                      0  COMPLETE  \n",
-              "6                           1                      0  COMPLETE  \n",
-              "7                           1                      0    PRUNED  \n",
-              "8                           1                      1  COMPLETE  \n",
-              "9                           1                      0    PRUNED  \n",
-              "10                          1                      1    PRUNED  \n",
-              "11                          1                      1    PRUNED  "
-            ]
-          },
-          "execution_count": 15,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
+      "outputs": [],
       "source": [
         "study.trials_dataframe(attrs=(\"number\", \"value\", \"params\", \"state\"))"
       ]
@@ -1243,47 +441,7 @@
         "outputId": "b80a13a5-3cf0-40b0-c33c-b9b83de43c1a",
         "scrolled": false
       },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<html>\n",
-              "<head><meta charset=\"utf-8\" /></head>\n",
-              "<body>\n",
-              "    <div>            <script src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG\"></script><script type=\"text/javascript\">if (window.MathJax) {MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}</script>                <script type=\"text/javascript\">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
-              "        <script src=\"https://cdn.plot.ly/plotly-2.8.3.min.js\"></script>                <div id=\"a3dbb9aa-a8c6-4a7e-b8c8-4ed350afc379\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"a3dbb9aa-a8c6-4a7e-b8c8-4ed350afc379\")) {                    Plotly.newPlot(                        \"a3dbb9aa-a8c6-4a7e-b8c8-4ed350afc379\",                        [{\"mode\":\"markers\",\"name\":\"Objective Value\",\"x\":[0,1,2,3,4,5,6,8],\"y\":[0.9729999899864197,0.9210000038146973,0.9240000247955322,0.9792500138282776,0.9254166483879089,0.9793333411216736,0.984083354473114,0.9818333387374878],\"type\":\"scatter\"},{\"name\":\"Best Value\",\"x\":[0,1,2,3,4,5,6,8],\"y\":[0.9729999899864197,0.9729999899864197,0.9729999899864197,0.9792500138282776,0.9792500138282776,0.9793333411216736,0.984083354473114,0.984083354473114],\"type\":\"scatter\"}],                        {\"title\":{\"text\":\"Optimization History Plot\"},\"xaxis\":{\"title\":{\"text\":\"#Trials\"}},\"yaxis\":{\"title\":{\"text\":\"Objective Value\"}},\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}}},                        {\"responsive\": true}                    ).then(function(){\n",
-              "                            \n",
-              "var gd = document.getElementById('a3dbb9aa-a8c6-4a7e-b8c8-4ed350afc379');\n",
-              "var x = new MutationObserver(function (mutations, observer) {{\n",
-              "        var display = window.getComputedStyle(gd).display;\n",
-              "        if (!display || display === 'none') {{\n",
-              "            console.log([gd, 'removed!']);\n",
-              "            Plotly.purge(gd);\n",
-              "            observer.disconnect();\n",
-              "        }}\n",
-              "}});\n",
-              "\n",
-              "// Listen for the removal of the full notebook cells\n",
-              "var notebookContainer = gd.closest('#notebook-container');\n",
-              "if (notebookContainer) {{\n",
-              "    x.observe(notebookContainer, {childList: true});\n",
-              "}}\n",
-              "\n",
-              "// Listen for the clearing of the current output cell\n",
-              "var outputEl = gd.closest('.output');\n",
-              "if (outputEl) {{\n",
-              "    x.observe(outputEl, {childList: true});\n",
-              "}}\n",
-              "\n",
-              "                        })                };                            </script>        </div>\n",
-              "</body>\n",
-              "</html>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "from bigdl.nano.automl.hpo.visualization import plot_optimization_history\n",
         "plot_optimization_history(study)"
@@ -1300,47 +458,7 @@
         "id": "QdZhgElEmexz",
         "outputId": "3da0abb3-bc1b-4412-8834-0e995ea27857"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<html>\n",
-              "<head><meta charset=\"utf-8\" /></head>\n",
-              "<body>\n",
-              "    <div>            <script src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG\"></script><script type=\"text/javascript\">if (window.MathJax) {MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}</script>                <script type=\"text/javascript\">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
-              "        <script src=\"https://cdn.plot.ly/plotly-2.8.3.min.js\"></script>                <div id=\"7c87d5b5-4588-45b4-9ee9-cd56cbeff5e1\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"7c87d5b5-4588-45b4-9ee9-cd56cbeff5e1\")) {                    Plotly.newPlot(                        \"7c87d5b5-4588-45b4-9ee9-cd56cbeff5e1\",                        [{\"dimensions\":[{\"label\":\"Objective Value\",\"range\":[0.9210000038146973,0.984083354473114],\"values\":[0.9793333411216736,0.9729999899864197,0.984083354473114,0.9792500138282776,0.9818333387374878,0.9254166483879089,0.9210000038146973,0.9240000247955322]},{\"label\":\"activation\\u2581choice\",\"range\":[0,1],\"ticktext\":[0,1],\"tickvals\":[0,1],\"values\":[0,0,0,0,0,1,1,1]},{\"label\":\"filters\\u2581choice\",\"range\":[0,1],\"ticktext\":[0,1],\"tickvals\":[0,1],\"values\":[0,0,0,0,1,0,0,0]},{\"label\":\"kernel_size\\u2581choice\",\"range\":[0,1],\"ticktext\":[0,1],\"tickvals\":[0,1],\"values\":[0,0,1,1,1,0,1,1]},{\"label\":\"strides\\u2581choice\",\"range\":[0,1],\"ticktext\":[0,1],\"tickvals\":[0,1],\"values\":[0,1,0,1,1,1,0,0]}],\"labelangle\":30,\"labelside\":\"bottom\",\"line\":{\"color\":[0.9793333411216736,0.9729999899864197,0.984083354473114,0.9792500138282776,0.9818333387374878,0.9254166483879089,0.9210000038146973,0.9240000247955322],\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0.0,\"rgb(247,251,255)\"],[0.125,\"rgb(222,235,247)\"],[0.25,\"rgb(198,219,239)\"],[0.375,\"rgb(158,202,225)\"],[0.5,\"rgb(107,174,214)\"],[0.625,\"rgb(66,146,198)\"],[0.75,\"rgb(33,113,181)\"],[0.875,\"rgb(8,81,156)\"],[1.0,\"rgb(8,48,107)\"]],\"reversescale\":false,\"showscale\":true},\"type\":\"parcoords\"}],                        {\"title\":{\"text\":\"Parallel Coordinate Plot\"},\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}}},                        {\"responsive\": true}                    ).then(function(){\n",
-              "                            \n",
-              "var gd = document.getElementById('7c87d5b5-4588-45b4-9ee9-cd56cbeff5e1');\n",
-              "var x = new MutationObserver(function (mutations, observer) {{\n",
-              "        var display = window.getComputedStyle(gd).display;\n",
-              "        if (!display || display === 'none') {{\n",
-              "            console.log([gd, 'removed!']);\n",
-              "            Plotly.purge(gd);\n",
-              "            observer.disconnect();\n",
-              "        }}\n",
-              "}});\n",
-              "\n",
-              "// Listen for the removal of the full notebook cells\n",
-              "var notebookContainer = gd.closest('#notebook-container');\n",
-              "if (notebookContainer) {{\n",
-              "    x.observe(notebookContainer, {childList: true});\n",
-              "}}\n",
-              "\n",
-              "// Listen for the clearing of the current output cell\n",
-              "var outputEl = gd.closest('.output');\n",
-              "if (outputEl) {{\n",
-              "    x.observe(outputEl, {childList: true});\n",
-              "}}\n",
-              "\n",
-              "                        })                };                            </script>        </div>\n",
-              "</body>\n",
-              "</html>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "from bigdl.nano.automl.hpo.visualization import plot_parallel_coordinate\n",
         "plot_parallel_coordinate(study)"
@@ -1357,47 +475,7 @@
         "id": "rL8-6vGYmex0",
         "outputId": "c7ac5ec6-2af9-4b9d-9815-e98b4466d732"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<html>\n",
-              "<head><meta charset=\"utf-8\" /></head>\n",
-              "<body>\n",
-              "    <div>            <script src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG\"></script><script type=\"text/javascript\">if (window.MathJax) {MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}</script>                <script type=\"text/javascript\">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
-              "        <script src=\"https://cdn.plot.ly/plotly-2.8.3.min.js\"></script>                <div id=\"e89c6280-813a-478f-bba0-49a4d2ca7875\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"e89c6280-813a-478f-bba0-49a4d2ca7875\")) {                    Plotly.newPlot(                        \"e89c6280-813a-478f-bba0-49a4d2ca7875\",                        [{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial0\",\"x\":[0,1,2,3,4],\"y\":[0.9334999918937683,0.9524166584014893,0.9670000076293945,0.972000002861023,0.9729999899864197],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial1\",\"x\":[0,1,2,3,4],\"y\":[0.9144166707992554,0.9164999723434448,0.9141666889190674,0.9196666479110718,0.9210000038146973],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial2\",\"x\":[0,1,2,3,4],\"y\":[0.9143333435058594,0.9204999804496765,0.9240000247955322,0.9225000143051147,0.921583354473114],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial3\",\"x\":[0,1,2,3,4],\"y\":[0.9457499980926514,0.9660833477973938,0.9750000238418579,0.9773333072662354,0.9792500138282776],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial4\",\"x\":[0,1,2,3,4],\"y\":[0.9190000295639038,0.9234166741371155,0.9254166483879089,0.922249972820282,0.9254166483879089],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial5\",\"x\":[0,1,2,3,4],\"y\":[0.9599166512489319,0.9750000238418579,0.9750833511352539,0.9784166812896729,0.9793333411216736],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial6\",\"x\":[0,1,2,3,4],\"y\":[0.9733333587646484,0.9775833487510681,0.9824166893959045,0.984083354473114,0.9834166765213013],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial7\",\"x\":[0,1,2,3],\"y\":[0.9722499847412109,0.9819999933242798,0.9815000295639038,0.9829166531562805],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial8\",\"x\":[0,1,2,3,4],\"y\":[0.9601666927337646,0.9727500081062317,0.9771666526794434,0.9803333282470703,0.9818333387374878],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial9\",\"x\":[0,1],\"y\":[0.9154999852180481,0.9135000109672546],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial10\",\"x\":[0,1,2,3],\"y\":[0.9131666421890259,0.9204999804496765,0.9208333492279053,0.9209166765213013],\"type\":\"scatter\"},{\"marker\":{\"maxdisplayed\":10},\"mode\":\"lines+markers\",\"name\":\"Trial11\",\"x\":[0,1],\"y\":[0.9193333387374878,0.9197499752044678],\"type\":\"scatter\"}],                        {\"showlegend\":false,\"title\":{\"text\":\"Intermediate Values Plot\"},\"xaxis\":{\"title\":{\"text\":\"Step\"}},\"yaxis\":{\"title\":{\"text\":\"Intermediate Value\"}},\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}}},                        {\"responsive\": true}                    ).then(function(){\n",
-              "                            \n",
-              "var gd = document.getElementById('e89c6280-813a-478f-bba0-49a4d2ca7875');\n",
-              "var x = new MutationObserver(function (mutations, observer) {{\n",
-              "        var display = window.getComputedStyle(gd).display;\n",
-              "        if (!display || display === 'none') {{\n",
-              "            console.log([gd, 'removed!']);\n",
-              "            Plotly.purge(gd);\n",
-              "            observer.disconnect();\n",
-              "        }}\n",
-              "}});\n",
-              "\n",
-              "// Listen for the removal of the full notebook cells\n",
-              "var notebookContainer = gd.closest('#notebook-container');\n",
-              "if (notebookContainer) {{\n",
-              "    x.observe(notebookContainer, {childList: true});\n",
-              "}}\n",
-              "\n",
-              "// Listen for the clearing of the current output cell\n",
-              "var outputEl = gd.closest('.output');\n",
-              "if (outputEl) {{\n",
-              "    x.observe(outputEl, {childList: true});\n",
-              "}}\n",
-              "\n",
-              "                        })                };                            </script>        </div>\n",
-              "</body>\n",
-              "</html>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "from bigdl.nano.automl.hpo.visualization import plot_intermediate_values\n",
         "plot_intermediate_values(study)"
@@ -1414,47 +492,7 @@
         "id": "A5mqqXg8mex0",
         "outputId": "325accdc-c371-48d1-d9e2-ce332759d9bb"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<html>\n",
-              "<head><meta charset=\"utf-8\" /></head>\n",
-              "<body>\n",
-              "    <div>            <script src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG\"></script><script type=\"text/javascript\">if (window.MathJax) {MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}</script>                <script type=\"text/javascript\">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
-              "        <script src=\"https://cdn.plot.ly/plotly-2.8.3.min.js\"></script>                <div id=\"4fa75e5b-111d-4d78-936c-357b16d5bb13\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"4fa75e5b-111d-4d78-936c-357b16d5bb13\")) {                    Plotly.newPlot(                        \"4fa75e5b-111d-4d78-936c-357b16d5bb13\",                        [{\"type\":\"scatter\",\"xaxis\":\"x\",\"yaxis\":\"y\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":true,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.984083354473114,0.9254166483879089,null],[null,0.9818333387374878,null,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x5\",\"yaxis\":\"y5\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[0,1,1,0,1,0,0,0],\"y\":[0,0,0,0,0,0,0,1],\"type\":\"scatter\",\"xaxis\":\"x5\",\"yaxis\":\"y5\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.9793333411216736,0.9254166483879089,null],[null,0.9818333387374878,0.9240000247955322,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x9\",\"yaxis\":\"y9\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[0,1,1,0,1,0,0,0],\"y\":[0,1,1,1,0,0,1,1],\"type\":\"scatter\",\"xaxis\":\"x9\",\"yaxis\":\"y9\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.984083354473114,0.9240000247955322,null],[null,0.9818333387374878,0.9254166483879089,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x13\",\"yaxis\":\"y13\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[0,1,1,0,1,0,0,0],\"y\":[1,0,0,1,1,0,0,1],\"type\":\"scatter\",\"xaxis\":\"x13\",\"yaxis\":\"y13\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.984083354473114,0.9818333387374878,null],[null,0.9254166483879089,null,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[0,0,0,0,0,0,0,1],\"y\":[0,1,1,0,1,0,0,0],\"type\":\"scatter\",\"xaxis\":\"x2\",\"yaxis\":\"y2\"},{\"type\":\"scatter\",\"xaxis\":\"x6\",\"yaxis\":\"y6\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.9793333411216736,null,null],[null,0.984083354473114,0.9818333387374878,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x10\",\"yaxis\":\"y10\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[0,0,0,0,0,0,0,1],\"y\":[0,1,1,1,0,0,1,1],\"type\":\"scatter\",\"xaxis\":\"x10\",\"yaxis\":\"y10\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.984083354473114,null,null],[null,0.9254166483879089,0.9818333387374878,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x14\",\"yaxis\":\"y14\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[0,0,0,0,0,0,0,1],\"y\":[1,0,0,1,1,0,0,1],\"type\":\"scatter\",\"xaxis\":\"x14\",\"yaxis\":\"y14\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.9793333411216736,0.9818333387374878,null],[null,0.9254166483879089,0.9240000247955322,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x3\",\"yaxis\":\"y3\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[0,1,1,1,0,0,1,1],\"y\":[0,1,1,0,1,0,0,0],\"type\":\"scatter\",\"xaxis\":\"x3\",\"yaxis\":\"y3\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.9793333411216736,0.984083354473114,null],[null,null,0.9818333387374878,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x7\",\"yaxis\":\"y7\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[0,1,1,1,0,0,1,1],\"y\":[0,0,0,0,0,0,0,1],\"type\":\"scatter\",\"xaxis\":\"x7\",\"yaxis\":\"y7\"},{\"type\":\"scatter\",\"xaxis\":\"x11\",\"yaxis\":\"y11\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.9793333411216736,0.984083354473114,null],[null,0.9254166483879089,0.9818333387374878,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x15\",\"yaxis\":\"y15\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[0,1,1,1,0,0,1,1],\"y\":[1,0,0,1,1,0,0,1],\"type\":\"scatter\",\"xaxis\":\"x15\",\"yaxis\":\"y15\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.984083354473114,0.9818333387374878,null],[null,0.9240000247955322,0.9254166483879089,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x4\",\"yaxis\":\"y4\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[1,0,0,1,1,0,0,1],\"y\":[0,1,1,0,1,0,0,0],\"type\":\"scatter\",\"xaxis\":\"x4\",\"yaxis\":\"y4\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.984083354473114,0.9254166483879089,null],[null,null,0.9818333387374878,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x8\",\"yaxis\":\"y8\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[1,0,0,1,1,0,0,1],\"y\":[0,0,0,0,0,0,0,1],\"type\":\"scatter\",\"xaxis\":\"x8\",\"yaxis\":\"y8\"},{\"colorbar\":{\"title\":{\"text\":\"Objective Value\"}},\"colorscale\":[[0,\"rgb(5,10,172)\"],[0.35,\"rgb(40,60,190)\"],[0.5,\"rgb(70,100,245)\"],[0.6,\"rgb(90,120,245)\"],[0.7,\"rgb(106,137,247)\"],[1,\"rgb(220,220,220)\"]],\"connectgaps\":true,\"contours\":{\"coloring\":\"heatmap\"},\"hoverinfo\":\"none\",\"line\":{\"smoothing\":1.3},\"reversescale\":false,\"showscale\":false,\"x\":[-0.05,0,1,1.05],\"y\":[-0.05,0,1,1.05],\"z\":[[null,null,null,null],[null,0.9793333411216736,0.9254166483879089,null],[null,0.984083354473114,0.9818333387374878,null],[null,null,null,null]],\"type\":\"contour\",\"xaxis\":\"x12\",\"yaxis\":\"y12\"},{\"marker\":{\"color\":\"black\",\"line\":{\"color\":\"Grey\",\"width\":0.5}},\"mode\":\"markers\",\"showlegend\":false,\"x\":[1,0,0,1,1,0,0,1],\"y\":[0,1,1,1,0,0,1,1],\"type\":\"scatter\",\"xaxis\":\"x12\",\"yaxis\":\"y12\"},{\"type\":\"scatter\",\"xaxis\":\"x16\",\"yaxis\":\"y16\"}],                        {\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}},\"xaxis\":{\"anchor\":\"y\",\"domain\":[0.0,0.2125],\"matches\":\"x13\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis\":{\"anchor\":\"x\",\"domain\":[0.80625,1.0],\"range\":[-0.05,1.05],\"title\":{\"text\":\"activation\\u2581choice\"}},\"xaxis2\":{\"anchor\":\"y2\",\"domain\":[0.2625,0.475],\"matches\":\"x14\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis2\":{\"anchor\":\"x2\",\"domain\":[0.80625,1.0],\"matches\":\"y\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis3\":{\"anchor\":\"y3\",\"domain\":[0.525,0.7375],\"matches\":\"x15\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis3\":{\"anchor\":\"x3\",\"domain\":[0.80625,1.0],\"matches\":\"y\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis4\":{\"anchor\":\"y4\",\"domain\":[0.7875,1.0],\"matches\":\"x16\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis4\":{\"anchor\":\"x4\",\"domain\":[0.80625,1.0],\"matches\":\"y\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis5\":{\"anchor\":\"y5\",\"domain\":[0.0,0.2125],\"matches\":\"x13\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis5\":{\"anchor\":\"x5\",\"domain\":[0.5375,0.73125],\"range\":[-0.05,1.05],\"title\":{\"text\":\"filters\\u2581choice\"}},\"xaxis6\":{\"anchor\":\"y6\",\"domain\":[0.2625,0.475],\"matches\":\"x14\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis6\":{\"anchor\":\"x6\",\"domain\":[0.5375,0.73125],\"matches\":\"y5\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis7\":{\"anchor\":\"y7\",\"domain\":[0.525,0.7375],\"matches\":\"x15\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis7\":{\"anchor\":\"x7\",\"domain\":[0.5375,0.73125],\"matches\":\"y5\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis8\":{\"anchor\":\"y8\",\"domain\":[0.7875,1.0],\"matches\":\"x16\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis8\":{\"anchor\":\"x8\",\"domain\":[0.5375,0.73125],\"matches\":\"y5\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis9\":{\"anchor\":\"y9\",\"domain\":[0.0,0.2125],\"matches\":\"x13\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis9\":{\"anchor\":\"x9\",\"domain\":[0.26875,0.4625],\"range\":[-0.05,1.05],\"title\":{\"text\":\"kernel_size\\u2581choice\"}},\"xaxis10\":{\"anchor\":\"y10\",\"domain\":[0.2625,0.475],\"matches\":\"x14\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis10\":{\"anchor\":\"x10\",\"domain\":[0.26875,0.4625],\"matches\":\"y9\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis11\":{\"anchor\":\"y11\",\"domain\":[0.525,0.7375],\"matches\":\"x15\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis11\":{\"anchor\":\"x11\",\"domain\":[0.26875,0.4625],\"matches\":\"y9\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis12\":{\"anchor\":\"y12\",\"domain\":[0.7875,1.0],\"matches\":\"x16\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"yaxis12\":{\"anchor\":\"x12\",\"domain\":[0.26875,0.4625],\"matches\":\"y9\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis13\":{\"anchor\":\"y13\",\"domain\":[0.0,0.2125],\"range\":[-0.05,1.05],\"title\":{\"text\":\"activation\\u2581choice\"}},\"yaxis13\":{\"anchor\":\"x13\",\"domain\":[0.0,0.19375],\"range\":[-0.05,1.05],\"title\":{\"text\":\"strides\\u2581choice\"}},\"xaxis14\":{\"anchor\":\"y14\",\"domain\":[0.2625,0.475],\"range\":[-0.05,1.05],\"title\":{\"text\":\"filters\\u2581choice\"}},\"yaxis14\":{\"anchor\":\"x14\",\"domain\":[0.0,0.19375],\"matches\":\"y13\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis15\":{\"anchor\":\"y15\",\"domain\":[0.525,0.7375],\"range\":[-0.05,1.05],\"title\":{\"text\":\"kernel_size\\u2581choice\"}},\"yaxis15\":{\"anchor\":\"x15\",\"domain\":[0.0,0.19375],\"matches\":\"y13\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"xaxis16\":{\"anchor\":\"y16\",\"domain\":[0.7875,1.0],\"range\":[-0.05,1.05],\"title\":{\"text\":\"strides\\u2581choice\"}},\"yaxis16\":{\"anchor\":\"x16\",\"domain\":[0.0,0.19375],\"matches\":\"y13\",\"showticklabels\":false,\"range\":[-0.05,1.05]},\"title\":{\"text\":\"Contour Plot\"}},                        {\"responsive\": true}                    ).then(function(){\n",
-              "                            \n",
-              "var gd = document.getElementById('4fa75e5b-111d-4d78-936c-357b16d5bb13');\n",
-              "var x = new MutationObserver(function (mutations, observer) {{\n",
-              "        var display = window.getComputedStyle(gd).display;\n",
-              "        if (!display || display === 'none') {{\n",
-              "            console.log([gd, 'removed!']);\n",
-              "            Plotly.purge(gd);\n",
-              "            observer.disconnect();\n",
-              "        }}\n",
-              "}});\n",
-              "\n",
-              "// Listen for the removal of the full notebook cells\n",
-              "var notebookContainer = gd.closest('#notebook-container');\n",
-              "if (notebookContainer) {{\n",
-              "    x.observe(notebookContainer, {childList: true});\n",
-              "}}\n",
-              "\n",
-              "// Listen for the clearing of the current output cell\n",
-              "var outputEl = gd.closest('.output');\n",
-              "if (outputEl) {{\n",
-              "    x.observe(outputEl, {childList: true});\n",
-              "}}\n",
-              "\n",
-              "                        })                };                            </script>        </div>\n",
-              "</body>\n",
-              "</html>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "from bigdl.nano.automl.hpo.visualization import plot_contour\n",
         "plot_contour(study)"
@@ -1471,47 +509,7 @@
         "id": "MUmsUyAfmex0",
         "outputId": "ea74030c-309f-468f-80e6-718956a44cc2"
       },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<html>\n",
-              "<head><meta charset=\"utf-8\" /></head>\n",
-              "<body>\n",
-              "    <div>            <script src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG\"></script><script type=\"text/javascript\">if (window.MathJax) {MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}</script>                <script type=\"text/javascript\">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
-              "        <script src=\"https://cdn.plot.ly/plotly-2.8.3.min.js\"></script>                <div id=\"6bf43d00-f567-4b01-b4b5-670ffbaf37b6\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"6bf43d00-f567-4b01-b4b5-670ffbaf37b6\")) {                    Plotly.newPlot(                        \"6bf43d00-f567-4b01-b4b5-670ffbaf37b6\",                        [{\"cliponaxis\":false,\"hovertemplate\":[\"filters\\u2581choice (CategoricalDistribution): 0.0018418691140907294<extra></extra>\",\"kernel_size\\u2581choice (CategoricalDistribution): 0.008168059594574145<extra></extra>\",\"strides\\u2581choice (CategoricalDistribution): 0.017955841523344354<extra></extra>\",\"activation\\u2581choice (CategoricalDistribution): 0.9720342297679908<extra></extra>\"],\"marker\":{\"color\":\"rgb(66,146,198)\"},\"orientation\":\"h\",\"text\":[\"0.0018418691140907294\",\"0.008168059594574145\",\"0.017955841523344354\",\"0.9720342297679908\"],\"textposition\":\"outside\",\"texttemplate\":\"%{text:.2f}\",\"x\":[0.0018418691140907294,0.008168059594574145,0.017955841523344354,0.9720342297679908],\"y\":[\"filters\\u2581choice\",\"kernel_size\\u2581choice\",\"strides\\u2581choice\",\"activation\\u2581choice\"],\"type\":\"bar\"}],                        {\"showlegend\":false,\"title\":{\"text\":\"Hyperparameter Importances\"},\"xaxis\":{\"title\":{\"text\":\"Importance for Objective Value\"}},\"yaxis\":{\"title\":{\"text\":\"Hyperparameter\"}},\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}}},                        {\"responsive\": true}                    ).then(function(){\n",
-              "                            \n",
-              "var gd = document.getElementById('6bf43d00-f567-4b01-b4b5-670ffbaf37b6');\n",
-              "var x = new MutationObserver(function (mutations, observer) {{\n",
-              "        var display = window.getComputedStyle(gd).display;\n",
-              "        if (!display || display === 'none') {{\n",
-              "            console.log([gd, 'removed!']);\n",
-              "            Plotly.purge(gd);\n",
-              "            observer.disconnect();\n",
-              "        }}\n",
-              "}});\n",
-              "\n",
-              "// Listen for the removal of the full notebook cells\n",
-              "var notebookContainer = gd.closest('#notebook-container');\n",
-              "if (notebookContainer) {{\n",
-              "    x.observe(notebookContainer, {childList: true});\n",
-              "}}\n",
-              "\n",
-              "// Listen for the clearing of the current output cell\n",
-              "var outputEl = gd.closest('.output');\n",
-              "if (outputEl) {{\n",
-              "    x.observe(outputEl, {childList: true});\n",
-              "}}\n",
-              "\n",
-              "                        })                };                            </script>        </div>\n",
-              "</body>\n",
-              "</html>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "from bigdl.nano.automl.hpo.visualization import plot_param_importances\n",
         "plot_param_importances(study)"
@@ -1529,47 +527,7 @@
         "outputId": "e678b912-7946-41c1-e431-8e61e9a28dca",
         "scrolled": true
       },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "<html>\n",
-              "<head><meta charset=\"utf-8\" /></head>\n",
-              "<body>\n",
-              "    <div>            <script src=\"https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_SVG\"></script><script type=\"text/javascript\">if (window.MathJax) {MathJax.Hub.Config({SVG: {font: \"STIX-Web\"}});}</script>                <script type=\"text/javascript\">window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n",
-              "        <script src=\"https://cdn.plot.ly/plotly-2.8.3.min.js\"></script>                <div id=\"e288ca9b-ca81-4788-9870-988a60bd95b5\" class=\"plotly-graph-div\" style=\"height:525px; width:100%;\"></div>            <script type=\"text/javascript\">                                    window.PLOTLYENV=window.PLOTLYENV || {};                                    if (document.getElementById(\"e288ca9b-ca81-4788-9870-988a60bd95b5\")) {                    Plotly.newPlot(                        \"e288ca9b-ca81-4788-9870-988a60bd95b5\",                        [{\"cliponaxis\":false,\"hovertemplate\":[\"activation\\u2581choice (CategoricalDistribution): 0.031071014437459847<extra></extra>\",\"filters\\u2581choice (CategoricalDistribution): 0.1548635182874492<extra></extra>\",\"kernel_size\\u2581choice (CategoricalDistribution): 0.30958575140327604<extra></extra>\",\"strides\\u2581choice (CategoricalDistribution): 0.5044797158718148<extra></extra>\"],\"marker\":{\"color\":\"rgb(66,146,198)\"},\"orientation\":\"h\",\"text\":[\"0.031071014437459847\",\"0.1548635182874492\",\"0.30958575140327604\",\"0.5044797158718148\"],\"textposition\":\"outside\",\"texttemplate\":\"%{text:.2f}\",\"x\":[0.031071014437459847,0.1548635182874492,0.30958575140327604,0.5044797158718148],\"y\":[\"activation\\u2581choice\",\"filters\\u2581choice\",\"kernel_size\\u2581choice\",\"strides\\u2581choice\"],\"type\":\"bar\"}],                        {\"showlegend\":false,\"title\":{\"text\":\"Hyperparameter Importances\"},\"xaxis\":{\"title\":{\"text\":\"Importance for duration\"}},\"yaxis\":{\"title\":{\"text\":\"Hyperparameter\"}},\"template\":{\"data\":{\"bar\":[{\"error_x\":{\"color\":\"#2a3f5f\"},\"error_y\":{\"color\":\"#2a3f5f\"},\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"bar\"}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"#E5ECF6\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"barpolar\"}],\"carpet\":[{\"aaxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"baxis\":{\"endlinecolor\":\"#2a3f5f\",\"gridcolor\":\"white\",\"linecolor\":\"white\",\"minorgridcolor\":\"white\",\"startlinecolor\":\"#2a3f5f\"},\"type\":\"carpet\"}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"choropleth\"}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"contour\"}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"contourcarpet\"}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmap\"}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"heatmapgl\"}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"type\":\"histogram\"}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2d\"}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"histogram2dcontour\"}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"type\":\"mesh3d\"}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"parcoords\"}],\"pie\":[{\"automargin\":true,\"type\":\"pie\"}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter\"}],\"scatter3d\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatter3d\"}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattercarpet\"}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergeo\"}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattergl\"}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scattermapbox\"}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolar\"}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterpolargl\"}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"type\":\"scatterternary\"}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"type\":\"surface\"}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"#EBF0F8\"},\"line\":{\"color\":\"white\"}},\"header\":{\"fill\":{\"color\":\"#C8D4E3\"},\"line\":{\"color\":\"white\"}},\"type\":\"table\"}]},\"layout\":{\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"autotypenumbers\":\"strict\",\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0,\"ticks\":\"\"}},\"colorscale\":{\"diverging\":[[0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"colorway\":[\"#636efa\",\"#EF553B\",\"#00cc96\",\"#ab63fa\",\"#FFA15A\",\"#19d3f3\",\"#FF6692\",\"#B6E880\",\"#FF97FF\",\"#FECB52\"],\"font\":{\"color\":\"#2a3f5f\"},\"geo\":{\"bgcolor\":\"white\",\"lakecolor\":\"white\",\"landcolor\":\"#E5ECF6\",\"showlakes\":true,\"showland\":true,\"subunitcolor\":\"white\"},\"hoverlabel\":{\"align\":\"left\"},\"hovermode\":\"closest\",\"mapbox\":{\"style\":\"light\"},\"paper_bgcolor\":\"white\",\"plot_bgcolor\":\"#E5ECF6\",\"polar\":{\"angularaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"radialaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"yaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"},\"zaxis\":{\"backgroundcolor\":\"#E5ECF6\",\"gridcolor\":\"white\",\"gridwidth\":2,\"linecolor\":\"white\",\"showbackground\":true,\"ticks\":\"\",\"zerolinecolor\":\"white\"}},\"shapedefaults\":{\"line\":{\"color\":\"#2a3f5f\"}},\"ternary\":{\"aaxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"baxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"},\"bgcolor\":\"#E5ECF6\",\"caxis\":{\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\"}},\"title\":{\"x\":0.05},\"xaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2},\"yaxis\":{\"automargin\":true,\"gridcolor\":\"white\",\"linecolor\":\"white\",\"ticks\":\"\",\"title\":{\"standoff\":15},\"zerolinecolor\":\"white\",\"zerolinewidth\":2}}}},                        {\"responsive\": true}                    ).then(function(){\n",
-              "                            \n",
-              "var gd = document.getElementById('e288ca9b-ca81-4788-9870-988a60bd95b5');\n",
-              "var x = new MutationObserver(function (mutations, observer) {{\n",
-              "        var display = window.getComputedStyle(gd).display;\n",
-              "        if (!display || display === 'none') {{\n",
-              "            console.log([gd, 'removed!']);\n",
-              "            Plotly.purge(gd);\n",
-              "            observer.disconnect();\n",
-              "        }}\n",
-              "}});\n",
-              "\n",
-              "// Listen for the removal of the full notebook cells\n",
-              "var notebookContainer = gd.closest('#notebook-container');\n",
-              "if (notebookContainer) {{\n",
-              "    x.observe(notebookContainer, {childList: true});\n",
-              "}}\n",
-              "\n",
-              "// Listen for the clearing of the current output cell\n",
-              "var outputEl = gd.closest('.output');\n",
-              "if (outputEl) {{\n",
-              "    x.observe(outputEl, {childList: true});\n",
-              "}}\n",
-              "\n",
-              "                        })                };                            </script>        </div>\n",
-              "</body>\n",
-              "</html>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
+      "outputs": [],
       "source": [
         "plot_param_importances(study, target=lambda t: t.duration.total_seconds(), target_name=\"duration\")"
       ]
@@ -1582,7 +540,7 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
+      "display_name": "Python 3.9.12 ('base': conda)",
       "language": "python",
       "name": "python3"
     },
@@ -1596,7 +554,12 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.7.13"
+      "version": "3.9.12"
+    },
+    "vscode": {
+      "interpreter": {
+        "hash": "f6c4fac624a9bd3b1c7bcafb358e36fcd9daccaa962ba059d07bbc89607fe634"
+      }
     }
   },
   "nbformat": 4,

--- a/docs/readthedocs/source/doc/Nano/Tutorials/seq_and_func.ipynb
+++ b/docs/readthedocs/source/doc/Nano/Tutorials/seq_and_func.ipynb
@@ -24,7 +24,7 @@
         "id": "onZXfhnkmexc"
       },
       "source": [
-        "# Introduction\n",
+        "# BigDL-Nano Hyperparameter Tuning (Tensorflow Sequential/Functional API) Quickstart\n",
         "In this notebook we demonstrates how to use Nano HPO to tune the hyperparameters in tensorflow training. The model is built using either tensorflow keras sequential API or functional API.\n"
       ]
     },
@@ -34,7 +34,7 @@
         "id": "i8kjsyL4mexd"
       },
       "source": [
-        "# Step0: Prepare Environment\n",
+        "## Step 0: Prepare Environment\n",
         "You can install the latest pre-release version with nano support using below commands.\n",
         "\n",
         "We recommend to run below commands, especially `source bigdl-nano-init` before jupyter kernel is started, or some of the optimizations may not take effect.\n"
@@ -84,7 +84,7 @@
         "id": "IswBKf39mexg"
       },
       "source": [
-        "# Step1: Init Nano AutoML\n",
+        "## Step 1: Init Nano AutoML\n",
         "We need to enable Nano HPO before we use it for tensorflow training."
       ]
     },
@@ -110,7 +110,7 @@
         "id": "ZiolCDSmmexj"
       },
       "source": [
-        "# Step2: Prepare data\n",
+        "## Step 2: Prepare data\n",
         "We use MNIST dataset for demonstration."
       ]
     },
@@ -143,7 +143,7 @@
         "id": "Pxvb3gKcmexk"
       },
       "source": [
-        "# Step3: Build model and specify search spaces"
+        "## Step 3: Build model and specify search spaces"
       ]
     },
     {
@@ -226,7 +226,7 @@
         "id": "O5SBRAawmexm"
       },
       "source": [
-        "# Step4: Compile model\n",
+        "## Step 4: Compile model\n",
         "We now compile our model with loss function, optimizer and metrics. If you want to tune learning rate and batch size, refer to [user guide](https://bigdl.readthedocs.io/en/latest/doc/Nano/QuickStart/hpo.html#search-the-learning-rate)."
       ]
     },
@@ -252,7 +252,7 @@
         "id": "fW1b_B9Kmexn"
       },
       "source": [
-        "# Step5: Run hyperparameter search\n",
+        "## Step 5: Run hyperparameter search\n",
         "Run hyperparameter search by calling `model.search`. Set `n_trials` to the number of trialials you want to run, and set the `target_metric` and `direction` so that HPO optimizes the `target_metric` in the specified `direction`. Each trial will use a different set of hyperparameters in the search space range. After search completes, you can use `search_summary` to retrive the search results for analysis. For more details, refer to [user doc](https://bigdl.readthedocs.io/en/latest/doc/Nano/QuickStart/hpo.html)"
       ]
     },
@@ -307,7 +307,7 @@
         "id": "xU_PnDXnmexo"
       },
       "source": [
-        "# Step6: (Optional) Resume training from memory\n",
+        "## Step 6: (Optional) Resume training from memory\n",
         "You can resume the previous search when a search completes by setting `resume=True`. Refer to [user doc](https://bigdl.readthedocs.io/en/latest/doc/Nano/QuickStart/hpo.html) for more details."
       ]
     },
@@ -361,7 +361,7 @@
         "id": "uI05vzTgmexy"
       },
       "source": [
-        "# Step 7: fit with the best hyperparameters\n",
+        "## Step 7: fit with the best hyperparameters\n",
         "After search, `model.fit` will autotmatically use the best hyperparmeters found in search to fit the model."
       ]
     },
@@ -392,7 +392,7 @@
         "id": "xYhKbOjYDzMv"
       },
       "source": [
-        "# Step 8: HPO Result Analysis and Visualization\n",
+        "## Step 8: HPO Result Analysis and Visualization\n",
         "Check out the summary of the model. The model has already been built with the best hyperparameters found by nano hpo."
       ]
     },
@@ -530,6 +530,13 @@
       "outputs": [],
       "source": [
         "plot_param_importances(study, target=lambda t: t.duration.total_seconds(), target_name=\"duration\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "You can find the running output from [here](https://github.com/intel-analytics/BigDL/blob/main/python/nano/notebooks/hpo/seq_and_func.ipynb), or run the notebook by yourself in [Google Colab](https://colab.research.google.com/github/intel-analytics/BigDL/blob/main/python/nano/notebooks/hpo/seq_and_func.ipynb)."
       ]
     }
   ],


### PR DESCRIPTION
## Description

Add two Nano tutorials to readthedocs through directly copying the corresponding ipynb files to the readthedocs folder:
- [BigDL-Nano Hyperparameter Tuning (Tensorflow Sequential/Functional API) Quickstart](https://yuwentestdocs.readthedocs.io/en/add-nano-tutorials-to-docs/doc/Nano/Tutorials/seq_and_func.html)
- [BigDL-Nano Hyperparameter Tuning (Tensorflow Subclassing Model) Quickstart](https://yuwentestdocs.readthedocs.io/en/add-nano-tutorials-to-docs/doc/Nano/Tutorials/custom.html)

### New dependencies
- nbsphinx: https://nbsphinx.readthedocs.io/en/0.8.9/ (MIT lisences)

### Further Improvements to do (#5248):
- Adding ipynb files through DIRECTLY LINKING to where they are, without copying them
- Hiding outputs with the help of nbsphinx extension, without deleting them manually
- Showing the interactive plots in the web pages generated by the ipynb files

