### PR TITLE
Nano: Fix torch.save will raise FileNotFound if parent directory is not created

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -472,7 +472,7 @@ class Trainer(pl.Trainer):
         :param path: Path to saved model. Path should be a directory.
         """
         path = Path(path)
-        Path.mkdir(path, exist_ok=True)
+        path.mkdir(parents=path.parent, exist_ok=True)
         if hasattr(model, '_save'):
             model._save(path)
         else:


### PR DESCRIPTION
## Description

Fix torch.save will raise FileNotFound if parent directory is not created.

### 1. Why the change?

releated issue: [issue-5466](https://github.com/intel-analytics/BigDL/issues/5466)

### 2. How to Test?
- [x] Jenkins
http://10.112.231.51:18889/view/BigDL-PR-Validation/job/BigDL-Chronos-PR-Validation/728/
