### PR TITLE
[PPML] Use tracker.py to build xgboost4j_2.12-1.1.2.jar

### DIFF
--- a/ppml/trusted-big-data-ml/python/docker-gramine/Dockerfile
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/Dockerfile
@@ -232,7 +232,7 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get install -y libsm6 make build-essential && \
     apt-get install -y autoconf gawk bison libcurl4-openssl-dev python3-protobuf libprotobuf-c-dev protobuf-c-compiler && \
     apt-get install -y netcat net-tools && \
-    zip -u ${BIGDL_HOME}/jars/bigdl-dllib-spark_${SPARK_VERSION}-${BIGDL_VERSION}.jar /tracker.py && \
+    zip -u ${BIGDL_HOME}/jars/xgboost4j_2.12-1.1.2.jar /tracker.py && \
     patch /usr/local/lib/python3.7/dist-packages/dill/_dill.py /_dill.py.patch && \
     patch /usr/lib/python3.7/uuid.py /python-uuid.patch && \
     patch /usr/local/lib/python3.7/dist-packages/psutil/_pslinux.py /python-pslinux.patch && \

--- a/ppml/trusted-big-data-ml/python/docker-graphene/Dockerfile
+++ b/ppml/trusted-big-data-ml/python/docker-graphene/Dockerfile
@@ -279,7 +279,7 @@ ADD ./_dill.py.patch ./_dill.py.patch
 ADD ./python-uuid.patch ./python-uuid.patch
 ADD ./python-pslinux.patch ./python-pslinux.patch
 
-RUN zip -u ${BIGDL_HOME}/jars/bigdl-dllib-spark_${SPARK_VERSION}-${BIGDL_VERSION}.jar ./tracker.py && \
+RUN zip -u ${BIGDL_HOME}/jars/xgboost4j_2.12-1.1.2.jar ./tracker.py && \
     patch /usr/local/lib/python3.7/dist-packages/dill/_dill.py ./_dill.py.patch && \
     patch /usr/lib/python3.7/uuid.py ./python-uuid.patch && \
     patch /usr/local/lib/python3.7/dist-packages/psutil/_pslinux.py ./python-pslinux.patch && \


### PR DESCRIPTION
## Description
Instead of using tracker.py to build `${BIGDL_HOME}/jars/bigdl-dllib-spark_${SPARK_VERSION}-${BIGDL_VERSION}.jar`, we now use it to build xgboost4j_2.12-1.1.2.jar.
### 1. Why the change?
The original tracker.py in `${BIGDL_HOME}/jars/bigdl-dllib-spark_${SPARK_VERSION}-${BIGDL_VERSION}.jar` cannot be reached when running xgboost code.
<!-- Provide the related github issue link if available -->

### 2. User API changes
None.

### 3. Summary of the change 
Change to use tracker.py to update the `xgboost4j_2.12-1.1.2.jar`

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [x] Github Action

