### PR TITLE
fix dllib pom scope and typo in examples

### DIFF
--- a/scala/dllib/pom.xml
+++ b/scala/dllib/pom.xml
@@ -324,11 +324,13 @@
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>1.2.17</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.7.16</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/scala/dllib/pom.xml
+++ b/scala/dllib/pom.xml
@@ -324,13 +324,11 @@
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>1.2.17</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.7.16</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/localEstimator/Cifar10DataLoader.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/localEstimator/Cifar10DataLoader.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.intel.analytics.bigdl.dllib.examples.localEstimator
+package com.intel.analytics.bigdl.dllib.example.localEstimator
 
 import java.nio.ByteBuffer
 import java.nio.file.{Files, Paths}

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/localEstimator/ImageProcessing.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/localEstimator/ImageProcessing.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.intel.analytics.bigdl.dllib.examples.localEstimator
+package com.intel.analytics.bigdl.dllib.example.localEstimator
 
 import java.awt.image.{BufferedImage, DataBufferByte}
 import java.nio.ByteBuffer

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/localEstimator/LenetLocalEstimator.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/localEstimator/LenetLocalEstimator.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.intel.analytics.bigdl.dllib.examples.localEstimator
+package com.intel.analytics.bigdl.dllib.example.localEstimator
 
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.dllib.models.lenet.LeNet5

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/localEstimator/MnistDataLoader.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/localEstimator/MnistDataLoader.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.intel.analytics.bigdl.dllib.examples.localEstimator
+package com.intel.analytics.bigdl.dllib.example.localEstimator
 
 import java.io.ByteArrayOutputStream
 import java.net.URI

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/localEstimator/ResnetLocalEstimator.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/localEstimator/ResnetLocalEstimator.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.intel.analytics.bigdl.dllib.examples.localEstimator
+package com.intel.analytics.bigdl.dllib.example.localEstimator
 
 import com.intel.analytics.bigdl.Module
 import com.intel.analytics.bigdl.dllib.models.resnet.ResNet

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/nnframes/imageInference/ImageInferenceExample.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/nnframes/imageInference/ImageInferenceExample.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.intel.analytics.bigdl.dllib.examples.nnframes.imageInference
+package com.intel.analytics.bigdl.dllib.example.nnframes.imageInference
 
 import com.intel.analytics.bigdl.dllib.nn.Module
 import com.intel.analytics.bigdl.dllib.tensor.TensorNumericMath.TensorNumeric.NumericFloat

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/nnframes/imageTransferLearning/ImageTransferLearning.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/nnframes/imageTransferLearning/ImageTransferLearning.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.intel.analytics.bigdl.dllib.examples.nnframes.imageTransferLearning
+package com.intel.analytics.bigdl.dllib.example.nnframes.imageTransferLearning
 
 import com.intel.analytics.bigdl.dllib.nn._
 import com.intel.analytics.bigdl.dllib.optim.Adam

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/nnframes/xgboost/xgbClassifierPredictExample.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/nnframes/xgboost/xgbClassifierPredictExample.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.intel.analytics.bigdl.dllib.examples.nnframes.xgboost
+package com.intel.analytics.bigdl.dllib.example.nnframes.xgboost
 
 import com.intel.analytics.bigdl.dllib.NNContext
 import com.intel.analytics.bigdl.dllib.nnframes.XGBClassifierModel

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/nnframes/xgboost/xgbClassifierTrainingExample.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/nnframes/xgboost/xgbClassifierTrainingExample.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.intel.analytics.bigdl.dllib.examples.nnframes.xgboost
+package com.intel.analytics.bigdl.dllib.example.nnframes.xgboost
 
 import ml.dmlc.xgboost4j.scala.spark.TrackerConf
 

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/nnframes/xgboost/xgbClassifierTrainingExampleOnCriteoClickLogsDataset.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/nnframes/xgboost/xgbClassifierTrainingExampleOnCriteoClickLogsDataset.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.intel.analytics.bigdl.dllib.examples.nnframes.xgboost
+package com.intel.analytics.bigdl.dllib.example.nnframes.xgboost
 
 import com.intel.analytics.bigdl.dllib.NNContext
 import com.intel.analytics.bigdl.dllib.nnframes.XGBClassifier


### PR DESCRIPTION
## fix slf4j and log4f scope of dllib and typo in examples

### 1. Why the change?
1. examples => example, it is typo when migrating the code
2. currently, dependencies of slf4j and log4f only cover scope of test, it fails when running scala examples in IDE, so remove the scope of the test only. 