### PR TITLE
Chronos: Lazy load Forecaster

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/__init__.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/__init__.py
@@ -61,7 +61,6 @@ if not orca_available:
     warnings.warn("Please install `bigdl-orca` to use full collection of forecasters.")
 
 # import forecasters
-bigdl = LazyImport('bigdl')
 PREFIXNAME = 'bigdl.chronos.forecaster.'
 if torch_available:
     LSTMForecaster = LazyImport(PREFIXNAME+'lstm_forecaster.LSTMForecaster')

--- a/python/chronos/src/bigdl/chronos/forecaster/__init__.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/__init__.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-import warnings
 import logging
 import importlib
 from bigdl.chronos.utils import LazyImport
@@ -32,16 +31,12 @@ class Disablelogging:
 
 # dependencies check
 torch_available = bool(importlib.util.find_spec('torch'))
-if not torch_available:
-    warnings.warn("Please install `torch` to use forecasters, including TCMFForecaster, "
-                  "TCNForecaster, LSTMForecaster, Seq2SeqForecaster.")
-
 tf_available = False
 try:
     tf = LazyImport('tensorflow')
     tf_available = tf.__version__ > "2.0.0"
 except:
-    warnings.warn("Please install `tensorflow>2.0.0` to use MTNetForecaster.")
+    pass
 
 # Avoid printing redundant message
 prophet_available = False
@@ -50,15 +45,10 @@ try:
         import prophet
     prophet_available = True
 except:
-    warnings.warn("Please install `prophet` to use ProphetForecaster.")
+    pass
 
 arima_available = bool(importlib.util.find_spec('pmdarima'))
-if not arima_available:
-    warnings.warn("Please install `pmdarima` to use ARIMAForecaster.")
-
 orca_available = bool(importlib.util.find_spec('bigdl.orca'))
-if not orca_available:
-    warnings.warn("Please install `bigdl-orca` to use full collection of forecasters.")
 
 # import forecasters
 PREFIXNAME = 'bigdl.chronos.forecaster.'

--- a/python/chronos/src/bigdl/chronos/forecaster/__init__.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/__init__.py
@@ -16,6 +16,7 @@
 
 import warnings
 import logging
+from bigdl.chronos.utils import LazyImport
 # unset the KMP_INIT_AT_FORK
 # which will cause significant slow down in multiprocessing training
 import os
@@ -64,16 +65,18 @@ except:
     warnings.warn("Please install `bigdl-orca` to use full collection of forecasters.")
 
 # import forecasters
+PREFIX_PATH = 'bigdl.chronos.forecaster'
 if torch_available:
-    from .lstm_forecaster import LSTMForecaster
-    from .tcn_forecaster import TCNForecaster
-    from .seq2seq_forecaster import Seq2SeqForecaster
-    from .nbeats_forecaster import NBeatsForecaster
-    if orca_available:
-        from .tcmf_forecaster import TCMFForecaster
+    LSTMForecaster = LazyImport('..LSTMForecaster', pkg=PREFIX_PATH+'.lstm_forecaster')
+    TCNForecaster = LazyImport('..TCNForecaster', pkg=PREFIX_PATH+'.tcn_forecaster')
+    Seq2SeqForecaster = LazyImport('..Seq2SeqForecaster', pkg=PREFIX_PATH+'.seq2seq_forecaster')
+    NBeatsForecaster = LazyImport('..NBeatsForecaster', pkg=PREFIX_PATH+'.nbeats_forecaster')
 if tf_available and orca_available:
     from .tf.mtnet_forecaster import MTNetForecaster
+    TCMFForecaster = LazyImport('..TCMFForecaster', pkg=PREFIX_PATH+'.tcmf_forecaster')
+if tf_available:
+    MTNetForecaster = LazyImport('..MTNetForecaster', pkg=PREFIX_PATH+'.tf.mtnet_forecaster')
 if prophet_available:
