### PR TITLE
change python style check runner

### DIFF
--- a/.github/workflows/python-style-check.yml
+++ b/.github/workflows/python-style-check.yml
@@ -20,7 +20,7 @@ jobs:
   # This workflow contains a single job called "build"
   style-check:
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
     strategy:
       matrix:
         python-version: [3.7]


### PR DESCRIPTION
## Description

change python style check runner
change ubuntu-20.04 to [ self-hosted, Gondolin, ubuntu-20.04-lts ]

### 1. Why the change?

When multiple pr validations are running at the same time, the action is in the pending state
~~~
Requested labels: ubuntu-20.04
Job defined at: intel-analytics/BigDL/.github/workflows/python-style-check.yml@refs/pull/5486/merge
Waiting for a runner to pick up this job...
~~~


