### PR TITLE
Chronos: add autots import check

### DIFF
--- a/python/chronos/src/bigdl/chronos/autots/__init__.py
+++ b/python/chronos/src/bigdl/chronos/autots/__init__.py
@@ -14,9 +14,20 @@
 # limitations under the License.
 #
 import warnings
+from bigdl.nano.utils.log4Error import invalidInputError
+import os
+
+
+if os.getenv("LD_PRELOAD", "null") != "null":
+    invalidInputError(False,
+                      errMsg="Users of `bigdl.chronos.autots` should "
+                             "unset bigdl-nano environment variables!",
+                      fixMsg="Please run `source bigdl-nano-unset-env` "
+                             "in your bash terminal")
 
 try:
+    # TODO: make this a LazyImport
     from .autotsestimator import AutoTSEstimator
+    from .tspipeline import TSPipeline
 except ImportError:
-    warnings.warn("Please install `bigdl-nano[all]` to use AutoTSEstimator")
-from .tspipeline import TSPipeline
+    pass


### PR DESCRIPTION
## Description

This PR is used to change the import logic of `bigdl.chronos.autots`
1. report an error if nano env var is included here
2. move tsppl's import to try

### 4. How to test?
- [x] Unit test http://10.112.231.51:18889/job/BigDL-Chronos-PR-Validation/692/
