### PR TITLE
PPML: Add Hadoop filesystem support when accessing keys in KeyManagementService

### DIFF
--- a/scala/ppml/pom.xml
+++ b/scala/ppml/pom.xml
@@ -188,11 +188,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-            <version>1.4</version>
-        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>commons-cli</groupId>-->
+            <!--<artifactId>commons-cli</artifactId>-->
+            <!--<version>1.4</version>-->
+        <!--</dependency>-->
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.major.version}</artifactId>

--- a/scala/ppml/pom.xml
+++ b/scala/ppml/pom.xml
@@ -188,11 +188,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!--<dependency>-->
-            <!--<groupId>commons-cli</groupId>-->
-            <!--<artifactId>commons-cli</artifactId>-->
-            <!--<version>1.4</version>-->
-        <!--</dependency>-->
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.major.version}</artifactId>

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/PPMLContext.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/PPMLContext.scala
@@ -24,7 +24,8 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.input.PortableDataStream
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, DataFrameReader, DataFrameWriter, Row, SparkSession}
-import com.intel.analytics.bigdl.ppml.kms.{AzureKeyManagementService, EHSMKeyManagementService, KMS_CONVENTION, KeyManagementService, SimpleKeyManagementService}
+import com.intel.analytics.bigdl.ppml.kms.{AzureKeyManagementService, EHSMKeyManagementService, KMS_CONVENTION,
+KeyManagementService, SimpleKeyManagementService}
 import com.intel.analytics.bigdl.ppml.crypto.dataframe.{EncryptedDataFrameReader, EncryptedDataFrameWriter}
 import org.apache.hadoop.fs.Path
 

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/PPMLContext.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/PPMLContext.scala
@@ -24,12 +24,9 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.input.PortableDataStream
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, DataFrameReader, DataFrameWriter, Row, SparkSession}
-
-import com.intel.analytics.bigdl.ppml.kms.{EHSMKeyManagementService, KMS_CONVENTION,
-KeyManagementService, SimpleKeyManagementService, AzureKeyManagementService}
+import com.intel.analytics.bigdl.ppml.kms.{AzureKeyManagementService, EHSMKeyManagementService, KMS_CONVENTION, KeyManagementService, SimpleKeyManagementService}
 import com.intel.analytics.bigdl.ppml.crypto.dataframe.{EncryptedDataFrameReader, EncryptedDataFrameWriter}
-
-import java.nio.file.Paths
+import org.apache.hadoop.fs.Path
 
 /**
  * PPMLContext who wraps a SparkSession and provides read functions to
@@ -50,7 +47,8 @@ class PPMLContext protected(kms: KeyManagementService, sparkSession: SparkSessio
    */
   def loadKeys(primaryKeyPath: String, dataKeyPath: String): this.type = {
     dataKeyPlainText = kms.retrieveDataKeyPlainText(
-      Paths.get(primaryKeyPath).toString, Paths.get(dataKeyPath).toString)
+      new Path(primaryKeyPath).toString, new Path(dataKeyPath).toString,
+      sparkSession.sparkContext.hadoopConfiguration)
     sparkSession.sparkContext.hadoopConfiguration.set("bigdl.kms.data.key", dataKeyPlainText)
     this
   }

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/kms/KeyManagementService.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/kms/KeyManagementService.scala
@@ -17,6 +17,7 @@
 package com.intel.analytics.bigdl.ppml.kms
 
 import com.intel.analytics.bigdl.ppml.utils.Supportive
