### PR TITLE
[PPML] Remove remaining kms-client in build-docker-image scripts

### DIFF
--- a/ppml/trusted-big-data-ml/python/docker-gramine/build-docker-image.sh
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/build-docker-image.sh
@@ -38,5 +38,3 @@ else
         $Proxy_Modified
     fi
 fi
-
-rm -r ./kms-client

--- a/ppml/trusted-big-data-ml/python/docker-graphene/build-docker-image.sh
+++ b/ppml/trusted-big-data-ml/python/docker-graphene/build-docker-image.sh
@@ -4,8 +4,6 @@ export HTTPS_PROXY_HOST=your_https_proxy_host
 export HTTPS_PROXY_PORT=your_https_proxy_port
 export JDK_URL=http://your-http-url-to-download-jdk
 
-cp -r ../../../kms-client ./
-
 Proxy_Modified="sudo docker build \
     --build-arg http_proxy=http://${HTTP_PROXY_HOST}:${HTTP_PROXY_PORT} \
     --build-arg https_proxy=http://${HTTPS_PROXY_HOST}:${HTTPS_PROXY_PORT} \
@@ -37,5 +35,3 @@ else
         $Proxy_Modified
     fi
 fi
-
-rm -r ./kms-client


### PR DESCRIPTION
## Description

Remove remaining kms-client in build-docker-image scripts.

### 1. Why the change?

There are still remaining kms-client related commands in build docker image scripts while the component has been removed. 

### 2. User API changes

None.

### 3. Summary of the change 

Remove remaining kms-client in build-docker-image scripts.

### 4. How to test?

Unit test.

### 5. New dependencies

None.