-    from .prophet_forecaster import ProphetForecaster
+    ProphetForecaster = LazyImport('..ProphetForecaster', pkg=PREFIX_PATH+'.ProphetForecaster')
 if arima_available:
-    from .arima_forecaster import ARIMAForecaster
+    ARIMAForecaster = LazyImport('..ARIMAForecaster', pkg=PREFIX_PATH+'.ARIMAForecaster')

--- a/python/chronos/src/bigdl/chronos/forecaster/pytorch.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/pytorch.py
@@ -15,8 +15,9 @@
 #
 
 from bigdl.chronos.utils import LazyImport
-TCNForecaster = LazyImport('bigdl.chronos.forecaster.tcn_forecaster.TCNForecaster')
-LSTMForecaster= LazyImport('bigdl.chronos.forecaster.lstm_forecaster.LSTMForecaster')
-NBeatsForecaster= LazyImport('bigdl.chronos.forecaster.nbeats_forecaster.NBeatsForecaster')
-Seq2SeqForecaster= LazyImport('bigdl.chronos.forecaster.seq2seq_forecaster.Seq2SeqForecaster')
-AutoformerForecaster= LazyImport('bigdl.chronos.forecaster.autoformer_forecaster.AutoformerForecaster')
+PREFIXNAME = 'bigdl.chronos.forecaster.'
+TCNForecaster = LazyImport(PREFIXNAME+'tcn_forecaster.TCNForecaster')
+LSTMForecaster = LazyImport(PREFIXNAME+'lstm_forecaster.LSTMForecaster')
+NBeatsForecaster = LazyImport(PREFIXNAME+'nbeats_forecaster.NBeatsForecaster')
+Seq2SeqForecaster = LazyImport(PREFIXNAME+'seq2seq_forecaster.Seq2SeqForecaster')
+AutoformerForecaster = LazyImport(PREFIXNAME+"autoformer_forecaster.AutoformerForecaster")

--- a/python/chronos/src/bigdl/chronos/forecaster/pytorch.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/pytorch.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 #
 
-from bigdl.chronos.forecaster.tcn_forecaster import TCNForecaster
-from bigdl.chronos.forecaster.lstm_forecaster import LSTMForecaster
-from bigdl.chronos.forecaster.nbeats_forecaster import NBeatsForecaster
-from bigdl.chronos.forecaster.seq2seq_forecaster import Seq2SeqForecaster
-from bigdl.chronos.forecaster.autoformer_forecaster import AutoformerForecaster
+from bigdl.chronos.utils import LazyImport
+TCNForecaster = LazyImport('bigdl.chronos.forecaster.tcn_forecaster.TCNForecaster')
+LSTMForecaster= LazyImport('bigdl.chronos.forecaster.lstm_forecaster.LSTMForecaster')
+NBeatsForecaster= LazyImport('bigdl.chronos.forecaster.nbeats_forecaster.NBeatsForecaster')
+Seq2SeqForecaster= LazyImport('bigdl.chronos.forecaster.seq2seq_forecaster.Seq2SeqForecaster')
+AutoformerForecaster= LazyImport('bigdl.chronos.forecaster.autoformer_forecaster.AutoformerForecaster')

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/__init__.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/__init__.py
@@ -20,7 +20,7 @@ from bigdl.chronos.utils import LazyImport
 tf_spec = bool(importlib.util.find_spec('tensorflow'))
 
 PREFIXNAME_TF2 = 'bigdl.chronos.forecaster.tf.'
-bigdl = LazyImport('bigdl')
+
 if tf_spec:
     LSTMForecaster = LazyImport(PREFIXNAME_TF2+'lstm_forecaster.LSTMForecaster')
     MTNetForecaster = LazyImport(PREFIXNAME_TF2+'metnet_forecaster.MTNetForecaster')

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/__init__.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/__init__.py
@@ -14,7 +14,13 @@
 # limitations under the License.
 #
 
