### PR TITLE
Chronos: how to speedup inference on one node

### DIFF
--- a/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_ONNXRuntime.ipynb
+++ b/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_ONNXRuntime.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/intel-analytics/BigDL/blob/main/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_on_one_node.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/intel-analytics/BigDL/blob/main/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_ONNXRuntime.ipynb)"
    ]
   },
   {
@@ -18,7 +18,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Speed up inference of forecaster on single node"
+    "# Speed up inference of forecaster through ONNXRuntime"
    ]
   },
   {
@@ -29,9 +29,9 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "Through the previous guidance \"Train forcaster on single node\", forecasters can be created and trained. Normally, input data to the trained forecaster to perform inference, observe and verify whether the inference result is as expected. In the inferencing process, it is desirable to speed up. One way to do this is to utilize some accelerators, such as onnxruntime and openvino.\n",
+    "Through the previous guidance \"Train forcaster on single node\", forecasters can be created and trained. Normally, input data to the trained forecaster to perform inference, observe and verify whether the inference result is as expected. In the inferencing process, it is desirable to speed up. One way to do this is to utilize some accelerators, such as ONNXRuntime.\n",
     "\n",
-    "Actually, utilizing accelerators is quite easy in Chronos, that is calling `predict_with_onnx` and `predict_with_openvino`. In this guidance, **we demonstrate how to speed up inference of forecaster on single node** in detail. Highlightly, although Chronos supports inferencing on a cluster, the methods to speed up can only be used when forecaster is a non-distributed version.\n",
+    "Actually, utilizing ONNXRuntime to accelerate is quite easy in Chronos, that is directly calling `predict_with_onnx`. In this guidance, **we demonstrate how to speed up inference of forecaster through ONNXRuntime** in detail. Highlightly, although Chronos supports inferencing on a cluster, the method to speed up can only be used when forecaster is a non-distributed version.\n",
     "\n",
     "We will take `TCNForecaster` and nyc_taxi dataset as an example in this guide."
    ]
@@ -52,16 +52,11 @@
    "outputs": [],
    "source": [
     "!pip install --pre --upgrade bigdl-chronos[pytorch]\n",
-    "\n",
-    "# install accelerators\n",
+    "# install ONNXRuntime\n",
     "!pip install onnx\n",
     "!pip install onnxruntime\n",
-    "!pip install openvino-dev\n",
-    "\n",
-    "# fix dependency conflict\n",
+    "# uninstall torchtext to avoid version conflict\n",
     "!pip uninstall -y torchtext\n",
-    "!pip install numpy==1.21\n",
-    "!pip install opencv-python-headless==4.1.2.30\n",
     "exit()"
    ]
   },
@@ -119,46 +114,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Inferencing\n",
-    "\n",
-    "When a trained forecaster is ready, just call `predict` to realize inference.\n",
-    "Forecaster supports predicting data in many formats, including:\n",
-    "\n",
-    "1. numpy ndarray (**recommended**)\n",
-    "2. xshard item\n",
-    "3. pytorch dataloader\n",
-    "4. `bigdl.chronos.data.TSDataset`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# get data for training and testing\n",
-    "train_data, test_data = get_data()\n",
-    "# get a trained forecaster\n",
-    "forecaster = get_trained_forecaster(train_data)\n",
-    "\n",
-    "for x, y in test_data:\n",
-    "    yhat = forecaster.predict(x.numpy()) # predict"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Speeding up inference\n",
     "\n",
-    "When forecaster is a non-distributed version, we provide with `predict_with_onnx` and `predict_with_openvino` methods to speed up inference. These methods can be directly called without calling `build_onnx` or `build_openvino` and forecaster will automatically build an onnxruntime or openvino session with default settings."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### with onnxruntime\n",
+    "When a trained forecaster is ready and forecaster is a non-distributed version, we provide with `predict_with_onnx` method to speed up inference. The method can be directly called without calling `build_onnx` and forecaster will automatically build an onnxruntime session with default settings.\n",
+    "\n",
     "The `predict_with_onnx` method supports data in following formats:\n",
     "\n",
     "1. numpy ndarray (**recommended**)\n",
@@ -174,38 +133,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# speed up inference with onnxruntime\n",
-    "for x, y in test_data:\n",
-    "    yhat = forecaster.predict_with_onnx(x.numpy())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### with openvino\n",
-    "The `predict_with_openvino` method currently only supports data in numpy ndarray format and the parameter `batch_size` can be changed. If not familiar with manual hyperparameters tuning, just leave `batch_size` to the default value."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# speed up inference with openvino\n",
-    "for x, y in test_data:\n",
-    "    yhat = forecaster.predict_with_openvino(x.numpy())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### acceleration performance\n",
-    "Let's see the performance of the acceleration methods.\n",
+    "# get data for training and testing\n",
+    "train_data, test_data = get_data()\n",
+    "# get a trained forecaster\n",
+    "forecaster = get_trained_forecaster(train_data)\n",
     "\n",
-    "The predict latency of without accelerator, with onnxruntime and with openvino are given below. The result \"p50\" means latency sorted to 50% in multiple predictions and the acceleration performance is significant.\n"
+    "# speed up inference through ONNXRuntime\n",
+    "for x, y in test_data:\n",
+    "    yhat = forecaster.predict_with_onnx(x.numpy()) # predict"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's see the acceleration performance of `predict_with_onnx`.\n",
+    "\n",
+    "The predict latency of without accelerator and with ONNXRuntime are given below. The result \"p50\" means latency sorted to 50% in multiple predictions and the acceleration performance is significant.\n"
    ]
   },
   {
@@ -218,21 +162,18 @@
     "\n",
     "x = next(iter(test_data))[0]\n",
     "def func_original():\n",
-    "    forecaster.predict(x.numpy())\n",
+    "    forecaster.predict(x.numpy()) # without accelerator\n",
     "def func_onnxruntime():\n",
-    "    forecaster.predict_with_onnx(x.numpy())\n",
-    "def func_openvino():\n",
-    "    forecaster.predict_with_openvino(x.numpy())\n",
+    "    forecaster.predict_with_onnx(x.numpy()) # with ONNXRuntime\n",
     "\n",
     "print(\"original predict runtime (ms):\", Evaluator.get_latency(func_original))\n",
-    "print(\"use accelerator (onnxruntime) (ms):\", Evaluator.get_latency(func_onnxruntime))\n",
-    "print(\"use accelerator (openvino) (ms):\", Evaluator.get_latency(func_openvino))"
+    "print(\"pridict runtime with ONNXRuntime (ms):\", Evaluator.get_latency(func_onnxruntime))"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.13 ('howto-env')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_ONNXRuntime.ipynb
+++ b/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_ONNXRuntime.ipynb
@@ -4,6 +4,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<style>\n",
+    "    .rst-content blockquote {\n",
+    "        margin-left: 0px;\n",
+    "    }\n",
+    "    \n",
+    "    blockquote > div {\n",
+    "        margin: 1.5625em auto;\n",
+    "        padding: 20px 15px 1px;\n",
+    "        border-left: 0.2rem solid rgb(59, 136, 219);  \n",
+    "        border-radius: 0.2rem;\n",
+    "        box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);\n",
+    "    }\n",
+    "</style>\n",
+    "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/intel-analytics/BigDL/blob/main/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_ONNXRuntime.ipynb)"
    ]
   },

--- a/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_ONNXRuntime.ipynb
+++ b/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_ONNXRuntime.ipynb
@@ -43,9 +43,9 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "Through the previous guidance [Train forcaster on single node](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Howto/how_to_train_forecaster_on_one_node.html), forecasters can be created and trained. Normally, input data to the trained forecaster to perform inference, observe and verify whether the inference result is as expected. In the inferencing process, it is desirable to speed up. One way to do this is to utilize some accelerators, such as ONNXRuntime.\n",
+    "In the inferencing process, it is desirable to speed up. One way to do this is to utilize some accelerators, such as ONNXRuntime.\n",
     "\n",
-    "Actually, utilizing ONNXRuntime to accelerate is quite easy in Chronos, that is directly calling `predict_with_onnx`. In this guidance, **we demonstrate how to speed up inference of forecaster through ONNXRuntime** in detail. Highlightly, although Chronos supports inferencing on a cluster, the method to speed up can only be used when forecaster is a non-distributed version.\n",
+    "Actually, utilizing ONNXRuntime to accelerate is easy in Chronos, that is directly calling `predict_with_onnx` (optionally `build_onnx`). In this guidance, **we demonstrate how to speed up inference of forecaster through ONNXRuntime** in detail.\n",
     "\n",
     "We will take `TCNForecaster` and nyc_taxi dataset as an example in this guide."
    ]