+import org.apache.hadoop.conf.Configuration
 
 object KMS_CONVENTION {
   val MODE_SIMPLE_KMS = "SimpleKeyManagementService"
@@ -25,7 +26,8 @@ object KMS_CONVENTION {
 }
 
 trait KeyManagementService extends Supportive {
-  def retrievePrimaryKey(primaryKeySavePath: String)
-  def retrieveDataKey(primaryKeyPath: String, dataKeySavePath: String)
-  def retrieveDataKeyPlainText(primaryKeyPath: String, dataKeyPath: String): String
+  def retrievePrimaryKey(primaryKeySavePath: String, config: Configuration = null)
+  def retrieveDataKey(primaryKeyPath: String, dataKeySavePath: String, config: Configuration = null)
+  def retrieveDataKeyPlainText(primaryKeyPath: String, dataKeyPath: String,
+                               config: Configuration = null): String
 }

--- a/scala/ppml/src/test/scala/com/intel/analytics/bigdl/ppml/crypto/dataframe/EncryptDataFrameHadoopSpec.scala
+++ b/scala/ppml/src/test/scala/com/intel/analytics/bigdl/ppml/crypto/dataframe/EncryptDataFrameHadoopSpec.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.ppml.crypto.dataframe
+
+import com.intel.analytics.bigdl.dllib.utils.LoggerFilter
+import com.intel.analytics.bigdl.ppml.PPMLContext
+import com.intel.analytics.bigdl.ppml.crypto.{AES_CBC_PKCS5PADDING, BigDLEncrypt, CryptoCodec, DECRYPT, ENCRYPT, PLAIN_TEXT}
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.SparkSession
+
+import java.io.{File, FileWriter}
+
+class EncryptDataFrameHadoopSpec extends DataFrameHelper {
+  LoggerFilter.redirectSparkInfoLogs()
+
+  val (plainFileName, encryptFileName, data, dataKeyPlaintext) = generateCsvData()
+
+
+  val ppmlArgs = Map(
+      "spark.bigdl.kms.simple.id" -> appid,
+      "spark.bigdl.kms.simple.key" -> appkey,
+      "spark.bigdl.kms.key.primary" -> (s"file://" + primaryKeyPath),
+      "spark.bigdl.kms.key.data" -> (s"file://" + dataKeyPath)
+  )
+  val sparkConf = new SparkConf().setMaster("local[4]")
+  val sc = PPMLContext.initPPMLContext(sparkConf, "SimpleQuery", ppmlArgs)
+
+  "textfile read from plaint text file" should "work" in {
+    val file = sc.textFile(plainFileName).collect()
+    file.mkString("\n") + "\n" should be (data)
+    val file2 = sc.textFile(encryptFileName, cryptoMode = AES_CBC_PKCS5PADDING).collect()
+    file2.mkString("\n") + "\n" should be (data)
+  }
+
+  "sparkSession.read" should "work" in {
+    val sparkSession: SparkSession = SparkSession.builder().getOrCreate()
+    val df = sparkSession.read.csv(plainFileName)
+    val d = df.collect().map(v => s"${v.get(0)},${v.get(1)},${v.get(2)}").mkString("\n")
+    d + "\n" should be (data)
+    val df2 = sparkSession.read.option("header", "true").csv(plainFileName)
+    val d2 = df2.schema.map(_.name).mkString(",") + "\n" +
+      df2.collect().map(v => s"${v.get(0)},${v.get(1)},${v.get(2)}").mkString("\n")
+    d2 + "\n" should be (data)
+  }
+
+  "read from encrypted csv with header" should "work" in {
+    val df = sc.read(cryptoMode = AES_CBC_PKCS5PADDING)
+      .option("header", "true").csv(encryptFileName)
+    val d = df.schema.map(_.name).mkString(",") + "\n" +
+      df.collect().map(v => s"${v.get(0)},${v.get(1)},${v.get(2)}").mkString("\n")
+    d + "\n" should be (data)
+  }
+
+  "save df" should "work" in {
+    val enWriteCsvPath = dir + "/en_write_csv"
+    val writeCsvPath = dir + "/write_csv"
+    val df = sc.read(cryptoMode = AES_CBC_PKCS5PADDING).csv(encryptFileName)
+    df.count() should be (totalNum + 1) // with header
+    sc.write(df, cryptoMode = AES_CBC_PKCS5PADDING).csv(enWriteCsvPath)
+    sc.write(df, cryptoMode = PLAIN_TEXT).csv(writeCsvPath)
+
+    val readEn = sc.read(cryptoMode = AES_CBC_PKCS5PADDING).csv(enWriteCsvPath)
+    val readEnCollect = readEn.collect().map(v =>
+      s"${v.get(0)},${v.get(1)},${v.get(2)}").mkString("\n")
+    readEnCollect + "\n" should be (data)
+
+    val readPlain = sc.read(cryptoMode = PLAIN_TEXT).csv(writeCsvPath)
+    val readPlainCollect = readPlain.collect().map(v =>
+      s"${v.get(0)},${v.get(1)},${v.get(2)}").mkString("\n")
+    readPlainCollect + "\n" should be (data)
+  }
+
+  "save df with multi-partition" should "work" in {
+    val enWriteCsvPath = dir + "/en_write_csv_multi"
+    val writeCsvPath = dir + "/write_csv_multi"
+    val df = sc.read(cryptoMode = AES_CBC_PKCS5PADDING)
+      .option("header", "true").csv(encryptFileName).repartition(4)
+    df.count() should be (totalNum) // with header
+    sc.write(df, cryptoMode = AES_CBC_PKCS5PADDING).csv(enWriteCsvPath)
+    sc.write(df, cryptoMode = PLAIN_TEXT).csv(writeCsvPath)
+
+    val readEn = sc.read(cryptoMode = AES_CBC_PKCS5PADDING).csv(enWriteCsvPath)
+    readEn.count() should be (totalNum)
+    val readEnCollect = readEn.collect()
+      .sortWith((a, b) => a.get(0).toString < b.get(0).toString)
+      .sortWith((a, b) => a.get(1).toString.toInt < b.get(1).toString.toInt)
+      .map(v => s"${v.get(0)},${v.get(1)},${v.get(2)}")
+      .mkString("\n")
+    header + readEnCollect + "\n" should be (data)
+
+    val readPlain = sc.read(cryptoMode = PLAIN_TEXT).csv(writeCsvPath)
+    readPlain.count() should be (totalNum)
+    val readPlainCollect = readPlain.collect()
+      .sortWith((a, b) => a.get(0).toString < b.get(0).toString)
+      .sortWith((a, b) => a.get(1).toString.toInt < b.get(1).toString.toInt)
+      .map(v => s"${v.get(0)},${v.get(1)},${v.get(2)}").mkString("\n")
+    header + readPlainCollect + "\n" should be (data)
+  }
+
+}
+


### PR DESCRIPTION
## Description

### 1. Why the change?
Current we can only read/write primary key/datakey from/to local file system. But for cluster mode, the primary key/datakey may not on the local file system. So add hadoop fs support for reading/writing primarykey/datakey in PPMLContext and KeyManagement.

### 2. User API changes
Add hadoop configuration option in KeyManagementService:
def retrievePrimaryKey(primaryKeySavePath: String, config: Configuration = null)
def retrieveDataKey(primaryKeyPath: String, dataKeySavePath: String, config: Configuration = null)
def retrieveDataKeyPlainText(primaryKeyPath: String, dataKeyPath: String,
                               config: Configuration = null): String

For PPMLContext APIs, no change. User uses same PPMLContext APIs.

### 3. Summary of the change 
Add hadoop configuration options for KeyManagementService.
In KeyManagementService, call keyReaderWriter.writeKeyToFile and keyReaderWriter.readKeyFromFile with hadoop configuration option.

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...

