### PR TITLE
PPML add psiSalt argument in config

### DIFF
--- a/ppml/ppml-conf.yaml
+++ b/ppml/ppml-conf.yaml
@@ -5,6 +5,7 @@ certChainFilePath:  /ppml/trusted-big-data-ml/work/keys/server.crt
 # serverPort:
 
 ##### Client property
+# psiSalt:
 # clientTarget:
 # taskID:
 

--- a/python/ppml/src/bigdl/ppml/fl/algorithms/psi.py
+++ b/python/ppml/src/bigdl/ppml/fl/algorithms/psi.py
@@ -20,6 +20,10 @@ from bigdl.ppml.fl import *
 from bigdl.dllib.utils.common import JavaValue
 
 
+def set_psi_salt(psi_salt):
+    callBigDlFunc("float", "setPsiSalt", psi_salt)
+
+
 class PSI(JavaValue):
     def __init__(self, jvalue=None, *args):
         self.bigdl_type = "float"

--- a/scala/ppml/src/main/java/com/intel/analytics/bigdl/ppml/fl/FLHelper.java
+++ b/scala/ppml/src/main/java/com/intel/analytics/bigdl/ppml/fl/FLHelper.java
@@ -22,12 +22,15 @@ public class FLHelper {
     int serverPort = 8980;
 
     // Client property
+    String psiSalt = null;
     String clientTarget = "localhost:8980";
     String taskID = "taskID";
     String certChainFilePath = null;
     String privateKeyFilePath = null;
 
     String fgBoostServerModelPath = null;
+
+    public void setPsiSalt(String psiSalt) { this.psiSalt = psiSalt; }
 
     public void setClientNum(int clientNum) {
         this.clientNum = clientNum;

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/FLClient.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/FLClient.scala
@@ -36,7 +36,9 @@ class FLClient(val _args: Array[String]) extends GrpcClientBase(_args) {
   var psiStub: PSIStub = null
   var nnStub: NNStub = null
   var fgbostStub: FGBoostStub = null
+  var psiSalt: String = null
   privateKeyFilePath = null
+
   def this() {
     this(null)
   }
@@ -53,6 +55,7 @@ class FLClient(val _args: Array[String]) extends GrpcClientBase(_args) {
       logger.debug(s"Loading target: $target")
       taskID = flHelper.taskID
       logger.debug(s"Loading taskID: $taskID")
+      psiSalt = flHelper.psiSalt
       privateKeyFilePath = flHelper.privateKeyFilePath
     }
     super.parseConfig()

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/FLContext.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/FLContext.scala
@@ -34,10 +34,10 @@ object FLContext {
     flClient = null
   }
 
-  def setPsiSalt(psiSalt: String) = {
+  def setPsiSalt(psiSalt: String): Unit = {
     flClient.psiSalt = psiSalt
   }
-  
+
   def getPsiSalt(): String = {
       flClient.psiSalt
   }

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/FLContext.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/FLContext.scala
@@ -34,6 +34,14 @@ object FLContext {
     flClient = null
   }
 
+  def setPsiSalt(psiSalt: String) = {
+    flClient.psiSalt = psiSalt
+  }
+  
+  def getPsiSalt(): String = {
+      flClient.psiSalt
+  }
+
   def initFLContext(id: String, target: String = null): Unit = {
     createSparkSession()
     Engine.init

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/algorithms/PSI.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/algorithms/PSI.scala
@@ -67,7 +67,7 @@ class PSI() extends FLClientClosable {
   def getIntersection(ids: util.List[String],
                       maxTry: Int = 100,
                       retry: Long = 3000): util.List[String] = {
-    val salt = getSalt()
+    val salt = if (FLContext.getPsiSalt() == null) getSalt() else FLContext.getPsiSalt()
     uploadSet(ids, salt)
     downloadIntersection(maxTry, retry)
   }

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/python/PythonPPML.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/python/PythonPPML.scala
@@ -43,6 +43,9 @@ class PythonPPML[T: ClassTag](implicit ev: TensorNumeric[T])
   def initFLContext(id: String, target: String): Unit = {
     FLContext.initFLContext(id, target)
   }
+  def setPsiSalt(psiSalt: String): Unit = {
+    FLContext.setPsiSalt(psiSalt)
+  }
   def createFLServer(): FLServer = {
     new FLServer()
   }


### PR DESCRIPTION
## Description

To support a user-defined `psiSalt` parameter in config file, and also `FLContext.setPsiSalt`

In the past, we only supported the `getSalt()` method which returns a random salt.