### PR TITLE
Chronos: handle redundant warning when forecasters are fitted

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -349,7 +349,8 @@ class BasePytorchForecaster(Forecaster):
             if isinstance(data, tuple):
                 data = np_to_dataloader(data, batch_size, self.num_processes)
             from pytorch_lightning.loggers import CSVLogger
-            logger = False if validation_data is None else CSVLogger(".", flush_logs_every_n_steps=10,
+            logger = False if validation_data is None else CSVLogger(".",
+                                                                     flush_logs_every_n_steps=10,
                                                                      name="forecaster_tmp_log")
             from pytorch_lightning.callbacks import EarlyStopping
             early_stopping = EarlyStopping('val/loss', patience=earlystop_patience)

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -186,7 +186,7 @@ class BasePytorchForecaster(Forecaster):
 
         # shall we use the same trainier
         self.tune_trainer = Trainer(logger=False, max_epochs=epochs,
-                                    checkpoint_callback=self.checkpoint_callback,
+                                    enable_checkpointing=self.checkpoint_callback,
                                     num_processes=self.num_processes, use_ipex=self.use_ipex,
                                     use_hpo=True)
 
@@ -349,7 +349,7 @@ class BasePytorchForecaster(Forecaster):
             if isinstance(data, tuple):
                 data = np_to_dataloader(data, batch_size, self.num_processes)
             from pytorch_lightning.loggers import CSVLogger
-            logger = False if validation_data is None else CSVLogger(".",
+            logger = False if validation_data is None else CSVLogger(".", flush_logs_every_n_steps=10,
                                                                      name="forecaster_tmp_log")
             from pytorch_lightning.callbacks import EarlyStopping
             early_stopping = EarlyStopping('val/loss', patience=earlystop_patience)
@@ -364,9 +364,9 @@ class BasePytorchForecaster(Forecaster):
                 callbacks = None
             # Trainer init
             self.trainer = Trainer(logger=logger, max_epochs=epochs, callbacks=callbacks,
-                                   checkpoint_callback=self.checkpoint_callback,
+                                   enable_checkpointing=self.checkpoint_callback,
                                    num_processes=self.num_processes, use_ipex=self.use_ipex,
-                                   flush_logs_every_n_steps=10, log_every_n_steps=10,
+                                   log_every_n_steps=10,
                                    distributed_backend=self.local_distributed_backend)
 
             # This error is only triggered when the python interpreter starts additional processes.
@@ -844,7 +844,7 @@ class BasePytorchForecaster(Forecaster):
             # This trainer is only for quantization, once the user call `fit`, it will be
             # replaced according to the new training config
             self.trainer = Trainer(logger=False, max_epochs=1,
-                                   checkpoint_callback=self.checkpoint_callback,
+                                   enable_checkpointing=self.checkpoint_callback,
                                    num_processes=self.num_processes, use_ipex=self.use_ipex)
 
     def to_local(self):
@@ -876,7 +876,7 @@ class BasePytorchForecaster(Forecaster):
         # This trainer is only for saving, once the user call `fit`, it will be
         # replaced according to the new training config
         self.trainer = Trainer(logger=False, max_epochs=1,
-                               checkpoint_callback=self.checkpoint_callback,
+                               enable_checkpointing=self.checkpoint_callback,
                                num_processes=self.num_processes, use_ipex=self.use_ipex)
 
         self.distributed = False


### PR DESCRIPTION
## Description

There are 2 warnings shown to users when `forecaster.fit` is called while they all may confuse our users. This is mainly because some parameters of the Trainer were discarded when the lightning version was upgraded to v1.7.

### 1. Why the change?

https://github.com/intel-analytics/BigDL/issues/5403
The last two issues were addressed.
### 2. User API changes



### 3. Summary of the change 

Change the parameter `checkpoint_callback` of the Trainer to `enable_checkpointing`.
Move the parameter `flush_logs_every_n_steps`  from Trainer to CSVLogger().

### 4. How to test?
- [ ] Unit test


### 5. New dependencies