@@ -72,6 +72,16 @@
     "# uninstall torchtext to avoid version conflict\n",
     "!pip uninstall -y torchtext\n",
     "exit()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 📝**Note**\n",
+    "> \n",
+    "> - Although Chronos supports inferencing on a cluster, the method to speed up can only be used when forecaster is a non-distributed version.\n",
+    "> - Only pytorch backend deep learning forecasters support onnxruntime acceleration."
    ]
   },
   {

--- a/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_ONNXRuntime.ipynb
+++ b/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_ONNXRuntime.ipynb
@@ -29,7 +29,7 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "Through the previous guidance \"Train forcaster on single node\", forecasters can be created and trained. Normally, input data to the trained forecaster to perform inference, observe and verify whether the inference result is as expected. In the inferencing process, it is desirable to speed up. One way to do this is to utilize some accelerators, such as ONNXRuntime.\n",
+    "Through the previous guidance [Train forcaster on single node](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Howto/how_to_train_forecaster_on_one_node.html), forecasters can be created and trained. Normally, input data to the trained forecaster to perform inference, observe and verify whether the inference result is as expected. In the inferencing process, it is desirable to speed up. One way to do this is to utilize some accelerators, such as ONNXRuntime.\n",
     "\n",
     "Actually, utilizing ONNXRuntime to accelerate is quite easy in Chronos, that is directly calling `predict_with_onnx`. In this guidance, **we demonstrate how to speed up inference of forecaster through ONNXRuntime** in detail. Highlightly, although Chronos supports inferencing on a cluster, the method to speed up can only be used when forecaster is a non-distributed version.\n",
     "\n",
@@ -66,7 +66,7 @@
    "source": [
     "## Forecaster preparation\n",
     "\n",
-    "Before the inferencing process, a forecaster should be created and trained. The training process is introduced in the previous guidance \"Train forcaster on single node\" in detail, therefore we directly create and train a `TCNForecaster` based on the nyc taxi dataset."
+    "Before the inferencing process, a forecaster should be created and trained. The training process is introduced in the previous guidance [Train forcaster on single node](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Howto/how_to_train_forecaster_on_one_node.html) in detail, therefore we directly create and train a `TCNForecaster` based on the nyc taxi dataset."
    ]
   },
   {
@@ -116,8 +116,27 @@
    "source": [
     "## Speeding up inference\n",
     "\n",
-    "When a trained forecaster is ready and forecaster is a non-distributed version, we provide with `predict_with_onnx` method to speed up inference. The method can be directly called without calling `build_onnx` and forecaster will automatically build an onnxruntime session with default settings.\n",
-    "\n",
+    "When a trained forecaster is ready and forecaster is a non-distributed version, we provide with `predict_with_onnx` method to speed up inference. The method can be directly called without calling `build_onnx` and forecaster will automatically build an onnxruntime session with default settings."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 📝**Note**\n",
+    "> \n",
+    "> `build_onnx` is recommended to use in following cases:\n",
+    "> \n",
+    "> 1. To strictly control the thread to be used during inferencing.\n",
+    "> 2. To alleviate the cold start problem when `predict_with_onnx` is called for the first time.\n",
+    "> \n",
+    "> Please refer to [API documentation](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Chronos/forecasters.html#bigdl.chronos.forecaster.tcn_forecaster.TCNForecaster.build_onnx) for more information on `build_onnx`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The `predict_with_onnx` method supports data in following formats:\n",
     "\n",
     "1. numpy ndarray (**recommended**)\n",
@@ -136,8 +155,15 @@
     "# get data for training and testing\n",
     "train_data, test_data = get_data()\n",
     "# get a trained forecaster\n",
-    "forecaster = get_trained_forecaster(train_data)\n",
-    "\n",
+    "forecaster = get_trained_forecaster(train_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# speed up inference through ONNXRuntime\n",
     "for x, y in test_data:\n",
     "    yhat = forecaster.predict_with_onnx(x.numpy()) # predict"

--- a/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.ipynb
+++ b/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.ipynb
@@ -27,7 +27,7 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "Through the previous guidance \"Train forcaster on single node\", forecasters can be created and trained. Normally, input data to the trained forecaster to perform inference, observe and verify whether the inference result is as expected. In the inferencing process, it is desirable to speed up. One way to do this is to utilize some accelerators, such as OpenVINO.\n",
+    "Through the previous guidance [Train forcaster on single node](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Howto/how_to_train_forecaster_on_one_node.html), forecasters can be created and trained. Normally, input data to the trained forecaster to perform inference, observe and verify whether the inference result is as expected. In the inferencing process, it is desirable to speed up. One way to do this is to utilize some accelerators, such as OpenVINO.\n",
     "\n",
     "Actually, utilizing OpenVINO to accelerate is quite easy in Chronos, that is directly calling `predict_with_openvino`. In this guidance, **we demonstrate how to speed up inference of forecaster through OpenVINO** in detail. Highlightly, although Chronos supports inferencing on a cluster, the method to speed up can only be used when forecaster is a non-distributed version.\n",
     "\n",
@@ -63,7 +63,7 @@
    "source": [
     "## Forecaster preparation\n",
     "\n",
-    "Before the inferencing process, a forecaster should be created and trained. The training process is introduced in the previous guidance \"Train forcaster on single node\" in detail, therefore we directly create and train a `TCNForecaster` based on the nyc taxi dataset."
+    "Before the inferencing process, a forecaster should be created and trained. The training process is introduced in the previous guidance [Train forcaster on single node](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Howto/how_to_train_forecaster_on_one_node.html) in detail, therefore we directly create and train a `TCNForecaster` based on the nyc taxi dataset."
    ]
   },
   {
@@ -113,8 +113,24 @@
    "source": [
     "## Speeding up inference\n",
     "\n",
-    "When a trained forecaster is ready and forecaster is a non-distributed version, we provide with `predict_with_openvino` method to speed up inference. The method can be directly called without calling `build_openvino` and forecaster will automatically build an openvino session with default settings.\n",
-    "\n",
+    "When a trained forecaster is ready and forecaster is a non-distributed version, we provide with `predict_with_openvino` method to speed up inference. The method can be directly called without calling `build_openvino` and forecaster will automatically build an openvino session with default settings."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 📝**Note**\n",
+    "> \n",
+    "> `build_openvino` is recommended to use when you want to alleviate the cold start problem when `predict_with_openvino` is called for the first time.\n",
+    "> \n",
+    "> Please refer to [API documentation](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Chronos/forecasters.html#bigdl.chronos.forecaster.tcn_forecaster.TCNForecaster.build_openvino) for more information on `build_openvino`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The `predict_with_openvino` method currently only supports data in numpy ndarray format and the parameter `batch_size` can be changed. If not familiar with manual hyperparameters tuning, just leave `batch_size` to the default value."
    ]
   },
@@ -127,8 +143,15 @@
     "# get data for training and testing\n",
     "train_data, test_data = get_data()\n",
     "# get a trained forecaster\n",
-    "forecaster = get_trained_forecaster(train_data)\n",
-    "\n",
+    "forecaster = get_trained_forecaster(train_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# speed up inference through OpenVINO\n",
     "for x, y in test_data:\n",
     "    yhat = forecaster.predict_with_openvino(x.numpy()) # predict"

--- a/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.ipynb
+++ b/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.ipynb
@@ -4,6 +4,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<style>\n",
+    "    .rst-content blockquote {\n",
+    "        margin-left: 0px;\n",
+    "    }\n",
+    "    \n",
+    "    blockquote > div {\n",
+    "        margin: 1.5625em auto;\n",
+    "        padding: 20px 15px 1px;\n",
+    "        border-left: 0.2rem solid rgb(59, 136, 219);  \n",
+    "        border-radius: 0.2rem;\n",
+    "        box-shadow: 0 0.2rem 0.5rem rgb(0 0 0 / 5%), 0 0 0.0625rem rgb(0 0 0 / 10%);\n",
+    "    }\n",
+    "</style>\n",
+    "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/intel-analytics/BigDL/blob/main/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.ipynb)"
    ]
   },

