### PR TITLE
[PPML] Fix tracker used for xgboost examples

### DIFF
--- a/ppml/trusted-big-data-ml/python/docker-graphene/tracker.py
+++ b/ppml/trusted-big-data-ml/python/docker-graphene/tracker.py
@@ -455,7 +455,7 @@ def start_rabit_tracker(args):
 
 def main():
     """Main function if tracker is executed in standalone mode."""
-    host_ip = os.environ['RABIT_TRACKER_IP']
+    host_ip = os.environ.get("RABIT_TRACKER_IP")
     if host_ip == None:
         sys.stdout.write("###PYTHONWARN### RABIT_TRACKER_IP not set in env")
 


### PR DESCRIPTION
## Description
The original code which is shown below
```python
host_ip = os.environ['RABIT_TRACKER_IP']
```
will lead to keyError if RABIT_TRACKER_IP is not set in the environment.

The ideal result should be return None.

### 1. Why the change?
To fix the error mentioned in description.

### 2. User API changes
None

### 3. Summary of the change 
Fix a potential error that would lead to unexpected keyError.

### 4. How to test?
- [x] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
