### PR TITLE
Orca: OMP env default value reset.

### DIFF
--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -250,11 +250,7 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=None, memory="2g
                 warnings.warn("Use an existing SparkContext, " +
                               "cluster_mode is determined by the existing SparkContext", Warning)
             from bigdl.dllib.nncontext import init_nncontext
-            sc = init_nncontext(conf=None, spark_log_level="WARN", redirect_spark_log=True)
-            del os.environ["KMP_AFFINITY"]
-            del os.environ["KMP_SETTINGS"]
-            del os.environ["OMP_NUM_THREADS"]
-            del os.environ["KMP_BLOCKTIME"]
+            sc = init_nncontext(conf=None, spark_log_level="WARN", redirect_spark_log=True, is_orca=True)
         else:
             cluster_mode = "local" if cluster_mode is None else cluster_mode
             if cluster_mode == "local":
@@ -273,15 +269,8 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=None, memory="2g
                                   + "specified in the spark-submit command, but got "
                                   + repr(spark_args["conf"]) + ", ignored", Warning)
                     spark_args["conf"] = None
+                spark_args["is_orca"] = True
                 sc = init_nncontext(**spark_args)
-                if "KMP_AFFINITY" not in spark_args:
-                    del os.environ["KMP_AFFINITY"]
-                if "KMP_SETTINGS" not in spark_args:
-                    del os.environ["KMP_SETTINGS"]
-                if "OMP_NUM_THREADS" not in spark_args:
-                    del os.environ["OMP_NUM_THREADS"]
-                if "KMP_BLOCKTIME" not in spark_args:
-                    del os.environ["KMP_BLOCKTIME"]
             elif cluster_mode.startswith("yarn"):  # yarn, yarn-client or yarn-cluster
                 hadoop_conf = os.environ.get("HADOOP_CONF_DIR")
                 if not hadoop_conf:

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -251,6 +251,10 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=None, memory="2g
                               "cluster_mode is determined by the existing SparkContext", Warning)
             from bigdl.dllib.nncontext import init_nncontext
             sc = init_nncontext(conf=None, spark_log_level="WARN", redirect_spark_log=True)
+            del os.environ["KMP_AFFINITY"]
+            del os.environ["KMP_SETTINGS"]
+            del os.environ["OMP_NUM_THREADS"]
+            del os.environ["KMP_BLOCKTIME"]
         else:
             cluster_mode = "local" if cluster_mode is None else cluster_mode
             if cluster_mode == "local":
@@ -270,6 +274,14 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=None, memory="2g
                                   + repr(spark_args["conf"]) + ", ignored", Warning)
                     spark_args["conf"] = None
                 sc = init_nncontext(**spark_args)
+                if "KMP_AFFINITY" not in spark_args:
+                    del os.environ["KMP_AFFINITY"]
+                if "KMP_SETTINGS" not in spark_args:
+                    del os.environ["KMP_SETTINGS"]
+                if "OMP_NUM_THREADS" not in spark_args:
+                    del os.environ["OMP_NUM_THREADS"]
+                if "KMP_BLOCKTIME" not in spark_args:
+                    del os.environ["KMP_BLOCKTIME"]
             elif cluster_mode.startswith("yarn"):  # yarn, yarn-client or yarn-cluster
                 hadoop_conf = os.environ.get("HADOOP_CONF_DIR")
                 if not hadoop_conf:

--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -250,7 +250,8 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=None, memory="2g
                 warnings.warn("Use an existing SparkContext, " +
                               "cluster_mode is determined by the existing SparkContext", Warning)
             from bigdl.dllib.nncontext import init_nncontext
-            sc = init_nncontext(conf=None, spark_log_level="WARN", redirect_spark_log=True, is_orca=True)
+            sc = init_nncontext(conf=None, spark_log_level="WARN", redirect_spark_log=True,
+                                is_orca=True)
         else:
             cluster_mode = "local" if cluster_mode is None else cluster_mode
             if cluster_mode == "local":


### PR DESCRIPTION
## Description

This PR is to reset OpenMP default value for Orca.

According to the users' feedback, the setting of environment variables in dllib `init_nncontext()` will affect the efficiency of other applications. Therefore, we propose the following two solutions to this issue and implement solution A.

- Solution A
  Since users are more likely to initialize through `init_orca_context`, we will reset these environment variables in `init_orca_context` to avoid the impact of these environment variables on orca and other applications.
**Pros**: Easy to implement.
**Cons**: May have trouble using estimator with bigdl backend.
- Solution B
  Do not set the default value of environment variables in dllib, only set the corresponding default value when dllib uses these environment variables
**Pros**: Can solve the problem without concerns.
**Cons**: Need to go through dlllib code to add the corresponding settings.