### PR TITLE
rollback tensorflow 1.15 dependency

### DIFF
--- a/docs/readthedocs/requirements-doc.txt
+++ b/docs/readthedocs/requirements-doc.txt
@@ -5,6 +5,7 @@ sphinx-jsonschema==1.19.1
 sphinxemoji==0.2.0
 click==8.1.3
 markdown<3.4
+tensorflow==1.15.2
 bigdl==0.12.0
 cloudpickle==2.1.0
 ray[tune]==1.9.2

--- a/docs/readthedocs/source/conf.py
+++ b/docs/readthedocs/source/conf.py
@@ -18,7 +18,7 @@ import glob
 import shutil
 import urllib
 
-autodoc_mock_imports = ["openvino", "pytorch_lightning", "keras", "tensorflow"]
+autodoc_mock_imports = ["openvino", "pytorch_lightning", "keras"]
 
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, '.')


### PR DESCRIPTION
## Description

rollback tf 1.15 dependency in docs to fix API docs problems. Will upgrade the later. 
