### PR TITLE
remove conditions for licsan-scan to run

### DIFF
--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -3,8 +3,8 @@ name: license-scan
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  #pull_request:
+    #branches: [ "main" ]
   schedule:
     - cron: '0 3 * * *'
 


### PR DESCRIPTION
## Description

remove pull_request for licsan-scan 

### 1. Why the change?

error
~~~
/home/runner/work/_actions/fossas/fossa-action/main/webpack:/fossa-action/node_modules/@actions/core/lib/core.js:110
        throw new Error(`Input required and not supplied: ${name}`);
^
Error: Input required and not supplied: api-key
    at exports (/home/runner/work/_actions/fossas/fossa-action/main/webpack:/fossa-action/node_modules/@actions/core/lib/core.js:110:1)
    at Object.__webpack_require__ (/home/runner/work/_actions/fossas/fossa-action/main/webpack:/fossa-action/src/config.ts:11:1)
    at __webpack_require__ (/home/runner/work/_actions/fossas/fossa-action/main/webpack:/fossa-action/webpack/bootstrap:21:1)
    at run (/home/runner/work/_actions/fossas/fossa-action/main/webpack:/fossa-action/src/index.ts:10:1)
    at run (/home/runner/work/_actions/fossas/fossa-action/main/webpack:/fossa-action/src/index.ts:[7](https://github.com/intel-analytics/BigDL/runs/7737263876?check_suite_focus=true#step:3:8)9:1)
    at Object.<anonymous> (/home/runner/work/_actions/fossas/fossa-action/main/webpack:/fossa-action/src/index.ts:79:1)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:9[8](https://github.com/intel-analytics/BigDL/runs/7737263876?check_suite_focus=true#step:3:9)1:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:[12](https://github.com/intel-analytics/BigDL/runs/7737263876?check_suite_focus=true#step:3:13))
~~~


