### PR TITLE
Chronos: Evaluator.get_latency() is added to evaluate the time cost of a workflow

### DIFF
--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -137,7 +137,7 @@ class Evaluator(object):
 
         :param num_running: Int and the value is positive. Specify the running number of
                the function.
-        :param func: The function to be tested for the latency.
+        :param func: The function to be tested for latency.
         :param args: other arguments to be inputted to func.
 
         :return: Dictionary of str:float.

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -160,10 +160,10 @@ class Evaluator(object):
         time_list = repeat(lambda: func(*args), number=1, repeat=num_running)
         sorted_time = np.sort(time_list)
 
-        latency_list = {"50p": '%.3f' % (1000 * np.median(time_list)),
-                        "90p": '%.3f' % (1000 * sorted_time[int(0.90 * num_running)]),
-                        "95p": '%.3f' % (1000 * sorted_time[int(0.95 * num_running)]),
-                        "99p": '%.3f' % (1000 * sorted_time[int(0.99 * num_running)])}
+        latency_list = {"50p": round(1000 * np.median(time_list), 3),
+                        "90p": round(1000 * sorted_time[int(0.90 * num_running)], 3),
+                        "95p": round(1000 * sorted_time[int(0.95 * num_running)], 3),
+                        "99p": round(1000 * sorted_time[int(0.99 * num_running)], 3)}
 
         print(">" * 20, "latency result of", str(func.__name__), ">" * 20)
         for info in ["50p", "90p", "95p", "99p"]:

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -153,7 +153,7 @@ class Evaluator(object):
             >>> # {"p50": 3.853, "p90": 3.881, "p95": 3.933, "p99": 4.107}
         """
         invalidInputError(isinstance(num_running, int), "num_running type must be int, "
-                              f"but found {type(num_running)}.")
+                          f"but found {type(num_running)}.")
         if num_running < 0:
             invalidInputError(False, "num_running value must be positive, "
                               f"but found {num_running}.")

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -131,14 +131,15 @@ class Evaluator(object):
                     res_list.append(res.numpy())
         return res_list
 
-    def get_latency(num_running, func, *args):
+    def get_latency(func, *args, num_running = 100, **kwargs):
         """
         Return the time cost in milliseconds of a specific function by running multiple times.
 
-        :param num_running: Int and the value is positive. Specify the running number of
-               the function.
         :param func: The function to be tested for latency.
-        :param args: other arguments to be inputted to func.
+        :param args: arguments for the tested function.
+        :param num_running: Int and the value is positive. Specify the running number of
+               the function and the value defaults to 100.
+        :param kwargs: other arguments for the tested function.
 
         :return: Dictionary of str:float.
                  Show the information of the time cost in milliseconds.
@@ -148,7 +149,8 @@ class Evaluator(object):
             >>> x = next(iter(test_loader))[0]
             >>> # run forecaster.predict(x.numpy()) for len(tsdata_test.df) times
             >>> # to evaluate the time cost
-            >>> latency = Evaluator.get_latency(len(tsdata_test.df), forecaster.predict, x.numpy())
+            >>> latency = Evaluator.get_latency(forecaster.predict, x.numpy(),\
+                          num_running = len(tsdata_test.df))
             >>> # an example output:
             >>> # {"p50": 3.853, "p90": 3.881, "p95": 3.933, "p99": 4.107}
         """
@@ -158,7 +160,7 @@ class Evaluator(object):
             invalidInputError(False, "num_running value must be positive, "
                               f"but found {num_running}.")
 
-        time_list = repeat(lambda: func(*args), number=1, repeat=num_running)
+        time_list = repeat(lambda: func(*args, **kwargs), number=1, repeat=num_running)
         sorted_time = np.sort(time_list)
 
         latency_list = {"p50": round(1000 * np.median(time_list), 3),

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -133,12 +133,12 @@ class Evaluator(object):
 
     def get_latency(num_running, func, *args):
         """
-        Display the time cost in milliseconds of a specific function by running multiple times.
+        Return the time cost in milliseconds of a specific function by running multiple times.
 
         :param num_running: Int and the value is positive. Specify the running number of
                the function.
