### PR TITLE
Change default cores of init_orca_context

### DIFF
--- a/python/dllib/src/bigdl/dllib/nncontext.py
+++ b/python/dllib/src/bigdl/dllib/nncontext.py
@@ -613,8 +613,8 @@ def init_nncontext(conf=None, cluster_mode="spark-submit", spark_log_level="WARN
                                    executor_memory=memory, **spark_args)
     else:
         invalidInputError(False,
-                          "cluster_mode can only be local, yarn-client, yarn-cluster, standalone "
-                          "or spark-submit, "
+                          "cluster_mode can only be local, yarn-client, yarn-cluster, standalone, "
+                          "spark-submit, spark-submit or bigdl-submit, "
                           "but got: %s".format(cluster_mode))
     return sc
 

--- a/python/dllib/src/bigdl/dllib/nncontext.py
+++ b/python/dllib/src/bigdl/dllib/nncontext.py
@@ -613,8 +613,8 @@ def init_nncontext(conf=None, cluster_mode="spark-submit", spark_log_level="WARN
                                    executor_memory=memory, **spark_args)
     else:
         invalidInputError(False,
-                          "cluster_mode can only be local, yarn-client, yarn-cluster, standalone, "
-                          "spark-submit, spark-submit or bigdl-submit, "
+                          "cluster_mode can only be local, yarn-client, yarn-cluster, standalone "
+                          "or spark-submit, "
                           "but got: %s".format(cluster_mode))
     return sc
 

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -172,7 +172,7 @@ def _check_python_micro_version():
                           f"with micro version >= 10 (e.g. 3.{sys.version_info[1]}.10)")
 
 
