### PR TITLE
Chronos : add regression functions for forecast metrics

### DIFF
--- a/python/chronos/src/bigdl/chronos/autots/tspipeline.py
+++ b/python/chronos/src/bigdl/chronos/autots/tspipeline.py
@@ -503,7 +503,11 @@ class TSPipeline:
         # map metric str to function
         from bigdl.chronos.metric.forecast_metrics import REGRESSION_MAP
         if isinstance(metric, str):
-            metric = REGRESSION_MAP[metric]
+            metric_func = REGRESSION_MAP[metric]
+            def metric(y_label, y_predict):
+                y_label = y_label.numpy()
+                y_predict = y_predict.numpy()
+                return metric_func(y_label, y_predict)
 
         # init acc criterion
         accuracy_criterion = None

--- a/python/chronos/src/bigdl/chronos/autots/tspipeline.py
+++ b/python/chronos/src/bigdl/chronos/autots/tspipeline.py
@@ -504,6 +504,7 @@ class TSPipeline:
         from bigdl.chronos.metric.forecast_metrics import REGRESSION_MAP
         if isinstance(metric, str):
             metric_func = REGRESSION_MAP[metric]
+
             def metric(y_label, y_predict):
                 y_label = y_label.numpy()
                 y_predict = y_predict.numpy()

--- a/python/chronos/src/bigdl/chronos/autots/tspipeline.py
+++ b/python/chronos/src/bigdl/chronos/autots/tspipeline.py
@@ -501,9 +501,9 @@ class TSPipeline:
         calib_data = preprocess_quantize_data(self, calib_data)
 
         # map metric str to function
-        from bigdl.chronos.metric.forecast_metrics import TORCHMETRICS_REGRESSION_MAP
+        from bigdl.chronos.metric.forecast_metrics import REGRESSION_MAP
         if isinstance(metric, str):
-            metric = TORCHMETRICS_REGRESSION_MAP[metric]
+            metric = REGRESSION_MAP[metric]
 
         # init acc criterion
         accuracy_criterion = None

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -441,6 +441,7 @@ def _str2metric(metric):
         metric_name = metric
         from bigdl.chronos.metric.forecast_metrics import REGRESSION_MAP
         metric_func = REGRESSION_MAP[metric_name]
+
         def metric(y_label, y_predict):
             y_label = y_label.numpy()
             y_predict = y_predict.numpy()

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -438,6 +438,6 @@ class AutoformerForecaster(Forecaster):
 def _str2metric(metric):
     # map metric str to function
     if isinstance(metric, str):
-        from bigdl.chronos.metric.forecast_metrics import TORCHMETRICS_REGRESSION_MAP
-        metric = TORCHMETRICS_REGRESSION_MAP[metric]
+        from bigdl.chronos.metric.forecast_metrics import REGRESSION_MAP
+        metric = REGRESSION_MAP[metric]
     return metric

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -438,6 +438,12 @@ class AutoformerForecaster(Forecaster):
 def _str2metric(metric):
     # map metric str to function
     if isinstance(metric, str):
+        metric_name = metric
         from bigdl.chronos.metric.forecast_metrics import REGRESSION_MAP
-        metric = REGRESSION_MAP[metric]
+        metric_func = REGRESSION_MAP[metric_name]
+        def metric(y_label, y_predict):
+            y_label = y_label.numpy()
+            y_predict = y_predict.numpy()
+            return metric_func(y_label, y_predict)
+        metric.__name__ = metric_name
     return metric

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -1161,6 +1161,12 @@ class BasePytorchForecaster(Forecaster):
 def _str2metric(metric):
     # map metric str to function
     if isinstance(metric, str):
+        metric_name = metric
         from bigdl.chronos.metric.forecast_metrics import REGRESSION_MAP
-        metric = REGRESSION_MAP[metric]
+        metric_func = REGRESSION_MAP[metric_name]
+        def metric(y_label, y_predict):
+            y_label = y_label.numpy()
+            y_predict = y_predict.numpy()
+            return metric_func(y_label, y_predict)
+        metric.__name__ = metric_name
     return metric

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -1161,6 +1161,6 @@ class BasePytorchForecaster(Forecaster):
 def _str2metric(metric):
     # map metric str to function
     if isinstance(metric, str):
