### PR TITLE
PPML FL FGBoost save/load server model

### DIFF
--- a/python/ppml/src/bigdl/ppml/fl/algorithms/fgboost_regression.py
+++ b/python/ppml/src/bigdl/ppml/fl/algorithms/fgboost_regression.py
@@ -25,9 +25,11 @@ import logging
 
 
 class FGBoostRegression(FLClientClosable):
-    def __init__(self, jvalue=None, learning_rate:float=0.1, max_depth=7, min_child_size=1):
+    def __init__(self, jvalue=None, learning_rate:float=0.1,
+                 max_depth=7, min_child_size=1, server_model_path=None):
         self.bigdl_type = "float"
-        super().__init__(jvalue, self.bigdl_type, learning_rate, max_depth, min_child_size)
+        super().__init__(jvalue, self.bigdl_type, learning_rate, 
+                         max_depth, min_child_size, server_model_path)
 
     def fit(self, x, y=None, num_round=5, **kargs):
         x = convert_to_numpy(x)
@@ -67,3 +69,6 @@ class FGBoostRegression(FLClientClosable):
         # the jvalue exists here so JVM constructor would not be called again
         # thus the parameters would remain the same as model loaded
         return cls(jvalue=callBigDlFunc("float", "fgBoostRegressionLoad", src))
+
+    def load_server_model(self, model_path):
+        callBigDlFunc(self.bigdl_type, "fgBoostLoadServerModel", self.value, model_path)

--- a/scala/ppml/conf/ppml-conf.yaml
+++ b/scala/ppml/conf/ppml-conf.yaml
@@ -2,8 +2,6 @@
 # clientNum:
 # serverPort:
 
-# fgBoostModelPath:
-
 ##### Client property
 # clientTarget:
 # taskID:

--- a/scala/ppml/src/main/java/com/intel/analytics/bigdl/ppml/fl/generated/FGBoostServiceGrpc.java
+++ b/scala/ppml/src/main/java/com/intel/analytics/bigdl/ppml/fl/generated/FGBoostServiceGrpc.java
@@ -14,29 +14,29 @@ public final class FGBoostServiceGrpc {
   public static final String SERVICE_NAME = "fgboost.FGBoostService";
 
   // Static method descriptors that strictly reflect the proto.
-  private static volatile io.grpc.MethodDescriptor<FGBoostServiceProto.UploadLabelRequest,
-      FGBoostServiceProto.UploadResponse> getUploadLabelMethod;
+  private static volatile io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest,
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse> getUploadLabelMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "uploadLabel",
-      requestType = FGBoostServiceProto.UploadLabelRequest.class,
-      responseType = FGBoostServiceProto.UploadResponse.class,
+      requestType = com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest.class,
+      responseType = com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<FGBoostServiceProto.UploadLabelRequest,
-      FGBoostServiceProto.UploadResponse> getUploadLabelMethod() {
-    io.grpc.MethodDescriptor<FGBoostServiceProto.UploadLabelRequest, FGBoostServiceProto.UploadResponse> getUploadLabelMethod;
+  public static io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest,
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse> getUploadLabelMethod() {
+    io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse> getUploadLabelMethod;
     if ((getUploadLabelMethod = FGBoostServiceGrpc.getUploadLabelMethod) == null) {
       synchronized (FGBoostServiceGrpc.class) {
         if ((getUploadLabelMethod = FGBoostServiceGrpc.getUploadLabelMethod) == null) {
           FGBoostServiceGrpc.getUploadLabelMethod = getUploadLabelMethod =
-              io.grpc.MethodDescriptor.<FGBoostServiceProto.UploadLabelRequest, FGBoostServiceProto.UploadResponse>newBuilder()
+              io.grpc.MethodDescriptor.<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse>newBuilder()
               .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
               .setFullMethodName(generateFullMethodName(SERVICE_NAME, "uploadLabel"))
               .setSampledToLocalTracing(true)
               .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  FGBoostServiceProto.UploadLabelRequest.getDefaultInstance()))
+                  com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest.getDefaultInstance()))
               .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  FGBoostServiceProto.UploadResponse.getDefaultInstance()))
+                  com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse.getDefaultInstance()))
               .setSchemaDescriptor(new FGBoostServiceMethodDescriptorSupplier("uploadLabel"))
               .build();
         }
@@ -45,29 +45,29 @@ public final class FGBoostServiceGrpc {
     return getUploadLabelMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<FGBoostServiceProto.DownloadLabelRequest,
-      FGBoostServiceProto.DownloadResponse> getDownloadLabelMethod;
+  private static volatile io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest,
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse> getDownloadLabelMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "downloadLabel",
-      requestType = FGBoostServiceProto.DownloadLabelRequest.class,
-      responseType = FGBoostServiceProto.DownloadResponse.class,
+      requestType = com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest.class,
+      responseType = com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<FGBoostServiceProto.DownloadLabelRequest,
-      FGBoostServiceProto.DownloadResponse> getDownloadLabelMethod() {
-    io.grpc.MethodDescriptor<FGBoostServiceProto.DownloadLabelRequest, FGBoostServiceProto.DownloadResponse> getDownloadLabelMethod;
+  public static io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest,
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse> getDownloadLabelMethod() {
+    io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse> getDownloadLabelMethod;
     if ((getDownloadLabelMethod = FGBoostServiceGrpc.getDownloadLabelMethod) == null) {
       synchronized (FGBoostServiceGrpc.class) {
         if ((getDownloadLabelMethod = FGBoostServiceGrpc.getDownloadLabelMethod) == null) {
           FGBoostServiceGrpc.getDownloadLabelMethod = getDownloadLabelMethod =
-              io.grpc.MethodDescriptor.<FGBoostServiceProto.DownloadLabelRequest, FGBoostServiceProto.DownloadResponse>newBuilder()
+              io.grpc.MethodDescriptor.<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse>newBuilder()
               .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
               .setFullMethodName(generateFullMethodName(SERVICE_NAME, "downloadLabel"))
               .setSampledToLocalTracing(true)
               .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  FGBoostServiceProto.DownloadLabelRequest.getDefaultInstance()))
+                  com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest.getDefaultInstance()))
               .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  FGBoostServiceProto.DownloadResponse.getDefaultInstance()))
+                  com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse.getDefaultInstance()))
               .setSchemaDescriptor(new FGBoostServiceMethodDescriptorSupplier("downloadLabel"))
               .build();
         }
@@ -76,29 +76,29 @@ public final class FGBoostServiceGrpc {
     return getDownloadLabelMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<FGBoostServiceProto.SplitRequest,
-      FGBoostServiceProto.SplitResponse> getSplitMethod;
+  private static volatile io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest,
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse> getSplitMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "split",
-      requestType = FGBoostServiceProto.SplitRequest.class,
-      responseType = FGBoostServiceProto.SplitResponse.class,
+      requestType = com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest.class,
+      responseType = com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<FGBoostServiceProto.SplitRequest,
-      FGBoostServiceProto.SplitResponse> getSplitMethod() {
-    io.grpc.MethodDescriptor<FGBoostServiceProto.SplitRequest, FGBoostServiceProto.SplitResponse> getSplitMethod;
+  public static io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest,
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse> getSplitMethod() {
+    io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse> getSplitMethod;
     if ((getSplitMethod = FGBoostServiceGrpc.getSplitMethod) == null) {
       synchronized (FGBoostServiceGrpc.class) {
         if ((getSplitMethod = FGBoostServiceGrpc.getSplitMethod) == null) {
           FGBoostServiceGrpc.getSplitMethod = getSplitMethod =
-              io.grpc.MethodDescriptor.<FGBoostServiceProto.SplitRequest, FGBoostServiceProto.SplitResponse>newBuilder()
+              io.grpc.MethodDescriptor.<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse>newBuilder()
               .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
               .setFullMethodName(generateFullMethodName(SERVICE_NAME, "split"))
               .setSampledToLocalTracing(true)
               .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  FGBoostServiceProto.SplitRequest.getDefaultInstance()))
+                  com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest.getDefaultInstance()))
               .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  FGBoostServiceProto.SplitResponse.getDefaultInstance()))
+                  com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse.getDefaultInstance()))
               .setSchemaDescriptor(new FGBoostServiceMethodDescriptorSupplier("split"))
               .build();
         }
@@ -107,29 +107,29 @@ public final class FGBoostServiceGrpc {
     return getSplitMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<FGBoostServiceProto.RegisterRequest,
-      FGBoostServiceProto.RegisterResponse> getRegisterMethod;
+  private static volatile io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest,
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse> getRegisterMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "register",
-      requestType = FGBoostServiceProto.RegisterRequest.class,
-      responseType = FGBoostServiceProto.RegisterResponse.class,
+      requestType = com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest.class,
+      responseType = com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<FGBoostServiceProto.RegisterRequest,
-      FGBoostServiceProto.RegisterResponse> getRegisterMethod() {
-    io.grpc.MethodDescriptor<FGBoostServiceProto.RegisterRequest, FGBoostServiceProto.RegisterResponse> getRegisterMethod;
+  public static io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest,
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse> getRegisterMethod() {
+    io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse> getRegisterMethod;
     if ((getRegisterMethod = FGBoostServiceGrpc.getRegisterMethod) == null) {
       synchronized (FGBoostServiceGrpc.class) {
         if ((getRegisterMethod = FGBoostServiceGrpc.getRegisterMethod) == null) {
           FGBoostServiceGrpc.getRegisterMethod = getRegisterMethod =
-              io.grpc.MethodDescriptor.<FGBoostServiceProto.RegisterRequest, FGBoostServiceProto.RegisterResponse>newBuilder()
+              io.grpc.MethodDescriptor.<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse>newBuilder()
               .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
               .setFullMethodName(generateFullMethodName(SERVICE_NAME, "register"))
               .setSampledToLocalTracing(true)
               .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  FGBoostServiceProto.RegisterRequest.getDefaultInstance()))
+                  com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest.getDefaultInstance()))
               .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  FGBoostServiceProto.RegisterResponse.getDefaultInstance()))
+                  com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse.getDefaultInstance()))
               .setSchemaDescriptor(new FGBoostServiceMethodDescriptorSupplier("register"))
               .build();
         }
@@ -138,29 +138,29 @@ public final class FGBoostServiceGrpc {
     return getRegisterMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<FGBoostServiceProto.UploadTreeLeafRequest,
-      FGBoostServiceProto.UploadResponse> getUploadTreeLeafMethod;
+  private static volatile io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest,
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse> getUploadTreeLeafMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "uploadTreeLeaf",
-      requestType = FGBoostServiceProto.UploadTreeLeafRequest.class,
-      responseType = FGBoostServiceProto.UploadResponse.class,
+      requestType = com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest.class,
+      responseType = com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<FGBoostServiceProto.UploadTreeLeafRequest,
-      FGBoostServiceProto.UploadResponse> getUploadTreeLeafMethod() {
-    io.grpc.MethodDescriptor<FGBoostServiceProto.UploadTreeLeafRequest, FGBoostServiceProto.UploadResponse> getUploadTreeLeafMethod;
+  public static io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest,
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse> getUploadTreeLeafMethod() {
+    io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse> getUploadTreeLeafMethod;
     if ((getUploadTreeLeafMethod = FGBoostServiceGrpc.getUploadTreeLeafMethod) == null) {
       synchronized (FGBoostServiceGrpc.class) {
         if ((getUploadTreeLeafMethod = FGBoostServiceGrpc.getUploadTreeLeafMethod) == null) {
           FGBoostServiceGrpc.getUploadTreeLeafMethod = getUploadTreeLeafMethod =
-              io.grpc.MethodDescriptor.<FGBoostServiceProto.UploadTreeLeafRequest, FGBoostServiceProto.UploadResponse>newBuilder()
+              io.grpc.MethodDescriptor.<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse>newBuilder()
               .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
               .setFullMethodName(generateFullMethodName(SERVICE_NAME, "uploadTreeLeaf"))
               .setSampledToLocalTracing(true)
               .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  FGBoostServiceProto.UploadTreeLeafRequest.getDefaultInstance()))
+                  com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest.getDefaultInstance()))
               .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  FGBoostServiceProto.UploadResponse.getDefaultInstance()))
+                  com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse.getDefaultInstance()))
               .setSchemaDescriptor(new FGBoostServiceMethodDescriptorSupplier("uploadTreeLeaf"))
               .build();
         }
@@ -169,29 +169,29 @@ public final class FGBoostServiceGrpc {
     return getUploadTreeLeafMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<FGBoostServiceProto.EvaluateRequest,
-      FGBoostServiceProto.EvaluateResponse> getEvaluateMethod;
+  private static volatile io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest,
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse> getEvaluateMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "evaluate",
-      requestType = FGBoostServiceProto.EvaluateRequest.class,
-      responseType = FGBoostServiceProto.EvaluateResponse.class,
+      requestType = com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest.class,
+      responseType = com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<FGBoostServiceProto.EvaluateRequest,
-      FGBoostServiceProto.EvaluateResponse> getEvaluateMethod() {
-    io.grpc.MethodDescriptor<FGBoostServiceProto.EvaluateRequest, FGBoostServiceProto.EvaluateResponse> getEvaluateMethod;
+  public static io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest,
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse> getEvaluateMethod() {
+    io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse> getEvaluateMethod;
     if ((getEvaluateMethod = FGBoostServiceGrpc.getEvaluateMethod) == null) {
       synchronized (FGBoostServiceGrpc.class) {
         if ((getEvaluateMethod = FGBoostServiceGrpc.getEvaluateMethod) == null) {
           FGBoostServiceGrpc.getEvaluateMethod = getEvaluateMethod =
-              io.grpc.MethodDescriptor.<FGBoostServiceProto.EvaluateRequest, FGBoostServiceProto.EvaluateResponse>newBuilder()
+              io.grpc.MethodDescriptor.<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse>newBuilder()
               .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
               .setFullMethodName(generateFullMethodName(SERVICE_NAME, "evaluate"))
               .setSampledToLocalTracing(true)
               .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  FGBoostServiceProto.EvaluateRequest.getDefaultInstance()))
+                  com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest.getDefaultInstance()))
               .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  FGBoostServiceProto.EvaluateResponse.getDefaultInstance()))
+                  com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse.getDefaultInstance()))
               .setSchemaDescriptor(new FGBoostServiceMethodDescriptorSupplier("evaluate"))
               .build();
         }
@@ -200,29 +200,29 @@ public final class FGBoostServiceGrpc {
     return getEvaluateMethod;
   }
 
-  private static volatile io.grpc.MethodDescriptor<FGBoostServiceProto.PredictRequest,
-      FGBoostServiceProto.PredictResponse> getPredictMethod;
+  private static volatile io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest,
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse> getPredictMethod;
 
   @io.grpc.stub.annotations.RpcMethod(
       fullMethodName = SERVICE_NAME + '/' + "predict",
-      requestType = FGBoostServiceProto.PredictRequest.class,
-      responseType = FGBoostServiceProto.PredictResponse.class,
+      requestType = com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest.class,
+      responseType = com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse.class,
       methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
-  public static io.grpc.MethodDescriptor<FGBoostServiceProto.PredictRequest,
-      FGBoostServiceProto.PredictResponse> getPredictMethod() {
-    io.grpc.MethodDescriptor<FGBoostServiceProto.PredictRequest, FGBoostServiceProto.PredictResponse> getPredictMethod;
+  public static io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest,
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse> getPredictMethod() {
+    io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse> getPredictMethod;
     if ((getPredictMethod = FGBoostServiceGrpc.getPredictMethod) == null) {
       synchronized (FGBoostServiceGrpc.class) {
         if ((getPredictMethod = FGBoostServiceGrpc.getPredictMethod) == null) {
           FGBoostServiceGrpc.getPredictMethod = getPredictMethod =
-              io.grpc.MethodDescriptor.<FGBoostServiceProto.PredictRequest, FGBoostServiceProto.PredictResponse>newBuilder()
+              io.grpc.MethodDescriptor.<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse>newBuilder()
               .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
               .setFullMethodName(generateFullMethodName(SERVICE_NAME, "predict"))
               .setSampledToLocalTracing(true)
               .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  FGBoostServiceProto.PredictRequest.getDefaultInstance()))
+                  com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest.getDefaultInstance()))
               .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-                  FGBoostServiceProto.PredictResponse.getDefaultInstance()))
+                  com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse.getDefaultInstance()))
               .setSchemaDescriptor(new FGBoostServiceMethodDescriptorSupplier("predict"))
               .build();
         }
@@ -231,13 +231,75 @@ public final class FGBoostServiceGrpc {
     return getPredictMethod;
   }
 
+  private static volatile io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest,
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse> getSaveServerModelMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "saveServerModel",
+      requestType = com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest.class,
+      responseType = com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest,
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse> getSaveServerModelMethod() {
+    io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse> getSaveServerModelMethod;
+    if ((getSaveServerModelMethod = FGBoostServiceGrpc.getSaveServerModelMethod) == null) {
+      synchronized (FGBoostServiceGrpc.class) {
+        if ((getSaveServerModelMethod = FGBoostServiceGrpc.getSaveServerModelMethod) == null) {
+          FGBoostServiceGrpc.getSaveServerModelMethod = getSaveServerModelMethod =
+              io.grpc.MethodDescriptor.<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "saveServerModel"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new FGBoostServiceMethodDescriptorSupplier("saveServerModel"))
+              .build();
+        }
+      }
+    }
+    return getSaveServerModelMethod;
+  }
+
+  private static volatile io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest,
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse> getLoadServerModelMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "loadServerModel",
+      requestType = com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest.class,
+      responseType = com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest,
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse> getLoadServerModelMethod() {
+    io.grpc.MethodDescriptor<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse> getLoadServerModelMethod;
+    if ((getLoadServerModelMethod = FGBoostServiceGrpc.getLoadServerModelMethod) == null) {
+      synchronized (FGBoostServiceGrpc.class) {
+        if ((getLoadServerModelMethod = FGBoostServiceGrpc.getLoadServerModelMethod) == null) {
+          FGBoostServiceGrpc.getLoadServerModelMethod = getLoadServerModelMethod =
+              io.grpc.MethodDescriptor.<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "loadServerModel"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new FGBoostServiceMethodDescriptorSupplier("loadServerModel"))
+              .build();
+        }
+      }
+    }
+    return getLoadServerModelMethod;
+  }
+
   /**
    * Creates a new async stub that supports all call types for the service
    */
   public static FGBoostServiceStub newStub(io.grpc.Channel channel) {
     io.grpc.stub.AbstractStub.StubFactory<FGBoostServiceStub> factory =
       new io.grpc.stub.AbstractStub.StubFactory<FGBoostServiceStub>() {
-        @Override
+        @java.lang.Override
         public FGBoostServiceStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
           return new FGBoostServiceStub(channel, callOptions);
         }
@@ -252,7 +314,7 @@ public final class FGBoostServiceGrpc {
       io.grpc.Channel channel) {
     io.grpc.stub.AbstractStub.StubFactory<FGBoostServiceBlockingStub> factory =
       new io.grpc.stub.AbstractStub.StubFactory<FGBoostServiceBlockingStub>() {
-        @Override
+        @java.lang.Override
         public FGBoostServiceBlockingStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
           return new FGBoostServiceBlockingStub(channel, callOptions);
         }
@@ -267,7 +329,7 @@ public final class FGBoostServiceGrpc {
       io.grpc.Channel channel) {
     io.grpc.stub.AbstractStub.StubFactory<FGBoostServiceFutureStub> factory =
       new io.grpc.stub.AbstractStub.StubFactory<FGBoostServiceFutureStub>() {
-        @Override
+        @java.lang.Override
         public FGBoostServiceFutureStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
           return new FGBoostServiceFutureStub(channel, callOptions);
         }
@@ -281,104 +343,132 @@ public final class FGBoostServiceGrpc {
 
     /**
      */
-    public void uploadLabel(FGBoostServiceProto.UploadLabelRequest request,
-                            io.grpc.stub.StreamObserver<FGBoostServiceProto.UploadResponse> responseObserver) {
+    public void uploadLabel(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest request,
+        io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getUploadLabelMethod(), responseObserver);
     }
 
     /**
      */
-    public void downloadLabel(FGBoostServiceProto.DownloadLabelRequest request,
-                              io.grpc.stub.StreamObserver<FGBoostServiceProto.DownloadResponse> responseObserver) {
+    public void downloadLabel(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest request,
+        io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getDownloadLabelMethod(), responseObserver);
     }
 
     /**
      */
-    public void split(FGBoostServiceProto.SplitRequest request,
-                      io.grpc.stub.StreamObserver<FGBoostServiceProto.SplitResponse> responseObserver) {
+    public void split(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest request,
+        io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getSplitMethod(), responseObserver);
     }
 
     /**
      */
-    public void register(FGBoostServiceProto.RegisterRequest request,
-                         io.grpc.stub.StreamObserver<FGBoostServiceProto.RegisterResponse> responseObserver) {
+    public void register(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest request,
+        io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getRegisterMethod(), responseObserver);
     }
 
     /**
      */
-    public void uploadTreeLeaf(FGBoostServiceProto.UploadTreeLeafRequest request,
-                               io.grpc.stub.StreamObserver<FGBoostServiceProto.UploadResponse> responseObserver) {
+    public void uploadTreeLeaf(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest request,
+        io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getUploadTreeLeafMethod(), responseObserver);
     }
 
     /**
      */
-    public void evaluate(FGBoostServiceProto.EvaluateRequest request,
-                         io.grpc.stub.StreamObserver<FGBoostServiceProto.EvaluateResponse> responseObserver) {
+    public void evaluate(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest request,
+        io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getEvaluateMethod(), responseObserver);
     }
 
     /**
      */
-    public void predict(FGBoostServiceProto.PredictRequest request,
-                        io.grpc.stub.StreamObserver<FGBoostServiceProto.PredictResponse> responseObserver) {
+    public void predict(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest request,
+        io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse> responseObserver) {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getPredictMethod(), responseObserver);
     }
 
-    @Override public final io.grpc.ServerServiceDefinition bindService() {
+    /**
+     */
+    public void saveServerModel(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest request,
+        io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getSaveServerModelMethod(), responseObserver);
+    }
+
+    /**
+     */
+    public void loadServerModel(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest request,
+        io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getLoadServerModelMethod(), responseObserver);
+    }
+
+    @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
             getUploadLabelMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
               new MethodHandlers<
-                FGBoostServiceProto.UploadLabelRequest,
-                FGBoostServiceProto.UploadResponse>(
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest,
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse>(
                   this, METHODID_UPLOAD_LABEL)))
           .addMethod(
             getDownloadLabelMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
               new MethodHandlers<
-                FGBoostServiceProto.DownloadLabelRequest,
-                FGBoostServiceProto.DownloadResponse>(
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest,
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse>(
                   this, METHODID_DOWNLOAD_LABEL)))
           .addMethod(
             getSplitMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
               new MethodHandlers<
-                FGBoostServiceProto.SplitRequest,
-                FGBoostServiceProto.SplitResponse>(
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest,
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse>(
                   this, METHODID_SPLIT)))
           .addMethod(
             getRegisterMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
               new MethodHandlers<
-                FGBoostServiceProto.RegisterRequest,
-                FGBoostServiceProto.RegisterResponse>(
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest,
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse>(
                   this, METHODID_REGISTER)))
           .addMethod(
             getUploadTreeLeafMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
               new MethodHandlers<
-                FGBoostServiceProto.UploadTreeLeafRequest,
-                FGBoostServiceProto.UploadResponse>(
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest,
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse>(
                   this, METHODID_UPLOAD_TREE_LEAF)))
           .addMethod(
             getEvaluateMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
               new MethodHandlers<
-                FGBoostServiceProto.EvaluateRequest,
-                FGBoostServiceProto.EvaluateResponse>(
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest,
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse>(
                   this, METHODID_EVALUATE)))
           .addMethod(
             getPredictMethod(),
             io.grpc.stub.ServerCalls.asyncUnaryCall(
               new MethodHandlers<
-                FGBoostServiceProto.PredictRequest,
-                FGBoostServiceProto.PredictResponse>(
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest,
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse>(
                   this, METHODID_PREDICT)))
+          .addMethod(
+            getSaveServerModelMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest,
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse>(
+                  this, METHODID_SAVE_SERVER_MODEL)))
+          .addMethod(
+            getLoadServerModelMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest,
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse>(
+                  this, METHODID_LOAD_SERVER_MODEL)))
           .build();
     }
   }
@@ -391,7 +481,7 @@ public final class FGBoostServiceGrpc {
       super(channel, callOptions);
     }
 
-    @Override
+    @java.lang.Override
     protected FGBoostServiceStub build(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new FGBoostServiceStub(channel, callOptions);
@@ -399,58 +489,74 @@ public final class FGBoostServiceGrpc {
 
     /**
      */
-    public void uploadLabel(FGBoostServiceProto.UploadLabelRequest request,
-                            io.grpc.stub.StreamObserver<FGBoostServiceProto.UploadResponse> responseObserver) {
+    public void uploadLabel(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest request,
+        io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getUploadLabelMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
      */
-    public void downloadLabel(FGBoostServiceProto.DownloadLabelRequest request,
-                              io.grpc.stub.StreamObserver<FGBoostServiceProto.DownloadResponse> responseObserver) {
+    public void downloadLabel(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest request,
+        io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getDownloadLabelMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
      */
-    public void split(FGBoostServiceProto.SplitRequest request,
-                      io.grpc.stub.StreamObserver<FGBoostServiceProto.SplitResponse> responseObserver) {
+    public void split(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest request,
+        io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getSplitMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
      */
-    public void register(FGBoostServiceProto.RegisterRequest request,
-                         io.grpc.stub.StreamObserver<FGBoostServiceProto.RegisterResponse> responseObserver) {
+    public void register(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest request,
+        io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getRegisterMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
      */
-    public void uploadTreeLeaf(FGBoostServiceProto.UploadTreeLeafRequest request,
-                               io.grpc.stub.StreamObserver<FGBoostServiceProto.UploadResponse> responseObserver) {
+    public void uploadTreeLeaf(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest request,
+        io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getUploadTreeLeafMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
      */
-    public void evaluate(FGBoostServiceProto.EvaluateRequest request,
-                         io.grpc.stub.StreamObserver<FGBoostServiceProto.EvaluateResponse> responseObserver) {
+    public void evaluate(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest request,
+        io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getEvaluateMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
      */
-    public void predict(FGBoostServiceProto.PredictRequest request,
-                        io.grpc.stub.StreamObserver<FGBoostServiceProto.PredictResponse> responseObserver) {
+    public void predict(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest request,
+        io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse> responseObserver) {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getPredictMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     */
+    public void saveServerModel(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest request,
+        io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getSaveServerModelMethod(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     */
+    public void loadServerModel(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest request,
+        io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getLoadServerModelMethod(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -462,7 +568,7 @@ public final class FGBoostServiceGrpc {
       super(channel, callOptions);
     }
 
-    @Override
+    @java.lang.Override
     protected FGBoostServiceBlockingStub build(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new FGBoostServiceBlockingStub(channel, callOptions);
@@ -470,51 +576,65 @@ public final class FGBoostServiceGrpc {
 
     /**
      */
-    public FGBoostServiceProto.UploadResponse uploadLabel(FGBoostServiceProto.UploadLabelRequest request) {
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse uploadLabel(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getUploadLabelMethod(), getCallOptions(), request);
     }
 
     /**
      */
-    public FGBoostServiceProto.DownloadResponse downloadLabel(FGBoostServiceProto.DownloadLabelRequest request) {
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse downloadLabel(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getDownloadLabelMethod(), getCallOptions(), request);
     }
 
     /**
      */
-    public FGBoostServiceProto.SplitResponse split(FGBoostServiceProto.SplitRequest request) {
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse split(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getSplitMethod(), getCallOptions(), request);
     }
 
     /**
      */
-    public FGBoostServiceProto.RegisterResponse register(FGBoostServiceProto.RegisterRequest request) {
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse register(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getRegisterMethod(), getCallOptions(), request);
     }
 
     /**
      */
-    public FGBoostServiceProto.UploadResponse uploadTreeLeaf(FGBoostServiceProto.UploadTreeLeafRequest request) {
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse uploadTreeLeaf(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getUploadTreeLeafMethod(), getCallOptions(), request);
     }
 
     /**
      */
-    public FGBoostServiceProto.EvaluateResponse evaluate(FGBoostServiceProto.EvaluateRequest request) {
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse evaluate(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getEvaluateMethod(), getCallOptions(), request);
     }
 
     /**
      */
-    public FGBoostServiceProto.PredictResponse predict(FGBoostServiceProto.PredictRequest request) {
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse predict(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getPredictMethod(), getCallOptions(), request);
+    }
+
+    /**
+     */
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse saveServerModel(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getSaveServerModelMethod(), getCallOptions(), request);
+    }
+
+    /**
+     */
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse loadServerModel(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getLoadServerModelMethod(), getCallOptions(), request);
     }
   }
 
@@ -526,7 +646,7 @@ public final class FGBoostServiceGrpc {
       super(channel, callOptions);
     }
 
-    @Override
+    @java.lang.Override
     protected FGBoostServiceFutureStub build(
         io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       return new FGBoostServiceFutureStub(channel, callOptions);
@@ -534,58 +654,74 @@ public final class FGBoostServiceGrpc {
 
     /**
      */
-    public com.google.common.util.concurrent.ListenableFuture<FGBoostServiceProto.UploadResponse> uploadLabel(
-        FGBoostServiceProto.UploadLabelRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse> uploadLabel(
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getUploadLabelMethod(), getCallOptions()), request);
     }
 
     /**
      */
-    public com.google.common.util.concurrent.ListenableFuture<FGBoostServiceProto.DownloadResponse> downloadLabel(
-        FGBoostServiceProto.DownloadLabelRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse> downloadLabel(
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getDownloadLabelMethod(), getCallOptions()), request);
     }
 
     /**
      */
-    public com.google.common.util.concurrent.ListenableFuture<FGBoostServiceProto.SplitResponse> split(
-        FGBoostServiceProto.SplitRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse> split(
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getSplitMethod(), getCallOptions()), request);
     }
 
     /**
      */
-    public com.google.common.util.concurrent.ListenableFuture<FGBoostServiceProto.RegisterResponse> register(
-        FGBoostServiceProto.RegisterRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse> register(
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getRegisterMethod(), getCallOptions()), request);
     }
 
     /**
      */
-    public com.google.common.util.concurrent.ListenableFuture<FGBoostServiceProto.UploadResponse> uploadTreeLeaf(
-        FGBoostServiceProto.UploadTreeLeafRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse> uploadTreeLeaf(
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getUploadTreeLeafMethod(), getCallOptions()), request);
     }
 
     /**
      */
-    public com.google.common.util.concurrent.ListenableFuture<FGBoostServiceProto.EvaluateResponse> evaluate(
-        FGBoostServiceProto.EvaluateRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse> evaluate(
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getEvaluateMethod(), getCallOptions()), request);
     }
 
     /**
      */
-    public com.google.common.util.concurrent.ListenableFuture<FGBoostServiceProto.PredictResponse> predict(
-        FGBoostServiceProto.PredictRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse> predict(
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest request) {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getPredictMethod(), getCallOptions()), request);
+    }
+
+    /**
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse> saveServerModel(
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getSaveServerModelMethod(), getCallOptions()), request);
+    }
+
+    /**
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse> loadServerModel(
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getLoadServerModelMethod(), getCallOptions()), request);
     }
   }
 
@@ -596,6 +732,8 @@ public final class FGBoostServiceGrpc {
   private static final int METHODID_UPLOAD_TREE_LEAF = 4;
   private static final int METHODID_EVALUATE = 5;
   private static final int METHODID_PREDICT = 6;
+  private static final int METHODID_SAVE_SERVER_MODEL = 7;
+  private static final int METHODID_LOAD_SERVER_MODEL = 8;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -610,45 +748,53 @@ public final class FGBoostServiceGrpc {
       this.methodId = methodId;
     }
 
-    @Override
-    @SuppressWarnings("unchecked")
+    @java.lang.Override
+    @java.lang.SuppressWarnings("unchecked")
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
         case METHODID_UPLOAD_LABEL:
-          serviceImpl.uploadLabel((FGBoostServiceProto.UploadLabelRequest) request,
-              (io.grpc.stub.StreamObserver<FGBoostServiceProto.UploadResponse>) responseObserver);
+          serviceImpl.uploadLabel((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest) request,
+              (io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse>) responseObserver);
           break;
         case METHODID_DOWNLOAD_LABEL:
-          serviceImpl.downloadLabel((FGBoostServiceProto.DownloadLabelRequest) request,
-              (io.grpc.stub.StreamObserver<FGBoostServiceProto.DownloadResponse>) responseObserver);
+          serviceImpl.downloadLabel((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest) request,
+              (io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse>) responseObserver);
           break;
         case METHODID_SPLIT:
-          serviceImpl.split((FGBoostServiceProto.SplitRequest) request,
-              (io.grpc.stub.StreamObserver<FGBoostServiceProto.SplitResponse>) responseObserver);
+          serviceImpl.split((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest) request,
+              (io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse>) responseObserver);
           break;
         case METHODID_REGISTER:
-          serviceImpl.register((FGBoostServiceProto.RegisterRequest) request,
-              (io.grpc.stub.StreamObserver<FGBoostServiceProto.RegisterResponse>) responseObserver);
+          serviceImpl.register((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest) request,
+              (io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse>) responseObserver);
           break;
         case METHODID_UPLOAD_TREE_LEAF:
-          serviceImpl.uploadTreeLeaf((FGBoostServiceProto.UploadTreeLeafRequest) request,
-              (io.grpc.stub.StreamObserver<FGBoostServiceProto.UploadResponse>) responseObserver);
+          serviceImpl.uploadTreeLeaf((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest) request,
+              (io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse>) responseObserver);
           break;
         case METHODID_EVALUATE:
-          serviceImpl.evaluate((FGBoostServiceProto.EvaluateRequest) request,
-              (io.grpc.stub.StreamObserver<FGBoostServiceProto.EvaluateResponse>) responseObserver);
+          serviceImpl.evaluate((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest) request,
+              (io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse>) responseObserver);
           break;
         case METHODID_PREDICT:
-          serviceImpl.predict((FGBoostServiceProto.PredictRequest) request,
-              (io.grpc.stub.StreamObserver<FGBoostServiceProto.PredictResponse>) responseObserver);
+          serviceImpl.predict((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest) request,
+              (io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse>) responseObserver);
+          break;
+        case METHODID_SAVE_SERVER_MODEL:
+          serviceImpl.saveServerModel((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest) request,
+              (io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse>) responseObserver);
+          break;
+        case METHODID_LOAD_SERVER_MODEL:
+          serviceImpl.loadServerModel((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest) request,
+              (io.grpc.stub.StreamObserver<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse>) responseObserver);
           break;
         default:
           throw new AssertionError();
       }
     }
 
-    @Override
-    @SuppressWarnings("unchecked")
+    @java.lang.Override
+    @java.lang.SuppressWarnings("unchecked")
     public io.grpc.stub.StreamObserver<Req> invoke(
         io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
@@ -662,12 +808,12 @@ public final class FGBoostServiceGrpc {
       implements io.grpc.protobuf.ProtoFileDescriptorSupplier, io.grpc.protobuf.ProtoServiceDescriptorSupplier {
     FGBoostServiceBaseDescriptorSupplier() {}
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Descriptors.FileDescriptor getFileDescriptor() {
-      return FGBoostServiceProto.getDescriptor();
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.getDescriptor();
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Descriptors.ServiceDescriptor getServiceDescriptor() {
       return getFileDescriptor().findServiceByName("FGBoostService");
     }
@@ -687,7 +833,7 @@ public final class FGBoostServiceGrpc {
       this.methodName = methodName;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Descriptors.MethodDescriptor getMethodDescriptor() {
       return getServiceDescriptor().findMethodByName(methodName);
     }
@@ -710,6 +856,8 @@ public final class FGBoostServiceGrpc {
               .addMethod(getUploadTreeLeafMethod())
               .addMethod(getEvaluateMethod())
               .addMethod(getPredictMethod())
+              .addMethod(getSaveServerModelMethod())
+              .addMethod(getLoadServerModelMethod())
               .build();
         }
       }

--- a/scala/ppml/src/main/java/com/intel/analytics/bigdl/ppml/fl/generated/FGBoostServiceProto.java
+++ b/scala/ppml/src/main/java/com/intel/analytics/bigdl/ppml/fl/generated/FGBoostServiceProto.java
@@ -22,7 +22,7 @@ public final class FGBoostServiceProto {
      * <code>string clientuuid = 1;</code>
      * @return The clientuuid.
      */
-    String getClientuuid();
+    java.lang.String getClientuuid();
     /**
      * <code>string clientuuid = 1;</code>
      * @return The bytes for clientuuid.
@@ -39,17 +39,17 @@ public final class FGBoostServiceProto {
      * <code>.TensorMap data = 2;</code>
      * @return The data.
      */
-    FlBaseProto.TensorMap getData();
+    com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap getData();
     /**
      * <code>.TensorMap data = 2;</code>
      */
-    FlBaseProto.TensorMapOrBuilder getDataOrBuilder();
+    com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder getDataOrBuilder();
 
     /**
      * <code>string algorithm = 3;</code>
      * @return The algorithm.
      */
-    String getAlgorithm();
+    java.lang.String getAlgorithm();
     /**
      * <code>string algorithm = 3;</code>
      * @return The bytes for algorithm.
@@ -74,14 +74,14 @@ public final class FGBoostServiceProto {
       algorithm_ = "";
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new UploadLabelRequest();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -92,7 +92,7 @@ public final class FGBoostServiceProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -105,17 +105,17 @@ public final class FGBoostServiceProto {
               done = true;
               break;
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               clientuuid_ = s;
               break;
             }
             case 18: {
-              FlBaseProto.TensorMap.Builder subBuilder = null;
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder subBuilder = null;
               if (data_ != null) {
                 subBuilder = data_.toBuilder();
               }
-              data_ = input.readMessage(FlBaseProto.TensorMap.parser(), extensionRegistry);
+              data_ = input.readMessage(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(data_);
                 data_ = subBuilder.buildPartial();
@@ -124,7 +124,7 @@ public final class FGBoostServiceProto {
               break;
             }
             case 26: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               algorithm_ = s;
               break;
@@ -150,32 +150,32 @@ public final class FGBoostServiceProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FGBoostServiceProto.internal_static_fgboost_UploadLabelRequest_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadLabelRequest_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FGBoostServiceProto.internal_static_fgboost_UploadLabelRequest_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadLabelRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              UploadLabelRequest.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest.Builder.class);
     }
 
     public static final int CLIENTUUID_FIELD_NUMBER = 1;
-    private volatile Object clientuuid_;
+    private volatile java.lang.Object clientuuid_;
     /**
      * <code>string clientuuid = 1;</code>
      * @return The clientuuid.
      */
-    @Override
-    public String getClientuuid() {
-      Object ref = clientuuid_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getClientuuid() {
+      java.lang.Object ref = clientuuid_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         clientuuid_ = s;
         return s;
       }
@@ -184,14 +184,14 @@ public final class FGBoostServiceProto {
      * <code>string clientuuid = 1;</code>
      * @return The bytes for clientuuid.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getClientuuidBytes() {
-      Object ref = clientuuid_;
-      if (ref instanceof String) {
+      java.lang.Object ref = clientuuid_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         clientuuid_ = b;
         return b;
       } else {
@@ -200,12 +200,12 @@ public final class FGBoostServiceProto {
     }
 
     public static final int DATA_FIELD_NUMBER = 2;
-    private FlBaseProto.TensorMap data_;
+    private com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap data_;
     /**
      * <code>.TensorMap data = 2;</code>
      * @return Whether the data field is set.
      */
-    @Override
+    @java.lang.Override
     public boolean hasData() {
       return data_ != null;
     }
@@ -213,33 +213,33 @@ public final class FGBoostServiceProto {
      * <code>.TensorMap data = 2;</code>
      * @return The data.
      */
-    @Override
-    public FlBaseProto.TensorMap getData() {
-      return data_ == null ? FlBaseProto.TensorMap.getDefaultInstance() : data_;
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap getData() {
+      return data_ == null ? com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.getDefaultInstance() : data_;
     }
     /**
      * <code>.TensorMap data = 2;</code>
      */
-    @Override
-    public FlBaseProto.TensorMapOrBuilder getDataOrBuilder() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder getDataOrBuilder() {
       return getData();
     }
 
     public static final int ALGORITHM_FIELD_NUMBER = 3;
-    private volatile Object algorithm_;
+    private volatile java.lang.Object algorithm_;
     /**
      * <code>string algorithm = 3;</code>
      * @return The algorithm.
      */
-    @Override
-    public String getAlgorithm() {
-      Object ref = algorithm_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getAlgorithm() {
+      java.lang.Object ref = algorithm_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         algorithm_ = s;
         return s;
       }
@@ -248,14 +248,14 @@ public final class FGBoostServiceProto {
      * <code>string algorithm = 3;</code>
      * @return The bytes for algorithm.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getAlgorithmBytes() {
-      Object ref = algorithm_;
-      if (ref instanceof String) {
+      java.lang.Object ref = algorithm_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         algorithm_ = b;
         return b;
       } else {
@@ -264,7 +264,7 @@ public final class FGBoostServiceProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -274,7 +274,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getClientuuidBytes().isEmpty()) {
@@ -289,7 +289,7 @@ public final class FGBoostServiceProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -310,15 +310,15 @@ public final class FGBoostServiceProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof UploadLabelRequest)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest)) {
         return super.equals(obj);
       }
-      UploadLabelRequest other = (UploadLabelRequest) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest) obj;
 
       if (!getClientuuid()
           .equals(other.getClientuuid())) return false;
@@ -333,7 +333,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -353,69 +353,69 @@ public final class FGBoostServiceProto {
       return hash;
     }
 
-    public static UploadLabelRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static UploadLabelRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static UploadLabelRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static UploadLabelRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static UploadLabelRequest parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static UploadLabelRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static UploadLabelRequest parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static UploadLabelRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static UploadLabelRequest parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static UploadLabelRequest parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static UploadLabelRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static UploadLabelRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -423,23 +423,23 @@ public final class FGBoostServiceProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(UploadLabelRequest prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -449,18 +449,18 @@ public final class FGBoostServiceProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:fgboost.UploadLabelRequest)
-        UploadLabelRequestOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FGBoostServiceProto.internal_static_fgboost_UploadLabelRequest_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadLabelRequest_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FGBoostServiceProto.internal_static_fgboost_UploadLabelRequest_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadLabelRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                UploadLabelRequest.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest.newBuilder()
@@ -469,7 +469,7 @@ public final class FGBoostServiceProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -478,7 +478,7 @@ public final class FGBoostServiceProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         clientuuid_ = "";
@@ -494,29 +494,29 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FGBoostServiceProto.internal_static_fgboost_UploadLabelRequest_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadLabelRequest_descriptor;
       }
 
-      @Override
-      public UploadLabelRequest getDefaultInstanceForType() {
-        return UploadLabelRequest.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest.getDefaultInstance();
       }
 
-      @Override
-      public UploadLabelRequest build() {
-        UploadLabelRequest result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public UploadLabelRequest buildPartial() {
-        UploadLabelRequest result = new UploadLabelRequest(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest(this);
         result.clientuuid_ = clientuuid_;
         if (dataBuilder_ == null) {
           result.data_ = data_;
@@ -528,50 +528,50 @@ public final class FGBoostServiceProto {
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof UploadLabelRequest) {
-          return mergeFrom((UploadLabelRequest)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(UploadLabelRequest other) {
-        if (other == UploadLabelRequest.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest.getDefaultInstance()) return this;
         if (!other.getClientuuid().isEmpty()) {
           clientuuid_ = other.clientuuid_;
           onChanged();
@@ -588,21 +588,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        UploadLabelRequest parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (UploadLabelRequest) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -612,21 +612,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private Object clientuuid_ = "";
+      private java.lang.Object clientuuid_ = "";
       /**
        * <code>string clientuuid = 1;</code>
        * @return The clientuuid.
        */
-      public String getClientuuid() {
-        Object ref = clientuuid_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getClientuuid() {
+        java.lang.Object ref = clientuuid_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           clientuuid_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -635,11 +635,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getClientuuidBytes() {
-        Object ref = clientuuid_;
+        java.lang.Object ref = clientuuid_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           clientuuid_ = b;
           return b;
         } else {
@@ -652,7 +652,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setClientuuid(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -688,9 +688,9 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private FlBaseProto.TensorMap data_;
+      private com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap data_;
       private com.google.protobuf.SingleFieldBuilderV3<
-          FlBaseProto.TensorMap, FlBaseProto.TensorMap.Builder, FlBaseProto.TensorMapOrBuilder> dataBuilder_;
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder> dataBuilder_;
       /**
        * <code>.TensorMap data = 2;</code>
        * @return Whether the data field is set.
@@ -702,9 +702,9 @@ public final class FGBoostServiceProto {
        * <code>.TensorMap data = 2;</code>
        * @return The data.
        */
-      public FlBaseProto.TensorMap getData() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap getData() {
         if (dataBuilder_ == null) {
-          return data_ == null ? FlBaseProto.TensorMap.getDefaultInstance() : data_;
+          return data_ == null ? com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.getDefaultInstance() : data_;
         } else {
           return dataBuilder_.getMessage();
         }
@@ -712,7 +712,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>.TensorMap data = 2;</code>
        */
-      public Builder setData(FlBaseProto.TensorMap value) {
+      public Builder setData(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap value) {
         if (dataBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -729,7 +729,7 @@ public final class FGBoostServiceProto {
        * <code>.TensorMap data = 2;</code>
        */
       public Builder setData(
-          FlBaseProto.TensorMap.Builder builderForValue) {
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder builderForValue) {
         if (dataBuilder_ == null) {
           data_ = builderForValue.build();
           onChanged();
@@ -742,11 +742,11 @@ public final class FGBoostServiceProto {
       /**
        * <code>.TensorMap data = 2;</code>
        */
-      public Builder mergeData(FlBaseProto.TensorMap value) {
+      public Builder mergeData(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap value) {
         if (dataBuilder_ == null) {
           if (data_ != null) {
             data_ =
-              FlBaseProto.TensorMap.newBuilder(data_).mergeFrom(value).buildPartial();
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.newBuilder(data_).mergeFrom(value).buildPartial();
           } else {
             data_ = value;
           }
@@ -774,7 +774,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>.TensorMap data = 2;</code>
        */
-      public FlBaseProto.TensorMap.Builder getDataBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder getDataBuilder() {
         
         onChanged();
         return getDataFieldBuilder().getBuilder();
@@ -782,23 +782,23 @@ public final class FGBoostServiceProto {
       /**
        * <code>.TensorMap data = 2;</code>
        */
-      public FlBaseProto.TensorMapOrBuilder getDataOrBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder getDataOrBuilder() {
         if (dataBuilder_ != null) {
           return dataBuilder_.getMessageOrBuilder();
         } else {
           return data_ == null ?
-              FlBaseProto.TensorMap.getDefaultInstance() : data_;
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.getDefaultInstance() : data_;
         }
       }
       /**
        * <code>.TensorMap data = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
-          FlBaseProto.TensorMap, FlBaseProto.TensorMap.Builder, FlBaseProto.TensorMapOrBuilder>
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder> 
           getDataFieldBuilder() {
         if (dataBuilder_ == null) {
           dataBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              FlBaseProto.TensorMap, FlBaseProto.TensorMap.Builder, FlBaseProto.TensorMapOrBuilder>(
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder>(
                   getData(),
                   getParentForChildren(),
                   isClean());
@@ -807,21 +807,21 @@ public final class FGBoostServiceProto {
         return dataBuilder_;
       }
 
-      private Object algorithm_ = "";
+      private java.lang.Object algorithm_ = "";
       /**
        * <code>string algorithm = 3;</code>
        * @return The algorithm.
        */
-      public String getAlgorithm() {
-        Object ref = algorithm_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getAlgorithm() {
+        java.lang.Object ref = algorithm_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           algorithm_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -830,11 +830,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getAlgorithmBytes() {
-        Object ref = algorithm_;
+        java.lang.Object ref = algorithm_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           algorithm_ = b;
           return b;
         } else {
@@ -847,7 +847,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setAlgorithm(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -882,13 +882,13 @@ public final class FGBoostServiceProto {
         onChanged();
         return this;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -899,18 +899,18 @@ public final class FGBoostServiceProto {
     }
 
     // @@protoc_insertion_point(class_scope:fgboost.UploadLabelRequest)
-    private static final UploadLabelRequest DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new UploadLabelRequest();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest();
     }
 
-    public static UploadLabelRequest getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<UploadLabelRequest>
         PARSER = new com.google.protobuf.AbstractParser<UploadLabelRequest>() {
-      @Override
+      @java.lang.Override
       public UploadLabelRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -923,13 +923,13 @@ public final class FGBoostServiceProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<UploadLabelRequest> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public UploadLabelRequest getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadLabelRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -948,17 +948,17 @@ public final class FGBoostServiceProto {
      * <code>.MetaData metaData = 1;</code>
      * @return The metaData.
      */
-    FlBaseProto.MetaData getMetaData();
+    com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData getMetaData();
     /**
      * <code>.MetaData metaData = 1;</code>
      */
-    FlBaseProto.MetaDataOrBuilder getMetaDataOrBuilder();
+    com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaDataOrBuilder getMetaDataOrBuilder();
 
     /**
      * <code>string algorithm = 2;</code>
      * @return The algorithm.
      */
-    String getAlgorithm();
+    java.lang.String getAlgorithm();
     /**
      * <code>string algorithm = 2;</code>
      * @return The bytes for algorithm.
@@ -982,14 +982,14 @@ public final class FGBoostServiceProto {
       algorithm_ = "";
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new DownloadLabelRequest();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -1000,7 +1000,7 @@ public final class FGBoostServiceProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -1013,11 +1013,11 @@ public final class FGBoostServiceProto {
               done = true;
               break;
             case 10: {
-              FlBaseProto.MetaData.Builder subBuilder = null;
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.Builder subBuilder = null;
               if (metaData_ != null) {
                 subBuilder = metaData_.toBuilder();
               }
-              metaData_ = input.readMessage(FlBaseProto.MetaData.parser(), extensionRegistry);
+              metaData_ = input.readMessage(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(metaData_);
                 metaData_ = subBuilder.buildPartial();
@@ -1026,7 +1026,7 @@ public final class FGBoostServiceProto {
               break;
             }
             case 18: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               algorithm_ = s;
               break;
@@ -1052,24 +1052,24 @@ public final class FGBoostServiceProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FGBoostServiceProto.internal_static_fgboost_DownloadLabelRequest_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_DownloadLabelRequest_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FGBoostServiceProto.internal_static_fgboost_DownloadLabelRequest_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_DownloadLabelRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              DownloadLabelRequest.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest.Builder.class);
     }
 
     public static final int METADATA_FIELD_NUMBER = 1;
-    private FlBaseProto.MetaData metaData_;
+    private com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData metaData_;
     /**
      * <code>.MetaData metaData = 1;</code>
      * @return Whether the metaData field is set.
      */
-    @Override
+    @java.lang.Override
     public boolean hasMetaData() {
       return metaData_ != null;
     }
@@ -1077,33 +1077,33 @@ public final class FGBoostServiceProto {
      * <code>.MetaData metaData = 1;</code>
      * @return The metaData.
      */
-    @Override
-    public FlBaseProto.MetaData getMetaData() {
-      return metaData_ == null ? FlBaseProto.MetaData.getDefaultInstance() : metaData_;
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData getMetaData() {
+      return metaData_ == null ? com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.getDefaultInstance() : metaData_;
     }
     /**
      * <code>.MetaData metaData = 1;</code>
      */
-    @Override
-    public FlBaseProto.MetaDataOrBuilder getMetaDataOrBuilder() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaDataOrBuilder getMetaDataOrBuilder() {
       return getMetaData();
     }
 
     public static final int ALGORITHM_FIELD_NUMBER = 2;
-    private volatile Object algorithm_;
+    private volatile java.lang.Object algorithm_;
     /**
      * <code>string algorithm = 2;</code>
      * @return The algorithm.
      */
-    @Override
-    public String getAlgorithm() {
-      Object ref = algorithm_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getAlgorithm() {
+      java.lang.Object ref = algorithm_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         algorithm_ = s;
         return s;
       }
@@ -1112,14 +1112,14 @@ public final class FGBoostServiceProto {
      * <code>string algorithm = 2;</code>
      * @return The bytes for algorithm.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getAlgorithmBytes() {
-      Object ref = algorithm_;
-      if (ref instanceof String) {
+      java.lang.Object ref = algorithm_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         algorithm_ = b;
         return b;
       } else {
@@ -1128,7 +1128,7 @@ public final class FGBoostServiceProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -1138,7 +1138,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (metaData_ != null) {
@@ -1150,7 +1150,7 @@ public final class FGBoostServiceProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -1168,15 +1168,15 @@ public final class FGBoostServiceProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof DownloadLabelRequest)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest)) {
         return super.equals(obj);
       }
-      DownloadLabelRequest other = (DownloadLabelRequest) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest) obj;
 
       if (hasMetaData() != other.hasMetaData()) return false;
       if (hasMetaData()) {
@@ -1189,7 +1189,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -1207,69 +1207,69 @@ public final class FGBoostServiceProto {
       return hash;
     }
 
-    public static DownloadLabelRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static DownloadLabelRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static DownloadLabelRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static DownloadLabelRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static DownloadLabelRequest parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static DownloadLabelRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static DownloadLabelRequest parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static DownloadLabelRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static DownloadLabelRequest parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static DownloadLabelRequest parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static DownloadLabelRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static DownloadLabelRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -1277,23 +1277,23 @@ public final class FGBoostServiceProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(DownloadLabelRequest prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -1303,18 +1303,18 @@ public final class FGBoostServiceProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:fgboost.DownloadLabelRequest)
-        DownloadLabelRequestOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FGBoostServiceProto.internal_static_fgboost_DownloadLabelRequest_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_DownloadLabelRequest_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FGBoostServiceProto.internal_static_fgboost_DownloadLabelRequest_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_DownloadLabelRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                DownloadLabelRequest.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest.newBuilder()
@@ -1323,7 +1323,7 @@ public final class FGBoostServiceProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -1332,7 +1332,7 @@ public final class FGBoostServiceProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (metaDataBuilder_ == null) {
@@ -1346,29 +1346,29 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FGBoostServiceProto.internal_static_fgboost_DownloadLabelRequest_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_DownloadLabelRequest_descriptor;
       }
 
-      @Override
-      public DownloadLabelRequest getDefaultInstanceForType() {
-        return DownloadLabelRequest.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest.getDefaultInstance();
       }
 
-      @Override
-      public DownloadLabelRequest build() {
-        DownloadLabelRequest result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public DownloadLabelRequest buildPartial() {
-        DownloadLabelRequest result = new DownloadLabelRequest(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest(this);
         if (metaDataBuilder_ == null) {
           result.metaData_ = metaData_;
         } else {
@@ -1379,50 +1379,50 @@ public final class FGBoostServiceProto {
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof DownloadLabelRequest) {
-          return mergeFrom((DownloadLabelRequest)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(DownloadLabelRequest other) {
-        if (other == DownloadLabelRequest.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest.getDefaultInstance()) return this;
         if (other.hasMetaData()) {
           mergeMetaData(other.getMetaData());
         }
@@ -1435,21 +1435,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        DownloadLabelRequest parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (DownloadLabelRequest) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -1459,9 +1459,9 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private FlBaseProto.MetaData metaData_;
+      private com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData metaData_;
       private com.google.protobuf.SingleFieldBuilderV3<
-          FlBaseProto.MetaData, FlBaseProto.MetaData.Builder, FlBaseProto.MetaDataOrBuilder> metaDataBuilder_;
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaDataOrBuilder> metaDataBuilder_;
       /**
        * <code>.MetaData metaData = 1;</code>
        * @return Whether the metaData field is set.
@@ -1473,9 +1473,9 @@ public final class FGBoostServiceProto {
        * <code>.MetaData metaData = 1;</code>
        * @return The metaData.
        */
-      public FlBaseProto.MetaData getMetaData() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData getMetaData() {
         if (metaDataBuilder_ == null) {
-          return metaData_ == null ? FlBaseProto.MetaData.getDefaultInstance() : metaData_;
+          return metaData_ == null ? com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.getDefaultInstance() : metaData_;
         } else {
           return metaDataBuilder_.getMessage();
         }
@@ -1483,7 +1483,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>.MetaData metaData = 1;</code>
        */
-      public Builder setMetaData(FlBaseProto.MetaData value) {
+      public Builder setMetaData(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData value) {
         if (metaDataBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -1500,7 +1500,7 @@ public final class FGBoostServiceProto {
        * <code>.MetaData metaData = 1;</code>
        */
       public Builder setMetaData(
-          FlBaseProto.MetaData.Builder builderForValue) {
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.Builder builderForValue) {
         if (metaDataBuilder_ == null) {
           metaData_ = builderForValue.build();
           onChanged();
@@ -1513,11 +1513,11 @@ public final class FGBoostServiceProto {
       /**
        * <code>.MetaData metaData = 1;</code>
        */
-      public Builder mergeMetaData(FlBaseProto.MetaData value) {
+      public Builder mergeMetaData(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData value) {
         if (metaDataBuilder_ == null) {
           if (metaData_ != null) {
             metaData_ =
-              FlBaseProto.MetaData.newBuilder(metaData_).mergeFrom(value).buildPartial();
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.newBuilder(metaData_).mergeFrom(value).buildPartial();
           } else {
             metaData_ = value;
           }
@@ -1545,7 +1545,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>.MetaData metaData = 1;</code>
        */
-      public FlBaseProto.MetaData.Builder getMetaDataBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.Builder getMetaDataBuilder() {
         
         onChanged();
         return getMetaDataFieldBuilder().getBuilder();
@@ -1553,23 +1553,23 @@ public final class FGBoostServiceProto {
       /**
        * <code>.MetaData metaData = 1;</code>
        */
-      public FlBaseProto.MetaDataOrBuilder getMetaDataOrBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaDataOrBuilder getMetaDataOrBuilder() {
         if (metaDataBuilder_ != null) {
           return metaDataBuilder_.getMessageOrBuilder();
         } else {
           return metaData_ == null ?
-              FlBaseProto.MetaData.getDefaultInstance() : metaData_;
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.getDefaultInstance() : metaData_;
         }
       }
       /**
        * <code>.MetaData metaData = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
-          FlBaseProto.MetaData, FlBaseProto.MetaData.Builder, FlBaseProto.MetaDataOrBuilder>
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaDataOrBuilder> 
           getMetaDataFieldBuilder() {
         if (metaDataBuilder_ == null) {
           metaDataBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              FlBaseProto.MetaData, FlBaseProto.MetaData.Builder, FlBaseProto.MetaDataOrBuilder>(
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaDataOrBuilder>(
                   getMetaData(),
                   getParentForChildren(),
                   isClean());
@@ -1578,21 +1578,21 @@ public final class FGBoostServiceProto {
         return metaDataBuilder_;
       }
 
-      private Object algorithm_ = "";
+      private java.lang.Object algorithm_ = "";
       /**
        * <code>string algorithm = 2;</code>
        * @return The algorithm.
        */
-      public String getAlgorithm() {
-        Object ref = algorithm_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getAlgorithm() {
+        java.lang.Object ref = algorithm_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           algorithm_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -1601,11 +1601,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getAlgorithmBytes() {
-        Object ref = algorithm_;
+        java.lang.Object ref = algorithm_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           algorithm_ = b;
           return b;
         } else {
@@ -1618,7 +1618,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setAlgorithm(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -1653,13 +1653,13 @@ public final class FGBoostServiceProto {
         onChanged();
         return this;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -1670,18 +1670,18 @@ public final class FGBoostServiceProto {
     }
 
     // @@protoc_insertion_point(class_scope:fgboost.DownloadLabelRequest)
-    private static final DownloadLabelRequest DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new DownloadLabelRequest();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest();
     }
 
-    public static DownloadLabelRequest getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<DownloadLabelRequest>
         PARSER = new com.google.protobuf.AbstractParser<DownloadLabelRequest>() {
-      @Override
+      @java.lang.Override
       public DownloadLabelRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1694,13 +1694,13 @@ public final class FGBoostServiceProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<DownloadLabelRequest> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public DownloadLabelRequest getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadLabelRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -1719,17 +1719,17 @@ public final class FGBoostServiceProto {
      * <code>.TensorMap data = 1;</code>
      * @return The data.
      */
-    FlBaseProto.TensorMap getData();
+    com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap getData();
     /**
      * <code>.TensorMap data = 1;</code>
      */
-    FlBaseProto.TensorMapOrBuilder getDataOrBuilder();
+    com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder getDataOrBuilder();
 
     /**
      * <code>string response = 2;</code>
      * @return The response.
      */
-    String getResponse();
+    java.lang.String getResponse();
     /**
      * <code>string response = 2;</code>
      * @return The bytes for response.
@@ -1759,14 +1759,14 @@ public final class FGBoostServiceProto {
       response_ = "";
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new DownloadResponse();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -1777,7 +1777,7 @@ public final class FGBoostServiceProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -1790,11 +1790,11 @@ public final class FGBoostServiceProto {
               done = true;
               break;
             case 10: {
-              FlBaseProto.TensorMap.Builder subBuilder = null;
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder subBuilder = null;
               if (data_ != null) {
                 subBuilder = data_.toBuilder();
               }
-              data_ = input.readMessage(FlBaseProto.TensorMap.parser(), extensionRegistry);
+              data_ = input.readMessage(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(data_);
                 data_ = subBuilder.buildPartial();
@@ -1803,7 +1803,7 @@ public final class FGBoostServiceProto {
               break;
             }
             case 18: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               response_ = s;
               break;
@@ -1834,24 +1834,24 @@ public final class FGBoostServiceProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FGBoostServiceProto.internal_static_fgboost_DownloadResponse_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_DownloadResponse_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FGBoostServiceProto.internal_static_fgboost_DownloadResponse_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_DownloadResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              DownloadResponse.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse.Builder.class);
     }
 
     public static final int DATA_FIELD_NUMBER = 1;
-    private FlBaseProto.TensorMap data_;
+    private com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap data_;
     /**
      * <code>.TensorMap data = 1;</code>
      * @return Whether the data field is set.
      */
-    @Override
+    @java.lang.Override
     public boolean hasData() {
       return data_ != null;
     }
@@ -1859,33 +1859,33 @@ public final class FGBoostServiceProto {
      * <code>.TensorMap data = 1;</code>
      * @return The data.
      */
-    @Override
-    public FlBaseProto.TensorMap getData() {
-      return data_ == null ? FlBaseProto.TensorMap.getDefaultInstance() : data_;
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap getData() {
+      return data_ == null ? com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.getDefaultInstance() : data_;
     }
     /**
      * <code>.TensorMap data = 1;</code>
      */
-    @Override
-    public FlBaseProto.TensorMapOrBuilder getDataOrBuilder() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder getDataOrBuilder() {
       return getData();
     }
 
     public static final int RESPONSE_FIELD_NUMBER = 2;
-    private volatile Object response_;
+    private volatile java.lang.Object response_;
     /**
      * <code>string response = 2;</code>
      * @return The response.
      */
-    @Override
-    public String getResponse() {
-      Object ref = response_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getResponse() {
+      java.lang.Object ref = response_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         response_ = s;
         return s;
       }
@@ -1894,14 +1894,14 @@ public final class FGBoostServiceProto {
      * <code>string response = 2;</code>
      * @return The bytes for response.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getResponseBytes() {
-      Object ref = response_;
-      if (ref instanceof String) {
+      java.lang.Object ref = response_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         response_ = b;
         return b;
       } else {
@@ -1915,13 +1915,13 @@ public final class FGBoostServiceProto {
      * <code>int32 code = 3;</code>
      * @return The code.
      */
-    @Override
+    @java.lang.Override
     public int getCode() {
       return code_;
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -1931,7 +1931,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (data_ != null) {
@@ -1946,7 +1946,7 @@ public final class FGBoostServiceProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -1968,15 +1968,15 @@ public final class FGBoostServiceProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof DownloadResponse)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse)) {
         return super.equals(obj);
       }
-      DownloadResponse other = (DownloadResponse) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse) obj;
 
       if (hasData() != other.hasData()) return false;
       if (hasData()) {
@@ -1991,7 +1991,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -2011,69 +2011,69 @@ public final class FGBoostServiceProto {
       return hash;
     }
 
-    public static DownloadResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static DownloadResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static DownloadResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static DownloadResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static DownloadResponse parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static DownloadResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static DownloadResponse parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static DownloadResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static DownloadResponse parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static DownloadResponse parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static DownloadResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static DownloadResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -2081,23 +2081,23 @@ public final class FGBoostServiceProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(DownloadResponse prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -2107,18 +2107,18 @@ public final class FGBoostServiceProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:fgboost.DownloadResponse)
-        DownloadResponseOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FGBoostServiceProto.internal_static_fgboost_DownloadResponse_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_DownloadResponse_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FGBoostServiceProto.internal_static_fgboost_DownloadResponse_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_DownloadResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                DownloadResponse.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse.newBuilder()
@@ -2127,7 +2127,7 @@ public final class FGBoostServiceProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -2136,7 +2136,7 @@ public final class FGBoostServiceProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (dataBuilder_ == null) {
@@ -2152,29 +2152,29 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FGBoostServiceProto.internal_static_fgboost_DownloadResponse_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_DownloadResponse_descriptor;
       }
 
-      @Override
-      public DownloadResponse getDefaultInstanceForType() {
-        return DownloadResponse.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse.getDefaultInstance();
       }
 
-      @Override
-      public DownloadResponse build() {
-        DownloadResponse result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public DownloadResponse buildPartial() {
-        DownloadResponse result = new DownloadResponse(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse(this);
         if (dataBuilder_ == null) {
           result.data_ = data_;
         } else {
@@ -2186,50 +2186,50 @@ public final class FGBoostServiceProto {
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof DownloadResponse) {
-          return mergeFrom((DownloadResponse)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(DownloadResponse other) {
-        if (other == DownloadResponse.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse.getDefaultInstance()) return this;
         if (other.hasData()) {
           mergeData(other.getData());
         }
@@ -2245,21 +2245,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        DownloadResponse parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (DownloadResponse) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -2269,9 +2269,9 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private FlBaseProto.TensorMap data_;
+      private com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap data_;
       private com.google.protobuf.SingleFieldBuilderV3<
-          FlBaseProto.TensorMap, FlBaseProto.TensorMap.Builder, FlBaseProto.TensorMapOrBuilder> dataBuilder_;
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder> dataBuilder_;
       /**
        * <code>.TensorMap data = 1;</code>
        * @return Whether the data field is set.
@@ -2283,9 +2283,9 @@ public final class FGBoostServiceProto {
        * <code>.TensorMap data = 1;</code>
        * @return The data.
        */
-      public FlBaseProto.TensorMap getData() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap getData() {
         if (dataBuilder_ == null) {
-          return data_ == null ? FlBaseProto.TensorMap.getDefaultInstance() : data_;
+          return data_ == null ? com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.getDefaultInstance() : data_;
         } else {
           return dataBuilder_.getMessage();
         }
@@ -2293,7 +2293,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>.TensorMap data = 1;</code>
        */
-      public Builder setData(FlBaseProto.TensorMap value) {
+      public Builder setData(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap value) {
         if (dataBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -2310,7 +2310,7 @@ public final class FGBoostServiceProto {
        * <code>.TensorMap data = 1;</code>
        */
       public Builder setData(
-          FlBaseProto.TensorMap.Builder builderForValue) {
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder builderForValue) {
         if (dataBuilder_ == null) {
           data_ = builderForValue.build();
           onChanged();
@@ -2323,11 +2323,11 @@ public final class FGBoostServiceProto {
       /**
        * <code>.TensorMap data = 1;</code>
        */
-      public Builder mergeData(FlBaseProto.TensorMap value) {
+      public Builder mergeData(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap value) {
         if (dataBuilder_ == null) {
           if (data_ != null) {
             data_ =
-              FlBaseProto.TensorMap.newBuilder(data_).mergeFrom(value).buildPartial();
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.newBuilder(data_).mergeFrom(value).buildPartial();
           } else {
             data_ = value;
           }
@@ -2355,7 +2355,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>.TensorMap data = 1;</code>
        */
-      public FlBaseProto.TensorMap.Builder getDataBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder getDataBuilder() {
         
         onChanged();
         return getDataFieldBuilder().getBuilder();
@@ -2363,23 +2363,23 @@ public final class FGBoostServiceProto {
       /**
        * <code>.TensorMap data = 1;</code>
        */
-      public FlBaseProto.TensorMapOrBuilder getDataOrBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder getDataOrBuilder() {
         if (dataBuilder_ != null) {
           return dataBuilder_.getMessageOrBuilder();
         } else {
           return data_ == null ?
-              FlBaseProto.TensorMap.getDefaultInstance() : data_;
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.getDefaultInstance() : data_;
         }
       }
       /**
        * <code>.TensorMap data = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
-          FlBaseProto.TensorMap, FlBaseProto.TensorMap.Builder, FlBaseProto.TensorMapOrBuilder>
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder> 
           getDataFieldBuilder() {
         if (dataBuilder_ == null) {
           dataBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              FlBaseProto.TensorMap, FlBaseProto.TensorMap.Builder, FlBaseProto.TensorMapOrBuilder>(
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder>(
                   getData(),
                   getParentForChildren(),
                   isClean());
@@ -2388,21 +2388,21 @@ public final class FGBoostServiceProto {
         return dataBuilder_;
       }
 
-      private Object response_ = "";
+      private java.lang.Object response_ = "";
       /**
        * <code>string response = 2;</code>
        * @return The response.
        */
-      public String getResponse() {
-        Object ref = response_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getResponse() {
+        java.lang.Object ref = response_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           response_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -2411,11 +2411,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getResponseBytes() {
-        Object ref = response_;
+        java.lang.Object ref = response_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           response_ = b;
           return b;
         } else {
@@ -2428,7 +2428,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setResponse(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -2469,7 +2469,7 @@ public final class FGBoostServiceProto {
        * <code>int32 code = 3;</code>
        * @return The code.
        */
-      @Override
+      @java.lang.Override
       public int getCode() {
         return code_;
       }
@@ -2494,13 +2494,13 @@ public final class FGBoostServiceProto {
         onChanged();
         return this;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -2511,18 +2511,18 @@ public final class FGBoostServiceProto {
     }
 
     // @@protoc_insertion_point(class_scope:fgboost.DownloadResponse)
-    private static final DownloadResponse DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new DownloadResponse();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse();
     }
 
-    public static DownloadResponse getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<DownloadResponse>
         PARSER = new com.google.protobuf.AbstractParser<DownloadResponse>() {
-      @Override
+      @java.lang.Override
       public DownloadResponse parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -2535,13 +2535,13 @@ public final class FGBoostServiceProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<DownloadResponse> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public DownloadResponse getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DownloadResponse getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -2555,7 +2555,7 @@ public final class FGBoostServiceProto {
      * <code>string treeID = 1;</code>
      * @return The treeID.
      */
-    String getTreeID();
+    java.lang.String getTreeID();
     /**
      * <code>string treeID = 1;</code>
      * @return The bytes for treeID.
@@ -2567,7 +2567,7 @@ public final class FGBoostServiceProto {
      * <code>repeated int32 leafIndex = 2;</code>
      * @return A list containing the leafIndex.
      */
-    java.util.List<Integer> getLeafIndexList();
+    java.util.List<java.lang.Integer> getLeafIndexList();
     /**
      * <code>repeated int32 leafIndex = 2;</code>
      * @return The count of leafIndex.
@@ -2584,7 +2584,7 @@ public final class FGBoostServiceProto {
      * <code>repeated float leafOutput = 3;</code>
      * @return A list containing the leafOutput.
      */
-    java.util.List<Float> getLeafOutputList();
+    java.util.List<java.lang.Float> getLeafOutputList();
     /**
      * <code>repeated float leafOutput = 3;</code>
      * @return The count of leafOutput.
@@ -2621,14 +2621,14 @@ public final class FGBoostServiceProto {
       leafOutput_ = emptyFloatList();
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new TreeLeaf();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -2639,7 +2639,7 @@ public final class FGBoostServiceProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
@@ -2653,7 +2653,7 @@ public final class FGBoostServiceProto {
               done = true;
               break;
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               treeID_ = s;
               break;
@@ -2732,32 +2732,32 @@ public final class FGBoostServiceProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FGBoostServiceProto.internal_static_fgboost_TreeLeaf_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_TreeLeaf_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FGBoostServiceProto.internal_static_fgboost_TreeLeaf_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_TreeLeaf_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              TreeLeaf.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf.Builder.class);
     }
 
     public static final int TREEID_FIELD_NUMBER = 1;
-    private volatile Object treeID_;
+    private volatile java.lang.Object treeID_;
     /**
      * <code>string treeID = 1;</code>
      * @return The treeID.
      */
-    @Override
-    public String getTreeID() {
-      Object ref = treeID_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getTreeID() {
+      java.lang.Object ref = treeID_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         treeID_ = s;
         return s;
       }
@@ -2766,14 +2766,14 @@ public final class FGBoostServiceProto {
      * <code>string treeID = 1;</code>
      * @return The bytes for treeID.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getTreeIDBytes() {
-      Object ref = treeID_;
-      if (ref instanceof String) {
+      java.lang.Object ref = treeID_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         treeID_ = b;
         return b;
       } else {
@@ -2787,8 +2787,8 @@ public final class FGBoostServiceProto {
      * <code>repeated int32 leafIndex = 2;</code>
      * @return A list containing the leafIndex.
      */
-    @Override
-    public java.util.List<Integer>
+    @java.lang.Override
+    public java.util.List<java.lang.Integer>
         getLeafIndexList() {
       return leafIndex_;
     }
@@ -2815,8 +2815,8 @@ public final class FGBoostServiceProto {
      * <code>repeated float leafOutput = 3;</code>
      * @return A list containing the leafOutput.
      */
-    @Override
-    public java.util.List<Float>
+    @java.lang.Override
+    public java.util.List<java.lang.Float>
         getLeafOutputList() {
       return leafOutput_;
     }
@@ -2843,13 +2843,13 @@ public final class FGBoostServiceProto {
      * <code>int32 version = 4;</code>
      * @return The version.
      */
-    @Override
+    @java.lang.Override
     public int getVersion() {
       return version_;
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -2859,7 +2859,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
@@ -2886,7 +2886,7 @@ public final class FGBoostServiceProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -2929,15 +2929,15 @@ public final class FGBoostServiceProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof TreeLeaf)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf)) {
         return super.equals(obj);
       }
-      TreeLeaf other = (TreeLeaf) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf) obj;
 
       if (!getTreeID()
           .equals(other.getTreeID())) return false;
@@ -2951,7 +2951,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -2975,69 +2975,69 @@ public final class FGBoostServiceProto {
       return hash;
     }
 
-    public static TreeLeaf parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static TreeLeaf parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static TreeLeaf parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static TreeLeaf parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static TreeLeaf parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static TreeLeaf parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static TreeLeaf parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static TreeLeaf parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static TreeLeaf parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static TreeLeaf parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static TreeLeaf parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static TreeLeaf parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -3045,23 +3045,23 @@ public final class FGBoostServiceProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(TreeLeaf prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -3071,18 +3071,18 @@ public final class FGBoostServiceProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:fgboost.TreeLeaf)
-        TreeLeafOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeafOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FGBoostServiceProto.internal_static_fgboost_TreeLeaf_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_TreeLeaf_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FGBoostServiceProto.internal_static_fgboost_TreeLeaf_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_TreeLeaf_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                TreeLeaf.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf.newBuilder()
@@ -3091,7 +3091,7 @@ public final class FGBoostServiceProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -3100,7 +3100,7 @@ public final class FGBoostServiceProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         treeID_ = "";
@@ -3114,29 +3114,29 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FGBoostServiceProto.internal_static_fgboost_TreeLeaf_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_TreeLeaf_descriptor;
       }
 
-      @Override
-      public TreeLeaf getDefaultInstanceForType() {
-        return TreeLeaf.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf.getDefaultInstance();
       }
 
-      @Override
-      public TreeLeaf build() {
-        TreeLeaf result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public TreeLeaf buildPartial() {
-        TreeLeaf result = new TreeLeaf(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf(this);
         int from_bitField0_ = bitField0_;
         result.treeID_ = treeID_;
         if (((bitField0_ & 0x00000001) != 0)) {
@@ -3154,50 +3154,50 @@ public final class FGBoostServiceProto {
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof TreeLeaf) {
-          return mergeFrom((TreeLeaf)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(TreeLeaf other) {
-        if (other == TreeLeaf.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf.getDefaultInstance()) return this;
         if (!other.getTreeID().isEmpty()) {
           treeID_ = other.treeID_;
           onChanged();
@@ -3230,21 +3230,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        TreeLeaf parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (TreeLeaf) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -3255,21 +3255,21 @@ public final class FGBoostServiceProto {
       }
       private int bitField0_;
 
-      private Object treeID_ = "";
+      private java.lang.Object treeID_ = "";
       /**
        * <code>string treeID = 1;</code>
        * @return The treeID.
        */
-      public String getTreeID() {
-        Object ref = treeID_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getTreeID() {
+        java.lang.Object ref = treeID_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           treeID_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -3278,11 +3278,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getTreeIDBytes() {
-        Object ref = treeID_;
+        java.lang.Object ref = treeID_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           treeID_ = b;
           return b;
         } else {
@@ -3295,7 +3295,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setTreeID(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -3342,7 +3342,7 @@ public final class FGBoostServiceProto {
        * <code>repeated int32 leafIndex = 2;</code>
        * @return A list containing the leafIndex.
        */
-      public java.util.List<Integer>
+      public java.util.List<java.lang.Integer>
           getLeafIndexList() {
         return ((bitField0_ & 0x00000001) != 0) ?
                  java.util.Collections.unmodifiableList(leafIndex_) : leafIndex_;
@@ -3392,7 +3392,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder addAllLeafIndex(
-          Iterable<? extends Integer> values) {
+          java.lang.Iterable<? extends java.lang.Integer> values) {
         ensureLeafIndexIsMutable();
         com.google.protobuf.AbstractMessageLite.Builder.addAll(
             values, leafIndex_);
@@ -3421,7 +3421,7 @@ public final class FGBoostServiceProto {
        * <code>repeated float leafOutput = 3;</code>
        * @return A list containing the leafOutput.
        */
-      public java.util.List<Float>
+      public java.util.List<java.lang.Float>
           getLeafOutputList() {
         return ((bitField0_ & 0x00000002) != 0) ?
                  java.util.Collections.unmodifiableList(leafOutput_) : leafOutput_;
@@ -3471,7 +3471,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder addAllLeafOutput(
-          Iterable<? extends Float> values) {
+          java.lang.Iterable<? extends java.lang.Float> values) {
         ensureLeafOutputIsMutable();
         com.google.protobuf.AbstractMessageLite.Builder.addAll(
             values, leafOutput_);
@@ -3494,7 +3494,7 @@ public final class FGBoostServiceProto {
        * <code>int32 version = 4;</code>
        * @return The version.
        */
-      @Override
+      @java.lang.Override
       public int getVersion() {
         return version_;
       }
@@ -3519,13 +3519,13 @@ public final class FGBoostServiceProto {
         onChanged();
         return this;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -3536,18 +3536,18 @@ public final class FGBoostServiceProto {
     }
 
     // @@protoc_insertion_point(class_scope:fgboost.TreeLeaf)
-    private static final TreeLeaf DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new TreeLeaf();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf();
     }
 
-    public static TreeLeaf getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<TreeLeaf>
         PARSER = new com.google.protobuf.AbstractParser<TreeLeaf>() {
-      @Override
+      @java.lang.Override
       public TreeLeaf parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -3560,13 +3560,13 @@ public final class FGBoostServiceProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<TreeLeaf> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public TreeLeaf getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -3580,7 +3580,7 @@ public final class FGBoostServiceProto {
      * <code>string clientuuid = 1;</code>
      * @return The clientuuid.
      */
-    String getClientuuid();
+    java.lang.String getClientuuid();
     /**
      * <code>string clientuuid = 1;</code>
      * @return The bytes for clientuuid.
@@ -3597,11 +3597,11 @@ public final class FGBoostServiceProto {
      * <code>.fgboost.TreeLeaf treeLeaf = 2;</code>
      * @return The treeLeaf.
      */
-    TreeLeaf getTreeLeaf();
+    com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf getTreeLeaf();
     /**
      * <code>.fgboost.TreeLeaf treeLeaf = 2;</code>
      */
-    TreeLeafOrBuilder getTreeLeafOrBuilder();
+    com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeafOrBuilder getTreeLeafOrBuilder();
   }
   /**
    * Protobuf type {@code fgboost.UploadTreeLeafRequest}
@@ -3619,14 +3619,14 @@ public final class FGBoostServiceProto {
       clientuuid_ = "";
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new UploadTreeLeafRequest();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -3637,7 +3637,7 @@ public final class FGBoostServiceProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -3650,17 +3650,17 @@ public final class FGBoostServiceProto {
               done = true;
               break;
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               clientuuid_ = s;
               break;
             }
             case 18: {
-              TreeLeaf.Builder subBuilder = null;
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf.Builder subBuilder = null;
               if (treeLeaf_ != null) {
                 subBuilder = treeLeaf_.toBuilder();
               }
-              treeLeaf_ = input.readMessage(TreeLeaf.parser(), extensionRegistry);
+              treeLeaf_ = input.readMessage(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(treeLeaf_);
                 treeLeaf_ = subBuilder.buildPartial();
@@ -3689,32 +3689,32 @@ public final class FGBoostServiceProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FGBoostServiceProto.internal_static_fgboost_UploadTreeLeafRequest_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadTreeLeafRequest_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FGBoostServiceProto.internal_static_fgboost_UploadTreeLeafRequest_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadTreeLeafRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              UploadTreeLeafRequest.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest.Builder.class);
     }
 
     public static final int CLIENTUUID_FIELD_NUMBER = 1;
-    private volatile Object clientuuid_;
+    private volatile java.lang.Object clientuuid_;
     /**
      * <code>string clientuuid = 1;</code>
      * @return The clientuuid.
      */
-    @Override
-    public String getClientuuid() {
-      Object ref = clientuuid_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getClientuuid() {
+      java.lang.Object ref = clientuuid_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         clientuuid_ = s;
         return s;
       }
@@ -3723,14 +3723,14 @@ public final class FGBoostServiceProto {
      * <code>string clientuuid = 1;</code>
      * @return The bytes for clientuuid.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getClientuuidBytes() {
-      Object ref = clientuuid_;
-      if (ref instanceof String) {
+      java.lang.Object ref = clientuuid_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         clientuuid_ = b;
         return b;
       } else {
@@ -3739,12 +3739,12 @@ public final class FGBoostServiceProto {
     }
 
     public static final int TREELEAF_FIELD_NUMBER = 2;
-    private TreeLeaf treeLeaf_;
+    private com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf treeLeaf_;
     /**
      * <code>.fgboost.TreeLeaf treeLeaf = 2;</code>
      * @return Whether the treeLeaf field is set.
      */
-    @Override
+    @java.lang.Override
     public boolean hasTreeLeaf() {
       return treeLeaf_ != null;
     }
@@ -3752,20 +3752,20 @@ public final class FGBoostServiceProto {
      * <code>.fgboost.TreeLeaf treeLeaf = 2;</code>
      * @return The treeLeaf.
      */
-    @Override
-    public TreeLeaf getTreeLeaf() {
-      return treeLeaf_ == null ? TreeLeaf.getDefaultInstance() : treeLeaf_;
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf getTreeLeaf() {
+      return treeLeaf_ == null ? com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf.getDefaultInstance() : treeLeaf_;
     }
     /**
      * <code>.fgboost.TreeLeaf treeLeaf = 2;</code>
      */
-    @Override
-    public TreeLeafOrBuilder getTreeLeafOrBuilder() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeafOrBuilder getTreeLeafOrBuilder() {
       return getTreeLeaf();
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -3775,7 +3775,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getClientuuidBytes().isEmpty()) {
@@ -3787,7 +3787,7 @@ public final class FGBoostServiceProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -3805,15 +3805,15 @@ public final class FGBoostServiceProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof UploadTreeLeafRequest)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest)) {
         return super.equals(obj);
       }
-      UploadTreeLeafRequest other = (UploadTreeLeafRequest) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest) obj;
 
       if (!getClientuuid()
           .equals(other.getClientuuid())) return false;
@@ -3826,7 +3826,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -3844,69 +3844,69 @@ public final class FGBoostServiceProto {
       return hash;
     }
 
-    public static UploadTreeLeafRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static UploadTreeLeafRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static UploadTreeLeafRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static UploadTreeLeafRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static UploadTreeLeafRequest parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static UploadTreeLeafRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static UploadTreeLeafRequest parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static UploadTreeLeafRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static UploadTreeLeafRequest parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static UploadTreeLeafRequest parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static UploadTreeLeafRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static UploadTreeLeafRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -3914,23 +3914,23 @@ public final class FGBoostServiceProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(UploadTreeLeafRequest prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -3940,18 +3940,18 @@ public final class FGBoostServiceProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:fgboost.UploadTreeLeafRequest)
-        UploadTreeLeafRequestOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FGBoostServiceProto.internal_static_fgboost_UploadTreeLeafRequest_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadTreeLeafRequest_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FGBoostServiceProto.internal_static_fgboost_UploadTreeLeafRequest_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadTreeLeafRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                UploadTreeLeafRequest.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest.newBuilder()
@@ -3960,7 +3960,7 @@ public final class FGBoostServiceProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -3969,7 +3969,7 @@ public final class FGBoostServiceProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         clientuuid_ = "";
@@ -3983,29 +3983,29 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FGBoostServiceProto.internal_static_fgboost_UploadTreeLeafRequest_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadTreeLeafRequest_descriptor;
       }
 
-      @Override
-      public UploadTreeLeafRequest getDefaultInstanceForType() {
-        return UploadTreeLeafRequest.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest.getDefaultInstance();
       }
 
-      @Override
-      public UploadTreeLeafRequest build() {
-        UploadTreeLeafRequest result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public UploadTreeLeafRequest buildPartial() {
-        UploadTreeLeafRequest result = new UploadTreeLeafRequest(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest(this);
         result.clientuuid_ = clientuuid_;
         if (treeLeafBuilder_ == null) {
           result.treeLeaf_ = treeLeaf_;
@@ -4016,50 +4016,50 @@ public final class FGBoostServiceProto {
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof UploadTreeLeafRequest) {
-          return mergeFrom((UploadTreeLeafRequest)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(UploadTreeLeafRequest other) {
-        if (other == UploadTreeLeafRequest.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest.getDefaultInstance()) return this;
         if (!other.getClientuuid().isEmpty()) {
           clientuuid_ = other.clientuuid_;
           onChanged();
@@ -4072,21 +4072,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        UploadTreeLeafRequest parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (UploadTreeLeafRequest) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -4096,21 +4096,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private Object clientuuid_ = "";
+      private java.lang.Object clientuuid_ = "";
       /**
        * <code>string clientuuid = 1;</code>
        * @return The clientuuid.
        */
-      public String getClientuuid() {
-        Object ref = clientuuid_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getClientuuid() {
+        java.lang.Object ref = clientuuid_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           clientuuid_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -4119,11 +4119,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getClientuuidBytes() {
-        Object ref = clientuuid_;
+        java.lang.Object ref = clientuuid_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           clientuuid_ = b;
           return b;
         } else {
@@ -4136,7 +4136,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setClientuuid(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -4172,9 +4172,9 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private TreeLeaf treeLeaf_;
+      private com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf treeLeaf_;
       private com.google.protobuf.SingleFieldBuilderV3<
-          TreeLeaf, TreeLeaf.Builder, TreeLeafOrBuilder> treeLeafBuilder_;
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeafOrBuilder> treeLeafBuilder_;
       /**
        * <code>.fgboost.TreeLeaf treeLeaf = 2;</code>
        * @return Whether the treeLeaf field is set.
@@ -4186,9 +4186,9 @@ public final class FGBoostServiceProto {
        * <code>.fgboost.TreeLeaf treeLeaf = 2;</code>
        * @return The treeLeaf.
        */
-      public TreeLeaf getTreeLeaf() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf getTreeLeaf() {
         if (treeLeafBuilder_ == null) {
-          return treeLeaf_ == null ? TreeLeaf.getDefaultInstance() : treeLeaf_;
+          return treeLeaf_ == null ? com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf.getDefaultInstance() : treeLeaf_;
         } else {
           return treeLeafBuilder_.getMessage();
         }
@@ -4196,7 +4196,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>.fgboost.TreeLeaf treeLeaf = 2;</code>
        */
-      public Builder setTreeLeaf(TreeLeaf value) {
+      public Builder setTreeLeaf(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf value) {
         if (treeLeafBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -4213,7 +4213,7 @@ public final class FGBoostServiceProto {
        * <code>.fgboost.TreeLeaf treeLeaf = 2;</code>
        */
       public Builder setTreeLeaf(
-          TreeLeaf.Builder builderForValue) {
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf.Builder builderForValue) {
         if (treeLeafBuilder_ == null) {
           treeLeaf_ = builderForValue.build();
           onChanged();
@@ -4226,11 +4226,11 @@ public final class FGBoostServiceProto {
       /**
        * <code>.fgboost.TreeLeaf treeLeaf = 2;</code>
        */
-      public Builder mergeTreeLeaf(TreeLeaf value) {
+      public Builder mergeTreeLeaf(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf value) {
         if (treeLeafBuilder_ == null) {
           if (treeLeaf_ != null) {
             treeLeaf_ =
-              TreeLeaf.newBuilder(treeLeaf_).mergeFrom(value).buildPartial();
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf.newBuilder(treeLeaf_).mergeFrom(value).buildPartial();
           } else {
             treeLeaf_ = value;
           }
@@ -4258,7 +4258,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>.fgboost.TreeLeaf treeLeaf = 2;</code>
        */
-      public TreeLeaf.Builder getTreeLeafBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf.Builder getTreeLeafBuilder() {
         
         onChanged();
         return getTreeLeafFieldBuilder().getBuilder();
@@ -4266,23 +4266,23 @@ public final class FGBoostServiceProto {
       /**
        * <code>.fgboost.TreeLeaf treeLeaf = 2;</code>
        */
-      public TreeLeafOrBuilder getTreeLeafOrBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeafOrBuilder getTreeLeafOrBuilder() {
         if (treeLeafBuilder_ != null) {
           return treeLeafBuilder_.getMessageOrBuilder();
         } else {
           return treeLeaf_ == null ?
-              TreeLeaf.getDefaultInstance() : treeLeaf_;
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf.getDefaultInstance() : treeLeaf_;
         }
       }
       /**
        * <code>.fgboost.TreeLeaf treeLeaf = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
-          TreeLeaf, TreeLeaf.Builder, TreeLeafOrBuilder>
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeafOrBuilder> 
           getTreeLeafFieldBuilder() {
         if (treeLeafBuilder_ == null) {
           treeLeafBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              TreeLeaf, TreeLeaf.Builder, TreeLeafOrBuilder>(
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeaf.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreeLeafOrBuilder>(
                   getTreeLeaf(),
                   getParentForChildren(),
                   isClean());
@@ -4290,13 +4290,13 @@ public final class FGBoostServiceProto {
         }
         return treeLeafBuilder_;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -4307,18 +4307,18 @@ public final class FGBoostServiceProto {
     }
 
     // @@protoc_insertion_point(class_scope:fgboost.UploadTreeLeafRequest)
-    private static final UploadTreeLeafRequest DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new UploadTreeLeafRequest();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest();
     }
 
-    public static UploadTreeLeafRequest getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<UploadTreeLeafRequest>
         PARSER = new com.google.protobuf.AbstractParser<UploadTreeLeafRequest>() {
-      @Override
+      @java.lang.Override
       public UploadTreeLeafRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -4331,13 +4331,13 @@ public final class FGBoostServiceProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<UploadTreeLeafRequest> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public UploadTreeLeafRequest getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeLeafRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -4351,7 +4351,7 @@ public final class FGBoostServiceProto {
      * <code>string treeID = 1;</code>
      * @return The treeID.
      */
-    String getTreeID();
+    java.lang.String getTreeID();
     /**
      * <code>string treeID = 1;</code>
      * @return The bytes for treeID.
@@ -4363,7 +4363,7 @@ public final class FGBoostServiceProto {
      * <code>string nodeID = 2;</code>
      * @return The nodeID.
      */
-    String getNodeID();
+    java.lang.String getNodeID();
     /**
      * <code>string nodeID = 2;</code>
      * @return The bytes for nodeID.
@@ -4399,7 +4399,7 @@ public final class FGBoostServiceProto {
      * <code>repeated int32 itemSet = 7;</code>
      * @return A list containing the itemSet.
      */
-    java.util.List<Integer> getItemSetList();
+    java.util.List<java.lang.Integer> getItemSetList();
     /**
      * <code>repeated int32 itemSet = 7;</code>
      * @return The count of itemSet.
@@ -4416,7 +4416,7 @@ public final class FGBoostServiceProto {
      * <code>string clientUid = 8;</code>
      * @return The clientUid.
      */
-    String getClientUid();
+    java.lang.String getClientUid();
     /**
      * <code>string clientUid = 8;</code>
      * @return The bytes for clientUid.
@@ -4449,14 +4449,14 @@ public final class FGBoostServiceProto {
       clientUid_ = "";
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new DataSplit();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -4467,7 +4467,7 @@ public final class FGBoostServiceProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
@@ -4481,13 +4481,13 @@ public final class FGBoostServiceProto {
               done = true;
               break;
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               treeID_ = s;
               break;
             }
             case 18: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               nodeID_ = s;
               break;
@@ -4534,7 +4534,7 @@ public final class FGBoostServiceProto {
               break;
             }
             case 66: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               clientUid_ = s;
               break;
@@ -4568,32 +4568,32 @@ public final class FGBoostServiceProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FGBoostServiceProto.internal_static_fgboost_DataSplit_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_DataSplit_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FGBoostServiceProto.internal_static_fgboost_DataSplit_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_DataSplit_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              DataSplit.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.Builder.class);
     }
 
     public static final int TREEID_FIELD_NUMBER = 1;
-    private volatile Object treeID_;
+    private volatile java.lang.Object treeID_;
     /**
      * <code>string treeID = 1;</code>
      * @return The treeID.
      */
-    @Override
-    public String getTreeID() {
-      Object ref = treeID_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getTreeID() {
+      java.lang.Object ref = treeID_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         treeID_ = s;
         return s;
       }
@@ -4602,14 +4602,14 @@ public final class FGBoostServiceProto {
      * <code>string treeID = 1;</code>
      * @return The bytes for treeID.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getTreeIDBytes() {
-      Object ref = treeID_;
-      if (ref instanceof String) {
+      java.lang.Object ref = treeID_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         treeID_ = b;
         return b;
       } else {
@@ -4618,20 +4618,20 @@ public final class FGBoostServiceProto {
     }
 
     public static final int NODEID_FIELD_NUMBER = 2;
-    private volatile Object nodeID_;
+    private volatile java.lang.Object nodeID_;
     /**
      * <code>string nodeID = 2;</code>
      * @return The nodeID.
      */
-    @Override
-    public String getNodeID() {
-      Object ref = nodeID_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getNodeID() {
+      java.lang.Object ref = nodeID_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         nodeID_ = s;
         return s;
       }
@@ -4640,14 +4640,14 @@ public final class FGBoostServiceProto {
      * <code>string nodeID = 2;</code>
      * @return The bytes for nodeID.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getNodeIDBytes() {
-      Object ref = nodeID_;
-      if (ref instanceof String) {
+      java.lang.Object ref = nodeID_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         nodeID_ = b;
         return b;
       } else {
@@ -4661,7 +4661,7 @@ public final class FGBoostServiceProto {
      * <code>int32 featureID = 3;</code>
      * @return The featureID.
      */
-    @Override
+    @java.lang.Override
     public int getFeatureID() {
       return featureID_;
     }
@@ -4672,7 +4672,7 @@ public final class FGBoostServiceProto {
      * <code>float splitValue = 4;</code>
      * @return The splitValue.
      */
-    @Override
+    @java.lang.Override
     public float getSplitValue() {
       return splitValue_;
     }
@@ -4683,7 +4683,7 @@ public final class FGBoostServiceProto {
      * <code>float gain = 5;</code>
      * @return The gain.
      */
-    @Override
+    @java.lang.Override
     public float getGain() {
       return gain_;
     }
@@ -4694,7 +4694,7 @@ public final class FGBoostServiceProto {
      * <code>int32 setLength = 6;</code>
      * @return The setLength.
      */
-    @Override
+    @java.lang.Override
     public int getSetLength() {
       return setLength_;
     }
@@ -4705,8 +4705,8 @@ public final class FGBoostServiceProto {
      * <code>repeated int32 itemSet = 7;</code>
      * @return A list containing the itemSet.
      */
-    @Override
-    public java.util.List<Integer>
+    @java.lang.Override
+    public java.util.List<java.lang.Integer>
         getItemSetList() {
       return itemSet_;
     }
@@ -4728,20 +4728,20 @@ public final class FGBoostServiceProto {
     private int itemSetMemoizedSerializedSize = -1;
 
     public static final int CLIENTUID_FIELD_NUMBER = 8;
-    private volatile Object clientUid_;
+    private volatile java.lang.Object clientUid_;
     /**
      * <code>string clientUid = 8;</code>
      * @return The clientUid.
      */
-    @Override
-    public String getClientUid() {
-      Object ref = clientUid_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getClientUid() {
+      java.lang.Object ref = clientUid_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         clientUid_ = s;
         return s;
       }
@@ -4750,14 +4750,14 @@ public final class FGBoostServiceProto {
      * <code>string clientUid = 8;</code>
      * @return The bytes for clientUid.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getClientUidBytes() {
-      Object ref = clientUid_;
-      if (ref instanceof String) {
+      java.lang.Object ref = clientUid_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         clientUid_ = b;
         return b;
       } else {
@@ -4771,13 +4771,13 @@ public final class FGBoostServiceProto {
      * <code>int32 version = 9;</code>
      * @return The version.
      */
-    @Override
+    @java.lang.Override
     public int getVersion() {
       return version_;
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -4787,7 +4787,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
@@ -4825,7 +4825,7 @@ public final class FGBoostServiceProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -4879,15 +4879,15 @@ public final class FGBoostServiceProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof DataSplit)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit)) {
         return super.equals(obj);
       }
-      DataSplit other = (DataSplit) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit) obj;
 
       if (!getTreeID()
           .equals(other.getTreeID())) return false;
@@ -4895,11 +4895,11 @@ public final class FGBoostServiceProto {
           .equals(other.getNodeID())) return false;
       if (getFeatureID()
           != other.getFeatureID()) return false;
-      if (Float.floatToIntBits(getSplitValue())
-          != Float.floatToIntBits(
+      if (java.lang.Float.floatToIntBits(getSplitValue())
+          != java.lang.Float.floatToIntBits(
               other.getSplitValue())) return false;
-      if (Float.floatToIntBits(getGain())
-          != Float.floatToIntBits(
+      if (java.lang.Float.floatToIntBits(getGain())
+          != java.lang.Float.floatToIntBits(
               other.getGain())) return false;
       if (getSetLength()
           != other.getSetLength()) return false;
@@ -4913,7 +4913,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -4927,10 +4927,10 @@ public final class FGBoostServiceProto {
       hash = (37 * hash) + FEATUREID_FIELD_NUMBER;
       hash = (53 * hash) + getFeatureID();
       hash = (37 * hash) + SPLITVALUE_FIELD_NUMBER;
-      hash = (53 * hash) + Float.floatToIntBits(
+      hash = (53 * hash) + java.lang.Float.floatToIntBits(
           getSplitValue());
       hash = (37 * hash) + GAIN_FIELD_NUMBER;
-      hash = (53 * hash) + Float.floatToIntBits(
+      hash = (53 * hash) + java.lang.Float.floatToIntBits(
           getGain());
       hash = (37 * hash) + SETLENGTH_FIELD_NUMBER;
       hash = (53 * hash) + getSetLength();
@@ -4947,69 +4947,69 @@ public final class FGBoostServiceProto {
       return hash;
     }
 
-    public static DataSplit parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static DataSplit parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static DataSplit parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static DataSplit parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static DataSplit parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static DataSplit parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static DataSplit parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static DataSplit parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static DataSplit parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static DataSplit parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static DataSplit parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static DataSplit parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -5017,23 +5017,23 @@ public final class FGBoostServiceProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(DataSplit prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -5043,18 +5043,18 @@ public final class FGBoostServiceProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:fgboost.DataSplit)
-        DataSplitOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplitOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FGBoostServiceProto.internal_static_fgboost_DataSplit_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_DataSplit_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FGBoostServiceProto.internal_static_fgboost_DataSplit_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_DataSplit_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                DataSplit.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.newBuilder()
@@ -5063,7 +5063,7 @@ public final class FGBoostServiceProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -5072,7 +5072,7 @@ public final class FGBoostServiceProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         treeID_ = "";
@@ -5096,29 +5096,29 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FGBoostServiceProto.internal_static_fgboost_DataSplit_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_DataSplit_descriptor;
       }
 
-      @Override
-      public DataSplit getDefaultInstanceForType() {
-        return DataSplit.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.getDefaultInstance();
       }
 
-      @Override
-      public DataSplit build() {
-        DataSplit result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public DataSplit buildPartial() {
-        DataSplit result = new DataSplit(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit(this);
         int from_bitField0_ = bitField0_;
         result.treeID_ = treeID_;
         result.nodeID_ = nodeID_;
@@ -5137,50 +5137,50 @@ public final class FGBoostServiceProto {
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof DataSplit) {
-          return mergeFrom((DataSplit)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(DataSplit other) {
-        if (other == DataSplit.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.getDefaultInstance()) return this;
         if (!other.getTreeID().isEmpty()) {
           treeID_ = other.treeID_;
           onChanged();
@@ -5223,21 +5223,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        DataSplit parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (DataSplit) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -5248,21 +5248,21 @@ public final class FGBoostServiceProto {
       }
       private int bitField0_;
 
-      private Object treeID_ = "";
+      private java.lang.Object treeID_ = "";
       /**
        * <code>string treeID = 1;</code>
        * @return The treeID.
        */
-      public String getTreeID() {
-        Object ref = treeID_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getTreeID() {
+        java.lang.Object ref = treeID_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           treeID_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -5271,11 +5271,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getTreeIDBytes() {
-        Object ref = treeID_;
+        java.lang.Object ref = treeID_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           treeID_ = b;
           return b;
         } else {
@@ -5288,7 +5288,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setTreeID(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -5324,21 +5324,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private Object nodeID_ = "";
+      private java.lang.Object nodeID_ = "";
       /**
        * <code>string nodeID = 2;</code>
        * @return The nodeID.
        */
-      public String getNodeID() {
-        Object ref = nodeID_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getNodeID() {
+        java.lang.Object ref = nodeID_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           nodeID_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -5347,11 +5347,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getNodeIDBytes() {
-        Object ref = nodeID_;
+        java.lang.Object ref = nodeID_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           nodeID_ = b;
           return b;
         } else {
@@ -5364,7 +5364,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setNodeID(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -5405,7 +5405,7 @@ public final class FGBoostServiceProto {
        * <code>int32 featureID = 3;</code>
        * @return The featureID.
        */
-      @Override
+      @java.lang.Override
       public int getFeatureID() {
         return featureID_;
       }
@@ -5436,7 +5436,7 @@ public final class FGBoostServiceProto {
        * <code>float splitValue = 4;</code>
        * @return The splitValue.
        */
-      @Override
+      @java.lang.Override
       public float getSplitValue() {
         return splitValue_;
       }
@@ -5467,7 +5467,7 @@ public final class FGBoostServiceProto {
        * <code>float gain = 5;</code>
        * @return The gain.
        */
-      @Override
+      @java.lang.Override
       public float getGain() {
         return gain_;
       }
@@ -5498,7 +5498,7 @@ public final class FGBoostServiceProto {
        * <code>int32 setLength = 6;</code>
        * @return The setLength.
        */
-      @Override
+      @java.lang.Override
       public int getSetLength() {
         return setLength_;
       }
@@ -5535,7 +5535,7 @@ public final class FGBoostServiceProto {
        * <code>repeated int32 itemSet = 7;</code>
        * @return A list containing the itemSet.
        */
-      public java.util.List<Integer>
+      public java.util.List<java.lang.Integer>
           getItemSetList() {
         return ((bitField0_ & 0x00000001) != 0) ?
                  java.util.Collections.unmodifiableList(itemSet_) : itemSet_;
@@ -5585,7 +5585,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder addAllItemSet(
-          Iterable<? extends Integer> values) {
+          java.lang.Iterable<? extends java.lang.Integer> values) {
         ensureItemSetIsMutable();
         com.google.protobuf.AbstractMessageLite.Builder.addAll(
             values, itemSet_);
@@ -5603,21 +5603,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private Object clientUid_ = "";
+      private java.lang.Object clientUid_ = "";
       /**
        * <code>string clientUid = 8;</code>
        * @return The clientUid.
        */
-      public String getClientUid() {
-        Object ref = clientUid_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getClientUid() {
+        java.lang.Object ref = clientUid_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           clientUid_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -5626,11 +5626,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getClientUidBytes() {
-        Object ref = clientUid_;
+        java.lang.Object ref = clientUid_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           clientUid_ = b;
           return b;
         } else {
@@ -5643,7 +5643,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setClientUid(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -5684,7 +5684,7 @@ public final class FGBoostServiceProto {
        * <code>int32 version = 9;</code>
        * @return The version.
        */
-      @Override
+      @java.lang.Override
       public int getVersion() {
         return version_;
       }
@@ -5709,13 +5709,13 @@ public final class FGBoostServiceProto {
         onChanged();
         return this;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -5726,18 +5726,18 @@ public final class FGBoostServiceProto {
     }
 
     // @@protoc_insertion_point(class_scope:fgboost.DataSplit)
-    private static final DataSplit DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new DataSplit();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit();
     }
 
-    public static DataSplit getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<DataSplit>
         PARSER = new com.google.protobuf.AbstractParser<DataSplit>() {
-      @Override
+      @java.lang.Override
       public DataSplit parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -5750,13 +5750,13 @@ public final class FGBoostServiceProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<DataSplit> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public DataSplit getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -5770,7 +5770,7 @@ public final class FGBoostServiceProto {
      * <code>string response = 1;</code>
      * @return The response.
      */
-    String getResponse();
+    java.lang.String getResponse();
     /**
      * <code>string response = 1;</code>
      * @return The bytes for response.
@@ -5800,14 +5800,14 @@ public final class FGBoostServiceProto {
       response_ = "";
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new UploadResponse();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -5818,7 +5818,7 @@ public final class FGBoostServiceProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -5831,7 +5831,7 @@ public final class FGBoostServiceProto {
               done = true;
               break;
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               response_ = s;
               break;
@@ -5862,32 +5862,32 @@ public final class FGBoostServiceProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FGBoostServiceProto.internal_static_fgboost_UploadResponse_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadResponse_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FGBoostServiceProto.internal_static_fgboost_UploadResponse_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              UploadResponse.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse.Builder.class);
     }
 
     public static final int RESPONSE_FIELD_NUMBER = 1;
-    private volatile Object response_;
+    private volatile java.lang.Object response_;
     /**
      * <code>string response = 1;</code>
      * @return The response.
      */
-    @Override
-    public String getResponse() {
-      Object ref = response_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getResponse() {
+      java.lang.Object ref = response_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         response_ = s;
         return s;
       }
@@ -5896,14 +5896,14 @@ public final class FGBoostServiceProto {
      * <code>string response = 1;</code>
      * @return The bytes for response.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getResponseBytes() {
-      Object ref = response_;
-      if (ref instanceof String) {
+      java.lang.Object ref = response_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         response_ = b;
         return b;
       } else {
@@ -5917,13 +5917,13 @@ public final class FGBoostServiceProto {
      * <code>int32 code = 2;</code>
      * @return The code.
      */
-    @Override
+    @java.lang.Override
     public int getCode() {
       return code_;
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -5933,7 +5933,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getResponseBytes().isEmpty()) {
@@ -5945,7 +5945,7 @@ public final class FGBoostServiceProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -5963,15 +5963,15 @@ public final class FGBoostServiceProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof UploadResponse)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse)) {
         return super.equals(obj);
       }
-      UploadResponse other = (UploadResponse) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse) obj;
 
       if (!getResponse()
           .equals(other.getResponse())) return false;
@@ -5981,7 +5981,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -5997,69 +5997,69 @@ public final class FGBoostServiceProto {
       return hash;
     }
 
-    public static UploadResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static UploadResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static UploadResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static UploadResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static UploadResponse parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static UploadResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static UploadResponse parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static UploadResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static UploadResponse parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static UploadResponse parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static UploadResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static UploadResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -6067,23 +6067,23 @@ public final class FGBoostServiceProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(UploadResponse prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -6093,18 +6093,18 @@ public final class FGBoostServiceProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:fgboost.UploadResponse)
-        UploadResponseOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FGBoostServiceProto.internal_static_fgboost_UploadResponse_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadResponse_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FGBoostServiceProto.internal_static_fgboost_UploadResponse_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                UploadResponse.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse.newBuilder()
@@ -6113,7 +6113,7 @@ public final class FGBoostServiceProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -6122,7 +6122,7 @@ public final class FGBoostServiceProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         response_ = "";
@@ -6132,79 +6132,79 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FGBoostServiceProto.internal_static_fgboost_UploadResponse_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadResponse_descriptor;
       }
 
-      @Override
-      public UploadResponse getDefaultInstanceForType() {
-        return UploadResponse.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse.getDefaultInstance();
       }
 
-      @Override
-      public UploadResponse build() {
-        UploadResponse result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public UploadResponse buildPartial() {
-        UploadResponse result = new UploadResponse(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse(this);
         result.response_ = response_;
         result.code_ = code_;
         onBuilt();
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof UploadResponse) {
-          return mergeFrom((UploadResponse)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(UploadResponse other) {
-        if (other == UploadResponse.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse.getDefaultInstance()) return this;
         if (!other.getResponse().isEmpty()) {
           response_ = other.response_;
           onChanged();
@@ -6217,21 +6217,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        UploadResponse parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (UploadResponse) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -6241,21 +6241,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private Object response_ = "";
+      private java.lang.Object response_ = "";
       /**
        * <code>string response = 1;</code>
        * @return The response.
        */
-      public String getResponse() {
-        Object ref = response_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getResponse() {
+        java.lang.Object ref = response_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           response_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -6264,11 +6264,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getResponseBytes() {
-        Object ref = response_;
+        java.lang.Object ref = response_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           response_ = b;
           return b;
         } else {
@@ -6281,7 +6281,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setResponse(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -6322,7 +6322,7 @@ public final class FGBoostServiceProto {
        * <code>int32 code = 2;</code>
        * @return The code.
        */
-      @Override
+      @java.lang.Override
       public int getCode() {
         return code_;
       }
@@ -6347,13 +6347,13 @@ public final class FGBoostServiceProto {
         onChanged();
         return this;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -6364,18 +6364,18 @@ public final class FGBoostServiceProto {
     }
 
     // @@protoc_insertion_point(class_scope:fgboost.UploadResponse)
-    private static final UploadResponse DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new UploadResponse();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse();
     }
 
-    public static UploadResponse getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<UploadResponse>
         PARSER = new com.google.protobuf.AbstractParser<UploadResponse>() {
-      @Override
+      @java.lang.Override
       public UploadResponse parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -6388,13 +6388,13 @@ public final class FGBoostServiceProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<UploadResponse> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public UploadResponse getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadResponse getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -6408,7 +6408,7 @@ public final class FGBoostServiceProto {
      * <code>string treeID = 1;</code>
      * @return The treeID.
      */
-    String getTreeID();
+    java.lang.String getTreeID();
     /**
      * <code>string treeID = 1;</code>
      * @return The bytes for treeID.
@@ -6420,7 +6420,7 @@ public final class FGBoostServiceProto {
      * <code>repeated bool predicts = 2;</code>
      * @return A list containing the predicts.
      */
-    java.util.List<Boolean> getPredictsList();
+    java.util.List<java.lang.Boolean> getPredictsList();
     /**
      * <code>repeated bool predicts = 2;</code>
      * @return The count of predicts.
@@ -6450,14 +6450,14 @@ public final class FGBoostServiceProto {
       predicts_ = emptyBooleanList();
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new TreePredict();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -6468,7 +6468,7 @@ public final class FGBoostServiceProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
@@ -6482,7 +6482,7 @@ public final class FGBoostServiceProto {
               done = true;
               break;
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               treeID_ = s;
               break;
@@ -6532,32 +6532,32 @@ public final class FGBoostServiceProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FGBoostServiceProto.internal_static_fgboost_TreePredict_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_TreePredict_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FGBoostServiceProto.internal_static_fgboost_TreePredict_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_TreePredict_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              TreePredict.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder.class);
     }
 
     public static final int TREEID_FIELD_NUMBER = 1;
-    private volatile Object treeID_;
+    private volatile java.lang.Object treeID_;
     /**
      * <code>string treeID = 1;</code>
      * @return The treeID.
      */
-    @Override
-    public String getTreeID() {
-      Object ref = treeID_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getTreeID() {
+      java.lang.Object ref = treeID_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         treeID_ = s;
         return s;
       }
@@ -6566,14 +6566,14 @@ public final class FGBoostServiceProto {
      * <code>string treeID = 1;</code>
      * @return The bytes for treeID.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getTreeIDBytes() {
-      Object ref = treeID_;
-      if (ref instanceof String) {
+      java.lang.Object ref = treeID_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         treeID_ = b;
         return b;
       } else {
@@ -6587,8 +6587,8 @@ public final class FGBoostServiceProto {
      * <code>repeated bool predicts = 2;</code>
      * @return A list containing the predicts.
      */
-    @Override
-    public java.util.List<Boolean>
+    @java.lang.Override
+    public java.util.List<java.lang.Boolean>
         getPredictsList() {
       return predicts_;
     }
@@ -6610,7 +6610,7 @@ public final class FGBoostServiceProto {
     private int predictsMemoizedSerializedSize = -1;
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -6620,7 +6620,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
@@ -6637,7 +6637,7 @@ public final class FGBoostServiceProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -6662,15 +6662,15 @@ public final class FGBoostServiceProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof TreePredict)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict)) {
         return super.equals(obj);
       }
-      TreePredict other = (TreePredict) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict) obj;
 
       if (!getTreeID()
           .equals(other.getTreeID())) return false;
@@ -6680,7 +6680,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -6698,69 +6698,69 @@ public final class FGBoostServiceProto {
       return hash;
     }
 
-    public static TreePredict parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static TreePredict parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static TreePredict parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static TreePredict parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static TreePredict parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static TreePredict parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static TreePredict parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static TreePredict parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static TreePredict parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static TreePredict parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static TreePredict parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static TreePredict parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -6768,23 +6768,23 @@ public final class FGBoostServiceProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(TreePredict prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -6794,18 +6794,18 @@ public final class FGBoostServiceProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:fgboost.TreePredict)
-        TreePredictOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredictOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FGBoostServiceProto.internal_static_fgboost_TreePredict_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_TreePredict_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FGBoostServiceProto.internal_static_fgboost_TreePredict_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_TreePredict_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                TreePredict.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.newBuilder()
@@ -6814,7 +6814,7 @@ public final class FGBoostServiceProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -6823,7 +6823,7 @@ public final class FGBoostServiceProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         treeID_ = "";
@@ -6833,29 +6833,29 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FGBoostServiceProto.internal_static_fgboost_TreePredict_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_TreePredict_descriptor;
       }
 
-      @Override
-      public TreePredict getDefaultInstanceForType() {
-        return TreePredict.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.getDefaultInstance();
       }
 
-      @Override
-      public TreePredict build() {
-        TreePredict result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public TreePredict buildPartial() {
-        TreePredict result = new TreePredict(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict(this);
         int from_bitField0_ = bitField0_;
         result.treeID_ = treeID_;
         if (((bitField0_ & 0x00000001) != 0)) {
@@ -6867,50 +6867,50 @@ public final class FGBoostServiceProto {
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof TreePredict) {
-          return mergeFrom((TreePredict)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(TreePredict other) {
-        if (other == TreePredict.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.getDefaultInstance()) return this;
         if (!other.getTreeID().isEmpty()) {
           treeID_ = other.treeID_;
           onChanged();
@@ -6930,21 +6930,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        TreePredict parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (TreePredict) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -6955,21 +6955,21 @@ public final class FGBoostServiceProto {
       }
       private int bitField0_;
 
-      private Object treeID_ = "";
+      private java.lang.Object treeID_ = "";
       /**
        * <code>string treeID = 1;</code>
        * @return The treeID.
        */
-      public String getTreeID() {
-        Object ref = treeID_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getTreeID() {
+        java.lang.Object ref = treeID_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           treeID_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -6978,11 +6978,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getTreeIDBytes() {
-        Object ref = treeID_;
+        java.lang.Object ref = treeID_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           treeID_ = b;
           return b;
         } else {
@@ -6995,7 +6995,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setTreeID(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -7042,7 +7042,7 @@ public final class FGBoostServiceProto {
        * <code>repeated bool predicts = 2;</code>
        * @return A list containing the predicts.
        */
-      public java.util.List<Boolean>
+      public java.util.List<java.lang.Boolean>
           getPredictsList() {
         return ((bitField0_ & 0x00000001) != 0) ?
                  java.util.Collections.unmodifiableList(predicts_) : predicts_;
@@ -7092,7 +7092,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder addAllPredicts(
-          Iterable<? extends Boolean> values) {
+          java.lang.Iterable<? extends java.lang.Boolean> values) {
         ensurePredictsIsMutable();
         com.google.protobuf.AbstractMessageLite.Builder.addAll(
             values, predicts_);
@@ -7109,13 +7109,13 @@ public final class FGBoostServiceProto {
         onChanged();
         return this;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -7126,18 +7126,18 @@ public final class FGBoostServiceProto {
     }
 
     // @@protoc_insertion_point(class_scope:fgboost.TreePredict)
-    private static final TreePredict DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new TreePredict();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict();
     }
 
-    public static TreePredict getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<TreePredict>
         PARSER = new com.google.protobuf.AbstractParser<TreePredict>() {
-      @Override
+      @java.lang.Override
       public TreePredict parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -7150,13 +7150,13 @@ public final class FGBoostServiceProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<TreePredict> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public TreePredict getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -7169,12 +7169,12 @@ public final class FGBoostServiceProto {
     /**
      * <code>repeated .fgboost.TreePredict predicts = 1;</code>
      */
-    java.util.List<TreePredict>
+    java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict> 
         getPredictsList();
     /**
      * <code>repeated .fgboost.TreePredict predicts = 1;</code>
      */
-    TreePredict getPredicts(int index);
+    com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict getPredicts(int index);
     /**
      * <code>repeated .fgboost.TreePredict predicts = 1;</code>
      */
@@ -7182,12 +7182,12 @@ public final class FGBoostServiceProto {
     /**
      * <code>repeated .fgboost.TreePredict predicts = 1;</code>
      */
-    java.util.List<? extends TreePredictOrBuilder>
+    java.util.List<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredictOrBuilder> 
         getPredictsOrBuilderList();
     /**
      * <code>repeated .fgboost.TreePredict predicts = 1;</code>
      */
-    TreePredictOrBuilder getPredictsOrBuilder(
+    com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredictOrBuilder getPredictsOrBuilder(
         int index);
   }
   /**
@@ -7206,14 +7206,14 @@ public final class FGBoostServiceProto {
       predicts_ = java.util.Collections.emptyList();
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new BoostPredict();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -7224,7 +7224,7 @@ public final class FGBoostServiceProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
@@ -7239,11 +7239,11 @@ public final class FGBoostServiceProto {
               break;
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-                predicts_ = new java.util.ArrayList<TreePredict>();
+                predicts_ = new java.util.ArrayList<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict>();
                 mutable_bitField0_ |= 0x00000001;
               }
               predicts_.add(
-                  input.readMessage(TreePredict.parser(), extensionRegistry));
+                  input.readMessage(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -7270,59 +7270,59 @@ public final class FGBoostServiceProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FGBoostServiceProto.internal_static_fgboost_BoostPredict_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_BoostPredict_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FGBoostServiceProto.internal_static_fgboost_BoostPredict_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_BoostPredict_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              BoostPredict.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict.Builder.class);
     }
 
     public static final int PREDICTS_FIELD_NUMBER = 1;
-    private java.util.List<TreePredict> predicts_;
+    private java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict> predicts_;
     /**
      * <code>repeated .fgboost.TreePredict predicts = 1;</code>
      */
-    @Override
-    public java.util.List<TreePredict> getPredictsList() {
+    @java.lang.Override
+    public java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict> getPredictsList() {
       return predicts_;
     }
     /**
      * <code>repeated .fgboost.TreePredict predicts = 1;</code>
      */
-    @Override
-    public java.util.List<? extends TreePredictOrBuilder>
+    @java.lang.Override
+    public java.util.List<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredictOrBuilder> 
         getPredictsOrBuilderList() {
       return predicts_;
     }
     /**
      * <code>repeated .fgboost.TreePredict predicts = 1;</code>
      */
-    @Override
+    @java.lang.Override
     public int getPredictsCount() {
       return predicts_.size();
     }
     /**
      * <code>repeated .fgboost.TreePredict predicts = 1;</code>
      */
-    @Override
-    public TreePredict getPredicts(int index) {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict getPredicts(int index) {
       return predicts_.get(index);
     }
     /**
      * <code>repeated .fgboost.TreePredict predicts = 1;</code>
      */
-    @Override
-    public TreePredictOrBuilder getPredictsOrBuilder(
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredictOrBuilder getPredictsOrBuilder(
         int index) {
       return predicts_.get(index);
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -7332,7 +7332,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       for (int i = 0; i < predicts_.size(); i++) {
@@ -7341,7 +7341,7 @@ public final class FGBoostServiceProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -7356,15 +7356,15 @@ public final class FGBoostServiceProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof BoostPredict)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict)) {
         return super.equals(obj);
       }
-      BoostPredict other = (BoostPredict) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict) obj;
 
       if (!getPredictsList()
           .equals(other.getPredictsList())) return false;
@@ -7372,7 +7372,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -7388,69 +7388,69 @@ public final class FGBoostServiceProto {
       return hash;
     }
 
-    public static BoostPredict parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static BoostPredict parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static BoostPredict parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static BoostPredict parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static BoostPredict parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static BoostPredict parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static BoostPredict parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static BoostPredict parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static BoostPredict parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static BoostPredict parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static BoostPredict parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static BoostPredict parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -7458,23 +7458,23 @@ public final class FGBoostServiceProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(BoostPredict prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -7484,18 +7484,18 @@ public final class FGBoostServiceProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:fgboost.BoostPredict)
-        BoostPredictOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredictOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FGBoostServiceProto.internal_static_fgboost_BoostPredict_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_BoostPredict_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FGBoostServiceProto.internal_static_fgboost_BoostPredict_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_BoostPredict_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                BoostPredict.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict.newBuilder()
@@ -7504,7 +7504,7 @@ public final class FGBoostServiceProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -7514,7 +7514,7 @@ public final class FGBoostServiceProto {
           getPredictsFieldBuilder();
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (predictsBuilder_ == null) {
@@ -7526,29 +7526,29 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FGBoostServiceProto.internal_static_fgboost_BoostPredict_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_BoostPredict_descriptor;
       }
 
-      @Override
-      public BoostPredict getDefaultInstanceForType() {
-        return BoostPredict.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict.getDefaultInstance();
       }
 
-      @Override
-      public BoostPredict build() {
-        BoostPredict result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public BoostPredict buildPartial() {
-        BoostPredict result = new BoostPredict(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict(this);
         int from_bitField0_ = bitField0_;
         if (predictsBuilder_ == null) {
           if (((bitField0_ & 0x00000001) != 0)) {
@@ -7563,50 +7563,50 @@ public final class FGBoostServiceProto {
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof BoostPredict) {
-          return mergeFrom((BoostPredict)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(BoostPredict other) {
-        if (other == BoostPredict.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict.getDefaultInstance()) return this;
         if (predictsBuilder_ == null) {
           if (!other.predicts_.isEmpty()) {
             if (predicts_.isEmpty()) {
@@ -7638,21 +7638,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        BoostPredict parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (BoostPredict) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -7663,22 +7663,22 @@ public final class FGBoostServiceProto {
       }
       private int bitField0_;
 
-      private java.util.List<TreePredict> predicts_ =
+      private java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict> predicts_ =
         java.util.Collections.emptyList();
       private void ensurePredictsIsMutable() {
         if (!((bitField0_ & 0x00000001) != 0)) {
-          predicts_ = new java.util.ArrayList<TreePredict>(predicts_);
+          predicts_ = new java.util.ArrayList<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict>(predicts_);
           bitField0_ |= 0x00000001;
          }
       }
 
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          TreePredict, TreePredict.Builder, TreePredictOrBuilder> predictsBuilder_;
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredictOrBuilder> predictsBuilder_;
 
       /**
        * <code>repeated .fgboost.TreePredict predicts = 1;</code>
        */
-      public java.util.List<TreePredict> getPredictsList() {
+      public java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict> getPredictsList() {
         if (predictsBuilder_ == null) {
           return java.util.Collections.unmodifiableList(predicts_);
         } else {
@@ -7698,7 +7698,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.TreePredict predicts = 1;</code>
        */
-      public TreePredict getPredicts(int index) {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict getPredicts(int index) {
         if (predictsBuilder_ == null) {
           return predicts_.get(index);
         } else {
@@ -7709,7 +7709,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.TreePredict predicts = 1;</code>
        */
       public Builder setPredicts(
-          int index, TreePredict value) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict value) {
         if (predictsBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -7726,7 +7726,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.TreePredict predicts = 1;</code>
        */
       public Builder setPredicts(
-          int index, TreePredict.Builder builderForValue) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder builderForValue) {
         if (predictsBuilder_ == null) {
           ensurePredictsIsMutable();
           predicts_.set(index, builderForValue.build());
@@ -7739,7 +7739,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.TreePredict predicts = 1;</code>
        */
-      public Builder addPredicts(TreePredict value) {
+      public Builder addPredicts(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict value) {
         if (predictsBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -7756,7 +7756,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.TreePredict predicts = 1;</code>
        */
       public Builder addPredicts(
-          int index, TreePredict value) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict value) {
         if (predictsBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -7773,7 +7773,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.TreePredict predicts = 1;</code>
        */
       public Builder addPredicts(
-          TreePredict.Builder builderForValue) {
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder builderForValue) {
         if (predictsBuilder_ == null) {
           ensurePredictsIsMutable();
           predicts_.add(builderForValue.build());
@@ -7787,7 +7787,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.TreePredict predicts = 1;</code>
        */
       public Builder addPredicts(
-          int index, TreePredict.Builder builderForValue) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder builderForValue) {
         if (predictsBuilder_ == null) {
           ensurePredictsIsMutable();
           predicts_.add(index, builderForValue.build());
@@ -7801,7 +7801,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.TreePredict predicts = 1;</code>
        */
       public Builder addAllPredicts(
-          Iterable<? extends TreePredict> values) {
+          java.lang.Iterable<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict> values) {
         if (predictsBuilder_ == null) {
           ensurePredictsIsMutable();
           com.google.protobuf.AbstractMessageLite.Builder.addAll(
@@ -7841,14 +7841,14 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.TreePredict predicts = 1;</code>
        */
-      public TreePredict.Builder getPredictsBuilder(
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder getPredictsBuilder(
           int index) {
         return getPredictsFieldBuilder().getBuilder(index);
       }
       /**
        * <code>repeated .fgboost.TreePredict predicts = 1;</code>
        */
-      public TreePredictOrBuilder getPredictsOrBuilder(
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredictOrBuilder getPredictsOrBuilder(
           int index) {
         if (predictsBuilder_ == null) {
           return predicts_.get(index);  } else {
@@ -7858,7 +7858,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.TreePredict predicts = 1;</code>
        */
-      public java.util.List<? extends TreePredictOrBuilder>
+      public java.util.List<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredictOrBuilder> 
            getPredictsOrBuilderList() {
         if (predictsBuilder_ != null) {
           return predictsBuilder_.getMessageOrBuilderList();
@@ -7869,31 +7869,31 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.TreePredict predicts = 1;</code>
        */
-      public TreePredict.Builder addPredictsBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder addPredictsBuilder() {
         return getPredictsFieldBuilder().addBuilder(
-            TreePredict.getDefaultInstance());
+            com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.getDefaultInstance());
       }
       /**
        * <code>repeated .fgboost.TreePredict predicts = 1;</code>
        */
-      public TreePredict.Builder addPredictsBuilder(
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder addPredictsBuilder(
           int index) {
         return getPredictsFieldBuilder().addBuilder(
-            index, TreePredict.getDefaultInstance());
+            index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.getDefaultInstance());
       }
       /**
        * <code>repeated .fgboost.TreePredict predicts = 1;</code>
        */
-      public java.util.List<TreePredict.Builder>
+      public java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder> 
            getPredictsBuilderList() {
         return getPredictsFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          TreePredict, TreePredict.Builder, TreePredictOrBuilder>
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredictOrBuilder> 
           getPredictsFieldBuilder() {
         if (predictsBuilder_ == null) {
           predictsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              TreePredict, TreePredict.Builder, TreePredictOrBuilder>(
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredictOrBuilder>(
                   predicts_,
                   ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
@@ -7902,13 +7902,13 @@ public final class FGBoostServiceProto {
         }
         return predictsBuilder_;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -7919,18 +7919,18 @@ public final class FGBoostServiceProto {
     }
 
     // @@protoc_insertion_point(class_scope:fgboost.BoostPredict)
-    private static final BoostPredict DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new BoostPredict();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict();
     }
 
-    public static BoostPredict getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<BoostPredict>
         PARSER = new com.google.protobuf.AbstractParser<BoostPredict>() {
-      @Override
+      @java.lang.Override
       public BoostPredict parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -7943,13 +7943,13 @@ public final class FGBoostServiceProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<BoostPredict> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public BoostPredict getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostPredict getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -7962,12 +7962,12 @@ public final class FGBoostServiceProto {
     /**
      * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
      */
-    java.util.List<TreePredict>
+    java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict> 
         getEvaluatesList();
     /**
      * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
      */
-    TreePredict getEvaluates(int index);
+    com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict getEvaluates(int index);
     /**
      * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
      */
@@ -7975,12 +7975,12 @@ public final class FGBoostServiceProto {
     /**
      * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
      */
-    java.util.List<? extends TreePredictOrBuilder>
+    java.util.List<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredictOrBuilder> 
         getEvaluatesOrBuilderList();
     /**
      * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
      */
-    TreePredictOrBuilder getEvaluatesOrBuilder(
+    com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredictOrBuilder getEvaluatesOrBuilder(
         int index);
   }
   /**
@@ -7999,14 +7999,14 @@ public final class FGBoostServiceProto {
       evaluates_ = java.util.Collections.emptyList();
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new BoostEval();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -8017,7 +8017,7 @@ public final class FGBoostServiceProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
@@ -8032,11 +8032,11 @@ public final class FGBoostServiceProto {
               break;
             case 10: {
               if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-                evaluates_ = new java.util.ArrayList<TreePredict>();
+                evaluates_ = new java.util.ArrayList<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict>();
                 mutable_bitField0_ |= 0x00000001;
               }
               evaluates_.add(
-                  input.readMessage(TreePredict.parser(), extensionRegistry));
+                  input.readMessage(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -8063,59 +8063,59 @@ public final class FGBoostServiceProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FGBoostServiceProto.internal_static_fgboost_BoostEval_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_BoostEval_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FGBoostServiceProto.internal_static_fgboost_BoostEval_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_BoostEval_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              BoostEval.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder.class);
     }
 
     public static final int EVALUATES_FIELD_NUMBER = 1;
-    private java.util.List<TreePredict> evaluates_;
+    private java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict> evaluates_;
     /**
      * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
      */
-    @Override
-    public java.util.List<TreePredict> getEvaluatesList() {
+    @java.lang.Override
+    public java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict> getEvaluatesList() {
       return evaluates_;
     }
     /**
      * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
      */
-    @Override
-    public java.util.List<? extends TreePredictOrBuilder>
+    @java.lang.Override
+    public java.util.List<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredictOrBuilder> 
         getEvaluatesOrBuilderList() {
       return evaluates_;
     }
     /**
      * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
      */
-    @Override
+    @java.lang.Override
     public int getEvaluatesCount() {
       return evaluates_.size();
     }
     /**
      * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
      */
-    @Override
-    public TreePredict getEvaluates(int index) {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict getEvaluates(int index) {
       return evaluates_.get(index);
     }
     /**
      * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
      */
-    @Override
-    public TreePredictOrBuilder getEvaluatesOrBuilder(
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredictOrBuilder getEvaluatesOrBuilder(
         int index) {
       return evaluates_.get(index);
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -8125,7 +8125,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       for (int i = 0; i < evaluates_.size(); i++) {
@@ -8134,7 +8134,7 @@ public final class FGBoostServiceProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -8149,15 +8149,15 @@ public final class FGBoostServiceProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof BoostEval)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval)) {
         return super.equals(obj);
       }
-      BoostEval other = (BoostEval) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval) obj;
 
       if (!getEvaluatesList()
           .equals(other.getEvaluatesList())) return false;
@@ -8165,7 +8165,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -8181,69 +8181,69 @@ public final class FGBoostServiceProto {
       return hash;
     }
 
-    public static BoostEval parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static BoostEval parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static BoostEval parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static BoostEval parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static BoostEval parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static BoostEval parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static BoostEval parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static BoostEval parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static BoostEval parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static BoostEval parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static BoostEval parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static BoostEval parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -8251,23 +8251,23 @@ public final class FGBoostServiceProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(BoostEval prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -8277,18 +8277,18 @@ public final class FGBoostServiceProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:fgboost.BoostEval)
-        BoostEvalOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FGBoostServiceProto.internal_static_fgboost_BoostEval_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_BoostEval_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FGBoostServiceProto.internal_static_fgboost_BoostEval_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_BoostEval_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                BoostEval.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.newBuilder()
@@ -8297,7 +8297,7 @@ public final class FGBoostServiceProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -8307,7 +8307,7 @@ public final class FGBoostServiceProto {
           getEvaluatesFieldBuilder();
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (evaluatesBuilder_ == null) {
@@ -8319,29 +8319,29 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FGBoostServiceProto.internal_static_fgboost_BoostEval_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_BoostEval_descriptor;
       }
 
-      @Override
-      public BoostEval getDefaultInstanceForType() {
-        return BoostEval.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.getDefaultInstance();
       }
 
-      @Override
-      public BoostEval build() {
-        BoostEval result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public BoostEval buildPartial() {
-        BoostEval result = new BoostEval(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval(this);
         int from_bitField0_ = bitField0_;
         if (evaluatesBuilder_ == null) {
           if (((bitField0_ & 0x00000001) != 0)) {
@@ -8356,50 +8356,50 @@ public final class FGBoostServiceProto {
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof BoostEval) {
-          return mergeFrom((BoostEval)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(BoostEval other) {
-        if (other == BoostEval.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.getDefaultInstance()) return this;
         if (evaluatesBuilder_ == null) {
           if (!other.evaluates_.isEmpty()) {
             if (evaluates_.isEmpty()) {
@@ -8431,21 +8431,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        BoostEval parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (BoostEval) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -8456,22 +8456,22 @@ public final class FGBoostServiceProto {
       }
       private int bitField0_;
 
-      private java.util.List<TreePredict> evaluates_ =
+      private java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict> evaluates_ =
         java.util.Collections.emptyList();
       private void ensureEvaluatesIsMutable() {
         if (!((bitField0_ & 0x00000001) != 0)) {
-          evaluates_ = new java.util.ArrayList<TreePredict>(evaluates_);
+          evaluates_ = new java.util.ArrayList<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict>(evaluates_);
           bitField0_ |= 0x00000001;
          }
       }
 
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          TreePredict, TreePredict.Builder, TreePredictOrBuilder> evaluatesBuilder_;
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredictOrBuilder> evaluatesBuilder_;
 
       /**
        * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
        */
-      public java.util.List<TreePredict> getEvaluatesList() {
+      public java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict> getEvaluatesList() {
         if (evaluatesBuilder_ == null) {
           return java.util.Collections.unmodifiableList(evaluates_);
         } else {
@@ -8491,7 +8491,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
        */
-      public TreePredict getEvaluates(int index) {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict getEvaluates(int index) {
         if (evaluatesBuilder_ == null) {
           return evaluates_.get(index);
         } else {
@@ -8502,7 +8502,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
        */
       public Builder setEvaluates(
-          int index, TreePredict value) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict value) {
         if (evaluatesBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -8519,7 +8519,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
        */
       public Builder setEvaluates(
-          int index, TreePredict.Builder builderForValue) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder builderForValue) {
         if (evaluatesBuilder_ == null) {
           ensureEvaluatesIsMutable();
           evaluates_.set(index, builderForValue.build());
@@ -8532,7 +8532,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
        */
-      public Builder addEvaluates(TreePredict value) {
+      public Builder addEvaluates(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict value) {
         if (evaluatesBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -8549,7 +8549,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
        */
       public Builder addEvaluates(
-          int index, TreePredict value) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict value) {
         if (evaluatesBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -8566,7 +8566,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
        */
       public Builder addEvaluates(
-          TreePredict.Builder builderForValue) {
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder builderForValue) {
         if (evaluatesBuilder_ == null) {
           ensureEvaluatesIsMutable();
           evaluates_.add(builderForValue.build());
@@ -8580,7 +8580,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
        */
       public Builder addEvaluates(
-          int index, TreePredict.Builder builderForValue) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder builderForValue) {
         if (evaluatesBuilder_ == null) {
           ensureEvaluatesIsMutable();
           evaluates_.add(index, builderForValue.build());
@@ -8594,7 +8594,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
        */
       public Builder addAllEvaluates(
-          Iterable<? extends TreePredict> values) {
+          java.lang.Iterable<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict> values) {
         if (evaluatesBuilder_ == null) {
           ensureEvaluatesIsMutable();
           com.google.protobuf.AbstractMessageLite.Builder.addAll(
@@ -8634,14 +8634,14 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
        */
-      public TreePredict.Builder getEvaluatesBuilder(
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder getEvaluatesBuilder(
           int index) {
         return getEvaluatesFieldBuilder().getBuilder(index);
       }
       /**
        * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
        */
-      public TreePredictOrBuilder getEvaluatesOrBuilder(
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredictOrBuilder getEvaluatesOrBuilder(
           int index) {
         if (evaluatesBuilder_ == null) {
           return evaluates_.get(index);  } else {
@@ -8651,7 +8651,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
        */
-      public java.util.List<? extends TreePredictOrBuilder>
+      public java.util.List<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredictOrBuilder> 
            getEvaluatesOrBuilderList() {
         if (evaluatesBuilder_ != null) {
           return evaluatesBuilder_.getMessageOrBuilderList();
@@ -8662,31 +8662,31 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
        */
-      public TreePredict.Builder addEvaluatesBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder addEvaluatesBuilder() {
         return getEvaluatesFieldBuilder().addBuilder(
-            TreePredict.getDefaultInstance());
+            com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.getDefaultInstance());
       }
       /**
        * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
        */
-      public TreePredict.Builder addEvaluatesBuilder(
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder addEvaluatesBuilder(
           int index) {
         return getEvaluatesFieldBuilder().addBuilder(
-            index, TreePredict.getDefaultInstance());
+            index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.getDefaultInstance());
       }
       /**
        * <code>repeated .fgboost.TreePredict evaluates = 1;</code>
        */
-      public java.util.List<TreePredict.Builder>
+      public java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder> 
            getEvaluatesBuilderList() {
         return getEvaluatesFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          TreePredict, TreePredict.Builder, TreePredictOrBuilder>
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredictOrBuilder> 
           getEvaluatesFieldBuilder() {
         if (evaluatesBuilder_ == null) {
           evaluatesBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              TreePredict, TreePredict.Builder, TreePredictOrBuilder>(
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredict.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.TreePredictOrBuilder>(
                   evaluates_,
                   ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
@@ -8695,13 +8695,13 @@ public final class FGBoostServiceProto {
         }
         return evaluatesBuilder_;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -8712,18 +8712,18 @@ public final class FGBoostServiceProto {
     }
 
     // @@protoc_insertion_point(class_scope:fgboost.BoostEval)
-    private static final BoostEval DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new BoostEval();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval();
     }
 
-    public static BoostEval getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<BoostEval>
         PARSER = new com.google.protobuf.AbstractParser<BoostEval>() {
-      @Override
+      @java.lang.Override
       public BoostEval parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -8736,13 +8736,13 @@ public final class FGBoostServiceProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<BoostEval> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public BoostEval getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -8756,7 +8756,7 @@ public final class FGBoostServiceProto {
      * <code>string clientuuid = 1;</code>
      * @return The clientuuid.
      */
-    String getClientuuid();
+    java.lang.String getClientuuid();
     /**
      * <code>string clientuuid = 1;</code>
      * @return The bytes for clientuuid.
@@ -8768,7 +8768,7 @@ public final class FGBoostServiceProto {
      * <code>string token = 2;</code>
      * @return The token.
      */
-    String getToken();
+    java.lang.String getToken();
     /**
      * <code>string token = 2;</code>
      * @return The bytes for token.
@@ -8793,14 +8793,14 @@ public final class FGBoostServiceProto {
       token_ = "";
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new RegisterRequest();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -8811,7 +8811,7 @@ public final class FGBoostServiceProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -8824,13 +8824,13 @@ public final class FGBoostServiceProto {
               done = true;
               break;
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               clientuuid_ = s;
               break;
             }
             case 18: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               token_ = s;
               break;
@@ -8856,32 +8856,32 @@ public final class FGBoostServiceProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FGBoostServiceProto.internal_static_fgboost_RegisterRequest_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_RegisterRequest_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FGBoostServiceProto.internal_static_fgboost_RegisterRequest_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_RegisterRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              RegisterRequest.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest.Builder.class);
     }
 
     public static final int CLIENTUUID_FIELD_NUMBER = 1;
-    private volatile Object clientuuid_;
+    private volatile java.lang.Object clientuuid_;
     /**
      * <code>string clientuuid = 1;</code>
      * @return The clientuuid.
      */
-    @Override
-    public String getClientuuid() {
-      Object ref = clientuuid_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getClientuuid() {
+      java.lang.Object ref = clientuuid_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         clientuuid_ = s;
         return s;
       }
@@ -8890,14 +8890,14 @@ public final class FGBoostServiceProto {
      * <code>string clientuuid = 1;</code>
      * @return The bytes for clientuuid.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getClientuuidBytes() {
-      Object ref = clientuuid_;
-      if (ref instanceof String) {
+      java.lang.Object ref = clientuuid_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         clientuuid_ = b;
         return b;
       } else {
@@ -8906,20 +8906,20 @@ public final class FGBoostServiceProto {
     }
 
     public static final int TOKEN_FIELD_NUMBER = 2;
-    private volatile Object token_;
+    private volatile java.lang.Object token_;
     /**
      * <code>string token = 2;</code>
      * @return The token.
      */
-    @Override
-    public String getToken() {
-      Object ref = token_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getToken() {
+      java.lang.Object ref = token_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         token_ = s;
         return s;
       }
@@ -8928,14 +8928,14 @@ public final class FGBoostServiceProto {
      * <code>string token = 2;</code>
      * @return The bytes for token.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getTokenBytes() {
-      Object ref = token_;
-      if (ref instanceof String) {
+      java.lang.Object ref = token_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         token_ = b;
         return b;
       } else {
@@ -8944,7 +8944,7 @@ public final class FGBoostServiceProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -8954,7 +8954,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getClientuuidBytes().isEmpty()) {
@@ -8966,7 +8966,7 @@ public final class FGBoostServiceProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -8983,15 +8983,15 @@ public final class FGBoostServiceProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof RegisterRequest)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest)) {
         return super.equals(obj);
       }
-      RegisterRequest other = (RegisterRequest) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest) obj;
 
       if (!getClientuuid()
           .equals(other.getClientuuid())) return false;
@@ -9001,7 +9001,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -9017,69 +9017,69 @@ public final class FGBoostServiceProto {
       return hash;
     }
 
-    public static RegisterRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static RegisterRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static RegisterRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static RegisterRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static RegisterRequest parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static RegisterRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static RegisterRequest parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static RegisterRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static RegisterRequest parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static RegisterRequest parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static RegisterRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static RegisterRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -9087,23 +9087,23 @@ public final class FGBoostServiceProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(RegisterRequest prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -9113,18 +9113,18 @@ public final class FGBoostServiceProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:fgboost.RegisterRequest)
-        RegisterRequestOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FGBoostServiceProto.internal_static_fgboost_RegisterRequest_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_RegisterRequest_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FGBoostServiceProto.internal_static_fgboost_RegisterRequest_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_RegisterRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                RegisterRequest.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest.newBuilder()
@@ -9133,7 +9133,7 @@ public final class FGBoostServiceProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -9142,7 +9142,7 @@ public final class FGBoostServiceProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         clientuuid_ = "";
@@ -9152,79 +9152,79 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FGBoostServiceProto.internal_static_fgboost_RegisterRequest_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_RegisterRequest_descriptor;
       }
 
-      @Override
-      public RegisterRequest getDefaultInstanceForType() {
-        return RegisterRequest.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest.getDefaultInstance();
       }
 
-      @Override
-      public RegisterRequest build() {
-        RegisterRequest result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public RegisterRequest buildPartial() {
-        RegisterRequest result = new RegisterRequest(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest(this);
         result.clientuuid_ = clientuuid_;
         result.token_ = token_;
         onBuilt();
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof RegisterRequest) {
-          return mergeFrom((RegisterRequest)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(RegisterRequest other) {
-        if (other == RegisterRequest.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest.getDefaultInstance()) return this;
         if (!other.getClientuuid().isEmpty()) {
           clientuuid_ = other.clientuuid_;
           onChanged();
@@ -9238,21 +9238,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        RegisterRequest parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (RegisterRequest) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -9262,21 +9262,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private Object clientuuid_ = "";
+      private java.lang.Object clientuuid_ = "";
       /**
        * <code>string clientuuid = 1;</code>
        * @return The clientuuid.
        */
-      public String getClientuuid() {
-        Object ref = clientuuid_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getClientuuid() {
+        java.lang.Object ref = clientuuid_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           clientuuid_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -9285,11 +9285,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getClientuuidBytes() {
-        Object ref = clientuuid_;
+        java.lang.Object ref = clientuuid_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           clientuuid_ = b;
           return b;
         } else {
@@ -9302,7 +9302,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setClientuuid(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -9338,21 +9338,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private Object token_ = "";
+      private java.lang.Object token_ = "";
       /**
        * <code>string token = 2;</code>
        * @return The token.
        */
-      public String getToken() {
-        Object ref = token_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getToken() {
+        java.lang.Object ref = token_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           token_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -9361,11 +9361,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getTokenBytes() {
-        Object ref = token_;
+        java.lang.Object ref = token_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           token_ = b;
           return b;
         } else {
@@ -9378,7 +9378,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setToken(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -9413,13 +9413,13 @@ public final class FGBoostServiceProto {
         onChanged();
         return this;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -9430,18 +9430,18 @@ public final class FGBoostServiceProto {
     }
 
     // @@protoc_insertion_point(class_scope:fgboost.RegisterRequest)
-    private static final RegisterRequest DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new RegisterRequest();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest();
     }
 
-    public static RegisterRequest getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<RegisterRequest>
         PARSER = new com.google.protobuf.AbstractParser<RegisterRequest>() {
-      @Override
+      @java.lang.Override
       public RegisterRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -9454,13 +9454,13 @@ public final class FGBoostServiceProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<RegisterRequest> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public RegisterRequest getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -9474,7 +9474,7 @@ public final class FGBoostServiceProto {
      * <code>string response = 1;</code>
      * @return The response.
      */
-    String getResponse();
+    java.lang.String getResponse();
     /**
      * <code>string response = 1;</code>
      * @return The bytes for response.
@@ -9504,14 +9504,14 @@ public final class FGBoostServiceProto {
       response_ = "";
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new RegisterResponse();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -9522,7 +9522,7 @@ public final class FGBoostServiceProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -9535,7 +9535,7 @@ public final class FGBoostServiceProto {
               done = true;
               break;
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               response_ = s;
               break;
@@ -9566,32 +9566,32 @@ public final class FGBoostServiceProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FGBoostServiceProto.internal_static_fgboost_RegisterResponse_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_RegisterResponse_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FGBoostServiceProto.internal_static_fgboost_RegisterResponse_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_RegisterResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              RegisterResponse.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse.Builder.class);
     }
 
     public static final int RESPONSE_FIELD_NUMBER = 1;
-    private volatile Object response_;
+    private volatile java.lang.Object response_;
     /**
      * <code>string response = 1;</code>
      * @return The response.
      */
-    @Override
-    public String getResponse() {
-      Object ref = response_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getResponse() {
+      java.lang.Object ref = response_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         response_ = s;
         return s;
       }
@@ -9600,14 +9600,14 @@ public final class FGBoostServiceProto {
      * <code>string response = 1;</code>
      * @return The bytes for response.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getResponseBytes() {
-      Object ref = response_;
-      if (ref instanceof String) {
+      java.lang.Object ref = response_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         response_ = b;
         return b;
       } else {
@@ -9621,13 +9621,13 @@ public final class FGBoostServiceProto {
      * <code>int32 code = 2;</code>
      * @return The code.
      */
-    @Override
+    @java.lang.Override
     public int getCode() {
       return code_;
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -9637,7 +9637,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getResponseBytes().isEmpty()) {
@@ -9649,7 +9649,7 @@ public final class FGBoostServiceProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -9667,15 +9667,15 @@ public final class FGBoostServiceProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof RegisterResponse)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse)) {
         return super.equals(obj);
       }
-      RegisterResponse other = (RegisterResponse) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse) obj;
 
       if (!getResponse()
           .equals(other.getResponse())) return false;
@@ -9685,7 +9685,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -9701,69 +9701,69 @@ public final class FGBoostServiceProto {
       return hash;
     }
 
-    public static RegisterResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static RegisterResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static RegisterResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static RegisterResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static RegisterResponse parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static RegisterResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static RegisterResponse parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static RegisterResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static RegisterResponse parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static RegisterResponse parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static RegisterResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static RegisterResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -9771,23 +9771,23 @@ public final class FGBoostServiceProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(RegisterResponse prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -9797,18 +9797,18 @@ public final class FGBoostServiceProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:fgboost.RegisterResponse)
-        RegisterResponseOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FGBoostServiceProto.internal_static_fgboost_RegisterResponse_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_RegisterResponse_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FGBoostServiceProto.internal_static_fgboost_RegisterResponse_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_RegisterResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                RegisterResponse.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse.newBuilder()
@@ -9817,7 +9817,7 @@ public final class FGBoostServiceProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -9826,7 +9826,7 @@ public final class FGBoostServiceProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         response_ = "";
@@ -9836,79 +9836,79 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FGBoostServiceProto.internal_static_fgboost_RegisterResponse_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_RegisterResponse_descriptor;
       }
 
-      @Override
-      public RegisterResponse getDefaultInstanceForType() {
-        return RegisterResponse.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse.getDefaultInstance();
       }
 
-      @Override
-      public RegisterResponse build() {
-        RegisterResponse result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public RegisterResponse buildPartial() {
-        RegisterResponse result = new RegisterResponse(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse(this);
         result.response_ = response_;
         result.code_ = code_;
         onBuilt();
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof RegisterResponse) {
-          return mergeFrom((RegisterResponse)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(RegisterResponse other) {
-        if (other == RegisterResponse.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse.getDefaultInstance()) return this;
         if (!other.getResponse().isEmpty()) {
           response_ = other.response_;
           onChanged();
@@ -9921,21 +9921,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        RegisterResponse parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (RegisterResponse) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -9945,21 +9945,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private Object response_ = "";
+      private java.lang.Object response_ = "";
       /**
        * <code>string response = 1;</code>
        * @return The response.
        */
-      public String getResponse() {
-        Object ref = response_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getResponse() {
+        java.lang.Object ref = response_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           response_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -9968,11 +9968,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getResponseBytes() {
-        Object ref = response_;
+        java.lang.Object ref = response_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           response_ = b;
           return b;
         } else {
@@ -9985,7 +9985,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setResponse(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -10026,7 +10026,7 @@ public final class FGBoostServiceProto {
        * <code>int32 code = 2;</code>
        * @return The code.
        */
-      @Override
+      @java.lang.Override
       public int getCode() {
         return code_;
       }
@@ -10051,13 +10051,13 @@ public final class FGBoostServiceProto {
         onChanged();
         return this;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -10068,18 +10068,18 @@ public final class FGBoostServiceProto {
     }
 
     // @@protoc_insertion_point(class_scope:fgboost.RegisterResponse)
-    private static final RegisterResponse DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new RegisterResponse();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse();
     }
 
-    public static RegisterResponse getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<RegisterResponse>
         PARSER = new com.google.protobuf.AbstractParser<RegisterResponse>() {
-      @Override
+      @java.lang.Override
       public RegisterResponse parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -10092,13 +10092,13 @@ public final class FGBoostServiceProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<RegisterResponse> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public RegisterResponse getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.RegisterResponse getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -10112,7 +10112,7 @@ public final class FGBoostServiceProto {
      * <code>string clientuuid = 1;</code>
      * @return The clientuuid.
      */
-    String getClientuuid();
+    java.lang.String getClientuuid();
     /**
      * <code>string clientuuid = 1;</code>
      * @return The bytes for clientuuid.
@@ -10129,12 +10129,12 @@ public final class FGBoostServiceProto {
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
      */
-    java.util.List<BoostEval>
+    java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval> 
         getTreeEvalList();
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
      */
-    BoostEval getTreeEval(int index);
+    com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval getTreeEval(int index);
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
      */
@@ -10142,12 +10142,12 @@ public final class FGBoostServiceProto {
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
      */
-    java.util.List<? extends BoostEvalOrBuilder>
+    java.util.List<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder> 
         getTreeEvalOrBuilderList();
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
      */
-    BoostEvalOrBuilder getTreeEvalOrBuilder(
+    com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder getTreeEvalOrBuilder(
         int index);
   }
   /**
@@ -10167,14 +10167,14 @@ public final class FGBoostServiceProto {
       treeEval_ = java.util.Collections.emptyList();
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new UploadTreeEvalRequest();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -10185,7 +10185,7 @@ public final class FGBoostServiceProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
@@ -10199,7 +10199,7 @@ public final class FGBoostServiceProto {
               done = true;
               break;
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               clientuuid_ = s;
               break;
@@ -10211,11 +10211,11 @@ public final class FGBoostServiceProto {
             }
             case 26: {
               if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-                treeEval_ = new java.util.ArrayList<BoostEval>();
+                treeEval_ = new java.util.ArrayList<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval>();
                 mutable_bitField0_ |= 0x00000001;
               }
               treeEval_.add(
-                  input.readMessage(BoostEval.parser(), extensionRegistry));
+                  input.readMessage(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.parser(), extensionRegistry));
               break;
             }
             default: {
@@ -10242,32 +10242,32 @@ public final class FGBoostServiceProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FGBoostServiceProto.internal_static_fgboost_UploadTreeEvalRequest_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadTreeEvalRequest_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FGBoostServiceProto.internal_static_fgboost_UploadTreeEvalRequest_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadTreeEvalRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              UploadTreeEvalRequest.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest.Builder.class);
     }
 
     public static final int CLIENTUUID_FIELD_NUMBER = 1;
-    private volatile Object clientuuid_;
+    private volatile java.lang.Object clientuuid_;
     /**
      * <code>string clientuuid = 1;</code>
      * @return The clientuuid.
      */
-    @Override
-    public String getClientuuid() {
-      Object ref = clientuuid_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getClientuuid() {
+      java.lang.Object ref = clientuuid_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         clientuuid_ = s;
         return s;
       }
@@ -10276,14 +10276,14 @@ public final class FGBoostServiceProto {
      * <code>string clientuuid = 1;</code>
      * @return The bytes for clientuuid.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getClientuuidBytes() {
-      Object ref = clientuuid_;
-      if (ref instanceof String) {
+      java.lang.Object ref = clientuuid_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         clientuuid_ = b;
         return b;
       } else {
@@ -10297,53 +10297,53 @@ public final class FGBoostServiceProto {
      * <code>int32 version = 2;</code>
      * @return The version.
      */
-    @Override
+    @java.lang.Override
     public int getVersion() {
       return version_;
     }
 
     public static final int TREEEVAL_FIELD_NUMBER = 3;
-    private java.util.List<BoostEval> treeEval_;
+    private java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval> treeEval_;
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
      */
-    @Override
-    public java.util.List<BoostEval> getTreeEvalList() {
+    @java.lang.Override
+    public java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval> getTreeEvalList() {
       return treeEval_;
     }
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
      */
-    @Override
-    public java.util.List<? extends BoostEvalOrBuilder>
+    @java.lang.Override
+    public java.util.List<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder> 
         getTreeEvalOrBuilderList() {
       return treeEval_;
     }
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
      */
-    @Override
+    @java.lang.Override
     public int getTreeEvalCount() {
       return treeEval_.size();
     }
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
      */
-    @Override
-    public BoostEval getTreeEval(int index) {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval getTreeEval(int index) {
       return treeEval_.get(index);
     }
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
      */
-    @Override
-    public BoostEvalOrBuilder getTreeEvalOrBuilder(
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder getTreeEvalOrBuilder(
         int index) {
       return treeEval_.get(index);
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -10353,7 +10353,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getClientuuidBytes().isEmpty()) {
@@ -10368,7 +10368,7 @@ public final class FGBoostServiceProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -10390,15 +10390,15 @@ public final class FGBoostServiceProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof UploadTreeEvalRequest)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest)) {
         return super.equals(obj);
       }
-      UploadTreeEvalRequest other = (UploadTreeEvalRequest) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest) obj;
 
       if (!getClientuuid()
           .equals(other.getClientuuid())) return false;
@@ -10410,7 +10410,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -10430,69 +10430,69 @@ public final class FGBoostServiceProto {
       return hash;
     }
 
-    public static UploadTreeEvalRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static UploadTreeEvalRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static UploadTreeEvalRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static UploadTreeEvalRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static UploadTreeEvalRequest parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static UploadTreeEvalRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static UploadTreeEvalRequest parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static UploadTreeEvalRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static UploadTreeEvalRequest parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static UploadTreeEvalRequest parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static UploadTreeEvalRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static UploadTreeEvalRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -10500,23 +10500,23 @@ public final class FGBoostServiceProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(UploadTreeEvalRequest prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -10526,18 +10526,18 @@ public final class FGBoostServiceProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:fgboost.UploadTreeEvalRequest)
-        UploadTreeEvalRequestOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FGBoostServiceProto.internal_static_fgboost_UploadTreeEvalRequest_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadTreeEvalRequest_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FGBoostServiceProto.internal_static_fgboost_UploadTreeEvalRequest_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadTreeEvalRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                UploadTreeEvalRequest.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest.newBuilder()
@@ -10546,7 +10546,7 @@ public final class FGBoostServiceProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -10556,7 +10556,7 @@ public final class FGBoostServiceProto {
           getTreeEvalFieldBuilder();
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         clientuuid_ = "";
@@ -10572,29 +10572,29 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FGBoostServiceProto.internal_static_fgboost_UploadTreeEvalRequest_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_UploadTreeEvalRequest_descriptor;
       }
 
-      @Override
-      public UploadTreeEvalRequest getDefaultInstanceForType() {
-        return UploadTreeEvalRequest.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest.getDefaultInstance();
       }
 
-      @Override
-      public UploadTreeEvalRequest build() {
-        UploadTreeEvalRequest result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public UploadTreeEvalRequest buildPartial() {
-        UploadTreeEvalRequest result = new UploadTreeEvalRequest(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest(this);
         int from_bitField0_ = bitField0_;
         result.clientuuid_ = clientuuid_;
         result.version_ = version_;
@@ -10611,50 +10611,50 @@ public final class FGBoostServiceProto {
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof UploadTreeEvalRequest) {
-          return mergeFrom((UploadTreeEvalRequest)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(UploadTreeEvalRequest other) {
-        if (other == UploadTreeEvalRequest.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest.getDefaultInstance()) return this;
         if (!other.getClientuuid().isEmpty()) {
           clientuuid_ = other.clientuuid_;
           onChanged();
@@ -10693,21 +10693,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        UploadTreeEvalRequest parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (UploadTreeEvalRequest) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -10718,21 +10718,21 @@ public final class FGBoostServiceProto {
       }
       private int bitField0_;
 
-      private Object clientuuid_ = "";
+      private java.lang.Object clientuuid_ = "";
       /**
        * <code>string clientuuid = 1;</code>
        * @return The clientuuid.
        */
-      public String getClientuuid() {
-        Object ref = clientuuid_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getClientuuid() {
+        java.lang.Object ref = clientuuid_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           clientuuid_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -10741,11 +10741,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getClientuuidBytes() {
-        Object ref = clientuuid_;
+        java.lang.Object ref = clientuuid_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           clientuuid_ = b;
           return b;
         } else {
@@ -10758,7 +10758,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setClientuuid(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -10799,7 +10799,7 @@ public final class FGBoostServiceProto {
        * <code>int32 version = 2;</code>
        * @return The version.
        */
-      @Override
+      @java.lang.Override
       public int getVersion() {
         return version_;
       }
@@ -10825,22 +10825,22 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private java.util.List<BoostEval> treeEval_ =
+      private java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval> treeEval_ =
         java.util.Collections.emptyList();
       private void ensureTreeEvalIsMutable() {
         if (!((bitField0_ & 0x00000001) != 0)) {
-          treeEval_ = new java.util.ArrayList<BoostEval>(treeEval_);
+          treeEval_ = new java.util.ArrayList<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval>(treeEval_);
           bitField0_ |= 0x00000001;
          }
       }
 
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          BoostEval, BoostEval.Builder, BoostEvalOrBuilder> treeEvalBuilder_;
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder> treeEvalBuilder_;
 
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
        */
-      public java.util.List<BoostEval> getTreeEvalList() {
+      public java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval> getTreeEvalList() {
         if (treeEvalBuilder_ == null) {
           return java.util.Collections.unmodifiableList(treeEval_);
         } else {
@@ -10860,7 +10860,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
        */
-      public BoostEval getTreeEval(int index) {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval getTreeEval(int index) {
         if (treeEvalBuilder_ == null) {
           return treeEval_.get(index);
         } else {
@@ -10871,7 +10871,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
        */
       public Builder setTreeEval(
-          int index, BoostEval value) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval value) {
         if (treeEvalBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -10888,7 +10888,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
        */
       public Builder setTreeEval(
-          int index, BoostEval.Builder builderForValue) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder builderForValue) {
         if (treeEvalBuilder_ == null) {
           ensureTreeEvalIsMutable();
           treeEval_.set(index, builderForValue.build());
@@ -10901,7 +10901,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
        */
-      public Builder addTreeEval(BoostEval value) {
+      public Builder addTreeEval(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval value) {
         if (treeEvalBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -10918,7 +10918,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
        */
       public Builder addTreeEval(
-          int index, BoostEval value) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval value) {
         if (treeEvalBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -10935,7 +10935,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
        */
       public Builder addTreeEval(
-          BoostEval.Builder builderForValue) {
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder builderForValue) {
         if (treeEvalBuilder_ == null) {
           ensureTreeEvalIsMutable();
           treeEval_.add(builderForValue.build());
@@ -10949,7 +10949,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
        */
       public Builder addTreeEval(
-          int index, BoostEval.Builder builderForValue) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder builderForValue) {
         if (treeEvalBuilder_ == null) {
           ensureTreeEvalIsMutable();
           treeEval_.add(index, builderForValue.build());
@@ -10963,7 +10963,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
        */
       public Builder addAllTreeEval(
-          Iterable<? extends BoostEval> values) {
+          java.lang.Iterable<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval> values) {
         if (treeEvalBuilder_ == null) {
           ensureTreeEvalIsMutable();
           com.google.protobuf.AbstractMessageLite.Builder.addAll(
@@ -11003,14 +11003,14 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
        */
-      public BoostEval.Builder getTreeEvalBuilder(
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder getTreeEvalBuilder(
           int index) {
         return getTreeEvalFieldBuilder().getBuilder(index);
       }
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
        */
-      public BoostEvalOrBuilder getTreeEvalOrBuilder(
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder getTreeEvalOrBuilder(
           int index) {
         if (treeEvalBuilder_ == null) {
           return treeEval_.get(index);  } else {
@@ -11020,7 +11020,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
        */
-      public java.util.List<? extends BoostEvalOrBuilder>
+      public java.util.List<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder> 
            getTreeEvalOrBuilderList() {
         if (treeEvalBuilder_ != null) {
           return treeEvalBuilder_.getMessageOrBuilderList();
@@ -11031,31 +11031,31 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
        */
-      public BoostEval.Builder addTreeEvalBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder addTreeEvalBuilder() {
         return getTreeEvalFieldBuilder().addBuilder(
-            BoostEval.getDefaultInstance());
+            com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.getDefaultInstance());
       }
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
        */
-      public BoostEval.Builder addTreeEvalBuilder(
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder addTreeEvalBuilder(
           int index) {
         return getTreeEvalFieldBuilder().addBuilder(
-            index, BoostEval.getDefaultInstance());
+            index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.getDefaultInstance());
       }
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 3;</code>
        */
-      public java.util.List<BoostEval.Builder>
+      public java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder> 
            getTreeEvalBuilderList() {
         return getTreeEvalFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          BoostEval, BoostEval.Builder, BoostEvalOrBuilder>
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder> 
           getTreeEvalFieldBuilder() {
         if (treeEvalBuilder_ == null) {
           treeEvalBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              BoostEval, BoostEval.Builder, BoostEvalOrBuilder>(
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder>(
                   treeEval_,
                   ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
@@ -11064,13 +11064,13 @@ public final class FGBoostServiceProto {
         }
         return treeEvalBuilder_;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -11081,18 +11081,18 @@ public final class FGBoostServiceProto {
     }
 
     // @@protoc_insertion_point(class_scope:fgboost.UploadTreeEvalRequest)
-    private static final UploadTreeEvalRequest DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new UploadTreeEvalRequest();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest();
     }
 
-    public static UploadTreeEvalRequest getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<UploadTreeEvalRequest>
         PARSER = new com.google.protobuf.AbstractParser<UploadTreeEvalRequest>() {
-      @Override
+      @java.lang.Override
       public UploadTreeEvalRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -11105,13 +11105,13 @@ public final class FGBoostServiceProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<UploadTreeEvalRequest> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public UploadTreeEvalRequest getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.UploadTreeEvalRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -11125,7 +11125,7 @@ public final class FGBoostServiceProto {
      * <code>string clientuuid = 1;</code>
      * @return The clientuuid.
      */
-    String getClientuuid();
+    java.lang.String getClientuuid();
     /**
      * <code>string clientuuid = 1;</code>
      * @return The bytes for clientuuid.
@@ -11136,12 +11136,12 @@ public final class FGBoostServiceProto {
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
-    java.util.List<BoostEval>
+    java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval> 
         getTreeEvalList();
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
-    BoostEval getTreeEval(int index);
+    com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval getTreeEval(int index);
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
@@ -11149,12 +11149,12 @@ public final class FGBoostServiceProto {
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
-    java.util.List<? extends BoostEvalOrBuilder>
+    java.util.List<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder> 
         getTreeEvalOrBuilderList();
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
-    BoostEvalOrBuilder getTreeEvalOrBuilder(
+    com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder getTreeEvalOrBuilder(
         int index);
 
     /**
@@ -11186,14 +11186,14 @@ public final class FGBoostServiceProto {
       treeEval_ = java.util.Collections.emptyList();
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new EvaluateRequest();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -11204,7 +11204,7 @@ public final class FGBoostServiceProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
@@ -11218,18 +11218,18 @@ public final class FGBoostServiceProto {
               done = true;
               break;
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               clientuuid_ = s;
               break;
             }
             case 18: {
               if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-                treeEval_ = new java.util.ArrayList<BoostEval>();
+                treeEval_ = new java.util.ArrayList<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval>();
                 mutable_bitField0_ |= 0x00000001;
               }
               treeEval_.add(
-                  input.readMessage(BoostEval.parser(), extensionRegistry));
+                  input.readMessage(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.parser(), extensionRegistry));
               break;
             }
             case 24: {
@@ -11266,32 +11266,32 @@ public final class FGBoostServiceProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FGBoostServiceProto.internal_static_fgboost_EvaluateRequest_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_EvaluateRequest_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FGBoostServiceProto.internal_static_fgboost_EvaluateRequest_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_EvaluateRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              EvaluateRequest.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest.Builder.class);
     }
 
     public static final int CLIENTUUID_FIELD_NUMBER = 1;
-    private volatile Object clientuuid_;
+    private volatile java.lang.Object clientuuid_;
     /**
      * <code>string clientuuid = 1;</code>
      * @return The clientuuid.
      */
-    @Override
-    public String getClientuuid() {
-      Object ref = clientuuid_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getClientuuid() {
+      java.lang.Object ref = clientuuid_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         clientuuid_ = s;
         return s;
       }
@@ -11300,14 +11300,14 @@ public final class FGBoostServiceProto {
      * <code>string clientuuid = 1;</code>
      * @return The bytes for clientuuid.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getClientuuidBytes() {
-      Object ref = clientuuid_;
-      if (ref instanceof String) {
+      java.lang.Object ref = clientuuid_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         clientuuid_ = b;
         return b;
       } else {
@@ -11316,41 +11316,41 @@ public final class FGBoostServiceProto {
     }
 
     public static final int TREEEVAL_FIELD_NUMBER = 2;
-    private java.util.List<BoostEval> treeEval_;
+    private java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval> treeEval_;
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
-    @Override
-    public java.util.List<BoostEval> getTreeEvalList() {
+    @java.lang.Override
+    public java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval> getTreeEvalList() {
       return treeEval_;
     }
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
-    @Override
-    public java.util.List<? extends BoostEvalOrBuilder>
+    @java.lang.Override
+    public java.util.List<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder> 
         getTreeEvalOrBuilderList() {
       return treeEval_;
     }
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
-    @Override
+    @java.lang.Override
     public int getTreeEvalCount() {
       return treeEval_.size();
     }
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
-    @Override
-    public BoostEval getTreeEval(int index) {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval getTreeEval(int index) {
       return treeEval_.get(index);
     }
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
-    @Override
-    public BoostEvalOrBuilder getTreeEvalOrBuilder(
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder getTreeEvalOrBuilder(
         int index) {
       return treeEval_.get(index);
     }
@@ -11361,7 +11361,7 @@ public final class FGBoostServiceProto {
      * <code>int32 version = 3;</code>
      * @return The version.
      */
-    @Override
+    @java.lang.Override
     public int getVersion() {
       return version_;
     }
@@ -11372,13 +11372,13 @@ public final class FGBoostServiceProto {
      * <code>bool lastBatch = 4;</code>
      * @return The lastBatch.
      */
-    @Override
+    @java.lang.Override
     public boolean getLastBatch() {
       return lastBatch_;
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -11388,7 +11388,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getClientuuidBytes().isEmpty()) {
@@ -11406,7 +11406,7 @@ public final class FGBoostServiceProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -11432,15 +11432,15 @@ public final class FGBoostServiceProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof EvaluateRequest)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest)) {
         return super.equals(obj);
       }
-      EvaluateRequest other = (EvaluateRequest) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest) obj;
 
       if (!getClientuuid()
           .equals(other.getClientuuid())) return false;
@@ -11454,7 +11454,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -11477,69 +11477,69 @@ public final class FGBoostServiceProto {
       return hash;
     }
 
-    public static EvaluateRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static EvaluateRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static EvaluateRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static EvaluateRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static EvaluateRequest parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static EvaluateRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static EvaluateRequest parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static EvaluateRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static EvaluateRequest parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static EvaluateRequest parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static EvaluateRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static EvaluateRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -11547,23 +11547,23 @@ public final class FGBoostServiceProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(EvaluateRequest prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -11573,18 +11573,18 @@ public final class FGBoostServiceProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:fgboost.EvaluateRequest)
-        EvaluateRequestOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FGBoostServiceProto.internal_static_fgboost_EvaluateRequest_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_EvaluateRequest_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FGBoostServiceProto.internal_static_fgboost_EvaluateRequest_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_EvaluateRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                EvaluateRequest.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest.newBuilder()
@@ -11593,7 +11593,7 @@ public final class FGBoostServiceProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -11603,7 +11603,7 @@ public final class FGBoostServiceProto {
           getTreeEvalFieldBuilder();
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         clientuuid_ = "";
@@ -11621,29 +11621,29 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FGBoostServiceProto.internal_static_fgboost_EvaluateRequest_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_EvaluateRequest_descriptor;
       }
 
-      @Override
-      public EvaluateRequest getDefaultInstanceForType() {
-        return EvaluateRequest.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest.getDefaultInstance();
       }
 
-      @Override
-      public EvaluateRequest build() {
-        EvaluateRequest result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public EvaluateRequest buildPartial() {
-        EvaluateRequest result = new EvaluateRequest(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest(this);
         int from_bitField0_ = bitField0_;
         result.clientuuid_ = clientuuid_;
         if (treeEvalBuilder_ == null) {
@@ -11661,50 +11661,50 @@ public final class FGBoostServiceProto {
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof EvaluateRequest) {
-          return mergeFrom((EvaluateRequest)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(EvaluateRequest other) {
-        if (other == EvaluateRequest.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest.getDefaultInstance()) return this;
         if (!other.getClientuuid().isEmpty()) {
           clientuuid_ = other.clientuuid_;
           onChanged();
@@ -11746,21 +11746,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        EvaluateRequest parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (EvaluateRequest) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -11771,21 +11771,21 @@ public final class FGBoostServiceProto {
       }
       private int bitField0_;
 
-      private Object clientuuid_ = "";
+      private java.lang.Object clientuuid_ = "";
       /**
        * <code>string clientuuid = 1;</code>
        * @return The clientuuid.
        */
-      public String getClientuuid() {
-        Object ref = clientuuid_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getClientuuid() {
+        java.lang.Object ref = clientuuid_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           clientuuid_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -11794,11 +11794,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getClientuuidBytes() {
-        Object ref = clientuuid_;
+        java.lang.Object ref = clientuuid_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           clientuuid_ = b;
           return b;
         } else {
@@ -11811,7 +11811,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setClientuuid(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -11847,22 +11847,22 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private java.util.List<BoostEval> treeEval_ =
+      private java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval> treeEval_ =
         java.util.Collections.emptyList();
       private void ensureTreeEvalIsMutable() {
         if (!((bitField0_ & 0x00000001) != 0)) {
-          treeEval_ = new java.util.ArrayList<BoostEval>(treeEval_);
+          treeEval_ = new java.util.ArrayList<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval>(treeEval_);
           bitField0_ |= 0x00000001;
          }
       }
 
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          BoostEval, BoostEval.Builder, BoostEvalOrBuilder> treeEvalBuilder_;
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder> treeEvalBuilder_;
 
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
-      public java.util.List<BoostEval> getTreeEvalList() {
+      public java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval> getTreeEvalList() {
         if (treeEvalBuilder_ == null) {
           return java.util.Collections.unmodifiableList(treeEval_);
         } else {
@@ -11882,7 +11882,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
-      public BoostEval getTreeEval(int index) {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval getTreeEval(int index) {
         if (treeEvalBuilder_ == null) {
           return treeEval_.get(index);
         } else {
@@ -11893,7 +11893,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
       public Builder setTreeEval(
-          int index, BoostEval value) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval value) {
         if (treeEvalBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -11910,7 +11910,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
       public Builder setTreeEval(
-          int index, BoostEval.Builder builderForValue) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder builderForValue) {
         if (treeEvalBuilder_ == null) {
           ensureTreeEvalIsMutable();
           treeEval_.set(index, builderForValue.build());
@@ -11923,7 +11923,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
-      public Builder addTreeEval(BoostEval value) {
+      public Builder addTreeEval(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval value) {
         if (treeEvalBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -11940,7 +11940,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
       public Builder addTreeEval(
-          int index, BoostEval value) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval value) {
         if (treeEvalBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -11957,7 +11957,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
       public Builder addTreeEval(
-          BoostEval.Builder builderForValue) {
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder builderForValue) {
         if (treeEvalBuilder_ == null) {
           ensureTreeEvalIsMutable();
           treeEval_.add(builderForValue.build());
@@ -11971,7 +11971,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
       public Builder addTreeEval(
-          int index, BoostEval.Builder builderForValue) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder builderForValue) {
         if (treeEvalBuilder_ == null) {
           ensureTreeEvalIsMutable();
           treeEval_.add(index, builderForValue.build());
@@ -11985,7 +11985,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
       public Builder addAllTreeEval(
-          Iterable<? extends BoostEval> values) {
+          java.lang.Iterable<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval> values) {
         if (treeEvalBuilder_ == null) {
           ensureTreeEvalIsMutable();
           com.google.protobuf.AbstractMessageLite.Builder.addAll(
@@ -12025,14 +12025,14 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
-      public BoostEval.Builder getTreeEvalBuilder(
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder getTreeEvalBuilder(
           int index) {
         return getTreeEvalFieldBuilder().getBuilder(index);
       }
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
-      public BoostEvalOrBuilder getTreeEvalOrBuilder(
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder getTreeEvalOrBuilder(
           int index) {
         if (treeEvalBuilder_ == null) {
           return treeEval_.get(index);  } else {
@@ -12042,7 +12042,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
-      public java.util.List<? extends BoostEvalOrBuilder>
+      public java.util.List<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder> 
            getTreeEvalOrBuilderList() {
         if (treeEvalBuilder_ != null) {
           return treeEvalBuilder_.getMessageOrBuilderList();
@@ -12053,31 +12053,31 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
-      public BoostEval.Builder addTreeEvalBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder addTreeEvalBuilder() {
         return getTreeEvalFieldBuilder().addBuilder(
-            BoostEval.getDefaultInstance());
+            com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.getDefaultInstance());
       }
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
-      public BoostEval.Builder addTreeEvalBuilder(
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder addTreeEvalBuilder(
           int index) {
         return getTreeEvalFieldBuilder().addBuilder(
-            index, BoostEval.getDefaultInstance());
+            index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.getDefaultInstance());
       }
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
-      public java.util.List<BoostEval.Builder>
+      public java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder> 
            getTreeEvalBuilderList() {
         return getTreeEvalFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          BoostEval, BoostEval.Builder, BoostEvalOrBuilder>
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder> 
           getTreeEvalFieldBuilder() {
         if (treeEvalBuilder_ == null) {
           treeEvalBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              BoostEval, BoostEval.Builder, BoostEvalOrBuilder>(
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder>(
                   treeEval_,
                   ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
@@ -12092,7 +12092,7 @@ public final class FGBoostServiceProto {
        * <code>int32 version = 3;</code>
        * @return The version.
        */
-      @Override
+      @java.lang.Override
       public int getVersion() {
         return version_;
       }
@@ -12123,7 +12123,7 @@ public final class FGBoostServiceProto {
        * <code>bool lastBatch = 4;</code>
        * @return The lastBatch.
        */
-      @Override
+      @java.lang.Override
       public boolean getLastBatch() {
         return lastBatch_;
       }
@@ -12148,13 +12148,13 @@ public final class FGBoostServiceProto {
         onChanged();
         return this;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -12165,18 +12165,18 @@ public final class FGBoostServiceProto {
     }
 
     // @@protoc_insertion_point(class_scope:fgboost.EvaluateRequest)
-    private static final EvaluateRequest DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new EvaluateRequest();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest();
     }
 
-    public static EvaluateRequest getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<EvaluateRequest>
         PARSER = new com.google.protobuf.AbstractParser<EvaluateRequest>() {
-      @Override
+      @java.lang.Override
       public EvaluateRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -12189,13 +12189,13 @@ public final class FGBoostServiceProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<EvaluateRequest> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public EvaluateRequest getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -12209,7 +12209,7 @@ public final class FGBoostServiceProto {
      * <code>string response = 1;</code>
      * @return The response.
      */
-    String getResponse();
+    java.lang.String getResponse();
     /**
      * <code>string response = 1;</code>
      * @return The bytes for response.
@@ -12226,11 +12226,11 @@ public final class FGBoostServiceProto {
      * <code>.TensorMap data = 2;</code>
      * @return The data.
      */
-    FlBaseProto.TensorMap getData();
+    com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap getData();
     /**
      * <code>.TensorMap data = 2;</code>
      */
-    FlBaseProto.TensorMapOrBuilder getDataOrBuilder();
+    com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder getDataOrBuilder();
 
     /**
      * <code>int32 code = 3;</code>
@@ -12242,7 +12242,7 @@ public final class FGBoostServiceProto {
      * <code>string message = 4;</code>
      * @return The message.
      */
-    String getMessage();
+    java.lang.String getMessage();
     /**
      * <code>string message = 4;</code>
      * @return The bytes for message.
@@ -12267,14 +12267,14 @@ public final class FGBoostServiceProto {
       message_ = "";
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new EvaluateResponse();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -12285,7 +12285,7 @@ public final class FGBoostServiceProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -12298,17 +12298,17 @@ public final class FGBoostServiceProto {
               done = true;
               break;
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               response_ = s;
               break;
             }
             case 18: {
-              FlBaseProto.TensorMap.Builder subBuilder = null;
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder subBuilder = null;
               if (data_ != null) {
                 subBuilder = data_.toBuilder();
               }
-              data_ = input.readMessage(FlBaseProto.TensorMap.parser(), extensionRegistry);
+              data_ = input.readMessage(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(data_);
                 data_ = subBuilder.buildPartial();
@@ -12322,7 +12322,7 @@ public final class FGBoostServiceProto {
               break;
             }
             case 34: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               message_ = s;
               break;
@@ -12348,32 +12348,32 @@ public final class FGBoostServiceProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FGBoostServiceProto.internal_static_fgboost_EvaluateResponse_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_EvaluateResponse_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FGBoostServiceProto.internal_static_fgboost_EvaluateResponse_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_EvaluateResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              EvaluateResponse.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse.Builder.class);
     }
 
     public static final int RESPONSE_FIELD_NUMBER = 1;
-    private volatile Object response_;
+    private volatile java.lang.Object response_;
     /**
      * <code>string response = 1;</code>
      * @return The response.
      */
-    @Override
-    public String getResponse() {
-      Object ref = response_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getResponse() {
+      java.lang.Object ref = response_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         response_ = s;
         return s;
       }
@@ -12382,14 +12382,14 @@ public final class FGBoostServiceProto {
      * <code>string response = 1;</code>
      * @return The bytes for response.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getResponseBytes() {
-      Object ref = response_;
-      if (ref instanceof String) {
+      java.lang.Object ref = response_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         response_ = b;
         return b;
       } else {
@@ -12398,12 +12398,12 @@ public final class FGBoostServiceProto {
     }
 
     public static final int DATA_FIELD_NUMBER = 2;
-    private FlBaseProto.TensorMap data_;
+    private com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap data_;
     /**
      * <code>.TensorMap data = 2;</code>
      * @return Whether the data field is set.
      */
-    @Override
+    @java.lang.Override
     public boolean hasData() {
       return data_ != null;
     }
@@ -12411,15 +12411,15 @@ public final class FGBoostServiceProto {
      * <code>.TensorMap data = 2;</code>
      * @return The data.
      */
-    @Override
-    public FlBaseProto.TensorMap getData() {
-      return data_ == null ? FlBaseProto.TensorMap.getDefaultInstance() : data_;
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap getData() {
+      return data_ == null ? com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.getDefaultInstance() : data_;
     }
     /**
      * <code>.TensorMap data = 2;</code>
      */
-    @Override
-    public FlBaseProto.TensorMapOrBuilder getDataOrBuilder() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder getDataOrBuilder() {
       return getData();
     }
 
@@ -12429,26 +12429,26 @@ public final class FGBoostServiceProto {
      * <code>int32 code = 3;</code>
      * @return The code.
      */
-    @Override
+    @java.lang.Override
     public int getCode() {
       return code_;
     }
 
     public static final int MESSAGE_FIELD_NUMBER = 4;
-    private volatile Object message_;
+    private volatile java.lang.Object message_;
     /**
      * <code>string message = 4;</code>
      * @return The message.
      */
-    @Override
-    public String getMessage() {
-      Object ref = message_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getMessage() {
+      java.lang.Object ref = message_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         message_ = s;
         return s;
       }
@@ -12457,14 +12457,14 @@ public final class FGBoostServiceProto {
      * <code>string message = 4;</code>
      * @return The bytes for message.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getMessageBytes() {
-      Object ref = message_;
-      if (ref instanceof String) {
+      java.lang.Object ref = message_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         message_ = b;
         return b;
       } else {
@@ -12473,7 +12473,7 @@ public final class FGBoostServiceProto {
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -12483,7 +12483,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getResponseBytes().isEmpty()) {
@@ -12501,7 +12501,7 @@ public final class FGBoostServiceProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -12526,15 +12526,15 @@ public final class FGBoostServiceProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof EvaluateResponse)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse)) {
         return super.equals(obj);
       }
-      EvaluateResponse other = (EvaluateResponse) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse) obj;
 
       if (!getResponse()
           .equals(other.getResponse())) return false;
@@ -12551,7 +12551,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -12573,69 +12573,69 @@ public final class FGBoostServiceProto {
       return hash;
     }
 
-    public static EvaluateResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static EvaluateResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static EvaluateResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static EvaluateResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static EvaluateResponse parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static EvaluateResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static EvaluateResponse parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static EvaluateResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static EvaluateResponse parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static EvaluateResponse parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static EvaluateResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static EvaluateResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -12643,23 +12643,23 @@ public final class FGBoostServiceProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(EvaluateResponse prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -12669,18 +12669,18 @@ public final class FGBoostServiceProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:fgboost.EvaluateResponse)
-        EvaluateResponseOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FGBoostServiceProto.internal_static_fgboost_EvaluateResponse_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_EvaluateResponse_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FGBoostServiceProto.internal_static_fgboost_EvaluateResponse_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_EvaluateResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                EvaluateResponse.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse.newBuilder()
@@ -12689,7 +12689,7 @@ public final class FGBoostServiceProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -12698,7 +12698,7 @@ public final class FGBoostServiceProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         response_ = "";
@@ -12716,29 +12716,29 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FGBoostServiceProto.internal_static_fgboost_EvaluateResponse_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_EvaluateResponse_descriptor;
       }
 
-      @Override
-      public EvaluateResponse getDefaultInstanceForType() {
-        return EvaluateResponse.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse.getDefaultInstance();
       }
 
-      @Override
-      public EvaluateResponse build() {
-        EvaluateResponse result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public EvaluateResponse buildPartial() {
-        EvaluateResponse result = new EvaluateResponse(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse(this);
         result.response_ = response_;
         if (dataBuilder_ == null) {
           result.data_ = data_;
@@ -12751,50 +12751,50 @@ public final class FGBoostServiceProto {
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof EvaluateResponse) {
-          return mergeFrom((EvaluateResponse)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(EvaluateResponse other) {
-        if (other == EvaluateResponse.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse.getDefaultInstance()) return this;
         if (!other.getResponse().isEmpty()) {
           response_ = other.response_;
           onChanged();
@@ -12814,21 +12814,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        EvaluateResponse parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (EvaluateResponse) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -12838,21 +12838,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private Object response_ = "";
+      private java.lang.Object response_ = "";
       /**
        * <code>string response = 1;</code>
        * @return The response.
        */
-      public String getResponse() {
-        Object ref = response_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getResponse() {
+        java.lang.Object ref = response_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           response_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -12861,11 +12861,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getResponseBytes() {
-        Object ref = response_;
+        java.lang.Object ref = response_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           response_ = b;
           return b;
         } else {
@@ -12878,7 +12878,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setResponse(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -12914,9 +12914,9 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private FlBaseProto.TensorMap data_;
+      private com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap data_;
       private com.google.protobuf.SingleFieldBuilderV3<
-          FlBaseProto.TensorMap, FlBaseProto.TensorMap.Builder, FlBaseProto.TensorMapOrBuilder> dataBuilder_;
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder> dataBuilder_;
       /**
        * <code>.TensorMap data = 2;</code>
        * @return Whether the data field is set.
@@ -12928,9 +12928,9 @@ public final class FGBoostServiceProto {
        * <code>.TensorMap data = 2;</code>
        * @return The data.
        */
-      public FlBaseProto.TensorMap getData() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap getData() {
         if (dataBuilder_ == null) {
-          return data_ == null ? FlBaseProto.TensorMap.getDefaultInstance() : data_;
+          return data_ == null ? com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.getDefaultInstance() : data_;
         } else {
           return dataBuilder_.getMessage();
         }
@@ -12938,7 +12938,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>.TensorMap data = 2;</code>
        */
-      public Builder setData(FlBaseProto.TensorMap value) {
+      public Builder setData(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap value) {
         if (dataBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -12955,7 +12955,7 @@ public final class FGBoostServiceProto {
        * <code>.TensorMap data = 2;</code>
        */
       public Builder setData(
-          FlBaseProto.TensorMap.Builder builderForValue) {
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder builderForValue) {
         if (dataBuilder_ == null) {
           data_ = builderForValue.build();
           onChanged();
@@ -12968,11 +12968,11 @@ public final class FGBoostServiceProto {
       /**
        * <code>.TensorMap data = 2;</code>
        */
-      public Builder mergeData(FlBaseProto.TensorMap value) {
+      public Builder mergeData(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap value) {
         if (dataBuilder_ == null) {
           if (data_ != null) {
             data_ =
-              FlBaseProto.TensorMap.newBuilder(data_).mergeFrom(value).buildPartial();
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.newBuilder(data_).mergeFrom(value).buildPartial();
           } else {
             data_ = value;
           }
@@ -13000,7 +13000,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>.TensorMap data = 2;</code>
        */
-      public FlBaseProto.TensorMap.Builder getDataBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder getDataBuilder() {
         
         onChanged();
         return getDataFieldBuilder().getBuilder();
@@ -13008,23 +13008,23 @@ public final class FGBoostServiceProto {
       /**
        * <code>.TensorMap data = 2;</code>
        */
-      public FlBaseProto.TensorMapOrBuilder getDataOrBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder getDataOrBuilder() {
         if (dataBuilder_ != null) {
           return dataBuilder_.getMessageOrBuilder();
         } else {
           return data_ == null ?
-              FlBaseProto.TensorMap.getDefaultInstance() : data_;
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.getDefaultInstance() : data_;
         }
       }
       /**
        * <code>.TensorMap data = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
-          FlBaseProto.TensorMap, FlBaseProto.TensorMap.Builder, FlBaseProto.TensorMapOrBuilder>
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder> 
           getDataFieldBuilder() {
         if (dataBuilder_ == null) {
           dataBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              FlBaseProto.TensorMap, FlBaseProto.TensorMap.Builder, FlBaseProto.TensorMapOrBuilder>(
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder>(
                   getData(),
                   getParentForChildren(),
                   isClean());
@@ -13038,7 +13038,7 @@ public final class FGBoostServiceProto {
        * <code>int32 code = 3;</code>
        * @return The code.
        */
-      @Override
+      @java.lang.Override
       public int getCode() {
         return code_;
       }
@@ -13064,21 +13064,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private Object message_ = "";
+      private java.lang.Object message_ = "";
       /**
        * <code>string message = 4;</code>
        * @return The message.
        */
-      public String getMessage() {
-        Object ref = message_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getMessage() {
+        java.lang.Object ref = message_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           message_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -13087,11 +13087,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getMessageBytes() {
-        Object ref = message_;
+        java.lang.Object ref = message_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           message_ = b;
           return b;
         } else {
@@ -13104,7 +13104,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setMessage(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -13139,13 +13139,13 @@ public final class FGBoostServiceProto {
         onChanged();
         return this;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -13156,18 +13156,18 @@ public final class FGBoostServiceProto {
     }
 
     // @@protoc_insertion_point(class_scope:fgboost.EvaluateResponse)
-    private static final EvaluateResponse DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new EvaluateResponse();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse();
     }
 
-    public static EvaluateResponse getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<EvaluateResponse>
         PARSER = new com.google.protobuf.AbstractParser<EvaluateResponse>() {
-      @Override
+      @java.lang.Override
       public EvaluateResponse parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -13180,13 +13180,13 @@ public final class FGBoostServiceProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<EvaluateResponse> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public EvaluateResponse getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.EvaluateResponse getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -13200,7 +13200,7 @@ public final class FGBoostServiceProto {
      * <code>string clientuuid = 1;</code>
      * @return The clientuuid.
      */
-    String getClientuuid();
+    java.lang.String getClientuuid();
     /**
      * <code>string clientuuid = 1;</code>
      * @return The bytes for clientuuid.
@@ -13211,12 +13211,12 @@ public final class FGBoostServiceProto {
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
-    java.util.List<BoostEval>
+    java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval> 
         getTreeEvalList();
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
-    BoostEval getTreeEval(int index);
+    com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval getTreeEval(int index);
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
@@ -13224,12 +13224,12 @@ public final class FGBoostServiceProto {
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
-    java.util.List<? extends BoostEvalOrBuilder>
+    java.util.List<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder> 
         getTreeEvalOrBuilderList();
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
-    BoostEvalOrBuilder getTreeEvalOrBuilder(
+    com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder getTreeEvalOrBuilder(
         int index);
 
     /**
@@ -13261,14 +13261,14 @@ public final class FGBoostServiceProto {
       treeEval_ = java.util.Collections.emptyList();
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new PredictRequest();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -13279,7 +13279,7 @@ public final class FGBoostServiceProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
@@ -13293,18 +13293,18 @@ public final class FGBoostServiceProto {
               done = true;
               break;
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               clientuuid_ = s;
               break;
             }
             case 18: {
               if (!((mutable_bitField0_ & 0x00000001) != 0)) {
-                treeEval_ = new java.util.ArrayList<BoostEval>();
+                treeEval_ = new java.util.ArrayList<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval>();
                 mutable_bitField0_ |= 0x00000001;
               }
               treeEval_.add(
-                  input.readMessage(BoostEval.parser(), extensionRegistry));
+                  input.readMessage(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.parser(), extensionRegistry));
               break;
             }
             case 24: {
@@ -13341,32 +13341,32 @@ public final class FGBoostServiceProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FGBoostServiceProto.internal_static_fgboost_PredictRequest_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_PredictRequest_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FGBoostServiceProto.internal_static_fgboost_PredictRequest_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_PredictRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              PredictRequest.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest.Builder.class);
     }
 
     public static final int CLIENTUUID_FIELD_NUMBER = 1;
-    private volatile Object clientuuid_;
+    private volatile java.lang.Object clientuuid_;
     /**
      * <code>string clientuuid = 1;</code>
      * @return The clientuuid.
      */
-    @Override
-    public String getClientuuid() {
-      Object ref = clientuuid_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getClientuuid() {
+      java.lang.Object ref = clientuuid_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         clientuuid_ = s;
         return s;
       }
@@ -13375,14 +13375,14 @@ public final class FGBoostServiceProto {
      * <code>string clientuuid = 1;</code>
      * @return The bytes for clientuuid.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getClientuuidBytes() {
-      Object ref = clientuuid_;
-      if (ref instanceof String) {
+      java.lang.Object ref = clientuuid_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         clientuuid_ = b;
         return b;
       } else {
@@ -13391,41 +13391,41 @@ public final class FGBoostServiceProto {
     }
 
     public static final int TREEEVAL_FIELD_NUMBER = 2;
-    private java.util.List<BoostEval> treeEval_;
+    private java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval> treeEval_;
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
-    @Override
-    public java.util.List<BoostEval> getTreeEvalList() {
+    @java.lang.Override
+    public java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval> getTreeEvalList() {
       return treeEval_;
     }
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
-    @Override
-    public java.util.List<? extends BoostEvalOrBuilder>
+    @java.lang.Override
+    public java.util.List<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder> 
         getTreeEvalOrBuilderList() {
       return treeEval_;
     }
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
-    @Override
+    @java.lang.Override
     public int getTreeEvalCount() {
       return treeEval_.size();
     }
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
-    @Override
-    public BoostEval getTreeEval(int index) {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval getTreeEval(int index) {
       return treeEval_.get(index);
     }
     /**
      * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
      */
-    @Override
-    public BoostEvalOrBuilder getTreeEvalOrBuilder(
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder getTreeEvalOrBuilder(
         int index) {
       return treeEval_.get(index);
     }
@@ -13436,7 +13436,7 @@ public final class FGBoostServiceProto {
      * <code>int32 version = 3;</code>
      * @return The version.
      */
-    @Override
+    @java.lang.Override
     public int getVersion() {
       return version_;
     }
@@ -13447,13 +13447,13 @@ public final class FGBoostServiceProto {
      * <code>bool lastBatch = 4;</code>
      * @return The lastBatch.
      */
-    @Override
+    @java.lang.Override
     public boolean getLastBatch() {
       return lastBatch_;
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -13463,7 +13463,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getClientuuidBytes().isEmpty()) {
@@ -13481,7 +13481,7 @@ public final class FGBoostServiceProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -13507,15 +13507,15 @@ public final class FGBoostServiceProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof PredictRequest)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest)) {
         return super.equals(obj);
       }
-      PredictRequest other = (PredictRequest) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest) obj;
 
       if (!getClientuuid()
           .equals(other.getClientuuid())) return false;
@@ -13529,7 +13529,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -13552,69 +13552,69 @@ public final class FGBoostServiceProto {
       return hash;
     }
 
-    public static PredictRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static PredictRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static PredictRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static PredictRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static PredictRequest parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static PredictRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static PredictRequest parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static PredictRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static PredictRequest parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static PredictRequest parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static PredictRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static PredictRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -13622,23 +13622,23 @@ public final class FGBoostServiceProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(PredictRequest prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -13648,18 +13648,18 @@ public final class FGBoostServiceProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:fgboost.PredictRequest)
-        PredictRequestOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FGBoostServiceProto.internal_static_fgboost_PredictRequest_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_PredictRequest_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FGBoostServiceProto.internal_static_fgboost_PredictRequest_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_PredictRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                PredictRequest.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest.newBuilder()
@@ -13668,7 +13668,7 @@ public final class FGBoostServiceProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -13678,7 +13678,7 @@ public final class FGBoostServiceProto {
           getTreeEvalFieldBuilder();
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         clientuuid_ = "";
@@ -13696,29 +13696,29 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FGBoostServiceProto.internal_static_fgboost_PredictRequest_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_PredictRequest_descriptor;
       }
 
-      @Override
-      public PredictRequest getDefaultInstanceForType() {
-        return PredictRequest.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest.getDefaultInstance();
       }
 
-      @Override
-      public PredictRequest build() {
-        PredictRequest result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public PredictRequest buildPartial() {
-        PredictRequest result = new PredictRequest(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest(this);
         int from_bitField0_ = bitField0_;
         result.clientuuid_ = clientuuid_;
         if (treeEvalBuilder_ == null) {
@@ -13736,50 +13736,50 @@ public final class FGBoostServiceProto {
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof PredictRequest) {
-          return mergeFrom((PredictRequest)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(PredictRequest other) {
-        if (other == PredictRequest.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest.getDefaultInstance()) return this;
         if (!other.getClientuuid().isEmpty()) {
           clientuuid_ = other.clientuuid_;
           onChanged();
@@ -13821,21 +13821,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        PredictRequest parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (PredictRequest) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -13846,21 +13846,21 @@ public final class FGBoostServiceProto {
       }
       private int bitField0_;
 
-      private Object clientuuid_ = "";
+      private java.lang.Object clientuuid_ = "";
       /**
        * <code>string clientuuid = 1;</code>
        * @return The clientuuid.
        */
-      public String getClientuuid() {
-        Object ref = clientuuid_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getClientuuid() {
+        java.lang.Object ref = clientuuid_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           clientuuid_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -13869,11 +13869,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getClientuuidBytes() {
-        Object ref = clientuuid_;
+        java.lang.Object ref = clientuuid_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           clientuuid_ = b;
           return b;
         } else {
@@ -13886,7 +13886,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setClientuuid(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -13922,22 +13922,22 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private java.util.List<BoostEval> treeEval_ =
+      private java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval> treeEval_ =
         java.util.Collections.emptyList();
       private void ensureTreeEvalIsMutable() {
         if (!((bitField0_ & 0x00000001) != 0)) {
-          treeEval_ = new java.util.ArrayList<BoostEval>(treeEval_);
+          treeEval_ = new java.util.ArrayList<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval>(treeEval_);
           bitField0_ |= 0x00000001;
          }
       }
 
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          BoostEval, BoostEval.Builder, BoostEvalOrBuilder> treeEvalBuilder_;
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder> treeEvalBuilder_;
 
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
-      public java.util.List<BoostEval> getTreeEvalList() {
+      public java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval> getTreeEvalList() {
         if (treeEvalBuilder_ == null) {
           return java.util.Collections.unmodifiableList(treeEval_);
         } else {
@@ -13957,7 +13957,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
-      public BoostEval getTreeEval(int index) {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval getTreeEval(int index) {
         if (treeEvalBuilder_ == null) {
           return treeEval_.get(index);
         } else {
@@ -13968,7 +13968,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
       public Builder setTreeEval(
-          int index, BoostEval value) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval value) {
         if (treeEvalBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -13985,7 +13985,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
       public Builder setTreeEval(
-          int index, BoostEval.Builder builderForValue) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder builderForValue) {
         if (treeEvalBuilder_ == null) {
           ensureTreeEvalIsMutable();
           treeEval_.set(index, builderForValue.build());
@@ -13998,7 +13998,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
-      public Builder addTreeEval(BoostEval value) {
+      public Builder addTreeEval(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval value) {
         if (treeEvalBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -14015,7 +14015,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
       public Builder addTreeEval(
-          int index, BoostEval value) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval value) {
         if (treeEvalBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -14032,7 +14032,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
       public Builder addTreeEval(
-          BoostEval.Builder builderForValue) {
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder builderForValue) {
         if (treeEvalBuilder_ == null) {
           ensureTreeEvalIsMutable();
           treeEval_.add(builderForValue.build());
@@ -14046,7 +14046,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
       public Builder addTreeEval(
-          int index, BoostEval.Builder builderForValue) {
+          int index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder builderForValue) {
         if (treeEvalBuilder_ == null) {
           ensureTreeEvalIsMutable();
           treeEval_.add(index, builderForValue.build());
@@ -14060,7 +14060,7 @@ public final class FGBoostServiceProto {
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
       public Builder addAllTreeEval(
-          Iterable<? extends BoostEval> values) {
+          java.lang.Iterable<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval> values) {
         if (treeEvalBuilder_ == null) {
           ensureTreeEvalIsMutable();
           com.google.protobuf.AbstractMessageLite.Builder.addAll(
@@ -14100,14 +14100,14 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
-      public BoostEval.Builder getTreeEvalBuilder(
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder getTreeEvalBuilder(
           int index) {
         return getTreeEvalFieldBuilder().getBuilder(index);
       }
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
-      public BoostEvalOrBuilder getTreeEvalOrBuilder(
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder getTreeEvalOrBuilder(
           int index) {
         if (treeEvalBuilder_ == null) {
           return treeEval_.get(index);  } else {
@@ -14117,7 +14117,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
-      public java.util.List<? extends BoostEvalOrBuilder>
+      public java.util.List<? extends com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder> 
            getTreeEvalOrBuilderList() {
         if (treeEvalBuilder_ != null) {
           return treeEvalBuilder_.getMessageOrBuilderList();
@@ -14128,31 +14128,31 @@ public final class FGBoostServiceProto {
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
-      public BoostEval.Builder addTreeEvalBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder addTreeEvalBuilder() {
         return getTreeEvalFieldBuilder().addBuilder(
-            BoostEval.getDefaultInstance());
+            com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.getDefaultInstance());
       }
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
-      public BoostEval.Builder addTreeEvalBuilder(
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder addTreeEvalBuilder(
           int index) {
         return getTreeEvalFieldBuilder().addBuilder(
-            index, BoostEval.getDefaultInstance());
+            index, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.getDefaultInstance());
       }
       /**
        * <code>repeated .fgboost.BoostEval treeEval = 2;</code>
        */
-      public java.util.List<BoostEval.Builder>
+      public java.util.List<com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder> 
            getTreeEvalBuilderList() {
         return getTreeEvalFieldBuilder().getBuilderList();
       }
       private com.google.protobuf.RepeatedFieldBuilderV3<
-          BoostEval, BoostEval.Builder, BoostEvalOrBuilder>
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder> 
           getTreeEvalFieldBuilder() {
         if (treeEvalBuilder_ == null) {
           treeEvalBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
-              BoostEval, BoostEval.Builder, BoostEvalOrBuilder>(
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEval.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.BoostEvalOrBuilder>(
                   treeEval_,
                   ((bitField0_ & 0x00000001) != 0),
                   getParentForChildren(),
@@ -14167,7 +14167,7 @@ public final class FGBoostServiceProto {
        * <code>int32 version = 3;</code>
        * @return The version.
        */
-      @Override
+      @java.lang.Override
       public int getVersion() {
         return version_;
       }
@@ -14198,7 +14198,7 @@ public final class FGBoostServiceProto {
        * <code>bool lastBatch = 4;</code>
        * @return The lastBatch.
        */
-      @Override
+      @java.lang.Override
       public boolean getLastBatch() {
         return lastBatch_;
       }
@@ -14223,13 +14223,13 @@ public final class FGBoostServiceProto {
         onChanged();
         return this;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -14240,18 +14240,18 @@ public final class FGBoostServiceProto {
     }
 
     // @@protoc_insertion_point(class_scope:fgboost.PredictRequest)
-    private static final PredictRequest DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new PredictRequest();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest();
     }
 
-    public static PredictRequest getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<PredictRequest>
         PARSER = new com.google.protobuf.AbstractParser<PredictRequest>() {
-      @Override
+      @java.lang.Override
       public PredictRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -14264,13 +14264,13 @@ public final class FGBoostServiceProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<PredictRequest> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public PredictRequest getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -14284,7 +14284,7 @@ public final class FGBoostServiceProto {
      * <code>string clientuuid = 1;</code>
      * @return The clientuuid.
      */
-    String getClientuuid();
+    java.lang.String getClientuuid();
     /**
      * <code>string clientuuid = 1;</code>
      * @return The bytes for clientuuid.
@@ -14301,11 +14301,11 @@ public final class FGBoostServiceProto {
      * <code>.fgboost.DataSplit split = 2;</code>
      * @return The split.
      */
-    DataSplit getSplit();
+    com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit getSplit();
     /**
      * <code>.fgboost.DataSplit split = 2;</code>
      */
-    DataSplitOrBuilder getSplitOrBuilder();
+    com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplitOrBuilder getSplitOrBuilder();
   }
   /**
    * Protobuf type {@code fgboost.SplitRequest}
@@ -14323,14 +14323,14 @@ public final class FGBoostServiceProto {
       clientuuid_ = "";
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new SplitRequest();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -14341,7 +14341,7 @@ public final class FGBoostServiceProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -14354,17 +14354,17 @@ public final class FGBoostServiceProto {
               done = true;
               break;
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               clientuuid_ = s;
               break;
             }
             case 18: {
-              DataSplit.Builder subBuilder = null;
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.Builder subBuilder = null;
               if (split_ != null) {
                 subBuilder = split_.toBuilder();
               }
-              split_ = input.readMessage(DataSplit.parser(), extensionRegistry);
+              split_ = input.readMessage(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(split_);
                 split_ = subBuilder.buildPartial();
@@ -14393,32 +14393,32 @@ public final class FGBoostServiceProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FGBoostServiceProto.internal_static_fgboost_SplitRequest_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SplitRequest_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FGBoostServiceProto.internal_static_fgboost_SplitRequest_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SplitRequest_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              SplitRequest.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest.Builder.class);
     }
 
     public static final int CLIENTUUID_FIELD_NUMBER = 1;
-    private volatile Object clientuuid_;
+    private volatile java.lang.Object clientuuid_;
     /**
      * <code>string clientuuid = 1;</code>
      * @return The clientuuid.
      */
-    @Override
-    public String getClientuuid() {
-      Object ref = clientuuid_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getClientuuid() {
+      java.lang.Object ref = clientuuid_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         clientuuid_ = s;
         return s;
       }
@@ -14427,14 +14427,14 @@ public final class FGBoostServiceProto {
      * <code>string clientuuid = 1;</code>
      * @return The bytes for clientuuid.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getClientuuidBytes() {
-      Object ref = clientuuid_;
-      if (ref instanceof String) {
+      java.lang.Object ref = clientuuid_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         clientuuid_ = b;
         return b;
       } else {
@@ -14443,12 +14443,12 @@ public final class FGBoostServiceProto {
     }
 
     public static final int SPLIT_FIELD_NUMBER = 2;
-    private DataSplit split_;
+    private com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit split_;
     /**
      * <code>.fgboost.DataSplit split = 2;</code>
      * @return Whether the split field is set.
      */
-    @Override
+    @java.lang.Override
     public boolean hasSplit() {
       return split_ != null;
     }
@@ -14456,20 +14456,20 @@ public final class FGBoostServiceProto {
      * <code>.fgboost.DataSplit split = 2;</code>
      * @return The split.
      */
-    @Override
-    public DataSplit getSplit() {
-      return split_ == null ? DataSplit.getDefaultInstance() : split_;
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit getSplit() {
+      return split_ == null ? com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.getDefaultInstance() : split_;
     }
     /**
      * <code>.fgboost.DataSplit split = 2;</code>
      */
-    @Override
-    public DataSplitOrBuilder getSplitOrBuilder() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplitOrBuilder getSplitOrBuilder() {
       return getSplit();
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -14479,7 +14479,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getClientuuidBytes().isEmpty()) {
@@ -14491,7 +14491,7 @@ public final class FGBoostServiceProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -14509,15 +14509,15 @@ public final class FGBoostServiceProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof SplitRequest)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest)) {
         return super.equals(obj);
       }
-      SplitRequest other = (SplitRequest) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest) obj;
 
       if (!getClientuuid()
           .equals(other.getClientuuid())) return false;
@@ -14530,7 +14530,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -14548,69 +14548,69 @@ public final class FGBoostServiceProto {
       return hash;
     }
 
-    public static SplitRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static SplitRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static SplitRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static SplitRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static SplitRequest parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static SplitRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static SplitRequest parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static SplitRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static SplitRequest parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static SplitRequest parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static SplitRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static SplitRequest parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -14618,23 +14618,23 @@ public final class FGBoostServiceProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(SplitRequest prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -14644,18 +14644,18 @@ public final class FGBoostServiceProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:fgboost.SplitRequest)
-        SplitRequestOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequestOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FGBoostServiceProto.internal_static_fgboost_SplitRequest_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SplitRequest_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FGBoostServiceProto.internal_static_fgboost_SplitRequest_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SplitRequest_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                SplitRequest.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest.newBuilder()
@@ -14664,7 +14664,7 @@ public final class FGBoostServiceProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -14673,7 +14673,7 @@ public final class FGBoostServiceProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         clientuuid_ = "";
@@ -14687,29 +14687,29 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FGBoostServiceProto.internal_static_fgboost_SplitRequest_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SplitRequest_descriptor;
       }
 
-      @Override
-      public SplitRequest getDefaultInstanceForType() {
-        return SplitRequest.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest.getDefaultInstance();
       }
 
-      @Override
-      public SplitRequest build() {
-        SplitRequest result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public SplitRequest buildPartial() {
-        SplitRequest result = new SplitRequest(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest(this);
         result.clientuuid_ = clientuuid_;
         if (splitBuilder_ == null) {
           result.split_ = split_;
@@ -14720,50 +14720,50 @@ public final class FGBoostServiceProto {
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof SplitRequest) {
-          return mergeFrom((SplitRequest)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(SplitRequest other) {
-        if (other == SplitRequest.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest.getDefaultInstance()) return this;
         if (!other.getClientuuid().isEmpty()) {
           clientuuid_ = other.clientuuid_;
           onChanged();
@@ -14776,21 +14776,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        SplitRequest parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (SplitRequest) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -14800,21 +14800,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private Object clientuuid_ = "";
+      private java.lang.Object clientuuid_ = "";
       /**
        * <code>string clientuuid = 1;</code>
        * @return The clientuuid.
        */
-      public String getClientuuid() {
-        Object ref = clientuuid_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getClientuuid() {
+        java.lang.Object ref = clientuuid_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           clientuuid_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -14823,11 +14823,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getClientuuidBytes() {
-        Object ref = clientuuid_;
+        java.lang.Object ref = clientuuid_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           clientuuid_ = b;
           return b;
         } else {
@@ -14840,7 +14840,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setClientuuid(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -14876,9 +14876,9 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private DataSplit split_;
+      private com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit split_;
       private com.google.protobuf.SingleFieldBuilderV3<
-          DataSplit, DataSplit.Builder, DataSplitOrBuilder> splitBuilder_;
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplitOrBuilder> splitBuilder_;
       /**
        * <code>.fgboost.DataSplit split = 2;</code>
        * @return Whether the split field is set.
@@ -14890,9 +14890,9 @@ public final class FGBoostServiceProto {
        * <code>.fgboost.DataSplit split = 2;</code>
        * @return The split.
        */
-      public DataSplit getSplit() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit getSplit() {
         if (splitBuilder_ == null) {
-          return split_ == null ? DataSplit.getDefaultInstance() : split_;
+          return split_ == null ? com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.getDefaultInstance() : split_;
         } else {
           return splitBuilder_.getMessage();
         }
@@ -14900,7 +14900,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>.fgboost.DataSplit split = 2;</code>
        */
-      public Builder setSplit(DataSplit value) {
+      public Builder setSplit(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit value) {
         if (splitBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -14917,7 +14917,7 @@ public final class FGBoostServiceProto {
        * <code>.fgboost.DataSplit split = 2;</code>
        */
       public Builder setSplit(
-          DataSplit.Builder builderForValue) {
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.Builder builderForValue) {
         if (splitBuilder_ == null) {
           split_ = builderForValue.build();
           onChanged();
@@ -14930,11 +14930,11 @@ public final class FGBoostServiceProto {
       /**
        * <code>.fgboost.DataSplit split = 2;</code>
        */
-      public Builder mergeSplit(DataSplit value) {
+      public Builder mergeSplit(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit value) {
         if (splitBuilder_ == null) {
           if (split_ != null) {
             split_ =
-              DataSplit.newBuilder(split_).mergeFrom(value).buildPartial();
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.newBuilder(split_).mergeFrom(value).buildPartial();
           } else {
             split_ = value;
           }
@@ -14962,7 +14962,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>.fgboost.DataSplit split = 2;</code>
        */
-      public DataSplit.Builder getSplitBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.Builder getSplitBuilder() {
         
         onChanged();
         return getSplitFieldBuilder().getBuilder();
@@ -14970,23 +14970,23 @@ public final class FGBoostServiceProto {
       /**
        * <code>.fgboost.DataSplit split = 2;</code>
        */
-      public DataSplitOrBuilder getSplitOrBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplitOrBuilder getSplitOrBuilder() {
         if (splitBuilder_ != null) {
           return splitBuilder_.getMessageOrBuilder();
         } else {
           return split_ == null ?
-              DataSplit.getDefaultInstance() : split_;
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.getDefaultInstance() : split_;
         }
       }
       /**
        * <code>.fgboost.DataSplit split = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
-          DataSplit, DataSplit.Builder, DataSplitOrBuilder>
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplitOrBuilder> 
           getSplitFieldBuilder() {
         if (splitBuilder_ == null) {
           splitBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              DataSplit, DataSplit.Builder, DataSplitOrBuilder>(
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplitOrBuilder>(
                   getSplit(),
                   getParentForChildren(),
                   isClean());
@@ -14994,13 +14994,13 @@ public final class FGBoostServiceProto {
         }
         return splitBuilder_;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -15011,18 +15011,18 @@ public final class FGBoostServiceProto {
     }
 
     // @@protoc_insertion_point(class_scope:fgboost.SplitRequest)
-    private static final SplitRequest DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new SplitRequest();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest();
     }
 
-    public static SplitRequest getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<SplitRequest>
         PARSER = new com.google.protobuf.AbstractParser<SplitRequest>() {
-      @Override
+      @java.lang.Override
       public SplitRequest parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -15035,13 +15035,13 @@ public final class FGBoostServiceProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<SplitRequest> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public SplitRequest getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitRequest getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -15055,7 +15055,7 @@ public final class FGBoostServiceProto {
      * <code>string response = 1;</code>
      * @return The response.
      */
-    String getResponse();
+    java.lang.String getResponse();
     /**
      * <code>string response = 1;</code>
      * @return The bytes for response.
@@ -15072,11 +15072,11 @@ public final class FGBoostServiceProto {
      * <code>.TensorMap data = 2;</code>
      * @return The data.
      */
-    FlBaseProto.TensorMap getData();
+    com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap getData();
     /**
      * <code>.TensorMap data = 2;</code>
      */
-    FlBaseProto.TensorMapOrBuilder getDataOrBuilder();
+    com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder getDataOrBuilder();
 
     /**
      * <code>int32 code = 3;</code>
@@ -15100,14 +15100,14 @@ public final class FGBoostServiceProto {
       response_ = "";
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new PredictResponse();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -15118,7 +15118,7 @@ public final class FGBoostServiceProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -15131,17 +15131,17 @@ public final class FGBoostServiceProto {
               done = true;
               break;
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               response_ = s;
               break;
             }
             case 18: {
-              FlBaseProto.TensorMap.Builder subBuilder = null;
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder subBuilder = null;
               if (data_ != null) {
                 subBuilder = data_.toBuilder();
               }
-              data_ = input.readMessage(FlBaseProto.TensorMap.parser(), extensionRegistry);
+              data_ = input.readMessage(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(data_);
                 data_ = subBuilder.buildPartial();
@@ -15175,32 +15175,32 @@ public final class FGBoostServiceProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FGBoostServiceProto.internal_static_fgboost_PredictResponse_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_PredictResponse_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FGBoostServiceProto.internal_static_fgboost_PredictResponse_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_PredictResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              PredictResponse.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse.Builder.class);
     }
 
     public static final int RESPONSE_FIELD_NUMBER = 1;
-    private volatile Object response_;
+    private volatile java.lang.Object response_;
     /**
      * <code>string response = 1;</code>
      * @return The response.
      */
-    @Override
-    public String getResponse() {
-      Object ref = response_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getResponse() {
+      java.lang.Object ref = response_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         response_ = s;
         return s;
       }
@@ -15209,14 +15209,14 @@ public final class FGBoostServiceProto {
      * <code>string response = 1;</code>
      * @return The bytes for response.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getResponseBytes() {
-      Object ref = response_;
-      if (ref instanceof String) {
+      java.lang.Object ref = response_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         response_ = b;
         return b;
       } else {
@@ -15225,12 +15225,12 @@ public final class FGBoostServiceProto {
     }
 
     public static final int DATA_FIELD_NUMBER = 2;
-    private FlBaseProto.TensorMap data_;
+    private com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap data_;
     /**
      * <code>.TensorMap data = 2;</code>
      * @return Whether the data field is set.
      */
-    @Override
+    @java.lang.Override
     public boolean hasData() {
       return data_ != null;
     }
@@ -15238,15 +15238,15 @@ public final class FGBoostServiceProto {
      * <code>.TensorMap data = 2;</code>
      * @return The data.
      */
-    @Override
-    public FlBaseProto.TensorMap getData() {
-      return data_ == null ? FlBaseProto.TensorMap.getDefaultInstance() : data_;
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap getData() {
+      return data_ == null ? com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.getDefaultInstance() : data_;
     }
     /**
      * <code>.TensorMap data = 2;</code>
      */
-    @Override
-    public FlBaseProto.TensorMapOrBuilder getDataOrBuilder() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder getDataOrBuilder() {
       return getData();
     }
 
@@ -15256,13 +15256,13 @@ public final class FGBoostServiceProto {
      * <code>int32 code = 3;</code>
      * @return The code.
      */
-    @Override
+    @java.lang.Override
     public int getCode() {
       return code_;
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -15272,7 +15272,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getResponseBytes().isEmpty()) {
@@ -15287,7 +15287,7 @@ public final class FGBoostServiceProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -15309,15 +15309,15 @@ public final class FGBoostServiceProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof PredictResponse)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse)) {
         return super.equals(obj);
       }
-      PredictResponse other = (PredictResponse) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse) obj;
 
       if (!getResponse()
           .equals(other.getResponse())) return false;
@@ -15332,7 +15332,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -15352,69 +15352,69 @@ public final class FGBoostServiceProto {
       return hash;
     }
 
-    public static PredictResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static PredictResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static PredictResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static PredictResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static PredictResponse parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static PredictResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static PredictResponse parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static PredictResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static PredictResponse parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static PredictResponse parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static PredictResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static PredictResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -15422,23 +15422,23 @@ public final class FGBoostServiceProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(PredictResponse prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -15448,18 +15448,18 @@ public final class FGBoostServiceProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:fgboost.PredictResponse)
-        PredictResponseOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FGBoostServiceProto.internal_static_fgboost_PredictResponse_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_PredictResponse_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FGBoostServiceProto.internal_static_fgboost_PredictResponse_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_PredictResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                PredictResponse.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse.newBuilder()
@@ -15468,7 +15468,7 @@ public final class FGBoostServiceProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -15477,7 +15477,7 @@ public final class FGBoostServiceProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         response_ = "";
@@ -15493,29 +15493,29 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FGBoostServiceProto.internal_static_fgboost_PredictResponse_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_PredictResponse_descriptor;
       }
 
-      @Override
-      public PredictResponse getDefaultInstanceForType() {
-        return PredictResponse.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse.getDefaultInstance();
       }
 
-      @Override
-      public PredictResponse build() {
-        PredictResponse result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public PredictResponse buildPartial() {
-        PredictResponse result = new PredictResponse(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse(this);
         result.response_ = response_;
         if (dataBuilder_ == null) {
           result.data_ = data_;
@@ -15527,50 +15527,50 @@ public final class FGBoostServiceProto {
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof PredictResponse) {
-          return mergeFrom((PredictResponse)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(PredictResponse other) {
-        if (other == PredictResponse.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse.getDefaultInstance()) return this;
         if (!other.getResponse().isEmpty()) {
           response_ = other.response_;
           onChanged();
@@ -15586,21 +15586,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        PredictResponse parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (PredictResponse) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -15610,21 +15610,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private Object response_ = "";
+      private java.lang.Object response_ = "";
       /**
        * <code>string response = 1;</code>
        * @return The response.
        */
-      public String getResponse() {
-        Object ref = response_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getResponse() {
+        java.lang.Object ref = response_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           response_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -15633,11 +15633,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getResponseBytes() {
-        Object ref = response_;
+        java.lang.Object ref = response_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           response_ = b;
           return b;
         } else {
@@ -15650,7 +15650,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setResponse(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -15686,9 +15686,9 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private FlBaseProto.TensorMap data_;
+      private com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap data_;
       private com.google.protobuf.SingleFieldBuilderV3<
-          FlBaseProto.TensorMap, FlBaseProto.TensorMap.Builder, FlBaseProto.TensorMapOrBuilder> dataBuilder_;
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder> dataBuilder_;
       /**
        * <code>.TensorMap data = 2;</code>
        * @return Whether the data field is set.
@@ -15700,9 +15700,9 @@ public final class FGBoostServiceProto {
        * <code>.TensorMap data = 2;</code>
        * @return The data.
        */
-      public FlBaseProto.TensorMap getData() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap getData() {
         if (dataBuilder_ == null) {
-          return data_ == null ? FlBaseProto.TensorMap.getDefaultInstance() : data_;
+          return data_ == null ? com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.getDefaultInstance() : data_;
         } else {
           return dataBuilder_.getMessage();
         }
@@ -15710,7 +15710,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>.TensorMap data = 2;</code>
        */
-      public Builder setData(FlBaseProto.TensorMap value) {
+      public Builder setData(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap value) {
         if (dataBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -15727,7 +15727,7 @@ public final class FGBoostServiceProto {
        * <code>.TensorMap data = 2;</code>
        */
       public Builder setData(
-          FlBaseProto.TensorMap.Builder builderForValue) {
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder builderForValue) {
         if (dataBuilder_ == null) {
           data_ = builderForValue.build();
           onChanged();
@@ -15740,11 +15740,11 @@ public final class FGBoostServiceProto {
       /**
        * <code>.TensorMap data = 2;</code>
        */
-      public Builder mergeData(FlBaseProto.TensorMap value) {
+      public Builder mergeData(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap value) {
         if (dataBuilder_ == null) {
           if (data_ != null) {
             data_ =
-              FlBaseProto.TensorMap.newBuilder(data_).mergeFrom(value).buildPartial();
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.newBuilder(data_).mergeFrom(value).buildPartial();
           } else {
             data_ = value;
           }
@@ -15772,7 +15772,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>.TensorMap data = 2;</code>
        */
-      public FlBaseProto.TensorMap.Builder getDataBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder getDataBuilder() {
         
         onChanged();
         return getDataFieldBuilder().getBuilder();
@@ -15780,23 +15780,23 @@ public final class FGBoostServiceProto {
       /**
        * <code>.TensorMap data = 2;</code>
        */
-      public FlBaseProto.TensorMapOrBuilder getDataOrBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder getDataOrBuilder() {
         if (dataBuilder_ != null) {
           return dataBuilder_.getMessageOrBuilder();
         } else {
           return data_ == null ?
-              FlBaseProto.TensorMap.getDefaultInstance() : data_;
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.getDefaultInstance() : data_;
         }
       }
       /**
        * <code>.TensorMap data = 2;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
-          FlBaseProto.TensorMap, FlBaseProto.TensorMap.Builder, FlBaseProto.TensorMapOrBuilder>
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder> 
           getDataFieldBuilder() {
         if (dataBuilder_ == null) {
           dataBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              FlBaseProto.TensorMap, FlBaseProto.TensorMap.Builder, FlBaseProto.TensorMapOrBuilder>(
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder>(
                   getData(),
                   getParentForChildren(),
                   isClean());
@@ -15810,7 +15810,7 @@ public final class FGBoostServiceProto {
        * <code>int32 code = 3;</code>
        * @return The code.
        */
-      @Override
+      @java.lang.Override
       public int getCode() {
         return code_;
       }
@@ -15835,13 +15835,13 @@ public final class FGBoostServiceProto {
         onChanged();
         return this;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -15852,18 +15852,18 @@ public final class FGBoostServiceProto {
     }
 
     // @@protoc_insertion_point(class_scope:fgboost.PredictResponse)
-    private static final PredictResponse DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new PredictResponse();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse();
     }
 
-    public static PredictResponse getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<PredictResponse>
         PARSER = new com.google.protobuf.AbstractParser<PredictResponse>() {
-      @Override
+      @java.lang.Override
       public PredictResponse parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -15876,13 +15876,13 @@ public final class FGBoostServiceProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<PredictResponse> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public PredictResponse getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.PredictResponse getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -15901,17 +15901,17 @@ public final class FGBoostServiceProto {
      * <code>.fgboost.DataSplit split = 1;</code>
      * @return The split.
      */
-    DataSplit getSplit();
+    com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit getSplit();
     /**
      * <code>.fgboost.DataSplit split = 1;</code>
      */
-    DataSplitOrBuilder getSplitOrBuilder();
+    com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplitOrBuilder getSplitOrBuilder();
 
     /**
      * <code>string response = 2;</code>
      * @return The response.
      */
-    String getResponse();
+    java.lang.String getResponse();
     /**
      * <code>string response = 2;</code>
      * @return The bytes for response.
@@ -15941,14 +15941,14 @@ public final class FGBoostServiceProto {
       response_ = "";
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new SplitResponse();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -15959,7 +15959,7 @@ public final class FGBoostServiceProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -15972,11 +15972,11 @@ public final class FGBoostServiceProto {
               done = true;
               break;
             case 10: {
-              DataSplit.Builder subBuilder = null;
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.Builder subBuilder = null;
               if (split_ != null) {
                 subBuilder = split_.toBuilder();
               }
-              split_ = input.readMessage(DataSplit.parser(), extensionRegistry);
+              split_ = input.readMessage(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(split_);
                 split_ = subBuilder.buildPartial();
@@ -15985,7 +15985,7 @@ public final class FGBoostServiceProto {
               break;
             }
             case 18: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               response_ = s;
               break;
@@ -16016,24 +16016,24 @@ public final class FGBoostServiceProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FGBoostServiceProto.internal_static_fgboost_SplitResponse_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SplitResponse_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FGBoostServiceProto.internal_static_fgboost_SplitResponse_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SplitResponse_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              SplitResponse.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse.Builder.class);
     }
 
     public static final int SPLIT_FIELD_NUMBER = 1;
-    private DataSplit split_;
+    private com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit split_;
     /**
      * <code>.fgboost.DataSplit split = 1;</code>
      * @return Whether the split field is set.
      */
-    @Override
+    @java.lang.Override
     public boolean hasSplit() {
       return split_ != null;
     }
@@ -16041,33 +16041,33 @@ public final class FGBoostServiceProto {
      * <code>.fgboost.DataSplit split = 1;</code>
      * @return The split.
      */
-    @Override
-    public DataSplit getSplit() {
-      return split_ == null ? DataSplit.getDefaultInstance() : split_;
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit getSplit() {
+      return split_ == null ? com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.getDefaultInstance() : split_;
     }
     /**
      * <code>.fgboost.DataSplit split = 1;</code>
      */
-    @Override
-    public DataSplitOrBuilder getSplitOrBuilder() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplitOrBuilder getSplitOrBuilder() {
       return getSplit();
     }
 
     public static final int RESPONSE_FIELD_NUMBER = 2;
-    private volatile Object response_;
+    private volatile java.lang.Object response_;
     /**
      * <code>string response = 2;</code>
      * @return The response.
      */
-    @Override
-    public String getResponse() {
-      Object ref = response_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getResponse() {
+      java.lang.Object ref = response_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         response_ = s;
         return s;
       }
@@ -16076,14 +16076,14 @@ public final class FGBoostServiceProto {
      * <code>string response = 2;</code>
      * @return The bytes for response.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getResponseBytes() {
-      Object ref = response_;
-      if (ref instanceof String) {
+      java.lang.Object ref = response_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         response_ = b;
         return b;
       } else {
@@ -16097,13 +16097,13 @@ public final class FGBoostServiceProto {
      * <code>int32 code = 3;</code>
      * @return The code.
      */
-    @Override
+    @java.lang.Override
     public int getCode() {
       return code_;
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -16113,7 +16113,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (split_ != null) {
@@ -16128,7 +16128,7 @@ public final class FGBoostServiceProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -16150,15 +16150,15 @@ public final class FGBoostServiceProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof SplitResponse)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse)) {
         return super.equals(obj);
       }
-      SplitResponse other = (SplitResponse) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse) obj;
 
       if (hasSplit() != other.hasSplit()) return false;
       if (hasSplit()) {
@@ -16173,7 +16173,7 @@ public final class FGBoostServiceProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -16193,69 +16193,69 @@ public final class FGBoostServiceProto {
       return hash;
     }
 
-    public static SplitResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static SplitResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static SplitResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static SplitResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static SplitResponse parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static SplitResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static SplitResponse parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static SplitResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static SplitResponse parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static SplitResponse parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static SplitResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static SplitResponse parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -16263,23 +16263,23 @@ public final class FGBoostServiceProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(SplitResponse prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -16289,18 +16289,18 @@ public final class FGBoostServiceProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:fgboost.SplitResponse)
-        SplitResponseOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponseOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FGBoostServiceProto.internal_static_fgboost_SplitResponse_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SplitResponse_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FGBoostServiceProto.internal_static_fgboost_SplitResponse_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SplitResponse_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                SplitResponse.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse.newBuilder()
@@ -16309,7 +16309,7 @@ public final class FGBoostServiceProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -16318,7 +16318,7 @@ public final class FGBoostServiceProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (splitBuilder_ == null) {
@@ -16334,29 +16334,29 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FGBoostServiceProto.internal_static_fgboost_SplitResponse_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SplitResponse_descriptor;
       }
 
-      @Override
-      public SplitResponse getDefaultInstanceForType() {
-        return SplitResponse.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse.getDefaultInstance();
       }
 
-      @Override
-      public SplitResponse build() {
-        SplitResponse result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public SplitResponse buildPartial() {
-        SplitResponse result = new SplitResponse(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse(this);
         if (splitBuilder_ == null) {
           result.split_ = split_;
         } else {
@@ -16368,50 +16368,50 @@ public final class FGBoostServiceProto {
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof SplitResponse) {
-          return mergeFrom((SplitResponse)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(SplitResponse other) {
-        if (other == SplitResponse.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse.getDefaultInstance()) return this;
         if (other.hasSplit()) {
           mergeSplit(other.getSplit());
         }
@@ -16427,21 +16427,21 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        SplitResponse parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (SplitResponse) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -16451,9 +16451,9 @@ public final class FGBoostServiceProto {
         return this;
       }
 
-      private DataSplit split_;
+      private com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit split_;
       private com.google.protobuf.SingleFieldBuilderV3<
-          DataSplit, DataSplit.Builder, DataSplitOrBuilder> splitBuilder_;
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplitOrBuilder> splitBuilder_;
       /**
        * <code>.fgboost.DataSplit split = 1;</code>
        * @return Whether the split field is set.
@@ -16465,9 +16465,9 @@ public final class FGBoostServiceProto {
        * <code>.fgboost.DataSplit split = 1;</code>
        * @return The split.
        */
-      public DataSplit getSplit() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit getSplit() {
         if (splitBuilder_ == null) {
-          return split_ == null ? DataSplit.getDefaultInstance() : split_;
+          return split_ == null ? com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.getDefaultInstance() : split_;
         } else {
           return splitBuilder_.getMessage();
         }
@@ -16475,7 +16475,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>.fgboost.DataSplit split = 1;</code>
        */
-      public Builder setSplit(DataSplit value) {
+      public Builder setSplit(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit value) {
         if (splitBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -16492,7 +16492,7 @@ public final class FGBoostServiceProto {
        * <code>.fgboost.DataSplit split = 1;</code>
        */
       public Builder setSplit(
-          DataSplit.Builder builderForValue) {
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.Builder builderForValue) {
         if (splitBuilder_ == null) {
           split_ = builderForValue.build();
           onChanged();
@@ -16505,11 +16505,11 @@ public final class FGBoostServiceProto {
       /**
        * <code>.fgboost.DataSplit split = 1;</code>
        */
-      public Builder mergeSplit(DataSplit value) {
+      public Builder mergeSplit(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit value) {
         if (splitBuilder_ == null) {
           if (split_ != null) {
             split_ =
-              DataSplit.newBuilder(split_).mergeFrom(value).buildPartial();
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.newBuilder(split_).mergeFrom(value).buildPartial();
           } else {
             split_ = value;
           }
@@ -16537,7 +16537,7 @@ public final class FGBoostServiceProto {
       /**
        * <code>.fgboost.DataSplit split = 1;</code>
        */
-      public DataSplit.Builder getSplitBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.Builder getSplitBuilder() {
         
         onChanged();
         return getSplitFieldBuilder().getBuilder();
@@ -16545,23 +16545,23 @@ public final class FGBoostServiceProto {
       /**
        * <code>.fgboost.DataSplit split = 1;</code>
        */
-      public DataSplitOrBuilder getSplitOrBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplitOrBuilder getSplitOrBuilder() {
         if (splitBuilder_ != null) {
           return splitBuilder_.getMessageOrBuilder();
         } else {
           return split_ == null ?
-              DataSplit.getDefaultInstance() : split_;
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.getDefaultInstance() : split_;
         }
       }
       /**
        * <code>.fgboost.DataSplit split = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
-          DataSplit, DataSplit.Builder, DataSplitOrBuilder>
+          com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplitOrBuilder> 
           getSplitFieldBuilder() {
         if (splitBuilder_ == null) {
           splitBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              DataSplit, DataSplit.Builder, DataSplitOrBuilder>(
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplit.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.DataSplitOrBuilder>(
                   getSplit(),
                   getParentForChildren(),
                   isClean());
@@ -16570,21 +16570,21 @@ public final class FGBoostServiceProto {
         return splitBuilder_;
       }
 
-      private Object response_ = "";
+      private java.lang.Object response_ = "";
       /**
        * <code>string response = 2;</code>
        * @return The response.
        */
-      public String getResponse() {
-        Object ref = response_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getResponse() {
+        java.lang.Object ref = response_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           response_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -16593,11 +16593,11 @@ public final class FGBoostServiceProto {
        */
       public com.google.protobuf.ByteString
           getResponseBytes() {
-        Object ref = response_;
+        java.lang.Object ref = response_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           response_ = b;
           return b;
         } else {
@@ -16610,7 +16610,7 @@ public final class FGBoostServiceProto {
        * @return This builder for chaining.
        */
       public Builder setResponse(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -16651,7 +16651,7 @@ public final class FGBoostServiceProto {
        * <code>int32 code = 3;</code>
        * @return The code.
        */
-      @Override
+      @java.lang.Override
       public int getCode() {
         return code_;
       }
@@ -16676,13 +16676,13 @@ public final class FGBoostServiceProto {
         onChanged();
         return this;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -16693,18 +16693,18 @@ public final class FGBoostServiceProto {
     }
 
     // @@protoc_insertion_point(class_scope:fgboost.SplitResponse)
-    private static final SplitResponse DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new SplitResponse();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse();
     }
 
-    public static SplitResponse getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<SplitResponse>
         PARSER = new com.google.protobuf.AbstractParser<SplitResponse>() {
-      @Override
+      @java.lang.Override
       public SplitResponse parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -16717,13 +16717,2725 @@ public final class FGBoostServiceProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<SplitResponse> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public SplitResponse getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SplitResponse getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface SaveModelRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:fgboost.SaveModelRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>string clientuuid = 1;</code>
+     * @return The clientuuid.
+     */
+    java.lang.String getClientuuid();
+    /**
+     * <code>string clientuuid = 1;</code>
+     * @return The bytes for clientuuid.
+     */
+    com.google.protobuf.ByteString
+        getClientuuidBytes();
+
+    /**
+     * <code>string modelPath = 2;</code>
+     * @return The modelPath.
+     */
+    java.lang.String getModelPath();
+    /**
+     * <code>string modelPath = 2;</code>
+     * @return The bytes for modelPath.
+     */
+    com.google.protobuf.ByteString
+        getModelPathBytes();
+  }
+  /**
+   * Protobuf type {@code fgboost.SaveModelRequest}
+   */
+  public static final class SaveModelRequest extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:fgboost.SaveModelRequest)
+      SaveModelRequestOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use SaveModelRequest.newBuilder() to construct.
+    private SaveModelRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private SaveModelRequest() {
+      clientuuid_ = "";
+      modelPath_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new SaveModelRequest();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private SaveModelRequest(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              clientuuid_ = s;
+              break;
+            }
+            case 18: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              modelPath_ = s;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SaveModelRequest_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SaveModelRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest.Builder.class);
+    }
+
+    public static final int CLIENTUUID_FIELD_NUMBER = 1;
+    private volatile java.lang.Object clientuuid_;
+    /**
+     * <code>string clientuuid = 1;</code>
+     * @return The clientuuid.
+     */
+    @java.lang.Override
+    public java.lang.String getClientuuid() {
+      java.lang.Object ref = clientuuid_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        clientuuid_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string clientuuid = 1;</code>
+     * @return The bytes for clientuuid.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getClientuuidBytes() {
+      java.lang.Object ref = clientuuid_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        clientuuid_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int MODELPATH_FIELD_NUMBER = 2;
+    private volatile java.lang.Object modelPath_;
+    /**
+     * <code>string modelPath = 2;</code>
+     * @return The modelPath.
+     */
+    @java.lang.Override
+    public java.lang.String getModelPath() {
+      java.lang.Object ref = modelPath_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        modelPath_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string modelPath = 2;</code>
+     * @return The bytes for modelPath.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getModelPathBytes() {
+      java.lang.Object ref = modelPath_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        modelPath_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!getClientuuidBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, clientuuid_);
+      }
+      if (!getModelPathBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, modelPath_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!getClientuuidBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, clientuuid_);
+      }
+      if (!getModelPathBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, modelPath_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest)) {
+        return super.equals(obj);
+      }
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest) obj;
+
+      if (!getClientuuid()
+          .equals(other.getClientuuid())) return false;
+      if (!getModelPath()
+          .equals(other.getModelPath())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + CLIENTUUID_FIELD_NUMBER;
+      hash = (53 * hash) + getClientuuid().hashCode();
+      hash = (37 * hash) + MODELPATH_FIELD_NUMBER;
+      hash = (53 * hash) + getModelPath().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code fgboost.SaveModelRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:fgboost.SaveModelRequest)
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SaveModelRequest_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SaveModelRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest.Builder.class);
+      }
+
+      // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        clientuuid_ = "";
+
+        modelPath_ = "";
+
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SaveModelRequest_descriptor;
+      }
+
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest(this);
+        result.clientuuid_ = clientuuid_;
+        result.modelPath_ = modelPath_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest.getDefaultInstance()) return this;
+        if (!other.getClientuuid().isEmpty()) {
+          clientuuid_ = other.clientuuid_;
+          onChanged();
+        }
+        if (!other.getModelPath().isEmpty()) {
+          modelPath_ = other.modelPath_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private java.lang.Object clientuuid_ = "";
+      /**
+       * <code>string clientuuid = 1;</code>
+       * @return The clientuuid.
+       */
+      public java.lang.String getClientuuid() {
+        java.lang.Object ref = clientuuid_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          clientuuid_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string clientuuid = 1;</code>
+       * @return The bytes for clientuuid.
+       */
+      public com.google.protobuf.ByteString
+          getClientuuidBytes() {
+        java.lang.Object ref = clientuuid_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          clientuuid_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string clientuuid = 1;</code>
+       * @param value The clientuuid to set.
+       * @return This builder for chaining.
+       */
+      public Builder setClientuuid(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        clientuuid_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string clientuuid = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearClientuuid() {
+        
+        clientuuid_ = getDefaultInstance().getClientuuid();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string clientuuid = 1;</code>
+       * @param value The bytes for clientuuid to set.
+       * @return This builder for chaining.
+       */
+      public Builder setClientuuidBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        clientuuid_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object modelPath_ = "";
+      /**
+       * <code>string modelPath = 2;</code>
+       * @return The modelPath.
+       */
+      public java.lang.String getModelPath() {
+        java.lang.Object ref = modelPath_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          modelPath_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string modelPath = 2;</code>
+       * @return The bytes for modelPath.
+       */
+      public com.google.protobuf.ByteString
+          getModelPathBytes() {
+        java.lang.Object ref = modelPath_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          modelPath_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string modelPath = 2;</code>
+       * @param value The modelPath to set.
+       * @return This builder for chaining.
+       */
+      public Builder setModelPath(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        modelPath_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string modelPath = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearModelPath() {
+        
+        modelPath_ = getDefaultInstance().getModelPath();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string modelPath = 2;</code>
+       * @param value The bytes for modelPath to set.
+       * @return This builder for chaining.
+       */
+      public Builder setModelPathBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        modelPath_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:fgboost.SaveModelRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:fgboost.SaveModelRequest)
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest();
+    }
+
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<SaveModelRequest>
+        PARSER = new com.google.protobuf.AbstractParser<SaveModelRequest>() {
+      @java.lang.Override
+      public SaveModelRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new SaveModelRequest(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<SaveModelRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<SaveModelRequest> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface SaveModelResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:fgboost.SaveModelResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>string message = 1;</code>
+     * @return The message.
+     */
+    java.lang.String getMessage();
+    /**
+     * <code>string message = 1;</code>
+     * @return The bytes for message.
+     */
+    com.google.protobuf.ByteString
+        getMessageBytes();
+
+    /**
+     * <code>int32 code = 2;</code>
+     * @return The code.
+     */
+    int getCode();
+  }
+  /**
+   * Protobuf type {@code fgboost.SaveModelResponse}
+   */
+  public static final class SaveModelResponse extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:fgboost.SaveModelResponse)
+      SaveModelResponseOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use SaveModelResponse.newBuilder() to construct.
+    private SaveModelResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private SaveModelResponse() {
+      message_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new SaveModelResponse();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private SaveModelResponse(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              message_ = s;
+              break;
+            }
+            case 16: {
+
+              code_ = input.readInt32();
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SaveModelResponse_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SaveModelResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse.Builder.class);
+    }
+
+    public static final int MESSAGE_FIELD_NUMBER = 1;
+    private volatile java.lang.Object message_;
+    /**
+     * <code>string message = 1;</code>
+     * @return The message.
+     */
+    @java.lang.Override
+    public java.lang.String getMessage() {
+      java.lang.Object ref = message_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        message_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string message = 1;</code>
+     * @return The bytes for message.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getMessageBytes() {
+      java.lang.Object ref = message_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        message_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int CODE_FIELD_NUMBER = 2;
+    private int code_;
+    /**
+     * <code>int32 code = 2;</code>
+     * @return The code.
+     */
+    @java.lang.Override
+    public int getCode() {
+      return code_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!getMessageBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, message_);
+      }
+      if (code_ != 0) {
+        output.writeInt32(2, code_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!getMessageBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, message_);
+      }
+      if (code_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(2, code_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse)) {
+        return super.equals(obj);
+      }
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse) obj;
+
+      if (!getMessage()
+          .equals(other.getMessage())) return false;
+      if (getCode()
+          != other.getCode()) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + MESSAGE_FIELD_NUMBER;
+      hash = (53 * hash) + getMessage().hashCode();
+      hash = (37 * hash) + CODE_FIELD_NUMBER;
+      hash = (53 * hash) + getCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code fgboost.SaveModelResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:fgboost.SaveModelResponse)
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SaveModelResponse_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SaveModelResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse.Builder.class);
+      }
+
+      // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        message_ = "";
+
+        code_ = 0;
+
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_SaveModelResponse_descriptor;
+      }
+
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse(this);
+        result.message_ = message_;
+        result.code_ = code_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse.getDefaultInstance()) return this;
+        if (!other.getMessage().isEmpty()) {
+          message_ = other.message_;
+          onChanged();
+        }
+        if (other.getCode() != 0) {
+          setCode(other.getCode());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private java.lang.Object message_ = "";
+      /**
+       * <code>string message = 1;</code>
+       * @return The message.
+       */
+      public java.lang.String getMessage() {
+        java.lang.Object ref = message_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          message_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string message = 1;</code>
+       * @return The bytes for message.
+       */
+      public com.google.protobuf.ByteString
+          getMessageBytes() {
+        java.lang.Object ref = message_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          message_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string message = 1;</code>
+       * @param value The message to set.
+       * @return This builder for chaining.
+       */
+      public Builder setMessage(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        message_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string message = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearMessage() {
+        
+        message_ = getDefaultInstance().getMessage();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string message = 1;</code>
+       * @param value The bytes for message to set.
+       * @return This builder for chaining.
+       */
+      public Builder setMessageBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        message_ = value;
+        onChanged();
+        return this;
+      }
+
+      private int code_ ;
+      /**
+       * <code>int32 code = 2;</code>
+       * @return The code.
+       */
+      @java.lang.Override
+      public int getCode() {
+        return code_;
+      }
+      /**
+       * <code>int32 code = 2;</code>
+       * @param value The code to set.
+       * @return This builder for chaining.
+       */
+      public Builder setCode(int value) {
+        
+        code_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>int32 code = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearCode() {
+        
+        code_ = 0;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:fgboost.SaveModelResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:fgboost.SaveModelResponse)
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse();
+    }
+
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<SaveModelResponse>
+        PARSER = new com.google.protobuf.AbstractParser<SaveModelResponse>() {
+      @java.lang.Override
+      public SaveModelResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new SaveModelResponse(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<SaveModelResponse> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<SaveModelResponse> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.SaveModelResponse getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface LoadModelRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:fgboost.LoadModelRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>string client_id = 1;</code>
+     * @return The clientId.
+     */
+    java.lang.String getClientId();
+    /**
+     * <code>string client_id = 1;</code>
+     * @return The bytes for clientId.
+     */
+    com.google.protobuf.ByteString
+        getClientIdBytes();
+
+    /**
+     * <code>string model_path = 2;</code>
+     * @return The modelPath.
+     */
+    java.lang.String getModelPath();
+    /**
+     * <code>string model_path = 2;</code>
+     * @return The bytes for modelPath.
+     */
+    com.google.protobuf.ByteString
+        getModelPathBytes();
+  }
+  /**
+   * Protobuf type {@code fgboost.LoadModelRequest}
+   */
+  public static final class LoadModelRequest extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:fgboost.LoadModelRequest)
+      LoadModelRequestOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use LoadModelRequest.newBuilder() to construct.
+    private LoadModelRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private LoadModelRequest() {
+      clientId_ = "";
+      modelPath_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new LoadModelRequest();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private LoadModelRequest(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              clientId_ = s;
+              break;
+            }
+            case 18: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              modelPath_ = s;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_LoadModelRequest_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_LoadModelRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest.Builder.class);
+    }
+
+    public static final int CLIENT_ID_FIELD_NUMBER = 1;
+    private volatile java.lang.Object clientId_;
+    /**
+     * <code>string client_id = 1;</code>
+     * @return The clientId.
+     */
+    @java.lang.Override
+    public java.lang.String getClientId() {
+      java.lang.Object ref = clientId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        clientId_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string client_id = 1;</code>
+     * @return The bytes for clientId.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getClientIdBytes() {
+      java.lang.Object ref = clientId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        clientId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int MODEL_PATH_FIELD_NUMBER = 2;
+    private volatile java.lang.Object modelPath_;
+    /**
+     * <code>string model_path = 2;</code>
+     * @return The modelPath.
+     */
+    @java.lang.Override
+    public java.lang.String getModelPath() {
+      java.lang.Object ref = modelPath_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        modelPath_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string model_path = 2;</code>
+     * @return The bytes for modelPath.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getModelPathBytes() {
+      java.lang.Object ref = modelPath_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        modelPath_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!getClientIdBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, clientId_);
+      }
+      if (!getModelPathBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, modelPath_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!getClientIdBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, clientId_);
+      }
+      if (!getModelPathBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, modelPath_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest)) {
+        return super.equals(obj);
+      }
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest) obj;
+
+      if (!getClientId()
+          .equals(other.getClientId())) return false;
+      if (!getModelPath()
+          .equals(other.getModelPath())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + CLIENT_ID_FIELD_NUMBER;
+      hash = (53 * hash) + getClientId().hashCode();
+      hash = (37 * hash) + MODEL_PATH_FIELD_NUMBER;
+      hash = (53 * hash) + getModelPath().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code fgboost.LoadModelRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:fgboost.LoadModelRequest)
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_LoadModelRequest_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_LoadModelRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest.Builder.class);
+      }
+
+      // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        clientId_ = "";
+
+        modelPath_ = "";
+
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_LoadModelRequest_descriptor;
+      }
+
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest(this);
+        result.clientId_ = clientId_;
+        result.modelPath_ = modelPath_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest.getDefaultInstance()) return this;
+        if (!other.getClientId().isEmpty()) {
+          clientId_ = other.clientId_;
+          onChanged();
+        }
+        if (!other.getModelPath().isEmpty()) {
+          modelPath_ = other.modelPath_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private java.lang.Object clientId_ = "";
+      /**
+       * <code>string client_id = 1;</code>
+       * @return The clientId.
+       */
+      public java.lang.String getClientId() {
+        java.lang.Object ref = clientId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          clientId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string client_id = 1;</code>
+       * @return The bytes for clientId.
+       */
+      public com.google.protobuf.ByteString
+          getClientIdBytes() {
+        java.lang.Object ref = clientId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          clientId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string client_id = 1;</code>
+       * @param value The clientId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setClientId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        clientId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string client_id = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearClientId() {
+        
+        clientId_ = getDefaultInstance().getClientId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string client_id = 1;</code>
+       * @param value The bytes for clientId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setClientIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        clientId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object modelPath_ = "";
+      /**
+       * <code>string model_path = 2;</code>
+       * @return The modelPath.
+       */
+      public java.lang.String getModelPath() {
+        java.lang.Object ref = modelPath_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          modelPath_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string model_path = 2;</code>
+       * @return The bytes for modelPath.
+       */
+      public com.google.protobuf.ByteString
+          getModelPathBytes() {
+        java.lang.Object ref = modelPath_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          modelPath_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string model_path = 2;</code>
+       * @param value The modelPath to set.
+       * @return This builder for chaining.
+       */
+      public Builder setModelPath(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        modelPath_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string model_path = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearModelPath() {
+        
+        modelPath_ = getDefaultInstance().getModelPath();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string model_path = 2;</code>
+       * @param value The bytes for modelPath to set.
+       * @return This builder for chaining.
+       */
+      public Builder setModelPathBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        modelPath_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:fgboost.LoadModelRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:fgboost.LoadModelRequest)
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest();
+    }
+
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<LoadModelRequest>
+        PARSER = new com.google.protobuf.AbstractParser<LoadModelRequest>() {
+      @java.lang.Override
+      public LoadModelRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new LoadModelRequest(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<LoadModelRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<LoadModelRequest> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface LoadModelResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:fgboost.LoadModelResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>string message = 1;</code>
+     * @return The message.
+     */
+    java.lang.String getMessage();
+    /**
+     * <code>string message = 1;</code>
+     * @return The bytes for message.
+     */
+    com.google.protobuf.ByteString
+        getMessageBytes();
+
+    /**
+     * <code>int32 code = 2;</code>
+     * @return The code.
+     */
+    int getCode();
+  }
+  /**
+   * Protobuf type {@code fgboost.LoadModelResponse}
+   */
+  public static final class LoadModelResponse extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:fgboost.LoadModelResponse)
+      LoadModelResponseOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use LoadModelResponse.newBuilder() to construct.
+    private LoadModelResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private LoadModelResponse() {
+      message_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new LoadModelResponse();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private LoadModelResponse(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              message_ = s;
+              break;
+            }
+            case 16: {
+
+              code_ = input.readInt32();
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_LoadModelResponse_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_LoadModelResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse.Builder.class);
+    }
+
+    public static final int MESSAGE_FIELD_NUMBER = 1;
+    private volatile java.lang.Object message_;
+    /**
+     * <code>string message = 1;</code>
+     * @return The message.
+     */
+    @java.lang.Override
+    public java.lang.String getMessage() {
+      java.lang.Object ref = message_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        message_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string message = 1;</code>
+     * @return The bytes for message.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getMessageBytes() {
+      java.lang.Object ref = message_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        message_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int CODE_FIELD_NUMBER = 2;
+    private int code_;
+    /**
+     * <code>int32 code = 2;</code>
+     * @return The code.
+     */
+    @java.lang.Override
+    public int getCode() {
+      return code_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!getMessageBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, message_);
+      }
+      if (code_ != 0) {
+        output.writeInt32(2, code_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!getMessageBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, message_);
+      }
+      if (code_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(2, code_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse)) {
+        return super.equals(obj);
+      }
+      com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse other = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse) obj;
+
+      if (!getMessage()
+          .equals(other.getMessage())) return false;
+      if (getCode()
+          != other.getCode()) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + MESSAGE_FIELD_NUMBER;
+      hash = (53 * hash) + getMessage().hashCode();
+      hash = (37 * hash) + CODE_FIELD_NUMBER;
+      hash = (53 * hash) + getCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code fgboost.LoadModelResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:fgboost.LoadModelResponse)
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_LoadModelResponse_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_LoadModelResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse.class, com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse.Builder.class);
+      }
+
+      // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        message_ = "";
+
+        code_ = 0;
+
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.internal_static_fgboost_LoadModelResponse_descriptor;
+      }
+
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse result = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse(this);
+        result.message_ = message_;
+        result.code_ = code_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse.getDefaultInstance()) return this;
+        if (!other.getMessage().isEmpty()) {
+          message_ = other.message_;
+          onChanged();
+        }
+        if (other.getCode() != 0) {
+          setCode(other.getCode());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private java.lang.Object message_ = "";
+      /**
+       * <code>string message = 1;</code>
+       * @return The message.
+       */
+      public java.lang.String getMessage() {
+        java.lang.Object ref = message_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          message_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string message = 1;</code>
+       * @return The bytes for message.
+       */
+      public com.google.protobuf.ByteString
+          getMessageBytes() {
+        java.lang.Object ref = message_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          message_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string message = 1;</code>
+       * @param value The message to set.
+       * @return This builder for chaining.
+       */
+      public Builder setMessage(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        message_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string message = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearMessage() {
+        
+        message_ = getDefaultInstance().getMessage();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string message = 1;</code>
+       * @param value The bytes for message to set.
+       * @return This builder for chaining.
+       */
+      public Builder setMessageBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        message_ = value;
+        onChanged();
+        return this;
+      }
+
+      private int code_ ;
+      /**
+       * <code>int32 code = 2;</code>
+       * @return The code.
+       */
+      @java.lang.Override
+      public int getCode() {
+        return code_;
+      }
+      /**
+       * <code>int32 code = 2;</code>
+       * @param value The code to set.
+       * @return This builder for chaining.
+       */
+      public Builder setCode(int value) {
+        
+        code_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>int32 code = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearCode() {
+        
+        code_ = 0;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:fgboost.LoadModelResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:fgboost.LoadModelResponse)
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse();
+    }
+
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<LoadModelResponse>
+        PARSER = new com.google.protobuf.AbstractParser<LoadModelResponse>() {
+      @java.lang.Override
+      public LoadModelResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new LoadModelResponse(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<LoadModelResponse> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<LoadModelResponse> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FGBoostServiceProto.LoadModelResponse getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -16824,6 +19536,26 @@ public final class FGBoostServiceProto {
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_fgboost_SplitResponse_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_fgboost_SaveModelRequest_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_fgboost_SaveModelRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_fgboost_SaveModelResponse_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_fgboost_SaveModelResponse_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_fgboost_LoadModelRequest_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_fgboost_LoadModelRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_fgboost_LoadModelResponse_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_fgboost_LoadModelResponse_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -16832,7 +19564,7 @@ public final class FGBoostServiceProto {
   private static  com.google.protobuf.Descriptors.FileDescriptor
       descriptor;
   static {
-    String[] descriptorData = {
+    java.lang.String[] descriptorData = {
       "\n\025fgboost_service.proto\022\007fgboost\032\rfl_bas" +
       "e.proto\"U\n\022UploadLabelRequest\022\022\n\nclientu" +
       "uid\030\001 \001(\t\022\030\n\004data\030\002 \001(\0132\n.TensorMap\022\021\n\ta" +
@@ -16872,143 +19604,176 @@ public final class FGBoostServiceProto {
       "sponse\022\020\n\010response\030\001 \001(\t\022\030\n\004data\030\002 \001(\0132\n" +
       ".TensorMap\022\014\n\004code\030\003 \001(\005\"R\n\rSplitRespons" +
       "e\022!\n\005split\030\001 \001(\0132\022.fgboost.DataSplit\022\020\n\010" +
-      "response\030\002 \001(\t\022\014\n\004code\030\003 \001(\0052\361\003\n\016FGBoost" +
-      "Service\022E\n\013uploadLabel\022\033.fgboost.UploadL" +
-      "abelRequest\032\027.fgboost.UploadResponse\"\000\022K" +
-      "\n\rdownloadLabel\022\035.fgboost.DownloadLabelR" +
-      "equest\032\031.fgboost.DownloadResponse\"\000\0228\n\005s" +
-      "plit\022\025.fgboost.SplitRequest\032\026.fgboost.Sp" +
-      "litResponse\"\000\022A\n\010register\022\030.fgboost.Regi" +
-      "sterRequest\032\031.fgboost.RegisterResponse\"\000" +
-      "\022K\n\016uploadTreeLeaf\022\036.fgboost.UploadTreeL" +
-      "eafRequest\032\027.fgboost.UploadResponse\"\000\022A\n" +
-      "\010evaluate\022\030.fgboost.EvaluateRequest\032\031.fg" +
-      "boost.EvaluateResponse\"\000\022>\n\007predict\022\027.fg" +
-      "boost.PredictRequest\032\030.fgboost.PredictRe" +
-      "sponse\"\000BB\n+com.intel.analytics.bigdl.pp" +
-      "ml.fl.generatedB\023FGBoostServiceProtob\006pr" +
-      "oto3"
+      "response\030\002 \001(\t\022\014\n\004code\030\003 \001(\005\"9\n\020SaveMode" +
+      "lRequest\022\022\n\nclientuuid\030\001 \001(\t\022\021\n\tmodelPat" +
+      "h\030\002 \001(\t\"2\n\021SaveModelResponse\022\017\n\007message\030" +
+      "\001 \001(\t\022\014\n\004code\030\002 \001(\005\"9\n\020LoadModelRequest\022" +
+      "\021\n\tclient_id\030\001 \001(\t\022\022\n\nmodel_path\030\002 \001(\t\"2" +
+      "\n\021LoadModelResponse\022\017\n\007message\030\001 \001(\t\022\014\n\004" +
+      "code\030\002 \001(\0052\211\005\n\016FGBoostService\022E\n\013uploadL" +
+      "abel\022\033.fgboost.UploadLabelRequest\032\027.fgbo" +
+      "ost.UploadResponse\"\000\022K\n\rdownloadLabel\022\035." +
+      "fgboost.DownloadLabelRequest\032\031.fgboost.D" +
+      "ownloadResponse\"\000\0228\n\005split\022\025.fgboost.Spl" +
+      "itRequest\032\026.fgboost.SplitResponse\"\000\022A\n\010r" +
+      "egister\022\030.fgboost.RegisterRequest\032\031.fgbo" +
+      "ost.RegisterResponse\"\000\022K\n\016uploadTreeLeaf" +
+      "\022\036.fgboost.UploadTreeLeafRequest\032\027.fgboo" +
+      "st.UploadResponse\"\000\022A\n\010evaluate\022\030.fgboos" +
+      "t.EvaluateRequest\032\031.fgboost.EvaluateResp" +
+      "onse\"\000\022>\n\007predict\022\027.fgboost.PredictReque" +
+      "st\032\030.fgboost.PredictResponse\"\000\022J\n\017saveSe" +
+      "rverModel\022\031.fgboost.SaveModelRequest\032\032.f" +
+      "gboost.SaveModelResponse\"\000\022J\n\017loadServer" +
+      "Model\022\031.fgboost.LoadModelRequest\032\032.fgboo" +
+      "st.LoadModelResponse\"\000BB\n+com.intel.anal" +
+      "ytics.bigdl.ppml.fl.generatedB\023FGBoostSe" +
+      "rviceProtob\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
         new com.google.protobuf.Descriptors.FileDescriptor[] {
-          FlBaseProto.getDescriptor(),
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.getDescriptor(),
         });
     internal_static_fgboost_UploadLabelRequest_descriptor =
       getDescriptor().getMessageTypes().get(0);
     internal_static_fgboost_UploadLabelRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_fgboost_UploadLabelRequest_descriptor,
-        new String[] { "Clientuuid", "Data", "Algorithm", });
+        new java.lang.String[] { "Clientuuid", "Data", "Algorithm", });
     internal_static_fgboost_DownloadLabelRequest_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_fgboost_DownloadLabelRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_fgboost_DownloadLabelRequest_descriptor,
-        new String[] { "MetaData", "Algorithm", });
+        new java.lang.String[] { "MetaData", "Algorithm", });
     internal_static_fgboost_DownloadResponse_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_fgboost_DownloadResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_fgboost_DownloadResponse_descriptor,
-        new String[] { "Data", "Response", "Code", });
+        new java.lang.String[] { "Data", "Response", "Code", });
     internal_static_fgboost_TreeLeaf_descriptor =
       getDescriptor().getMessageTypes().get(3);
     internal_static_fgboost_TreeLeaf_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_fgboost_TreeLeaf_descriptor,
-        new String[] { "TreeID", "LeafIndex", "LeafOutput", "Version", });
+        new java.lang.String[] { "TreeID", "LeafIndex", "LeafOutput", "Version", });
     internal_static_fgboost_UploadTreeLeafRequest_descriptor =
       getDescriptor().getMessageTypes().get(4);
     internal_static_fgboost_UploadTreeLeafRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_fgboost_UploadTreeLeafRequest_descriptor,
-        new String[] { "Clientuuid", "TreeLeaf", });
+        new java.lang.String[] { "Clientuuid", "TreeLeaf", });
     internal_static_fgboost_DataSplit_descriptor =
       getDescriptor().getMessageTypes().get(5);
     internal_static_fgboost_DataSplit_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_fgboost_DataSplit_descriptor,
-        new String[] { "TreeID", "NodeID", "FeatureID", "SplitValue", "Gain", "SetLength", "ItemSet", "ClientUid", "Version", });
+        new java.lang.String[] { "TreeID", "NodeID", "FeatureID", "SplitValue", "Gain", "SetLength", "ItemSet", "ClientUid", "Version", });
     internal_static_fgboost_UploadResponse_descriptor =
       getDescriptor().getMessageTypes().get(6);
     internal_static_fgboost_UploadResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_fgboost_UploadResponse_descriptor,
-        new String[] { "Response", "Code", });
+        new java.lang.String[] { "Response", "Code", });
     internal_static_fgboost_TreePredict_descriptor =
       getDescriptor().getMessageTypes().get(7);
     internal_static_fgboost_TreePredict_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_fgboost_TreePredict_descriptor,
-        new String[] { "TreeID", "Predicts", });
+        new java.lang.String[] { "TreeID", "Predicts", });
     internal_static_fgboost_BoostPredict_descriptor =
       getDescriptor().getMessageTypes().get(8);
     internal_static_fgboost_BoostPredict_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_fgboost_BoostPredict_descriptor,
-        new String[] { "Predicts", });
+        new java.lang.String[] { "Predicts", });
     internal_static_fgboost_BoostEval_descriptor =
       getDescriptor().getMessageTypes().get(9);
     internal_static_fgboost_BoostEval_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_fgboost_BoostEval_descriptor,
-        new String[] { "Evaluates", });
+        new java.lang.String[] { "Evaluates", });
     internal_static_fgboost_RegisterRequest_descriptor =
       getDescriptor().getMessageTypes().get(10);
     internal_static_fgboost_RegisterRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_fgboost_RegisterRequest_descriptor,
-        new String[] { "Clientuuid", "Token", });
+        new java.lang.String[] { "Clientuuid", "Token", });
     internal_static_fgboost_RegisterResponse_descriptor =
       getDescriptor().getMessageTypes().get(11);
     internal_static_fgboost_RegisterResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_fgboost_RegisterResponse_descriptor,
-        new String[] { "Response", "Code", });
+        new java.lang.String[] { "Response", "Code", });
     internal_static_fgboost_UploadTreeEvalRequest_descriptor =
       getDescriptor().getMessageTypes().get(12);
     internal_static_fgboost_UploadTreeEvalRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_fgboost_UploadTreeEvalRequest_descriptor,
-        new String[] { "Clientuuid", "Version", "TreeEval", });
+        new java.lang.String[] { "Clientuuid", "Version", "TreeEval", });
     internal_static_fgboost_EvaluateRequest_descriptor =
       getDescriptor().getMessageTypes().get(13);
     internal_static_fgboost_EvaluateRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_fgboost_EvaluateRequest_descriptor,
-        new String[] { "Clientuuid", "TreeEval", "Version", "LastBatch", });
+        new java.lang.String[] { "Clientuuid", "TreeEval", "Version", "LastBatch", });
     internal_static_fgboost_EvaluateResponse_descriptor =
       getDescriptor().getMessageTypes().get(14);
     internal_static_fgboost_EvaluateResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_fgboost_EvaluateResponse_descriptor,
-        new String[] { "Response", "Data", "Code", "Message", });
+        new java.lang.String[] { "Response", "Data", "Code", "Message", });
     internal_static_fgboost_PredictRequest_descriptor =
       getDescriptor().getMessageTypes().get(15);
     internal_static_fgboost_PredictRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_fgboost_PredictRequest_descriptor,
-        new String[] { "Clientuuid", "TreeEval", "Version", "LastBatch", });
+        new java.lang.String[] { "Clientuuid", "TreeEval", "Version", "LastBatch", });
     internal_static_fgboost_SplitRequest_descriptor =
       getDescriptor().getMessageTypes().get(16);
     internal_static_fgboost_SplitRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_fgboost_SplitRequest_descriptor,
-        new String[] { "Clientuuid", "Split", });
+        new java.lang.String[] { "Clientuuid", "Split", });
     internal_static_fgboost_PredictResponse_descriptor =
       getDescriptor().getMessageTypes().get(17);
     internal_static_fgboost_PredictResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_fgboost_PredictResponse_descriptor,
-        new String[] { "Response", "Data", "Code", });
+        new java.lang.String[] { "Response", "Data", "Code", });
     internal_static_fgboost_SplitResponse_descriptor =
       getDescriptor().getMessageTypes().get(18);
     internal_static_fgboost_SplitResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_fgboost_SplitResponse_descriptor,
-        new String[] { "Split", "Response", "Code", });
-    FlBaseProto.getDescriptor();
+        new java.lang.String[] { "Split", "Response", "Code", });
+    internal_static_fgboost_SaveModelRequest_descriptor =
+      getDescriptor().getMessageTypes().get(19);
+    internal_static_fgboost_SaveModelRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_fgboost_SaveModelRequest_descriptor,
+        new java.lang.String[] { "Clientuuid", "ModelPath", });
+    internal_static_fgboost_SaveModelResponse_descriptor =
+      getDescriptor().getMessageTypes().get(20);
+    internal_static_fgboost_SaveModelResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_fgboost_SaveModelResponse_descriptor,
+        new java.lang.String[] { "Message", "Code", });
+    internal_static_fgboost_LoadModelRequest_descriptor =
+      getDescriptor().getMessageTypes().get(21);
+    internal_static_fgboost_LoadModelRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_fgboost_LoadModelRequest_descriptor,
+        new java.lang.String[] { "ClientId", "ModelPath", });
+    internal_static_fgboost_LoadModelResponse_descriptor =
+      getDescriptor().getMessageTypes().get(22);
+    internal_static_fgboost_LoadModelResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_fgboost_LoadModelResponse_descriptor,
+        new java.lang.String[] { "Message", "Code", });
+    com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.getDescriptor();
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/scala/ppml/src/main/java/com/intel/analytics/bigdl/ppml/fl/generated/FlBaseProto.java
+++ b/scala/ppml/src/main/java/com/intel/analytics/bigdl/ppml/fl/generated/FlBaseProto.java
@@ -66,7 +66,7 @@ public final class FlBaseProto {
 
     public final int getNumber() {
       if (this == UNRECOGNIZED) {
-        throw new IllegalArgumentException(
+        throw new java.lang.IllegalArgumentException(
             "Can't get the number of an unknown enum value.");
       }
       return value;
@@ -77,7 +77,7 @@ public final class FlBaseProto {
      * @return The enum associated with the given numeric wire value.
      * @deprecated Use {@link #forNumber(int)} instead.
      */
-    @Deprecated
+    @java.lang.Deprecated
     public static SIGNAL valueOf(int value) {
       return forNumber(value);
     }
@@ -112,7 +112,7 @@ public final class FlBaseProto {
     public final com.google.protobuf.Descriptors.EnumValueDescriptor
         getValueDescriptor() {
       if (this == UNRECOGNIZED) {
-        throw new IllegalStateException(
+        throw new java.lang.IllegalStateException(
             "Can't get the descriptor of an unrecognized enum value.");
       }
       return getDescriptor().getValues().get(ordinal());
@@ -123,7 +123,7 @@ public final class FlBaseProto {
     }
     public static final com.google.protobuf.Descriptors.EnumDescriptor
         getDescriptor() {
-      return FlBaseProto.getDescriptor().getEnumTypes().get(0);
+      return com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.getDescriptor().getEnumTypes().get(0);
     }
 
     private static final SIGNAL[] VALUES = values();
@@ -131,7 +131,7 @@ public final class FlBaseProto {
     public static SIGNAL valueOf(
         com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
       if (desc.getType() != getDescriptor()) {
-        throw new IllegalArgumentException(
+        throw new java.lang.IllegalArgumentException(
           "EnumValueDescriptor is not for this type.");
       }
       if (desc.getIndex() == -1) {
@@ -157,7 +157,7 @@ public final class FlBaseProto {
      * <code>repeated int32 shape = 1;</code>
      * @return A list containing the shape.
      */
-    java.util.List<Integer> getShapeList();
+    java.util.List<java.lang.Integer> getShapeList();
     /**
      * <code>repeated int32 shape = 1;</code>
      * @return The count of shape.
@@ -174,7 +174,7 @@ public final class FlBaseProto {
      * <code>repeated float tensor = 2;</code>
      * @return A list containing the tensor.
      */
-    java.util.List<Float> getTensorList();
+    java.util.List<java.lang.Float> getTensorList();
     /**
      * <code>repeated float tensor = 2;</code>
      * @return The count of tensor.
@@ -186,6 +186,18 @@ public final class FlBaseProto {
      * @return The tensor at the given index.
      */
     float getTensor(int index);
+
+    /**
+     * <code>string dtype = 3;</code>
+     * @return The dtype.
+     */
+    java.lang.String getDtype();
+    /**
+     * <code>string dtype = 3;</code>
+     * @return The bytes for dtype.
+     */
+    com.google.protobuf.ByteString
+        getDtypeBytes();
   }
   /**
    * Protobuf type {@code FloatTensor}
@@ -202,16 +214,17 @@ public final class FlBaseProto {
     private FloatTensor() {
       shape_ = emptyIntList();
       tensor_ = emptyFloatList();
+      dtype_ = "";
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new FloatTensor();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -222,7 +235,7 @@ public final class FlBaseProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
@@ -277,6 +290,12 @@ public final class FlBaseProto {
               input.popLimit(limit);
               break;
             }
+            case 26: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              dtype_ = s;
+              break;
+            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -304,15 +323,15 @@ public final class FlBaseProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FlBaseProto.internal_static_FloatTensor_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.internal_static_FloatTensor_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FlBaseProto.internal_static_FloatTensor_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.internal_static_FloatTensor_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              FloatTensor.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor.class, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor.Builder.class);
     }
 
     public static final int SHAPE_FIELD_NUMBER = 1;
@@ -321,8 +340,8 @@ public final class FlBaseProto {
      * <code>repeated int32 shape = 1;</code>
      * @return A list containing the shape.
      */
-    @Override
-    public java.util.List<Integer>
+    @java.lang.Override
+    public java.util.List<java.lang.Integer>
         getShapeList() {
       return shape_;
     }
@@ -349,8 +368,8 @@ public final class FlBaseProto {
      * <code>repeated float tensor = 2;</code>
      * @return A list containing the tensor.
      */
-    @Override
-    public java.util.List<Float>
+    @java.lang.Override
+    public java.util.List<java.lang.Float>
         getTensorList() {
       return tensor_;
     }
@@ -371,8 +390,46 @@ public final class FlBaseProto {
     }
     private int tensorMemoizedSerializedSize = -1;
 
+    public static final int DTYPE_FIELD_NUMBER = 3;
+    private volatile java.lang.Object dtype_;
+    /**
+     * <code>string dtype = 3;</code>
+     * @return The dtype.
+     */
+    @java.lang.Override
+    public java.lang.String getDtype() {
+      java.lang.Object ref = dtype_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        dtype_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string dtype = 3;</code>
+     * @return The bytes for dtype.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getDtypeBytes() {
+      java.lang.Object ref = dtype_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        dtype_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -382,7 +439,7 @@ public final class FlBaseProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       getSerializedSize();
@@ -400,10 +457,13 @@ public final class FlBaseProto {
       for (int i = 0; i < tensor_.size(); i++) {
         output.writeFloatNoTag(tensor_.getFloat(i));
       }
+      if (!getDtypeBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, dtype_);
+      }
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -434,30 +494,35 @@ public final class FlBaseProto {
         }
         tensorMemoizedSerializedSize = dataSize;
       }
+      if (!getDtypeBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, dtype_);
+      }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof FloatTensor)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor)) {
         return super.equals(obj);
       }
-      FloatTensor other = (FloatTensor) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor other = (com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor) obj;
 
       if (!getShapeList()
           .equals(other.getShapeList())) return false;
       if (!getTensorList()
           .equals(other.getTensorList())) return false;
+      if (!getDtype()
+          .equals(other.getDtype())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -472,74 +537,76 @@ public final class FlBaseProto {
         hash = (37 * hash) + TENSOR_FIELD_NUMBER;
         hash = (53 * hash) + getTensorList().hashCode();
       }
+      hash = (37 * hash) + DTYPE_FIELD_NUMBER;
+      hash = (53 * hash) + getDtype().hashCode();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
     }
 
-    public static FloatTensor parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static FloatTensor parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static FloatTensor parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static FloatTensor parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static FloatTensor parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static FloatTensor parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static FloatTensor parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static FloatTensor parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static FloatTensor parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static FloatTensor parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static FloatTensor parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static FloatTensor parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -547,23 +614,23 @@ public final class FlBaseProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(FloatTensor prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -573,18 +640,18 @@ public final class FlBaseProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:FloatTensor)
-        FloatTensorOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensorOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FlBaseProto.internal_static_FloatTensor_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.internal_static_FloatTensor_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FlBaseProto.internal_static_FloatTensor_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.internal_static_FloatTensor_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                FloatTensor.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor.class, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor.newBuilder()
@@ -593,7 +660,7 @@ public final class FlBaseProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -602,39 +669,41 @@ public final class FlBaseProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         shape_ = emptyIntList();
         bitField0_ = (bitField0_ & ~0x00000001);
         tensor_ = emptyFloatList();
         bitField0_ = (bitField0_ & ~0x00000002);
+        dtype_ = "";
+
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FlBaseProto.internal_static_FloatTensor_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.internal_static_FloatTensor_descriptor;
       }
 
-      @Override
-      public FloatTensor getDefaultInstanceForType() {
-        return FloatTensor.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor.getDefaultInstance();
       }
 
-      @Override
-      public FloatTensor build() {
-        FloatTensor result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public FloatTensor buildPartial() {
-        FloatTensor result = new FloatTensor(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor result = new com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor(this);
         int from_bitField0_ = bitField0_;
         if (((bitField0_ & 0x00000001) != 0)) {
           shape_.makeImmutable();
@@ -646,54 +715,55 @@ public final class FlBaseProto {
           bitField0_ = (bitField0_ & ~0x00000002);
         }
         result.tensor_ = tensor_;
+        result.dtype_ = dtype_;
         onBuilt();
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof FloatTensor) {
-          return mergeFrom((FloatTensor)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(FloatTensor other) {
-        if (other == FloatTensor.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor.getDefaultInstance()) return this;
         if (!other.shape_.isEmpty()) {
           if (shape_.isEmpty()) {
             shape_ = other.shape_;
@@ -714,26 +784,30 @@ public final class FlBaseProto {
           }
           onChanged();
         }
+        if (!other.getDtype().isEmpty()) {
+          dtype_ = other.dtype_;
+          onChanged();
+        }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        FloatTensor parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (FloatTensor) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -755,7 +829,7 @@ public final class FlBaseProto {
        * <code>repeated int32 shape = 1;</code>
        * @return A list containing the shape.
        */
-      public java.util.List<Integer>
+      public java.util.List<java.lang.Integer>
           getShapeList() {
         return ((bitField0_ & 0x00000001) != 0) ?
                  java.util.Collections.unmodifiableList(shape_) : shape_;
@@ -805,7 +879,7 @@ public final class FlBaseProto {
        * @return This builder for chaining.
        */
       public Builder addAllShape(
-          Iterable<? extends Integer> values) {
+          java.lang.Iterable<? extends java.lang.Integer> values) {
         ensureShapeIsMutable();
         com.google.protobuf.AbstractMessageLite.Builder.addAll(
             values, shape_);
@@ -834,7 +908,7 @@ public final class FlBaseProto {
        * <code>repeated float tensor = 2;</code>
        * @return A list containing the tensor.
        */
-      public java.util.List<Float>
+      public java.util.List<java.lang.Float>
           getTensorList() {
         return ((bitField0_ & 0x00000002) != 0) ?
                  java.util.Collections.unmodifiableList(tensor_) : tensor_;
@@ -884,7 +958,7 @@ public final class FlBaseProto {
        * @return This builder for chaining.
        */
       public Builder addAllTensor(
-          Iterable<? extends Float> values) {
+          java.lang.Iterable<? extends java.lang.Float> values) {
         ensureTensorIsMutable();
         com.google.protobuf.AbstractMessageLite.Builder.addAll(
             values, tensor_);
@@ -901,13 +975,89 @@ public final class FlBaseProto {
         onChanged();
         return this;
       }
-      @Override
+
+      private java.lang.Object dtype_ = "";
+      /**
+       * <code>string dtype = 3;</code>
+       * @return The dtype.
+       */
+      public java.lang.String getDtype() {
+        java.lang.Object ref = dtype_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          dtype_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string dtype = 3;</code>
+       * @return The bytes for dtype.
+       */
+      public com.google.protobuf.ByteString
+          getDtypeBytes() {
+        java.lang.Object ref = dtype_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          dtype_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string dtype = 3;</code>
+       * @param value The dtype to set.
+       * @return This builder for chaining.
+       */
+      public Builder setDtype(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        dtype_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string dtype = 3;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearDtype() {
+        
+        dtype_ = getDefaultInstance().getDtype();
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string dtype = 3;</code>
+       * @param value The bytes for dtype to set.
+       * @return This builder for chaining.
+       */
+      public Builder setDtypeBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        dtype_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -918,18 +1068,18 @@ public final class FlBaseProto {
     }
 
     // @@protoc_insertion_point(class_scope:FloatTensor)
-    private static final FloatTensor DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new FloatTensor();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor();
     }
 
-    public static FloatTensor getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<FloatTensor>
         PARSER = new com.google.protobuf.AbstractParser<FloatTensor>() {
-      @Override
+      @java.lang.Override
       public FloatTensor parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -942,13 +1092,13 @@ public final class FlBaseProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<FloatTensor> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public FloatTensor getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -967,11 +1117,11 @@ public final class FlBaseProto {
      * <code>.MetaData metaData = 1;</code>
      * @return The metaData.
      */
-    MetaData getMetaData();
+    com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData getMetaData();
     /**
      * <code>.MetaData metaData = 1;</code>
      */
-    MetaDataOrBuilder getMetaDataOrBuilder();
+    com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaDataOrBuilder getMetaDataOrBuilder();
 
     /**
      * <code>map&lt;string, .FloatTensor&gt; tensorMap = 2;</code>
@@ -981,31 +1131,31 @@ public final class FlBaseProto {
      * <code>map&lt;string, .FloatTensor&gt; tensorMap = 2;</code>
      */
     boolean containsTensorMap(
-        String key);
+        java.lang.String key);
     /**
      * Use {@link #getTensorMapMap()} instead.
      */
-    @Deprecated
-    java.util.Map<String, FloatTensor>
+    @java.lang.Deprecated
+    java.util.Map<java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor>
     getTensorMap();
     /**
      * <code>map&lt;string, .FloatTensor&gt; tensorMap = 2;</code>
      */
-    java.util.Map<String, FloatTensor>
+    java.util.Map<java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor>
     getTensorMapMap();
     /**
      * <code>map&lt;string, .FloatTensor&gt; tensorMap = 2;</code>
      */
 
-    FloatTensor getTensorMapOrDefault(
-        String key,
-        FloatTensor defaultValue);
+    com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor getTensorMapOrDefault(
+        java.lang.String key,
+        com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor defaultValue);
     /**
      * <code>map&lt;string, .FloatTensor&gt; tensorMap = 2;</code>
      */
 
-    FloatTensor getTensorMapOrThrow(
-        String key);
+    com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor getTensorMapOrThrow(
+        java.lang.String key);
   }
   /**
    * <pre>
@@ -1025,14 +1175,14 @@ public final class FlBaseProto {
     private TensorMap() {
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new TensorMap();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -1043,7 +1193,7 @@ public final class FlBaseProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       int mutable_bitField0_ = 0;
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
@@ -1057,11 +1207,11 @@ public final class FlBaseProto {
               done = true;
               break;
             case 10: {
-              MetaData.Builder subBuilder = null;
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.Builder subBuilder = null;
               if (metaData_ != null) {
                 subBuilder = metaData_.toBuilder();
               }
-              metaData_ = input.readMessage(MetaData.parser(), extensionRegistry);
+              metaData_ = input.readMessage(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.parser(), extensionRegistry);
               if (subBuilder != null) {
                 subBuilder.mergeFrom(metaData_);
                 metaData_ = subBuilder.buildPartial();
@@ -1075,7 +1225,7 @@ public final class FlBaseProto {
                     TensorMapDefaultEntryHolder.defaultEntry);
                 mutable_bitField0_ |= 0x00000001;
               }
-              com.google.protobuf.MapEntry<String, FloatTensor>
+              com.google.protobuf.MapEntry<java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor>
               tensorMap__ = input.readMessage(
                   TensorMapDefaultEntryHolder.defaultEntry.getParserForType(), extensionRegistry);
               tensorMap_.getMutableMap().put(
@@ -1103,11 +1253,11 @@ public final class FlBaseProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FlBaseProto.internal_static_TensorMap_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.internal_static_TensorMap_descriptor;
     }
 
     @SuppressWarnings({"rawtypes"})
-    @Override
+    @java.lang.Override
     protected com.google.protobuf.MapField internalGetMapField(
         int number) {
       switch (number) {
@@ -1118,21 +1268,21 @@ public final class FlBaseProto {
               "Invalid map field number: " + number);
       }
     }
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FlBaseProto.internal_static_TensorMap_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.internal_static_TensorMap_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              TensorMap.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.class, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder.class);
     }
 
     public static final int METADATA_FIELD_NUMBER = 1;
-    private MetaData metaData_;
+    private com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData metaData_;
     /**
      * <code>.MetaData metaData = 1;</code>
      * @return Whether the metaData field is set.
      */
-    @Override
+    @java.lang.Override
     public boolean hasMetaData() {
       return metaData_ != null;
     }
@@ -1140,33 +1290,33 @@ public final class FlBaseProto {
      * <code>.MetaData metaData = 1;</code>
      * @return The metaData.
      */
-    @Override
-    public MetaData getMetaData() {
-      return metaData_ == null ? MetaData.getDefaultInstance() : metaData_;
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData getMetaData() {
+      return metaData_ == null ? com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.getDefaultInstance() : metaData_;
     }
     /**
      * <code>.MetaData metaData = 1;</code>
      */
-    @Override
-    public MetaDataOrBuilder getMetaDataOrBuilder() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaDataOrBuilder getMetaDataOrBuilder() {
       return getMetaData();
     }
 
     public static final int TENSORMAP_FIELD_NUMBER = 2;
     private static final class TensorMapDefaultEntryHolder {
       static final com.google.protobuf.MapEntry<
-          String, FloatTensor> defaultEntry =
+          java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor> defaultEntry =
               com.google.protobuf.MapEntry
-              .<String, FloatTensor>newDefaultInstance(
-                  FlBaseProto.internal_static_TensorMap_TensorMapEntry_descriptor,
+              .<java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor>newDefaultInstance(
+                  com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.internal_static_TensorMap_TensorMapEntry_descriptor, 
                   com.google.protobuf.WireFormat.FieldType.STRING,
                   "",
                   com.google.protobuf.WireFormat.FieldType.MESSAGE,
-                  FloatTensor.getDefaultInstance());
+                  com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor.getDefaultInstance());
     }
     private com.google.protobuf.MapField<
-        String, FloatTensor> tensorMap_;
-    private com.google.protobuf.MapField<String, FloatTensor>
+        java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor> tensorMap_;
+    private com.google.protobuf.MapField<java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor>
     internalGetTensorMap() {
       if (tensorMap_ == null) {
         return com.google.protobuf.MapField.emptyMapField(
@@ -1182,59 +1332,59 @@ public final class FlBaseProto {
      * <code>map&lt;string, .FloatTensor&gt; tensorMap = 2;</code>
      */
 
-    @Override
+    @java.lang.Override
     public boolean containsTensorMap(
-        String key) {
-      if (key == null) { throw new NullPointerException(); }
+        java.lang.String key) {
+      if (key == null) { throw new java.lang.NullPointerException(); }
       return internalGetTensorMap().getMap().containsKey(key);
     }
     /**
      * Use {@link #getTensorMapMap()} instead.
      */
-    @Override
-    @Deprecated
-    public java.util.Map<String, FloatTensor> getTensorMap() {
+    @java.lang.Override
+    @java.lang.Deprecated
+    public java.util.Map<java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor> getTensorMap() {
       return getTensorMapMap();
     }
     /**
      * <code>map&lt;string, .FloatTensor&gt; tensorMap = 2;</code>
      */
-    @Override
+    @java.lang.Override
 
-    public java.util.Map<String, FloatTensor> getTensorMapMap() {
+    public java.util.Map<java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor> getTensorMapMap() {
       return internalGetTensorMap().getMap();
     }
     /**
      * <code>map&lt;string, .FloatTensor&gt; tensorMap = 2;</code>
      */
-    @Override
+    @java.lang.Override
 
-    public FloatTensor getTensorMapOrDefault(
-        String key,
-        FloatTensor defaultValue) {
-      if (key == null) { throw new NullPointerException(); }
-      java.util.Map<String, FloatTensor> map =
+    public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor getTensorMapOrDefault(
+        java.lang.String key,
+        com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor defaultValue) {
+      if (key == null) { throw new java.lang.NullPointerException(); }
+      java.util.Map<java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor> map =
           internalGetTensorMap().getMap();
       return map.containsKey(key) ? map.get(key) : defaultValue;
     }
     /**
      * <code>map&lt;string, .FloatTensor&gt; tensorMap = 2;</code>
      */
-    @Override
+    @java.lang.Override
 
-    public FloatTensor getTensorMapOrThrow(
-        String key) {
-      if (key == null) { throw new NullPointerException(); }
-      java.util.Map<String, FloatTensor> map =
+    public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor getTensorMapOrThrow(
+        java.lang.String key) {
+      if (key == null) { throw new java.lang.NullPointerException(); }
+      java.util.Map<java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor> map =
           internalGetTensorMap().getMap();
       if (!map.containsKey(key)) {
-        throw new IllegalArgumentException();
+        throw new java.lang.IllegalArgumentException();
       }
       return map.get(key);
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -1244,7 +1394,7 @@ public final class FlBaseProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (metaData_ != null) {
@@ -1259,7 +1409,7 @@ public final class FlBaseProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -1269,9 +1419,9 @@ public final class FlBaseProto {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getMetaData());
       }
-      for (java.util.Map.Entry<String, FloatTensor> entry
+      for (java.util.Map.Entry<java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor> entry
            : internalGetTensorMap().getMap().entrySet()) {
-        com.google.protobuf.MapEntry<String, FloatTensor>
+        com.google.protobuf.MapEntry<java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor>
         tensorMap__ = TensorMapDefaultEntryHolder.defaultEntry.newBuilderForType()
             .setKey(entry.getKey())
             .setValue(entry.getValue())
@@ -1284,15 +1434,15 @@ public final class FlBaseProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof TensorMap)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap)) {
         return super.equals(obj);
       }
-      TensorMap other = (TensorMap) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap other = (com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap) obj;
 
       if (hasMetaData() != other.hasMetaData()) return false;
       if (hasMetaData()) {
@@ -1305,7 +1455,7 @@ public final class FlBaseProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -1325,69 +1475,69 @@ public final class FlBaseProto {
       return hash;
     }
 
-    public static TensorMap parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static TensorMap parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static TensorMap parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static TensorMap parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static TensorMap parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static TensorMap parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static TensorMap parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static TensorMap parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static TensorMap parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static TensorMap parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static TensorMap parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static TensorMap parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -1395,23 +1545,23 @@ public final class FlBaseProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(TensorMap prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -1424,10 +1574,10 @@ public final class FlBaseProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:TensorMap)
-        TensorMapOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMapOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FlBaseProto.internal_static_TensorMap_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.internal_static_TensorMap_descriptor;
       }
 
       @SuppressWarnings({"rawtypes"})
@@ -1452,12 +1602,12 @@ public final class FlBaseProto {
                 "Invalid map field number: " + number);
         }
       }
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FlBaseProto.internal_static_TensorMap_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.internal_static_TensorMap_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                TensorMap.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.class, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.newBuilder()
@@ -1466,7 +1616,7 @@ public final class FlBaseProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -1475,7 +1625,7 @@ public final class FlBaseProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         if (metaDataBuilder_ == null) {
@@ -1488,29 +1638,29 @@ public final class FlBaseProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FlBaseProto.internal_static_TensorMap_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.internal_static_TensorMap_descriptor;
       }
 
-      @Override
-      public TensorMap getDefaultInstanceForType() {
-        return TensorMap.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.getDefaultInstance();
       }
 
-      @Override
-      public TensorMap build() {
-        TensorMap result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public TensorMap buildPartial() {
-        TensorMap result = new TensorMap(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap result = new com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap(this);
         int from_bitField0_ = bitField0_;
         if (metaDataBuilder_ == null) {
           result.metaData_ = metaData_;
@@ -1523,50 +1673,50 @@ public final class FlBaseProto {
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof TensorMap) {
-          return mergeFrom((TensorMap)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(TensorMap other) {
-        if (other == TensorMap.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap.getDefaultInstance()) return this;
         if (other.hasMetaData()) {
           mergeMetaData(other.getMetaData());
         }
@@ -1577,21 +1727,21 @@ public final class FlBaseProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        TensorMap parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (TensorMap) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -1602,9 +1752,9 @@ public final class FlBaseProto {
       }
       private int bitField0_;
 
-      private MetaData metaData_;
+      private com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData metaData_;
       private com.google.protobuf.SingleFieldBuilderV3<
-          MetaData, MetaData.Builder, MetaDataOrBuilder> metaDataBuilder_;
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaDataOrBuilder> metaDataBuilder_;
       /**
        * <code>.MetaData metaData = 1;</code>
        * @return Whether the metaData field is set.
@@ -1616,9 +1766,9 @@ public final class FlBaseProto {
        * <code>.MetaData metaData = 1;</code>
        * @return The metaData.
        */
-      public MetaData getMetaData() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData getMetaData() {
         if (metaDataBuilder_ == null) {
-          return metaData_ == null ? MetaData.getDefaultInstance() : metaData_;
+          return metaData_ == null ? com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.getDefaultInstance() : metaData_;
         } else {
           return metaDataBuilder_.getMessage();
         }
@@ -1626,7 +1776,7 @@ public final class FlBaseProto {
       /**
        * <code>.MetaData metaData = 1;</code>
        */
-      public Builder setMetaData(MetaData value) {
+      public Builder setMetaData(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData value) {
         if (metaDataBuilder_ == null) {
           if (value == null) {
             throw new NullPointerException();
@@ -1643,7 +1793,7 @@ public final class FlBaseProto {
        * <code>.MetaData metaData = 1;</code>
        */
       public Builder setMetaData(
-          MetaData.Builder builderForValue) {
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.Builder builderForValue) {
         if (metaDataBuilder_ == null) {
           metaData_ = builderForValue.build();
           onChanged();
@@ -1656,11 +1806,11 @@ public final class FlBaseProto {
       /**
        * <code>.MetaData metaData = 1;</code>
        */
-      public Builder mergeMetaData(MetaData value) {
+      public Builder mergeMetaData(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData value) {
         if (metaDataBuilder_ == null) {
           if (metaData_ != null) {
             metaData_ =
-              MetaData.newBuilder(metaData_).mergeFrom(value).buildPartial();
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.newBuilder(metaData_).mergeFrom(value).buildPartial();
           } else {
             metaData_ = value;
           }
@@ -1688,7 +1838,7 @@ public final class FlBaseProto {
       /**
        * <code>.MetaData metaData = 1;</code>
        */
-      public MetaData.Builder getMetaDataBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.Builder getMetaDataBuilder() {
         
         onChanged();
         return getMetaDataFieldBuilder().getBuilder();
@@ -1696,23 +1846,23 @@ public final class FlBaseProto {
       /**
        * <code>.MetaData metaData = 1;</code>
        */
-      public MetaDataOrBuilder getMetaDataOrBuilder() {
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaDataOrBuilder getMetaDataOrBuilder() {
         if (metaDataBuilder_ != null) {
           return metaDataBuilder_.getMessageOrBuilder();
         } else {
           return metaData_ == null ?
-              MetaData.getDefaultInstance() : metaData_;
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.getDefaultInstance() : metaData_;
         }
       }
       /**
        * <code>.MetaData metaData = 1;</code>
        */
       private com.google.protobuf.SingleFieldBuilderV3<
-          MetaData, MetaData.Builder, MetaDataOrBuilder>
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaDataOrBuilder> 
           getMetaDataFieldBuilder() {
         if (metaDataBuilder_ == null) {
           metaDataBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
-              MetaData, MetaData.Builder, MetaDataOrBuilder>(
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.Builder, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaDataOrBuilder>(
                   getMetaData(),
                   getParentForChildren(),
                   isClean());
@@ -1722,8 +1872,8 @@ public final class FlBaseProto {
       }
 
       private com.google.protobuf.MapField<
-          String, FloatTensor> tensorMap_;
-      private com.google.protobuf.MapField<String, FloatTensor>
+          java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor> tensorMap_;
+      private com.google.protobuf.MapField<java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor>
       internalGetTensorMap() {
         if (tensorMap_ == null) {
           return com.google.protobuf.MapField.emptyMapField(
@@ -1731,7 +1881,7 @@ public final class FlBaseProto {
         }
         return tensorMap_;
       }
-      private com.google.protobuf.MapField<String, FloatTensor>
+      private com.google.protobuf.MapField<java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor>
       internalGetMutableTensorMap() {
         onChanged();;
         if (tensorMap_ == null) {
@@ -1751,53 +1901,53 @@ public final class FlBaseProto {
        * <code>map&lt;string, .FloatTensor&gt; tensorMap = 2;</code>
        */
 
-      @Override
+      @java.lang.Override
       public boolean containsTensorMap(
-          String key) {
-        if (key == null) { throw new NullPointerException(); }
+          java.lang.String key) {
+        if (key == null) { throw new java.lang.NullPointerException(); }
         return internalGetTensorMap().getMap().containsKey(key);
       }
       /**
        * Use {@link #getTensorMapMap()} instead.
        */
-      @Override
-      @Deprecated
-      public java.util.Map<String, FloatTensor> getTensorMap() {
+      @java.lang.Override
+      @java.lang.Deprecated
+      public java.util.Map<java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor> getTensorMap() {
         return getTensorMapMap();
       }
       /**
        * <code>map&lt;string, .FloatTensor&gt; tensorMap = 2;</code>
        */
-      @Override
+      @java.lang.Override
 
-      public java.util.Map<String, FloatTensor> getTensorMapMap() {
+      public java.util.Map<java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor> getTensorMapMap() {
         return internalGetTensorMap().getMap();
       }
       /**
        * <code>map&lt;string, .FloatTensor&gt; tensorMap = 2;</code>
        */
-      @Override
+      @java.lang.Override
 
-      public FloatTensor getTensorMapOrDefault(
-          String key,
-          FloatTensor defaultValue) {
-        if (key == null) { throw new NullPointerException(); }
-        java.util.Map<String, FloatTensor> map =
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor getTensorMapOrDefault(
+          java.lang.String key,
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor defaultValue) {
+        if (key == null) { throw new java.lang.NullPointerException(); }
+        java.util.Map<java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor> map =
             internalGetTensorMap().getMap();
         return map.containsKey(key) ? map.get(key) : defaultValue;
       }
       /**
        * <code>map&lt;string, .FloatTensor&gt; tensorMap = 2;</code>
        */
-      @Override
+      @java.lang.Override
 
-      public FloatTensor getTensorMapOrThrow(
-          String key) {
-        if (key == null) { throw new NullPointerException(); }
-        java.util.Map<String, FloatTensor> map =
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor getTensorMapOrThrow(
+          java.lang.String key) {
+        if (key == null) { throw new java.lang.NullPointerException(); }
+        java.util.Map<java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor> map =
             internalGetTensorMap().getMap();
         if (!map.containsKey(key)) {
-          throw new IllegalArgumentException();
+          throw new java.lang.IllegalArgumentException();
         }
         return map.get(key);
       }
@@ -1812,8 +1962,8 @@ public final class FlBaseProto {
        */
 
       public Builder removeTensorMap(
-          String key) {
-        if (key == null) { throw new NullPointerException(); }
+          java.lang.String key) {
+        if (key == null) { throw new java.lang.NullPointerException(); }
         internalGetMutableTensorMap().getMutableMap()
             .remove(key);
         return this;
@@ -1821,8 +1971,8 @@ public final class FlBaseProto {
       /**
        * Use alternate mutation accessors instead.
        */
-      @Deprecated
-      public java.util.Map<String, FloatTensor>
+      @java.lang.Deprecated
+      public java.util.Map<java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor>
       getMutableTensorMap() {
         return internalGetMutableTensorMap().getMutableMap();
       }
@@ -1830,10 +1980,10 @@ public final class FlBaseProto {
        * <code>map&lt;string, .FloatTensor&gt; tensorMap = 2;</code>
        */
       public Builder putTensorMap(
-          String key,
-          FloatTensor value) {
-        if (key == null) { throw new NullPointerException(); }
-        if (value == null) { throw new NullPointerException(); }
+          java.lang.String key,
+          com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor value) {
+        if (key == null) { throw new java.lang.NullPointerException(); }
+        if (value == null) { throw new java.lang.NullPointerException(); }
         internalGetMutableTensorMap().getMutableMap()
             .put(key, value);
         return this;
@@ -1843,18 +1993,18 @@ public final class FlBaseProto {
        */
 
       public Builder putAllTensorMap(
-          java.util.Map<String, FloatTensor> values) {
+          java.util.Map<java.lang.String, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.FloatTensor> values) {
         internalGetMutableTensorMap().getMutableMap()
             .putAll(values);
         return this;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -1865,18 +2015,18 @@ public final class FlBaseProto {
     }
 
     // @@protoc_insertion_point(class_scope:TensorMap)
-    private static final TensorMap DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new TensorMap();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap();
     }
 
-    public static TensorMap getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<TensorMap>
         PARSER = new com.google.protobuf.AbstractParser<TensorMap>() {
-      @Override
+      @java.lang.Override
       public TensorMap parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -1889,13 +2039,13 @@ public final class FlBaseProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<TensorMap> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public TensorMap getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.TensorMap getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -1909,7 +2059,7 @@ public final class FlBaseProto {
      * <code>string name = 1;</code>
      * @return The name.
      */
-    String getName();
+    java.lang.String getName();
     /**
      * <code>string name = 1;</code>
      * @return The bytes for name.
@@ -1942,14 +2092,14 @@ public final class FlBaseProto {
       name_ = "";
     }
 
-    @Override
+    @java.lang.Override
     @SuppressWarnings({"unused"})
-    protected Object newInstance(
+    protected java.lang.Object newInstance(
         UnusedPrivateParameter unused) {
       return new MetaData();
     }
 
-    @Override
+    @java.lang.Override
     public final com.google.protobuf.UnknownFieldSet
     getUnknownFields() {
       return this.unknownFields;
@@ -1960,7 +2110,7 @@ public final class FlBaseProto {
         throws com.google.protobuf.InvalidProtocolBufferException {
       this();
       if (extensionRegistry == null) {
-        throw new NullPointerException();
+        throw new java.lang.NullPointerException();
       }
       com.google.protobuf.UnknownFieldSet.Builder unknownFields =
           com.google.protobuf.UnknownFieldSet.newBuilder();
@@ -1973,7 +2123,7 @@ public final class FlBaseProto {
               done = true;
               break;
             case 10: {
-              String s = input.readStringRequireUtf8();
+              java.lang.String s = input.readStringRequireUtf8();
 
               name_ = s;
               break;
@@ -2004,32 +2154,32 @@ public final class FlBaseProto {
     }
     public static final com.google.protobuf.Descriptors.Descriptor
         getDescriptor() {
-      return FlBaseProto.internal_static_MetaData_descriptor;
+      return com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.internal_static_MetaData_descriptor;
     }
 
-    @Override
-    protected FieldAccessorTable
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
         internalGetFieldAccessorTable() {
-      return FlBaseProto.internal_static_MetaData_fieldAccessorTable
+      return com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.internal_static_MetaData_fieldAccessorTable
           .ensureFieldAccessorsInitialized(
-              MetaData.class, Builder.class);
+              com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.class, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.Builder.class);
     }
 
     public static final int NAME_FIELD_NUMBER = 1;
-    private volatile Object name_;
+    private volatile java.lang.Object name_;
     /**
      * <code>string name = 1;</code>
      * @return The name.
      */
-    @Override
-    public String getName() {
-      Object ref = name_;
-      if (ref instanceof String) {
-        return (String) ref;
+    @java.lang.Override
+    public java.lang.String getName() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
       } else {
         com.google.protobuf.ByteString bs = 
             (com.google.protobuf.ByteString) ref;
-        String s = bs.toStringUtf8();
+        java.lang.String s = bs.toStringUtf8();
         name_ = s;
         return s;
       }
@@ -2038,14 +2188,14 @@ public final class FlBaseProto {
      * <code>string name = 1;</code>
      * @return The bytes for name.
      */
-    @Override
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getNameBytes() {
-      Object ref = name_;
-      if (ref instanceof String) {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
         com.google.protobuf.ByteString b = 
             com.google.protobuf.ByteString.copyFromUtf8(
-                (String) ref);
+                (java.lang.String) ref);
         name_ = b;
         return b;
       } else {
@@ -2059,13 +2209,13 @@ public final class FlBaseProto {
      * <code>int32 version = 2;</code>
      * @return The version.
      */
-    @Override
+    @java.lang.Override
     public int getVersion() {
       return version_;
     }
 
     private byte memoizedIsInitialized = -1;
-    @Override
+    @java.lang.Override
     public final boolean isInitialized() {
       byte isInitialized = memoizedIsInitialized;
       if (isInitialized == 1) return true;
@@ -2075,7 +2225,7 @@ public final class FlBaseProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
       if (!getNameBytes().isEmpty()) {
@@ -2087,7 +2237,7 @@ public final class FlBaseProto {
       unknownFields.writeTo(output);
     }
 
-    @Override
+    @java.lang.Override
     public int getSerializedSize() {
       int size = memoizedSize;
       if (size != -1) return size;
@@ -2105,15 +2255,15 @@ public final class FlBaseProto {
       return size;
     }
 
-    @Override
-    public boolean equals(final Object obj) {
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
       if (obj == this) {
        return true;
       }
-      if (!(obj instanceof MetaData)) {
+      if (!(obj instanceof com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData)) {
         return super.equals(obj);
       }
-      MetaData other = (MetaData) obj;
+      com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData other = (com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData) obj;
 
       if (!getName()
           .equals(other.getName())) return false;
@@ -2123,7 +2273,7 @@ public final class FlBaseProto {
       return true;
     }
 
-    @Override
+    @java.lang.Override
     public int hashCode() {
       if (memoizedHashCode != 0) {
         return memoizedHashCode;
@@ -2139,69 +2289,69 @@ public final class FlBaseProto {
       return hash;
     }
 
-    public static MetaData parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData parseFrom(
         java.nio.ByteBuffer data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static MetaData parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData parseFrom(
         java.nio.ByteBuffer data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static MetaData parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData parseFrom(
         com.google.protobuf.ByteString data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static MetaData parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData parseFrom(
         com.google.protobuf.ByteString data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static MetaData parseFrom(byte[] data)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData parseFrom(byte[] data)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data);
     }
-    public static MetaData parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData parseFrom(
         byte[] data,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
       return PARSER.parseFrom(data, extensionRegistry);
     }
-    public static MetaData parseFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData parseFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static MetaData parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData parseFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
-    public static MetaData parseDelimitedFrom(java.io.InputStream input)
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData parseDelimitedFrom(java.io.InputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input);
     }
-    public static MetaData parseDelimitedFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData parseDelimitedFrom(
         java.io.InputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
     }
-    public static MetaData parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData parseFrom(
         com.google.protobuf.CodedInputStream input)
         throws java.io.IOException {
       return com.google.protobuf.GeneratedMessageV3
           .parseWithIOException(PARSER, input);
     }
-    public static MetaData parseFrom(
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData parseFrom(
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
@@ -2209,23 +2359,23 @@ public final class FlBaseProto {
           .parseWithIOException(PARSER, input, extensionRegistry);
     }
 
-    @Override
+    @java.lang.Override
     public Builder newBuilderForType() { return newBuilder(); }
     public static Builder newBuilder() {
       return DEFAULT_INSTANCE.toBuilder();
     }
-    public static Builder newBuilder(MetaData prototype) {
+    public static Builder newBuilder(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData prototype) {
       return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
     }
-    @Override
+    @java.lang.Override
     public Builder toBuilder() {
       return this == DEFAULT_INSTANCE
           ? new Builder() : new Builder().mergeFrom(this);
     }
 
-    @Override
+    @java.lang.Override
     protected Builder newBuilderForType(
-        BuilderParent parent) {
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       Builder builder = new Builder(parent);
       return builder;
     }
@@ -2238,18 +2388,18 @@ public final class FlBaseProto {
     public static final class Builder extends
         com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
         // @@protoc_insertion_point(builder_implements:MetaData)
-        MetaDataOrBuilder {
+        com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaDataOrBuilder {
       public static final com.google.protobuf.Descriptors.Descriptor
           getDescriptor() {
-        return FlBaseProto.internal_static_MetaData_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.internal_static_MetaData_descriptor;
       }
 
-      @Override
-      protected FieldAccessorTable
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
           internalGetFieldAccessorTable() {
-        return FlBaseProto.internal_static_MetaData_fieldAccessorTable
+        return com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.internal_static_MetaData_fieldAccessorTable
             .ensureFieldAccessorsInitialized(
-                MetaData.class, Builder.class);
+                com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.class, com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.Builder.class);
       }
 
       // Construct using com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.newBuilder()
@@ -2258,7 +2408,7 @@ public final class FlBaseProto {
       }
 
       private Builder(
-          BuilderParent parent) {
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
         maybeForceBuilderInitialization();
       }
@@ -2267,7 +2417,7 @@ public final class FlBaseProto {
                 .alwaysUseFieldBuilders) {
         }
       }
-      @Override
+      @java.lang.Override
       public Builder clear() {
         super.clear();
         name_ = "";
@@ -2277,79 +2427,79 @@ public final class FlBaseProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public com.google.protobuf.Descriptors.Descriptor
           getDescriptorForType() {
-        return FlBaseProto.internal_static_MetaData_descriptor;
+        return com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.internal_static_MetaData_descriptor;
       }
 
-      @Override
-      public MetaData getDefaultInstanceForType() {
-        return MetaData.getDefaultInstance();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData getDefaultInstanceForType() {
+        return com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.getDefaultInstance();
       }
 
-      @Override
-      public MetaData build() {
-        MetaData result = buildPartial();
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData build() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData result = buildPartial();
         if (!result.isInitialized()) {
           throw newUninitializedMessageException(result);
         }
         return result;
       }
 
-      @Override
-      public MetaData buildPartial() {
-        MetaData result = new MetaData(this);
+      @java.lang.Override
+      public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData buildPartial() {
+        com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData result = new com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData(this);
         result.name_ = name_;
         result.version_ = version_;
         onBuilt();
         return result;
       }
 
-      @Override
+      @java.lang.Override
       public Builder clone() {
         return super.clone();
       }
-      @Override
+      @java.lang.Override
       public Builder setField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.setField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder clearField(
           com.google.protobuf.Descriptors.FieldDescriptor field) {
         return super.clearField(field);
       }
-      @Override
+      @java.lang.Override
       public Builder clearOneof(
           com.google.protobuf.Descriptors.OneofDescriptor oneof) {
         return super.clearOneof(oneof);
       }
-      @Override
+      @java.lang.Override
       public Builder setRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, Object value) {
+          int index, java.lang.Object value) {
         return super.setRepeatedField(field, index, value);
       }
-      @Override
+      @java.lang.Override
       public Builder addRepeatedField(
           com.google.protobuf.Descriptors.FieldDescriptor field,
-          Object value) {
+          java.lang.Object value) {
         return super.addRepeatedField(field, value);
       }
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof MetaData) {
-          return mergeFrom((MetaData)other);
+        if (other instanceof com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData) {
+          return mergeFrom((com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData)other);
         } else {
           super.mergeFrom(other);
           return this;
         }
       }
 
-      public Builder mergeFrom(MetaData other) {
-        if (other == MetaData.getDefaultInstance()) return this;
+      public Builder mergeFrom(com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData other) {
+        if (other == com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData.getDefaultInstance()) return this;
         if (!other.getName().isEmpty()) {
           name_ = other.name_;
           onChanged();
@@ -2362,21 +2512,21 @@ public final class FlBaseProto {
         return this;
       }
 
-      @Override
+      @java.lang.Override
       public final boolean isInitialized() {
         return true;
       }
 
-      @Override
+      @java.lang.Override
       public Builder mergeFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
           throws java.io.IOException {
-        MetaData parsedMessage = null;
+        com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData parsedMessage = null;
         try {
           parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
         } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (MetaData) e.getUnfinishedMessage();
+          parsedMessage = (com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData) e.getUnfinishedMessage();
           throw e.unwrapIOException();
         } finally {
           if (parsedMessage != null) {
@@ -2386,21 +2536,21 @@ public final class FlBaseProto {
         return this;
       }
 
-      private Object name_ = "";
+      private java.lang.Object name_ = "";
       /**
        * <code>string name = 1;</code>
        * @return The name.
        */
-      public String getName() {
-        Object ref = name_;
-        if (!(ref instanceof String)) {
+      public java.lang.String getName() {
+        java.lang.Object ref = name_;
+        if (!(ref instanceof java.lang.String)) {
           com.google.protobuf.ByteString bs =
               (com.google.protobuf.ByteString) ref;
-          String s = bs.toStringUtf8();
+          java.lang.String s = bs.toStringUtf8();
           name_ = s;
           return s;
         } else {
-          return (String) ref;
+          return (java.lang.String) ref;
         }
       }
       /**
@@ -2409,11 +2559,11 @@ public final class FlBaseProto {
        */
       public com.google.protobuf.ByteString
           getNameBytes() {
-        Object ref = name_;
+        java.lang.Object ref = name_;
         if (ref instanceof String) {
           com.google.protobuf.ByteString b = 
               com.google.protobuf.ByteString.copyFromUtf8(
-                  (String) ref);
+                  (java.lang.String) ref);
           name_ = b;
           return b;
         } else {
@@ -2426,7 +2576,7 @@ public final class FlBaseProto {
        * @return This builder for chaining.
        */
       public Builder setName(
-          String value) {
+          java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
   }
@@ -2467,7 +2617,7 @@ public final class FlBaseProto {
        * <code>int32 version = 2;</code>
        * @return The version.
        */
-      @Override
+      @java.lang.Override
       public int getVersion() {
         return version_;
       }
@@ -2492,13 +2642,13 @@ public final class FlBaseProto {
         onChanged();
         return this;
       }
-      @Override
+      @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.setUnknownFields(unknownFields);
       }
 
-      @Override
+      @java.lang.Override
       public final Builder mergeUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
         return super.mergeUnknownFields(unknownFields);
@@ -2509,18 +2659,18 @@ public final class FlBaseProto {
     }
 
     // @@protoc_insertion_point(class_scope:MetaData)
-    private static final MetaData DEFAULT_INSTANCE;
+    private static final com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData DEFAULT_INSTANCE;
     static {
-      DEFAULT_INSTANCE = new MetaData();
+      DEFAULT_INSTANCE = new com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData();
     }
 
-    public static MetaData getDefaultInstance() {
+    public static com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData getDefaultInstance() {
       return DEFAULT_INSTANCE;
     }
 
     private static final com.google.protobuf.Parser<MetaData>
         PARSER = new com.google.protobuf.AbstractParser<MetaData>() {
-      @Override
+      @java.lang.Override
       public MetaData parsePartialFrom(
           com.google.protobuf.CodedInputStream input,
           com.google.protobuf.ExtensionRegistryLite extensionRegistry)
@@ -2533,13 +2683,13 @@ public final class FlBaseProto {
       return PARSER;
     }
 
-    @Override
+    @java.lang.Override
     public com.google.protobuf.Parser<MetaData> getParserForType() {
       return PARSER;
     }
 
-    @Override
-    public MetaData getDefaultInstanceForType() {
+    @java.lang.Override
+    public com.intel.analytics.bigdl.ppml.fl.generated.FlBaseProto.MetaData getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -2573,17 +2723,18 @@ public final class FlBaseProto {
   private static  com.google.protobuf.Descriptors.FileDescriptor
       descriptor;
   static {
-    String[] descriptorData = {
-      "\n\rfl_base.proto\",\n\013FloatTensor\022\r\n\005shape\030" +
-      "\001 \003(\005\022\016\n\006tensor\030\002 \003(\002\"\226\001\n\tTensorMap\022\033\n\010m" +
-      "etaData\030\001 \001(\0132\t.MetaData\022,\n\ttensorMap\030\002 " +
-      "\003(\0132\031.TensorMap.TensorMapEntry\032>\n\016Tensor" +
-      "MapEntry\022\013\n\003key\030\001 \001(\t\022\033\n\005value\030\002 \001(\0132\014.F" +
-      "loatTensor:\0028\001\")\n\010MetaData\022\014\n\004name\030\001 \001(\t" +
-      "\022\017\n\007version\030\002 \001(\005*H\n\006SIGNAL\022\013\n\007SUCCESS\020\000" +
-      "\022\010\n\004WAIT\020\001\022\013\n\007TIMEOUT\020\002\022\017\n\013EMPTY_INPUT\020\003" +
-      "\022\t\n\005ERROR\020\004B:\n+com.intel.analytics.bigdl" +
-      ".ppml.fl.generatedB\013FlBaseProtob\006proto3"
+    java.lang.String[] descriptorData = {
+      "\n\rfl_base.proto\";\n\013FloatTensor\022\r\n\005shape\030" +
+      "\001 \003(\005\022\016\n\006tensor\030\002 \003(\002\022\r\n\005dtype\030\003 \001(\t\"\226\001\n" +
+      "\tTensorMap\022\033\n\010metaData\030\001 \001(\0132\t.MetaData\022" +
+      ",\n\ttensorMap\030\002 \003(\0132\031.TensorMap.TensorMap" +
+      "Entry\032>\n\016TensorMapEntry\022\013\n\003key\030\001 \001(\t\022\033\n\005" +
+      "value\030\002 \001(\0132\014.FloatTensor:\0028\001\")\n\010MetaDat" +
+      "a\022\014\n\004name\030\001 \001(\t\022\017\n\007version\030\002 \001(\005*H\n\006SIGN" +
+      "AL\022\013\n\007SUCCESS\020\000\022\010\n\004WAIT\020\001\022\013\n\007TIMEOUT\020\002\022\017" +
+      "\n\013EMPTY_INPUT\020\003\022\t\n\005ERROR\020\004B:\n+com.intel." +
+      "analytics.bigdl.ppml.fl.generatedB\013FlBas" +
+      "eProtob\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -2594,25 +2745,25 @@ public final class FlBaseProto {
     internal_static_FloatTensor_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_FloatTensor_descriptor,
-        new String[] { "Shape", "Tensor", });
+        new java.lang.String[] { "Shape", "Tensor", "Dtype", });
     internal_static_TensorMap_descriptor =
       getDescriptor().getMessageTypes().get(1);
     internal_static_TensorMap_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_TensorMap_descriptor,
-        new String[] { "MetaData", "TensorMap", });
+        new java.lang.String[] { "MetaData", "TensorMap", });
     internal_static_TensorMap_TensorMapEntry_descriptor =
       internal_static_TensorMap_descriptor.getNestedTypes().get(0);
     internal_static_TensorMap_TensorMapEntry_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_TensorMap_TensorMapEntry_descriptor,
-        new String[] { "Key", "Value", });
+        new java.lang.String[] { "Key", "Value", });
     internal_static_MetaData_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_MetaData_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_MetaData_descriptor,
-        new String[] { "Name", "Version", });
+        new java.lang.String[] { "Name", "Version", });
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/scala/ppml/src/main/java/com/intel/analytics/bigdl/ppml/fl/vfl/FGBoostStub.java
+++ b/scala/ppml/src/main/java/com/intel/analytics/bigdl/ppml/fl/vfl/FGBoostStub.java
@@ -116,4 +116,22 @@ public class FGBoostStub {
                 .build();
         return stub.uploadTreeLeaf(uploadTreeLeafRequest);
     }
+
+    public SaveModelResponse saveServerModel(String modelPath) {
+        SaveModelRequest saveModelRequest = SaveModelRequest
+                .newBuilder()
+                .setClientuuid(clientID)
+                .setModelPath(modelPath)
+                .build();
+        return stub.saveServerModel(saveModelRequest);
+    }
+
+    public LoadModelResponse loadServerModel(String modelPath) {
+        LoadModelRequest loadModelRequest = LoadModelRequest
+                .newBuilder()
+                .setClientId(clientID)
+                .setModelPath(modelPath)
+                .build();
+        return stub.loadServerModel(loadModelRequest);
+    }
 }

--- a/scala/ppml/src/main/proto/fgboost_service.proto
+++ b/scala/ppml/src/main/proto/fgboost_service.proto
@@ -28,6 +28,8 @@ service FGBoostService {
     rpc uploadTreeLeaf(UploadTreeLeafRequest) returns (UploadResponse) {}
     rpc evaluate(EvaluateRequest) returns (EvaluateResponse) {}
     rpc predict(PredictRequest) returns (PredictResponse) {}
+    rpc saveServerModel(SaveModelRequest) returns (SaveModelResponse) {}
+    rpc loadServerModel(LoadModelRequest) returns (LoadModelResponse) {}
 }
 
 message UploadLabelRequest {
@@ -139,4 +141,20 @@ message SplitResponse {
     string response = 2;
     int32 code = 3;
 }
+message SaveModelRequest {
+    string clientuuid = 1;
+    string modelPath = 2;
+}
+message SaveModelResponse {
+    string message = 1;
+    int32 code = 2;
+}
+message LoadModelRequest {
+    string client_id = 1;
+    string model_path = 2;
+}
 
+message LoadModelResponse {
+    string message = 1;
+    int32 code = 2;
+}

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/algorithms/FGBoostRegression.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/algorithms/FGBoostRegression.scala
@@ -33,12 +33,15 @@ import scala.util.parsing.json.{JSON, JSONObject}
  */
 class FGBoostRegression(learningRate: Float = 0.005f,
                         maxDepth: Int = 6,
-                        minChildSize: Int = 1)
+                        minChildSize: Int = 1,
+                        serverModelPath: String = null)
   extends FGBoostModel(continuous = true,
     learningRate = learningRate,
     maxDepth = maxDepth,
     minChildSize = minChildSize,
-    validationMethods = Array(new MAE())) {
+    validationMethods = Array(new MAE()),
+    serverModelPath = serverModelPath) {
+
   def toJSON(): JSONObject = {
     JSONObject(Map(
       "maxDepth" -> maxDepth,

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/fgboost/FGBoostAggregator.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/fgboost/FGBoostAggregator.scala
@@ -65,25 +65,19 @@ class FGBoostAggregator(config: FLConfig,
   def getResultStorage(): Storage[TensorMap] =
     aggregateTypeMap.get(FLPhase.RESULT).getTensorMapStorage()
 
-  loadConfig()
-
-  def loadConfig(): Unit = {
-    if (config.modelPath != null) {
-      logger.info(s"Loading FGBoostAggregator model from ${config.modelPath}")
-      if (new File(config.modelPath).exists()) {
-        val is = new ObjectInputStream(new FileInputStream(config.modelPath))
-        serverTreeLeaf = is.readObject().asInstanceOf[ArrayBuffer[Map[Int, Float]]]
-      } else {
-        logger.warn(s"${config.modelPath} does not exist, will create new model")
-      }
-
+  def loadModel(modelPath: String): Unit = {
+    if (new File(modelPath).exists()) {
+      val is = new ObjectInputStream(new FileInputStream(modelPath))
+      serverTreeLeaf = is.readObject().asInstanceOf[ArrayBuffer[Map[Int, Float]]]
+    } else {
+      logger.warn(s"$modelPath does not exist, will create new model")
     }
   }
 
-  def saveModel(): Unit = {
-    if (config.modelPath != null) {
-      logger.info(s"Saving FGBoostAggregator model to ${config.modelPath}")
-      val os = new ObjectOutputStream(new FileOutputStream(config.modelPath))
+  def saveModel(modelPath: String): Unit = {
+    if (modelPath != null) {
+      logger.info(s"Saving FGBoostAggregator model to ${modelPath}")
+      val os = new ObjectOutputStream(new FileOutputStream(modelPath))
       os.writeObject(serverTreeLeaf)
       os.close()
     }
@@ -239,7 +233,6 @@ class FGBoostAggregator(config: FLConfig,
     serverTreeLeaf += treeLeaf
     leafMap.clear()
     getEvalStorage().version += 1
-    saveModel()
   }
 
   def updateGradient(newPredict: Array[Float]): Unit = {

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/fgboost/FGBoostServiceImpl.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/fgboost/FGBoostServiceImpl.scala
@@ -247,5 +247,42 @@ class FGBoostServiceImpl(clientNum: Int, config: FLConfig)
     }
   }
 
+  override def saveServerModel(request: SaveModelRequest,
+                               responseObserver: StreamObserver[SaveModelResponse]): Unit = {
+    try {
+      aggregator.saveModel(request.getModelPath)
+      val response = "Save model on server successfully"
+      responseObserver.onNext(
+        SaveModelResponse.newBuilder.setMessage(response).setCode(1).build)
+      responseObserver.onCompleted()
+    } catch {
+      case e: Exception =>
+        val error = e.getStackTrace.map(_.toString).mkString("\n")
+        logger.error(e.getMessage + "\n" + error)
+        val response = SaveModelResponse.newBuilder.setMessage(e.getMessage).setCode(1).build
+        responseObserver.onNext(response)
+        responseObserver.onCompleted()
+    }
+
+  }
+
+  override def loadServerModel(request: LoadModelRequest,
+                               responseObserver: StreamObserver[LoadModelResponse]): Unit = {
+    try {
+      aggregator.loadModel(request.getModelPath)
+      val response = "Save model on server successfully"
+      responseObserver.onNext(
+        LoadModelResponse.newBuilder.setMessage(response).setCode(1).build)
+      responseObserver.onCompleted()
+    } catch {
+      case e: Exception =>
+        val error = e.getStackTrace.map(_.toString).mkString("\n")
+        logger.error(e.getMessage + "\n" + error)
+        val response = LoadModelResponse.newBuilder.setMessage(e.getMessage).setCode(1).build
+        responseObserver.onNext(response)
+        responseObserver.onCompleted()
+    }
+
+  }
 
 }

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/python/PythonPPML.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/python/PythonPPML.scala
@@ -71,7 +71,7 @@ class PythonPPML[T: ClassTag](implicit ev: TensorNumeric[T])
                               serverModelPath: String): FGBoostRegression = {
     new FGBoostRegression(learningRate.toFloat, maxDepth, minChildSize, serverModelPath)
   }
-  def fgBoostLoadServerModel(fgBoost: FGBoostModel, modelPath: String) = {
+  def fgBoostLoadServerModel(fgBoost: FGBoostModel, modelPath: String): Unit = {
     fgBoost.loadServerModel(modelPath)
   }
   def createFGBoostClassification(): Unit = {

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/python/PythonPPML.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/python/PythonPPML.scala
@@ -66,8 +66,13 @@ class PythonPPML[T: ClassTag](implicit ev: TensorNumeric[T])
   }
 
   def createFGBoostRegression(learningRate: Double,
-                              maxDepth: Int, minChildSize: Int): FGBoostRegression = {
-    new FGBoostRegression(learningRate.toFloat, maxDepth, minChildSize)
+                              maxDepth: Int,
+                              minChildSize: Int,
+                              serverModelPath: String): FGBoostRegression = {
+    new FGBoostRegression(learningRate.toFloat, maxDepth, minChildSize, serverModelPath)
+  }
+  def fgBoostLoadServerModel(fgBoost: FGBoostModel, modelPath: String) = {
+    fgBoost.loadServerModel(modelPath)
   }
   def createFGBoostClassification(): Unit = {
 


### PR DESCRIPTION
## Description
This is the functionality change. Updates of the tutorial would be done after this is merged.
### 1. Why the change?

to refine save/load server model logic 

### 2. User API changes
* User could pass an argument `serverModelPath` when create `FGBoostRegression/FGBoostClassification` instance
* User could call `model.loadServerModel` to ask server to load the model on aggregator
Scala
```scala
//train and configure saving model
model = FGBoostRegression(serverModelPath = path)
model.fit(...)
//load and continue training
model = FGBoostRegression()
model.loadServerModel(path)
model.fit(...)
```
Python
```python
model = FGBoostRegression(server_model_path = path)
model.fit(...)
//load and continue training
model = FGBoostRegression()
model.load_server_model(path)
model.fit(...)
```
### 3. Summary of the change 
Refine FGBoost save/load server model to the one consistent with the NN. User could pass an argument `serverModelPath` when create `FGBoostRegression/FGBoostClassification` instance and server would save it after every boost round. This model is on disk and could be loaded later.

This is a refinement based on #5361 

### 4. How to test?
Use existed unittests

