### PR TITLE
[Nano] enable BFloat16 in IPEX inference model

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
@@ -63,8 +63,7 @@ def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
     '''
     from .ipex_inference_bf16_model import PytorchIPEXJITBF16Model
     return PytorchIPEXJITBF16Model(model, input_sample=input_sample, use_ipex=use_ipex,
-                                   dtype=torch.bfloat16, use_jit=use_jit,
-                                   channels_last=channels_last)
+                                   use_jit=use_jit, channels_last=channels_last)
 
 
 def load_ipexjit_model(path, model):

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
@@ -50,6 +50,23 @@ def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
                                use_jit=use_jit, channels_last=channels_last)
 
 
+def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
+                            use_jit=False, channels_last=None):
+    '''
+    :param model: the model(nn.module) to be transform.
+    :param input_sample: torch tensor indicate the data sample to be used
+            for tracing.
+    :param use_ipex: if use ipex to optimize the model
+    :param use_jit: if use jit to accelerate the model
+    :param channels_last: if set model and data to be channels-last mode.
+            the parameter will be ignored if use_ipex is False.
+    '''
+    from .ipex_inference_bf16_model import PytorchIPEXJITBF16Model
+    return PytorchIPEXJITBF16Model(model, input_sample=input_sample, use_ipex=use_ipex,
+                                   dtype=torch.bfloat16, use_jit=use_jit,
+                                   channels_last=channels_last)
+
+
 def load_ipexjit_model(path, model):
     from .ipex_inference_model import PytorchIPEXJITModel
     return PytorchIPEXJITModel._load(path, model)

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -1,0 +1,79 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from .ipex_inference_model import PytorchIPEXJITModel
+from bigdl.nano.pytorch.amp.bfloat16 import autocast
+import torch
+
+
+class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
+    def __init__(self, model, input_sample=None, use_ipex=False, dtype=None,
+                 use_jit=False, channels_last=None, from_load=False):
+        '''
+        This is the accelerated model for pytorch and ipex/jit.
+        All the external API is based on Trainer, so what we have here is
+        basically internal APIs and subject to change.
+
+        This PytorchIPEXJITModel will serve for fp32 and ipex>1.9 models.
+        :param model: the model(nn.module) to be transform if from_load is False
+               the accelerated model if from_load is True.
+        :param input_sample: torch tensor indicate the data sample to be used
+               for tracing.
+        :param use_ipex: if use ipex to optimize the model
+        :param use_jit: if use jit to accelerate the model
+        :param channels_last: if set model and data to be channels-last mode.
+               the parameter will be ignored if use_ipex is False.
+        :param from_load: this will only be set by _load method.
+        '''
+        PytorchIPEXJITModel.__init__(self, model, input_sample=input_sample, use_ipex=use_ipex,
+                                     dtype=dtype, use_jit=use_jit, channels_last=channels_last,
+                                     from_load=from_load)
+
+    @autocast()
+    def forward_step(self, *inputs):
+        return super().forward_step(*inputs)
+
+    @property
+    def status(self):
+        status = super().status
+        status.update({"use_ipex": self.use_ipex,
+                       "use_jit": self.use_jit,
+                       "channels_last": self.channels_last,
+                       "checkpoint": "ckpt.pth"})
+        return status
+
+    @staticmethod
+    def _load(path, model):
+        status = PytorchIPEXJITModel._load_status(path)
+        checkpoint_path = path / status['checkpoint']
+        if status["use_jit"]:
+            model = torch.jit.load(checkpoint_path)
+            model.eval()
+            model = torch.jit.freeze(model)
+            from_load = True
+        else:
+            state_dict = torch.load(checkpoint_path)
+            model.eval()
+            model.load_state_dict(state_dict)
+            from_load = False
+        return PytorchIPEXJITModel(model, use_ipex=status['use_ipex'],
+                                   use_jit=status['use_jit'],
+                                   channels_last=status['channels_last'],
+                                   from_load=from_load)
+
+    def _save_model(self, path):
+        super()._save_model(path)
+

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -49,30 +49,6 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
     @property
     def status(self):
         status = super().status
-        status.update({"use_ipex": self.use_ipex,
-                       "use_jit": self.use_jit,
-                       "channels_last": self.channels_last,
-                       "checkpoint": "ckpt.pth"})
+        status.update({"precision": "bfloat16"})
         return status
 
-    @staticmethod
-    def _load(path, model):
-        status = PytorchIPEXJITModel._load_status(path)
-        checkpoint_path = path / status['checkpoint']
-        if status["use_jit"]:
-            model = torch.jit.load(checkpoint_path)
-            model.eval()
-            model = torch.jit.freeze(model)
-            from_load = True
-        else:
-            state_dict = torch.load(checkpoint_path)
-            model.eval()
-            model.load_state_dict(state_dict)
-            from_load = False
-        return PytorchIPEXJITModel(model, use_ipex=status['use_ipex'],
-                                   use_jit=status['use_jit'],
-                                   channels_last=status['channels_last'],
-                                   from_load=from_load)
-
-    def _save_model(self, path):
-        super()._save_model(path)

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -20,7 +20,7 @@ import torch
 
 
 class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
-    def __init__(self, model, input_sample=None, use_ipex=False, dtype=None,
+    def __init__(self, model, input_sample=None, use_ipex=False,
                  use_jit=False, channels_last=None, from_load=False):
         '''
         This is the accelerated model for pytorch and ipex/jit.