-        from bigdl.chronos.metric.forecast_metrics import TORCHMETRICS_REGRESSION_MAP
-        metric = TORCHMETRICS_REGRESSION_MAP[metric]
+        from bigdl.chronos.metric.forecast_metrics import REGRESSION_MAP
+        metric = REGRESSION_MAP[metric]
     return metric

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -1164,6 +1164,7 @@ def _str2metric(metric):
         metric_name = metric
         from bigdl.chronos.metric.forecast_metrics import REGRESSION_MAP
         metric_func = REGRESSION_MAP[metric_name]
+
         def metric(y_label, y_predict):
             y_label = y_label.numpy()
             y_predict = y_predict.numpy()

--- a/python/chronos/src/bigdl/chronos/forecaster/utils_hpo.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/utils_hpo.py
@@ -303,8 +303,8 @@ def _format_metric_str(prefix, metric):
                 metrics.append(_format_metric_str(prefix, target_metric))
         return metrics
     if isinstance(metric, str):
-        from bigdl.chronos.metric.forecast_metrics import TORCHMETRICS_REGRESSION_MAP
-        metric_func = TORCHMETRICS_REGRESSION_MAP.get(metric, None)
+        from bigdl.chronos.metric.forecast_metrics import REGRESSION_MAP
+        metric_func = REGRESSION_MAP.get(metric, None)
         invalidInputError(metric_func is not None,
                           "{} is not found in available metrics.".format(metric))
     return _format_metric(prefix, metric_func)

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -133,11 +133,11 @@ class Evaluator(object):
         res_list = []
         for metric in metrics:
             if len(original_shape) in [2, 3] and aggregate is None:
-                res = torch.zeros(y_true.shape[-1])
+                res = np.zeros(y_true.shape[-1])
                 for i in range(y_true.shape[-1]):
                     res[i] = eval(metric)(y_true[..., i], y_pred[..., i])
                 res = res.reshape(original_shape[1:])
-                res_list.append(res.numpy())
+                res_list.append(res)
             else:
                 res = eval(metric)(y_true, y_pred)
                 res_list.append(res)

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -35,9 +35,7 @@ def mae(y_label, y_predict):
     :return: Ndarray of floats.
              An array of non-negative floating point values (the best value is 0.0).
     """
-    y_label = np.array(y_label)
-    y_predict = np.array(y_predict)
-    result= np.mean(np.abs(y_label - y_predict))
+    result = np.mean(np.abs(y_label - y_predict))
     return result
 
 
@@ -53,8 +51,6 @@ def mse(y_label, y_predict):
     :return: Ndarray of floats.
              An array of non-negative floating point values (the best value is 0.0).
     """
-    y_label = np.array(y_label)
-    y_predict = np.array(y_predict)
     result = np.mean((y_label - y_predict) ** 2)
     return result
 
@@ -86,8 +82,7 @@ def mape(y_label, y_predict):
     :return: Ndarray of floats.
              An array of non-negative floating point values (the best value is 0.0).
     """
-    y_label, y_predict = np.array(y_label), np.array(y_predict)
-    return np.mean(np.abs((y_label - y_predict) / y_label))
+    return np.mean(np.abs((y_label - y_predict) / (y_label + EPSILON)))
 
 
 def smape(y_label, y_predict):
@@ -120,7 +115,6 @@ def r2(y_label, y_predict):
     :return: Ndarray of floats.
              An array of non-negative floating point values (the best value is 1.0).
     """
-    y_label, y_predict = np.array(y_label), np.array(y_predict)
     return 1 - np.sum((y_label - y_predict)**2) / np.sum((y_label - np.mean(y_label))**2)
 
 
@@ -193,7 +187,10 @@ class Evaluator(object):
 
         res_list = []
         for metric in metrics:
