### PR TITLE
[Nano] Fix python data type cannot be converted in Pytorch Dataloader

### DIFF
--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/model.py
@@ -44,7 +44,9 @@ class AcceleratedLightningModule(AcceleratedModel, LightningModule):
 
     @staticmethod
     def tensors_to_numpy(tensors):
-        np_data = tuple(map(lambda x: x.cpu().numpy(), tensors))
+        np_data = tuple(map(
+            lambda x: x.cpu().numpy() if isinstance(x, torch.Tensor) else x,
+            tensors))
         return np_data
 
     @staticmethod


### PR DESCRIPTION
## Description

Fix quantization using openvino cannot handle when target in dataloader is of python int instead of torch tensor.

### 1. Why the change?

#5229 

### 2. User API changes

N/A

### 3. Summary of the change 

Only when the data is of `torch.Tensor`, the data will be converted to numpy.

### 4. How to test?
- [ ] #5229 script
