### PR TITLE
add script to check ckpt file

### DIFF
--- a/python/friesian/example/deeprec/README.md
+++ b/python/friesian/example/deeprec/README.md
@@ -60,7 +60,10 @@ python wdl.py \
     --ev True \
     --data_location /folder/path/to/train/and/test/files \
     --checkpoint /path/to/save/model/checkpoint \
-    --instances_per_node 3
+    --instances_per_node 3 \
+    --ev True \
+    --emb_fusion false \
+    --ev_filter counter
 ```
 - K8s mode:
 ```bash
@@ -71,7 +74,10 @@ python wdl.py \
     --checkpoint /path/to/save/model/checkpoint \
     --cluster_mode k8s \
     --num_nodes 3 \
-    --master k8s://https://ip:port
+    --master k8s://https://ip:port \
+    --ev True \
+    --emb_fusion false \
+    --ev_filter counter
 ```
 
 For DeepRec related arguments, please refer to the original example for more description.

--- a/python/friesian/example/deeprec/README.md
+++ b/python/friesian/example/deeprec/README.md
@@ -56,27 +56,25 @@ Please refer to the [README](https://github.com/alibaba/DeepRec/tree/main/modelz
 - Local mode:
 ```bash
 python wdl.py \
-    --smartstaged false \
-    --ev True \
+    --instances_per_node 3 \
+    --smartstaged False \
     --data_location /folder/path/to/train/and/test/files \
     --checkpoint /path/to/save/model/checkpoint \
-    --instances_per_node 3 \
     --ev True \ 
-    --emb_fusion false \
+    --emb_fusion False \
     --ev_filter counter
 ```
 - K8s mode:
 ```bash
 python wdl.py \
-    --smartstaged false \
-    --ev True \
-    --data_location /folder/path/to/train/and/test/files \
-    --checkpoint /path/to/save/model/checkpoint \
     --cluster_mode k8s \
     --num_nodes 3 \
     --master k8s://https://ip:port \
+    --smartstaged False \
+    --data_location /folder/path/to/train/and/test/files \
+    --checkpoint /path/to/save/model/checkpoint \
     --ev True \
-    --emb_fusion false \
+    --emb_fusion False \
     --ev_filter counter
 ```
 

--- a/python/friesian/example/deeprec/README.md
+++ b/python/friesian/example/deeprec/README.md
@@ -61,7 +61,7 @@ python wdl.py \
     --data_location /folder/path/to/train/and/test/files \
     --checkpoint /path/to/save/model/checkpoint \
     --instances_per_node 3 \
-    --ev True \
+    --ev True \ 
     --emb_fusion false \
     --ev_filter counter
 ```