-            metric_func = REGRESSION_MAP[metric]
+            if callable(metric):
+                metric_func = metric
+            else:
+                metric_func = REGRESSION_MAP[metric]
             if len(original_shape) in [2, 3] and aggregate is None:
                 res = np.zeros(y_true.shape[-1])
                 for i in range(y_true.shape[-1]):

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -35,9 +35,9 @@ def mae(y_label, y_predict):
     :return: Ndarray of floats.
              An array of non-negative floating point values (the best value is 0.0).
     """
-    y_label=np.array(y_label)
-    y_predict=np.array(y_predict)
-    result= np.mean(np.abs(y_label-y_predict))
+    y_label = np.array(y_label)
+    y_predict = np.array(y_predict)
+    result= np.mean(np.abs(y_label - y_predict))
     return result
 
 
@@ -53,9 +53,9 @@ def mse(y_label, y_predict):
     :return: Ndarray of floats.
              An array of non-negative floating point values (the best value is 0.0).
     """
-    y_label=np.array(y_label)
-    y_predict=np.array(y_predict)
-    result= np.mean((y_label-y_predict)**2)
+    y_label = np.array(y_label)
+    y_predict = np.array(y_predict)
+    result = np.mean((y_label - y_predict) ** 2)
     return result
 
 
@@ -124,7 +124,14 @@ def r2(y_label, y_predict):
     return 1 - np.sum((y_label - y_predict)**2) / np.sum((y_label - np.mean(y_label))**2)
 
 
-REGRESSION_MAP = {'mae', 'mse', 'rmse', 'mape', 'smape', 'r2'}
+REGRESSION_MAP = {
+    'mae': mae,
+    'mse': mse,
+    'rmse': rmse,
+    'mape': mape,
+    'smape': smape,
+    'r2': r2,
+}
 
 
 def _standard_input(metrics, y_true, y_pred):
@@ -137,8 +144,8 @@ def _standard_input(metrics, y_true, y_pred):
         metrics = [metrics]
     if isinstance(metrics[0], str):
         metrics = list(map(lambda x: x.lower(), metrics))
