### PR TITLE
Orca: refactor HDFS operation in estimator

### DIFF
--- a/python/orca/src/bigdl/orca/data/file.py
+++ b/python/orca/src/bigdl/orca/data/file.py
@@ -377,10 +377,12 @@ def put_local_file_to_remote(local_path, remote_path, filemode=None):
     if remote_path.startswith("hdfs"):  # hdfs://url:port/file_path
         try:
             cmd = 'hdfs dfs -put -f {} {}'.format(local_path, remote_path)
-            subprocess.Popen(cmd, shell=True)
+            process = subprocess.Popen(cmd, shell=True)
+            process.wait()
             if filemode:
                 chmod_cmd = 'hdfs dfs -chmod {} {}'.format(filemode, remote_path)
-                subprocess.Popen(chmod_cmd, shell=True)
+                process = subprocess.Popen(chmod_cmd, shell=True)
+                process.wait()
         except Exception as e:
             logger.error("Cannot upload file {} to {}: error: "
                          .format(local_path, remote_path, str(e)))

--- a/python/orca/src/bigdl/orca/data/file.py
+++ b/python/orca/src/bigdl/orca/data/file.py
@@ -160,7 +160,10 @@ def exists(path):
         classpath = subprocess.Popen(["hadoop", "classpath", "--glob"],
                                      stdout=subprocess.PIPE).communicate()[0]
         os.environ["CLASSPATH"] = classpath.decode("utf-8")
-        fs = pa.hdfs.connect(host=host_port[0], port=int(host_port[1]))
+        if len(host_port) > 1:
+            fs = pa.hdfs.connect(host=host_port[0], port=int(host_port[1]))
+        else:
+            fs = pa.hdfs.connect(host=host_port[0])
         return fs.exists(path)
     else:
         if path.startswith("file://"):
@@ -193,7 +196,10 @@ def makedirs(path):
         classpath = subprocess.Popen(["hadoop", "classpath", "--glob"],
                                      stdout=subprocess.PIPE).communicate()[0]
         os.environ["CLASSPATH"] = classpath.decode("utf-8")
-        fs = pa.hdfs.connect(host=host_port[0], port=int(host_port[1]))
+        if len(host_port) > 1:
+            fs = pa.hdfs.connect(host=host_port[0], port=int(host_port[1]))
+        else:
+            fs = pa.hdfs.connect(host=host_port[0])
         return fs.mkdir(path)
     else:
         if path.startswith("file://"):
@@ -272,7 +278,10 @@ def is_file(path):
         classpath = subprocess.Popen(["hadoop", "classpath", "--glob"],
                                      stdout=subprocess.PIPE).communicate()[0]
         os.environ["CLASSPATH"] = classpath.decode("utf-8")
-        fs = pa.hdfs.connect(host=host_port[0], port=int(host_port[1]))
+        if len(host_port) > 1:
+            fs = pa.hdfs.connect(host=host_port[0], port=int(host_port[1]))
+        else:
+            fs = pa.hdfs.connect(host=host_port[0])
         return fs.isfile(path)
     else:
         if path.startswith("file://"):
@@ -288,7 +297,10 @@ def put_local_dir_to_remote(local_dir, remote_dir):
         classpath = subprocess.Popen(["hadoop", "classpath", "--glob"],
                                      stdout=subprocess.PIPE).communicate()[0]
         os.environ["CLASSPATH"] = classpath.decode("utf-8")
-        fs = pa.hdfs.connect(host=host_port[0], port=int(host_port[1]))
+        if len(host_port) > 1:
+            fs = pa.hdfs.connect(host=host_port[0], port=int(host_port[1]))
+        else:
+            fs = pa.hdfs.connect(host=host_port[0])
         if not fs.exists(remote_dir):
             fs.mkdir(remote_dir)
         for file in os.listdir(local_dir):
@@ -375,7 +387,10 @@ def put_local_file_to_remote(local_path, remote_path, filemode=None):
                                      stdout=subprocess.PIPE).communicate()[0]
         os.environ["CLASSPATH"] = classpath.decode("utf-8")
         try:
-            fs = pa.hdfs.connect(host=host_port[0], port=int(host_port[1]))
+            if len(host_port) > 1:
+                fs = pa.hdfs.connect(host=host_port[0], port=int(host_port[1]))
+            else:
+                fs = pa.hdfs.connect(host=host_port[0])
             remote_dir = os.path.dirname(remote_path)
             if not fs.exists(remote_dir):
                 fs.mkdir(remote_dir)

--- a/python/orca/src/bigdl/orca/learn/utils.py
+++ b/python/orca/src/bigdl/orca/learn/utils.py
@@ -468,7 +468,10 @@ def save_pkl(data, path):
         classpath = subprocess.Popen(["hadoop", "classpath", "--glob"],
                                      stdout=subprocess.PIPE).communicate()[0]
         os.environ["CLASSPATH"] = classpath.decode("utf-8")
-        fs = pa.hdfs.connect(host=host_port[0], port=int(host_port[1]))
+        if len(host_port) > 1:
+            fs = pa.hdfs.connect(host=host_port[0], port=int(host_port[1]))
+        else:
+            fs = pa.hdfs.connect(host=host_port[0])
         with fs.open(path, 'wb') as f:
             pickle.dump(data, f)
     elif path.startswith("s3"):  # s3://bucket/file_path

--- a/python/orca/src/bigdl/orca/learn/utils.py
+++ b/python/orca/src/bigdl/orca/learn/utils.py
@@ -462,7 +462,7 @@ def data_length(data):
 
 
 def save_pkl(data, path):
-    if path.startswith("hdfs"):  # hdfs://url:port/
+    if path.startswith("hdfs"):  # hdfs://url:port/file_path
         import uuid
         file_name = str(uuid.uuid1()) + ".pkl"
         temp_path = os.path.join(tempfile.gettempdir(), file_name)


### PR DESCRIPTION
## Description
Refer to the report by customers, the program reported `list index out of range` error if they do not specify the HDFS port. Because that the port is always set to default value(8020/9000) in real deployments, users are used to ignore the setting of HDFS port. This PR is to improve user experience that they do not have to specify the HDFS port for the connection to HDFS.

Refactor HDFS operations in estimator.