### PR TITLE
[PPML] Fix graphene image nightly build failure

### DIFF
--- a/ppml/trusted-big-data-ml/python/docker-graphene/Dockerfile
+++ b/ppml/trusted-big-data-ml/python/docker-graphene/Dockerfile
@@ -4,13 +4,14 @@ ARG TINI_VERSION=v0.18.0
 ARG JDK_VERSION=8u192
 ARG JDK_URL=your_jdk_url
 ARG SPARK_JAR_REPO_URL=your_spark_jar_repo_url
+
+# stage.1 graphene
+FROM ubuntu:20.04 AS graphene
+
 ARG HTTP_PROXY_HOST
 ARG HTTP_PROXY_PORT
 ARG HTTPS_PROXY_HOST
 ARG HTTPS_PROXY_PORT
-
-# stage.1 graphene
-FROM ubuntu:20.04 AS graphene
 
 RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     env DEBIAN_FRONTEND=noninteractive apt-get install -y autoconf bison build-essential coreutils gawk git libcurl4-openssl-dev libprotobuf-c-dev protobuf-c-compiler python3-protobuf wget


### PR DESCRIPTION
## Description

Move the proxy ARG declaration to the specific stage where it is used.

### 1. Why the change?

As the ARG scope is different among different docker versions, the pre-declaration at the beginning of Dockerfile caused a nightly-build failure.

Move the ARG to be under the specific stage can enable the right build-argvs pass.

### 2. User API changes

None.

### 3. Summary of the change 

Fix graphene image nightly build failure

### 4. How to test?

Github action job.

Has been tested with @Romanticoseu .
