### PR TITLE
Rename `transform_to_shard_dict` api to `shardsPreprocessing` and other small improvements

### DIFF
--- a/python/orca/example/shard_keras_tutorial.py
+++ b/python/orca/example/shard_keras_tutorial.py
@@ -37,10 +37,10 @@ model.add(Dense(1, activation='sigmoid'))
 # compile the keras model
 model.compile(loss='binary_crossentropy', optimizer='adam', metrics=['accuracy'])
 
-data_shard = shardsPreprocessing(data_shard,
-                                     featureCols=['f1', 'f2', 'f3',
-                                                  'f4', 'f5', 'f6', 'f7', 'f8'],
-                                     labelCol='label')
+data_shard = shards_pd_df_to_shards_dic(data_shard,
+                                        featureCols=['f1', 'f2', 'f3',
+                                                     'f4', 'f5', 'f6', 'f7', 'f8'],
+                                        labelCol='label')
 
 est = Estimator.from_keras(keras_model=model)
 est.fit(data=data_shard,

--- a/python/orca/example/shard_keras_tutorial.py
+++ b/python/orca/example/shard_keras_tutorial.py
@@ -37,7 +37,7 @@ model.add(Dense(1, activation='sigmoid'))
 # compile the keras model
 model.compile(loss='binary_crossentropy', optimizer='adam', metrics=['accuracy'])
 
-data_shard = transform_to_shard_dict(data_shard,
+data_shard = shardsPreprocessing(data_shard,
                                      featureCols=['f1', 'f2', 'f3',
                                                   'f4', 'f5', 'f6', 'f7', 'f8'],
                                      labelCol='label')

--- a/python/orca/example/shard_pytorch_regression.py
+++ b/python/orca/example/shard_pytorch_regression.py
@@ -82,8 +82,8 @@ orca_estimator = Estimator.from_torch(model=model,
                                       metrics=[Accuracy()],
                                       backend="bigdl")
 
-data_shard = shardsPreprocessing(data_shard,
-                                     featureCols=list(column[:-1]),
-                                     labelCol=column[-1])
+data_shard = shards_pd_df_to_shards_dic(data_shard,
+                                        featureCols=list(column[:-1]),
+                                        labelCol=column[-1])
 
 orca_estimator.fit(data=data_shard, epochs=8, batch_size=4)

--- a/python/orca/example/shard_pytorch_regression.py
+++ b/python/orca/example/shard_pytorch_regression.py
@@ -67,11 +67,7 @@ init_orca_context(memory="4g")
 path = 'new_ionosphere.csv'
 data_shard = bigdl.orca.data.pandas.read_csv(path)
 
-def getSchema(iter):
-    for pdf in iter:
-        return [pdf.columns.values]
-
-column = data_shard.rdd.mapPartitions(getSchema).first()
+column = data_shard.get_schema()['columns']
 
 label_encoder = StringIndexer(inputCol=column[-1])
 data_shard = label_encoder.fit_transform(data_shard)
@@ -86,7 +82,7 @@ orca_estimator = Estimator.from_torch(model=model,
                                       metrics=[Accuracy()],
                                       backend="bigdl")
 
-data_shard = transform_to_shard_dict(data_shard,
+data_shard = shardsPreprocessing(data_shard,
                                      featureCols=list(column[:-1]),
                                      labelCol=column[-1])
 

--- a/python/orca/src/bigdl/orca/data/shard.py
+++ b/python/orca/src/bigdl/orca/data/shard.py
@@ -238,7 +238,7 @@ class SparkXShards(XShards):
                              .values.tolist())\
                     .partitionBy(num_partitions)
 
-                schema = self._get_schema()
+                schema = self.get_schema()
 
                 def merge_rows(iter):
                     data = [value[1] for value in list(iter)]
@@ -352,7 +352,7 @@ class SparkXShards(XShards):
         """
         if self._get_class_name() == 'pandas.core.frame.DataFrame':
             import pandas as pd
-            schema = self._get_schema()
+            schema = self.get_schema()
             # if partition by a column
             if isinstance(cols, str):
                 if cols not in schema['columns']:
@@ -535,7 +535,7 @@ class SparkXShards(XShards):
         result_rdd = self.rdd.map(lambda x: utility_func(x, func, *args, **kwargs))
         return result_rdd
 
-    def _get_schema(self):
+    def get_schema(self):
         if 'schema' in self.type:
             return self.type['schema']
         else:

--- a/python/orca/src/bigdl/orca/data/utils.py
+++ b/python/orca/src/bigdl/orca/data/utils.py
@@ -467,7 +467,15 @@ def check_col_exists(df, columns):
                           str(col_not_exist) + " do not exist in this Table")
 
 
-def transform_to_shard_dict(data, featureCols, labelCol):
+def shardsPreprocessing(data, featureCols, labelCol):
+    """
+    This api is used to process SparkXShards of pandas dataframe to SparkXShards of
+    dictionary, x is feature, y is label
+    :param data: SparkXShards of pandas dataframe.
+    :param featureCols: a list of featurecols.
+    :param labelCol: label col.
+    :return: SparkXShards of dictionary
+    """
     def to_shard_dict(df):
         featureLists = [df[feature_col].to_numpy() for feature_col in featureCols]
         result = {

--- a/python/orca/src/bigdl/orca/data/utils.py
+++ b/python/orca/src/bigdl/orca/data/utils.py
@@ -467,14 +467,21 @@ def check_col_exists(df, columns):
                           str(col_not_exist) + " do not exist in this Table")
 
 
-def shardsPreprocessing(data, featureCols, labelCol):
+def shards_pd_df_to_shards_dic(data, featureCols, labelCol):
     """
     This api is used to process SparkXShards of pandas dataframe to SparkXShards of
     dictionary, x is feature, y is label
     :param data: SparkXShards of pandas dataframe.
     :param featureCols: a list of featurecols.
-    :param labelCol: label col.
+    :param labelCol: single label col.
     :return: SparkXShards of dictionary
+    
+    eg:
+    shards: SparkXShards of pandas dataframe with 2 cols ['f1', 'lable'], 
+    transform_shards = shards_pd_df_to_shards_dic(shards, featureCols=[''], labelCol='')
+    
+    transform_shards will be SparkXShards of dictionary. x will be a stacked numpy array
+    (stack feature columns), y will be a numpy array
     """
     def to_shard_dict(df):
         featureLists = [df[feature_col].to_numpy() for feature_col in featureCols]

--- a/python/orca/src/bigdl/orca/data/utils.py
+++ b/python/orca/src/bigdl/orca/data/utils.py
@@ -475,11 +475,11 @@ def shards_pd_df_to_shards_dic(data, featureCols, labelCol):
     :param featureCols: a list of featurecols.
     :param labelCol: single label col.
     :return: SparkXShards of dictionary
-    
+
     eg:
-    shards: SparkXShards of pandas dataframe with 2 cols ['f1', 'lable'], 
+    shards: SparkXShards of pandas dataframe with 2 cols ['f1', 'lable'],
     transform_shards = shards_pd_df_to_shards_dic(shards, featureCols=[''], labelCol='')
-    
+
     transform_shards will be SparkXShards of dictionary. x will be a stacked numpy array
     (stack feature columns), y will be a numpy array
     """


### PR DESCRIPTION
## Description

Rename `transform_to_shard_dict` api to `shardsPreprocessing` and add documents about this api.
Remove rdd operations in pytorch tutorials

### 1. Why the change?

Fix comments in https://github.com/intel-analytics/BigDL/pull/5077#pullrequestreview-1055487451

### 2. User API changes

Rename `transform_to_shard_dict` api to `shardsPreprocessing`, no parameters change

### 3. Summary of the change 

Rename `transform_to_shard_dict` api to `shardsPreprocessing` and add documents about this api.
Remove rdd operations in pytorch tutorials

### 4. How to test?
-  Application test