--- a/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.ipynb
+++ b/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.ipynb
@@ -41,9 +41,9 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "Through the previous guidance [Train forcaster on single node](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Howto/how_to_train_forecaster_on_one_node.html), forecasters can be created and trained. Normally, input data to the trained forecaster to perform inference, observe and verify whether the inference result is as expected. In the inferencing process, it is desirable to speed up. One way to do this is to utilize some accelerators, such as OpenVINO.\n",
+    "In the inferencing process, it is desirable to speed up. One way to do this is to utilize some accelerators, such as OpenVINO.\n",
     "\n",
-    "Actually, utilizing OpenVINO to accelerate is quite easy in Chronos, that is directly calling `predict_with_openvino`. In this guidance, **we demonstrate how to speed up inference of forecaster through OpenVINO** in detail. Highlightly, although Chronos supports inferencing on a cluster, the method to speed up can only be used when forecaster is a non-distributed version.\n",
+    "Actually, utilizing OpenVINO to accelerate is easy in Chronos, that is directly calling `predict_with_openvino` (optionally `build_openvino`). In this guidance, **we demonstrate how to speed up inference of forecaster through OpenVINO** in detail.\n",
     "\n",
     "We will take `TCNForecaster` and nyc_taxi dataset as an example in this guide."
    ]
@@ -69,6 +69,15 @@
     "# uninstall torchtext to avoid version conflict\n",
     "!pip uninstall -y torchtext\n",
     "exit()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 📝**Note**\n",
+    "> \n",
+    "> Although Chronos supports inferencing on a cluster, the method to speed up can only be used when forecaster is a non-distributed version."
    ]
   },
   {

--- a/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.ipynb
+++ b/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.ipynb
@@ -66,8 +66,9 @@
     "!pip install --pre --upgrade bigdl-chronos[pytorch]\n",
     "# install OpenVINO\n",
     "!pip install openvino-dev\n",
-    "# uninstall torchtext to avoid version conflict\n",
+    "# fix conflict with google colab\n",
     "!pip uninstall -y torchtext\n",
+    "!pip install numpy==1.21\n",
     "exit()"
    ]
   },
