### PR TITLE
[Orca] Replace pyarrow dependency in tf2 ray estimator

### DIFF
--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -561,7 +561,7 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                            options)
                 if save_format == 'h5' or filepath.endswith('.h5') or filepath.endswith('.keras'):
                     # hdf5 format
-                    put_local_file_to_remote(temp_path, filepath, over_write=overwrite)
+                    put_local_file_to_remote(temp_path, filepath)
                 else:
                     # tf format
                     put_local_dir_tree_to_remote(temp_path, filepath)

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -25,7 +25,7 @@ import ray
 
 from bigdl.dllib.utils import log4Error
 from bigdl.dllib.utils.file_utils import enable_multi_fs_load, enable_multi_fs_save, \
-    is_local_path, put_local_file_to_remote, put_local_dir_tree_to_remote
+    is_local_path
 
 from bigdl.orca.data.ray_xshards import RayXShards
 from bigdl.orca.learn.dl_cluster import RayDLCluster
@@ -34,6 +34,7 @@ from bigdl.orca.learn.ray_estimator import Estimator as OrcaRayEstimator
 from bigdl.orca.learn.utils import maybe_dataframe_to_xshards, dataframe_to_xshards, \
     convert_predict_xshards_to_dataframe, update_predict_xshards, \
     process_xshards_of_pandas_dataframe, make_data_creator
+from bigdl.orca.data.file import put_local_file_to_remote, put_local_dir_tree_to_remote
 from bigdl.orca.data.utils import process_spark_xshards
 from bigdl.dllib.utils.log4Error import *
 from bigdl.orca.ray import OrcaRayContext

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -42,6 +42,7 @@ from contextlib import closing
 
 from bigdl.dllib.utils import log4Error
 from bigdl.orca.data.utils import ray_partitions_get_data_label, ray_partitions_get_tf_dataset
+from bigdl.orca.data.file import is_file, get_remote_file_to_local, get_remote_dir_to_local
 from bigdl.dllib.utils.log4Error import *
 
 logger = logging.getLogger(__name__)
@@ -502,20 +503,18 @@ class TFRunner:
         self.model = tf.keras.models.load_model(filepath, custom_objects, compile, options)
 
     def load_remote_model(self, filepath, custom_objects, compile, options):
-        """Load the model from provided hdfs filepath."""
-        import pyarrow as pa
-        import pyarrow.fs as pafs
+        """Load the model from provided remote filepath."""
         import tensorflow as tf
         file_name = os.path.basename(filepath)
         temp_path = os.path.join(tempfile.mkdtemp(), file_name)
-        classpath = subprocess.Popen(["hadoop", "classpath", "--glob"],
-                                     stdout=subprocess.PIPE).communicate()[0]
-        os.environ["CLASSPATH"] = classpath.decode("utf-8")
-        hdfs = pa.hdfs.connect()
-        if not hdfs.isfile(filepath):
+        if is_file(filepath):
+            # h5 format
+            get_remote_file_to_local(file_path, temp_path)
+        else:
+            # savemodel format
             if os.path.exists(temp_path):
                 os.makedirs(temp_path)
-        pafs.copy_files(filepath, temp_path)
+            get_remote_dir_to_local(filepath, temp_path)
         try:
             self.model = tf.keras.models.load_model(temp_path, custom_objects, compile, options)
         finally:

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -509,7 +509,7 @@ class TFRunner:
         temp_path = os.path.join(tempfile.mkdtemp(), file_name)
         if is_file(filepath):
             # h5 format
-            get_remote_file_to_local(file_path, temp_path)
+            get_remote_file_to_local(filepath, temp_path)
         else:
             # savemodel format
             if os.path.exists(temp_path):

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
@@ -13,25 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import os
 import shutil
 from unittest import TestCase
 
 import numpy as np
 import pytest
 import tensorflow as tf
-
-from bigdl.dllib.nncontext import init_nncontext
-from bigdl.orca.data import XShards
+import ray
 
 import bigdl.orca.data.pandas
+from bigdl.dllib.nncontext import init_nncontext
+from bigdl.orca.data import XShards
 from bigdl.orca.learn.tf2 import Estimator
 from bigdl.orca.ray import OrcaRayContext
-import ray
+from bigdl.orca import OrcaContext
+
 
 NUM_TRAIN_SAMPLES = 1000
 NUM_TEST_SAMPLES = 400
-
-import os
 
 resource_path = os.path.join(
     os.path.realpath(os.path.dirname(__file__)), "../../../resources")

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
@@ -15,6 +15,7 @@
 #
 import os
 import shutil
+import tempfile
 from unittest import TestCase
 
 import numpy as np


### PR DESCRIPTION
## Description

Repace pyarrow dependency with `bigdl.orca.data.file` features.

### 1. Why the change?

Users need to specify `ARROW_LIBHDFS_DIR` when submitting orca applications on yarn, which is not user-friendly.
https://github.com/analytics-zoo/orca/issues/101

### 2. User API changes

Do not need to set `ARROW_LIBHDFS_DIR` anymore.

### 3. Summary of the change 

Use functions in `get_remote_file_local` instead of `pyarrow` import.

### 4. How to test?
- [x] Unit test
- [x] Test on Yarn
