### PR TITLE
Chronos: Fix `LazyImport` known issue

### DIFF
--- a/python/chronos/src/bigdl/chronos/utils.py
+++ b/python/chronos/src/bigdl/chronos/utils.py
@@ -88,11 +88,6 @@ class LazyImport:
         except KeyError:
             pass
 
-        try:
-            module = importlib.import_module(module_name, package=self.pkg)
-        except ModuleNotFoundError:
-            spec = importlib.util.find_spec(module_name)
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
+        module = importlib.import_module(module_name, package=self.pkg)
         function = getattr(module, function_name)
         return function(*args, **kwargs)


### PR DESCRIPTION
Description:
When a duplicate package name appears in the module name, split only gets the first one.
```python
VanillaLSTM = LazyImport('bigdl.chronos.model.tf1.VanillaLSTM_keras.VanillaLSTM')
```