### PR TITLE
DLlib: add enable_hdfs_load decorator

### DIFF
--- a/python/dllib/src/bigdl/dllib/utils/file_utils.py
+++ b/python/dllib/src/bigdl/dllib/utils/file_utils.py
@@ -160,7 +160,7 @@ def enable_hdfs_load(load_func):
                                          stdout=subprocess.PIPE).communicate()[0]
             os.environ["CLASSPATH"] = classpath.decode("utf-8")
             import pyarrow.fs as pafs
-            if "isdir" in kwargs and kwargs["isdir"]:
+            if not pafs.FileInfo(path).is_file: 
                 os.mkdir(temp_path)
             pafs.copy_files(path, temp_path)
             try:

--- a/python/dllib/src/bigdl/dllib/utils/file_utils.py
+++ b/python/dllib/src/bigdl/dllib/utils/file_utils.py
@@ -160,7 +160,7 @@ def enable_hdfs_load(load_func):
                                          stdout=subprocess.PIPE).communicate()[0]
             os.environ["CLASSPATH"] = classpath.decode("utf-8")
             import pyarrow.fs as pafs
-            if not pafs.FileInfo(path).is_file: 
+            if not pafs.FileInfo(path).is_file:
                 os.mkdir(temp_path)
             pafs.copy_files(path, temp_path)
             try:

--- a/python/dllib/src/bigdl/dllib/utils/file_utils.py
+++ b/python/dllib/src/bigdl/dllib/utils/file_utils.py
@@ -160,7 +160,9 @@ def enable_hdfs_load(load_func):
                                          stdout=subprocess.PIPE).communicate()[0]
             os.environ["CLASSPATH"] = classpath.decode("utf-8")
             import pyarrow.fs as pafs
-            if not pafs.FileInfo(path).is_file:
+            import pyarrow as pa
+            hdfs = pa.hdfs.connect()
+            if not hdfs.isfile(path):
                 os.mkdir(temp_path)
             pafs.copy_files(path, temp_path)
             try:

--- a/python/dllib/src/bigdl/dllib/utils/file_utils.py
+++ b/python/dllib/src/bigdl/dllib/utils/file_utils.py
@@ -19,11 +19,10 @@ import glob
 import os
 import subprocess
 import tempfile
-from urllib.parse import urlparse
 import uuid
+from urllib.parse import urlparse
 
 import numpy as np
-import pyarrow as pa
 
 from bigdl.dllib.utils.common import Sample as BSample, JTensor as BJTensor,\
     JavaCreator, _get_gateway, _py2java, _java2py
@@ -161,6 +160,7 @@ def enable_hdfs_load(load_func):
             classpath = subprocess.Popen(["hadoop", "classpath", "--glob"],
                                          stdout=subprocess.PIPE).communicate()[0]
             os.environ["CLASSPATH"] = classpath.decode("utf-8")
+            import pyarrow as pa
             if len(host_port) > 1:
                 fs = pa.hdfs.connect(host=host_port[0], port=int(host_port[1]))
             else:

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
@@ -555,7 +555,7 @@ class TestTFEstimator(TestCase):
         model_path = os.path.join(tempfile.gettempdir(), str(uuid.uuid1()) + ".json")
         try:
             model = simple_model(config)
-            with open(model_path, "wb") as f:
+            with open(model_path, "w") as f:
                 f.write(model.to_json())
         
             from bigdl.dllib.utils.file_utils import enable_hdfs_load

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
@@ -551,6 +551,7 @@ class TestTFEstimator(TestCase):
         config = {
             "lr": 0.2
         }
+        import uuid
         model_path = os.path.join(tempfile.gettempdir(), str(uuid.uuid1()) + ".json")
         try:
             model = simple_model(config)

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
@@ -551,9 +551,9 @@ class TestTFEstimator(TestCase):
         config = {
             "lr": 0.2
         }
+        model_path = os.path.join(tempfile.gettempdir(), str(uuid.uuid1()) + ".json")
         try:
             model = simple_model(config)
-            model_path = os.path.join(tempfile.gettempdir(), str(uuid.uuid1()) + ".json")
             with open(model_path, "wb") as f:
                 f.write(model.to_json())
         
@@ -568,7 +568,8 @@ class TestTFEstimator(TestCase):
             model_load = load_model_architecture(model_path)
             assert model.summary() == model_load.summary()
         finally:
-            os.remove(model_path)
+            if os.path.exists(model_path):
+                os.remove(model_path)
 
 
 

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
@@ -546,6 +546,30 @@ class TestTFEstimator(TestCase):
             print("predict result: ", res)
         finally:
             shutil.rmtree(temp_dir)
+    
+    def test_save_load_model_architecture(self):
+        config = {
+            "lr": 0.2
+        }
+        try:
+            model = simple_model(config)
+            model_path = os.path.join(tempfile.gettempdir(), str(uuid.uuid1()) + ".json")
+            with open(model_path, "wb") as f:
+                f.write(model.to_json())
+        
+            from bigdl.dllib.utils.file_utils import enable_hdfs_load
+
+            @enable_hdfs_load
+            def load_model_architecture(path):
+                with open(path, "rb") as f:
+                    model = tf.keras.models.model_from_json(f.read())
+                return model
+
+            model_load = load_model_architecture(model_path)
+            assert model.summary() == model_load.summary()
+        finally:
+            os.remove(model_path)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
According to the customer feedback, there is no `SparkContext` error while loading HDFS file in ray workers, which is because users use `enable_multi_fs_load` decorator to load HDFS file and need `SparkContext` to get gateway of Scala service in each worker. This PR is to add `enable_hdfs_load` decorator, which is totally implemented in Python, to address the customer issues. 