### PR TITLE
Chronos: Add support for `id_sensitive`=True to Forecaster.from_tsdataset

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -59,6 +59,7 @@ class TSDataset:
         self.scaler_index = [i for i in range(len(self.target_col))]
         self.id_sensitive = None
         self._has_generate_agg_feature = False
+        self.is_predict = False
         self._check_basic_invariants()
 
         self._id_list = list(np.unique(self.df[self.id_col]))
@@ -609,7 +610,8 @@ class TSDataset:
         # horizon_time is only for time_enc, the time_enc numpy ndarray won't have any
         # shape change when the dataset is for prediction.
         horizon_time = self.horizon
-        if is_predict:
+        self.is_predict = is_predict
+        if self.is_predict:
             self.horizon = 0
 
         if self.lookback == 'auto':
@@ -785,6 +787,7 @@ class TSDataset:
                                   "of lookback and horizon, while get lookback+horizon="
                                   f"{need_dflen} and the length of dataset is {len(self.df)}.")
 
+            self.is_predict = is_predict
             torch_dataset = RollDataset(self.df,
                                         dt_col=self.dt_col,
                                         freq=self._freq,
@@ -795,7 +798,7 @@ class TSDataset:
                                         id_col=self.id_col,
                                         time_enc=time_enc,
                                         label_len=label_len,
-                                        is_predict=is_predict)
+                                        is_predict=self.is_predict)
             # TODO gen_rolling_feature and gen_global_feature will be support later
             self.roll_target = target_col
             self.roll_feature = feature_col

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -59,7 +59,6 @@ class TSDataset:
         self.scaler_index = [i for i in range(len(self.target_col))]
         self.id_sensitive = None
         self._has_generate_agg_feature = False
-        self.is_predict = False
         self._check_basic_invariants()
 
         self._id_list = list(np.unique(self.df[self.id_col]))
@@ -610,8 +609,7 @@ class TSDataset:
         # horizon_time is only for time_enc, the time_enc numpy ndarray won't have any
         # shape change when the dataset is for prediction.
         horizon_time = self.horizon
-        self.is_predict = is_predict
-        if self.is_predict:
+        if is_predict:
             self.horizon = 0
 
         if self.lookback == 'auto':
@@ -787,7 +785,6 @@ class TSDataset:
                                   "of lookback and horizon, while get lookback+horizon="
                                   f"{need_dflen} and the length of dataset is {len(self.df)}.")
 
-            self.is_predict = is_predict
             torch_dataset = RollDataset(self.df,
                                         dt_col=self.dt_col,
                                         freq=self._freq,
@@ -798,7 +795,7 @@ class TSDataset:
                                         id_col=self.id_col,
                                         time_enc=time_enc,
                                         label_len=label_len,
-                                        is_predict=self.is_predict)
+                                        is_predict=is_predict)
             # TODO gen_rolling_feature and gen_global_feature will be support later
             self.roll_target = target_col
             self.roll_feature = feature_col

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -450,7 +450,7 @@ class BasePytorchForecaster(Forecaster):
                                              feature_col=data.roll_feature,
                                              target_col=data.roll_target,
                                              shuffle=False,
-                                             is_predict=True)
+                                             is_predict=data.is_predict)
         # data transform
         is_local_data = isinstance(data, (np.ndarray, DataLoader))
         if is_local_data and self.distributed:
@@ -544,7 +544,7 @@ class BasePytorchForecaster(Forecaster):
                                              feature_col=data.roll_feature,
                                              target_col=data.roll_target,
                                              shuffle=False,
-                                             is_predict=True)
+                                             is_predict=data.is_predict)
         if quantize:
             return _pytorch_fashion_inference(model=self.onnxruntime_int8,
                                               input_data=data,
@@ -654,7 +654,8 @@ class BasePytorchForecaster(Forecaster):
                                              horizon=self.data_config['future_seq_len'],
                                              feature_col=data.roll_feature,
                                              target_col=data.roll_target,
-                                             shuffle=False)
+                                             shuffle=False,
+                                             is_predict=False)
         is_local_data = isinstance(data, (tuple, DataLoader))
         if not is_local_data and not self.distributed:
             data = xshard_to_np(data, mode="fit")
