### PR TITLE
[PPML] Fix spark jar url missing in build-docker-image

### DIFF
--- a/ppml/trusted-big-data-ml/python/docker-gramine/build-docker-image.sh
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/build-docker-image.sh
@@ -3,7 +3,7 @@ export HTTP_PROXY_PORT=your_http_proxy_port
 export HTTPS_PROXY_HOST=your_https_proxy_host
 export HTTPS_PROXY_PORT=your_https_proxy_port
 export JDK_URL=http://your-http-url-to-download-jdk
-export SPARK_JAR_REPO_URL=your_spark_jar_repo_url
+export SPARK_JAR_REPO_URL=http://your_spark_jar_repo_url
 
 Proxy_Modified="sudo docker build \
     --build-arg http_proxy=http://${HTTP_PROXY_HOST}:${HTTP_PROXY_PORT} \
@@ -25,9 +25,9 @@ No_Proxy_Modified="sudo docker build \
     --build-arg no_proxy=x.x.x.x \
     -t intelanalytics/bigdl-ppml-trusted-big-data-ml-python-gramine:2.1.0-SNAPSHOT -f ./Dockerfile ."
 
-if [ "$JDK_URL" == "http://your-http-url-to-download-jdk" ]
+if [[ "$JDK_URL" == "http://your-http-url-to-download-jdk" ]] || [[ "$SPARK_JAR_REPO_URL" == "http://your_spark_jar_repo_url" ]]
 then
-    echo "Please modify the path of JDK_URL to the suitable url in this script, then rerun this script. And if your environment don't need to set proxy, please ignore this notice information; if your environment need to set proxy, please modify the proxy in the script, then rerun this script."
+    echo "Please modify the path of JDK_URL and SPARK_JAR_REPO_URL to the suitable url in this script, then rerun this script. And if your environment don't need to set proxy, please ignore this notice information; if your environment need to set proxy, please modify the proxy in the script, then rerun this script."
 else
     if [[ "$HTTP_PROXY_HOST" == "your_http_proxy_host" ]] || [[ "$HTTP_PROXY_PORT" == "your_http_proxy_port" ]] || [[ "$HTTPS_PROXY_HOST" == "your_https_proxy_host" ]] || [[ "$HTTPS_PROXY_PORT" == "your_https_proxy_port" ]]
     then

--- a/ppml/trusted-big-data-ml/python/docker-gramine/build-docker-image.sh
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/build-docker-image.sh
@@ -15,6 +15,7 @@ Proxy_Modified="sudo docker build \
     --build-arg JDK_VERSION=8u192 \
     --build-arg JDK_URL=${JDK_URL} \
     --build-arg JDK_URL=${SPARK_JAR_REPO_URL} \
+    --build-arg SPARK_JAR_REPO_URL=${SPARK_JAR_REPO_URL} \
     --build-arg no_proxy=x.x.x.x \
     -t intelanalytics/bigdl-ppml-trusted-big-data-ml-python-gramine:2.1.0-SNAPSHOT -f ./Dockerfile ."
 
@@ -22,6 +23,7 @@ No_Proxy_Modified="sudo docker build \
     --build-arg JDK_VERSION=8u192 \
     --build-arg JDK_URL=${JDK_URL} \
     --build-arg JDK_URL=${SPARK_JAR_REPO_URL} \
+    --build-arg SPARK_JAR_REPO_URL=${SPARK_JAR_REPO_URL} \
     --build-arg no_proxy=x.x.x.x \
     -t intelanalytics/bigdl-ppml-trusted-big-data-ml-python-gramine:2.1.0-SNAPSHOT -f ./Dockerfile ."
 

--- a/ppml/trusted-big-data-ml/python/docker-graphene/build-docker-image.sh
+++ b/ppml/trusted-big-data-ml/python/docker-graphene/build-docker-image.sh
@@ -3,6 +3,7 @@ export HTTP_PROXY_PORT=your_http_proxy_port
 export HTTPS_PROXY_HOST=your_https_proxy_host
 export HTTPS_PROXY_PORT=your_https_proxy_port
 export JDK_URL=http://your-http-url-to-download-jdk
+export SPARK_JAR_REPO_URL=http://your_spark_jar_repo_url
 
 Proxy_Modified="sudo docker build \
     --build-arg http_proxy=http://${HTTP_PROXY_HOST}:${HTTP_PROXY_PORT} \
@@ -22,9 +23,9 @@ No_Proxy_Modified="sudo docker build \
     --build-arg no_proxy=x.x.x.x \
     -t intelanalytics/bigdl-ppml-trusted-big-data-ml-python-graphene:2.1.0-SNAPSHOT -f ./Dockerfile ."
 
-if [ "$JDK_URL" == "http://your-http-url-to-download-jdk" ]
+if [[ "$JDK_URL" == "http://your-http-url-to-download-jdk" ]] || [[ "$SPARK_JAR_REPO_URL" == "http://your_spark_jar_repo_url" ]]
 then
-    echo "Please modify the path of JDK_URL to the suitable url in this script, then rerun this script. And if your environment don't need to set proxy, please ignore this notice information; if your environment need to set proxy, please modify the proxy in the script, then rerun this script."
+    echo "Please modify the path of JDK_URL and SPARK_JAR_REPO_URL to the suitable url in this script, then rerun this script. And if your environment don't need to set proxy, please ignore this notice information; if your environment need to set proxy, please modify the proxy in the script, then rerun this script."
 else
     if [[ "$HTTP_PROXY_HOST" == "your_http_proxy_host" ]] || [[ "$HTTP_PROXY_PORT" == "your_http_proxy_port" ]] || [[ "$HTTPS_PROXY_HOST" == "your_https_proxy_host" ]] || [[ "$HTTPS_PROXY_PORT" == "your_https_proxy_port" ]]
     then

--- a/ppml/trusted-big-data-ml/python/docker-graphene/build-docker-image.sh
+++ b/ppml/trusted-big-data-ml/python/docker-graphene/build-docker-image.sh
@@ -14,12 +14,14 @@ Proxy_Modified="sudo docker build \
     --build-arg HTTPS_PROXY_PORT=${HTTPS_PROXY_PORT} \
     --build-arg JDK_VERSION=8u192 \
     --build-arg JDK_URL=${JDK_URL} \
+    --build-arg SPARK_JAR_REPO_URL=${SPARK_JAR_REPO_URL} \
     --build-arg no_proxy=x.x.x.x \
     -t intelanalytics/bigdl-ppml-trusted-big-data-ml-python-graphene:2.1.0-SNAPSHOT -f ./Dockerfile ."
 
 No_Proxy_Modified="sudo docker build \
     --build-arg JDK_VERSION=8u192 \
     --build-arg JDK_URL=${JDK_URL} \
+    --build-arg SPARK_JAR_REPO_URL=${SPARK_JAR_REPO_URL} \
     --build-arg no_proxy=x.x.x.x \
     -t intelanalytics/bigdl-ppml-trusted-big-data-ml-python-graphene:2.1.0-SNAPSHOT -f ./Dockerfile ."
 


### PR DESCRIPTION
## Description

Append SPARK_JAR_URL in build-docker-image API of both graphene and gramine.

### 1. Why the change?

SPARK_JAR_URL is missed in build-docker-image.sh script, which is necessary in Dockerfile and this will cause a build failure when users build image through this script.

### 2. User API changes

Users should specify SPARK_JAR_URL in build-docker-image.sh

### 3. Summary of the change 

Fix spark jar url missing in build-docker-image

### 4. How to test?

Unit test.