@@ -77,7 +78,8 @@
    "source": [
     "> 📝**Note**\n",
     "> \n",
-    "> Although Chronos supports inferencing on a cluster, the method to speed up can only be used when forecaster is a non-distributed version."
+    "> - Although Chronos supports inferencing on a cluster, the method to speed up can only be used when forecaster is a non-distributed version.\n",
+    "> - Only pytorch backend deep learning forecasters support openvino acceleration."
    ]
   },
   {

--- a/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.ipynb
+++ b/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.ipynb
@@ -1,0 +1,191 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/intel-analytics/BigDL/blob/main/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![image.png](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJsAAABHCAMAAAAnQ8XqAAAACXBIWXMAAA7DAAAOwwHHb6hkAAADAFBMVEVHcEyAgYR+gYU0OD85OTuOkZSChYk5OTs5OTs5OTuAgYR/gYM5OTuAgYSAgYSBgoWAgoU5OTs+NTg5OTs4ODs5OTsAccQ1NTk3Nzo4ODuBg4U4ODs5OTs4ODs5OTuRlJY6OjwAccM4ODs5OTs3Nzo4ODuBgoQ3Nzo4OTo3NzqSlJc5OTsBccOAgYSRlJeRk5Y5OTs5OTs5OTs4ODuPkpQ4ODo4ODs5OTs5OTs4ODuRlJeSlJeJio4BccM5OTsDbrw4ODuPkpU4ODuVmJs4ODsBccOTlpk2Njo3OTwBccOSlZiUmJo5OTs5OTs5OTyPkZSRk5eTlpk5OTw4ODs5OTw2Njk5OTuRlJeUl5pzi6EAccM5OTsBcMM4ODs4ODs4ODs4ODs4ODs5OTs4ODuAgYSAgYM4ODs4ODuTl5kBccM4ODo4ODs4ODs5OTs4ODs5OTs5OTuSlJc4ODs4ODs5OTs4ODuAgYSRk5aFh4o4ODucn6I4ODs4ODv7/P4BccM5OTuAgoVDQ0c4ODsBccM4ODtFf7ABcMM5OTuTlZh/goM4ODqAgYSFhomnrK4jTnCDhYeAgYUCb744OTyChIc4ODsAcMI5OTsBccM5OTt/gYSChIeFh4paW15/gYOChIcDbrs5OTv///+AgYT+/v6IiYw6OjyBgoX9/f47Oz09PT99foF+f4KDhIc5OTw8PD88PD73+Pj9/v6Oj5KCg4Z/gIMBccOJio1/gYTq6us7Oz56e3719fU6Oj2AgYV8fYCAgoR4eXzm5ud7fH/7+/s9PUDs7Ozh4uLi4uOCg4W2triJio6RkpTq6+s+PkCOj5F5en2RkpXs7O2HiIz8/P2Gh4qDhIgBdMj09PX5+fn29vaPkJP29/cBcsW1treKi46XmJvT1NV3eHs4ODqEhYh8fIDf3+Dp6emjpKYBccTb29zOz9A/P0HDw8WdnqCUlZjz8/O+v8Hv7/Dx8fGysrSvr7F9foJzdHiqq60Bdcv+/v/HyMm2t7nGxsien6Hj4+S3t7nLBRsYAAAAoHRSTlMA+wMC/QEC/vz7nyP6+nL7oAIBBFHrAQovQgQZ1xA/PAP+OvIHYnISoA438Pz+KDPv+d+EDBR/pveBMCUFI+c+Sg+tByH9HAicJCsi2S3+CRYSHCklOEo/Ggb02xjUorKptvFb/J0xZSD6dJErwpXkbkJHactLmEcjRAvQiQMZ0qkMV/I0DiG8TiId+NMuBMn7E5u0efzF5LlkvllplbYvkV0hXwAADA1JREFUaN7MmXtUFNcdx6867OyY9dTl4QPFRYNH3FjeKoLaoIgK8oqgMa2KWo3G+k7qqWliEnPS1qbtSWPb056ednZwhtmF3W1lhYC7LCIx+ABSwdpo1CiN2hiNzyRt/2jvvTM7O6996Dnafs/CDDNz3I/f3/397u/eAeB/qRgs8H8lJdDcgqp1o3T0mE2S/Tlz2cxn80vS0pdaLemzacqo1eMPW05FRUWxNc8CofLW5xflLCsHcQk86VSLpR+XS+W7youK0/Ks1nRLcXpxUWVluezm6wksQWr1iF2KqSwqKsmzQJcseSVF6ysSDYbgPZE/FrJ5CVqrR2LS3IKCyvz0NKt1qTU9Py+/MidnZshEEHx7JGyJiYmBrywvLy9Ky0+zbrNuy1uanl9UVJE4eLBwL9YwU1CiSgYppo/It1de2fVsSVHx+vySosqKuQ/xDzwKthhQMXz48N+9/fYv/vDuu6+tXbv2+1BDhw4dHqWGvvZbEPMwbCMMIwIK9YgBPHG8qal/YGCgv79//wVBTcebjsNPE/o0NQknslPxvAk9dOrD18DgSGyxgh7ct58MGzTsu1CDoIY9sH7avxYYovbNHGcOnL66cNZCpFkL3xocku0JxvdNphGqC/90oV9cI8dxjEJcoyj0WPDyoP1DRTY+JFtc0mSsIQIfCih45zfXNkxB2jDvubfAiJBsjK+5Ham3vV089va2djgYf6OMr7Vdutve69Fh0/dt4vJNm8auzkB6avevV04bB0AyYnv1uY8PCrr2q4Xh2Dz9d4+dP3b+PPo5duzY3XtfXb1x8WxDW3sr0xWw7d5/8H381N0GBOeLhi37Ou/mWUG8227nl4+Dzo0A39lzbd54pHkHN8wKw8Y5ztba1Ko9d/vTz284WruQdz5Pwx3ZvSP766P1bZo910iIMhopytjCTwTJiO3j8di28QenhGFr5up7Dtn66pQSKD642osI/EzDFemJPtsX++s50biIbN0mp3AKD2QZTVKssxT8PFo26NuBc7ZarerqoJ23OhjI4Wk4aasLXLcdEtiY6NgUF0ja5N4EhkTP1obYtFFFeLW2W72Y7T1bXeA6ZHNEw3ZZh40lSSMPE0LLZk5OjtUdb3psGAO6dKOV45pVbNA3z4P4RpI0ZSLQARpn34jZhFwYL+SCUPfM8BBrRnXaHGuWxVSGU4uZhL/qbJ+2cT4cU+mJM/vr/dHGtFP0jbR3wydIeGJs2Q1L756DU+YhTRmP2GBdKd2+vRAXGPmcpWTDJzK42tp/XuzgGAVbcLz55Gx6vaXIRpLs5n1ZuDyTBJswBryz5+u/Cvr62iyYG6NfNrrcuTWQLnvVHKSVqfMBYruv8K3v9hfYPpGtzna3vdGjjanGN6MWrUxiI/gqUIp9g5zedSD2j9+StCwWxHtbyiiK7ly9OC632+1yudyd9CTMVq9g+8vAqat3gn/X2T6/1OhR++YXSm+QLSNQYWXyXpaxvQnAi24jjYNaDYYoRv2kDN4EhyKZ6c5ag6ogRZnojCSgHW8nGc+X92x14oXaPttnlxqYSL6ZJ4wep9bo6t9LuUDw6wBYaacwm3siSMlO/eUCQal7wQv2TEhWRtJGNhd7S5Psk3ps73Nc28XAeEO+fdKqjalPxabfsf5M5htcq64S2CjX8+D1LddddixXZykyFBGh0uwkhcALbH7O0aNkY9pu2mxBtn+0qWrIGa1vMP3VSgY7c2Rs1ZDNJbGNXM5mUlgmZ9X8DJhIqC6TLE+UqdgOqNk+PCJdgEXE4Q+Vp8ygU6F8M4D0PCCxoTjKfRs5ljcKtYX07i2FFRmfO3N3s4qYNuuwnZCzHfVwzac1uRAxpjnbYPVUsom+uXdAtpYAGz/mB52U8FDLDlDjpshw441xKHw7CrsO9XiLgs2C1tYSmwuyrXSJubBE7hs/ZrRd5MndC/a5IrEpfPvAo5lP6xlVDdHO02n5aJETyFPMhmsILHtsqS4bwcK6sSYCm1853g77GE19i5inBRZ8gL6Rglc7QLyTJC+TNMFnzQfz5TGV2J6aBLYr2Joj+XaYYZofuIZYcvBhRmCud24Z62RRMhK517NBbEqQzatgeykCG6fyjWMizln6EQVgn+Ab+jKexHXC270pBYAU3ZhCtqcjxJRT5imMKaMdb2F9y7EIaCCeJ4Q5lCaMZbhVyppmhh2RjM0bhk3rm08z3nTy1IfTIUR92xnY/4oXKj7uyVFXTj8JcyIujG9LlL51aecF1XjzMRHnBUXVteaJtoH4lgCb2Max3uXVsEuL0jcm0rxw2K/1LWwulG+TTuN5oxRTEve9Rrf3aZQLIdiWPGAN4ZjmELng12GLCeSowjfS62ZxU05ntuAaEhWbp1E73tQ1JPR8qmEzgPy04CXJNzbrRQrCwZnTabLDPuThYnpSE1N17Q0/3nYFclTmG55PS7cITTllXxnRN4JdPVlgi5QLTKhc4DRsiogq2cAcYT6FE8OQuEgxpel1+mwObX2LMqaw6qbJbFOyZQs9EpzTnwGRai/JToiq9sKVfYhcaNb4lmNRBFiHDbZp9JtgUbRsPZHm02h7JFVEQ7DR5Ch9NtiHIDYWT8CIrbnr/oGI4+10VDE1gGKr0kaJzSVng2Npkd54Wz016Btm82vyVFNDfJ4ofZu7U1WGlb65RDaiVMEW6HtpulrqQ8SYNkbukaKb62OAtSAsm+ib0f0S+HaQ7ZnqFkLMzQkq3zzc/Qhzlg4bJ/a935CxxYCSYhATmY02da6RsxXuzWTJAPM0e9g89XGR2XR9K7doGhJd30ydbyjYxuQ68cRG8C/PyOBJOmwN6bhZq1hnaedTv0/DBiNaqbZNmrMoezZsgnV9YxeDLF5YnxJeOyuunUOx+TqC63rM5lflQpOH44Rd/iAbjqghhG+0qXszAKmib5Rd7hv7PbQZIQw4ghL6gcB40/PtqrQfgtbO9ZyS7cxAq6PNAcXJfdOJaDCmps6NIF4MnaqGwFXXVrwfgiufkQ7rW0PDl/8O7tXgPQflXP/RxZ4TJ86ePdEj8w1W3YLQbLCvSFjkFbcP4QX5vAB9mzybN6HFIW0k3bRivPnlbH+2vdd76cIVicSG9mpUvtX+CemjuqP1Uv8Gq266XnMe7N94niDE76VNVXK2xQBsZ3kTEs9nz8b/gxC+nfvXJ4ekvUFxj0vOFtziPFwf9K38x7qLezEXULQI0ikMJcK7JU7Wh0C2ODA6AW8qJbwBxN1Ncbw1yudT4aRWvsd1S71vKW7xy9gMwFIBYsLEVL5koFyr5P0bYksBSc8vWJC6NQnEKdnUe9HovYKEBhG+6lWwBYMtscWA9Xn6S+hSwSsZGUln2rfK+14U0+CbwtgAG46pcg2oecdg+1uPQ5ELOmxg5tIQ24OFQrkSw4pEZLqzUsB8af+NclYlrZg+fXpNTc2c1MmgcLU43pzVGt9UaLYjts/aG5nwvulWXZGNokySEImRtdPb4Tpry3W3y4U+7u7Cwha7C+9gOpNAFYU3+mH/OUZYy/TovpdBrvXZ7lxwcEwo33CeJoaMKABVnXaZ3C43n/GjUXB9GvfDOdNF1UydnODE3JneGVM34gEK82X2SNG3Q7Y6PUHg9292NKJ3Rlc0b+P6Ar6BZUtDvteemhrUio07XlgzYSoAZvVTu4XVP0nzTl44oewrYPbid0Z1Nn3dvjXw90YPZDt9W+fuSZEtZER1ZTar9oeTwWY7LL1OXGcIPCxp6r9bHwZx2+p7L/8dQwXHj7188Ofu3zUHtoBqzWXbNz84eOw4Kjh28NXqRROWCDDoyeMeKmcQRgYKCgqCmEsKFBgkd3Kyg+e6wCQoKx9xYhACzxnp6h7ahQHO7zr/cNeWzUBJMDi06xA62HVIV5dxSSpDB6WrU4QYZhyxAI9IrIUMTwCzsimDECtDJ2MKIyM/LsAIAzhku6/M1XNjoHBtniBDV/7ZBTyQCWoOTp6lZ6ODgKEJDLclhMAlPFKXzvV744lRoh1nOsnwyPo9oEn9netWKmdrQiYEHfnU+EAIBKAUH7KAGp+aGpoAisrZ1FhzBMwewVPajUTt7OyqzQu6sGTlAQRCoHBSMQUCcO6AZRgmygAblVwnqCAIYwjRJTgAjNdLil1g3K4AAAAASUVORK5CYII=)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Speed up inference of forecaster through OpenVINO"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "Through the previous guidance \"Train forcaster on single node\", forecasters can be created and trained. Normally, input data to the trained forecaster to perform inference, observe and verify whether the inference result is as expected. In the inferencing process, it is desirable to speed up. One way to do this is to utilize some accelerators, such as OpenVINO.\n",
+    "\n",
+    "Actually, utilizing OpenVINO to accelerate is quite easy in Chronos, that is directly calling `predict_with_openvino`. In this guidance, **we demonstrate how to speed up inference of forecaster through OpenVINO** in detail. Highlightly, although Chronos supports inferencing on a cluster, the method to speed up can only be used when forecaster is a non-distributed version.\n",
+    "\n",
+    "We will take `TCNForecaster` and nyc_taxi dataset as an example in this guide."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Before we begin, we need to install chronos if it isn’t already available, we choose to use pytorch as deep learning backend."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --pre --upgrade bigdl-chronos[pytorch]\n",
+    "# install OpenVINO\n",
+    "!pip install openvino-dev\n",
+    "# uninstall torchtext to avoid version conflict\n",
+    "!pip uninstall -y torchtext\n",
+    "exit()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Forecaster preparation\n",
+    "\n",
+    "Before the inferencing process, a forecaster should be created and trained. The training process is introduced in the previous guidance \"Train forcaster on single node\" in detail, therefore we directly create and train a `TCNForecaster` based on the nyc taxi dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "outputs": [],
+   "source": [
+    "# data preparation\n",
+    "def get_data():\n",
+    "    from bigdl.chronos.data.repo_dataset import get_public_dataset\n",
+    "    from sklearn.preprocessing import StandardScaler\n",
+    "\n",
+    "    # load the nyc taxi dataset\n",
+    "    tsdata_train, tsdata_val, tsdata_test = get_public_dataset(name='nyc_taxi')\n",
+    "\n",
+    "    stand = StandardScaler()\n",
+    "    for tsdata in [tsdata_train, tsdata_val, tsdata_test]:\n",
+    "        tsdata.impute()\\\n",
+    "              .scale(stand, fit=tsdata is tsdata_train)\n",
+    "\n",
+    "    # convert `tsdata_train` and `tsdata_test` to pytorch dataloader\n",
+    "    train_data = tsdata_train.to_torch_data_loader(roll=True, lookback=48, horizon=1)\n",
+    "    test_data = tsdata_test.to_torch_data_loader(roll=True, lookback=48, horizon=1)\n",
+    "\n",
+    "    return train_data, test_data\n",
+    "\n",
+    "# trained forecaster preparation\n",
+    "def get_trained_forecaster(train_data):\n",
+    "    from bigdl.chronos.forecaster.tcn_forecaster import TCNForecaster\n",
+    "    # create a TCNForecaster\n",
+    "    forecaster = TCNForecaster(past_seq_len=48,\n",
+    "                               future_seq_len=1,\n",
+    "                               input_feature_num=1,\n",
+    "                               output_feature_num=1)\n",
+    "\n",
+    "    # train the forecaster on the training data\n",
+    "    forecaster.fit(train_data)\n",
+    "    return forecaster"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Speeding up inference\n",
+    "\n",
+    "When a trained forecaster is ready and forecaster is a non-distributed version, we provide with `predict_with_openvino` method to speed up inference. The method can be directly called without calling `build_openvino` and forecaster will automatically build an openvino session with default settings.\n",
+    "\n",
+    "The `predict_with_openvino` method currently only supports data in numpy ndarray format and the parameter `batch_size` can be changed. If not familiar with manual hyperparameters tuning, just leave `batch_size` to the default value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get data for training and testing\n",
+    "train_data, test_data = get_data()\n",
+    "# get a trained forecaster\n",
+    "forecaster = get_trained_forecaster(train_data)\n",
+    "\n",
+    "# speed up inference through OpenVINO\n",
+    "for x, y in test_data:\n",
+    "    yhat = forecaster.predict_with_openvino(x.numpy()) # predict"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's see the acceleration performance of `predict_with_openvino`.\n",
+    "\n",
+    "The predict latency of without accelerator and with OpenVINO are given below. The result \"p50\" means latency sorted to 50% in multiple predictions and the acceleration performance is significant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bigdl.chronos.metric.forecast_metrics import Evaluator\n",
+    "\n",
+    "x = next(iter(test_data))[0]\n",
+    "def func_original():\n",
+    "    forecaster.predict(x.numpy()) # without accelerator\n",
+    "def func_openvino():\n",
+    "    forecaster.predict_with_openvino(x.numpy()) # with OpenVINO\n",
+    "\n",
+    "print(\"original predict runtime (ms):\", Evaluator.get_latency(func_original))\n",
+    "print(\"pridict runtime with OpenVINO (ms):\", Evaluator.get_latency(func_openvino))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "08f205d83aa93bf00288c36236890a907831cd95d5c91acb243adbba6993e97a"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_on_one_node.ipynb
+++ b/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_on_one_node.ipynb
@@ -123,6 +123,7 @@
     "\n",
     "When a trained forecaster is ready, just call `predict` to realize inference.\n",
     "Forecaster supports predicting data in many formats, including:\n",
+    "\n",
     "1. numpy ndarray (**recommended**)\n",
     "2. xshard item\n",
     "3. pytorch dataloader\n",
@@ -159,6 +160,7 @@
    "source": [
     "### with onnxruntime\n",
     "The `predict_with_onnx` method supports data in following formats:\n",
+    "\n",
     "1. numpy ndarray (**recommended**)\n",
     "2. pytorch dataloader\n",
     "3. `bigdl.chronos.data.TSDataset`\n",
@@ -202,6 +204,7 @@
    "source": [
     "### acceleration performance\n",
     "Let's see the performance of the acceleration methods.\n",
+    "\n",
     "The predict latency of without accelerator, with onnxruntime and with openvino are given below. The result \"p50\" means latency sorted to 50% in multiple predictions and the acceleration performance is significant.\n"
    ]
   },

--- a/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_on_one_node.ipynb
+++ b/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_on_one_node.ipynb
@@ -1,0 +1,206 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/intel-analytics/BigDL/blob/main/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_on_one_node.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![image.png](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJsAAABHCAMAAAAnQ8XqAAAACXBIWXMAAA7DAAAOwwHHb6hkAAADAFBMVEVHcEyAgYR+gYU0OD85OTuOkZSChYk5OTs5OTs5OTuAgYR/gYM5OTuAgYSAgYSBgoWAgoU5OTs+NTg5OTs4ODs5OTsAccQ1NTk3Nzo4ODuBg4U4ODs5OTs4ODs5OTuRlJY6OjwAccM4ODs5OTs3Nzo4ODuBgoQ3Nzo4OTo3NzqSlJc5OTsBccOAgYSRlJeRk5Y5OTs5OTs5OTs4ODuPkpQ4ODo4ODs5OTs5OTs4ODuRlJeSlJeJio4BccM5OTsDbrw4ODuPkpU4ODuVmJs4ODsBccOTlpk2Njo3OTwBccOSlZiUmJo5OTs5OTs5OTyPkZSRk5eTlpk5OTw4ODs5OTw2Njk5OTuRlJeUl5pzi6EAccM5OTsBcMM4ODs4ODs4ODs4ODs4ODs5OTs4ODuAgYSAgYM4ODs4ODuTl5kBccM4ODo4ODs4ODs5OTs4ODs5OTs5OTuSlJc4ODs4ODs5OTs4ODuAgYSRk5aFh4o4ODucn6I4ODs4ODv7/P4BccM5OTuAgoVDQ0c4ODsBccM4ODtFf7ABcMM5OTuTlZh/goM4ODqAgYSFhomnrK4jTnCDhYeAgYUCb744OTyChIc4ODsAcMI5OTsBccM5OTt/gYSChIeFh4paW15/gYOChIcDbrs5OTv///+AgYT+/v6IiYw6OjyBgoX9/f47Oz09PT99foF+f4KDhIc5OTw8PD88PD73+Pj9/v6Oj5KCg4Z/gIMBccOJio1/gYTq6us7Oz56e3719fU6Oj2AgYV8fYCAgoR4eXzm5ud7fH/7+/s9PUDs7Ozh4uLi4uOCg4W2triJio6RkpTq6+s+PkCOj5F5en2RkpXs7O2HiIz8/P2Gh4qDhIgBdMj09PX5+fn29vaPkJP29/cBcsW1treKi46XmJvT1NV3eHs4ODqEhYh8fIDf3+Dp6emjpKYBccTb29zOz9A/P0HDw8WdnqCUlZjz8/O+v8Hv7/Dx8fGysrSvr7F9foJzdHiqq60Bdcv+/v/HyMm2t7nGxsien6Hj4+S3t7nLBRsYAAAAoHRSTlMA+wMC/QEC/vz7nyP6+nL7oAIBBFHrAQovQgQZ1xA/PAP+OvIHYnISoA438Pz+KDPv+d+EDBR/pveBMCUFI+c+Sg+tByH9HAicJCsi2S3+CRYSHCklOEo/Ggb02xjUorKptvFb/J0xZSD6dJErwpXkbkJHactLmEcjRAvQiQMZ0qkMV/I0DiG8TiId+NMuBMn7E5u0efzF5LlkvllplbYvkV0hXwAADA1JREFUaN7MmXtUFNcdx6867OyY9dTl4QPFRYNH3FjeKoLaoIgK8oqgMa2KWo3G+k7qqWliEnPS1qbtSWPb056ednZwhtmF3W1lhYC7LCIx+ABSwdpo1CiN2hiNzyRt/2jvvTM7O6996Dnafs/CDDNz3I/f3/397u/eAeB/qRgs8H8lJdDcgqp1o3T0mE2S/Tlz2cxn80vS0pdaLemzacqo1eMPW05FRUWxNc8CofLW5xflLCsHcQk86VSLpR+XS+W7youK0/Ks1nRLcXpxUWVluezm6wksQWr1iF2KqSwqKsmzQJcseSVF6ysSDYbgPZE/FrJ5CVqrR2LS3IKCyvz0NKt1qTU9Py+/MidnZshEEHx7JGyJiYmBrywvLy9Ky0+zbrNuy1uanl9UVJE4eLBwL9YwU1CiSgYppo/It1de2fVsSVHx+vySosqKuQ/xDzwKthhQMXz48N+9/fYv/vDuu6+tXbv2+1BDhw4dHqWGvvZbEPMwbCMMIwIK9YgBPHG8qal/YGCgv79//wVBTcebjsNPE/o0NQknslPxvAk9dOrD18DgSGyxgh7ct58MGzTsu1CDoIY9sH7avxYYovbNHGcOnL66cNZCpFkL3xocku0JxvdNphGqC/90oV9cI8dxjEJcoyj0WPDyoP1DRTY+JFtc0mSsIQIfCih45zfXNkxB2jDvubfAiJBsjK+5Ham3vV089va2djgYf6OMr7Vdutve69Fh0/dt4vJNm8auzkB6avevV04bB0AyYnv1uY8PCrr2q4Xh2Dz9d4+dP3b+PPo5duzY3XtfXb1x8WxDW3sr0xWw7d5/8H381N0GBOeLhi37Ou/mWUG8227nl4+Dzo0A39lzbd54pHkHN8wKw8Y5ztba1Ko9d/vTz284WruQdz5Pwx3ZvSP766P1bZo910iIMhopytjCTwTJiO3j8di28QenhGFr5up7Dtn66pQSKD642osI/EzDFemJPtsX++s50biIbN0mp3AKD2QZTVKssxT8PFo26NuBc7ZarerqoJ23OhjI4Wk4aasLXLcdEtiY6NgUF0ja5N4EhkTP1obYtFFFeLW2W72Y7T1bXeA6ZHNEw3ZZh40lSSMPE0LLZk5OjtUdb3psGAO6dKOV45pVbNA3z4P4RpI0ZSLQARpn34jZhFwYL+SCUPfM8BBrRnXaHGuWxVSGU4uZhL/qbJ+2cT4cU+mJM/vr/dHGtFP0jbR3wydIeGJs2Q1L756DU+YhTRmP2GBdKd2+vRAXGPmcpWTDJzK42tp/XuzgGAVbcLz55Gx6vaXIRpLs5n1ZuDyTBJswBryz5+u/Cvr62iyYG6NfNrrcuTWQLnvVHKSVqfMBYruv8K3v9hfYPpGtzna3vdGjjanGN6MWrUxiI/gqUIp9g5zedSD2j9+StCwWxHtbyiiK7ly9OC632+1yudyd9CTMVq9g+8vAqat3gn/X2T6/1OhR++YXSm+QLSNQYWXyXpaxvQnAi24jjYNaDYYoRv2kDN4EhyKZ6c5ag6ogRZnojCSgHW8nGc+X92x14oXaPttnlxqYSL6ZJ4wep9bo6t9LuUDw6wBYaacwm3siSMlO/eUCQal7wQv2TEhWRtJGNhd7S5Psk3ps73Nc28XAeEO+fdKqjalPxabfsf5M5htcq64S2CjX8+D1LddddixXZykyFBGh0uwkhcALbH7O0aNkY9pu2mxBtn+0qWrIGa1vMP3VSgY7c2Rs1ZDNJbGNXM5mUlgmZ9X8DJhIqC6TLE+UqdgOqNk+PCJdgEXE4Q+Vp8ygU6F8M4D0PCCxoTjKfRs5ljcKtYX07i2FFRmfO3N3s4qYNuuwnZCzHfVwzac1uRAxpjnbYPVUsom+uXdAtpYAGz/mB52U8FDLDlDjpshw441xKHw7CrsO9XiLgs2C1tYSmwuyrXSJubBE7hs/ZrRd5MndC/a5IrEpfPvAo5lP6xlVDdHO02n5aJETyFPMhmsILHtsqS4bwcK6sSYCm1853g77GE19i5inBRZ8gL6Rglc7QLyTJC+TNMFnzQfz5TGV2J6aBLYr2Joj+XaYYZofuIZYcvBhRmCud24Z62RRMhK517NBbEqQzatgeykCG6fyjWMizln6EQVgn+Ab+jKexHXC270pBYAU3ZhCtqcjxJRT5imMKaMdb2F9y7EIaCCeJ4Q5lCaMZbhVyppmhh2RjM0bhk3rm08z3nTy1IfTIUR92xnY/4oXKj7uyVFXTj8JcyIujG9LlL51aecF1XjzMRHnBUXVteaJtoH4lgCb2Max3uXVsEuL0jcm0rxw2K/1LWwulG+TTuN5oxRTEve9Rrf3aZQLIdiWPGAN4ZjmELng12GLCeSowjfS62ZxU05ntuAaEhWbp1E73tQ1JPR8qmEzgPy04CXJNzbrRQrCwZnTabLDPuThYnpSE1N17Q0/3nYFclTmG55PS7cITTllXxnRN4JdPVlgi5QLTKhc4DRsiogq2cAcYT6FE8OQuEgxpel1+mwObX2LMqaw6qbJbFOyZQs9EpzTnwGRai/JToiq9sKVfYhcaNb4lmNRBFiHDbZp9JtgUbRsPZHm02h7JFVEQ7DR5Ch9NtiHIDYWT8CIrbnr/oGI4+10VDE1gGKr0kaJzSVng2Npkd54Wz016Btm82vyVFNDfJ4ofZu7U1WGlb65RDaiVMEW6HtpulrqQ8SYNkbukaKb62OAtSAsm+ib0f0S+HaQ7ZnqFkLMzQkq3zzc/Qhzlg4bJ/a935CxxYCSYhATmY02da6RsxXuzWTJAPM0e9g89XGR2XR9K7doGhJd30ydbyjYxuQ68cRG8C/PyOBJOmwN6bhZq1hnaedTv0/DBiNaqbZNmrMoezZsgnV9YxeDLF5YnxJeOyuunUOx+TqC63rM5lflQpOH44Rd/iAbjqghhG+0qXszAKmib5Rd7hv7PbQZIQw4ghL6gcB40/PtqrQfgtbO9ZyS7cxAq6PNAcXJfdOJaDCmps6NIF4MnaqGwFXXVrwfgiufkQ7rW0PDl/8O7tXgPQflXP/RxZ4TJ86ePdEj8w1W3YLQbLCvSFjkFbcP4QX5vAB9mzybN6HFIW0k3bRivPnlbH+2vdd76cIVicSG9mpUvtX+CemjuqP1Uv8Gq266XnMe7N94niDE76VNVXK2xQBsZ3kTEs9nz8b/gxC+nfvXJ4ekvUFxj0vOFtziPFwf9K38x7qLezEXULQI0ikMJcK7JU7Wh0C2ODA6AW8qJbwBxN1Ncbw1yudT4aRWvsd1S71vKW7xy9gMwFIBYsLEVL5koFyr5P0bYksBSc8vWJC6NQnEKdnUe9HovYKEBhG+6lWwBYMtscWA9Xn6S+hSwSsZGUln2rfK+14U0+CbwtgAG46pcg2oecdg+1uPQ5ELOmxg5tIQ24OFQrkSw4pEZLqzUsB8af+NclYlrZg+fXpNTc2c1MmgcLU43pzVGt9UaLYjts/aG5nwvulWXZGNokySEImRtdPb4Tpry3W3y4U+7u7Cwha7C+9gOpNAFYU3+mH/OUZYy/TovpdBrvXZ7lxwcEwo33CeJoaMKABVnXaZ3C43n/GjUXB9GvfDOdNF1UydnODE3JneGVM34gEK82X2SNG3Q7Y6PUHg9292NKJ3Rlc0b+P6Ar6BZUtDvteemhrUio07XlgzYSoAZvVTu4XVP0nzTl44oewrYPbid0Z1Nn3dvjXw90YPZDt9W+fuSZEtZER1ZTar9oeTwWY7LL1OXGcIPCxp6r9bHwZx2+p7L/8dQwXHj7188Ofu3zUHtoBqzWXbNz84eOw4Kjh28NXqRROWCDDoyeMeKmcQRgYKCgqCmEsKFBgkd3Kyg+e6wCQoKx9xYhACzxnp6h7ahQHO7zr/cNeWzUBJMDi06xA62HVIV5dxSSpDB6WrU4QYZhyxAI9IrIUMTwCzsimDECtDJ2MKIyM/LsAIAzhku6/M1XNjoHBtniBDV/7ZBTyQCWoOTp6lZ6ODgKEJDLclhMAlPFKXzvV744lRoh1nOsnwyPo9oEn9netWKmdrQiYEHfnU+EAIBKAUH7KAGp+aGpoAisrZ1FhzBMwewVPajUTt7OyqzQu6sGTlAQRCoHBSMQUCcO6AZRgmygAblVwnqCAIYwjRJTgAjNdLil1g3K4AAAAASUVORK5CYII=)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Speed up inference of forcaster on single node"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "onZXfhnkmexc"
+   },
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "In Chronos, Forecaster (`bigdl.chronos.forecaster.Forecaster`) is the forecasting abstraction. It hides the complex logic of model's creation, training, scaling to cluster, tuning, optimization and inferencing while expose some APIs for users (e.g. `predict` in this guide) to control.\n",
+    "\n",
+    "Through the previous guidance \"Train forcaster on single node\", forecasters can be created and trained. Then, in this guidance, **we demonstrate how to speed up inference of forecaster on single node**. During the inferencing process, a trained forecaster will predict according to the input data while Chronos also supports onnxruntime and openvino to speed up inference. Highlightly, although Chronos supports inferencing on a cluster, the methods to speed up can only be used when forecaster is a non-distributed version.\n",
+    "\n",
+    "We will take `TCNForecaster` and nyc_taxi dataset as an exmaple in this guide."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Before we begin, we need to install chronos if it isn’t already available, we choose to use pytorch as deep learning backend."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --pre --upgrade bigdl-chronos[pytorch]\n",
+    "!pip uninstall -y torchtext # uninstall torchtext to avoid version conflict\n",
+    "exit()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Forecaster preparation\n",
+    "\n",
+    "Before the inferencing process, a forecaster should be created and trained. The training process is introduced in the previous guidance \"Train forcaster on single node\" in detail, therefore we directly create and train a `TCNForecaster` based on the nyc taxi dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bigdl.chronos.data.repo_dataset import get_public_dataset\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from bigdl.chronos.forecaster.tcn_forecaster import TCNForecaster\n",
+    "\n",
+    "# load the nyc taxi dataset\n",
+    "tsdata_train, tsdata_val, tsdata_test = get_public_dataset(name='nyc_taxi')\n",
+    "\n",
+    "stand = StandardScaler()\n",
+    "for tsdata in [tsdata_train, tsdata_val, tsdata_test]:\n",
+    "    tsdata.impute()\\\n",
+    "          .scale(stand, fit=tsdata is tsdata_train)\n",
+    "\n",
+    "# convert `tsdata_train` and `tsdata_test` to pytorch dataloader\n",
+    "train_data = tsdata_train.to_torch_data_loader(roll=True, lookback=48, horizon=1)\n",
+    "test_data = tsdata_test.to_torch_data_loader(roll=True, lookback=48, horizon=1)\n",
+    "\n",
+    "# create a TCNForecaster\n",
+    "forecaster = TCNForecaster(past_seq_len=48,\n",
+    "                           future_seq_len=1,\n",
+    "                           input_feature_num=1,\n",
+    "                           output_feature_num=1)\n",
+    "\n",
+    "# train the forecaster on the training data\n",
+    "forecaster.fit(train_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inferencing\n",
+    "\n",
+    "A trained forecaster is ready, then just call `predict` to realize inference.\n",
+    "Forecaster supports predicting data in many formats, including:\n",
+    "1. numpy ndarray (**recommended**)\n",
+    "2. xshard item\n",
+    "3. pytorch dataloader\n",
+    "4. `bigdl.chronos.data.TSDataset`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for x, y in test_data:\n",
+    "    yhat = forecaster.predict(x.numpy()) # predict"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Speeding up inference\n",
+    "\n",
+    "When forecaster is a non-distributed version, we provide with `predict_with_onnx` and `predict_with_openvino` methods to speed up inference. These methods can be directly called without calling `build_onnx` or `build_openvino` and forecaster will automatically build an onnxruntime or openvino session with default settings."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### with onnxruntime\n",
+    "The `predict_with_onnx` method supports data in following formats:\n",
+    "1. numpy ndarray (**recommended**)\n",
+    "2. pytorch dataloader\n",
+    "3. `bigdl.chronos.data.TSDataset`\n",
+    "\n",
+    "And there are `batch_size` and `quantize` parameters you may want to change. If not familiar with manual hyperparameters tuning, just leave `batch_size` to the default value. Additionally, `quantize` can be set to `True` to use the quantized onnx model to predict."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install onnx==1.10.1\n",
+    "!pip install onnxruntime==1.11.1\n",
+    "# speed up inference with onnxruntime\n",
+    "for x, y in test_data:\n",
+    "    yhat = forecaster.predict_with_onnx(x.numpy())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### with openvino\n",
+    "The `predict_with_openvino` method currently only supports data in numpy ndarray format and the parameter `batch_size` can be changed. If not familiar with manual hyperparameters tuning, just leave `batch_size` to the default value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install openvino-dev\n",
+    "# speed up inference with openvino\n",
+    "for x, y in test_data:\n",
+    "    yhat = forecaster.predict_with_openvino(x.numpy())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.7.13 ('howto-env')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "08f205d83aa93bf00288c36236890a907831cd95d5c91acb243adbba6993e97a"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_on_one_node.ipynb
+++ b/docs/readthedocs/source/doc/Chronos/Howto/how_to_speedup_inference_on_one_node.ipynb
@@ -18,7 +18,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Speed up inference of forcaster on single node"
+    "# Speed up inference of forecaster on single node"
    ]
   },
   {
@@ -29,11 +29,11 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "In Chronos, Forecaster (`bigdl.chronos.forecaster.Forecaster`) is the forecasting abstraction. It hides the complex logic of model's creation, training, scaling to cluster, tuning, optimization and inferencing while expose some APIs for users (e.g. `predict` in this guide) to control.\n",
+    "Through the previous guidance \"Train forcaster on single node\", forecasters can be created and trained. Normally, input data to the trained forecaster to perform inference, observe and verify whether the inference result is as expected. In the inferencing process, it is desirable to speed up. One way to do this is to utilize some accelerators, such as onnxruntime and openvino.\n",
     "\n",
-    "Through the previous guidance \"Train forcaster on single node\", forecasters can be created and trained. Then, in this guidance, **we demonstrate how to speed up inference of forecaster on single node**. During the inferencing process, a trained forecaster will predict according to the input data while Chronos also supports onnxruntime and openvino to speed up inference. Highlightly, although Chronos supports inferencing on a cluster, the methods to speed up can only be used when forecaster is a non-distributed version.\n",
+    "Actually, utilizing accelerators is quite easy in Chronos, that is calling `predict_with_onnx` and `predict_with_openvino`. In this guidance, **we demonstrate how to speed up inference of forecaster on single node** in detail. Highlightly, although Chronos supports inferencing on a cluster, the methods to speed up can only be used when forecaster is a non-distributed version.\n",
     "\n",
-    "We will take `TCNForecaster` and nyc_taxi dataset as an exmaple in this guide."
+    "We will take `TCNForecaster` and nyc_taxi dataset as an example in this guide."
    ]
   },
   {
@@ -52,7 +52,16 @@
    "outputs": [],
    "source": [
     "!pip install --pre --upgrade bigdl-chronos[pytorch]\n",
-    "!pip uninstall -y torchtext # uninstall torchtext to avoid version conflict\n",
+    "\n",
+    "# install accelerators\n",
+    "!pip install onnx\n",
+    "!pip install onnxruntime\n",
+    "!pip install openvino-dev\n",
+    "\n",
+    "# fix dependency conflict\n",
+    "!pip uninstall -y torchtext\n",
+    "!pip install numpy==1.21\n",
+    "!pip install opencv-python-headless==4.1.2.30\n",
     "exit()"
    ]
   },