-from .lstm_forecaster import LSTMForecaster
-from .mtnet_forecaster import MTNetForecaster
-from .seq2seq_forecaster import Seq2SeqForecaster
-from .tcn_forecaster import TCNForecaster
+import importlib
+from bigdl.chronos.utils import LazyImport
+
+tf_spec = importlib.util.from_spec('tensorflow')
+PREFIXPATH_TF2 = 'bigdl.chronos.forecaster.tf'
+if tf_spec:
+    LSTMForecaster = LazyImport('..LSTMForecaster', pkg=PREFIXPATH_TF2+'.LSTMForecaster')
+    MTNetForecaster = LazyImport('..MTNetForecaster', pkg=PREFIXPATH_TF2+'.MTNetForecaster')
+    Seq2SeqForecaster = LazyImport('..Seq2SeqForecaster', pkg=PREFIXPATH_TF2+'.Seq2SeqForecaster')
+    TCNForecaster = LazyImport('..TCNForecaster', pkg=PREFIXPATH_TF2+'.TCNForecaster')

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/__init__.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/__init__.py
@@ -17,10 +17,12 @@
 import importlib
 from bigdl.chronos.utils import LazyImport
 
-tf_spec = importlib.util.find_spec('tensorflow')
-PREFIXPATH_TF2 = 'bigdl.chronos.forecaster.tf'
+tf_spec = bool(importlib.util.find_spec('tensorflow'))
+
+PREFIXNAME_TF2 = 'bigdl.chronos.forecaster.tf.'
+bigdl = LazyImport('bigdl')
 if tf_spec:
-    LSTMForecaster = LazyImport('..LSTMForecaster', pkg=PREFIXPATH_TF2+'.LSTMForecaster')
-    MTNetForecaster = LazyImport('..MTNetForecaster', pkg=PREFIXPATH_TF2+'.MTNetForecaster')
-    Seq2SeqForecaster = LazyImport('..Seq2SeqForecaster', pkg=PREFIXPATH_TF2+'.Seq2SeqForecaster')
-    TCNForecaster = LazyImport('..TCNForecaster', pkg=PREFIXPATH_TF2+'.TCNForecaster')
+    LSTMForecaster = LazyImport(PREFIXNAME_TF2+'lstm_forecaster.LSTMForecaster')
+    MTNetForecaster = LazyImport(PREFIXNAME_TF2+'metnet_forecaster.MTNetForecaster')
+    Seq2SeqForecaster = LazyImport(PREFIXNAME_TF2+'seq2seq_forecaster.Seq2SeqForecaster')
+    TCNForecaster = LazyImport(PREFIXNAME_TF2+'tcn_forecaster.TCNForecaster')

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/__init__.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/__init__.py
@@ -18,11 +18,13 @@ import importlib
 from bigdl.chronos.utils import LazyImport
 
 tf_spec = bool(importlib.util.find_spec('tensorflow'))
+orca_available = bool(importlib.util.find_spec('bigdl.orca'))
 
 PREFIXNAME_TF2 = 'bigdl.chronos.forecaster.tf.'
 
 if tf_spec:
     LSTMForecaster = LazyImport(PREFIXNAME_TF2+'lstm_forecaster.LSTMForecaster')
-    MTNetForecaster = LazyImport(PREFIXNAME_TF2+'metnet_forecaster.MTNetForecaster')
     Seq2SeqForecaster = LazyImport(PREFIXNAME_TF2+'seq2seq_forecaster.Seq2SeqForecaster')
     TCNForecaster = LazyImport(PREFIXNAME_TF2+'tcn_forecaster.TCNForecaster')
+    if orca_available:
+        MTNetForecaster = LazyImport(PREFIXNAME_TF2+'metnet_forecaster.MTNetForecaster')

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/__init__.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/__init__.py
@@ -17,7 +17,7 @@
 import importlib
 from bigdl.chronos.utils import LazyImport
 
