### PR TITLE
[Nano] add __call__ method for OpenVINOModel

### DIFF
--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -53,18 +53,17 @@ class OpenVINOModel:
         input_names = [t.any_name for t in self._ie_network.inputs]
         self._forward_args = input_names
 
-    def _save_model(self, path):
+    def _save(self, path):
         """
         Save OpenVINOModel to local as xml and bin file
 
         :param path: Directory to save the model.
         """
-        path = Path(path)
-        path.mkdir(exist_ok=True)
-        invalidInputError(self.ie_network,
-                          "self.ie_network shouldn't be None.")
-        xml_path = path / self.status['xml_path']
-        save(self.ie_network, xml_path)
+        if self._model_exists_or_err("self.ie_network shouldn't be None."):
+            path = Path(path)
+            path.mkdir(exist_ok=True)
+            xml_path = path / 'ov_saved_model.xml'
+            save(self.ie_network, xml_path)
 
     def pot(self,
             dataloader,
@@ -151,3 +150,8 @@ class OpenVINOModel:
             model = Core().read_model(model_path)
             model.reshape(orig_shape)
         return model
+
+    def _model_exists_or_err(self, err_msg):
+        if self.ie_network is None:
+            invalidInputError(False, err_msg)
+        return True

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -53,18 +53,17 @@ class OpenVINOModel:
         input_names = [t.any_name for t in self._ie_network.inputs]
         self._forward_args = input_names
 
-    def _save_model(self, path, model):
+    def _save_model(self, path):
         """
         Save OpenVINOModel to local as xml and bin file
 
         :param path: Directory to save the model.
-        :param model: Model object to get status property
         """
         path = Path(path)
         path.mkdir(exist_ok=True)
         invalidInputError(self.ie_network,
                           "self.ie_network shouldn't be None.")
-        xml_path = path / model.status['xml_path']
+        xml_path = path / self.status['xml_path']
         save(self.ie_network, xml_path)
 
     def pot(self,

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -53,17 +53,18 @@ class OpenVINOModel:
         input_names = [t.any_name for t in self._ie_network.inputs]
         self._forward_args = input_names
 
-    def _save_model(self, path):
+    def _save_model(self, path, model):
         """
         Save PytorchOpenVINOModel to local as xml and bin file
 
         :param path: Directory to save the model.
+        :param model: Model object to get status property
         """
         path = Path(path)
         path.mkdir(exist_ok=True)
         invalidInputError(self.ie_network,
                           "self.ie_network shouldn't be None.")
-        xml_path = path / self.status['xml_path']
+        xml_path = path / model.status['xml_path']
         save(self.ie_network, xml_path)
 
     def pot(self,

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -30,8 +30,8 @@ class OpenVINOModel:
     def forward_step(self, *inputs):
         return self._infer_request.infer(list(inputs))
 
-    def __call__(self, *inputs, **kwargs):
-        return self.forward_step(*inputs, **kwargs)
+    def __call__(self, *inputs):
+        return self.forward_step(*inputs)
 
     @property
     def forward_args(self):

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -30,6 +30,9 @@ class OpenVINOModel:
     def forward_step(self, *inputs):
         return self._infer_request.infer(list(inputs))
 
+    def __call__(self, *inputs, **kwargs):
+        return self.forward_step(*inputs, **kwargs)
+
     @property
     def forward_args(self):
         return self._forward_args

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -55,7 +55,7 @@ class OpenVINOModel:
 
     def _save_model(self, path, model):
         """
-        Save PytorchOpenVINOModel to local as xml and bin file
+        Save OpenVINOModel to local as xml and bin file
 
         :param path: Directory to save the model.
         :param model: Model object to get status property

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -59,11 +59,11 @@ class OpenVINOModel:
 
         :param path: Directory to save the model.
         """
-        if self._model_exists_or_err("self.ie_network shouldn't be None."):
-            path = Path(path)
-            path.mkdir(exist_ok=True)
-            xml_path = path / 'ov_saved_model.xml'
-            save(self.ie_network, xml_path)
+        self._model_exists_or_err()
+        path = Path(path)
+        path.mkdir(exist_ok=True)
+        xml_path = path / 'ov_saved_model.xml'
+        save(self.ie_network, xml_path)
 
     def pot(self,
             dataloader,
@@ -151,7 +151,5 @@ class OpenVINOModel:
             model.reshape(orig_shape)
         return model
 
-    def _model_exists_or_err(self, err_msg):
-        if self.ie_network is None:
-            invalidInputError(False, err_msg)
-        return True
+    def _model_exists_or_err(self):
+        invalidInputError(self.ie_network is not None, "self.ie_network shouldn't be None.")

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -48,10 +48,9 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
             super().__init__(self.ov_model)
 
     def on_forward_start(self, inputs):
-        if self.ov_model._model_exists_or_err("Please create an instance by PytorchOpenVINOModel()"
-                                              " or PytorchOpenVINOModel.load()"):
-            inputs = self.tensors_to_numpy(inputs)
-            return inputs
+        self.ov_model._model_exists_or_err()
+        inputs = self.tensors_to_numpy(inputs)
+        return inputs
 
     def on_forward_end(self, outputs):
         outputs = self.numpy_to_tensors(outputs.values())
@@ -109,8 +108,8 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
 
         :param path: Directory to save the model.
         """
-        if self.ov_model._model_exists_or_err(err_msg="model shouldn't be None"):
-            path = Path(path)
-            path.mkdir(exist_ok=True)
-            xml_path = path / self.status['xml_path']
-            save(self.ov_model.ie_network, xml_path)
+        self.ov_model._model_exists_or_err()
+        path = Path(path)
+        path.mkdir(exist_ok=True)
+        xml_path = path / self.status['xml_path']
+        save(self.ov_model.ie_network, xml_path)

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -24,6 +24,7 @@ import torch
 from bigdl.nano.utils.log4Error import invalidInputError
 from ..core.utils import save
 
+
 class PytorchOpenVINOModel(AcceleratedLightningModule):
     def __init__(self, model, input_sample=None, logging=True, **export_kwargs):
         """
@@ -47,12 +48,10 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
             super().__init__(self.ov_model)
 
     def on_forward_start(self, inputs):
-        if self.ov_model.ie_network is None:
-            invalidInputError(False,
-                              "Please create an instance by PytorchOpenVINOModel()"
-                              " or PytorchOpenVINOModel.load()")
-        inputs = self.tensors_to_numpy(inputs)
-        return inputs
+        if self.ov_model._model_exists_or_err("Please create an instance by PytorchOpenVINOModel()"
+                                              " or PytorchOpenVINOModel.load()"):
+            inputs = self.tensors_to_numpy(inputs)
+            return inputs
 
     def on_forward_end(self, outputs):
         outputs = self.numpy_to_tensors(outputs.values())
@@ -110,9 +109,8 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
 
         :param path: Directory to save the model.
         """
-        path = Path(path)
-        path.mkdir(exist_ok=True)
-        invalidInputError(self.ov_model.ie_network,
-                          "self.ie_network shouldn't be None.")
-        xml_path = path / self.status['xml_path']
-        save(self.ov_model.ie_network, xml_path)
+        if self.ov_model._model_exists_or_err(err_msg="model shouldn't be None"):
+            path = Path(path)
+            path.mkdir(exist_ok=True)
+            xml_path = path / self.status['xml_path']
+            save(self.ov_model.ie_network, xml_path)

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -22,7 +22,7 @@ from bigdl.nano.utils.inference.pytorch.model import AcceleratedLightningModule
 from .utils import export
 import torch
 from bigdl.nano.utils.log4Error import invalidInputError
-
+from ..core.utils import save
 
 class PytorchOpenVINOModel(AcceleratedLightningModule):
     def __init__(self, model, input_sample=None, logging=True, **export_kwargs):
@@ -45,9 +45,6 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
                 ov_model_path = dir / 'tmp.xml'
             self.ov_model = OpenVINOModel(ov_model_path)
             super().__init__(self.ov_model)
-
-    def forward_step(self, *inputs):
-        return self.ov_model.forward_step(*inputs)
 
     def on_forward_start(self, inputs):
         if self.ov_model.ie_network is None:
@@ -108,4 +105,14 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         return PytorchOpenVINOModel(model)
 
     def _save_model(self, path):
-        self.ov_model._save_model(path, model=self)
+        """
+        Save PytorchOpenVINOModel to local as xml and bin file
+
+        :param path: Directory to save the model.
+        """
+        path = Path(path)
+        path.mkdir(exist_ok=True)
+        invalidInputError(self.ov_model.ie_network,
+                          "self.ie_network shouldn't be None.")
+        xml_path = path / self.status['xml_path']
+        save(self.ov_model.ie_network, xml_path)

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -46,6 +46,9 @@ class PytorchOpenVINOModel(OpenVINOModel, AcceleratedLightningModule):
             OpenVINOModel.__init__(self, ov_model_path)
             AcceleratedLightningModule.__init__(self, None)
 
+    def __call__(self, *inputs, **kwargs):
+        return AcceleratedLightningModule.__call__(self, *inputs, **kwargs)
+
     def on_forward_start(self, inputs):
         if self.ie_network is None:
             invalidInputError(False,

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 from pathlib import Path
-from statistics import mode
 from tempfile import TemporaryDirectory
 from ..core.model import OpenVINOModel
 from bigdl.nano.utils.inference.tf.model import AcceleratedKerasModel

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -41,6 +41,9 @@ class KerasOpenVINOModel(OpenVINOModel, AcceleratedKerasModel):
                 ov_model_path = dir / 'tmp.xml'
             OpenVINOModel.__init__(self, ov_model_path)
             AcceleratedKerasModel.__init__(self, None)
+    
+    def __call__(self, *args, **kwds):
+        return AcceleratedKerasModel.__call__(self, *args, **kwds)
 
     def on_forward_start(self, inputs):
         if self.ie_network is None:

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -20,7 +20,7 @@ from bigdl.nano.utils.inference.tf.model import AcceleratedKerasModel
 from .utils import export
 import tensorflow as tf
 from bigdl.nano.utils.log4Error import invalidInputError
-
+from ..core.utils import save
 
 class KerasOpenVINOModel(AcceleratedKerasModel):
     def __init__(self, model):
@@ -40,7 +40,7 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
                 export(model, str(dir / 'tmp.xml'))
                 ov_model_path = dir / 'tmp.xml'
             self.ov_model = OpenVINOModel(ov_model_path)
-            AcceleratedKerasModel.__init__(self, None)
+            super().__init__(self.ov_model)
 
     def forward_step(self, *inputs):
         return self.ov_model.forward_step(*inputs)
@@ -84,4 +84,14 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
         return KerasOpenVINOModel(xml_path)
 
     def _save_model(self, path):
-        self.ov_model._save_model(path, model=self)
+        """
+        Save KerasOpenVINOModel to local as xml and bin file
+
+        :param path: Directory to save the model.
+        """
+        path = Path(path)
+        path.mkdir(exist_ok=True)
+        invalidInputError(self.ov_model.ie_network,
+                          "self.ie_network shouldn't be None.")
+        xml_path = path / self.status['xml_path']
+        save(self.ov_model.ie_network, xml_path)

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -47,10 +47,9 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
         return self.ov_model.forward_step(*inputs)
 
     def on_forward_start(self, inputs):
-        if self.ov_model._model_exists_or_err("Please create an instance by KerasOpenVINOModel()"
-                                              " or KerasOpenVINOModel.load()"):
-            inputs = self.tensors_to_numpy(inputs)
-            return inputs
+        self.ov_model._model_exists_or_err()
+        inputs = self.tensors_to_numpy(inputs)
+        return inputs
 
     def on_forward_end(self, outputs):
         outputs = tuple(outputs.values())
@@ -88,8 +87,8 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
 
         :param path: Directory to save the model.
         """
-        if self.ov_model._model_exists_or_err("model shouldn't be None"):
-            path = Path(path)
-            path.mkdir(exist_ok=True)
-            xml_path = path / self.status['xml_path']
-            save(self.ov_model.ie_network, xml_path)
+        self.ov_model._model_exists_or_err()
+        path = Path(path)
+        path.mkdir(exist_ok=True)
+        xml_path = path / self.status['xml_path']
+        save(self.ov_model.ie_network, xml_path)

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -41,7 +41,7 @@ class KerasOpenVINOModel(OpenVINOModel, AcceleratedKerasModel):
                 ov_model_path = dir / 'tmp.xml'
             OpenVINOModel.__init__(self, ov_model_path)
             AcceleratedKerasModel.__init__(self, None)
-    
+
     def __call__(self, *args, **kwds):
         return AcceleratedKerasModel.__call__(self, *args, **kwds)
 

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -22,6 +22,7 @@ import tensorflow as tf
 from bigdl.nano.utils.log4Error import invalidInputError
 from ..core.utils import save
 
+
 class KerasOpenVINOModel(AcceleratedKerasModel):
     def __init__(self, model):
         """
@@ -46,12 +47,10 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
         return self.ov_model.forward_step(*inputs)
 
     def on_forward_start(self, inputs):
-        if self.ov_model.ie_network is None:
-            invalidInputError(False,
-                              "Please create an instance by KerasOpenVINOModel()"
-                              " or KerasOpenVINOModel.load()")
-        inputs = self.tensors_to_numpy(inputs)
-        return inputs
+        if self.ov_model._model_exists_or_err("Please create an instance by KerasOpenVINOModel()"
+                                              " or KerasOpenVINOModel.load()"):
+            inputs = self.tensors_to_numpy(inputs)
+            return inputs
 
     def on_forward_end(self, outputs):
         outputs = tuple(outputs.values())
@@ -89,9 +88,8 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
 
         :param path: Directory to save the model.
         """
-        path = Path(path)
-        path.mkdir(exist_ok=True)
-        invalidInputError(self.ov_model.ie_network,
-                          "self.ie_network shouldn't be None.")
-        xml_path = path / self.status['xml_path']
-        save(self.ov_model.ie_network, xml_path)
+        if self.ov_model._model_exists_or_err("model shouldn't be None"):
+            path = Path(path)
+            path.mkdir(exist_ok=True)
+            xml_path = path / self.status['xml_path']
+            save(self.ov_model.ie_network, xml_path)

--- a/python/nano/test/openvino/basic/test_openvino.py
+++ b/python/nano/test/openvino/basic/test_openvino.py
@@ -24,5 +24,5 @@ class TestOpenVINO(TestCase):
     def test_openvino_model(self):
         openvino_model = OpenVINOModel("./intel/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.xml")
         x = np.random.randn(1, 3, 224, 224)
-        y_hat = openvino_model.forward_step(x)
+        y_hat = openvino_model(x)
         assert tuple(next(iter(y_hat)).shape) == (1, 1000)


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

<!-- Provide the related github issue link if available -->
In OpenVINOModel, we can only call `OpenVINOModel.forward_step()` to inference:
```python
from bigdl.nano.openvino import OpenVINOModel
openvino_model = OpenVINOModel(model_path)
result = openvino_model.forward_step(x)
```
To simplify the usage and make it consistent with pytorch, we can add `__call__` method for OpenVINOModel, then users can directly call the OpenVINOModel object to inference.

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->
**Before**
```python
from bigdl.nano.openvino import OpenVINOModel
openvino_model = OpenVINOModel(model_path)
result = openvino_model.forward_step(x)
```
**After**
```python
from bigdl.nano.openvino import OpenVINOModel
openvino_model = OpenVINOModel(model_path)
result = openvino_model(x)
```
### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
1. Add `__call__` method for OpenVINOModel class.
2. Now all base classes of PytorchOpenVINOModel have `__call__` method, so  `__call__` method is added for PytorchOpenVINOModel to specify which method it should call.

### 4. How to test?
- [ ] Unit test