### PR TITLE
Chronos: add best validation mode to forecasters' fit

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -263,6 +263,10 @@ class BasePytorchForecaster(Forecaster):
                |
                | 2. earlystop:
                | Monitor the val_loss and stop training when it stops improving.
+               |
+               | 3. best validation:
+               | Monitor the val_loss. And load the checkpoint of the epoch with the smallest
+               | val_loss after the training.
 
         :param earlystop_patience: Number of checks with no improvement after which training will
                be stopped. It takes effect when 'validation_mode' is 'earlystop'. Under the default
@@ -334,7 +338,14 @@ class BasePytorchForecaster(Forecaster):
                                                                      name="forecaster_tmp_log")
             from pytorch_lightning.callbacks import EarlyStopping
             early_stopping = EarlyStopping('val/loss', patience=earlystop_patience)
-            callbacks = [early_stopping] if validation_mode == 'earlystop' else None
+            from pytorch_lightning.callbacks import ModelCheckpoint
+            checkpoint_callback = ModelCheckpoint(monitor="val/loss", dirpath='validation',
+                                                  filename='best', save_on_train_epoch_end=True)
+            if validation_mode == 'earlystop':
+                callbacks = [early_stopping]
+            elif validation_mode == 'best validation':
+                callbacks = [checkpoint_callback]
+            else: callbacks = None
             # Trainer init
             self.trainer = Trainer(logger=logger, max_epochs=epochs, callbacks=callbacks,
                                    checkpoint_callback=self.checkpoint_callback,
@@ -363,6 +374,9 @@ class BasePytorchForecaster(Forecaster):
                 self.fitted = True
                 fit_out = read_csv('./forecaster_tmp_log/version_0/metrics.csv')
                 delete_folder("./forecaster_tmp_log")
+                if validation_mode == 'best validation':
+                    self.load('validation/best.ckpt')
+                    delete_folder("./validation")
                 return fit_out
 
     def predict(self, data, batch_size=32, quantize=False):

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -264,7 +264,7 @@ class BasePytorchForecaster(Forecaster):
                | 2. earlystop:
                | Monitor the val_loss and stop training when it stops improving.
                |
-               | 3. best validation:
+               | 3. best_epoch:
                | Monitor the val_loss. And load the checkpoint of the epoch with the smallest
                | val_loss after the training.
 
@@ -343,9 +343,10 @@ class BasePytorchForecaster(Forecaster):
                                                   filename='best', save_on_train_epoch_end=True)
             if validation_mode == 'earlystop':
                 callbacks = [early_stopping]
-            elif validation_mode == 'best validation':
+            elif validation_mode == 'best_epoch':
                 callbacks = [checkpoint_callback]
-            else: callbacks = None
+            else:
+                callbacks = None
             # Trainer init
             self.trainer = Trainer(logger=logger, max_epochs=epochs, callbacks=callbacks,
                                    checkpoint_callback=self.checkpoint_callback,
@@ -374,7 +375,7 @@ class BasePytorchForecaster(Forecaster):
                 self.fitted = True
                 fit_out = read_csv('./forecaster_tmp_log/version_0/metrics.csv')
                 delete_folder("./forecaster_tmp_log")
-                if validation_mode == 'best validation':
+                if validation_mode == 'best_epoch':
                     self.load('validation/best.ckpt')
                     delete_folder("./validation")
                 return fit_out

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -510,4 +510,4 @@ class TestChronosModelLSTMForecaster(TestCase):
                                     dropout=[0.1, 0.2],
                                     loss="mae",
                                     lr=0.01)
-        val_loss = forecaster.fit(train_data, val_data, validation_mode='best validation', epochs=10)
+        val_loss = forecaster.fit(train_data, val_data, validation_mode='best_epoch', epochs=10)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -485,7 +485,7 @@ class TestChronosModelLSTMForecaster(TestCase):
                                     dropout=[0.1, 0.2],
                                     loss="mae",
                                     lr=0.01)
-        val_loss = forecaster.fit(train_data, val_data, validation_mode='earlystop', epochs=50)
+        val_loss = forecaster.fit(train_data, val_data, validation_mode='earlystop', epochs=10)
 
     def test_lstm_forecaster_fit_earlystop_patience(self):
         train_data, val_data, _ = create_data()
@@ -498,4 +498,16 @@ class TestChronosModelLSTMForecaster(TestCase):
                                     loss="mae",
                                     lr=0.01)
         val_loss = forecaster.fit(train_data, val_data, validation_mode='earlystop',
-                                  earlystop_patience=6, epochs=50)
+                                  earlystop_patience=6, epochs=10)
+
+    def test_lstm_forecaster_fit_best_val(self):
+        train_data, val_data, _ = create_data()
+        forecaster = LSTMForecaster(past_seq_len=24,
+                                    input_feature_num=2,
+                                    output_feature_num=2,
+                                    hidden_dim=[32, 16],
+                                    layer_num=2,
+                                    dropout=[0.1, 0.2],
+                                    loss="mae",
+                                    lr=0.01)
+        val_loss = forecaster.fit(train_data, val_data, validation_mode='best validation', epochs=10)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -468,7 +468,7 @@ class TestChronosNBeatsForecaster(TestCase):
                                       metrics=['mae'],
                                       lr=0.01)
         val_loss = forecaster.fit((train_data[0], train_data[1]), val_data,
-                                  validation_mode='earlystop', epochs=50)
+                                  validation_mode='earlystop', epochs=10)
 
     def test_nbeats_forecaster_fit_earlystop_patience(self):
         train_data, val_data, _ = create_data()