-        invalidInputError(all(metric in REGRESSION_MAP for metric in metrics),
-                          f"metric should be one of {REGRESSION_MAP},"
+        invalidInputError(all(metric in REGRESSION_MAP.keys() for metric in metrics),
+                          f"metric should be one of {REGRESSION_MAP.keys()},"
                           f" but get {metrics}.")
         invalidInputError(type(y_true) is type(y_pred) and isinstance(y_pred, ndarray),
                           "y_pred and y_true type must be numpy.ndarray,"
@@ -186,14 +193,15 @@ class Evaluator(object):
 
         res_list = []
         for metric in metrics:
+            metric_func = REGRESSION_MAP[metric]
             if len(original_shape) in [2, 3] and aggregate is None:
                 res = np.zeros(y_true.shape[-1])
                 for i in range(y_true.shape[-1]):
-                    res[i] = eval(metric)(y_true[..., i], y_pred[..., i])
+                    res[i] = metric_func(y_true[..., i], y_pred[..., i])
                 res = res.reshape(original_shape[1:])
                 res_list.append(res)
             else:
-                res = eval(metric)(y_true, y_pred)
+                res = metric_func(y_true, y_pred)
                 res_list.append(res)
         return res_list
 

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -33,8 +33,7 @@ def mae(y_label, y_predict):
     :param y_predict: Array-like of shape = (n_samples, \*).
            Estimated target values.
     :return: Ndarray of floats.
-             A non-negative floating point value (the best value is 0.0), or an
-             array of floating point values, one for each individual target.
+             An array of non-negative floating point values (the best value is 0.0).
     """
     y_label=np.array(y_label)
     y_predict=np.array(y_predict)
@@ -43,6 +42,17 @@ def mae(y_label, y_predict):
 
 
 def mse(y_label, y_predict):
+    """
+    Calculate the mean squared error (MSE).
+    .. math::
+        \\text{MSE} = \\frac{1}{n}\\sum_{t=1}^n (y_t-\\hat{y_t})^2
+    :param y_label: Array-like of shape = (n_samples, \*).
+           Ground truth (correct) target values.
+    :param y_predict: Array-like of shape = (n_samples, \*).
+           Estimated target values.
+    :return: Ndarray of floats.
+             An array of non-negative floating point values (the best value is 0.0).
+    """
     y_label=np.array(y_label)
     y_predict=np.array(y_predict)
     result= np.mean((y_label-y_predict)**2)
@@ -50,15 +60,48 @@ def mse(y_label, y_predict):
 
 
 def rmse(y_label, y_predict):
+    """
+    Calculate square root of the mean squared error (RMSE).
+    .. math::
+        \\text{RMSE} = \\sqrt{(\\frac{1}{n}\\sum_{t=1}^n (y_t-\\hat{y_t})^2)}
+    :param y_label: Array-like of shape = (n_samples, \*).
+           Ground truth (correct) target values.
+    :param y_predict: Array-like of shape = (n_samples, \*).
+           Estimated target values.
+    :return: Ndarray of floats.
+             An array of non-negative floating point values (the best value is 0.0).
+    """
     return np.sqrt(mse(y_label, y_predict))
 
 
 def mape(y_label, y_predict):
+    """
+    Calculate mean absolute percentage error (MAPE).
+    .. math::
+        \\text{MAPE} = \\frac{100\%}{n}\\sum_{t=1}^n  |\\frac{y_t-\\hat{y_t}}{y_t}|
+    :param y_label: Array-like of shape = (n_samples, \*).
+           Ground truth (correct) target values.
+    :param y_predict: Array-like of shape = (n_samples, \*).
+           Estimated target values.
+    :return: Ndarray of floats.
+             An array of non-negative floating point values (the best value is 0.0).
+    """
     y_label, y_predict = np.array(y_label), np.array(y_predict)
     return np.mean(np.abs((y_label - y_predict) / y_label))
 
 
 def smape(y_label, y_predict):
+    """
+    Calculate Symmetric mean absolute percentage error (sMAPE).
+    .. math::
+        \\text{sMAPE} = \\frac{100\%}{n} \\sum_{t=1}^n \\frac{|y_t-\\hat{y_t}|}{|y_t|+|\\hat{y_t}|}
+    :param y_label: Array-like of shape = (n_samples, \*).
+           Ground truth (correct) target values.
+    :param y_predict: Array-like of shape = (n_samples, \*).
+           Estimated target values.
+    :return: Ndarray of floats.
+             An array of non-negative floating point values (the best value is 0.0).
+    """
     abs_diff = np.abs(y_predict - y_label)
     abs_per_error = abs_diff / (np.abs(y_predict) + np.abs(y_label) + EPSILON)
     sum_abs_per_error = np.mean(abs_per_error)
@@ -66,6 +109,17 @@ def smape(y_label, y_predict):
 
 
 def r2(y_label, y_predict):
+    """
+    Calculate the r2 score.
+    .. math::
+        R^2 = 1-\\frac{\\sum_{t=1}^n (y_t-\\hat{y_t})^2}{\\sum_{t=1}^n (y_t-\\bar{y})^2}
+    :param y_label: Array-like of shape = (n_samples, \*).
+           Ground truth (correct) target values.
+    :param y_predict: Array-like of shape = (n_samples, \*).
+           Estimated target values.
+    :return: Ndarray of floats.
+             An array of non-negative floating point values (the best value is 1.0).
+    """
     y_label, y_predict = np.array(y_label), np.array(y_predict)
     return 1 - np.sum((y_label - y_predict)**2) / np.sum((y_label - np.mean(y_label))**2)
 


### PR DESCRIPTION
## Description

Rewrites the regression functions whose input and output are Numpy. 
### 1. Why the change?

To facilitate customers to use metrics without torchmetrics. Only Numpy is required to complete relevant operations.

### 2. User API changes

### 3. Summary of the change 
Rewrites the regression functions whose input and output are Numpy according to the calculation formula of relevant regression functions.

### 4. How to test?
- [x] Unit test

http://10.112.231.51:18889/job/BigDL-PRNV-chronos-Python-Spark-2.4-py37-Horovod/814/
http://10.112.231.51:18889/job/BigDL-Chronos-PR-Validation/784/
### 5. New dependencies
