### PR TITLE
fix org.slf4j.slf4j-api vulnerability

### DIFF
--- a/scala/dllib/pom.xml
+++ b/scala/dllib/pom.xml
@@ -73,7 +73,7 @@
             <artifactId>joda-time</artifactId>
             <version>2.9.9</version>
             <scope>${spark-scope}</scope>
-        </dependency>
+    	</dependency>
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
@@ -83,6 +83,10 @@
                 <exclusion>
                     <groupId>io.netty</groupId>
                     <artifactId>netty-codec</artifactId>
+	    	</exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -108,6 +112,12 @@
                     <artifactId>joda-time</artifactId>
                 </exclusion>
             </exclusions>
+    	</dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+            <scope>${spark-scope}</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
## Description
![image](https://user-images.githubusercontent.com/30695225/184273314-ebf49229-44c2-4ce0-97cd-67e49927166b.png)

slf4j 1.7.25 has high vulnerability

### 4. How to test?
- [x] Jenkins

### 5. New dependencies

- [x] New Scala dependencies
       -  org.slf4j.slf4j-api  MIT License https://mvnrepository.com/artifact/org.slf4j/slf4j-api/1.7.36
