### PR TITLE
fix spark-shell-with-dllib.sh

### DIFF
--- a/scripts/spark-shell-with-dllib.sh
+++ b/scripts/spark-shell-with-dllib.sh
@@ -12,8 +12,7 @@ if [ -z "${SPARK_HOME}" ]; then
 fi
 
 #setup paths
-export BIGDL_JAR_NAME=`find ${BIGDL_HOME}/jars -name bigdl-dllib*jar-with-dependencies.jar`
-export BIGDL_JAR="$BIGDL_JAR_NAME"
+export BIGDL_JAR=${BIGDL_HOME}/jars/*
 export BIGDL_CONF=${BIGDL_HOME}/conf/spark-bigdl.conf
 echo $BIGDL_JAR
 

--- a/scripts/spark-submit-with-dllib.sh
+++ b/scripts/spark-submit-with-dllib.sh
@@ -12,8 +12,7 @@ if [ -z "${SPARK_HOME}" ]; then
 fi
 
 #setup paths
-export BIGDL_JAR_NAME=`find ${BIGDL_HOME}/jars -name bigdl-dllib*jar-with-dependencies.jar`
-export BIGDL_JAR="$BIGDL_JAR_NAME"
+export BIGDL_JAR_NAME=${BIGDL_HOME}/jars/*
 export BIGDL_CONF=${BIGDL_HOME}/conf/spark-bigdl.conf
 
 # Check files


### PR DESCRIPTION
## Description
To fix: https://github.com/intel-analytics/BigDL/issues/5246
```
object intel is not a member of package com
       import com.intel.analytics.bigdl.dllib.NNContext
```

### Summary of the change 

bigdl jars path is `${BIGDL_HOME}/jars/*`

###  How to test?
- [x] manual

