### PR TITLE
Orca: delete pyarrow global dependency

### DIFF
--- a/python/orca/src/setup.py
+++ b/python/orca/src/setup.py
@@ -97,7 +97,7 @@ def setup_package():
         packages=get_bigdl_packages(),
         install_requires=['packaging', 'filelock',
                           'bigdl-tf==0.14.0.dev1', 'bigdl-math==0.14.0.dev1',
-                          'bigdl-dllib=='+VERSION, 'pyzmq', 'pyarrow'],
+                          'bigdl-dllib=='+VERSION, 'pyzmq'],
         extras_require={'ray': RAY_DEP,
                         'automl': AUTOML_DEP,
                         },


### PR DESCRIPTION
## Description
This PR is to delete Python package `pyarrow` global dependency in `setup.py`.