### PR TITLE
[PPML] Remove private key generation in gramine Dockerfile

### DIFF
--- a/ppml/trusted-big-data-ml/python/docker-gramine/Dockerfile
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/Dockerfile
@@ -225,8 +225,6 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     meson setup build/ --buildtype=release  -Dsgx=enabled   -Dsgx_driver=dcap1.10 && \
     ninja -C build/ && \
     ninja -C build/ install && \
-    cd / && \
-    gramine-sgx-gen-private-key && \
 #
     apt-get update --fix-missing && \
     env DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y tzdata && \

--- a/ppml/trusted-big-data-ml/python/docker-gramine/README.md
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/README.md
@@ -37,7 +37,7 @@ sudo docker run -itd \
     --device=/dev/gsgx \
     --device=/dev/sgx/enclave \
     --device=/dev/sgx/provision \
-    -v $ENCLAVE_KEY_PATH:/graphene/Pal/src/host/Linux-SGX/signer/enclave-key.pem \
+    -v $ENCLAVE_KEY_PATH:/root/.config/gramine/enclave-key.pem \
     -v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
     -v $SSL_KEYS_PATH:/ppml/trusted-big-data-ml/work/keys \
     --name=gramine-test \


### PR DESCRIPTION
## Description

Remove the automated enclave-key generation when building the image, which should use the key mounted by users.

### 1. Why the change?

The `enclave-key.pem` refers to the mounted one, rather than the demo key generated by `gramine-sgx-gen-private-key` API.

### 2. User API changes

None.

### 3. Summary of the change 

Remove private key generation in gramine Dockerfile.

### 4. How to test?

Unit test.
