### PR TITLE
add jar-with-dependency in assembly

### DIFF
--- a/scala/assembly/src/main/assembly/assembly.xml
+++ b/scala/assembly/src/main/assembly/assembly.xml
@@ -120,6 +120,34 @@
           <include>/**</include>
       </includes>
     </fileSet>
+    <fileSet>
+      <outputDirectory>/assembly</outputDirectory>
+      <directory>${project.parent.basedir}/dllib/target</directory>
+      <includes>
+          <include>bigdl-dllib*-jar-with-dependencies.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <outputDirectory>/assembly</outputDirectory>
+      <directory>${project.parent.basedir}/orca/target</directory>
+      <includes>
+          <include>bigdl-orca*-jar-with-dependencies.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <outputDirectory>/assembly</outputDirectory>
+      <directory>${project.parent.basedir}/friesian/target</directory>
+      <includes>
+          <include>bigdl-friesian*-jar-with-dependencies.jar</include>
+      </includes>
+    </fileSet>
+    <fileSet>
+      <outputDirectory>/assembly</outputDirectory>
+      <directory>${project.parent.basedir}/ppml/target</directory>
+      <includes>
+          <include>bigdl-ppml*-jar-with-dependencies.jar</include>
+      </includes>
+    </fileSet>
   </fileSets>
   <dependencySets>
     <dependencySet>


### PR DESCRIPTION
## Description
To fix https://github.com/intel-analytics/arda-docker/issues/692
add a series of jar-with-denpendency jar in assembly.

![image](https://user-images.githubusercontent.com/30695225/184837935-73ca0bc5-0ab7-4b47-a5af-49b1b96b34ee.png)