@@ -754,7 +755,8 @@ class BasePytorchForecaster(Forecaster):
                                              horizon=self.data_config['future_seq_len'],
                                              feature_col=data.roll_feature,
                                              target_col=data.roll_target,
-                                             shuffle=False)
+                                             shuffle=False,
+                                             is_predict=False)
         if isinstance(data, DataLoader):
             input_data = data
             target = np.concatenate(tuple(val[1] for val in data), axis=0)
@@ -1098,7 +1100,7 @@ class BasePytorchForecaster(Forecaster):
         """
         Build a Forecaster Model.
 
-        :param tsdataset: A bigdl.chronos.data.tsdataset.TSDataset instance.
+        :param tsdataset: Train tsdataset, a bigdl.chronos.data.tsdataset.TSDataset instance.
         :param past_seq_len: int or "auto", Specify the history time steps (i.e. lookback).
                Do not specify the 'past_seq_len' if your tsdataset has called
                the 'TSDataset.roll' method or 'TSDataset.to_torch_data_loader'.

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -449,8 +449,7 @@ class BasePytorchForecaster(Forecaster):
                                              horizon=self.data_config['future_seq_len'],
                                              feature_col=data.roll_feature,
                                              target_col=data.roll_target,
-                                             shuffle=False,
-                                             is_predict=data.is_predict)
+                                             shuffle=False)
         # data transform
         is_local_data = isinstance(data, (np.ndarray, DataLoader))
         if is_local_data and self.distributed:
@@ -543,8 +542,7 @@ class BasePytorchForecaster(Forecaster):
                                              horizon=self.data_config['future_seq_len'],
                                              feature_col=data.roll_feature,
                                              target_col=data.roll_target,
-                                             shuffle=False,
-                                             is_predict=data.is_predict)
+                                             shuffle=False)
         if quantize:
             return _pytorch_fashion_inference(model=self.onnxruntime_int8,
                                               input_data=data,
@@ -654,8 +652,7 @@ class BasePytorchForecaster(Forecaster):
                                              horizon=self.data_config['future_seq_len'],
                                              feature_col=data.roll_feature,
                                              target_col=data.roll_target,
-                                             shuffle=False,
-                                             is_predict=False)
+                                             shuffle=False)
         is_local_data = isinstance(data, (tuple, DataLoader))
         if not is_local_data and not self.distributed:
             data = xshard_to_np(data, mode="fit")
@@ -755,8 +752,7 @@ class BasePytorchForecaster(Forecaster):
                                              horizon=self.data_config['future_seq_len'],
                                              feature_col=data.roll_feature,
                                              target_col=data.roll_target,
-                                             shuffle=False,
-                                             is_predict=False)
+                                             shuffle=False)
         if isinstance(data, DataLoader):
             input_data = data
             target = np.concatenate(tuple(val[1] for val in data), axis=0)

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -449,7 +449,8 @@ class BasePytorchForecaster(Forecaster):
                                              horizon=self.data_config['future_seq_len'],
                                              feature_col=data.roll_feature,
                                              target_col=data.roll_target,
-                                             shuffle=False)
+                                             shuffle=False,
+                                             is_predict=True)
         # data transform
         is_local_data = isinstance(data, (np.ndarray, DataLoader))
         if is_local_data and self.distributed:
@@ -542,7 +543,8 @@ class BasePytorchForecaster(Forecaster):
                                              horizon=self.data_config['future_seq_len'],
                                              feature_col=data.roll_feature,
                                              target_col=data.roll_target,
-                                             shuffle=False)
+                                             shuffle=False,
+                                             is_predict=True)
         if quantize:
             return _pytorch_fashion_inference(model=self.onnxruntime_int8,
                                               input_data=data,
@@ -1150,6 +1152,11 @@ class BasePytorchForecaster(Forecaster):
                           f"but found {past_seq_len, future_seq_len}.",
                           fixMsg="Do not specify past_seq_len and future seq_len "
                           "or call tsdataset.roll method again and specify time step")
+
+        if tsdataset.id_sensitive:
+            _id_list_len = len(tsdataset.id_col)
+            input_feature_num *= _id_list_len
+            output_feature_num *= _id_list_len
 
         return cls(past_seq_len=past_seq_len,
                    future_seq_len=future_seq_len,

--- a/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
@@ -152,7 +152,7 @@ class LSTMForecaster(BasePytorchForecaster):
         '''
         Build a LSTM Forecaster Model.
 
-        :param tsdataset: A bigdl.chronos.data.tsdataset.TSDataset instance.
+        :param tsdataset: Train tsdataset, a bigdl.chronos.data.tsdataset.TSDataset instance.
         :param past_seq_len: Specify the history time steps (i.e. lookback).
                Do not specify the 'past_seq_len' if your tsdataset has called
                the 'TSDataset.roll' method or 'TSDataset.to_torch_data_loader'.

--- a/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
@@ -198,6 +198,11 @@ class LSTMForecaster(BasePytorchForecaster):
                           fixMsg="Do not specify past_seq_len "
                           "or call tsdataset.roll method again and specify time step.")
 
+        if tsdataset.id_sensitive:
+            _id_list_len = len(tsdataset._id_list)
+            input_feature_num *= _id_list_len
+            output_feature_num *= _id_list_len
+
         return cls(past_seq_len=past_seq_len,
                    input_feature_num=input_feature_num,
                    output_feature_num=output_feature_num,

--- a/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
@@ -224,6 +224,9 @@ class NBeatsForecaster(BasePytorchForecaster):
                           f"but found {past_seq_len, future_seq_len}",
                           fixMsg="Do not specify past_seq_len and future seq_len "
                           "or call tsdataset.roll method again and specify time step")
+        
+        invalidInputError(tsdataset.id_sensitive and len(tsdataset._id_list) > 1,
+                          "NBeats only supports univariate forecasting.")
 
         return cls(past_seq_len=past_seq_len,
                    future_seq_len=future_seq_len,

--- a/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
@@ -174,7 +174,7 @@ class NBeatsForecaster(BasePytorchForecaster):
         """
         Build a NBeats Forecaster Model.
 
