### PR TITLE
[ORCA] Remove org.codehaus.plexus.util.FileUtils in OpenVINOModelSuite

### DIFF
--- a/scala/orca/src/test/scala/com/intel/analytics/bigdl/orca/inference/OpenVINOModelSuite.scala
+++ b/scala/orca/src/test/scala/com/intel/analytics/bigdl/orca/inference/OpenVINOModelSuite.scala
@@ -22,7 +22,6 @@ import java.util
 import java.util.{Arrays, Properties}
 
 import com.intel.analytics.bigdl.dllib.common.zooUtils
-import org.codehaus.plexus.util.FileUtils
 import org.scalatest._
 import org.slf4j.LoggerFactory
 


### PR DESCRIPTION
## Description

Remove org.codehaus.plexus.util.FileUtils 

### 1. Why the change?

Encountered error during jenkins unit test.
[ERROR] /opt/work/jenkins/workspace/ZOO-NB-BigDL-Python-Spark-2.4-py37/scala/orca/src/test/scala/com/intel/analytics/bigdl/orca/inference/OpenVINOModelSuite.scala:25: object plexus is not a member of package org.codehaus

### 2. User API changes

None.

### 3. Summary of the change 

Delete L25 in `scala/orca/src/test/scala/com/intel/analytics/bigdl/orca/inference/OpenVINOModelSuite.scala`.

### 4. How to test?
Unit test

