### PR TITLE
support OxfordIIITPet in nano

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/pytorch/utils.py
@@ -26,7 +26,7 @@ from logging import warning
 TORCH_VERSION_LESS_1_10 = _compare_version("torch", operator.lt, "1.10")
 TORCH_VERSION_LESS_1_11 = _compare_version("torch", operator.lt, "1.11")
 TORCH_VERSION_LESS_1_12 = _compare_version("torch", operator.lt, "1.12")
-TORCHVERSION_VERSION_LESS_1_12 = _compare_version("torchvision", operator.lt, "0.12.0")
+TORCHVISION_VERSION_LESS_1_12 = _compare_version("torchvision", operator.lt, "0.12.0")
 
 
 def batch_call(func):

--- a/python/nano/src/bigdl/nano/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/pytorch/utils.py
@@ -26,6 +26,7 @@ from logging import warning
 TORCH_VERSION_LESS_1_10 = _compare_version("torch", operator.lt, "1.10")
 TORCH_VERSION_LESS_1_11 = _compare_version("torch", operator.lt, "1.11")
 TORCH_VERSION_LESS_1_12 = _compare_version("torch", operator.lt, "1.12")
+TORCHVERSION_VERSION_LESS_1_12 = _compare_version("torchvision", operator.lt, "0.12.0")
 
 
 def batch_call(func):

--- a/python/nano/src/bigdl/nano/pytorch/vision/datasets/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/vision/datasets/__init__.py
@@ -14,8 +14,11 @@
 # limitations under the License.
 #
 
+from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_12
 from torchvision.datasets import *
 del ImageFolder
-del OxfordIIITPet
+if TORCH_VERSION_LESS_1_12:
+    del OxfordIIITPet
+    from .datasets import OxfordIIITPet
 
-from .datasets import ImageFolder, SegmentationImageFolder, OxfordIIITPet
+from .datasets import ImageFolder, SegmentationImageFolder

--- a/python/nano/src/bigdl/nano/pytorch/vision/datasets/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/vision/datasets/__init__.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 #
 
-from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_11
+from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_12
 from torchvision.datasets import *
 del ImageFolder
-if not TORCH_VERSION_LESS_1_11:
+if not TORCH_VERSION_LESS_1_12:
     del OxfordIIITPet
 
 from .datasets import ImageFolder, SegmentationImageFolder, OxfordIIITPet

--- a/python/nano/src/bigdl/nano/pytorch/vision/datasets/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/vision/datasets/__init__.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 #
 
-from bigdl.nano.pytorch.utils import TORCHVERSION_VERSION_LESS_1_12
+from bigdl.nano.pytorch.utils import TORCHVISION_VERSION_LESS_1_12
 from torchvision.datasets import *
 del ImageFolder
-if not TORCHVERSION_VERSION_LESS_1_12:
+if not TORCHVISION_VERSION_LESS_1_12:
     del OxfordIIITPet
 
 from .datasets import ImageFolder, SegmentationImageFolder, OxfordIIITPet

--- a/python/nano/src/bigdl/nano/pytorch/vision/datasets/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/vision/datasets/__init__.py
@@ -14,11 +14,10 @@
 # limitations under the License.
 #
 
-from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_12
+from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_11
 from torchvision.datasets import *
 del ImageFolder
-if TORCH_VERSION_LESS_1_12:
+if not TORCH_VERSION_LESS_1_11:
     del OxfordIIITPet
-    from .datasets import OxfordIIITPet
 
-from .datasets import ImageFolder, SegmentationImageFolder
+from .datasets import ImageFolder, SegmentationImageFolder, OxfordIIITPet

--- a/python/nano/src/bigdl/nano/pytorch/vision/datasets/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/vision/datasets/__init__.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 #
 
-from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_12
+from bigdl.nano.pytorch.utils import TORCHVERSION_VERSION_LESS_1_12
 from torchvision.datasets import *
 del ImageFolder
