### PR TITLE
Fix issue #5236, fix the bug when try to encrypt empty partition

### DIFF
--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/BigDLEncryptCompressor.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/BigDLEncryptCompressor.scala
@@ -55,7 +55,11 @@ class BigDLEncryptCompressor(cryptoMode: CryptoMode, dataKeyPlaintext: String) e
   }
 
   override def finish(): Unit = {
-    tryFinished = true
+    if (lv2Len == 0 && len == 0) {
+      isFinished = true
+    } else {
+      tryFinished = true
+    }
   }
 
   override def finished(): Boolean = {

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/CryptoCodec.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/CryptoCodec.scala
@@ -112,16 +112,17 @@ object CryptoCodec {
     var headerVerified = false
 
     override def decompress(b: Array[Byte], off: Int, len: Int): Int = {
-      if (!headerVerified) {
-        bigdlEncrypt.verifyHeader(in)
-        headerVerified = true
-      }
-
       if (in.available() == 0) { // apparently the previous end-of-stream was also end-of-file:
         // return success, as if we had never called getCompressedData()
         eof = true
         return -1
       }
+
+      if (!headerVerified) {
+        bigdlEncrypt.verifyHeader(in)
+        headerVerified = true
+      }
+
       val decompressed = bigdlEncrypt.decryptPart(in, buffer)
 
       decompressed.copyToArray(b, 0)


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->
when the partition number is more than the actual data record number(maybe because we config --master 'local[n]' or use df.repartition(n) where n > data record number). some partitions may be empty. when try to encrypt the empty partition, there will be a "Bad Argument" error in our custom `codec`.
this error may happen when the DataFrame is really small. so this pr fix this problem. 
related issue: https://github.com/intel-analytics/BigDL/issues/5236