-tf_spec = importlib.util.from_spec('tensorflow')
+tf_spec = importlib.util.find_spec('tensorflow')
 PREFIXPATH_TF2 = 'bigdl.chronos.forecaster.tf'
 if tf_spec:
     LSTMForecaster = LazyImport('..LSTMForecaster', pkg=PREFIXPATH_TF2+'.LSTMForecaster')

--- a/python/chronos/src/bigdl/chronos/utils.py
+++ b/python/chronos/src/bigdl/chronos/utils.py
@@ -35,6 +35,9 @@ def deprecated(message=""):
 
 class LazyImport:
     """
+        code adaptted from https://github.com/intel/neural-compressor
+        /blob/master/neural_compressor/utils/utility.py#L62
+
         :param module_name: The name of module imported later
         :param pkg: prefix path.
     """

--- a/python/chronos/src/bigdl/chronos/utils.py
+++ b/python/chronos/src/bigdl/chronos/utils.py
@@ -67,11 +67,12 @@ class LazyImport:
             parent_name, child_name = absolute_name, None
 
         try:
-            # For import parent module
+            # For import parent module and get the submodule with getattr.
             module = importlib.import_module(parent_name)
             module = getattr(module, child_name) if child_name else module
         except AttributeError:
-            #  When calling staticmethod or classmethod, such as Forecaster.from_tsdataset
+            # Triggered when the parent module cannot get the child module using getattr.
+            # More common when calling staticmethods or classmethods. e.g. from_tsdataset.
             full_module_name = parent_name+'.'+child_name if child_name else parent_name
             spec = importlib.util.find_spec(full_module_name)
             module = importlib.util.module_from_spec(spec)

--- a/python/chronos/src/bigdl/chronos/utils.py
+++ b/python/chronos/src/bigdl/chronos/utils.py
@@ -67,10 +67,11 @@ class LazyImport:
             parent_name, child_name = absolute_name, None
 
         try:
+            # For import parent module
             module = importlib.import_module(parent_name)
             module = getattr(module, child_name) if child_name else module
         except AttributeError:
-            # concatenate possible class names
+            #  When calling staticmethod or classmethod, such as Forecaster.from_tsdataset
             full_module_name = parent_name+'.'+child_name if child_name else parent_name
             spec = importlib.util.find_spec(full_module_name)
             module = importlib.util.module_from_spec(spec)

--- a/python/chronos/src/bigdl/chronos/utils.py
+++ b/python/chronos/src/bigdl/chronos/utils.py
@@ -60,15 +60,6 @@ class LazyImport:
         except (KeyError, AttributeError):
             pass
 
-        # Because early LazyImport does not allow absolute_name to contain class name,
-        # original usage:
-        #   lstm = LazyImport('bigdl.chronos.forecaster.lstm_forecaster')
-        #   lstm.LSTMForecaster() and lstm.LSTMForecaster.from_tsdataset()
-        # But including the class name is better for our needs.
-        # Usage: forecaster = LazyImport('bigdl.chronos.forecaster.lstm_forecaster.LSTMForecaster')
-        # forecaster() and forecaster.from_tsdataset()
-        # This comment will be removed later and migrated to pr..
-
         if "." in absolute_name:
             # Split module name to prevent class name from being introduced as package
             parent_name, _, child_name = absolute_name.rpartition('.')

--- a/python/chronos/test/bigdl/chronos/forecaster/test_pytorch.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_pytorch.py
@@ -15,6 +15,7 @@
 #
 
 from unittest import TestCase
+from bigdl.chronos.utils import LazyImport
 
 class TestChronosModelPytorch(TestCase):
 
@@ -26,15 +27,60 @@ class TestChronosModelPytorch(TestCase):
 
     def test_tcn_forecaster_import(self):
         from bigdl.chronos.forecaster.pytorch import TCNForecaster
