### PR TITLE
add new ways to create PPMLContext in python

### DIFF
--- a/python/ppml/src/bigdl/ppml/README.md
+++ b/python/ppml/src/bigdl/ppml/README.md
@@ -8,7 +8,19 @@ This is a tutorial about how to use `PPMLContext` in python to read/write files 
 
 So before you read/write files, you need to create a PPMLConext first. 
 
-#### 1.1 create with app_name & ppml_args
+#### 1.1 create with app_name
+
+This is the simplest way to create a `PPMLContext`. When you don't need to read/write encrypted files, you can use this way to create a `PPMLContext`.
+
+```python
+from bigdl.ppml.ppml_context import *
+   
+sc = PPMLContext("MyApp")
+```
+
+If you want to read/write encrypted files, then you need to provide more information.
+
+#### 1.2 create with app_name & ppml_args
 
 `ppml_args` is a dict, you need to provide the following parameters
 
@@ -46,6 +58,27 @@ args = {"kms_type": "SimpleKeyManagementService",
        }
 
 sc = PPMLContext("MyApp", args)
+```
+
+#### 1.3 create with app_name & ppml_args & spark_conf
+
+If you need to set Spark configurations, you can provide a `SparkConf` with Spark configurations to create a `PPMLContext`.
+
+```python
+from bigdl.ppml.ppml_context import *
+from pyspark import SparkConf
+   
+ppml_args = {"kms_type": "SimpleKeyManagementService",
+             "simple_app_id": "your_app_id",
+             "simple_app_key": "your_app_key",
+             "primary_key_path": "/your/primary/key/path/primaryKey",
+             "data_key_path": "/your/data/key/path/dataKey"
+            }
+   
+conf = SparkConf()
+conf.setMaster("local[4]")
+
+sc = PPMLContext("MyApp", ppml_args, conf)
 ```
 
 ### 2.Read & Write Files

--- a/python/ppml/src/bigdl/ppml/ppml_context.py
+++ b/python/ppml/src/bigdl/ppml/ppml_context.py
@@ -20,6 +20,7 @@ from enum import Enum
 
 from pyspark.sql import SparkSession
 
+
 def check(ppml_args, arg_name):
     try:
         value = ppml_args[arg_name]
@@ -29,10 +30,13 @@ def check(ppml_args, arg_name):
 
 
 class PPMLContext(JavaValue):
-    def __init__(self, app_name, ppml_args):
+    def __init__(self, app_name, ppml_args=None, spark_conf=None):
         self.bigdl_type = "float"
         conf = {"spark.app.name": app_name,
                 "spark.hadoop.io.compression.codecs": "com.intel.analytics.bigdl.ppml.crypto.CryptoCodec"}
+        if spark_conf:
+            for (k, v) in spark_conf.getAll():
+                conf[k] = v
         if ppml_args:
             kms_type = ppml_args.get("kms_type", "SimpleKeyManagementService")
             conf["spark.bigdl.kms.type"] = kms_type

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/PPMLContext.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/PPMLContext.scala
@@ -199,7 +199,7 @@ object PPMLContext{
    */
   def initPPMLContext(sparkSession: SparkSession): PPMLContext = {
     val conf = sparkSession.sparkContext.getConf
-    val kmsType = conf.get("spark.bigdl.kms.type")
+    val kmsType = conf.get("spark.bigdl.kms.type", defaultValue = "SimpleKeyManagementService")
     val kms = kmsType match {
       case KMS_CONVENTION.MODE_EHSM_KMS =>
         val ip = conf.get("spark.bigdl.kms.ehs.ip")
@@ -208,9 +208,9 @@ object PPMLContext{
         val appKey = conf.get("spark.bigdl.kms.ehs.key")
         new EHSMKeyManagementService(ip, port, appId, appKey)
       case KMS_CONVENTION.MODE_SIMPLE_KMS =>
-        val id = conf.get("spark.bigdl.kms.simple.id")
+        val id = conf.get("spark.bigdl.kms.simple.id", defaultValue = "simpleAPPID")
         // println(id + "=-------------------")
-        val key = conf.get("spark.bigdl.kms.simple.key")
+        val key = conf.get("spark.bigdl.kms.simple.key", defaultValue = "simpleAPPKEY")
         // println(key + "=-------------------")
         SimpleKeyManagementService(id, key)
       case KMS_CONVENTION.MODE_AZURE_KMS =>


### PR DESCRIPTION
## Description

provide more ways to create PPMLContext in Python API

### 1. Why the change?

In Scala API, there are many ways to create PPMLContext, but Python API provide only one way to create. so we add more ways in Python API to keep consistent with Scala API.

### 2. User API changes

Before, the only way to create a PPMLContext in Python is to provide 2 parameters(app_name and ppml_args)
```python
sc = PPMLContext("MyApp", args)
```

Now, there are more ways
- only provide a app_name
  ```python
  sc = PPMLContext("MyApp")
  ```
  When you don't need to read/write encrypted files, you can use this way

- provide app_name and ppml_args(as before)

- provide app_name, ppml_args and a sparkConf
  If you need to set Spark configurations, you can provide a `SparkConf`  to create a `PPMLContext`.
  ```python
  conf = SparkConf()
  conf.setMaster("local[4]")
  sc = PPMLContext("MyApp", ppml_args, conf)
  ```


### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
provide more ways to create PPMLContext in Python API
### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...
