### PR TITLE
GRPC package do not force to call parseConfig

### DIFF
--- a/scala/grpc/src/main/java/com/intel/analytics/bigdl/grpc/GrpcClientBase.java
+++ b/scala/grpc/src/main/java/com/intel/analytics/bigdl/grpc/GrpcClientBase.java
@@ -78,7 +78,6 @@ public class GrpcClientBase extends AbstractGrpcBase {
     }
 
     public void build() throws IOException {
-        parseConfig();
         if (channel == null) {
             if(privateKeyFilePath == null) {
                 channel = ManagedChannelBuilder.forTarget(target)

--- a/scala/grpc/src/main/java/com/intel/analytics/bigdl/grpc/GrpcServerBase.java
+++ b/scala/grpc/src/main/java/com/intel/analytics/bigdl/grpc/GrpcServerBase.java
@@ -57,7 +57,7 @@ public abstract class GrpcServerBase extends AbstractGrpcBase {
      * One Server could support multiple services.
      * @param args
      */
-    public GrpcServerBase(String[] args) throws Exception {
+    public GrpcServerBase(String[] args) {
         this.args = args;
     }
 

--- a/scala/grpc/src/main/java/com/intel/analytics/bigdl/grpc/GrpcServerBase.java
+++ b/scala/grpc/src/main/java/com/intel/analytics/bigdl/grpc/GrpcServerBase.java
@@ -57,7 +57,7 @@ public abstract class GrpcServerBase extends AbstractGrpcBase {
      * One Server could support multiple services.
      * @param args
      */
-    public GrpcServerBase(String[] args) {
+    public GrpcServerBase(String[] args) throws Exception {
         this.args = args;
     }
 
@@ -70,7 +70,6 @@ public abstract class GrpcServerBase extends AbstractGrpcBase {
 
     /** Entrypoint of GrpcServerBase */
     public void build() throws Exception {
-        parseConfig();
         ServerBuilder builder = ServerBuilder.forPort(port);
         for (BindableService bindableService : serverServices) {
             builder.addService(bindableService);
@@ -82,7 +81,6 @@ public abstract class GrpcServerBase extends AbstractGrpcBase {
     }
 
     public void buildWithTls() throws Exception {
-        parseConfig();
         NettyServerBuilder serverBuilder = NettyServerBuilder.forPort(port);
         for (BindableService bindableService : serverServices) {
             serverBuilder.addService(bindableService);


### PR DESCRIPTION
Change to not forcing to call `parseConfig` before the `build` method.

Servers can call it manually anytime, to meet the specific priority needs, e.g. config overwrite in-code settings or opposite.