-        :param tsdataset: A bigdl.chronos.data.tsdataset.TSDataset instance.
+        :param tsdataset: Train tsdataset, a bigdl.chronos.data.tsdataset.TSDataset instance.
         :param past_seq_len: Specify the history time steps (i.e. lookback).
                Do not specify the 'past_seq_len' if your tsdataset has called
                the 'TSDataset.roll' method or 'TSDataset.to_torch_data_loader'.

--- a/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
@@ -225,7 +225,7 @@ class NBeatsForecaster(BasePytorchForecaster):
                           fixMsg="Do not specify past_seq_len and future seq_len "
                           "or call tsdataset.roll method again and specify time step")
         
-        invalidInputError(tsdataset.id_sensitive and len(tsdataset._id_list) > 1,
+        invalidInputError(not all([tsdataset.id_sensitive, len(tsdataset._id_list) > 1]),
                           "NBeats only supports univariate forecasting.")
 
         return cls(past_seq_len=past_seq_len,

--- a/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
@@ -224,7 +224,7 @@ class NBeatsForecaster(BasePytorchForecaster):
                           f"but found {past_seq_len, future_seq_len}",
                           fixMsg="Do not specify past_seq_len and future seq_len "
                           "or call tsdataset.roll method again and specify time step")
-        
+
         invalidInputError(not all([tsdataset.id_sensitive, len(tsdataset._id_list) > 1]),
                           "NBeats only supports univariate forecasting.")
 


### PR DESCRIPTION
## Description

When the user's `tsdataset` has multiple ids, `tsdataset.id_sensitive`=True may be used and additional `target_col(input_feature_num)` will be generated.

### 1. Why the change?

1. `from_tsdataset` does not support id sensitive=True.

### 2. User API changes

No changed.

### 3. Summary of the change 

1. Fix `Forecaster.from_tsdataset` does not support `id_sensitive`=True.

### 4. How to test?

- [ ] Unit test