### PR TITLE
Chronos: support tsdataset for validation_data in forecasters' fit

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -260,6 +260,13 @@ class BasePytorchForecaster(Forecaster):
                | should be the same as past_seq_len and input_feature_num.
                | y's shape is (num_samples, horizon, target_dim), where horizon and target_dim
                | should be the same as future_seq_len and output_feature_num.
+               |
+               | 3. A bigdl.chronos.data.tsdataset.TSDataset instance:
+               | Forecaster will automatically process the TSDataset.
+               | By default, TSDataset will be transformed to a pytorch dataloader,
+               | which is memory-friendly while a little bit slower.
+               | Users may call `roll` on the TSDataset before calling `fit`
+               | Then the training speed will be faster but will consume more memory.
 
         :param epochs: Number of epochs you want to train. The value defaults to 1.
         :param batch_size: Number of batch size you want to train. The value defaults to 32.

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -406,7 +406,7 @@ class BasePytorchForecaster(Forecaster):
                                                          horizon=self.data_config['future_seq_len'],
                                                          feature_col=validation_data.roll_feature,
                                                          target_col=validation_data.roll_target,
-                                                         shuffle=True)
+                                                         shuffle=False)
                 if isinstance(validation_data, tuple):
                     validation_data = np_to_dataloader(validation_data, batch_size,
                                                        self.num_processes)

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -390,6 +390,16 @@ class BasePytorchForecaster(Forecaster):
                 self.trainer.fit(self.internal, data)
                 self.fitted = True
             else:
+                if isinstance(validation_data, TSDataset):
+                    _rolled = validation_data.numpy_x is None
+                    validation_data =\
+                    validation_data.to_torch_data_loader(batch_size=batch_size,
+                                                         roll=_rolled,
+                                                         lookback=self.data_config['past_seq_len'],
+                                                         horizon=self.data_config['future_seq_len'],
+                                                         feature_col=validation_data.roll_feature,
+                                                         target_col=validation_data.roll_target,
+                                                         shuffle=True)
                 if isinstance(validation_data, tuple):
                     validation_data = np_to_dataloader(validation_data, batch_size,
                                                        self.num_processes)

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -400,13 +400,14 @@ class BasePytorchForecaster(Forecaster):
                 if isinstance(validation_data, TSDataset):
                     _rolled = validation_data.numpy_x is None
                     validation_data =\
-                    validation_data.to_torch_data_loader(batch_size=batch_size,
-                                                         roll=_rolled,
-                                                         lookback=self.data_config['past_seq_len'],
-                                                         horizon=self.data_config['future_seq_len'],
-                                                         feature_col=validation_data.roll_feature,
-                                                         target_col=validation_data.roll_target,
-                                                         shuffle=False)
+                        validation_data.to_torch_data_loader(
+                            batch_size=batch_size,
+                            roll=_rolled,
+                            lookback=self.data_config['past_seq_len'],
+                            horizon=self.data_config['future_seq_len'],
+                            feature_col=validation_data.roll_feature,
+                            target_col=validation_data.roll_target,
+                            shuffle=False)
                 if isinstance(validation_data, tuple):
                     validation_data = np_to_dataloader(validation_data, batch_size,
                                                        self.num_processes)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -74,6 +74,27 @@ def create_tsdataset(roll=True, horizon=5):
             tsdata.roll(lookback=24, horizon=horizon)
     return train, test
 
+
+def create_tsdataset_val(roll=True, horizon=5):
+    from bigdl.chronos.data import TSDataset
+    import pandas as pd
+    timeseries = pd.date_range(start='2020-01-01', freq='D', periods=1000)
+    df = pd.DataFrame(np.random.rand(1000, 1),
+                      columns=['value1'],
+                      index=timeseries)
+    df.reset_index(inplace=True)
+    df.rename(columns={'index': 'timeseries'}, inplace=True)
+    train, val, test = TSDataset.from_pandas(df=df,
+                                             dt_col='timeseries',
+                                             target_col=['value1'],
+                                             with_split=True,
+                                             val_ratio = 0.1)
+    if roll:
+        for tsdata in [train, test]:
+            tsdata.roll(lookback=24, horizon=horizon)
+    return train, val, test
+
+
 class TestChronosNBeatsForecaster(TestCase):
     def setUp(self):
         pass
@@ -510,3 +531,35 @@ class TestChronosNBeatsForecaster(TestCase):
                                                   repetition_times=5)
         assert y_pred.shape == test_data[1].shape
         assert y_pred.shape == std.shape
+
+    def test_forecaster_fit_val_from_tsdataset(self):
+        train, val, test = create_tsdataset_val()
+        nbeats = NBeatsForecaster.from_tsdataset(train,
+                                                 stack_types=("generic", "seasnoality"),
+                                                 share_weights_in_stack=True,
+                                                 hidden_layer_units=32)
+        nbeats.fit(train, val,
+                   epochs=2,
+                   batch_size=32)
+        yhat = nbeats.predict(test, batch_size=32)
+        test.roll(lookback=nbeats.data_config['past_seq_len'],
+                  horizon=nbeats.data_config['future_seq_len'])
+        _, y_test = test.to_numpy()
+        assert yhat.shape == y_test.shape
+
+        del nbeats
+        train, val, test = create_tsdataset_val(roll=False, horizon=[1, 3, 5])
+        nbeats = NBeatsForecaster.from_tsdataset(train,
+                                                 past_seq_len=24,
+                                                 future_seq_len=2,
+                                                 stack_types=("generic", "seasnoality"),
+                                                 share_weights_in_stack=True,
+                                                 hidden_layer_units=32)
+        nbeats.fit(train, val,
+                   epochs=2,
+                   batch_size=32)
+        yhat = nbeats.predict(test, batch_size=None)
+        test.roll(lookback=nbeats.data_config['past_seq_len'],
+                  horizon=nbeats.data_config['future_seq_len'])
+        _, y_test = test.to_numpy()
+        assert yhat.shape == y_test.shape

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -75,6 +75,7 @@ def create_tsdataset(roll=True, horizon=5):
             tsdata.roll(lookback=24, horizon=horizon)
     return train, test
 
+
 def create_tsdataset_val(roll=True, horizon=5):
     from bigdl.chronos.data import TSDataset
     import pandas as pd


### PR DESCRIPTION
## Description
At present in forecasters' fit, validation data supports the numpy ndarray and pytorch dataloader.

### 1. Why the change?

Support tsdataset for validation_data in forecasters' fit.

### 2. User API changes


### 3. Summary of the change 

Changed `fit` in `base_forecaster`.
And changed unit test files for 4 forecasters: lstm, s2s, tcn and nbeats.

### 4. How to test?
- [ ] Unit test


### 5. New dependencies