@@ -68,33 +77,42 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
    "outputs": [],
    "source": [
-    "from bigdl.chronos.data.repo_dataset import get_public_dataset\n",
-    "from sklearn.preprocessing import StandardScaler\n",
-    "from bigdl.chronos.forecaster.tcn_forecaster import TCNForecaster\n",
+    "# data preparation\n",
+    "def get_data():\n",
+    "    from bigdl.chronos.data.repo_dataset import get_public_dataset\n",
+    "    from sklearn.preprocessing import StandardScaler\n",
     "\n",
-    "# load the nyc taxi dataset\n",
-    "tsdata_train, tsdata_val, tsdata_test = get_public_dataset(name='nyc_taxi')\n",
+    "    # load the nyc taxi dataset\n",
+    "    tsdata_train, tsdata_val, tsdata_test = get_public_dataset(name='nyc_taxi')\n",
     "\n",
-    "stand = StandardScaler()\n",
-    "for tsdata in [tsdata_train, tsdata_val, tsdata_test]:\n",
-    "    tsdata.impute()\\\n",
-    "          .scale(stand, fit=tsdata is tsdata_train)\n",
+    "    stand = StandardScaler()\n",
+    "    for tsdata in [tsdata_train, tsdata_val, tsdata_test]:\n",
+    "        tsdata.impute()\\\n",
+    "              .scale(stand, fit=tsdata is tsdata_train)\n",
     "\n",
-    "# convert `tsdata_train` and `tsdata_test` to pytorch dataloader\n",
-    "train_data = tsdata_train.to_torch_data_loader(roll=True, lookback=48, horizon=1)\n",
-    "test_data = tsdata_test.to_torch_data_loader(roll=True, lookback=48, horizon=1)\n",
+    "    # convert `tsdata_train` and `tsdata_test` to pytorch dataloader\n",
+    "    train_data = tsdata_train.to_torch_data_loader(roll=True, lookback=48, horizon=1)\n",
+    "    test_data = tsdata_test.to_torch_data_loader(roll=True, lookback=48, horizon=1)\n",
     "\n",
-    "# create a TCNForecaster\n",
-    "forecaster = TCNForecaster(past_seq_len=48,\n",
-    "                           future_seq_len=1,\n",
-    "                           input_feature_num=1,\n",
-    "                           output_feature_num=1)\n",
+    "    return train_data, test_data\n",
     "\n",
-    "# train the forecaster on the training data\n",
-    "forecaster.fit(train_data)"
+    "# trained forecaster preparation\n",
+    "def get_trained_forecaster(train_data):\n",
+    "    from bigdl.chronos.forecaster.tcn_forecaster import TCNForecaster\n",
+    "    # create a TCNForecaster\n",
+    "    forecaster = TCNForecaster(past_seq_len=48,\n",
+    "                               future_seq_len=1,\n",
+    "                               input_feature_num=1,\n",
+    "                               output_feature_num=1)\n",
+    "\n",
+    "    # train the forecaster on the training data\n",
+    "    forecaster.fit(train_data)\n",
+    "    return forecaster"
    ]
   },
   {
@@ -103,7 +121,7 @@
    "source": [
     "## Inferencing\n",
     "\n",
-    "A trained forecaster is ready, then just call `predict` to realize inference.\n",
+    "When a trained forecaster is ready, just call `predict` to realize inference.\n",
     "Forecaster supports predicting data in many formats, including:\n",
     "1. numpy ndarray (**recommended**)\n",
     "2. xshard item\n",
@@ -113,10 +131,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# get data for training and testing\n",
+    "train_data, test_data = get_data()\n",
+    "# get a trained forecaster\n",
+    "forecaster = get_trained_forecaster(train_data)\n",
+    "\n",
     "for x, y in test_data:\n",
     "    yhat = forecaster.predict(x.numpy()) # predict"
    ]
@@ -149,8 +172,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install onnx==1.10.1\n",
-    "!pip install onnxruntime==1.11.1\n",
     "# speed up inference with onnxruntime\n",
     "for x, y in test_data:\n",
     "    yhat = forecaster.predict_with_onnx(x.numpy())"
@@ -170,10 +191,39 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install openvino-dev\n",
     "# speed up inference with openvino\n",
     "for x, y in test_data:\n",
     "    yhat = forecaster.predict_with_openvino(x.numpy())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### acceleration performance\n",
+    "Let's see the performance of the acceleration methods.\n",
+    "The predict latency of without accelerator, with onnxruntime and with openvino are given below. The result \"p50\" means latency sorted to 50% in multiple predictions and the acceleration performance is significant.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bigdl.chronos.metric.forecast_metrics import Evaluator\n",
+    "\n",
+    "x = next(iter(test_data))[0]\n",
+    "def func_original():\n",
+    "    forecaster.predict(x.numpy())\n",
+    "def func_onnxruntime():\n",
+    "    forecaster.predict_with_onnx(x.numpy())\n",
+    "def func_openvino():\n",
+    "    forecaster.predict_with_openvino(x.numpy())\n",
+    "\n",
+    "print(\"original predict runtime (ms):\", Evaluator.get_latency(func_original))\n",
+    "print(\"use accelerator (onnxruntime) (ms):\", Evaluator.get_latency(func_onnxruntime))\n",
+    "print(\"use accelerator (openvino) (ms):\", Evaluator.get_latency(func_openvino))"
    ]
   }
  ],