@@ -39,8 +39,8 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         :param from_load: this will only be set by _load method.
         '''
         PytorchIPEXJITModel.__init__(self, model, input_sample=input_sample, use_ipex=use_ipex,
-                                     dtype=dtype, use_jit=use_jit, channels_last=channels_last,
-                                     from_load=from_load)
+                                     dtype=torch.bfloat16, use_jit=use_jit,
+                                     channels_last=channels_last, from_load=from_load)
 
     @autocast()
     def forward_step(self, *inputs):

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -51,4 +51,3 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         status = super().status
         status.update({"precision": "bfloat16"})
         return status
-

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -76,4 +76,3 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
 
     def _save_model(self, path):
         super()._save_model(path)
-

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -19,66 +19,10 @@ import intel_extension_for_pytorch as ipex
 import torch
 
 
-class IPEXJITModel:
-    def __init__(self,
-                 model,
-                 input_sample=None,
-                 use_ipex=False,
-                 use_jit=False,
-                 channels_last=None,
-                 from_load=False):
-        '''
-        :param model: the model(nn.module) to be transform if from_load is False
-               the accelerated model if from_load is True.
-        :param input_sample: torch tensor indicate the data sample to be used
-               for tracing.
-        :param use_ipex: if use ipex to optimize the model
-        :param use_jit: if use jit to accelerate the model
-        :param channels_last: if set model and data to be channels-last mode.
-               the parameter will be ignored if use_ipex is False.
-        :param from_load: this will only be set by _load method.
-        '''
-        if from_load:
-            self.model = model
-            self.use_ipex = use_ipex
-            self.use_jit = use_jit
-            self.channels_last = channels_last
-            return
-        self.channels_last = use_ipex if (channels_last is None or not use_ipex) else channels_last
-        model.eval()
-        self.original_state_dict = model.state_dict()
-        self.model = model
-        self.use_ipex = use_ipex
-        self.use_jit = use_jit
-        if self.channels_last:
-            self.model = self.model.to(memory_format=torch.channels_last)
-        if self.use_ipex:
-            self.model = ipex.optimize(self.model)
-        if self.use_jit:
-            self.model = torch.jit.trace(self.model, input_sample)
-            self.model = torch.jit.freeze(self.model)
-
-    @property
-    def forward_args(self):
-        return [input_value.debugName() for input_value in self.model.graph.inputs()
-                if not input_value.debugName().startswith('self')]
-
-    def forward_step(self, *inputs):
-        if self.channels_last:
-            inputs = tuple(map(lambda x: x.to(memory_format=torch.channels_last), inputs))
-        return self.model(*inputs)
-
-    def _save_model(self, path):
-        if self.use_jit:
-            self.model.save(path / "ckpt.pth")
-        else:
-            torch.save(self.original_state_dict, path / "ckpt.pth")
-
-
-class PytorchIPEXJITModel(IPEXJITModel, AcceleratedLightningModule):
-    def __init__(self, model, input_sample=None, use_ipex=False,
+class PytorchIPEXJITModel(AcceleratedLightningModule):
+    def __init__(self, model: torch.nn.Module, input_sample=None, use_ipex=False, dtype=None,
                  use_jit=False, channels_last=None, from_load=False):
-        '''
+        """
         This is the accelerated model for pytorch and ipex/jit.
         All the external API is based on Trainer, so what we have here is
         basically internal APIs and subject to change.
@@ -93,15 +37,38 @@ class PytorchIPEXJITModel(IPEXJITModel, AcceleratedLightningModule):
         :param channels_last: if set model and data to be channels-last mode.
                the parameter will be ignored if use_ipex is False.
         :param from_load: this will only be set by _load method.
-        '''
-        AcceleratedLightningModule.__init__(self, None)
-        IPEXJITModel.__init__(self, model, input_sample=input_sample,
-                              use_ipex=use_ipex, use_jit=use_jit,
-                              channels_last=channels_last,
-                              from_load=from_load)
+        """
+        model.eval()
+        super().__init__(model)
+        if from_load:
+            self.use_ipex = use_ipex
+            self.use_jit = use_jit
+            self.channels_last = channels_last
+            return
+        self.channels_last = use_ipex if (channels_last is None or not use_ipex) else channels_last
+        self.original_state_dict = model.state_dict()
+        self.use_ipex = use_ipex
+        self.use_jit = use_jit
+        if self.channels_last:
+            self.model = self.model.to(memory_format=torch.channels_last)
+        if self.use_ipex:
+            self.model = ipex.optimize(self.model, dtype=dtype)
+        if self.use_jit:
+            self.model = torch.jit.trace(self.model, input_sample)
+            self.model = torch.jit.freeze(self.model)
+
+    @property
+    def forward_args(self):
+        return [input_value.debugName() for input_value in self.model.graph.inputs()
+                if not input_value.debugName().startswith('self')]
 
     def on_forward_start(self, inputs):
         return inputs
