### PR TITLE
uncache shards if it's converted to spark df

### DIFF
--- a/python/orca/src/bigdl/orca/data/shard.py
+++ b/python/orca/src/bigdl/orca/data/shard.py
@@ -548,6 +548,9 @@ class SparkXShards(XShards):
         rdd = self.rdd.mapPartitions(f)
         column = self.rdd.mapPartitions(getSchema).first()
         df = rdd.toDF(list(column))
+        df.cache()
+        df.count()
+        self.uncache()
         return df
 
     def __len__(self):

--- a/python/orca/src/bigdl/orca/data/utils.py
+++ b/python/orca/src/bigdl/orca/data/utils.py
@@ -398,6 +398,7 @@ def spark_df_to_pd_sparkxshards(df, squeeze=False, index_col=None,
     pd_rdd = spark_df_to_rdd_pd(df, squeeze, index_col, dtype, index_map)
     from bigdl.orca.data import SparkXShards
     spark_xshards = SparkXShards(pd_rdd)
+    df.unpersist()
     return spark_xshards
 
 


### PR DESCRIPTION
## Description

This PR is used to reduce memory usage. If shards is converted to spark df, most likely we will create a new shards, we can uncache the original shards to save memory.

### 1. How to test?
- Application test
