### PR TITLE
PPML support Python PSI hashing

### DIFF
--- a/python/ppml/src/bigdl/ppml/fl/psi/psi.py
+++ b/python/ppml/src/bigdl/ppml/fl/psi/psi.py
@@ -17,6 +17,7 @@
 import logging
 
 from bigdl.dllib.utils.log4Error import invalidOperationError
+from bigdl.ppml.fl.psi.utils import to_hex_string
 from ..nn.fl_client import FLClient
 from bigdl.ppml.fl.nn.generated.psi_service_pb2_grpc import *
 from ..nn.generated.psi_service_pb2 import DownloadIntersectionRequest, SaltRequest, UploadSetRequest
@@ -24,22 +25,27 @@ from ..nn.generated.psi_service_pb2 import DownloadIntersectionRequest, SaltRequ
 class PSI(object):
     def __init__(self) -> None:
         self.stub = PSIServiceStub(FLClient.channel)
+        self.hashed_ids_to_ids = {}
     
     def get_salt(self, secure_code=""):
         return self.stub.getSalt(SaltRequest(secure_code=secure_code)).salt_reply
     
     def upload_set(self, ids, salt=""):
         # TODO: add hashing
+        hashed_ids = to_hex_string(ids, salt)
+        self.hashed_ids_to_ids = dict(zip(hashed_ids, ids))
+
         return self.stub.uploadSet(
-            UploadSetRequest(client_id=FLClient.client_id, hashedID=ids))
+            UploadSetRequest(client_id=FLClient.client_id, hashedID=hashed_ids))
 
     def download_intersection(self, max_try=100, retry=3):
         for i in range(max_try):
             intersection = self.stub.downloadIntersection(
                 DownloadIntersectionRequest()).intersection
             if intersection is not None:
-                intersection = list(intersection)
+                hashed_intersection = list(intersection)
                 logging.info(f"Intersection completed, size {len(intersection)}")
+                intersection = [self.hashed_ids_to_ids[i] for i in hashed_intersection]
                 return intersection
         invalidOperationError(False, "Max retry reached, could not get intersection, exiting.")
 

--- a/python/ppml/test/bigdl/ppml/fl/psi/test_hashing.py
+++ b/python/ppml/test/bigdl/ppml/fl/psi/test_hashing.py
@@ -14,16 +14,21 @@
 # limitations under the License.
 #
 
+import unittest
+from uuid import uuid4
 
-import hashlib
 
-def to_hex_string(ids, salt, padding_size=32):
-    hashing = hashlib.sha384()
-    hex_string = []
-    for ch in ids:
-        hashing.update(bytearray(ch, 'utf-8') + bytearray(salt, 'utf-8'))
-        ch = hashing.hexdigest()
-        while len(ch) < padding_size:
-            ch.insert(0, '0')
-        hex_string.append(ch)
-    return hex_string
+from bigdl.ppml.fl.psi.utils import *
+
+from bigdl.ppml.fl.utils import FLTest
+
+class TestHashing(FLTest):           
+    def test_hashing(self):        
+        ids = ['1', '2', '4', '5']
+        salt = str(uuid4())
+        hex_string = to_hex_string(ids, salt)
+        hex_string
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/ppml/test/bigdl/ppml/fl/psi/test_psi.py
+++ b/python/ppml/test/bigdl/ppml/fl/psi/test_psi.py
@@ -47,7 +47,7 @@ class TestPSI(FLTest):
         psi.upload_set(key, salt)
         intersection = psi.download_intersection()
         assert (isinstance(intersection, list))
-        self.assertEqual(len(intersection), 2)
+        self.assertEqual(key, intersection)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

* Support PSI hashing util (single-thread)
* Hashing is called before uploading set and reverse is called after downloading intersection

No API changes for users, an unittest is added to test the hashing