-def init_orca_context(cluster_mode=None, runtime="spark", cores=2, memory="2g", num_nodes=1,
+def init_orca_context(cluster_mode=None, runtime="spark", cores=None, memory="2g", num_nodes=1,
                       init_ray_on_spark=False, **kwargs):
     """
     Creates or gets a SparkContext for different Spark cluster modes (and launch Ray services
@@ -210,6 +210,11 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=2, memory="2g", 
     print("Initializing orca context")
     import atexit
     atexit.register(stop_orca_context)
+    if not cores:
+        if cluster_mode == "local":
+            cores = "*"
+        else:
+            cores = 2
     if runtime == "ray":
         invalidInputError(cluster_mode is None,
                           "Currently, cluster_mode is not supported for ray runtime and"

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -222,7 +222,7 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=None, memory="2g
             cores = 2
             import warnings
             warnings.warn("Cores is not specified, using 2 cores per node by default.", Warning)
-            
+
     if runtime == "ray":
         invalidInputError(cluster_mode is None,
                           "Currently, cluster_mode is not supported for ray runtime and"
@@ -336,7 +336,8 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=None, memory="2g
             else:
                 invalidInputError(False,
                                   "cluster_mode can only be local, yarn-client, yarn-cluster,"
-                                  "k8s-client, k8s-cluster, standalone, spark-submit or bigdl-submit, "
+                                  "k8s-client, k8s-cluster, standalone,"
+                                  "spark-submit or bigdl-submit, "
                                   "but got: %s".format(cluster_mode))
         ray_args = {}
         for key in ["redis_port", "password", "object_store_memory", "verbose", "env",

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -217,11 +217,11 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=None, memory="2g
     if not cores:
         if cluster_mode == "local" and runtime == "spark":
             cores = "*"
-            print("Cluster_mode is local and runtime is spark, default to be '*'.")
+            print("For spark local mode, default to use all the cores on the node.")
         else:
             cores = 2
             import warnings
-            warnings.warn("No cores are specified, default to be 2.", Warning)
+            warnings.warn("Cores is not specified, using 2 cores per node by default.", Warning)
             
     if runtime == "ray":
         invalidInputError(cluster_mode is None,

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -333,7 +333,7 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=None, memory="2g
             else:
                 invalidInputError(False,
                                   "cluster_mode can only be local, yarn-client, yarn-cluster,"
-                                  "k8s-client or standalone, "
+                                  "k8s-client, standalone, spark-submit or bigdl-submit, "
                                   "but got: %s".format(cluster_mode))
         ray_args = {}
         for key in ["redis_port", "password", "object_store_memory", "verbose", "env",

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -196,7 +196,10 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=None, memory="2g
            For "k8s-client" and "k8s-cluster", you are supposed to additionally specify the
            arguments master and container_image.
     :param runtime: The runtime for backend. One of "ray" and "spark". Default to be "spark".
-    :param cores: The number of cores to be used on each node. Default to be None.
+    :param cores: The number of cores to be used on each node.
+           For spark local mode, default to use all the cores on the node.
+           For other cluster_mode, default to use 2 cores per node.
+           You are highly recommended to set this value by yourself.
     :param memory: The memory allocated for each node. Default to be '2g'.
     :param num_nodes: The number of nodes to be used in the cluster. Default to be 1.
            For Spark local, num_nodes should always be 1 and you don't need to change it.

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -203,7 +203,7 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=None, memory="2g
            instead of using the default one.
     :param memory: The memory allocated for each node. Default to be '2g'.
     :param num_nodes: The number of nodes to be used in the cluster. Default to be 1.
-           For Spark local, num_nodes should always be 1 and you don't need to change it.
+           For Spark local mode, num_nodes should always be 1 and you don't need to change it.
     :param init_ray_on_spark: Whether to launch Ray services across the cluster.
            Default to be False and in this case the Ray cluster would be launched lazily when
            Ray is involved in Project Orca.

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -180,7 +180,8 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=None, memory="2g
 
     :param runtime: The runtime for backend. One of "ray" and "spark". Default to be "spark".
     :param cluster_mode: The mode for the Spark cluster. One of "local", "yarn-client",
-           "yarn-cluster", "k8s-client", "k8s-cluster" and "standalone".
+           "yarn-cluster", "k8s-client", "k8s-cluster", "standalone", "spark-submit"
+           and "bigdl-submit".
            You are highly recommended to install and run bigdl through pip, which is more
            convenient.
 
@@ -195,7 +196,7 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=None, memory="2g
            For "k8s-client" and "k8s-cluster", you are supposed to additionally specify the
            arguments master and container_image.
     :param runtime: The runtime for backend. One of "ray" and "spark". Default to be "spark".
-    :param cores: The number of cores to be used on each node. Default to be 2.
+    :param cores: The number of cores to be used on each node. Default to be None.
     :param memory: The memory allocated for each node. Default to be '2g'.
     :param num_nodes: The number of nodes to be used in the cluster. Default to be 1.
            For Spark local, num_nodes should always be 1 and you don't need to change it.
@@ -211,10 +212,14 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=None, memory="2g
     import atexit
     atexit.register(stop_orca_context)
     if not cores:
-        if cluster_mode == "local":
+        if cluster_mode == "local" and runtime == "spark":
             cores = "*"
+            print("Cluster_mode is local and runtime is spark, default to be '*'.")
         else:
             cores = 2
+            import warnings
+            warnings.warn("No cores are specified, default to be 2.", Warning)
+            
     if runtime == "ray":
         invalidInputError(cluster_mode is None,
                           "Currently, cluster_mode is not supported for ray runtime and"

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -336,7 +336,7 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=None, memory="2g
             else:
                 invalidInputError(False,
                                   "cluster_mode can only be local, yarn-client, yarn-cluster,"
-                                  "k8s-client, standalone, spark-submit or bigdl-submit, "
+                                  "k8s-client, k8s-cluster, standalone, spark-submit or bigdl-submit, "
                                   "but got: %s".format(cluster_mode))
         ray_args = {}
         for key in ["redis_port", "password", "object_store_memory", "verbose", "env",

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -197,9 +197,10 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=None, memory="2g
            arguments master and container_image.
     :param runtime: The runtime for backend. One of "ray" and "spark". Default to be "spark".
     :param cores: The number of cores to be used on each node.
-           For spark local mode, default to use all the cores on the node.
+           For Spark local mode, default to use all the cores on the node.
            For other cluster_mode, default to use 2 cores per node.
-           You are highly recommended to set this value by yourself.
+           You are highly recommended to set this value by yourself,
+           instead of using the default one.
     :param memory: The memory allocated for each node. Default to be '2g'.
     :param num_nodes: The number of nodes to be used in the cluster. Default to be 1.
            For Spark local, num_nodes should always be 1 and you don't need to change it.
@@ -217,11 +218,11 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=None, memory="2g
     if not cores:
         if cluster_mode == "local" and runtime == "spark":
             cores = "*"
-            print("For spark local mode, default to use all the cores on the node.")
+            print("For Spark local mode, default to use all the cores on the node.")
         else:
             cores = 2
             import warnings
-            warnings.warn("Cores is not specified, using 2 cores per node by default.", Warning)
+            warnings.warn("Cores not specified, using 2 cores per node by default.", Warning)
 
     if runtime == "ray":
         invalidInputError(cluster_mode is None,


### PR DESCRIPTION
- Set core to None by default
- If in local mode, set core="*", in other mode, set core=2


Issue fix:
init_orca_context default cores=2, and users may not be aware of this setting and may just call it with default parameters. And in this case if user compare the local performance between the original TF/PyTorch script with the Orca version, they will find much performance drop since Orca is only using two cores while the original script will use all cores in most cases.
Changing to "*" for local mode and add print/warnings.