### PR TITLE
Upgrade IPEX version to 1.12.100 in test

### DIFF
--- a/.github/workflows/nano_unit_tests_pytorch.yml
+++ b/.github/workflows/nano_unit_tests_pytorch.yml
@@ -197,7 +197,7 @@ jobs:
           # will change the require_grad attribute of layers, which will make some tests of nano fail.
           "torch==1.9.0+cpu torchvision==0.10.0+cpu torch_ipex==1.9.0",
           "",
-          "torch==1.12.0+cpu torchvision==0.13.0+cpu intel_extension_for_pytorch==1.12.0"
+          "torch==1.12.0+cpu torchvision==0.13.0+cpu intel_extension_for_pytorch==1.12.100"
           # "torch==1.10.1+cpu torchvision==0.11.2+cpu intel_extension_for_pytorch==1.10.0 psutil"
           ]
 


### PR DESCRIPTION
## Description

Upgrade IPEX version to 1.12.100 in test to avoid illegal instruction error on machines w/o AVX-512.