### PR TITLE
Chronos: an error message is added to AutoformerForecaster.predict()

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -370,6 +370,9 @@ class AutoformerForecaster(Forecaster):
         """
         if self.distributed:
             invalidInputError(False, "distributed is not support in Autoformer")
+        invalidInputError(isinstance(data, tuple) or isinstance(data, DataLoader),
+                          "The input data to predict() support formats: numpy ndarray tuple"
+                          f" and pytorch dataloader, but found {type(data)}.")
         if isinstance(data, tuple):
             data = DataLoader(TensorDataset(torch.from_numpy(data[0]),
                                             torch.from_numpy(data[1]),


### PR DESCRIPTION
## Description

When the input data to AutoformerForecaster.predict() is incorrect, the error message is confusing. Thus, a new error message is added.

(http://10.112.231.51:18889/view/BigDL-PR-Validation/job/BigDL-Chronos-PR-Validation/738/)