### PR TITLE
[Nano] Revise Tutorial Notebook: Apply ONNXRuntime Acceleration on Inference Pipeline

### DIFF
--- a/python/nano/notebooks/pytorch/tutorial/pytorch_inference_onnx.ipynb
+++ b/python/nano/notebooks/pytorch/tutorial/pytorch_inference_onnx.ipynb
@@ -58,7 +58,7 @@
    "metadata": {},
    "source": [
     "### Step 1: Load Data\n",
-    "Here we use two images from the dog_vs_cat dataset from kaggle. You can get the images from [here](https://www.kaggle.com/c/dogs-vs-cats)"
+    "Here we use the Oxford-IIIT Pet Dataset, you could find more information from [here](https://www.robots.ox.ac.uk/~vgg/data/pets/). Note that the dataset is hosted on https://www.robots.ox.ac.uk, and its server sometimes may fail. If you got an `HTTP 500` error when downloading the dataset, it may be because that their server just failed. You could wait for some time and try again."
    ]
   },
   {

--- a/python/nano/notebooks/pytorch/tutorial/pytorch_inference_onnx.ipynb
+++ b/python/nano/notebooks/pytorch/tutorial/pytorch_inference_onnx.ipynb
@@ -4,6 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<a href=\"https://colab.research.google.com/github/intel-analytics/BigDL/blob/main/python/nano/notebooks/pytorch/tutorial/pytorch_inference_onnx.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Apply ONNXRuntime Acceleration on Inference Pipeline"
    ]
   },
@@ -229,13 +236,6 @@
     "y_hat = ort_model(x)\n",
     "y_hat.argmax(dim=1)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/python/nano/notebooks/pytorch/tutorial/pytorch_inference_onnx.ipynb
+++ b/python/nano/notebooks/pytorch/tutorial/pytorch_inference_onnx.ipynb
@@ -240,7 +240,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.13 ('nano-pytorch': conda)",
+   "display_name": "Python 3.7.10 ('testVscode')",
    "language": "python",
    "name": "python3"
   },
@@ -254,12 +254,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.7.10"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "09344c7f3239fd422839751f876786d6b1a624c40f19af1b43cb2737f421c2b2"
+    "hash": "1e4962c53c6ef7ea4348d410747e78580ab0e1631d139dfbe170b5701abbb022"
    }
   }
  },

--- a/python/nano/notebooks/pytorch/tutorial/pytorch_inference_onnx.ipynb
+++ b/python/nano/notebooks/pytorch/tutorial/pytorch_inference_onnx.ipynb
@@ -100,7 +100,21 @@
    "metadata": {},
    "source": [
     "### Step 2: Custom Model\n",
-    "Regarding the model, we used pretrained torchvision.models.resnet18. More details, please refer to [here](https://pytorch.org/vision/0.12/generated/torchvision.models.resnet18.html?highlight=resnet18)"
+    "Regarding the model, we used pretrained torchvision.models.resnet18. More details, please refer to [here](https://pytorch.org/vision/0.12/generated/torchvision.models.resnet18.html?highlight=resnet18).\n",
+    "\n",
+    "If you run the notebook on Colab, you may meet `OSError:... undefined symbol...` error regarding `torchtext` when importing `Trainer` from `bigdl.nano.pytorch`. To solve this, you could try to downgrade `torchtext` to the compatible version with `torch`. You could refer to the table [here](https://pypi.org/project/torchtext/) for which verison of `torchtext` you should install.\n",
+    "\n",
+    "Our nightly-built `bigdl-nano[pytorch]` is currently based on `torch==1.11.0`. So you could run the following command to solve this problem:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Please ignore this if you do not met problem with torchtext\n",
+    "!pip install torchtext==0.12.0 "
    ]
   },
   {

--- a/python/nano/notebooks/pytorch/tutorial/pytorch_inference_onnx.ipynb
+++ b/python/nano/notebooks/pytorch/tutorial/pytorch_inference_onnx.ipynb
@@ -11,19 +11,53 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Environment Preparation\n",
-    "Before you start with APIs delivered by bigdl-nano, you have to make sure BigDL-Nano is correctly installed for PyTorch. If not, please follow [this](../../../../../docs/readthedocs/source/doc/Nano/Overview/nano.md) to set up your environment.<br><br>\n",
-    "To use onnxruntime accelerator, you need to install some onnx packages as follows to set up your environment with ONNXRuntime acceleration.\n",
-    "```bash\n",
-    "pip install onnx onnxruntime\n",
-    "```"
+    "### Introduction\n",
+    "In this notebook we will describe how to apply ONNXRuntime Acceleration on inference pipeline with the APIs delivered by BigDL-Nano in 4 simple steps."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Step 0: Load Data\n",
+    "### Step 0: Prepare Environment\n",
+    "Before you start with APIs delivered by bigdl-nano, you have to make sure BigDL-Nano is correctly installed for PyTorch.\n",
+    "\n",
+    "We recommend to run below commands, especially `source bigdl-nano-init` before jupyter kernel is started, or some of the optimizations may not take effect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# nightly bulit version\n",
+    "!pip install --pre --upgrade bigdl-nano[pytorch]\n",
+    "# set env variables\n",
+    "!source bigdl-nano-init"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before you start with onnxruntime accelerator, you need to install some onnx packages as follows to set up your environment with ONNXRuntime acceleration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install onnx onnxruntime"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Step 1: Load Data\n",
     "Here we use two images from the dog_vs_cat dataset from kaggle. You can get the images from [here](https://www.kaggle.com/c/dogs-vs-cats)"
    ]
   },
@@ -140,7 +174,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### **Step 3: ONNXRuntime Acceleration**\n",
+    "### Step 3: ONNXRuntime Acceleration\n",
     "trace your model as an ONNXRuntime model using `Trainer.trace()`"
    ]
   },
@@ -192,7 +226,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.10 ('testVscode')",
+   "display_name": "Python 3.7.13 ('nano-pytorch': conda)",
    "language": "python",
    "name": "python3"
   },
@@ -206,12 +240,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.13"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "1e4962c53c6ef7ea4348d410747e78580ab0e1631d139dfbe170b5701abbb022"
+    "hash": "09344c7f3239fd422839751f876786d6b1a624c40f19af1b43cb2737f421c2b2"
    }
   }
  },


### PR DESCRIPTION
## Description
Revise tutorial notebook "Apply ONNXRuntime Acceleration on Inference Pipeline" to make it more user-friendly.

### 1. Why the change?
There are some misleading descriptions in the notebook which could make it hard for users to run the notebook successfully.

### 2. User API changes
N/A

### 3. Summary of the change 
- Add pip install commands to highlight the installation of nightly-built `bigdl-nano[pytorch]` (stable version 2.0.0 depends on `torchvision==0.10.0` which does not include dataset `OxfordIIITPet`)
- Revise description of Load Data part to explain the reason of possible download failure of `OxfordIIITPet` dataset
- Add explanation and possible solution of the conflict between `torch` and `torchtext` when running the notebook on Colab
- Add Colab link of this notebook

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...
