### PR TITLE
[Nano] add errmsg when loading pytorch quantized model and FP32 model is not provided

### DIFF
--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
@@ -19,6 +19,7 @@ from bigdl.nano.utils.inference.pytorch.model import AcceleratedLightningModule
 from ..core import version as inc_version
 from neural_compressor.utils.pytorch import load
 from neural_compressor.model.model import PyTorchModel
+from bigdl.nano.utils.log4Error import invalidInputError
 
 
 class PytorchQuantizedModel(AcceleratedLightningModule):
@@ -32,6 +33,10 @@ class PytorchQuantizedModel(AcceleratedLightningModule):
 
     @staticmethod
     def _load(path, model):
+        invalidInputError(
+            model is not None,
+            errMsg="FP32 model is required to create a quantized model."
+        )
         qmodel = PyTorchModel(load(path, model))
         from packaging import version
         if version.parse(inc_version) < version.parse("1.11"):


### PR DESCRIPTION
## Description

To load a pytorch quantized model, a FP32 model should be provided.

### 1. Why the change?

resolve #5228 

### 2. User API changes

N/A

### 3. Summary of the change 

Add error message when the usage is wrong. It will remind the user to pass a FP32 model.

### 4. How to test?
- [ ] Unit test
