### PR TITLE
Friesian serving http add shutdown hook

### DIFF
--- a/scala/friesian/src/main/java/com/intel/analytics/bigdl/friesian/serving/recommender/HTTP/RecommenderHTTP.java
+++ b/scala/friesian/src/main/java/com/intel/analytics/bigdl/friesian/serving/recommender/HTTP/RecommenderHTTP.java
@@ -4,6 +4,8 @@ import com.intel.analytics.bigdl.friesian.serving.utils.CMDParser;
 import com.intel.analytics.bigdl.friesian.serving.utils.Utils;
 import com.intel.analytics.bigdl.friesian.serving.utils.gRPCHelper;
 import com.intel.analytics.bigdl.grpc.ConfigParser;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -14,6 +16,7 @@ import java.net.URI;
 
 public class RecommenderHTTP {
     private static URI baseUri;
+    private static final Logger logger = LogManager.getLogger(RecommenderHTTP.class.getName());
     /**
      * Starts Grizzly HTTP server exposing JAX-RS resources defined in this application.
      * @return Grizzly HTTP server.
@@ -55,9 +58,21 @@ public class RecommenderHTTP {
      */
     public static void main(String[] args) throws IOException {
         final HttpServer server = startServer(args);
-        System.out.println(String.format("Recommender Jersey app started with endpoints " +
-                "available at %s%nHit Ctrl-C to stop it...", baseUri.toString()));
-        System.in.read();
-        server.shutdownNow();
+
+        // register shutdown hook
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            logger.info("Stopping server..");
+            server.shutdown();
+        }, "shutdownHook"));
+
+        // run
+        try {
+            server.start();
+            logger.info(String.format("Recommender Jersey app started with endpoints " +
+                    "available at %s%nHit Ctrl-C to stop it...", baseUri.toString()));
+            Thread.currentThread().join();
+        } catch (Exception e) {
+            logger.error("There was an error while starting Grizzly HTTP server.", e);
+        }
     }
 }

--- a/scala/friesian/src/main/resources/config/config_recommender.yaml
+++ b/scala/friesian/src/main/resources/config/config_recommender.yaml
@@ -1,7 +1,7 @@
 ######## Recommend Service
 
 # Default: 8980, which port to create the server
-servicePort: 8980
+#servicePort: 8980
 
 # Default: null, open a port for prometheus monitoring tool, if set, user can check the
 # performance using prometheus


### PR DESCRIPTION
## Description

`System.in.read();` will be killed in k8s deployment, use `shutdown hook` to fix this issue.