--- a/docs/readthedocs/source/doc/Chronos/Howto/index.rst
+++ b/docs/readthedocs/source/doc/Chronos/Howto/index.rst
@@ -12,6 +12,14 @@ Forecasting
 
     In this guidance, we demonstrate **how to tune forecaster on single node**. In tuning process, forecaster will find the best hyperparameter combination among user-defined search space, which is a common process if users pursue a forecaster with higher accuracy.
 
+* `Speed up inference of forecaster through ONNXRuntime <how_to_speedup_inference_of_forecaster_through_ONNXRuntime.html>`__
+
+    In this guidance, **we demonstrate how to speed up inference of forecaster through ONNXRuntime**. In inferencing process, Chronos supports ONNXRuntime to accelerate inferencing which is helpful to users.
+
+* `Speed up inference of forecaster through OpenVINO <how_to_speedup_inference_of_forecaster_through_OpenVINO.html>`__
+
+    In this guidance, **we demonstrate how to speed up inference of forecaster through OpenVINO**. In inferencing process, Chronos supports OpenVINO to accelerate inferencing which is helpful to users.
+
 
 .. toctree::
     :maxdepth: 1
@@ -19,4 +27,6 @@ Forecasting
 
     how_to_train_forecaster_on_one_node
     how_to_tune_forecaster_model