+        assert isinstance(TCNForecaster, LazyImport)
+
+        tcn = TCNForecaster(input_feature_num=1,
+                            output_feature_num=1,
+                            past_seq_len=48,
+                            future_seq_len=5)
+        from bigdl.chronos.forecaster.tcn_forecaster import TCNForecaster
+        assert not isinstance(TCNForecaster, LazyImport)
+        assert isinstance(tcn, TCNForecaster)
 
     def test_lstm_forecaster_import(self):
         from bigdl.chronos.forecaster.pytorch import LSTMForecaster
+        assert isinstance(LSTMForecaster, LazyImport)
+
+        lstm = LSTMForecaster(input_feature_num=1,
+                              output_feature_num=1,
+                              past_seq_len=48)
+        from bigdl.chronos.forecaster.lstm_forecaster import LSTMForecaster
+        assert not isinstance(LSTMForecaster, LazyImport)
+        assert isinstance(lstm, LSTMForecaster)
+                                      
 
     def test_nbeats_forecaster_import(self):
         from bigdl.chronos.forecaster.pytorch import NBeatsForecaster
+        assert isinstance(NBeatsForecaster, LazyImport)
+
+        nbeats = NBeatsForecaster(past_seq_len=48,
+                                  future_seq_len=5)
+        from bigdl.chronos.forecaster.nbeats_forecaster import NBeatsForecaster
+        assert not isinstance(NBeatsForecaster, LazyImport)
+        assert isinstance(nbeats, NBeatsForecaster)
 
     def test_s2s_forecaster_import(self):
         from bigdl.chronos.forecaster.pytorch import Seq2SeqForecaster
+        assert isinstance(Seq2SeqForecaster, LazyImport)
+
+        from bigdl.chronos.forecaster.seq2seq_forecaster import Seq2SeqForecaster
+        s2s = Seq2SeqForecaster(past_seq_len=48,
+                                future_seq_len=5,
+                                input_feature_num=1,
+                                output_feature_num=1)
+        assert not isinstance(Seq2SeqForecaster, LazyImport)
+        assert isinstance(s2s, Seq2SeqForecaster)
 
     def test_autoformer_forecaster_import(self):
         from bigdl.chronos.forecaster.pytorch import AutoformerForecaster
+        assert isinstance(AutoformerForecaster, LazyImport)
+
+        from bigdl.chronos.forecaster.autoformer_forecaster import AutoformerForecaster
+        autoformer = AutoformerForecaster(past_seq_len=48,
+                                          future_seq_len=5,
+                                          input_feature_num=1,
+                                          output_feature_num=1,
+                                          label_len=12,
+                                          freq="s")
+        assert not isinstance(autoformer, LazyImport)
+        assert isinstance(autoformer, AutoformerForecaster)


### PR DESCRIPTION
## Description

LazyImport does not load the required module immediately, it only loads the module when it is called, makes module loading more friendly.

### 1. Why the change?

The coupling between modules is too high, the first load time is too long, and all modules will be loaded.
Not all modules need to be loaded when using Installation Options.

### 2. User API changes

No changed

### 3. Summary of the change 

Optimized forecaster startup time, Runs 100% faster.
Increase flexibility in writing code and reduce coupling.

### 4. How to test?
- [ ] Unit test
- [ ] Application test

### 5. API usage

```python
# 1. will use __call__
LSTMForecaster = LazyImport('bigdl.chronos.forecaster.LSTMForecaster')
forecaster = LSTMForecaster(input_feature_num=1,
                                               output_feature_num=1,
                                               past_seq_len=48)


# 2. will use __getattr__
TCNForecaster = LazyImport('bigdl.chronos.forecaster.TCNForecaster')
tcn = TCNForecaster.from_tsdataset(tsdataset. ...)
```

### 6. Known issues
- [x] LazyImport imports may import multiple times
- [x] LazyImport does not throw errors and warnings
- [x] LazyImport may import all Forecasters, making the message unfriendly.
- [x] other possible changes: remove all warnings.
- [x] The form bigdl.chronos.forecaster.lstm_forecaster.LSTMForecaster is not accepted because LSTMForecaster is a class
- [x] Migration Comments and remove warnings.warn.