### PR TITLE
[Friesian] Fix wrong assert can cause unittest bug

### DIFF
--- a/scala/friesian/src/main/java/com/intel/analytics/bigdl/friesian/serving/recall/IndexService.java
+++ b/scala/friesian/src/main/java/com/intel/analytics/bigdl/friesian/serving/recall/IndexService.java
@@ -47,7 +47,6 @@ public class IndexService {
     }
 
     public void addWithIds(float[] data, int[] ids) {
-        assert(ids.length == data.length);
         int dataNum = ids.length;
         longArray idsInput = convertIdsToLongArray(ids);
         floatArray dataInput = vectorToFloatArray(data);


### PR DESCRIPTION
* remove length equal assert in IndexService#addWithIds
* ids is an id array with n elements, but data is a flattenMaped array. It's length is n*d.