--- a/python/friesian/example/deeprec/README.md
+++ b/python/friesian/example/deeprec/README.md
@@ -57,9 +57,9 @@ Please refer to the [README](https://github.com/alibaba/DeepRec/tree/main/modelz
 ```bash
 python wdl.py \
     --instances_per_node 3 \
-    --smartstaged False \
     --data_location /folder/path/to/train/and/test/files \
     --checkpoint /path/to/save/model/checkpoint \
+    --smartstaged False \
     --ev True \ 
     --emb_fusion False \
     --ev_filter counter
@@ -70,9 +70,9 @@ python wdl.py \
     --cluster_mode k8s \
     --num_nodes 3 \
     --master k8s://https://ip:port \
-    --smartstaged False \
     --data_location /folder/path/to/train/and/test/files \
     --checkpoint /path/to/save/model/checkpoint \
+    --smartstaged False \
     --ev True \
     --emb_fusion False \
     --ev_filter counter

--- a/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
+++ b/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-from tensorflow.contrib.framework.python.framework import checkpoint_utils
 import argparse
+from tensorflow.contrib.framework.python.framework import checkpoint_utils
 
 def get_arg_parser():
     parser = argparse.ArgumentParser()

--- a/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
+++ b/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
@@ -1,15 +1,34 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Original imports
 from tensorflow.contrib.framework.python.framework import checkpoint_utils
 import argparse
 
 def get_arg_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument('--checkpoint',
-                        help='Full path to checkpoints input/output.',
+                        help='Path to the model checkpoint.',
                         type=str,
                         required=False)
     return parser
+
 parser = get_arg_parser()
 args = parser.parse_args()
 checkpoint_dir = args.checkpoint
+
 for name, shape in checkpoint_utils.list_variables(checkpoint_dir):
      print('loading...', name, shape, checkpoint_utils.load_variable(checkpoint_dir,name))

--- a/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
+++ b/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
@@ -29,5 +29,14 @@ parser = get_arg_parser()
 args = parser.parse_args()
 checkpoint_dir = args.checkpoint
 
+# After using EmbeddingVariable, the characteristics of admission can be viewed through ckpt
+
+# xxxxx-freqs is the frequencies of features that have been admitted.
+# xxxxx-freqs_filtered is a freqs that have not yet reached the characteristics of the access filtered out. 
+# xxxxx-keys is id that has been admitted.
+# xxxxx-keys_filtered corresponds to xxxxx-freqs_filteredr.
+# xxxxx-values is the embedding vector that has been allocated, is the actual embedding vector.
+# xxxxx/Adagrad is the embedding vector of the backward.
+# xxxxx-versions is the most recent globalstep to be visited.
 for name, shape in checkpoint_utils.list_variables(checkpoint_dir):
      print('loading...', name, shape, checkpoint_utils.load_variable(checkpoint_dir,name))

--- a/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
+++ b/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-# Original imports
 from tensorflow.contrib.framework.python.framework import checkpoint_utils
 import argparse
 

--- a/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
+++ b/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
@@ -17,6 +17,7 @@
 import argparse
 from tensorflow.contrib.framework.python.framework import checkpoint_utils
 
+
 def get_arg_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument('--checkpoint',
@@ -32,11 +33,12 @@ checkpoint_dir = args.checkpoint
 # After using EmbeddingVariable, the characteristics of features can be viewed through ckpt
 
 # xxxxx-freqs are the features that have been admitted.
-# xxxxx-freqs_filtered are the features that have been filtered, corresponding to xxxxx-freqs_filtered.
+# xxxxx-freqs_filtered are the features that have been filtered, 
+# corresponding to xxxxx-freqs_filtered.
 # xxxxx-keys are the id that has been admitted.
 # xxxxx-keys_filtered correspond to xxxxx-freqs_filteredr.
 # xxxxx-values are the embedding vectors of the admitted features.
 # xxxxx/Adagrad are the backward embedding gradients.
 # xxxxx-versions are the most recent global steps of each feature.
 for name, shape in checkpoint_utils.list_variables(checkpoint_dir):
-     print('loading...', name, shape, checkpoint_utils.load_variable(checkpoint_dir,name))
+    print('loading...', name, shape, checkpoint_utils.load_variable(checkpoint_dir, name))

--- a/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
+++ b/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
@@ -40,4 +40,3 @@ checkpoint_dir = args.checkpoint
 # xxxxx-versions are the most recent global steps of each feature.
 for name, shape in checkpoint_utils.list_variables(checkpoint_dir):
      print('loading...', name, shape, checkpoint_utils.load_variable(checkpoint_dir,name))
-     

--- a/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
+++ b/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
@@ -33,7 +33,7 @@ checkpoint_dir = args.checkpoint
 # After using EmbeddingVariable, the characteristics of features can be viewed through ckpt
 
 # xxxxx-freqs are the features that have been admitted.
-# xxxxx-freqs_filtered are the features that have been filtered, 
+# xxxxx-freqs_filtered are the features that have been filtered,
 # corresponding to xxxxx-freqs_filtered.
 # xxxxx-keys are the id that has been admitted.
 # xxxxx-keys_filtered correspond to xxxxx-freqs_filteredr.

--- a/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
+++ b/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
@@ -1,0 +1,15 @@
+from tensorflow.contrib.framework.python.framework import checkpoint_utils
+import argparse
+
+def get_arg_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--checkpoint',
+                        help='Full path to checkpoints input/output.',
+                        type=str,
+                        required=False)
+    return parser
+parser = get_arg_parser()
+args = parser.parse_args()
+checkpoint_dir = args.checkpoint
+for name, shape in checkpoint_utils.list_variables(checkpoint_dir):
+     print('loading...', name, shape, checkpoint_utils.load_variable(checkpoint_dir,name))

--- a/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
+++ b/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
@@ -29,14 +29,14 @@ parser = get_arg_parser()
 args = parser.parse_args()
 checkpoint_dir = args.checkpoint
 
-# After using EmbeddingVariable, the characteristics of admission can be viewed through ckpt
+# After using EmbeddingVariable, the characteristics of features can be viewed through ckpt
 
-# xxxxx-freqs is the frequencies of features that have been admitted.
-# xxxxx-freqs_filtered is a freqs that have not yet reached the characteristics of the access filtered out. 
-# xxxxx-keys is id that has been admitted.
-# xxxxx-keys_filtered corresponds to xxxxx-freqs_filteredr.
-# xxxxx-values is the embedding vector that has been allocated, is the actual embedding vector.
-# xxxxx/Adagrad is the embedding vector of the backward.
-# xxxxx-versions is the most recent globalstep to be visited.
+# xxxxx-freqs are the features that have been admitted.
+# xxxxx-freqs_filtered are the features that have been filtered, corresponding to xxxxx-freqs_filtered.
+# xxxxx-keys are the id that has been admitted.
+# xxxxx-keys_filtered correspond to xxxxx-freqs_filteredr.
+# xxxxx-values are the embedding vectors of the admitted features.
+# xxxxx/Adagrad are the backward embedding gradients.
+# xxxxx-versions are the most recent global steps of each feature.
 for name, shape in checkpoint_utils.list_variables(checkpoint_dir):
      print('loading...', name, shape, checkpoint_utils.load_variable(checkpoint_dir,name))

--- a/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
+++ b/python/friesian/example/deeprec/embedding_variable_checkoutpoint.py
@@ -40,3 +40,4 @@ checkpoint_dir = args.checkpoint
 # xxxxx-versions are the most recent global steps of each feature.
 for name, shape in checkpoint_utils.list_variables(checkpoint_dir):
      print('loading...', name, shape, checkpoint_utils.load_variable(checkpoint_dir,name))
+     


### PR DESCRIPTION
After using EmbeddingVariable, the characteristics of admission can be viewed through ckpt

- xxxxx-freqs is the frequencies of features that have been admitted. [Total number of admission features] [Freq for each feature]. (Freq that have reached the admission will only record the freq limit, not the actual number of occurrences)
- xxxxx-freqs_filtered is a freqs that have not yet reached the characteristics of the access filtered out. [The total number of features filtered out] [Each feature corresponds to the number of times it has already appeared]. (If it occurs again after that, it will continue to accumulate and update after reaching admission)
- xxxxx-keys is id that has been admitted.
- xxxxx-keys_filtered corresponds to xxxxx-freqs_filtered, and the id, order, corresponds to the frequencies they currently appear.
- xxxxx-values is the embedding vector that has been allocated, [total number of admission features, embedding dim], is the actual embedding vector.
- xxxxx/Adagrad is the embedding vector of the backward.
- xxxxx-versions is the most recent globalstep to be visited, and it only makes sense to turn on feature elimination of this field.