+
+    def forward_step(self, *inputs):
+        if self.channels_last:
+            inputs = tuple(map(lambda x: x.to(memory_format=torch.channels_last), inputs))
+        return self.model(*inputs)
 
     def on_forward_end(self, outputs):
         return outputs
@@ -135,4 +102,7 @@ class PytorchIPEXJITModel(IPEXJITModel, AcceleratedLightningModule):
                                    from_load=from_load)
 
     def _save_model(self, path):
-        super()._save_model(path)
+        if self.use_jit:
+            self.model.save(path / "ckpt.pth")
+        else:
+            torch.save(self.original_state_dict, path / "ckpt.pth")

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -37,7 +37,7 @@ from bigdl.nano.deps.automl.hpo_api import create_hpo_searcher, check_hpo_status
 from bigdl.nano.deps.ray.ray_api import distributed_ray
 from bigdl.nano.deps.openvino.openvino_api import PytorchOpenVINOModel, load_openvino_model
 from bigdl.nano.deps.ipex.ipex_api import create_IPEXAccelerator, create_IPEXAccelerator_1_9, \
-    PytorchIPEXJITModel, load_ipexjit_model
+    PytorchIPEXJITModel, PytorchIPEXJITBF16Model, load_ipexjit_model
 from bigdl.nano.deps.onnxruntime.onnxruntime_api import PytorchONNXRuntimeModel, \
     load_onnxruntime_model
 from bigdl.nano.deps.neural_compressor.inc_api import load_inc_model, quantize as inc_quantize
