### PR TITLE
Add python hint to bigdl.friesian

### DIFF
--- a/docs/docs/DeveloperGuide/typehint.md
+++ b/docs/docs/DeveloperGuide/typehint.md
@@ -4,7 +4,7 @@ This page describes how to add type annotations to unmarked code efficiently.
 
 ## Introduction
 
-we need to declare that the python runtime does not enforce function and variable [type annotations](https://docs.python.org/3/library/typing.html#module-typing). But they can actually be used by third party tools such as type checkers, IDEs, linters, etc.
+We need to declare that the python runtime does not enforce function and variable [type annotations](https://docs.python.org/3/library/typing.html#module-typing). But they can actually be used by third party tools such as type checkers, IDEs, linters, etc.
 
 **Python Enhancement Proposals(PEPs)** are widely accepted python standards, and [PEP 484](https://peps.python.org/pep-0484/) introduced syntax for function annotations, for example:
 ```python
@@ -79,12 +79,12 @@ which indicates the annotations involved in the UTs. More usages about stub see 
 
 3. Apply type annotaions manually (recommended) or use `monkeytype apply some.module`.
 
-4. **Check again if annotations consistent with comments or documents.(IMPORTANT)**
+4. **Manually** check again if annotations **are** consistent
 
 ## Notes
 1. `monkeytype apply` may not work for some cases. 
 
-For example, `friesian.feature.table` invokes two kinds of DataFrame in this module:` pyspark.sql.dataframe.DataFrame `and `pandas.core.frame.DataFrame`. To avoid ambiguity of type `DataFrame`, we rename `pyspark.sql.dataframe.DataFrame t` o SparkDataFrame like:
+For example, `friesian.feature.table` invokes two kinds of DataFrame in this module:` pyspark.sql.dataframe.DataFrame `and `pandas.core.frame.DataFrame`. To avoid ambiguity of type `DataFrame`, we rename `pyspark.sql.dataframe.DataFrame` o SparkDataFrame like:
 ```
 from pyspark.sql.dataframe import DataFrame as SparkDataFrame
 ```

--- a/docs/docs/DeveloperGuide/typehint.md
+++ b/docs/docs/DeveloperGuide/typehint.md
@@ -84,7 +84,7 @@ which indicates the annotations involved in the UTs. More usages about stub see 
 ## Notes
 1. `monkeytype apply` may not work for some cases. 
 
-For example, `friesian.feature.table` invokes two kinds of DataFrame in this module:` pyspark.sql.dataframe.DataFrame `and `pandas.core.frame.DataFrame`. To avoid ambiguity of type `DataFrame`, we rename `pyspark.sql.dataframe.DataFrame` o SparkDataFrame like:
+For example, `friesian.feature.table` invokes two kinds of DataFrame in this module:` pyspark.sql.dataframe.DataFrame `and `pandas.core.frame.DataFrame`. To avoid ambiguity of type `DataFrame`, we rename `pyspark.sql.dataframe.DataFrame` to SparkDataFrame like:
 ```
 from pyspark.sql.dataframe import DataFrame as SparkDataFrame
 ```

--- a/docs/docs/DeveloperGuide/typehint.md
+++ b/docs/docs/DeveloperGuide/typehint.md
@@ -1,0 +1,102 @@
+# Python Type hint
+
+This page describes how to add type annotations to unmarked code efficiently.
+
+## Introduction
+
+we need to declare that the python runtime does not enforce function and variable [type annotations](https://docs.python.org/3/library/typing.html#module-typing). But they can actually be used by third party tools such as type checkers, IDEs, linters, etc.
+
+**Python Enhancement Proposals(PEPs)** are widely accepted python standards, and [PEP 484](https://peps.python.org/pep-0484/) introduced syntax for function annotations, for example:
+```python
+def greeting(name: str) -> str:
+    return 'Hello ' + name
+```
+This states that the expected type of the name argument is str. Analogically, the expected return type is str.
+
+Expressions whose type is a subtype of a specific argument type are also accepted for that argument.
+
+## MonkeyType: Automatic Annotation
+
+MonkeyType is a python tools collects runtime types of function arguments and return values, and can automatically generate stub files or even add draft type annotations directly to your Python code based on the types collected at runtime. More details at [MonkeyType github](https://github.com/Instagram/MonkeyType#example).
+
+We can collect the types of interface exposed to the user by running unit tests with monkeytype, but we recommend achieving this by previewing the changes first with `monkey stub` and then manually applying them.
+
+## How Do We Work on Type Hint
+Takes bigdl.friesian.feature as an example.
+
+0. Preparation
+```shell
+pip install monkeytype
+
+cd Bigdl/python
+source friesian/dev/prepare_env.sh
+```
+
+1. Collect runtime types with monkeytype
+Since monkeytype can only operate file-by-file, we shall run uts individually or Or automate the process with the help of `add_type_hint.sh`.
+```shell
+#  Usage:
+#   bash dev/add_type_hint.sh module_name submodule_name
+#   module_names: orca, dllib, chronos, friesian, etc.
+#   submodule_name: directories under module_names/test/bigdl/module_names
+#  
+#  Example:
+#   `bash dev/add_type_hint.sh friesian feature` will run all unit tests 
+#   under python/friesian/test/bigdl/friesian/feature
+
+bash dev/add_type_hint.sh friesian feature
+```
+If all UTs pass, you will see `friesian_hint.sqlite3` under `dev/`, which contains stubs of refactors. Check the list of all modules which have traces present in the trace store:
+```shell
+> export MT_DB_PATH="dev/friesian_hint.sqlite3" # monkeytype will read this traces database
+> monkeytype list-modules
+test.bigdl.friesian.feature.test_table
+test.bigdl.friesian.feature.conftest
+pyspark.traceback_utils
+... ...
+bigdl.friesian.feature.utils
+bigdl.friesian.feature.table
+... ...
+```
+
+2. Run `monkeytype stub some.module` to generate a stub file for the given module based on call traces queried from the trace store.
+```shell
+> monkeytype stub bigdl.friesian.feature.table
+
+...
+class Table:
+    def __init__(self, df: "SparkDataFrame") -> None: ...
+
+    @property
+    def schema(self) -> "StructType": ...
+
+    @staticmethod
+    def _read_parquet(paths: Union[List[str], str]) -> "SparkDataFrame": ...
+...
+
+```
+which indicates the annotations involved in the UTs. More usages about stub see [docs](https://monkeytype.readthedocs.io/en/latest/generation.html#monkeytype-stub).
+
+3. Apply type annotaions manually (recommended) or use `monkeytype apply some.module`.
+
+4. **Check again if annotations consistent with comments or documents.(IMPORTANT)**
+
+## Notes
+1. `monkeytype apply` may not work for some cases. 
+
+For example, `friesian.feature.table` invokes two kinds of DataFrame in this module:` pyspark.sql.dataframe.DataFrame `and `pandas.core.frame.DataFrame`. To avoid ambiguity of type `DataFrame`, we rename `pyspark.sql.dataframe.DataFrame t` o SparkDataFrame like:
+```
+from pyspark.sql.dataframe import DataFrame as SparkDataFrame
+```
+And so do PandasDataFrame.
+
+2. Use [TYPE_CHECKING](https://docs.python.org/3/library/typing.html#constant) constant to avoid import unnecessary libraries at runtime.
+```python
+if TYPE_CHECKING:
+    from pandas.core.frame import DataFrame as PandasDataFrame
+    from pyspark.sql.column import Column
+    from pyspark.sql import Row
+    from pyspark.sql.dataframe import DataFrame as SparkDataFrame
+    from pyspark.sql.types import StructType
+```
+3. Mark `TODO` if there are methods not caught by UTs.

--- a/python/dev/add_type_hint.sh
+++ b/python/dev/add_type_hint.sh
@@ -17,43 +17,38 @@
 #
 
 
-# set -ex
-# . `dirname $0`/../prepare_env.sh
+hint_module_name="friesian"
+if [ "$1" ]; then
+    hint_module_name=$1
+    echo hint_module_name:${hint_module_name}
+fi
+
+hint_submodule_name="feature"
+if [ "$2" ]; then
+    hint_submodule_name=$2
+    echo hint_submodule_name:${hint_submodule_name}
+fi
 
 cd "`dirname $0`"
-export MT_DB_PATH="$(pwd)/friesian_hint.sqlite3"
+export MT_DB_PATH="$(pwd)/${hint_module_name}_hint.sqlite3"
 echo $MT_DB_PATH
 
 export PYSPARK_PYTHON=python
 export PYSPARK_DRIVER_PYTHON=python
 
-cd ../../
+cd ../${hint_module_name}
 echo "Automatically Add Type Hint"
-
-test_dir_name="data"
-if [ "$1" ]; then
-    test_dir_name=$1
-    echo test_dir_name:${test_dir_name}
-fi
 
 
 if [ -f $MT_DB_PATH ];then
     rm $MT_DB_PATH
 fi
 
-for file in $(find test/bigdl/friesian/${test_dir_name}  -maxdepth 1 -name test_*.py)
+for file in $(find test/bigdl/${hint_module_name}/${hint_submodule_name} -name test_*.py)
 do
     echo $file
     monkeytype run $file
 done
 
 cd -
-# for module in $add_hint_modules
-# do
-#     monkeytype apply $module
-# done
-
-# if [ -f $MT_DB_PATH ];then
-#     rm $MT_DB_PATH
-# fi
 unset MT_DB_PATH

--- a/python/friesian/dev/test/add_type_hint.sh
+++ b/python/friesian/dev/test/add_type_hint.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2022 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+# set -ex
+# . `dirname $0`/../prepare_env.sh
+
+cd "`dirname $0`"
+export MT_DB_PATH="$(pwd)/friesian_hint.sqlite3"
+echo $MT_DB_PATH
+
+export PYSPARK_PYTHON=python
+export PYSPARK_DRIVER_PYTHON=python
+
+cd ../../
+echo "Automatically Add Type Hint"
+
+test_dir_name="data"
+if [ "$1" ]; then
+    test_dir_name=$1
+    echo test_dir_name:${test_dir_name}
+fi
+
+
+if [ -f $MT_DB_PATH ];then
+    rm $MT_DB_PATH
+fi
+
+for file in $(find test/bigdl/friesian/${test_dir_name}  -maxdepth 1 -name test_*.py)
+do
+    echo $file
+    monkeytype run $file
+done
+
+cd -
+# for module in $add_hint_modules
+# do
+#     monkeytype apply $module
+# done
+
+# if [ -f $MT_DB_PATH ];then
+#     rm $MT_DB_PATH
+# fi
+unset MT_DB_PATH

--- a/python/friesian/src/bigdl/friesian/feature/table.py
+++ b/python/friesian/src/bigdl/friesian/feature/table.py
@@ -19,6 +19,7 @@ import os
 import random
 import sys
 from functools import reduce
+from xmlrpc.client import boolean
 
 import numpy as np
 import pyspark.sql.functions as F
@@ -154,7 +155,7 @@ class Table:
         cnt = self.df.count()
         return cnt
 
-    def broadcast(self):
+    def broadcast(self) -> None:
         """
         Marks the Table as small enough for use in broadcast join.
         """
@@ -216,9 +217,10 @@ class Table:
         return self._clone(self.df.withColumn("partitionId", spark_partition_id())
                            .groupBy("partitionId").count())
 
+    # TODO: UTs on `value` of boolean
     def fillna(
         self,
-        value: Union[int, float, str],
+        value: Union[int, float, str, boolean],
         columns: Optional[Union[List[str], str]]
     ) -> "FeatureTable":
         """

--- a/python/friesian/src/bigdl/friesian/feature/table.py
+++ b/python/friesian/src/bigdl/friesian/feature/table.py
@@ -76,7 +76,7 @@ class Table:
         return df
 
     @staticmethod
-    def _read_json(paths: str, cols: Union[List, str]) -> "SparkDataFrame":
+    def _read_json(paths: str, cols: Union[List[str], str]) -> "SparkDataFrame":
         if not isinstance(paths, list):
             paths = [paths]
         spark = OrcaContext.get_spark_session()
@@ -96,7 +96,7 @@ class Table:
         paths: str,
         delimiter: str = ",",
         header: bool = False,
-        names: Optional[List[str]] = None,
+        names: Optional[Union[List[str], str]] = None,
         dtype: Optional[Union[List[str], Dict[str, str], str]]=None
     ) -> "SparkDataFrame":
         if not isinstance(paths, list):
@@ -162,7 +162,7 @@ class Table:
         """
         self.df = broadcast(self.df)
 
-    def select(self, *cols: Union[List, str]) -> "Table":
+    def select(self, *cols: Union[List[str], str]) -> "Table":
         """
         Select specific columns.
 
@@ -178,7 +178,7 @@ class Table:
                               "cols should be str or a list of str, but got None.")
         return self._clone(self.df.select(*cols))
 
-    def drop(self, *cols: Union[List, str]) -> "Table":
+    def drop(self, *cols: Union[List[str], str]) -> "Table":
         """
         Returns a new Table that drops the specified column.
         This is a no-op if schema doesn't contain the given column name(s).
@@ -251,7 +251,7 @@ class Table:
 
     def dropna(
         self,
-        columns: List[str],
+        columns: Optional[Union[List[str], str]],
         how: str = "any",
         thresh: Optional[int] = None
     ) -> "Table":
@@ -311,7 +311,7 @@ class Table:
 
     def clip(
         self,
-        columns: Optional[List[str]],
+        columns: Optional[Union[List[str], str]] = None,
         min: Optional[NUMERIC_TYPE] = None,
         max: Optional[NUMERIC_TYPE] = None
     ) -> "Table":
@@ -340,7 +340,7 @@ class Table:
 
     def log(
         self,
-        columns: List[str],
+        columns: Optional[Union[List[str], str]] = None,
         clipping: bool = True
     ) -> "Table":
         """
@@ -361,7 +361,7 @@ class Table:
         check_col_exists(self.df, columns)
         return self._clone(log_with_clip(self.df, columns, clipping))
 
-    def fill_median(self, columns: List[str]) -> "Table":
+    def fill_median(self, columns: Optional[Union[List[str], str]]=None) -> "Table":
         """
         Replaces null values with the median in the specified numeric columns. Any column to be
         filled should not contain only null values.
@@ -394,7 +394,9 @@ class Table:
             check_col_exists(self.df, columns)
         return self._clone(median(self.df, columns))
 
-    def merge_cols(self, columns: List[str], target: str) -> "Table":
+    def merge_cols(self,
+                   columns: Union[List[str], str],
+                   target: str) -> "Table":
         """
         Merge the target column values as a list to a new column.
         The original columns will be dropped.
@@ -484,7 +486,7 @@ class Table:
             stats[column] = values[0] if len(values) == 1 else values
         return stats
 
-    def min(self, columns: Optional[Union[str, List[str]]]) -> "Table":
+    def min(self, columns: Optional[Union[str, List[str]]]=None) -> "Table":
         """
         Returns a new Table that has two columns, `column` and `min`, containing the column
         names and the minimum values of the specified numeric columns.
@@ -501,7 +503,7 @@ class Table:
         spark = OrcaContext.get_spark_session()
         return self._clone(spark.createDataFrame(data, schema))
 
-    def max(self, columns: Optional[Union[str, List[str]]]) -> "Table":
+    def max(self, columns: Optional[Union[str, List[str]]]=None) -> "Table":
         """
         Returns a new Table that has two columns, `column` and `max`, containing the column
         names and the maximum values of the specified numeric columns.
@@ -547,7 +549,7 @@ class Table:
             result[column] = [row[i] for row in rows]
         return result
 
-    def add(self, columns: List[str], value: NUMERIC_TYPE=1) -> "Table":
+    def add(self, columns: Union[List[str], str], value: NUMERIC_TYPE=1) -> "Table":
         """
         Increase all of values of the target numeric column(s) by a constant value.
 
@@ -622,7 +624,7 @@ class Table:
         """
         write_parquet(self.df, path, mode)
 
-    def cast(self, columns: Union[str, List[str]], dtype: str) -> "StringIndex":
+    def cast(self, columns: Optional[Union[List[str], str]], dtype: str) -> "StringIndex":
         """
         Cast columns to the specified type.
 
@@ -735,7 +737,7 @@ class Table:
 
     def drop_duplicates(
         self,
-        subset: Optional[List[str]]=None,
+        subset: Optional[Union[List[str], str]]=None,
         sort_cols: Optional[Union[List[str], str]]=None,
         keep: str="min"
     ) -> "Table":
@@ -891,7 +893,7 @@ class Table:
 
 class FeatureTable(Table):
     @classmethod
-    def read_parquet(cls, paths: str) -> "FeatureTable":
+    def read_parquet(cls, paths: Union[List[str], str]) -> "FeatureTable":
         """
         Loads Parquet files as a FeatureTable.
 
@@ -1103,7 +1105,7 @@ class FeatureTable(Table):
     def cross_hash_encode(
         self,
         cross_columns: Union[List[str], List[List[str]], str],
-        bin_sizes: Union[int, List[int]],
+        bin_sizes: List[int],
         cross_col_names: Optional[Union[List[str], str, List[int]]]=None,
         method: str = 'md5'
     ) -> "FeatureTable":
@@ -1650,7 +1652,7 @@ class FeatureTable(Table):
         cols: Union[str, List[str]],
         seq_len: int = 100,
         mask_cols: Union[str, List[str]]=None,
-        mask_token: Union[int, str]=0
+        mask_token: Union[NUMERIC_TYPE, str]=0
     ) -> "FeatureTable":
         """
         Add padding on specified column(s).

--- a/python/friesian/src/bigdl/friesian/feature/table.py
+++ b/python/friesian/src/bigdl/friesian/feature/table.py
@@ -16,13 +16,11 @@
 import copy
 import hashlib
 import os
-from pickle import DICT
 import random
 import sys
 from functools import reduce
-from tkinter.messagebox import NO
 
-import numpy as np 
+import numpy as np
 import pyspark.sql.functions as F
 from bigdl.friesian.feature.utils import *
 from bigdl.dllib.utils.log4Error import *
@@ -97,7 +95,7 @@ class Table:
         delimiter: str = ",",
         header: bool = False,
         names: Optional[List[str]] = None,
-        dtype: Optional[Union[List[str], Dict[str, str], str]] = None
+        dtype: Optional[Union[List[str], Dict[str, str], str]]=None
     ) -> "SparkDataFrame":
         if not isinstance(paths, list):
             paths = [paths]
@@ -253,7 +251,7 @@ class Table:
         columns: List[str],
         how: str = "any",
         thresh: Optional[int] = None
-    ) -> "Table": 
+    ) -> "Table":
         """
         Drops the rows containing null values in the specified columns.
 
@@ -341,7 +339,7 @@ class Table:
         self,
         columns: List[str],
         clipping: bool = True
-    ) -> "Table": 
+    ) -> "Table":
         """
         Calculates the log of continuous columns.
 
@@ -424,7 +422,7 @@ class Table:
             new_df = new_df.withColumnRenamed(old_name, new_name)
         return self._clone(new_df)
 
-    def show(self, n: int = 20, truncate: bool = True) -> None: 
+    def show(self, n: int = 20, truncate: bool = True) -> None:
         """
         Prints the first `n` rows to the console.
 
@@ -517,7 +515,7 @@ class Table:
         spark = OrcaContext.get_spark_session()
         return self._clone(spark.createDataFrame(data, schema))
 
-    def to_list(self, column: str) -> List: 
+    def to_list(self, column: str) -> List:
         """
         Convert all values of the target column to a list.
         Only call this if the Table is small enough.
@@ -546,7 +544,7 @@ class Table:
             result[column] = [row[i] for row in rows]
         return result
 
-    def add(self, columns: List[str], value: Union[int, float] = 1) -> "Table":
+    def add(self, columns: List[str], value: Union[int, float]=1) -> "Table":
         """
         Increase all of values of the target numeric column(s) by a constant value.
 
@@ -586,7 +584,7 @@ class Table:
         fraction: float,
         replace: bool = False,
         seed: Optional[int] = None
-    ) -> "Table": 
+    ) -> "Table":
         """
         Return a sampled subset of Table.
 
@@ -707,7 +705,7 @@ class Table:
         tables: Union["Table", List["Table"]],
         mode: str = "inner",
         distinct: bool = False
-    ) -> "Table": 
+    ) -> "Table":
         """
         Concatenate a list of Tables into one Table in the dimension of row.
 
@@ -734,10 +732,10 @@ class Table:
 
     def drop_duplicates(
         self,
-        subset: Optional[List[str]] = None,
-        sort_cols: Optional[Union[List[str], str]] = None,
-        keep: str = "min"
-    ) -> "Table": 
+        subset: Optional[List[str]]=None,
+        sort_cols: Optional[Union[List[str], str]]=None,
+        keep: str="min"
+    ) -> "Table":
         """
         Return a new Table with duplicate rows removed.
 
@@ -777,7 +775,7 @@ class Table:
         df = df.filter(pyspark_col('rank') == 1).drop('rank', 'id')
         return self._clone(df)
 
-    def append_column(self, name: str, column: "Column") -> "Table": 
+    def append_column(self, name: str, column: "Column") -> "Table":
         """
         Append a column with a constant value to the Table.
 
@@ -812,7 +810,7 @@ class Table:
         """
         return pyspark_col(name)
 
-    def sort(self, *cols: List["Column"], **kwargs: Union[bool, List[bool]]) -> "Table": 
+    def sort(self, *cols: List["Column"], **kwargs: Union[bool, List[bool]]) -> "Table":
         """
         Sort the Table by specified column(s).
 
@@ -881,7 +879,7 @@ class Table:
         return self.df.collect()
 
     @property
-    def dtypes(self) -> List[Tuple[str,str]]:
+    def dtypes(self) -> List[Tuple[str, str]]:
         """
         Returns all column names and their data types as a list.
         """
@@ -920,7 +918,7 @@ class FeatureTable(Table):
         delimiter: str = ",",
         header: bool = False,
         names: Optional[List[str]] = None,
-        dtype: Optional[Union[List[str], str, Dict[str, str]]] = None
+        dtype: Optional[Union[List[str], str, Dict[str, str]]]=None
     ) -> "FeatureTable":
         """
         Loads csv files as a FeatureTable.
@@ -1099,7 +1097,7 @@ class FeatureTable(Table):
         self,
         cross_columns: Union[List[str], List[List[str]], str],
         bin_sizes: Union[int, List[int]],
-        cross_col_names: Optional[Union[List[str], str, List[int]]] = None,
+        cross_col_names: Optional[Union[List[str], str, List[int]]]=None,
         method: str = 'md5'
     ) -> "FeatureTable":
         """
@@ -1162,7 +1160,7 @@ class FeatureTable(Table):
     def category_encode(
         self,
         columns: List[str],
-        freq_limit: Union[int, Dict] = None,
+        freq_limit: Union[int, Dict]=None,
         order_by_freq: bool = False,
         do_split: bool = False,
         sep: str = ',',
@@ -1204,8 +1202,8 @@ class FeatureTable(Table):
     def one_hot_encode(
         self,
         columns: List[str],
-        sizes: Union[int, List[int]] = None,
-        prefix: Union[str, List[str]] = None,
+        sizes: Union[int, List[int]]=None,
+        prefix: Union[str, List[str]]=None,
         keep_original_columns: bool = False
     ) -> "FeatureTable":
         """
@@ -1306,7 +1304,7 @@ class FeatureTable(Table):
                        str,
                        List[Union[str, Dict[str, Union[str, List[str]]]]],
                        Dict[str, Union[str, List[str]]]],
-        freq_limit: Optional[Union[int, str, Dict[str, int]]] = None,
+        freq_limit: Optional[Union[int, str, Dict[str, int]]]=None,
         order_by_freq: bool = False,
         do_split: bool = False,
         sep: str = ','
@@ -1316,8 +1314,8 @@ class FeatureTable(Table):
         start from 1 with 0 reserved for unknown features.
 
         :param columns: str, dict or a list of str, dict, target column(s) to generate StringIndex.
-               dict is a mapping of source column names -> target column name if needs to combine multiple
-               source columns to generate index.
+               dict is a mapping of source column names -> target column name
+               if needs to combine multiple source columns to generate index.
                For example: {'src_cols':['a_user', 'b_user'], 'col_name':'user'}.
         :param freq_limit: int, dict or None. Categories with a count/frequency below freq_limit
                will be omitted from the encoding. Can be represented as either an integer,
@@ -1502,7 +1500,7 @@ class FeatureTable(Table):
         self,
         columns: List[str],
         min_max_dict: Dict[str, Union[Tuple[float, float], Tuple[List[float], List[float]]]]
-    ) -> "FeatureTable": 
+    ) -> "FeatureTable":
         """
         Rescale each column individually with the given [min, max] range of each column.
 
@@ -1565,7 +1563,7 @@ class FeatureTable(Table):
         item_col: str = "item",
         label_col: str = "label",
         neg_num: int = 1
-    ) -> "FeatureTable": 
+    ) -> "FeatureTable":
         """
         Generate negative records for each record in the FeatureTable. All the records in the
         original FeatureTable will be treated as positive samples with value 1 for label_col
@@ -1590,7 +1588,7 @@ class FeatureTable(Table):
         min_len: int = 1,
         max_len: int = 100,
         num_seqs: int = 2147483647
-    ) -> "FeatureTable": 
+    ) -> "FeatureTable":
         """
         Add a column of history visits of each user.
 
@@ -1645,8 +1643,8 @@ class FeatureTable(Table):
         self,
         cols: List[str],
         seq_len: int = 100,
-        mask_cols: Union[str, List[str]] = None,
-        mask_token: Union[int, str] = 0
+        mask_cols: Union[str, List[str]]=None,
+        mask_token: Union[int, str]=0
     ) -> "FeatureTable":
         """
         Add padding on specified column(s).
@@ -1672,7 +1670,7 @@ class FeatureTable(Table):
         out_col: str,
         func: Callable,
         dtype: str = "string"
-    ) -> "FeatureTable": 
+    ) -> "FeatureTable":
         """
         Transform a FeatureTable using a user-defined Python function.
 
@@ -1737,7 +1735,7 @@ class FeatureTable(Table):
         dict_tbl: "FeatureTable",
         key: str,
         value: str
-    ) -> "FeatureTable": 
+    ) -> "FeatureTable":
         """
          Add features based on key columns and the key value Table.
          For each column in columns, it adds a value column using key-value pairs from dict_tbl.
@@ -1760,7 +1758,7 @@ class FeatureTable(Table):
         self,
         columns: List[str] = [],
         index_tbls: List["FeatureTable"] = []
-    ) -> "FeatureTable": 
+    ) -> "FeatureTable":
         """
         Replace the value using index_dicts for each col in columns, set 0 for default
 
@@ -1788,7 +1786,7 @@ class FeatureTable(Table):
         self,
         columns: List[str] = [],
         freq_limit: int = 10
-    ) -> List["FeatureTable"]: 
+    ) -> List["FeatureTable"]:
         """
         Generate a mapping from old index to new one based on popularity count on descending order
          :param columns: str or a list of str
@@ -1820,8 +1818,8 @@ class FeatureTable(Table):
 
     def group_by(
         self,
-        columns: Union[List[str], str] = [],
-        agg: Union[Dict[str, List[str]], List[str], Dict[str, str], str] = "count",
+        columns: Union[List[str], str]=[],
+        agg: Union[Dict[str, List[str]], List[str], Dict[str, str], str]="count",
         join: bool = False
     ) -> "FeatureTable":
         """
@@ -1898,7 +1896,7 @@ class FeatureTable(Table):
         self,
         cat_cols: Union[List[str], List[List[str]], str],
         target_cols: Union[List[str], str],
-        target_mean: Optional[Union[Dict[str, str], Dict[str, Union[int, float]]]] = None,
+        target_mean: Optional[Union[Dict[str, str], Dict[str, Union[int, float]]]]=None,
         smooth: int = 20,
         kfold: int = 2,
         fold_seed: Optional[int] = None,
@@ -1906,7 +1904,7 @@ class FeatureTable(Table):
         drop_cat: bool = False,
         drop_fold: bool = True,
         out_cols: Optional[List[List[str]]] = None
-    ) -> Tuple["FeatureTable", List["TargetCode"]]: 
+    ) -> Tuple["FeatureTable", List["TargetCode"]]:
         """
         For each categorical column or column group in cat_cols, calculate the mean of target
         columns in target_cols and encode the FeatureTable with the target mean(s) to generate
@@ -2155,10 +2153,10 @@ class FeatureTable(Table):
         self,
         columns: Union[List[str], str],
         sort_cols: Union[List[str], str],
-        shifts: Union[int, List[int]] = 1,
+        shifts: Union[int, List[int]]=1,
         partition_cols: Optional[List[str]] = None,
-        out_cols: Optional[Union[List[str], List[List[str]], str]] = None
-    ) -> "FeatureTable": 
+        out_cols: Optional[Union[List[str], List[List[str]], str]]=None
+    ) -> "FeatureTable":
         """
         Calculates the difference between two consecutive rows, or two rows with certain interval
         of the specified continuous columns. The table is first partitioned by partition_cols if it
@@ -2249,7 +2247,7 @@ class FeatureTable(Table):
         self,
         columns: Union[List[str], str],
         bins: Union[Dict[str, List[int]], int, List[int]],
-        labels: Optional[Union[List[str], Dict[str, List[str]]]] = None,
+        labels: Optional[Union[List[str], Dict[str, List[str]]]]=None,
         out_cols: Optional[str] = None,
         drop: bool = True
     ) -> "FeatureTable":
@@ -2336,7 +2334,7 @@ class FeatureTable(Table):
         return self._clone(df_buck)
 
     # TODO: Add UT
-    def get_vocabularies(self, columns: Union[str, List[str]]) -> Dict[str, Union[str,List[str]]]:
+    def get_vocabularies(self, columns: Union[str, List[str]]) -> Dict[str, Union[str, List[str]]]:
         """
         Create vocabulary for each column, and return dict of vocabularies
 
@@ -2647,7 +2645,7 @@ class TargetCode(Table):
         df: "SparkDataFrame",
         cat_col: Union[List[str], str],
         out_target_mean: Dict[str, Union[Tuple[str, str], Tuple[str, float], Tuple[str, int]]]
-    ) -> None: 
+    ) -> None:
         """
         Target Encoding output used for encoding new FeatureTables, which consists of the encoded
         categorical column or column group and the target encoded columns (mean statistics of

--- a/python/friesian/src/bigdl/friesian/feature/table.py
+++ b/python/friesian/src/bigdl/friesian/feature/table.py
@@ -981,7 +981,7 @@ class FeatureTable(Table):
     def encode_string(
         self,
         columns: Union[str, List[str]],
-        indices: Union["StringIndex", Dict[str,int], List[Dict[str, int]], List["StringIndex"]],
+        indices: Union["StringIndex", Dict[str, int], List[Dict[str, int]], List["StringIndex"]],
         broadcast: bool = True,
         do_split: bool = False,
         sep: str = ',',

--- a/python/friesian/src/bigdl/friesian/feature/table.py
+++ b/python/friesian/src/bigdl/friesian/feature/table.py
@@ -902,7 +902,9 @@ class FeatureTable(Table):
         return cls(Table._read_parquet(paths))
 
     @classmethod
-    def read_json(cls, paths: Union[str, List[str]], cols: Union[str, List[str]]=None) -> "FeatureTable":
+    def read_json(cls,
+                  paths: Union[str, List[str]],
+                  cols: Union[str, List[str]]=None) -> "FeatureTable":
         """
         Loads json files as a FeatureTable.
 
@@ -920,7 +922,7 @@ class FeatureTable(Table):
         paths: Union[str, List[str]],
         delimiter: str = ",",
         header: bool = False,
-        names: Optional[Union[str, List[str]]] = None,
+        names: Optional[Union[str, List[str]]]=None,
         dtype: Optional[Union[List[str], str, Dict[str, str]]]=None
     ) -> "FeatureTable":
         """
@@ -1049,7 +1051,9 @@ class FeatureTable(Table):
 
         return FeatureTable(data_df)
 
-    def filter_by_frequency(self, columns: Union[str, List[str]], min_freq: int = 2) -> "FeatureTable":
+    def filter_by_frequency(self,
+                            columns: Union[str, List[str]],
+                            min_freq: int = 2) -> "FeatureTable":
         """
         Filter the FeatureTable by the given minimum frequency on the target columns.
 
@@ -1699,7 +1703,7 @@ class FeatureTable(Table):
     def join(
         self,
         table: "FeatureTable",
-        on: Optional[Union[str, List[str]]] = None,
+        on: Optional[Union[str, List[str]]]=None,
         how: str = "inner",
         lsuffix: Optional[str] = None,
         rsuffix: Optional[str] = None
@@ -1758,8 +1762,8 @@ class FeatureTable(Table):
 
     def reindex(
         self,
-        columns: Union[str, List[str]] = [],
-        index_tbls: Union["FeatureTable", List["FeatureTable"]] = []
+        columns: Union[str, List[str]]=[],
+        index_tbls: Union["FeatureTable", List["FeatureTable"]]=[]
     ) -> "FeatureTable":
         """
         Replace the value using index_dicts for each col in columns, set 0 for default
@@ -1787,7 +1791,7 @@ class FeatureTable(Table):
     def gen_reindex_mapping(
         self,
         columns: List[str] = [],
-        freq_limit: Optional[Union[int, Dict[str,int]]] = 10
+        freq_limit: Optional[Union[int, Dict[str, int]]]=10
     ) -> List["FeatureTable"]:
         """
         Generate a mapping from old index to new one based on popularity count on descending order
@@ -1905,7 +1909,7 @@ class FeatureTable(Table):
         fold_col: str = "__fold__",
         drop_cat: bool = False,
         drop_fold: bool = True,
-        out_cols: Optional[Union[str, List[str], List[List[str]]]] = None
+        out_cols: Optional[Union[str, List[str], List[List[str]]]]=None
     ) -> Tuple["FeatureTable", List["TargetCode"]]:
         """
         For each categorical column or column group in cat_cols, calculate the mean of target
@@ -2112,7 +2116,7 @@ class FeatureTable(Table):
     def encode_target(
         self,
         targets: Union["TargetCode", List["TargetCode"]],
-        target_cols: Union[List[str], str] = None,
+        target_cols: Union[List[str], str]=None,
         drop_cat: bool = True
     ) -> "FeatureTable":
         """
@@ -2250,7 +2254,7 @@ class FeatureTable(Table):
         columns: Union[List[str], str],
         bins: Union[Dict[str, List[int]], int, List[int]],
         labels: Optional[Union[List[str], Dict[str, List[str]]]]=None,
-        out_cols: Optional[Union[List[str], str]] = None,
+        out_cols: Optional[Union[List[str], str]]=None,
         drop: bool = True
     ) -> "FeatureTable":
         """

--- a/python/friesian/src/bigdl/friesian/feature/table.py
+++ b/python/friesian/src/bigdl/friesian/feature/table.py
@@ -218,7 +218,6 @@ class Table:
         return self._clone(self.df.withColumn("partitionId", spark_partition_id())
                            .groupBy("partitionId").count())
 
-    # TODO: UTs on `value` of boolean
     def fillna(
         self,
         value: Union[int, float, str, bool],
@@ -982,7 +981,7 @@ class FeatureTable(Table):
     def encode_string(
         self,
         columns: Union[str, List[str]],
-        indices: Union["StringIndex", List[Dict[str, int]], List["StringIndex"]],
+        indices: Union["StringIndex", Dict[str,int], List[Dict[str, int]], List["StringIndex"]],
         broadcast: bool = True,
         do_split: bool = False,
         sep: str = ',',
@@ -2342,7 +2341,7 @@ class FeatureTable(Table):
         return self._clone(df_buck)
 
     # TODO: Add UT
-    def get_vocabularies(self, columns: Union[str, List[str]]) -> Dict[str, Union[str, List[str]]]:
+    def get_vocabularies(self, columns: Union[str, List[str]]) -> Dict[str, List[str]]:
         """
         Create vocabulary for each column, and return dict of vocabularies
 
@@ -2357,7 +2356,6 @@ class FeatureTable(Table):
                 .distinct().rdd.map(lambda row: row[col]).collect()
         return vocabularies
 
-    # TODO: Add UT when columns is str
     def sample_listwise(
         self,
         columns: Union[str, List[str]],

--- a/python/friesian/src/bigdl/friesian/feature/table.py
+++ b/python/friesian/src/bigdl/friesian/feature/table.py
@@ -377,7 +377,7 @@ class Table:
             check_col_exists(self.df, columns)
         return self._clone(fill_median(self.df, columns))
 
-    def fill_median(self, columns: List[str]) -> "Table":
+    def median(self, columns: List[str]) -> "Table":
         """
         Returns a new Table that has two columns, `column` and `median`, containing the column
         names and the medians of the specified numeric columns.

--- a/python/friesian/src/bigdl/friesian/feature/table.py
+++ b/python/friesian/src/bigdl/friesian/feature/table.py
@@ -68,7 +68,7 @@ class Table:
         return self.df.schema
 
     @staticmethod
-    def _read_parquet(paths: Union[List[str], str]) -> "SparkDataFrame":
+    def _read_parquet(paths: Union[str, List[str]]) -> "SparkDataFrame":
         if not isinstance(paths, list):
             paths = [paths]
         spark = OrcaContext.get_spark_session()
@@ -76,7 +76,7 @@ class Table:
         return df
 
     @staticmethod
-    def _read_json(paths: str, cols: Union[List[str], str]) -> "SparkDataFrame":
+    def _read_json(paths: Union[str, List[str]], cols: Union[str, List[str]]) -> "SparkDataFrame":
         if not isinstance(paths, list):
             paths = [paths]
         spark = OrcaContext.get_spark_session()
@@ -96,7 +96,7 @@ class Table:
         paths: str,
         delimiter: str = ",",
         header: bool = False,
-        names: Optional[Union[List[str], str]]=None,
+        names: Optional[Union[str, List[str]]]=None,
         dtype: Optional[Union[List[str], Dict[str, str], str]]=None
     ) -> "SparkDataFrame":
         if not isinstance(paths, list):
@@ -162,7 +162,7 @@ class Table:
         """
         self.df = broadcast(self.df)
 
-    def select(self, *cols: Union[List[str], str]) -> "Table":
+    def select(self, *cols: Union[str, List[str]]) -> "Table":
         """
         Select specific columns.
 
@@ -178,7 +178,7 @@ class Table:
                               "cols should be str or a list of str, but got None.")
         return self._clone(self.df.select(*cols))
 
-    def drop(self, *cols: Union[List[str], str]) -> "Table":
+    def drop(self, *cols: Union[str, List[str]]) -> "Table":
         """
         Returns a new Table that drops the specified column.
         This is a no-op if schema doesn't contain the given column name(s).
@@ -222,7 +222,7 @@ class Table:
     def fillna(
         self,
         value: Union[int, float, str, bool],
-        columns: Optional[Union[List[str], str]]
+        columns: Optional[Union[str, List[str]]]
     ) -> "FeatureTable":
         """
         Replace null values.
@@ -251,7 +251,7 @@ class Table:
 
     def dropna(
         self,
-        columns: Optional[Union[List[str], str]],
+        columns: Optional[Union[str, List[str]]],
         how: str = "any",
         thresh: Optional[int] = None
     ) -> "Table":
@@ -311,7 +311,7 @@ class Table:
 
     def clip(
         self,
-        columns: Optional[Union[List[str], str]]=None,
+        columns: Optional[Union[str, List[str]]]=None,
         min: Optional[NUMERIC_TYPE] = None,
         max: Optional[NUMERIC_TYPE] = None
     ) -> "Table":
@@ -340,7 +340,7 @@ class Table:
 
     def log(
         self,
-        columns: Optional[Union[List[str], str]]=None,
+        columns: Optional[Union[str, List[str]]]=None,
         clipping: bool = True
     ) -> "Table":
         """
@@ -361,7 +361,7 @@ class Table:
         check_col_exists(self.df, columns)
         return self._clone(log_with_clip(self.df, columns, clipping))
 
-    def fill_median(self, columns: Optional[Union[List[str], str]]=None) -> "Table":
+    def fill_median(self, columns: Optional[Union[str, List[str]]]=None) -> "Table":
         """
         Replaces null values with the median in the specified numeric columns. Any column to be
         filled should not contain only null values.
@@ -395,7 +395,7 @@ class Table:
         return self._clone(median(self.df, columns))
 
     def merge_cols(self,
-                   columns: Union[List[str], str],
+                   columns: Union[str, List[str]],
                    target: str) -> "Table":
         """
         Merge the target column values as a list to a new column.
@@ -440,9 +440,9 @@ class Table:
 
     def get_stats(
         self,
-        columns: Optional[Union[List[str], str]],
+        columns: Optional[Union[str, List[str]]],
         aggr: Union[Dict[str, List[str]], List[str], Dict[str, str], str]
-    ) -> Dict[str, Union[List[Union[float, int]], int, float]]:
+    ) -> Dict[str, Union[List[NUMERIC_TYPE], NUMERIC_TYPE]]:
         """
         Calculate the statistics of the values over the target column(s).
 
@@ -549,7 +549,7 @@ class Table:
             result[column] = [row[i] for row in rows]
         return result
 
-    def add(self, columns: Union[List[str], str], value: NUMERIC_TYPE=1) -> "Table":
+    def add(self, columns: Union[str, List[str]], value: NUMERIC_TYPE=1) -> "Table":
         """
         Increase all of values of the target numeric column(s) by a constant value.
 
@@ -624,7 +624,7 @@ class Table:
         """
         write_parquet(self.df, path, mode)
 
-    def cast(self, columns: Optional[Union[List[str], str]], dtype: str) -> "StringIndex":
+    def cast(self, columns: Optional[Union[str, List[str]]], dtype: str) -> "Table":
         """
         Cast columns to the specified type.
 
@@ -737,9 +737,9 @@ class Table:
 
     def drop_duplicates(
         self,
-        subset: Optional[Union[List[str], str]]=None,
-        sort_cols: Optional[Union[List[str], str]]=None,
-        keep: str="min"
+        subset: Optional[Union[str, List[str]]]=None,
+        sort_cols: Optional[Union[str, List[str]]]=None,
+        keep: str = "min"
     ) -> "Table":
         """
         Return a new Table with duplicate rows removed.
@@ -893,7 +893,7 @@ class Table:
 
 class FeatureTable(Table):
     @classmethod
-    def read_parquet(cls, paths: Union[List[str], str]) -> "FeatureTable":
+    def read_parquet(cls, paths: Union[str, List[str]]) -> "FeatureTable":
         """
         Loads Parquet files as a FeatureTable.
 
@@ -925,7 +925,7 @@ class FeatureTable(Table):
         delimiter: str = ",",
         header: bool = False,
         names: Optional[Union[str, List[str]]]=None,
-        dtype: Optional[Union[List[str], str, Dict[str, str]]]=None
+        dtype: Optional[Union[str, List[str], Dict[str, str]]]=None
     ) -> "FeatureTable":
         """
         Loads csv files as a FeatureTable.
@@ -981,7 +981,7 @@ class FeatureTable(Table):
 
     def encode_string(
         self,
-        columns: Union[List[str], str],
+        columns: Union[str, List[str]],
         indices: Union["StringIndex", List[Dict[str, int]], List["StringIndex"]],
         broadcast: bool = True,
         do_split: bool = False,
@@ -1078,7 +1078,7 @@ class FeatureTable(Table):
 
     def hash_encode(
         self,
-        columns: Union[List[str], str],
+        columns: Union[str, List[str]],
         bins: int,
         method: str = 'md5'
     ) -> "FeatureTable":
@@ -1104,9 +1104,9 @@ class FeatureTable(Table):
 
     def cross_hash_encode(
         self,
-        cross_columns: Union[List[str], List[List[str]], str],
-        bin_sizes: List[int],
-        cross_col_names: Optional[Union[List[str], str, List[int]]]=None,
+        cross_columns: Union[List[str], List[List[str]]],
+        bin_sizes: Union[int, List[int]],
+        cross_col_names: Optional[Union[str, List[str]]]=None,
         method: str = 'md5'
     ) -> "FeatureTable":
         """
@@ -1169,7 +1169,7 @@ class FeatureTable(Table):
     def category_encode(
         self,
         columns: Union[str, List[str]],
-        freq_limit: Optional[Union[int, Dict]]=None,
+        freq_limit: Optional[Union[int, Dict[str, int]]]=None,
         order_by_freq: bool = False,
         do_split: bool = False,
         sep: str = ',',
@@ -1674,7 +1674,7 @@ class FeatureTable(Table):
 
     def apply(
         self,
-        in_col: Union[List[str], str],
+        in_col: Union[str, List[str]],
         out_col: str,
         func: Callable,
         dtype: str = "string"
@@ -1739,8 +1739,8 @@ class FeatureTable(Table):
 
     def add_value_features(
         self,
-        columns: Union[List[str], str],
-        dict_tbl: "FeatureTable",
+        columns: Union[str, List[str]],
+        dict_tbl: "Table",
         key: str,
         value: str
     ) -> "FeatureTable":
@@ -1765,7 +1765,7 @@ class FeatureTable(Table):
     def reindex(
         self,
         columns: Union[str, List[str]]=[],
-        index_tbls: Union["FeatureTable", List["FeatureTable"]]=[]
+        index_tbls: Union["Table", List["Table"]]=[]
     ) -> "FeatureTable":
         """
         Replace the value using index_dicts for each col in columns, set 0 for default
@@ -1826,7 +1826,7 @@ class FeatureTable(Table):
 
     def group_by(
         self,
-        columns: Union[List[str], str]=[],
+        columns: Union[str, List[str]]=[],
         agg: Union[Dict[str, List[str]], List[str], Dict[str, str], str]="count",
         join: bool = False
     ) -> "FeatureTable":
@@ -1903,8 +1903,8 @@ class FeatureTable(Table):
     def target_encode(
         self,
         cat_cols: Union[List[str], List[List[str]], str],
-        target_cols: Union[List[str], str],
-        target_mean: Optional[Dict[str, Union[int, float, str]]]=None,
+        target_cols: Union[str, List[str]],
+        target_mean: Optional[Dict[str, NUMERIC_TYPE]]=None,
         smooth: int = 20,
         kfold: int = 2,
         fold_seed: Optional[int] = None,
@@ -2118,7 +2118,7 @@ class FeatureTable(Table):
     def encode_target(
         self,
         targets: Union["TargetCode", List["TargetCode"]],
-        target_cols: Union[List[str], str]=None,
+        target_cols: Union[str, List[str]]=None,
         drop_cat: bool = True
     ) -> "FeatureTable":
         """
@@ -2159,10 +2159,10 @@ class FeatureTable(Table):
 
     def difference_lag(
         self,
-        columns: Union[List[str], str],
-        sort_cols: Union[List[str], str],
+        columns: Union[str, List[str]],
+        sort_cols: Union[str, List[str]],
         shifts: Union[int, List[int]]=1,
-        partition_cols: Optional[List[str]] = None,
+        partition_cols: Optional[Union[str, List[str]]]=None,
         out_cols: Optional[Union[List[str], List[List[str]], str]]=None
     ) -> "FeatureTable":
         """
@@ -2253,10 +2253,10 @@ class FeatureTable(Table):
 
     def cut_bins(
         self,
-        columns: Union[List[str], str],
-        bins: Union[Dict[str, List[int]], int, List[int]],
+        columns: Union[str, List[str]],
+        bins: Union[Dict[str, Union[int, List[int]]], int, List[int]],
         labels: Optional[Union[List[str], Dict[str, List[str]]]]=None,
-        out_cols: Optional[Union[List[str], str]]=None,
+        out_cols: Optional[Union[str, List[str]]]=None,
         drop: bool = True
     ) -> "FeatureTable":
         """
@@ -2363,7 +2363,7 @@ class FeatureTable(Table):
         columns: Union[str, List[str]],
         num_sampled_list: int,
         num_sampled_item: int,
-        random_seed: int = None,
+        random_seed: Optional[int] = None,
         replace: bool = True
     ) -> "FeatureTable":
         """
@@ -2476,7 +2476,7 @@ class FeatureTable(Table):
 
     def string_embed(
         self,
-        columns: Union[List[str], str],
+        columns: Union[str, List[str]],
         bert_model: str = 'distilbert-base-uncased',
         reduce_dim: Optional[int] = None,
         replace: bool = True
@@ -2563,7 +2563,7 @@ class StringIndex(Table):
 
     @classmethod
     def read_parquet(cls,
-                     paths: Union[List[str], str],
+                     paths: Union[str, List[str]],
                      col_name: Optional[str] = None) -> "StringIndex":
         """
         Loads Parquet files as a StringIndex.
@@ -2653,8 +2653,8 @@ class TargetCode(Table):
     def __init__(
         self,
         df: "SparkDataFrame",
-        cat_col: Union[List[str], str],
-        out_target_mean: Dict[str, Tuple[str, Union[str, float, int]]]
+        cat_col: Union[str, List[str]],
+        out_target_mean: Dict[str, Tuple[str, NUMERIC_TYPE]]
     ) -> None:
         """
         Target Encoding output used for encoding new FeatureTables, which consists of the encoded

--- a/python/friesian/src/bigdl/friesian/feature/table.py
+++ b/python/friesian/src/bigdl/friesian/feature/table.py
@@ -44,6 +44,7 @@ from typing import (
     Tuple,
     Union,
 )
+NUMERIC_TYPE = TypeVar('NUMERIC_TYPE', int, float, complex)
 
 if TYPE_CHECKING:
     from pandas.core.frame import DataFrame as PandasDataFrame
@@ -51,7 +52,6 @@ if TYPE_CHECKING:
     from pyspark.sql import Row
     from pyspark.sql.dataframe import DataFrame as SparkDataFrame
     from pyspark.sql.types import StructType
-    NUMERIC_TYPE = TypeVar('NUMERIC_TYPE', int, float, complex)
 
 
 JAVA_INT_MIN = -2147483648
@@ -96,7 +96,7 @@ class Table:
         paths: str,
         delimiter: str = ",",
         header: bool = False,
-        names: Optional[Union[List[str], str]] = None,
+        names: Optional[Union[List[str], str]]=None,
         dtype: Optional[Union[List[str], Dict[str, str], str]]=None
     ) -> "SparkDataFrame":
         if not isinstance(paths, list):
@@ -311,7 +311,7 @@ class Table:
 
     def clip(
         self,
-        columns: Optional[Union[List[str], str]] = None,
+        columns: Optional[Union[List[str], str]]=None,
         min: Optional[NUMERIC_TYPE] = None,
         max: Optional[NUMERIC_TYPE] = None
     ) -> "Table":
@@ -340,7 +340,7 @@ class Table:
 
     def log(
         self,
-        columns: Optional[Union[List[str], str]] = None,
+        columns: Optional[Union[List[str], str]]=None,
         clipping: bool = True
     ) -> "Table":
         """

--- a/python/friesian/src/bigdl/friesian/feature/table.py
+++ b/python/friesian/src/bigdl/friesian/feature/table.py
@@ -93,7 +93,7 @@ class Table:
 
     @staticmethod
     def _read_csv(
-        paths: str,
+        paths: Union[str, List[str]],
         delimiter: str = ",",
         header: bool = False,
         names: Optional[Union[str, List[str]]]=None,

--- a/python/friesian/src/bigdl/friesian/feature/table.py
+++ b/python/friesian/src/bigdl/friesian/feature/table.py
@@ -16,11 +16,13 @@
 import copy
 import hashlib
 import os
+from pickle import DICT
 import random
 import sys
 from functools import reduce
+from tkinter.messagebox import NO
 
-import numpy as np
+import numpy as np 
 import pyspark.sql.functions as F
 from bigdl.friesian.feature.utils import *
 from bigdl.dllib.utils.log4Error import *
@@ -34,21 +36,39 @@ from pyspark.sql.functions import col as pyspark_col, concat, udf, array, broadc
     lit, rank, monotonically_increasing_id, row_number, desc
 from pyspark.sql.types import ArrayType, DataType, StructType, StringType, StructField
 
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
+
+if TYPE_CHECKING:
+    from pandas.core.frame import DataFrame as PandasDataFrame
+    from pyspark.sql.column import Column
+    from pyspark.sql import Row
+    from pyspark.sql.dataframe import DataFrame as SparkDataFrame
+    from pyspark.sql.types import StructType
+
+
 JAVA_INT_MIN = -2147483648
 JAVA_INT_MAX = 2147483647
 
 
 class Table:
-    def __init__(self, df):
+    def __init__(self, df: "SparkDataFrame") -> None:
         self.df = df
         self.__column_names = self.df.schema.names
 
     @property
-    def schema(self):
+    def schema(self) -> "StructType":
         return self.df.schema
 
     @staticmethod
-    def _read_parquet(paths):
+    def _read_parquet(paths: Union[List[str], str]) -> "SparkDataFrame":
         if not isinstance(paths, list):
             paths = [paths]
         spark = OrcaContext.get_spark_session()
@@ -56,7 +76,7 @@ class Table:
         return df
 
     @staticmethod
-    def _read_json(paths, cols):
+    def _read_json(paths: str, cols: Union[List, str]):
         if not isinstance(paths, list):
             paths = [paths]
         spark = OrcaContext.get_spark_session()
@@ -72,7 +92,13 @@ class Table:
         return df
 
     @staticmethod
-    def _read_csv(paths, delimiter=",", header=False, names=None, dtype=None):
+    def _read_csv(
+        paths: str,
+        delimiter: str = ",",
+        header: bool = False,
+        names: Optional[List[str]] = None,
+        dtype: Optional[Union[List[str], Dict[str, str], str]] = None
+    ) -> "SparkDataFrame":
         if not isinstance(paths, list):
             paths = [paths]
         spark = OrcaContext.get_spark_session()
@@ -103,17 +129,17 @@ class Table:
                                   "dtype should be str or a list of str or dict")
         return tbl.df
 
-    def _clone(self, df):
+    def _clone(self, df: "SparkDataFrame") -> "Table":
         return Table(df)
 
-    def compute(self):
+    def compute(self) -> "Table":
         """
         Trigger computation of the Table.
         """
         compute(self.df)
         return self
 
-    def to_spark_df(self):
+    def to_spark_df(self) -> "SparkDataFrame":
         """
         Convert the current Table to a Spark DataFrame.
 
@@ -121,7 +147,7 @@ class Table:
         """
         return self.df
 
-    def size(self):
+    def size(self) -> int:
         """
         Returns the number of rows in this Table.
 
@@ -136,7 +162,7 @@ class Table:
         """
         self.df = broadcast(self.df)
 
-    def select(self, *cols):
+    def select(self, *cols: Union[List, str]) -> "Table":
         """
         Select specific columns.
 
@@ -152,7 +178,7 @@ class Table:
                               "cols should be str or a list of str, but got None.")
         return self._clone(self.df.select(*cols))
 
-    def drop(self, *cols):
+    def drop(self, *cols: Union[List, str]) -> "Table":
         """
         Returns a new Table that drops the specified column.
         This is a no-op if schema doesn't contain the given column name(s).
@@ -164,7 +190,7 @@ class Table:
         """
         return self._clone(self.df.drop(*cols))
 
-    def limit(self, num):
+    def limit(self, num: int) -> "Table":
         """
         Limits the result count to the number specified.
 
@@ -173,7 +199,7 @@ class Table:
         """
         return self._clone(self.df.limit(num))
 
-    def repartition(self, num_partitions):
+    def repartition(self, num_partitions: int) -> "Table":
         """
         Return a new Table that has exactly num_partitions partitions.
 
@@ -182,7 +208,7 @@ class Table:
         """
         return self._clone(self.df.repartition(num_partitions))
 
-    def get_partition_row_number(self):
+    def get_partition_row_number(self) -> "Table":
         """
         Return a Table that contains partitionId and corresponding row number.
 
@@ -192,7 +218,11 @@ class Table:
         return self._clone(self.df.withColumn("partitionId", spark_partition_id())
                            .groupBy("partitionId").count())
 
-    def fillna(self, value, columns):
+    def fillna(
+        self,
+        value: Union[int, float, str],
+        columns: Optional[Union[List[str], str]]
+    ) -> "FeatureTable":
         """
         Replace null values.
 
@@ -218,7 +248,12 @@ class Table:
                 return self._clone(fill_na_int(self.df, value, columns))
         return self._clone(fill_na(self.df, value, columns))
 
-    def dropna(self, columns, how='any', thresh=None):
+    def dropna(
+        self,
+        columns: List[str],
+        how: str = "any",
+        thresh: Optional[int] = None
+    ) -> "Table": 
         """
         Drops the rows containing null values in the specified columns.
 
@@ -234,7 +269,7 @@ class Table:
         """
         return self._clone(self.df.dropna(how, thresh, subset=columns))
 
-    def distinct(self):
+    def distinct(self) -> "Table":
         """
         Select the distinct rows of the Table.
 
@@ -242,7 +277,7 @@ class Table:
         """
         return self._clone(self.df.distinct())
 
-    def filter(self, condition):
+    def filter(self, condition: Union[str, "Column"]) -> "Table":
         """
         Filters the rows that satisfy `condition`. For instance, filter("col_1 == 1") will filter
         the rows that has value 1 at column col_1.
@@ -253,7 +288,11 @@ class Table:
         """
         return self._clone(self.df.filter(condition))
 
-    def random_split(self, weights, seed=None):
+    def random_split(
+        self,
+        weights: List[float],
+        seed: Optional[int] = None
+    ) -> List["Table"]:
         """
         Randomly split Table into multiple Tables with the provided weights for train, validation
         and test.
@@ -269,7 +308,12 @@ class Table:
 
     split = random_split
 
-    def clip(self, columns, min=None, max=None):
+    def clip(
+        self,
+        columns: Optional[List[str]],
+        min: Optional[int] = None,
+        max: Optional[int] = None
+    ) -> "Table":
         """
         Clips continuous values so that they are within the range [min, max]. For instance, by
         setting the min value to 0, all negative values in columns will be replaced with 0.
@@ -293,7 +337,11 @@ class Table:
         check_col_exists(self.df, columns)
         return self._clone(clip(self.df, columns, min, max))
 
-    def log(self, columns, clipping=True):
+    def log(
+        self,
+        columns: List[str],
+        clipping: bool = True
+    ) -> "Table": 
         """
         Calculates the log of continuous columns.
 
@@ -312,7 +360,7 @@ class Table:
         check_col_exists(self.df, columns)
         return self._clone(log_with_clip(self.df, columns, clipping))
 
-    def fill_median(self, columns):
+    def fill_median(self, columns: List[str]) -> "Table":
         """
         Replaces null values with the median in the specified numeric columns. Any column to be
         filled should not contain only null values.
@@ -329,7 +377,7 @@ class Table:
             check_col_exists(self.df, columns)
         return self._clone(fill_median(self.df, columns))
 
-    def median(self, columns):
+    def fill_median(self, columns: List[str]) -> "Table":
         """
         Returns a new Table that has two columns, `column` and `median`, containing the column
         names and the medians of the specified numeric columns.
@@ -345,7 +393,7 @@ class Table:
             check_col_exists(self.df, columns)
         return self._clone(median(self.df, columns))
 
-    def merge_cols(self, columns, target):
+    def merge_cols(self, columns: List[str], target: str) -> "Table":
         """
         Merge the target column values as a list to a new column.
         The original columns will be dropped.
@@ -359,7 +407,7 @@ class Table:
                           "columns must be a list of column names")
         return self._clone(self.df.withColumn(target, array(columns)).drop(*columns))
 
-    def rename(self, columns):
+    def rename(self, columns: Dict[str, str]) -> "Table":
         """
         Rename columns with new column names
 
@@ -376,7 +424,7 @@ class Table:
             new_df = new_df.withColumnRenamed(old_name, new_name)
         return self._clone(new_df)
 
-    def show(self, n=20, truncate=True):
+    def show(self, n: int = 20, truncate: bool = True) -> None: 
         """
         Prints the first `n` rows to the console.
 
@@ -387,7 +435,11 @@ class Table:
         """
         self.df.show(n, truncate)
 
-    def get_stats(self, columns, aggr):
+    def get_stats(
+        self,
+        columns: Optional[Union[List[str], str]],
+        aggr: Union[Dict[str, List[str]], List[str], Dict[str, str], str]
+    ) -> Dict[str, Union[List[Union[float, int]], int, float]]:
         """
         Calculate the statistics of the values over the target column(s).
 
@@ -431,7 +483,7 @@ class Table:
             stats[column] = values[0] if len(values) == 1 else values
         return stats
 
-    def min(self, columns):
+    def min(self, columns: Union[str, List[str]]) -> "Table":
         """
         Returns a new Table that has two columns, `column` and `min`, containing the column
         names and the minimum values of the specified numeric columns.
@@ -448,7 +500,7 @@ class Table:
         spark = OrcaContext.get_spark_session()
         return self._clone(spark.createDataFrame(data, schema))
 
-    def max(self, columns):
+    def max(self, columns: Union[str, List[str]]) -> "Table":
         """
         Returns a new Table that has two columns, `column` and `max`, containing the column
         names and the maximum values of the specified numeric columns.
@@ -465,7 +517,7 @@ class Table:
         spark = OrcaContext.get_spark_session()
         return self._clone(spark.createDataFrame(data, schema))
 
-    def to_list(self, column):
+    def to_list(self, column: str) -> List: 
         """
         Convert all values of the target column to a list.
         Only call this if the Table is small enough.
@@ -480,7 +532,7 @@ class Table:
         check_col_exists(self.df, [column])
         return self.df.select(column).rdd.flatMap(lambda x: x).collect()
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, List]:
         """
         Convert the Table to a dictionary.
         Only call this if the Table is small enough.
@@ -494,7 +546,7 @@ class Table:
             result[column] = [row[i] for row in rows]
         return result
 
-    def add(self, columns, value=1):
+    def add(self, columns: List[str], value: Union[int, float] = 1) -> "Table":
         """
         Increase all of values of the target numeric column(s) by a constant value.
 
@@ -521,7 +573,7 @@ class Table:
         return self._clone(new_df)
 
     @property
-    def columns(self):
+    def columns(self) -> List[str]:
         """
         Get column names of the Table.
 
@@ -529,7 +581,12 @@ class Table:
         """
         return self.__column_names
 
-    def sample(self, fraction, replace=False, seed=None):
+    def sample(
+        self,
+        fraction: float,
+        replace: bool = False,
+        seed: Optional[int] = None
+    ) -> "Table": 
         """
         Return a sampled subset of Table.
 
@@ -542,7 +599,7 @@ class Table:
         """
         return self._clone(self.df.sample(withReplacement=replace, fraction=fraction, seed=seed))
 
-    def ordinal_shuffle_partition(self):
+    def ordinal_shuffle_partition(self) -> "Table":
         """
         Shuffle each partition of the Table by adding a random ordinal column for each row and sort
         by this ordinal column within each partition.
@@ -551,7 +608,7 @@ class Table:
         """
         return self._clone(ordinal_shuffle_partition(self.df))
 
-    def write_parquet(self, path, mode="overwrite"):
+    def write_parquet(self, path: str, mode: str = "overwrite") -> None:
         """
         Write the Table to Parquet file.
 
@@ -564,7 +621,7 @@ class Table:
         """
         write_parquet(self.df, path, mode)
 
-    def cast(self, columns, dtype):
+    def cast(self, columns: str, dtype: str) -> "StringIndex":
         """
         Cast columns to the specified type.
 
@@ -593,7 +650,14 @@ class Table:
             df_cast.df = df_cast.df.withColumn(i, pyspark_col(i).cast(dtype))
         return df_cast
 
-    def write_csv(self, path, delimiter=",", mode="overwrite", header=True, num_partitions=None):
+    def write_csv(
+        self,
+        path: str,
+        delimiter: str = ",",
+        mode: str = "overwrite",
+        header: bool = True,
+        num_partitions: Optional[int] = None
+    ) -> None:
         """
         Write the Table to csv file.
 
@@ -614,7 +678,7 @@ class Table:
         else:
             self.df.write.csv(path=path, mode=mode, header=header, sep=delimiter)
 
-    def _concat(self, join="outer"):
+    def _concat(self, join: str = "outer") -> Callable:
         def concat_inner(self, df2):
             col_names_1 = set(self.schema.names)
             col_names_2 = set(df2.schema.names)
@@ -638,7 +702,12 @@ class Table:
         else:
             return concat_inner
 
-    def concat(self, tables, mode="inner", distinct=False):
+    def concat(
+        self,
+        tables: Union["Table", List["Table"]],
+        mode: str = "inner",
+        distinct: bool = False
+    ) -> "Table": 
         """
         Concatenate a list of Tables into one Table in the dimension of row.
 
@@ -663,7 +732,12 @@ class Table:
             df = df.distinct()
         return self._clone(df)
 
-    def drop_duplicates(self, subset=None, sort_cols=None, keep="min"):
+    def drop_duplicates(
+        self,
+        subset: Optional[List[str]] = None,
+        sort_cols: Optional[Union[List[str], str]] = None,
+        keep: str = "min"
+    ) -> "Table": 
         """
         Return a new Table with duplicate rows removed.
 
@@ -703,7 +777,7 @@ class Table:
         df = df.filter(pyspark_col('rank') == 1).drop('rank', 'id')
         return self._clone(df)
 
-    def append_column(self, name, column):
+    def append_column(self, name: str, column: "Column") -> "Table": 
         """
         Append a column with a constant value to the Table.
 
@@ -716,7 +790,7 @@ class Table:
                           "column should be a pyspark.sql.column.Column")
         return self._clone(self.df.withColumn(name, column))
 
-    def subtract(self, other):
+    def subtract(self, other: "Table") -> "Table":
         """
         Return a new :class:`Table` containing rows in this :class:`Table`
         but not in another :class:`Table`
@@ -726,19 +800,19 @@ class Table:
         """
         return self._clone(self.df.subtract(other.df))
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> "Column":
         """
         Get the target column of the Table.
         """
         return self.df.__getattr__(name)
 
-    def col(self, name):
+    def col(self, name: str) -> "Column":
         """
         Get the target column of the Table.
         """
         return pyspark_col(name)
 
-    def sort(self, *cols, **kwargs):
+    def sort(self, *cols: List["Column"], **kwargs: Union[bool, List[bool]]) -> "Table": 
         """
         Sort the Table by specified column(s).
 
@@ -754,10 +828,10 @@ class Table:
 
     order_by = sort
 
-    def to_pandas(self):
+    def to_pandas(self) -> "PandasDataFrame":
         return self.df.toPandas()
 
-    def cache(self):
+    def cache(self) -> "Table":
         """
         Persist this Table in memory.
 
@@ -766,7 +840,7 @@ class Table:
         self.df.cache()
         return self
 
-    def uncache(self):
+    def uncache(self) -> "Table":
         """
 
         Make this table as non-persistent and remove all its blocks from memory.
@@ -780,7 +854,7 @@ class Table:
                 print("Try to unpersist an uncached table")
         return self
 
-    def coalesce(self, num_partitions):
+    def coalesce(self, num_partitions: int) -> "Table":
         """
         Return a new Table that has exactly num_partitions partitions.
         coalesce uses existing partitions to minimize the amount of data that's shuffled.
@@ -790,7 +864,7 @@ class Table:
         """
         return self._clone(self.df.coalesce(num_partitions))
 
-    def intersect(self, other):
+    def intersect(self, other: "Table") -> "Table":
         """
         Return a new :class:`Table` containing rows only in both this :class:`Table`
         and another :class:`Table`
@@ -800,14 +874,14 @@ class Table:
         """
         return self._clone(self.df.intersect(other.df))
 
-    def collect(self):
+    def collect(self) -> List["Row"]:
         """
         Returns all the records as a list of :class:`Row`.
         """
         return self.df.collect()
 
     @property
-    def dtypes(self):
+    def dtypes(self) -> List[Tuple[str,str]]:
         """
         Returns all column names and their data types as a list.
         """
@@ -816,7 +890,7 @@ class Table:
 
 class FeatureTable(Table):
     @classmethod
-    def read_parquet(cls, paths):
+    def read_parquet(cls, paths: str) -> "FeatureTable":
         """
         Loads Parquet files as a FeatureTable.
 
@@ -827,7 +901,7 @@ class FeatureTable(Table):
         return cls(Table._read_parquet(paths))
 
     @classmethod
-    def read_json(cls, paths, cols=None):
+    def read_json(cls, paths: str, cols=None) -> "FeatureTable":
         """
         Loads json files as a FeatureTable.
 
@@ -840,7 +914,14 @@ class FeatureTable(Table):
         return cls(Table._read_json(paths, cols))
 
     @classmethod
-    def read_csv(cls, paths, delimiter=",", header=False, names=None, dtype=None):
+    def read_csv(
+        cls,
+        paths: str,
+        delimiter: str = ",",
+        header: bool = False,
+        names: Optional[List[str]] = None,
+        dtype: Optional[Union[List[str], str, Dict[str, str]]] = None
+    ) -> "FeatureTable":
         """
         Loads csv files as a FeatureTable.
 
@@ -865,7 +946,7 @@ class FeatureTable(Table):
         return cls(Table._read_csv(paths, delimiter, header, names, dtype))
 
     @classmethod
-    def read_text(cls, paths, col_name="value"):
+    def read_text(cls, paths: str, col_name: str = "value") -> "FeatureTable":
         """
         Loads text files as a FeatureTable.
 
@@ -881,7 +962,7 @@ class FeatureTable(Table):
         return tbl
 
     @staticmethod
-    def from_pandas(pandas_df):
+    def from_pandas(pandas_df: "PandasDataFrame") -> "FeatureTable":
         """
         Returns the contents of of a pandas DataFrame as FeatureTable.
 
@@ -893,8 +974,16 @@ class FeatureTable(Table):
         sparkDF = spark.createDataFrame(pandas_df)
         return FeatureTable(sparkDF)
 
-    def encode_string(self, columns, indices, broadcast=True, do_split=False,
-                      sep=',', sort_for_array=False, keep_most_frequent=False):
+    def encode_string(
+        self,
+        columns: Union[List[str], str],
+        indices: Union["StringIndex", List[Dict[str, int]], List["StringIndex"]],
+        broadcast: bool = True,
+        do_split: bool = False,
+        sep: str = ',',
+        sort_for_array: bool = False,
+        keep_most_frequent: bool = False
+    ) -> "FeatureTable":
         """
         Encode columns with provided list of StringIndex. Unknown string will be
         None after the encoding and you may need to fillna with 0.
@@ -959,7 +1048,7 @@ class FeatureTable(Table):
 
         return FeatureTable(data_df)
 
-    def filter_by_frequency(self, columns, min_freq=2):
+    def filter_by_frequency(self, columns: List[str], min_freq: int = 2) -> "FeatureTable":
         """
         Filter the FeatureTable by the given minimum frequency on the target columns.
 
@@ -980,7 +1069,12 @@ class FeatureTable(Table):
         group = key.filter(key[filter_col_name] >= min_freq).drop(filter_col_name)
         return FeatureTable(group)
 
-    def hash_encode(self, columns, bins, method='md5'):
+    def hash_encode(
+        self,
+        columns: Union[List[str], str],
+        bins: int,
+        method: str = 'md5'
+    ) -> "FeatureTable":
         """
         Hash encode for categorical column(s).
 
@@ -1001,7 +1095,13 @@ class FeatureTable(Table):
             hash_df = hash_df.withColumn(col_name, hash_int(pyspark_col(col_name)))
         return FeatureTable(hash_df)
 
-    def cross_hash_encode(self, cross_columns, bin_sizes, cross_col_names=None, method='md5'):
+    def cross_hash_encode(
+        self,
+        cross_columns: Union[List[str], List[List[str]], str],
+        bin_sizes: Union[int, List[int]],
+        cross_col_names: Optional[Union[List[str], str, List[int]]] = None,
+        method: str = 'md5'
+    ) -> "FeatureTable":
         """
         Cross columns and hashed to specified bin size.
 
@@ -1059,9 +1159,17 @@ class FeatureTable(Table):
 
     cross_columns = cross_hash_encode
 
-    def category_encode(self, columns, freq_limit=None, order_by_freq=False,
-                        do_split=False, sep=',', sort_for_array=False, keep_most_frequent=False,
-                        broadcast=True):
+    def category_encode(
+        self,
+        columns: List[str],
+        freq_limit: Union[int, Dict] = None,
+        order_by_freq: bool = False,
+        do_split: bool = False,
+        sep: str = ',',
+        sort_for_array: bool = False,
+        keep_most_frequent: bool = False,
+        broadcast: bool = True
+    ) -> Tuple["FeatureTable", List["StringIndex"]]:
         """
         Category encode the given columns.
 
@@ -1093,7 +1201,13 @@ class FeatureTable(Table):
                                   keep_most_frequent=keep_most_frequent,
                                   broadcast=broadcast), indices
 
-    def one_hot_encode(self, columns, sizes=None, prefix=None, keep_original_columns=False):
+    def one_hot_encode(
+        self,
+        columns: List[str],
+        sizes: Union[int, List[int]] = None,
+        prefix: Union[str, List[str]] = None,
+        keep_original_columns: bool = False
+    ) -> "FeatureTable":
         """
         Convert categorical features into ont hot encodings.
         If the features are string, you should first call category_encode to encode them into
@@ -1186,16 +1300,25 @@ class FeatureTable(Table):
         data_df = data_df.drop("friesian_onehot")
         return FeatureTable(data_df)
 
-    def gen_string_idx(self, columns, freq_limit=None, order_by_freq=False,
-                       do_split=False, sep=','):
+    def gen_string_idx(
+        self,
+        columns: Union[List[str],
+                       str,
+                       List[Union[str, Dict[str, Union[str, List[str]]]]],
+                       Dict[str, Union[str, List[str]]]],
+        freq_limit: Optional[Union[int, str, Dict[str, int]]] = None,
+        order_by_freq: bool = False,
+        do_split: bool = False,
+        sep: str = ','
+    ) -> Union["StringIndex", List["StringIndex"]]:
         """
         Generate unique index value of categorical features. The resulting index would
         start from 1 with 0 reserved for unknown features.
 
         :param columns: str, dict or a list of str, dict, target column(s) to generate StringIndex.
-         dict is a mapping of source column names -> target column name if needs to combine multiple
-         source columns to generate index.
-         For example: {'src_cols':['a_user', 'b_user'], 'col_name':'user'}.
+               dict is a mapping of source column names -> target column name if needs to combine multiple
+               source columns to generate index.
+               For example: {'src_cols':['a_user', 'b_user'], 'col_name':'user'}.
         :param freq_limit: int, dict or None. Categories with a count/frequency below freq_limit
                will be omitted from the encoding. Can be represented as either an integer,
                dict. For instance, 15, {'col_4': 10, 'col_5': 2} etc. Default is None,
@@ -1290,10 +1413,16 @@ class FeatureTable(Table):
         else:
             return string_idx_list
 
-    def _clone(self, df):
+    def _clone(self, df: "SparkDataFrame") -> "FeatureTable":
         return FeatureTable(df)
 
-    def min_max_scale(self, columns, min=0.0, max=1.0):
+    def min_max_scale(
+        self,
+        columns: List[str],
+        min: float = 0.0,
+        max: float = 1.0
+    ) -> Tuple["FeatureTable", Dict[str, Union[Tuple[float, float],
+                                    Tuple[List[float], List[float]]]]]:
         """
         Rescale each column individually to a common range [min, max] linearly using
         column summary statistics, which is also known as min-max normalization or rescaling.
@@ -1369,7 +1498,11 @@ class FeatureTable(Table):
 
         return FeatureTable(df), min_max_dict
 
-    def transform_min_max_scale(self, columns, min_max_dict):
+    def transform_min_max_scale(
+        self,
+        columns: List[str],
+        min_max_dict: Dict[str, Union[Tuple[float, float], Tuple[List[float], List[float]]]]
+    ) -> "FeatureTable": 
         """
         Rescale each column individually with the given [min, max] range of each column.
 
@@ -1426,7 +1559,13 @@ class FeatureTable(Table):
 
         return tbl
 
-    def add_negative_samples(self, item_size, item_col="item", label_col="label", neg_num=1):
+    def add_negative_samples(
+        self,
+        item_size: int,
+        item_col: str = "item",
+        label_col: str = "label",
+        neg_num: int = 1
+    ) -> "FeatureTable": 
         """
         Generate negative records for each record in the FeatureTable. All the records in the
         original FeatureTable will be treated as positive samples with value 1 for label_col
@@ -1443,8 +1582,15 @@ class FeatureTable(Table):
         df = add_negative_samples(self.df, item_size, item_col, label_col, neg_num)
         return FeatureTable(df)
 
-    def add_hist_seq(self, cols, user_col, sort_col='time',
-                     min_len=1, max_len=100, num_seqs=2147483647):
+    def add_hist_seq(
+        self,
+        cols: List[str],
+        user_col: str,
+        sort_col: str = 'time',
+        min_len: int = 1,
+        max_len: int = 100,
+        num_seqs: int = 2147483647
+    ) -> "FeatureTable": 
         """
         Add a column of history visits of each user.
 
@@ -1463,7 +1609,12 @@ class FeatureTable(Table):
         df = add_hist_seq(self.df, cols, user_col, sort_col, min_len, max_len, num_seqs)
         return FeatureTable(df)
 
-    def add_neg_hist_seq(self, item_size, item_history_col, neg_num):
+    def add_neg_hist_seq(
+        self,
+        item_size: int,
+        item_history_col: str,
+        neg_num: int
+    ) -> "FeatureTable":
         """
         Generate a list of negative samples for each item in the history sequence.
 
@@ -1476,7 +1627,7 @@ class FeatureTable(Table):
         df = add_neg_hist_seq(self.df, item_size, item_history_col, neg_num)
         return FeatureTable(df)
 
-    def mask(self, mask_cols, seq_len=100):
+    def mask(self, mask_cols: Union[str, List[str]], seq_len: int = 100) -> "FeatureTable":
         """
         Add mask on specified column(s).
 
@@ -1490,7 +1641,13 @@ class FeatureTable(Table):
         df = mask(self.df, mask_cols, seq_len)
         return FeatureTable(df)
 
-    def pad(self, cols, seq_len=100, mask_cols=None, mask_token=0):
+    def pad(
+        self,
+        cols: List[str],
+        seq_len: int = 100,
+        mask_cols: Union[str, List[str]] = None,
+        mask_token: Union[int, str] = 0
+    ) -> "FeatureTable":
         """
         Add padding on specified column(s).
 
@@ -1509,7 +1666,13 @@ class FeatureTable(Table):
         df = pad(self.df, cols, seq_len, mask_cols, mask_token)
         return FeatureTable(df)
 
-    def apply(self, in_col, out_col, func, dtype="string"):
+    def apply(
+        self,
+        in_col: Union[List[str], str],
+        out_col: str,
+        func: Callable,
+        dtype: str = "string"
+    ) -> "FeatureTable": 
         """
         Transform a FeatureTable using a user-defined Python function.
 
@@ -1533,7 +1696,14 @@ class FeatureTable(Table):
             df = self.df.withColumn(out_col, udf_func(array(in_col)))
         return FeatureTable(df)
 
-    def join(self, table, on=None, how=None, lsuffix=None, rsuffix=None):
+    def join(
+        self,
+        table: "FeatureTable",
+        on: Optional[str] = None,
+        how: None = None,
+        lsuffix: Optional[str] = None,
+        rsuffix: Optional[str] = None
+    ) -> "FeatureTable":
         """
         Join a FeatureTable with another FeatureTable.
 
@@ -1561,7 +1731,13 @@ class FeatureTable(Table):
         joined_df = self.df.join(table.df, on=on, how=how)
         return FeatureTable(joined_df)
 
-    def add_value_features(self, columns, dict_tbl, key, value):
+    def add_value_features(
+        self,
+        columns: Union[List[str], str],
+        dict_tbl: "FeatureTable",
+        key: str,
+        value: str
+    ) -> "FeatureTable": 
         """
          Add features based on key columns and the key value Table.
          For each column in columns, it adds a value column using key-value pairs from dict_tbl.
@@ -1580,7 +1756,11 @@ class FeatureTable(Table):
         df = add_value_features(self.df, columns, dict_tbl.df, key, value)
         return FeatureTable(df)
 
-    def reindex(self, columns=[], index_tbls=[]):
+    def reindex(
+        self,
+        columns: List[str] = [],
+        index_tbls: List["FeatureTable"] = []
+    ) -> "FeatureTable": 
         """
         Replace the value using index_dicts for each col in columns, set 0 for default
 
@@ -1604,7 +1784,11 @@ class FeatureTable(Table):
             tbl = tbl.add_value_features(c, index_tbls[i], key=c, value=c)
         return tbl
 
-    def gen_reindex_mapping(self, columns=[], freq_limit=10):
+    def gen_reindex_mapping(
+        self,
+        columns: List[str] = [],
+        freq_limit: int = 10
+    ) -> List["FeatureTable"]: 
         """
         Generate a mapping from old index to new one based on popularity count on descending order
          :param columns: str or a list of str
@@ -1634,7 +1818,12 @@ class FeatureTable(Table):
 
         return index_tbls
 
-    def group_by(self, columns=[], agg="count", join=False):
+    def group_by(
+        self,
+        columns: Union[List[str], str] = [],
+        agg: Union[Dict[str, List[str]], List[str], Dict[str, str], str] = "count",
+        join: bool = False
+    ) -> "FeatureTable":
         """
         Group the Table with specified columns and then run aggregation. Optionally join the result
         with the original Table.
@@ -1705,9 +1894,19 @@ class FeatureTable(Table):
         else:
             return FeatureTable(agg_df)
 
-    def target_encode(self, cat_cols, target_cols, target_mean=None, smooth=20, kfold=2,
-                      fold_seed=None, fold_col="__fold__", drop_cat=False, drop_fold=True,
-                      out_cols=None):
+    def target_encode(
+        self,
+        cat_cols: Union[List[str], List[List[str]], str],
+        target_cols: Union[List[str], str],
+        target_mean: Optional[Union[Dict[str, str], Dict[str, Union[int, float]]]] = None,
+        smooth: int = 20,
+        kfold: int = 2,
+        fold_seed: Optional[int] = None,
+        fold_col: str = "__fold__",
+        drop_cat: bool = False,
+        drop_fold: bool = True,
+        out_cols: Optional[List[List[str]]] = None
+    ) -> Tuple["FeatureTable", List["TargetCode"]]: 
         """
         For each categorical column or column group in cat_cols, calculate the mean of target
         columns in target_cols and encode the FeatureTable with the target mean(s) to generate
@@ -1910,7 +2109,12 @@ class FeatureTable(Table):
 
         return result_tbl, all_targets
 
-    def encode_target(self, targets, target_cols=None, drop_cat=True):
+    def encode_target(
+        self,
+        targets: Union["TargetCode", List["TargetCode"]],
+        target_cols: Optional[str] = None,
+        drop_cat: bool = True
+    ) -> "FeatureTable":
         """
         Encode columns with the provided TargetCode(s).
 
@@ -1947,7 +2151,14 @@ class FeatureTable(Table):
 
         return result_tbl
 
-    def difference_lag(self, columns, sort_cols, shifts=1, partition_cols=None, out_cols=None):
+    def difference_lag(
+        self,
+        columns: Union[List[str], str],
+        sort_cols: Union[List[str], str],
+        shifts: Union[int, List[int]] = 1,
+        partition_cols: Optional[List[str]] = None,
+        out_cols: Optional[Union[List[str], List[List[str]], str]] = None
+    ) -> "FeatureTable": 
         """
         Calculates the difference between two consecutive rows, or two rows with certain interval
         of the specified continuous columns. The table is first partitioned by partition_cols if it
@@ -2034,7 +2245,14 @@ class FeatureTable(Table):
 
         return FeatureTable(result_df)
 
-    def cut_bins(self, columns, bins, labels=None, out_cols=None, drop=True):
+    def cut_bins(
+        self,
+        columns: Union[List[str], str],
+        bins: Union[Dict[str, List[int]], int, List[int]],
+        labels: Optional[Union[List[str], Dict[str, List[str]]]] = None,
+        out_cols: Optional[str] = None,
+        drop: bool = True
+    ) -> "FeatureTable":
         """
         Segment values of the target column(s) into bins, which is also known as bucketization.
 
@@ -2117,7 +2335,8 @@ class FeatureTable(Table):
                     df_buck = df_buck.drop(column)
         return self._clone(df_buck)
 
-    def get_vocabularies(self, columns):
+    # TODO: Add UT
+    def get_vocabularies(self, columns: Union[str, List[str]]) -> Dict[str, Union[str,List[str]]]:
         """
         Create vocabulary for each column, and return dict of vocabularies
 
@@ -2132,8 +2351,15 @@ class FeatureTable(Table):
                 .distinct().rdd.map(lambda row: row[col]).collect()
         return vocabularies
 
-    def sample_listwise(self, columns, num_sampled_list, num_sampled_item, random_seed=None,
-                        replace=True):
+    # TODO: Add UT when columns is str
+    def sample_listwise(
+        self,
+        columns: Union[str, List[str]],
+        num_sampled_list: int,
+        num_sampled_item: int,
+        random_seed: int = None,
+        replace: bool = True
+    ) -> "FeatureTable":
         """
         Convert the FeatureTable to a sample listwise FeatureTable. The columns should be of list
         type and have the same length. Note that the rows with list length < num_sampled_item will
@@ -2242,8 +2468,13 @@ class FeatureTable(Table):
 
         return FeatureTable(df)
 
-    def string_embed(self, columns, bert_model='distilbert-base-uncased', reduce_dim=None,
-                     replace=True):
+    def string_embed(
+        self,
+        columns: List[str],
+        bert_model: str = 'distilbert-base-uncased',
+        reduce_dim: Optional[int] = None,
+        replace: bool = True
+    ) -> "FeatureTable":
         """
         Convert the columns of string to bert embeddings in FeatureTable. The columns should be of
         string type.
@@ -2315,7 +2546,7 @@ class FeatureTable(Table):
 
 
 class StringIndex(Table):
-    def __init__(self, df, col_name):
+    def __init__(self, df: "SparkDataFrame", col_name: str) -> None:
         super().__init__(df)
         cols = df.columns
         invalidInputError(len(cols) >= 2,
@@ -2325,7 +2556,7 @@ class StringIndex(Table):
         self.col_name = col_name
 
     @classmethod
-    def read_parquet(cls, paths, col_name=None):
+    def read_parquet(cls, paths: str, col_name: Optional[str] = None) -> "StringIndex":
         """
         Loads Parquet files as a StringIndex.
 
@@ -2342,7 +2573,11 @@ class StringIndex(Table):
         return cls(Table._read_parquet(paths), col_name)
 
     @classmethod
-    def from_dict(cls, indices, col_name):
+    def from_dict(
+        cls,
+        indices: Dict[str, int],
+        col_name: str
+    ) -> "StringIndex":
         """
         Create the StringIndex from a dict of indices.
 
@@ -2369,7 +2604,7 @@ class StringIndex(Table):
         df = spark.createDataFrame((Row(**x) for x in indices), schema=schema)
         return cls(df, col_name)
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, int]:
         """
         Convert the StringIndex to a dict, with the categorical features as keys and indices
         as values.
@@ -2386,7 +2621,7 @@ class StringIndex(Table):
             res_dict[row[col_id]] = row[index_id]
         return res_dict
 
-    def write_parquet(self, path, mode="overwrite"):
+    def write_parquet(self, path: str, mode: str = "overwrite") -> None:
         """
         Write the StringIndex to Parquet file.
 
@@ -2401,13 +2636,18 @@ class StringIndex(Table):
         path = path + "/" + self.col_name + ".parquet"
         write_parquet(self.df, path, mode)
 
-    def cast(self, columns, dtype):
+    def cast(self, columns: str, dtype: str) -> "StringIndex":
         df_cast = super().cast(columns, dtype)
         return StringIndex(df_cast.df, self.col_name)
 
 
 class TargetCode(Table):
-    def __init__(self, df, cat_col, out_target_mean):
+    def __init__(
+        self,
+        df: "SparkDataFrame",
+        cat_col: Union[List[str], str],
+        out_target_mean: Dict[str, Union[Tuple[str, str], Tuple[str, float], Tuple[str, int]]]
+    ) -> None: 
         """
         Target Encoding output used for encoding new FeatureTables, which consists of the encoded
         categorical column or column group and the target encoded columns (mean statistics of
@@ -2431,10 +2671,10 @@ class TargetCode(Table):
 
         invalidInputError(isinstance(out_target_mean, dict), "out_target_mean should be dict")
 
-    def _clone(self, df):
+    def _clone(self, df: "SparkDataFrame") -> "TargetCode":
         return TargetCode(df, self.cat_col, self.out_target_mean)
 
-    def rename(self, columns):
+    def rename(self, columns: Dict[str, str]) -> "TargetCode":
         invalidInputError(isinstance(columns, dict),
                           "columns should be a dictionary of "
                           "{'old_name1': 'new_name1', 'old_name2': 'new_name2'}")

--- a/python/friesian/src/bigdl/friesian/feature/utils.py
+++ b/python/friesian/src/bigdl/friesian/feature/utils.py
@@ -21,37 +21,54 @@ from pyspark.sql.functions import broadcast, udf
 from bigdl.dllib.utils.log4Error import *
 import warnings
 from bigdl.dllib.utils.log4Error import *
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
+
+if TYPE_CHECKING:
+    from bigdl.friesian.feature.table import FeatureTable, TargetCode
+    from pyspark.sql.dataframe import DataFrame as SparkDataFrame
 
 
 def compute(df):
     return callZooFunc("float", "compute", df)
 
 
-def log_with_clip(df, columns, clip=True):
+def log_with_clip(df: "SparkDataFrame", columns: List[str], clip: bool=True) -> "SparkDataFrame":
     return callZooFunc("float", "log", df, columns, clip)
 
 
-def generate_string_idx(df, columns, freq_limit, order_by_freq):
+def generate_string_idx(df: "SparkDataFrame",
+                        columns: List[str],
+                        freq_limit: Optional[str],
+                        order_by_freq: bool) -> List["SparkDataFrame"]:
     return callZooFunc("float", "generateStringIdx", df, columns, freq_limit, order_by_freq)
 
 
-def fill_na(df, fill_val, columns):
+def fill_na(df: "SparkDataFrame",
+            fill_val: Union[int, str, float],
+            columns: List[str]) -> "SparkDataFrame":
     return callZooFunc("float", "fillNa", df, fill_val, columns)
 
 
-def fill_na_int(df, fill_val, columns):
+def fill_na_int(df: "SparkDataFrame",
+                fill_val: int,
+                columns: Optional[List[str]]) -> "SparkDataFrame":
     return callZooFunc("float", "fillNaInt", df, fill_val, columns)
 
 
-def clip(df, columns, min, max):
+def clip(df: "SparkDataFrame",
+         columns: List[str],
+         min: Optional[int],
+         max: Optional[int]) -> "SparkDataFrame":
     return callZooFunc("float", "clip", df, columns, min, max)
 
 
-def fill_median(df, columns):
+def fill_median(df: "SparkDataFrame", columns: List[str]) -> "SparkDataFrame":
     return callZooFunc("float", "fillMedian", df, columns)
 
 
-def median(df, columns, relative_error=0.001):
+def median(df: "SparkDataFrame",
+           columns: List[str],
+           relative_error: float=0.001) -> "SparkDataFrame":
     return callZooFunc("float", "median", df, columns, relative_error)
 
 
@@ -59,7 +76,7 @@ def cross_columns(df, cross_column_list, bucket_sizes):
     return callZooFunc("float", "crossColumns", df, cross_column_list, bucket_sizes)
 
 
-def check_col_exists(df, columns):
+def check_col_exists(df: "SparkDataFrame", columns: List[str]) -> None:
     df_cols = df.columns
     col_not_exist = list(filter(lambda x: x not in df_cols, columns))
     if len(col_not_exist) > 0:
@@ -67,20 +84,37 @@ def check_col_exists(df, columns):
                           str(col_not_exist) + " do not exist in this Table")
 
 
-def add_negative_samples(df, item_size, item_col, label_col, neg_num):
+def add_negative_samples(df: "SparkDataFrame",
+                         item_size: int,
+                         item_col: str,
+                         label_col: str,
+                         neg_num: int) -> "SparkDataFrame":
     return callZooFunc("float", "addNegSamples", df, item_size, item_col, label_col, neg_num)
 
 
-def add_hist_seq(df, cols, user_col, sort_col, min_len, max_len, num_seqs):
+def add_hist_seq(df: "SparkDataFrame",
+                 cols: List[str],
+                 user_col: str,
+                 sort_col: str,
+                 min_len: int,
+                 max_len: int,
+                 num_seqs: int) -> "SparkDataFrame":
     return callZooFunc("float", "addHistSeq", df, cols, user_col, sort_col, min_len, max_len,
                        num_seqs)
 
 
-def add_neg_hist_seq(df, item_size, item_history_col, neg_num):
+def add_neg_hist_seq(df: "SparkDataFrame",
+                     item_size: int,
+                     item_history_col: str,
+                     neg_num: int) -> "SparkDataFrame":
     return callZooFunc("float", "addNegHisSeq", df, item_size, item_history_col, neg_num)
 
 
-def add_value_features(df, cols, map_df, key, value):
+def add_value_features(df: "SparkDataFrame",
+                       cols: List[str],
+                       map_df: "SparkDataFrame",
+                       key: str,
+                       value: str) -> "SparkDataFrame":
     return callZooFunc("float", "addValueFeatures", df, cols, map_df, key, value)
 
 
@@ -88,27 +122,32 @@ def mask(df, mask_cols, seq_len):
     return callZooFunc("float", "mask", df, mask_cols, seq_len)
 
 
-def pad(df, cols, seq_len, mask_cols, mask_token):
+def pad(df: "SparkDataFrame",
+        cols: List[str],
+        seq_len: int, mask_cols: Optional[List[str]],
+        mask_token: Union[int, str]) -> "SparkDataFrame":
     df = callZooFunc("float", "mask", df, mask_cols, seq_len) if mask_cols else df
     df = callZooFunc("float", "postPad", df, cols, seq_len, mask_token)
     return df
 
 
-def check_column_numeric(df, column):
+def check_column_numeric(df: "SparkDataFrame", column: str) -> bool:
     return df.schema[column].dataType in [IntegerType(), ShortType(),
                                           LongType(), FloatType(),
                                           DecimalType(), DoubleType()]
 
 
-def ordinal_shuffle_partition(df):
+def ordinal_shuffle_partition(df: "SparkDataFrame") -> "SparkDataFrame":
     return callZooFunc("float", "ordinalShufflePartition", df)
 
 
-def write_parquet(df, path, mode):
+def write_parquet(df: "SparkDataFrame", path: str, mode: str) -> None:
     callZooFunc("float", "dfWriteParquet", df, path, mode)
 
 
-def check_col_str_list_exists(df, column, arg_name):
+def check_col_str_list_exists(df: "SparkDataFrame",
+                              column: Union[List[str], str],
+                              arg_name: str) -> None:
     if isinstance(column, str):
         invalidInputError(column in df.columns,
                           column + " in " + arg_name + " does not exist in Table")
@@ -122,14 +161,15 @@ def check_col_str_list_exists(df, column, arg_name):
                           " get " + str(column))
 
 
-def get_nonnumeric_col_type(df, columns):
+def get_nonnumeric_col_type(df: "SparkDataFrame",
+                            columns: List[str]) -> List[Union[Tuple[str, str], Any]]:
     return list(filter(
         lambda x: x[0] in columns and not (x[1] == "smallint" or x[1] == "int" or
                                            x[1] == "bigint" or x[1] == "float" or x[1] == "double"),
         df.dtypes))
 
 
-def gen_cols_name(columns, name_sep="_"):
+def gen_cols_name(columns: Union[List[str], str], name_sep: str="_") -> str:
     if isinstance(columns, str):
         return columns
     elif isinstance(columns, list):
@@ -139,7 +179,12 @@ def gen_cols_name(columns, name_sep="_"):
                           "item should be either str or list of str")
 
 
-def encode_target_(tbl, targets, target_cols=None, drop_cat=True, drop_fold=True, fold_col=None):
+def encode_target_(tbl: "FeatureTable",
+                   targets: List["TargetCode"],
+                   target_cols: Optional[List[str]]=None,
+                   drop_cat: bool=True,
+                   drop_fold: bool=True,
+                   fold_col: Optional[str]=None) -> "FeatureTable":
     for target_code in targets:
         cat_col = target_code.cat_col
         out_target_mean = target_code.out_target_mean
@@ -215,7 +260,7 @@ def encode_target_(tbl, targets, target_cols=None, drop_cat=True, drop_fold=True
     return tbl
 
 
-def str_to_list(arg, arg_name):
+def str_to_list(arg: Union[List[str], str], arg_name: str) -> List[str]:
     if isinstance(arg, str):
         return [arg]
     invalidInputError(isinstance(arg, list), arg_name + " should be str or a list of str")

--- a/python/friesian/src/bigdl/friesian/feature/utils.py
+++ b/python/friesian/src/bigdl/friesian/feature/utils.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from pyspark.sql.dataframe import DataFrame as SparkDataFrame
 
 
-def compute(df):
+def compute(df: "SparkDataFrame"):
     return callZooFunc("float", "compute", df)
 
 
@@ -118,13 +118,14 @@ def add_value_features(df: "SparkDataFrame",
     return callZooFunc("float", "addValueFeatures", df, cols, map_df, key, value)
 
 
-def mask(df, mask_cols, seq_len):
+def mask(df: "SparkDataFrame", mask_cols: Optional[Union[str,List[str]]], seq_len: int):
     return callZooFunc("float", "mask", df, mask_cols, seq_len)
 
 
 def pad(df: "SparkDataFrame",
         cols: List[str],
-        seq_len: int, mask_cols: Optional[List[str]],
+        seq_len: int,
+        mask_cols: Optional[Union[str,List[str]]],
         mask_token: Union[int, str]) -> "SparkDataFrame":
     df = callZooFunc("float", "mask", df, mask_cols, seq_len) if mask_cols else df
     df = callZooFunc("float", "postPad", df, cols, seq_len, mask_token)
@@ -162,7 +163,8 @@ def check_col_str_list_exists(df: "SparkDataFrame",
 
 
 def get_nonnumeric_col_type(df: "SparkDataFrame",
-                            columns: List[str]) -> List[Union[Tuple[str, str], Any]]:
+                            columns: Optional[Union[str,List[str]]]
+) -> List[Union[Tuple[str, str], Any]]:
     return list(filter(
         lambda x: x[0] in columns and not (x[1] == "smallint" or x[1] == "int" or
                                            x[1] == "bigint" or x[1] == "float" or x[1] == "double"),
@@ -267,7 +269,8 @@ def str_to_list(arg: Union[List[str], str], arg_name: str) -> List[str]:
     return arg
 
 
-def featuretable_to_xshards(tbl, convert_cols=None):
+def featuretable_to_xshards(tbl: "SparkDataFrame",
+                            convert_cols: Optional[Union[List[str],str]]=None):
     from bigdl.orca.learn.utils import dataframe_to_xshards_of_feature_dict
     # TODO: partition < node num
     if convert_cols is None:

--- a/python/friesian/src/bigdl/friesian/feature/utils.py
+++ b/python/friesian/src/bigdl/friesian/feature/utils.py
@@ -72,7 +72,10 @@ def median(df: "SparkDataFrame",
     return callZooFunc("float", "median", df, columns, relative_error)
 
 
-def cross_columns(df, cross_column_list, bucket_sizes):
+# TODO: ADD UTS
+def cross_columns(df,
+                  cross_column_list: Union[List[str], List[List[str]], str],
+                  bucket_sizes: int):
     return callZooFunc("float", "crossColumns", df, cross_column_list, bucket_sizes)
 
 
@@ -163,7 +166,7 @@ def check_col_str_list_exists(df: "SparkDataFrame",
 
 
 def get_nonnumeric_col_type(df: "SparkDataFrame",
-                                columns: Optional[Union[str, List[str]]]) \
+                            columns: Optional[Union[str, List[str]]]) \
         -> List[Union[Tuple[str, str], Any]]:
     return list(filter(
         lambda x: x[0] in columns and not (x[1] == "smallint" or x[1] == "int" or

--- a/python/friesian/src/bigdl/friesian/feature/utils.py
+++ b/python/friesian/src/bigdl/friesian/feature/utils.py
@@ -118,14 +118,14 @@ def add_value_features(df: "SparkDataFrame",
     return callZooFunc("float", "addValueFeatures", df, cols, map_df, key, value)
 
 
-def mask(df: "SparkDataFrame", mask_cols: Optional[Union[str,List[str]]], seq_len: int):
+def mask(df: "SparkDataFrame", mask_cols: Optional[Union[str, List[str]]], seq_len: int):
     return callZooFunc("float", "mask", df, mask_cols, seq_len)
 
 
 def pad(df: "SparkDataFrame",
         cols: List[str],
         seq_len: int,
-        mask_cols: Optional[Union[str,List[str]]],
+        mask_cols: Optional[Union[str, List[str]]],
         mask_token: Union[int, str]) -> "SparkDataFrame":
     df = callZooFunc("float", "mask", df, mask_cols, seq_len) if mask_cols else df
     df = callZooFunc("float", "postPad", df, cols, seq_len, mask_token)
@@ -163,8 +163,8 @@ def check_col_str_list_exists(df: "SparkDataFrame",
 
 
 def get_nonnumeric_col_type(df: "SparkDataFrame",
-                            columns: Optional[Union[str,List[str]]]
-) -> List[Union[Tuple[str, str], Any]]:
+                                columns: Optional[Union[str, List[str]]]) \
+        -> List[Union[Tuple[str, str], Any]]:
     return list(filter(
         lambda x: x[0] in columns and not (x[1] == "smallint" or x[1] == "int" or
                                            x[1] == "bigint" or x[1] == "float" or x[1] == "double"),
@@ -270,7 +270,7 @@ def str_to_list(arg: Union[List[str], str], arg_name: str) -> List[str]:
 
 
 def featuretable_to_xshards(tbl: "SparkDataFrame",
-                            convert_cols: Optional[Union[List[str],str]]=None):
+                            convert_cols: Optional[Union[List[str], str]]=None):
     from bigdl.orca.learn.utils import dataframe_to_xshards_of_feature_dict
     # TODO: partition < node num
     if convert_cols is None:

--- a/python/friesian/src/bigdl/friesian/models/tfrs_model.py
+++ b/python/friesian/src/bigdl/friesian/models/tfrs_model.py
@@ -21,10 +21,7 @@ import tensorflow_recommenders as tfrs
 from tensorflow_recommenders.tasks import base
 from bigdl.dllib.utils import log4Error
 
-from typing import TYPE_CHECKING, Dict, Union, Tuple
-
-if TYPE_CHECKING:
-    from tensorflow import Tensor
+from typing import Dict
 
 
 class TFRSModel(tf.keras.Model):
@@ -55,7 +52,7 @@ class TFRSModel(tf.keras.Model):
     def call(self, features):
         return self.model.call(features)
 
-    def train_step(self, inputs) -> Dict[str, "tf.Tensor"]:
+    def train_step(self, inputs) -> Dict[str, tf.Tensor]:
         """
         Custom train step using the `compute_loss` method.
 
@@ -89,7 +86,7 @@ class TFRSModel(tf.keras.Model):
 
         return metrics
 
-    def test_step(self, inputs) -> Dict[str, "tf.Tensor"]:
+    def test_step(self, inputs) -> Dict[str, tf.Tensor]:
         """
         Custom test step using the `compute_loss` method.
 

--- a/python/friesian/src/bigdl/friesian/models/tfrs_model.py
+++ b/python/friesian/src/bigdl/friesian/models/tfrs_model.py
@@ -14,15 +14,21 @@
 # limitations under the License.
 #
 
+from turtle import Turtle
 import tensorflow as tf
 import warnings
 import tensorflow_recommenders as tfrs
 from tensorflow_recommenders.tasks import base
 from bigdl.dllib.utils import log4Error
 
+from typing import TYPE_CHECKING, Dict, Union, Tuple
+
+if TYPE_CHECKING:
+    from tensorflow import Tensor
+
 
 class TFRSModel(tf.keras.Model):
-    def __init__(self, tfrs_model):
+    def __init__(self, tfrs_model: tfrs.Model) -> None:
         super().__init__()
         log4Error.invalidInputError(isinstance(tfrs_model, tfrs.Model),
                                     "FriesianTFRSModel only support tfrs.Model, but got " +
@@ -49,8 +55,17 @@ class TFRSModel(tf.keras.Model):
     def call(self, features):
         return self.model.call(features)
 
-    def train_step(self, inputs):
-        """Custom train step using the `compute_loss` method."""
+    def train_step(self, inputs) -> Dict[str, "tf.Tensor"]:
+        """
+        Custom train step using the `compute_loss` method.
+
+        Args:
+        inputs: A data structure of tensors: raw inputs to the model. These will
+            usually contain labels and weights as well as features.
+
+        Returns:
+        metrics: A dict of loss tensors of metrics names.
+        """
 
         with tf.GradientTape() as tape:
             loss = self.model.compute_loss(inputs, training=True)
@@ -74,8 +89,17 @@ class TFRSModel(tf.keras.Model):
 
         return metrics
 
-    def test_step(self, inputs):
-        """Custom test step using the `compute_loss` method."""
+    def test_step(self, inputs) -> Dict[str, "tf.Tensor"]:
+        """
+        Custom test step using the `compute_loss` method.
+
+        Args:
+        inputs: A data structure of tensors: raw inputs to the model. These will
+            usually contain labels and weights as well as features.
+
+        Returns:
+        metrics: A dict of loss tensors of metrics names.
+        """
 
         # unscaled test loss
         loss = self.model.compute_loss(inputs, training=False)


### PR DESCRIPTION
## Description

This is a preview of a small part of the entire project before adding python type hint, including templates, tools and modification processes

### 1. Why the change?

In order to standardize the development process and improve the user experience

### 2. User API changes

For user: no
For developer: adapt and run `add_type_hint.sh test_dir` to generate diff database of add hints, more details refer to [Monkeytype](https://monkeytype.readthedocs.io/en/latest/)

### 3. Summary of the change 

1. Add python hint to bigdl.friesian
2. Provide a way to help add hints, which is:

-  pip install monkeytype
-  Auto-annotate our code by leveraging our test files,  you can use add_type_hint.sh to do this for example 

`add_type_hint.sh test_dir feature` will test pytest under bigdl/friesian/test/feature/ and generate an `friesian_hint.sqlite3` including diffs monkeytype collected. You can also [do it manually](https://monkeytype.readthedocs.io/en/latest/#example)
- Apply changes(monkeytype stub, for there are issues with monkeytype apply )

### 4. How to test?
- [ ] N/A
- [X] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [x] New Python dependencies
       - monkeytype(only for developers)
       - ...
