### PR TITLE
fix apps/textclassfication compile failure

### DIFF
--- a/apps/model-inference-examples/text-classification-training/src/main/scala/com/intel/analytics/bigdl/apps/textclassfication/training/TextClassificationTrainer.scala
+++ b/apps/model-inference-examples/text-classification-training/src/main/scala/com/intel/analytics/bigdl/apps/textclassfication/training/TextClassificationTrainer.scala
@@ -7,7 +7,7 @@ import com.intel.analytics.bigdl.dllib.optim.{Adagrad, Trigger}
 import com.intel.analytics.bigdl.dllib.tensor.Tensor
 import com.intel.analytics.bigdl.dllib.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.apps.textclassfication.processing.TextProcessing
-import com.intel.analytics.bigdl.dllib.common.NNContext
+import com.intel.analytics.bigdl.dllib.NNContext
 import com.intel.analytics.bigdl.dllib.feature.FeatureSet
 import com.intel.analytics.bigdl.dllib.keras.layers._
 import com.intel.analytics.bigdl.dllib.keras.metrics.Accuracy


### PR DESCRIPTION
## Description

There is failure for BigDL-NB-Scala-AppTests, fix the compile issue. http://10.112.231.51:18889/view/BigDL-NB-Test/job/BigDL-NB-Scala-AppTests/810/consoleFull. 

The failure is:
[ERROR] /opt/work/jenkins/workspace/BigDL-NB-Scala-AppTests/apps/model-inference-examples/text-classification-training/src/main/scala/com/intel/analytics/bigdl/apps/textclassfication/training/TextClassificationTrainer.scala:10: object NNContext is not a member of package com.intel.analytics.bigdl.dllib.common
[ERROR] import com.intel.analytics.bigdl.dllib.common.NNContext
[ERROR]        ^
[ERROR] /opt/work/jenkins/workspace/BigDL-NB-Scala-AppTests/apps/model-inference-examples/text-classification-training/src/main/scala/com/intel/analytics/bigdl/apps/textclassfication/training/TextClassificationTrainer.scala:110: not found: value NNContext
[ERROR]       val sc = NNContext.initNNContext(conf)
[ERROR]                ^
[ERROR] /opt/work/jenkins/workspace/BigDL-NB-Scala-AppTests/apps/model-inference-examples/text-classification-training/src/main/scala/com/intel/analytics/bigdl/apps/textclassfication/training/TextClassificationTrainer.scala:117: recursive value x$3 needs type
[ERROR]       val Array(trainings, validations) = samples.randomSplit(Array(0.8, 1 - 0.8))
[ERROR]                 ^
[ERROR] three errors found