-        :param func: The python function to be captured the latency.
-        :param args: other arguments in this function.
+        :param func: The function to be tested for latency.
+        :param args: other arguments to be inputted to func.
 
         :return: Dictionary of str:float.
                  Show the information of the time cost in milliseconds.
@@ -149,25 +149,21 @@ class Evaluator(object):
             >>> # run forecaster.predict(x.numpy()) for len(tsdata_test.df) times
             >>> # to evaluate the time cost
             >>> latency = Evaluator.get_latency(len(tsdata_test.df), forecaster.predict, x.numpy())
+            >>> # an example output:
+            >>> # {"p50": 3.853, "p90": 3.881, "p95": 3.933, "p99": 4.107}
         """
-        if not isinstance(num_running, int):
-            invalidInputError(False, "num_running type must be int, "
+        invalidInputError(isinstance(num_running, int), "num_running type must be int, "
                               f"but found {type(num_running)}.")
-        elif num_running < 0:
+        if num_running < 0:
             invalidInputError(False, "num_running value must be positive, "
                               f"but found {num_running}.")
 
         time_list = repeat(lambda: func(*args), number=1, repeat=num_running)
         sorted_time = np.sort(time_list)
 
-        latency_list = {"50p": round(1000 * np.median(time_list), 3),
-                        "90p": round(1000 * sorted_time[int(0.90 * num_running)], 3),
-                        "95p": round(1000 * sorted_time[int(0.95 * num_running)], 3),
-                        "99p": round(1000 * sorted_time[int(0.99 * num_running)], 3)}
-
-        print(">" * 20, "latency result of", str(func.__name__), ">" * 20)
-        for info in ["50p", "90p", "95p", "99p"]:
-            print(info, "latency:", latency_list[info], "ms")
-        print("<" * 20, "latency result of", str(func.__name__), "<" * 20, "\n")
+        latency_list = {"p50": round(1000 * np.median(time_list), 3),
+                        "p90": round(1000 * sorted_time[int(0.90 * num_running)], 3),
+                        "p95": round(1000 * sorted_time[int(0.95 * num_running)], 3),
+                        "p99": round(1000 * sorted_time[int(0.99 * num_running)], 3)}
 
         return latency_list

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -131,7 +131,6 @@ class Evaluator(object):
                     res_list.append(res.numpy())
         return res_list
 
-
     def get_latency(num_running, func, *args):
         """
         Display the time cost in milliseconds of a specific function by running multiple times.
@@ -161,10 +160,10 @@ class Evaluator(object):
         time_list = repeat(lambda: func(*args), number=1, repeat=num_running)
         sorted_time = np.sort(time_list)
 
-        latency_list = {"50p": '%.3f' %(1000 * np.median(time_list)),
-                        "90p": '%.3f' %(1000 * sorted_time[int(0.90 * num_running)]),
-                        "95p": '%.3f' %(1000 * sorted_time[int(0.95 * num_running)]),
-                        "99p": '%.3f' %(1000 * sorted_time[int(0.99 * num_running)])}
+        latency_list = {"50p" : '%.3f'%(1000 * np.median(time_list)),
+                        "90p" : '%.3f'%(1000 * sorted_time[int(0.90 * num_running)]),
+                        "95p" : '%.3f'%(1000 * sorted_time[int(0.95 * num_running)]),
+                        "99p" : '%.3f'%(1000 * sorted_time[int(0.99 * num_running)])}
 
         print(">" * 20, "latency result of", str(func.__name__), ">" * 20)
         for info in ["50p", "90p", "95p", "99p"]:

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -131,13 +131,13 @@ class Evaluator(object):
                     res_list.append(res.numpy())
         return res_list
 
-    
+
     @staticmethod
     def get_latency(num_running, func, *args):
         """
-        Display the time cost in milliseconds of a specific function by running multiple times. 
+        Display the time cost in milliseconds of a specific function by running multiple times.
 
-        :param num_running: Int and the value is positive. Specify the running number of 
+        :param num_running: Int and the value is positive. Specify the running number of
                the function.
         :param func: The python function to be captured the latency.
         :param args: other arguments in this function.
@@ -152,25 +152,25 @@ class Evaluator(object):
             >>> # to evaluate the time cost
             >>> latency = Evaluator.get_latency(len(tsdata_test.df), forecaster.predict, x.numpy())
         """
