### PR TITLE
fix akka vulnerability dllib

### DIFF
--- a/scala/dllib/pom.xml
+++ b/scala/dllib/pom.xml
@@ -235,9 +235,18 @@
                 <exclusion>
                     <groupId>org.scala-lang</groupId>
                     <artifactId>scala-compiler</artifactId>
+	    	</exclusion>
+                <exclusion>
+                    <groupId>com.typesafe.akka</groupId>
+                    <artifactId>akka-actor_2.11</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
+    	</dependency>
+	<dependency>
+    	    <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-actor_2.11</artifactId>
+            <version>2.5.32</version>
+	</dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>


### PR DESCRIPTION
## Description
Fix high vulnerability in dllib akka 
![image](https://user-images.githubusercontent.com/30695225/184277582-33e9596c-6385-4639-a0f3-da213bf0f578.png)

Upgrade com.typesafe.akka:akka-actor_2.11:jar to 2.5.32
![image](https://user-images.githubusercontent.com/30695225/184277722-b326983b-0a88-41cb-8a31-5146388b1905.png)

### 4. How to test?
- [x] Jenkins

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [x] New Java/Scala dependencies and their license
       - com.typesafe.akka:akka-actor_2.11:jar and license Apache 2.0 
      https://mvnrepository.com/artifact/com.typesafe.akka/akka-actor_2.11/2.5.32