-if not TORCH_VERSION_LESS_1_12:
+if not TORCHVERSION_VERSION_LESS_1_12:
     del OxfordIIITPet
 
 from .datasets import ImageFolder, SegmentationImageFolder, OxfordIIITPet

--- a/python/nano/src/bigdl/nano/pytorch/vision/datasets/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/vision/datasets/__init__.py
@@ -19,5 +19,6 @@ from torchvision.datasets import *
 del ImageFolder
 if not TORCHVISION_VERSION_LESS_1_12:
     del OxfordIIITPet
+    from .oxfordpet_datasets import OxfordIIITPet
 
-from .datasets import ImageFolder, SegmentationImageFolder, OxfordIIITPet
+from .datasets import ImageFolder, SegmentationImageFolder

--- a/python/nano/src/bigdl/nano/pytorch/vision/datasets/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/vision/datasets/__init__.py
@@ -16,6 +16,6 @@
 
 from torchvision.datasets import *
 del ImageFolder
+del OxfordIIITPet
 
-
-from .datasets import ImageFolder, SegmentationImageFolder
+from .datasets import ImageFolder, SegmentationImageFolder, OxfordIIITPet

--- a/python/nano/src/bigdl/nano/pytorch/vision/datasets/datasets.py
+++ b/python/nano/src/bigdl/nano/pytorch/vision/datasets/datasets.py
@@ -24,8 +24,6 @@ import numpy as np
 import torch
 from logging import warning
 from os.path import split, join, realpath