-        if not isinstance(num_running, int):            
-            invalidInputError(False,"num_running type must be int,"
-                              f" but found {type(num_running)}.")
+        if not isinstance(num_running, int):        
+            invalidInputError(False,"num_running type must be int, "
+                              f"but found {type(num_running)}.")
         elif num_running < 0:
-            invalidInputError(False,"num_running value must be positive,"
-                              f" but found {num_running}.")
-        
-        time_list = repeat(lambda : func(*args), number = 1, repeat = num_running)
+            invalidInputError(False,"num_running value must be positive, "
+                              f"but found {num_running}.")
+
+        time_list = repeat(lambda:func(*args), number=1, repeat=num_running)
         sorted_time = np.sort(time_list)
 
-        latency_list = {"50p": '%.3f' %(1000*np.median(time_list)), 
+        latency_list = {"50p": '%.3f' %(1000*np.median(time_list)),
                         "90p": '%.3f' %(1000*sorted_time[int(0.90*num_running)]),
                         "95p": '%.3f' %(1000*sorted_time[int(0.95*num_running)]),
                         "99p": '%.3f' %(1000*sorted_time[int(0.99*num_running)])}
-        
+
         print(">" * 20, "latency result of", str(func.__name__), ">" * 20)
         for info in ["50p", "90p", "95p", "99p"]:
             print(info, "latency:", latency_list[info], "ms")
         print("<" * 20, "latency result of", str(func.__name__), "<" * 20, "\n")
-        
+
         return latency_list
-        
+

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -132,7 +132,6 @@ class Evaluator(object):
         return res_list
 
 
-    @staticmethod
     def get_latency(num_running, func, *args):
         """
         Display the time cost in milliseconds of a specific function by running multiple times.
@@ -152,20 +151,20 @@ class Evaluator(object):
             >>> # to evaluate the time cost
             >>> latency = Evaluator.get_latency(len(tsdata_test.df), forecaster.predict, x.numpy())
         """
-        if not isinstance(num_running, int):        
-            invalidInputError(False,"num_running type must be int, "
+        if not isinstance(num_running, int):
+            invalidInputError(False, "num_running type must be int, "
                               f"but found {type(num_running)}.")
         elif num_running < 0:
-            invalidInputError(False,"num_running value must be positive, "
+            invalidInputError(False, "num_running value must be positive, "
                               f"but found {num_running}.")
 
-        time_list = repeat(lambda:func(*args), number=1, repeat=num_running)
+        time_list = repeat(lambda: func(*args), number=1, repeat=num_running)
         sorted_time = np.sort(time_list)
 
-        latency_list = {"50p": '%.3f' %(1000*np.median(time_list)),
-                        "90p": '%.3f' %(1000*sorted_time[int(0.90*num_running)]),
-                        "95p": '%.3f' %(1000*sorted_time[int(0.95*num_running)]),
-                        "99p": '%.3f' %(1000*sorted_time[int(0.99*num_running)])}
+        latency_list = {"50p": '%.3f' %(1000 * np.median(time_list)),
+                        "90p": '%.3f' %(1000 * sorted_time[int(0.90 * num_running)]),
+                        "95p": '%.3f' %(1000 * sorted_time[int(0.95 * num_running)]),
+                        "99p": '%.3f' %(1000 * sorted_time[int(0.99 * num_running)])}
 
         print(">" * 20, "latency result of", str(func.__name__), ">" * 20)
         for info in ["50p", "90p", "95p", "99p"]:
@@ -173,4 +172,3 @@ class Evaluator(object):
         print("<" * 20, "latency result of", str(func.__name__), "<" * 20, "\n")
 
         return latency_list
-

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -137,7 +137,7 @@ class Evaluator(object):
 
         :param num_running: Int and the value is positive. Specify the running number of
                the function.
-        :param func: The function to be tested for latency.
+        :param func: The function to be tested for the latency.
         :param args: other arguments to be inputted to func.
 
         :return: Dictionary of str:float.

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -131,7 +131,7 @@ class Evaluator(object):
                     res_list.append(res.numpy())
         return res_list
 
-    def get_latency(func, *args, num_running = 100, **kwargs):
+    def get_latency(func, *args, num_running=100, **kwargs):
         """
         Return the time cost in milliseconds of a specific function by running multiple times.
 

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -160,10 +160,10 @@ class Evaluator(object):
         time_list = repeat(lambda: func(*args), number=1, repeat=num_running)
         sorted_time = np.sort(time_list)
 
-        latency_list = {"50p" : '%.3f'%(1000 * np.median(time_list)),
-                        "90p" : '%.3f'%(1000 * sorted_time[int(0.90 * num_running)]),
-                        "95p" : '%.3f'%(1000 * sorted_time[int(0.95 * num_running)]),
-                        "99p" : '%.3f'%(1000 * sorted_time[int(0.99 * num_running)])}
+        latency_list = {"50p": '%.3f' % (1000 * np.median(time_list)),
+                        "90p": '%.3f' % (1000 * sorted_time[int(0.90 * num_running)]),
+                        "95p": '%.3f' % (1000 * sorted_time[int(0.95 * num_running)]),
+                        "99p": '%.3f' % (1000 * sorted_time[int(0.99 * num_running)])}
 
         print(">" * 20, "latency result of", str(func.__name__), ">" * 20)
         for info in ["50p", "90p", "95p", "99p"]:

--- a/python/chronos/test/bigdl/chronos/metric/test_forecast_metrics.py
+++ b/python/chronos/test/bigdl/chronos/metric/test_forecast_metrics.py
@@ -116,11 +116,11 @@ class TestChronosForecastMetrics(TestCase):
         def test_func(count):
             time.sleep(0.001*count)
         with pytest.raises(RuntimeError):
-            Evaluator.get_latency("10", test_func, 5)
+            Evaluator.get_latency(test_func, 5, num_running = "10")
         with pytest.raises(RuntimeError):
-            Evaluator.get_latency(-2, test_func, 5)
+            Evaluator.get_latency(test_func, 5, num_running = -10)
 
-        latency_list = Evaluator.get_latency(100, test_func, 5)
+        latency_list = Evaluator.get_latency(test_func, 5)
         assert isinstance(latency_list, dict)
         for info in ["p50", "p90", "p95", "p99"]:
             assert info in latency_list

--- a/python/chronos/test/bigdl/chronos/metric/test_forecast_metrics.py
+++ b/python/chronos/test/bigdl/chronos/metric/test_forecast_metrics.py
@@ -121,8 +121,7 @@ class TestChronosForecastMetrics(TestCase):
             Evaluator.get_latency(-2, test_func, 5)
 
         latency_list = Evaluator.get_latency(100, test_func, 5)
-        ref_list = {"50p": 5.0, "90p": 5.0, "95p": 5.1, "99p": 5.1}
         assert isinstance(latency_list, dict)
-        for info in ["50p", "90p", "95p", "99p"]:
+        for info in ["p50", "p90", "p95", "p99"]:
             assert info in latency_list
-            assert_almost_equal(latency_list[info], ref_list[info], 1)
+            assert isinstance(latency_list[info], float)


### PR DESCRIPTION
Evaluator.get_latency() is added to evaluate the time cost of a workflow, the API helps display the time cost in milliseconds of a specific function by running multiple times. 

### 1. Why the change?

https://github.com/intel-analytics/BigDL/issues/5331

### 2. User API changes
Example:
 ```python
 # run forecaster.predict(x.numpy()) for len(tsdata_test.df) times
 # to evaluate the time cost
 latency = Evaluator.get_latency(len(tsdata_test.df), forecaster.predict, x.numpy())
 ```
### 4. How to test?
- Unit test
(http://10.112.231.51:18889/view/BigDL-PR-Validation/job/BigDL-Chronos-PR-Validation/697/)