@@ -481,4 +481,16 @@ class TestChronosNBeatsForecaster(TestCase):
                                       lr=0.01)
         val_loss = forecaster.fit((train_data[0], train_data[1]), val_data,
                                   validation_mode='earlystop', earlystop_patience=6,
-                                  epochs=50)
+                                  epochs=10)
+
+    def test_nbeats_forecaster_fit_best_val(self):
+        train_data, val_data, _ = create_data()
+        forecaster = NBeatsForecaster(past_seq_len=24,
+                                      future_seq_len=5,
+                                      stack_types=('generic', 'generic'),
+                                      nb_blocks_per_stack=3,
+                                      hidden_layer_units=256,
+                                      metrics=['mae'],
+                                      lr=0.01)
+        val_loss = forecaster.fit((train_data[0], train_data[1]), val_data,
+                                  validation_mode='best validation', epochs=10)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -493,4 +493,4 @@ class TestChronosNBeatsForecaster(TestCase):
                                       metrics=['mae'],
                                       lr=0.01)
         val_loss = forecaster.fit((train_data[0], train_data[1]), val_data,
-                                  validation_mode='best validation', epochs=10)
+                                  validation_mode='best_epoch', epochs=10)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -418,7 +418,8 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
                                        output_feature_num=1,
                                        loss="mae",
                                        lr=0.01)
-        val_loss = forecaster.fit(train_data, val_data, validation_mode='earlystop', epochs=50)
+        val_loss = forecaster.fit(train_data, val_data,
+                                  validation_mode='earlystop', epochs=10)
 
     def test_s2s_forecaster_fit_earlystop_patience(self):
         train_data, val_data, _ = create_data()
@@ -429,4 +430,15 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
                                        loss="mae",
                                        lr=0.01)
         val_loss = forecaster.fit(train_data, val_data, validation_mode='earlystop',
-                                  earlystop_patience=6, epochs=50)
+                                  earlystop_patience=6, epochs=10)
+
+    def test_s2s_forecaster_fit_best_val(self):
+        train_data, val_data, _ = create_data()
+        forecaster = Seq2SeqForecaster(past_seq_len=24,
+                                       future_seq_len=5,
+                                       input_feature_num=1,
+                                       output_feature_num=1,
+                                       loss="mae",
+                                       lr=0.01)
+        val_loss = forecaster.fit(train_data, val_data,
+                                  validation_mode='best validation', epochs=10)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -441,4 +441,4 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
                                        loss="mae",
                                        lr=0.01)
         val_loss = forecaster.fit(train_data, val_data,
-                                  validation_mode='best validation', epochs=10)
+                                  validation_mode='best_epoch', epochs=10)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -544,7 +544,7 @@ class TestChronosModelTCNForecaster(TestCase):
                                    num_channels=[16, 16],
                                    loss="mae",
                                    lr=0.01)
-        train_loss = forecaster.fit(train_data, val_data, validation_mode='earlystop', epochs=50)
+        train_loss = forecaster.fit(train_data, val_data, validation_mode='earlystop', epochs=10)
 
     def test_tcn_forecaster_fit_earlystop_patience(self):
         train_data, val_data, test_data = create_data()
@@ -557,4 +557,16 @@ class TestChronosModelTCNForecaster(TestCase):
                                    loss="mae",
                                    lr=0.01)
         train_loss = forecaster.fit(train_data, val_data, validation_mode='earlystop',
-                                    earlystop_patience=6, epochs=50)
+                                    earlystop_patience=6, epochs=10)
+
+    def test_tcn_forecaster_fit_best_val(self):
+        train_data, val_data, _ = create_data()
+        forecaster = TCNForecaster(past_seq_len=24,
+                                   future_seq_len=5,
+                                   input_feature_num=1,
+                                   output_feature_num=1,
+                                   kernel_size=4,
+                                   num_channels=[16, 16],
+                                   loss="mae",
+                                   lr=0.01)
+        val_loss = forecaster.fit(train_data, val_data, validation_mode='best validation', epochs=10)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -569,4 +569,4 @@ class TestChronosModelTCNForecaster(TestCase):
                                    num_channels=[16, 16],
                                    loss="mae",
                                    lr=0.01)
-        val_loss = forecaster.fit(train_data, val_data, validation_mode='best validation', epochs=10)
+        val_loss = forecaster.fit(train_data, val_data, validation_mode='best_epoch', epochs=10)


### PR DESCRIPTION
## Description

1. Why the change?
To add best validation mode to forecasters' fit. Forecasters will monitor the validation_loss and And load the checkpoint of the epoch with the smallest val_loss after the training in this mode.
https://github.com/intel-analytics/BigDL/issues/4958

2. User API changes
Add a mode best validation for validation_mode.

3. Summary of the change
Change the file [python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py](https://github.com/intel-analytics/BigDL/pull/5290/files#diff-f90b2e349024be33300085266c59def4560dd7b81de6573ad6b93a51fd382fb0).

4. How to test?
Add unit test in
[python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py](https://github.com/intel-analytics/BigDL/pull/5290/files#diff-802bb8b90c18a761e7e0d4eb000cebddfde5366a48cb7201533a4ca4d0c295ce)
[python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py](https://github.com/intel-analytics/BigDL/pull/5290/files#diff-2d759068533e4a21b1b0e56c77e144731d37b63ff3ee83f7dd0721dce5c62458)
[python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py](https://github.com/intel-analytics/BigDL/pull/5290/files#diff-7f8329eefc66b1ba67d3c33380fff7e3d7134181812f20b197f53964616e3337)
[python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py](https://github.com/intel-analytics/BigDL/pull/5290/files#diff-779e0b1ffaba1d91d35970801d1c9c81958393d710ea1d6286913c421d76c2c7)

5. New dependencies