@@ -253,6 +253,7 @@ class Trainer(pl.Trainer):
     def quantize(model,  # remove the type requirement for type checking
                  precision: str = 'int8',
                  accelerator=None,
+                 use_ipex=False,
                  calib_dataloader: DataLoader = None,
                  metric: Metric = None,
                  accuracy_criterion: dict = None,
@@ -313,6 +314,13 @@ class Trainer(pl.Trainer):
         """
         if precision == 'bf16':
             if accelerator is None:
+                if use_ipex:
+                    use_jit = (accelerator == "jit")
+                    channels_last = export_kwargs["channels_last"] \
+                        if "channels_last" in export_kwargs else None
+                    return PytorchIPEXJITBF16Model(model, input_sample=input_sample,
+                                                   use_ipex=use_ipex, use_jit=use_jit,
+                                                   channels_last=channels_last)
                 bf16_model = BF16Model(model)
                 return bf16_model
             else:

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -315,6 +315,8 @@ class Trainer(pl.Trainer):
         if precision == 'bf16':
             if accelerator is None:
                 if use_ipex:
+                    invalidInputError(not TORCH_VERSION_LESS_1_10,
+                                      "torch version should >=1.10 to use ipex")
                     use_jit = (accelerator == "jit")
                     channels_last = export_kwargs["channels_last"] \
                         if "channels_last" in export_kwargs else None

--- a/python/nano/test/pytorch/tests/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/test_bf16_ipex.py
@@ -30,7 +30,7 @@ class Pytorch1_9:
 
         with pytest.raises(
             RuntimeError,
-            match="Require torch>=1.10 to convert type as bfloat16."
+            match="torch version should >=1.10 to use ipex"
         ):
             trainer.quantize(model, precision='bf16', use_ipex=True)
 

--- a/python/nano/test/pytorch/tests/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/test_bf16_ipex.py
@@ -36,10 +36,6 @@ class Pytorch1_9:
 
 
 class Pytorch1_12:
-    """
-    Pytorch version >= 1.10 and <1.12, bfloat16 precision is supported.
-    But there is no optimization on bfloat16.
-    """
     def test_bf16_common(self):
         """
         Debug mode. Allow run bf16 forward without bf16 instruction support.

--- a/python/nano/test/pytorch/tests/test_ipex_bf16.py
+++ b/python/nano/test/pytorch/tests/test_ipex_bf16.py
@@ -1,0 +1,96 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from unittest import TestCase
+import pytest
+import torch
+from bigdl.nano.pytorch import Trainer
+from torchvision.models.resnet import resnet18
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
+from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10, TORCH_VERSION_LESS_1_12
+
+
+class Pytorch1_9:
+    """Pytorch version < 1.10, bfloat16 precision is not supported."""
+    def test_bf16_pytorch_less_1_10(self):
+        trainer = Trainer(max_epochs=1)
+        model = resnet18(num_classes=10)
+
+        with pytest.raises(
+            RuntimeError,
+            match="Require torch>=1.10 to convert type as bfloat16."
+        ):
+            trainer.quantize(model, precision='bf16', use_ipex=True)
+
+
+class Pytorch1_12:
+    """
+    Pytorch version >= 1.10 and <1.12, bfloat16 precision is supported.
+    But there is no optimization on bfloat16.
+    """
+    def test_bf16_common(self):
+        """
+        Debug mode. Allow run bf16 forward without bf16 instruction support.
+        """
+        trainer = Trainer(max_epochs=1)
+        model = resnet18(num_classes=10)
+
+        x = torch.rand((10, 3, 256, 256))
+        y = torch.ones((10,), dtype=torch.long)
+
+        bf16_model = trainer.quantize(model, precision='bf16', use_ipex=True)
+        # Debug mode to test functionality, make sure forward is called sucessfully
+        y_hat = bf16_model(x)
+        assert y_hat.shape == (10, 10) and y_hat.dtype == torch.bfloat16
+
+    def test_bf16_with_amx_bf16(self):
+        trainer = Trainer(max_epochs=1)
+        model = resnet18(num_classes=10)
+
+        x = torch.rand((10, 3, 256, 256))
+        y = torch.ones((10,), dtype=torch.long)
+
+        bf16_model = trainer.quantize(model, precision='bf16')
+        with patch.object(type(bf16_model), "_has_bf16_isa", PropertyMock(return_value=True)):
+            bf16_model._max_bf16_isa = MagicMock(return_value="AMX")
+            y_hat = bf16_model(x)
+        assert y_hat.shape == (10, 10) and y_hat.dtype == torch.bfloat16
+
+    def test_bf16_with_avx512_bf16(self):
+        trainer = Trainer(max_epochs=1)
+        model = resnet18(num_classes=10)
+
+        x = torch.rand((10, 3, 256, 256))
+        y = torch.ones((10,), dtype=torch.long)
+
+        bf16_model = trainer.quantize(model, precision='bf16')
+        with patch.object(type(bf16_model), "_has_bf16_isa", PropertyMock(return_value=True)):
+            bf16_model._max_bf16_isa = MagicMock(return_value="AVX512")
+            y_hat = bf16_model(x)
+        assert y_hat.shape == (10, 10) and y_hat.dtype == torch.bfloat16
+
+
+TORCH_VERSION_CLS = Pytorch1_12
+
+if TORCH_VERSION_LESS_1_10:
+    TORCH_VERSION_CLS = Pytorch1_9
+
+
+class TestBF16(TORCH_VERSION_CLS, TestCase):
+    pass
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/python/nano/test/pytorch/tests/test_ipex_bf16.py
+++ b/python/nano/test/pytorch/tests/test_ipex_bf16.py
@@ -55,32 +55,6 @@ class Pytorch1_12:
         y_hat = bf16_model(x)
         assert y_hat.shape == (10, 10) and y_hat.dtype == torch.bfloat16
 
-    def test_bf16_with_amx_bf16(self):
-        trainer = Trainer(max_epochs=1)
-        model = resnet18(num_classes=10)
-
-        x = torch.rand((10, 3, 256, 256))
-        y = torch.ones((10,), dtype=torch.long)
-
-        bf16_model = trainer.quantize(model, precision='bf16')
-        with patch.object(type(bf16_model), "_has_bf16_isa", PropertyMock(return_value=True)):
-            bf16_model._max_bf16_isa = MagicMock(return_value="AMX")
-            y_hat = bf16_model(x)
-        assert y_hat.shape == (10, 10) and y_hat.dtype == torch.bfloat16
-
-    def test_bf16_with_avx512_bf16(self):
-        trainer = Trainer(max_epochs=1)
-        model = resnet18(num_classes=10)
-
-        x = torch.rand((10, 3, 256, 256))
-        y = torch.ones((10,), dtype=torch.long)
-
-        bf16_model = trainer.quantize(model, precision='bf16')
-        with patch.object(type(bf16_model), "_has_bf16_isa", PropertyMock(return_value=True)):
-            bf16_model._max_bf16_isa = MagicMock(return_value="AVX512")
-            y_hat = bf16_model(x)
-        assert y_hat.shape == (10, 10) and y_hat.dtype == torch.bfloat16
-
 
 TORCH_VERSION_CLS = Pytorch1_12
 


### PR DESCRIPTION
## Description

Enable BFloat16 precision in IPEX. This is a quick implementation for inference only.

### 1. Why the change?

IPEX with BFloat16 is not supported in Nano.

### 2. User API changes
With this PR, users are able to use IPEX with BFloat16 acceleration as follow:
```python
bf16_model = trainer.quantize(model, precision='bf16')
y_hat = bf16_model(x)
```

### 3. Summary of the change 

- Merge `IPEXJITModel` to `PytorchIPEXJITModel`. IPEX is for Pytorch only, so we don't need to have two classes.
- Add `PytorchIPEXJITBF16Model` to enable precision autocasting.
- Add unit tests to verify ipex bf16 is working

### 4. How to test?
- [ ] Unit test
