### PR TITLE
Fix duplicate repartition in tf2 estimator spark backend

### DIFF
--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -288,7 +288,7 @@ class SparkTFEstimator():
             data_config=data_config,
         )
 
-        if isinstance(data, SparkXShards):
+        if isinstance(data, SparkXShards):  # In this case, data partitions must be >= num_workers
             # set train/validation data
             if data._get_class_name() == 'pandas.core.frame.DataFrame':
                 data = process_xshards_of_pandas_dataframe(data, feature_cols, label_cols)
@@ -300,7 +300,7 @@ class SparkTFEstimator():
 
             rdd = data.rdd
             if rdd.getNumPartitions() > self.num_workers:
-                rdd = rdd.coalesce(self.num_workers)
+                rdd = rdd.coalesce(self.num_workers)  # Use coalesce to avoid repartition
             res = rdd.barrier().mapPartitions(
                 lambda iter: transform_func(iter, init_params, params)).collect()
         else:

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -167,6 +167,7 @@ class SparkTFEstimator():
             data_config=data_config
         )
 
+        # In this case, data partitions must be >= num_workers
         if isinstance(data, SparkXShards):
             # set train/validation data
             if data._get_class_name() == 'pandas.core.frame.DataFrame':
@@ -183,7 +184,7 @@ class SparkTFEstimator():
 
                 rdd = data.rdd
                 if rdd.getNumPartitions() > self.num_workers:
-                    rdd = rdd.coalesce(self.num_workers)
+                    rdd = rdd.coalesce(self.num_workers)  # Use coalesce to avoid repartition
                 res = rdd.barrier().mapPartitions(
                     lambda iter: transform_func(iter, init_params, params)).collect()
             else:
@@ -288,7 +289,7 @@ class SparkTFEstimator():
             data_config=data_config,
         )
 
-        if isinstance(data, SparkXShards):  # In this case, data partitions must be >= num_workers
+        if isinstance(data, SparkXShards):
             # set train/validation data
             if data._get_class_name() == 'pandas.core.frame.DataFrame':
                 data = process_xshards_of_pandas_dataframe(data, feature_cols, label_cols)
@@ -300,7 +301,7 @@ class SparkTFEstimator():
 
             rdd = data.rdd
             if rdd.getNumPartitions() > self.num_workers:
-                rdd = rdd.coalesce(self.num_workers)  # Use coalesce to avoid repartition
+                rdd = rdd.coalesce(self.num_workers)
             res = rdd.barrier().mapPartitions(
                 lambda iter: transform_func(iter, init_params, params)).collect()
         else:

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -181,8 +181,7 @@ class SparkTFEstimator():
                     param["data_creator"] = make_data_creator(partition_data)
                     return SparkRunner(**init_param).step(**param)
 
-                res = data.rdd.repartition(self.num_workers).barrier() \
-                    .mapPartitions(
+                res = data.rdd.barrier().mapPartitions(
                     lambda iter: transform_func(iter, init_params, params)).collect()
             else:
                 def transform_func(iter, init_param, param):
@@ -195,8 +194,7 @@ class SparkTFEstimator():
 
                 train_rdd = data.rdd.mapPartitions(lambda iter: [list(iter)])
                 val_rdd = validation_data.rdd.mapPartitions(lambda iter: [list(iter)])
-                res = train_rdd.zip(val_rdd).repartition(self.num_workers).barrier()\
-                    .mapPartitions(
+                res = train_rdd.zip(val_rdd).barrier().mapPartitions(
                     lambda iter: transform_func(iter, init_params, params)).collect()
         else:
             params["data_creator"] = data
@@ -294,8 +292,8 @@ class SparkTFEstimator():
                 param["data_creator"] = make_data_creator(partition_data)
                 return SparkRunner(**init_param).validate(**param)
 
-            res = data.rdd.repartition(self.num_workers).barrier() \
-                .mapPartitions(lambda iter: transform_func(iter, init_params, params)).collect()
+            res = data.rdd.barrier().mapPartitions(
+                lambda iter: transform_func(iter, init_params, params)).collect()
         else:
             params["data_creator"] = data
 

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
@@ -13,20 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+import os
+import pytest
 import shutil
 import tempfile
 from unittest import TestCase
-import time
 
-import time
 import numpy as np
-import pytest
 import tensorflow as tf
 
 from bigdl.orca.learn.tf2 import Estimator
 from bigdl.orca import OrcaContext
 
-import os
 
 resource_path = os.path.join(
     os.path.realpath(os.path.dirname(__file__)), "../../../../resources")
@@ -126,7 +125,7 @@ class TestTFEstimator(TestCase):
                 model_creator=model_creator,
                 verbose=True,
                 config=config,
-                workers_per_node=2,
+                workers_per_node=3,
                 backend="spark",
                 model_dir=temp_dir)
 


### PR DESCRIPTION
## Description

In fit, if input is dataframe, we will do repartition if partition < num workers when converting to SparkXShards.
After converting to SparkXShards, the data should have num_partitions >= num_workers for training (if there is no empty partition in original user's data, which is assumed).
Since in SparkXShards, each partition is combined to a single dict, if you call repartition once more on SparkXShards, it will result in empty partitions again.

```
>>> rdd = sc.parallelize([1, 2, 3, 4], numSlices=4)
>>> rdd.glom().collect()
[[1], [2], [3], [4]]
>>> rdd2 = rdd.repartition(4)
>>> rdd2.glom().collect()
[[4, 3], [2], [], [1]]

# 1, 2, 3, 4 correspond to the entire dict of data in each SparkXShards partition
```