+    how_to_speedup_inference_of_forecaster_through_ONNXRuntime
+    how_to_speedup_inference_of_forecaster_through_OpenVINO
 

--- a/docs/readthedocs/source/doc/Chronos/Howto/index.rst
+++ b/docs/readthedocs/source/doc/Chronos/Howto/index.rst
@@ -13,7 +13,6 @@ Forecasting
     In this guidance, we demonstrate **how to tune forecaster on single node**. In tuning process, forecaster will find the best hyperparameter combination among user-defined search space, which is a common process if users pursue a forecaster with higher accuracy.
 
 
-
 .. toctree::
     :maxdepth: 1
     :hidden:

--- a/docs/readthedocs/source/doc/Chronos/Howto/index.rst
+++ b/docs/readthedocs/source/doc/Chronos/Howto/index.rst
@@ -13,10 +13,11 @@ Forecasting
     In this guidance, we demonstrate **how to tune forecaster on single node**. In tuning process, forecaster will find the best hyperparameter combination among user-defined search space, which is a common process if users pursue a forecaster with higher accuracy.
 
 
+
 .. toctree::
     :maxdepth: 1
     :hidden:
 
     how_to_train_forecaster_on_one_node
-
     how_to_tune_forecaster_model
+


### PR DESCRIPTION
## Description


### 1. Why the change?

Add Chronos how-to guides to our documentation for better user experience. How-to guides aim at providing task-oriented examples for users to check when they need to do similar tasks.
This guide demonstrates how to speedup inference on one node.


### 2. Summary of the change 

Introduce how to use predict_with_onnx and predict_with_openvino to speed up inference.

### 3. How to test?
- [x] Document test
(https://binbin-howto1.readthedocs.io/en/howto-predict/doc/Chronos/Howto/
https://binbin-howto1.readthedocs.io/en/howto-predict/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_ONNXRuntime.html
https://binbin-howto1.readthedocs.io/en/howto-predict/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.html)