-from PIL import Image
-from typing import Any
 
 local_libturbo_path = None
 _turbo_path = realpath(join(split(realpath(__file__))[0],
@@ -34,24 +32,6 @@ if os.path.exists(_turbo_path):
     local_libturbo_path = _turbo_path
 else:
     warning("libturbojpeg.so.0 not found in bigdl-nano, try to load from system.")
-
-# These images in the pet dataset that don't have a proper format.
-# Some of them are actually .png files instead .jpg,
-# even though they are in .jpg extension.
-SPECIAL_IMAGES = [
-    "oxford-iiit-pet/images/Egyptian_Mau_14.jpg",
-    "oxford-iiit-pet/images/Egyptian_Mau_139.jpg",
-    "oxford-iiit-pet/images/Egyptian_Mau_145.jpg",
-    "oxford-iiit-pet/images/Egyptian_Mau_156.jpg",
-    "oxford-iiit-pet/images/Egyptian_Mau_167.jpg",
-    "oxford-iiit-pet/images/Egyptian_Mau_177.jpg",
-    "oxford-iiit-pet/images/Egyptian_Mau_186.jpg",
-    "oxford-iiit-pet/images/Egyptian_Mau_191.jpg",
-    "oxford-iiit-pet/images/Abyssinian_5.jpg",
-    "oxford-iiit-pet/images/Abyssinian_34.jpg",
-    "oxford-iiit-pet/images/chihuahua_121.jpg",
-    "oxford-iiit-pet/images/beagle_116.jpg",
-]
 
 
 class ImageFolder(torchvision.datasets.ImageFolder):
@@ -203,74 +183,3 @@ class SegmentationImageFolder:
 
     def __len__(self):
         return len(self.imgs)
-
-
-class OxfordIIITPet(torchvision.datasets.OxfordIIITPet):
-    """A optimzied OxfordIIITPet using libjpeg_turbo to load jpg images."""
-
-    def __init__(
-        self,
-        root: str,
-        transform: Optional[Callable] = None,
-        target_transform: Optional[Callable] = None,
-        download: bool = False,
-    ):
-        """
-        Create a OxfordIIITPet.
-
-        :param root: A string represting the root directory path.
-        :param transform: A function/transform that takes in an ndarray image
-            and returns a transformed version. E.g, ``transforms.RandomCrop``
-        :param target_transform: A function/transform that takes in the
-            target and transforms it.
-        :param download: If True, downloads the dataset from the internet
-        """
-        super(OxfordIIITPet, self).__init__(root, transform=transform,
-                                            target_transform=target_transform, download=download)
-        self.jpeg: Optional[TurboJPEG] = None
-        self.special_images = []
-        for image in SPECIAL_IMAGES:
-            self.special_images.append(os.path.join(root, image))
-
-    def _read_image_to_bytes(self, path: str):
-        fd = open(path, 'rb')
-        img_str = fd.read()
-        fd.close()
-        return img_str
-
-    def _decode_img_libjpeg_turbo(self, img_str: str):
-        if self.jpeg is None:
-            self.jpeg = TurboJPEG(lib_path=local_libturbo_path)
-        bgr_array = self.jpeg.decode(img_str)
-        return bgr_array
-
-    def __getitem__(self, idx: int):
-        path = str(self._images[idx])
-        target: Any = []
-        for target_type in self._target_types:
-            if target_type == "category":
-                target.append(self._labels[idx])
-            else:  # target_type == "segmentation"
-                target.append(Image.open(self._segs[idx]))
-
-        if not target:
-            target = None
-        elif len(target) == 1:
-            target = target[0]
-        else:
-            target = tuple(target)
-
-        if path in self.special_images:
-            img = Image.open(path).convert("RGB")
-        else:
-            if path.endswith(".jpg") or path.endswith(".jpeg"):
-                img_str = self._read_image_to_bytes(path)
-                img = self._decode_img_libjpeg_turbo(img_str)
-            else:
-                img = cv2.imread(path)
-            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-        if self.transform:
-            img, target = self.transforms(img, target)
-
-        img = img.numpy()
-        return img.astype('float32'), target

--- a/python/nano/src/bigdl/nano/pytorch/vision/datasets/datasets.py
+++ b/python/nano/src/bigdl/nano/pytorch/vision/datasets/datasets.py
@@ -259,4 +259,4 @@ class OxfordIIITPet(torchvision.datasets.OxfordIIITPet):
             img, target = self.transforms(img, target)
 
         img = img.numpy()
-        return img.astype('float32'), target  
+        return img.astype('float32'), target

--- a/python/nano/src/bigdl/nano/pytorch/vision/datasets/datasets.py
+++ b/python/nano/src/bigdl/nano/pytorch/vision/datasets/datasets.py
@@ -24,7 +24,7 @@ import numpy as np
 import torch
 from logging import warning
 from os.path import split, join, realpath
-
+from PIL import Image
 
 local_libturbo_path = None
 _turbo_path = realpath(join(split(realpath(__file__))[0],
@@ -33,6 +33,24 @@ if os.path.exists(_turbo_path):
     local_libturbo_path = _turbo_path
 else:
     warning("libturbojpeg.so.0 not found in bigdl-nano, try to load from system.")
+
+# These images in the pet dataset that don't have a proper format. 
+# Some of them are actually .png files instead .jpg, 
+# even though they are in .jpg extension.
+SPECIAL_IMAGES = [
+    "oxford-iiit-pet/images/Egyptian_Mau_14.jpg",
+    "oxford-iiit-pet/images/Egyptian_Mau_139.jpg",
+    "oxford-iiit-pet/images/Egyptian_Mau_145.jpg",
+    "oxford-iiit-pet/images/Egyptian_Mau_156.jpg",
+    "oxford-iiit-pet/images/Egyptian_Mau_167.jpg",
+    "oxford-iiit-pet/images/Egyptian_Mau_177.jpg",
+    "oxford-iiit-pet/images/Egyptian_Mau_186.jpg",
+    "oxford-iiit-pet/images/Egyptian_Mau_191.jpg",
+    "oxford-iiit-pet/images/Abyssinian_5.jpg",
+    "oxford-iiit-pet/images/Abyssinian_34.jpg",
+    "oxford-iiit-pet/images/chihuahua_121.jpg",
+    "oxford-iiit-pet/images/beagle_116.jpg",
+]
 
 
 class ImageFolder(torchvision.datasets.ImageFolder):
@@ -184,3 +202,61 @@ class SegmentationImageFolder:
 
     def __len__(self):
         return len(self.imgs)
+
+
+class OxfordIIITPet(torchvision.datasets.OxfordIIITPet):
+    def __init__(
+        self,
+        root: str,
+        transform: Optional[Callable] = None,
+        target_transform: Optional[Callable] = None,
+        download: bool = False,
+    ):
+        super(OxfordIIITPet, self).__init__(root, transform=transform, target_transform=target_transform, download=download)
+        self.jpeg: Optional[TurboJPEG] = None
+        self.special_images = []
+        for image in SPECIAL_IMAGES:
+            self.special_images.append(os.path.join(root,image))
+        
+    def _read_image_to_bytes(self, path: str):
+        fd = open(path, 'rb')
+        img_str = fd.read()
+        fd.close()
+        return img_str
+
+    def _decode_img_libjpeg_turbo(self, img_str: str):
+        if self.jpeg is None:
+            self.jpeg = TurboJPEG(lib_path=local_libturbo_path)
+        bgr_array = self.jpeg.decode(img_str)
+        return bgr_array
+
+    def __getitem__(self, idx: int):
+        path = str(self._images[idx])
+        target: Any = []
+        for target_type in self._target_types:
+            if target_type == "category":
+                target.append(self._labels[idx])
+            else:  # target_type == "segmentation"
+                target.append(Image.open(self._segs[idx]))
+        
+        if not target:
+            target = None
+        elif len(target) == 1:
+            target = target[0]
+        else:
+            target = tuple(target)
+            
+        if path in self.special_images:
+            img = Image.open(path).convert("RGB")
+        else:        
+            if path.endswith(".jpg") or path.endswith(".jpeg"):
+                img_str = self._read_image_to_bytes(path)
+                img = self._decode_img_libjpeg_turbo(img_str)
+            else:
+                img = cv2.imread(path)
+            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        if self.transform:
+            img, target = self.transforms(img, target)
+
+        img = img.numpy()
+        return img.astype('float32'), target  

--- a/python/nano/src/bigdl/nano/pytorch/vision/datasets/oxfordpet_datasets.py
+++ b/python/nano/src/bigdl/nano/pytorch/vision/datasets/oxfordpet_datasets.py
@@ -1,0 +1,125 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from typing import Union, Callable, Optional
+from turbojpeg import TurboJPEG, TJPF_GRAY
+import torchvision
+import cv2
+import os
+import numpy as np
+import torch
+from logging import warning
+from os.path import split, join, realpath
+from PIL import Image
+from typing import Any
+
+# These images in the pet dataset that don't have a proper format.
+# Some of them are actually .png files instead .jpg,
+# even though they are in .jpg extension.
+SPECIAL_IMAGES = [
+    "oxford-iiit-pet/images/Egyptian_Mau_14.jpg",
+    "oxford-iiit-pet/images/Egyptian_Mau_139.jpg",
+    "oxford-iiit-pet/images/Egyptian_Mau_145.jpg",
+    "oxford-iiit-pet/images/Egyptian_Mau_156.jpg",
+    "oxford-iiit-pet/images/Egyptian_Mau_167.jpg",
+    "oxford-iiit-pet/images/Egyptian_Mau_177.jpg",
+    "oxford-iiit-pet/images/Egyptian_Mau_186.jpg",
+    "oxford-iiit-pet/images/Egyptian_Mau_191.jpg",
+    "oxford-iiit-pet/images/Abyssinian_5.jpg",
+    "oxford-iiit-pet/images/Abyssinian_34.jpg",
+    "oxford-iiit-pet/images/chihuahua_121.jpg",
+    "oxford-iiit-pet/images/beagle_116.jpg",
+]
+
+local_libturbo_path = None
+_turbo_path = realpath(join(split(realpath(__file__))[0],
+                            "../../../libs/libturbojpeg.so.0.2.0"))
+if os.path.exists(_turbo_path):
+    local_libturbo_path = _turbo_path
+else:
+    warning("libturbojpeg.so.0 not found in bigdl-nano, try to load from system.")
+
+
+class OxfordIIITPet(torchvision.datasets.OxfordIIITPet):
+    """A optimzied OxfordIIITPet using libjpeg_turbo to load jpg images."""
+
+    def __init__(
+        self,
+        root: str,
+        transform: Optional[Callable] = None,
+        target_transform: Optional[Callable] = None,
+        download: bool = False,
+    ):
+        """
+        Create a OxfordIIITPet.
+
+        :param root: A string represting the root directory path.
+        :param transform: A function/transform that takes in an ndarray image
+            and returns a transformed version. E.g, ``transforms.RandomCrop``
+        :param target_transform: A function/transform that takes in the
+            target and transforms it.
+        :param download: If True, downloads the dataset from the internet
+        """
+        super(OxfordIIITPet, self).__init__(root, transform=transform,
+                                            target_transform=target_transform, download=download)
+        self.jpeg: Optional[TurboJPEG] = None
+        self.special_images = []
+        for image in SPECIAL_IMAGES:
+            self.special_images.append(os.path.join(root, image))
+
+    def _read_image_to_bytes(self, path: str):
+        fd = open(path, 'rb')
+        img_str = fd.read()
+        fd.close()
+        return img_str
+
+    def _decode_img_libjpeg_turbo(self, img_str: str):
+        if self.jpeg is None:
+            self.jpeg = TurboJPEG(lib_path=local_libturbo_path)
+        bgr_array = self.jpeg.decode(img_str)
+        return bgr_array
+
+    def __getitem__(self, idx: int):
+        path = str(self._images[idx])
+        target: Any = []
+        for target_type in self._target_types:
+            if target_type == "category":
+                target.append(self._labels[idx])
+            else:  # target_type == "segmentation"
+                target.append(Image.open(self._segs[idx]))
+
+        if not target:
+            target = None
+        elif len(target) == 1:
+            target = target[0]
+        else:
+            target = tuple(target)
+
+        if path in self.special_images:
+            img = Image.open(path).convert("RGB")
+        else:
+            if path.endswith(".jpg") or path.endswith(".jpeg"):
+                img_str = self._read_image_to_bytes(path)
+                img = self._decode_img_libjpeg_turbo(img_str)
+            else:
+                img = cv2.imread(path)
+            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        if self.transform:
+            img, target = self.transforms(img, target)
+
+        img = img.numpy()
+        return img.astype('float32'), target

--- a/python/nano/tutorial/training/pytorch-lightning/lightning_cv_data_pipeline.py
+++ b/python/nano/tutorial/training/pytorch-lightning/lightning_cv_data_pipeline.py
@@ -106,4 +106,3 @@ if __name__ == "__main__":
     trainer = Trainer(max_epochs=5)
     trainer.fit(model, train_dataloaders=train_loader)
     trainer.validate(model, dataloaders=val_loader)
-

--- a/python/nano/tutorial/training/pytorch-lightning/lightning_cv_data_pipeline.py
+++ b/python/nano/tutorial/training/pytorch-lightning/lightning_cv_data_pipeline.py
@@ -15,117 +15,18 @@
 
 import torch
 import torchvision
-from turbojpeg import TurboJPEG, TJPF_GRAY
-from typing import Sequence
-from typing import Any, Callable, Optional, Union, Tuple
+from typing import Any
 from torch.utils.data.dataloader import DataLoader
 from torchvision.models import resnet18
 from bigdl.nano.pytorch import Trainer
-from torchmetrics import Accuracy
 import pytorch_lightning as pl
-from bigdl.nano.pytorch.vision import transforms
-from torchvision.datasets.utils import download_and_extract_archive
 from os.path import split, join, realpath
 import cv2
-import os
 from logging import warning
-from PIL import Image
-import urllib.request
 import os
-import stat
+from bigdl.nano.pytorch.vision.datasets import OxfordIIITPet
 
-LIB_URL = "https://github.com/leonardozcm/libjpeg-turbo/releases/download/2.1.1/libturbojpeg.so.0.2.0"
-# These images in the pet dataset that don't have a proper format. 
-# Some of them are actually .png files instead .jpg, 
-# even though they are in .jpg extension.
-SPECIAL_IMAGES = [
-    "/tmp/data/oxford-iiit-pet/images/Egyptian_Mau_14.jpg",
-    "/tmp/data/oxford-iiit-pet/images/Egyptian_Mau_139.jpg",
-    "/tmp/data/oxford-iiit-pet/images/Egyptian_Mau_145.jpg",
-    "/tmp/data/oxford-iiit-pet/images/Egyptian_Mau_156.jpg",
-    "/tmp/data/oxford-iiit-pet/images/Egyptian_Mau_167.jpg",
-    "/tmp/data/oxford-iiit-pet/images/Egyptian_Mau_177.jpg",
-    "/tmp/data/oxford-iiit-pet/images/Egyptian_Mau_186.jpg",
-    "/tmp/data/oxford-iiit-pet/images/Egyptian_Mau_191.jpg",
-    "/tmp/data/oxford-iiit-pet/images/Abyssinian_5.jpg",
-    "/tmp/data/oxford-iiit-pet/images/Abyssinian_34.jpg",
-    "/tmp/data/oxford-iiit-pet/images/chihuahua_121.jpg",
-    "/tmp/data/oxford-iiit-pet/images/beagle_116.jpg",
-]
-def download_libs(url: str):
-    libs_dir = "/tmp/libs"
-    if not os.path.exists(libs_dir):
-        os.makedirs(libs_dir, exist_ok=True)
-    libso_file_name = url.split('/')[-1]
-    libso_file = os.path.join(libs_dir, libso_file_name)
-    if not os.path.exists(libso_file):
-        print('downloading libturbojpeg.so.0.2.0.....')
-        urllib.request.urlretrieve(url, libso_file)
-    st = os.stat(libso_file)
-    os.chmod(libso_file, st.st_mode | stat.S_IEXEC)
-local_libturbo_path = None
-_turbo_path = realpath(join(split(realpath(__file__))[0],
-                            "/tmp/libs/libturbojpeg.so.0.2.0"))
 
-if not os.path.exists(_turbo_path):
-    download_libs(LIB_URL)
-local_libturbo_path = _turbo_path
-    
-class OxfordIIITPet(torchvision.datasets.OxfordIIITPet):
-    def __init__(
-        self,
-        root: str,
-        transform: Optional[Callable] = None,
-        target_transform: Optional[Callable] = None,
-        download: bool = False,
-    ):
-        super(OxfordIIITPet, self).__init__(root, transform=transform, target_transform=target_transform, download=download)
-        self.jpeg: Optional[TurboJPEG] = None
-        
-    def _read_image_to_bytes(self, path: str):
-        fd = open(path, 'rb')
-        img_str = fd.read()
-        fd.close()
-        return img_str
-
-    def _decode_img_libjpeg_turbo(self, img_str: str):
-        if self.jpeg is None:
-            self.jpeg = TurboJPEG(lib_path=local_libturbo_path)
-        bgr_array = self.jpeg.decode(img_str)
-        return bgr_array
-
-    def __getitem__(self, idx: int):
-        path = str(self._images[idx])
-        target: Any = []
-        for target_type in self._target_types:
-            if target_type == "category":
-                target.append(self._labels[idx])
-            else:  # target_type == "segmentation"
-                target.append(Image.open(self._segs[idx]))
-        
-        if not target:
-            target = None
-        elif len(target) == 1:
-            target = target[0]
-        else:
-            target = tuple(target)
-            
-        if path in SPECIAL_IMAGES:
-                img = Image.open(path).convert("RGB")
-        else:        
-            if path.endswith(".jpg") or path.endswith(".jpeg"):
-                # Use turbo-jpg to accelerate baseline JPEG compression and decompression.
-                img_str = self._read_image_to_bytes(path)
-                img = self._decode_img_libjpeg_turbo(img_str)
-            else:
-                img = cv2.imread(path)
-            img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-        if self.transform:
-            img, target = self.transforms(img, target)
-
-        img = img.numpy()
-        return img.astype('float32'), target  
-  
 class MyLightningModule(pl.LightningModule):
 
     def __init__(self):
@@ -160,6 +61,7 @@ class MyLightningModule(pl.LightningModule):
 
 
 def create_dataloaders():
+    from bigdl.nano.pytorch.vision import transforms
     train_transform = transforms.Compose([transforms.Resize(256),
                                           transforms.RandomCrop(224),
                                           transforms.RandomHorizontalFlip(),
@@ -172,7 +74,7 @@ def create_dataloaders():
                                         transforms.ToTensor(),
                                         transforms.Normalize([0.485, 0.456, 0.406],
                                                              [0.229, 0.224, 0.225])])
-    
+
     train_dataset = OxfordIIITPet(root="/tmp/data", transform=train_transform, download=True)
     val_dataset = OxfordIIITPet(root="/tmp/data", transform=val_transform)
 
@@ -190,15 +92,17 @@ def create_dataloaders():
 
 
 if __name__ == "__main__":
-    # get dataset
     model = MyLightningModule()
-    train_loader, val_loader = create_dataloaders()
     # CV Data Pipelines
     #
     # Computer Vision task often needs a data processing pipeline that sometimes constitutes a 
     # non-trivial part of the whole training pipeline. 
     # BigDL-Nano can accelerate computer vision data pipelines.
-    
+    #
+    # BigDL-Nano can accelerate computer vision data pipelines
+    # by providing a drop-in replacement of torch_vision’s datasets and transforms
+    #
+    train_loader, val_loader = create_dataloaders()
     trainer = Trainer(max_epochs=5)
     trainer.fit(model, train_dataloaders=train_loader)
     trainer.validate(model, dataloaders=val_loader)

--- a/python/nano/tutorial/training/pytorch-lightning/lightning_cv_data_pipeline.py
+++ b/python/nano/tutorial/training/pytorch-lightning/lightning_cv_data_pipeline.py
@@ -106,3 +106,4 @@ if __name__ == "__main__":
     trainer = Trainer(max_epochs=5)
     trainer.fit(model, train_dataloaders=train_loader)
     trainer.validate(model, dataloaders=val_loader)
+

--- a/python/nano/tutorial/training/pytorch-lightning/lightning_cv_data_pipeline.py
+++ b/python/nano/tutorial/training/pytorch-lightning/lightning_cv_data_pipeline.py
@@ -24,7 +24,7 @@ from os.path import split, join, realpath
 import cv2
 from logging import warning
 import os
-from bigdl.nano.pytorch.vision.datasets import OxfordIIITPet
+from bigdl.nano.pytorch.vision.oxfordpet_datasets import OxfordIIITPet
 
 
 class MyLightningModule(pl.LightningModule):

--- a/python/nano/tutorial/training/pytorch-lightning/lightning_cv_data_pipeline.py
+++ b/python/nano/tutorial/training/pytorch-lightning/lightning_cv_data_pipeline.py
@@ -24,7 +24,7 @@ from os.path import split, join, realpath
 import cv2
 from logging import warning
 import os
-from bigdl.nano.pytorch.vision.oxfordpet_datasets import OxfordIIITPet
+from bigdl.nano.pytorch.vision.datasets import OxfordIIITPet
 
 
 class MyLightningModule(pl.LightningModule):


### PR DESCRIPTION
- Support for JPEP decode in nano with OxfordIIITPet dataset
- In nano data pipeline example, use dataset OxfordIIITPet from nano instead of implement it 