### PR TITLE
[PPML] Remove hard coded spark mode in xgboost examples

### DIFF
--- a/python/dllib/examples/nnframes/xgboost/xgboost_classifier.py
+++ b/python/dllib/examples/nnframes/xgboost/xgboost_classifier.py
@@ -37,7 +37,7 @@ import errno
 
 
 def process(filepath, demo):
-    sparkConf = init_spark_conf().setMaster("local[1]").setAppName("testXGBClassifier")
+    sparkConf = init_spark_conf().setAppName("testXGBClassifier")
     sc = init_nncontext(sparkConf)
     sqlContext = SQLContext(sc)
     if demo:

--- a/python/dllib/examples/nnframes/xgboost/xgboost_example.py
+++ b/python/dllib/examples/nnframes/xgboost/xgboost_example.py
@@ -43,7 +43,7 @@ def Processdata(filepath, demo):
     :param filepath:
     :return: assembledf:
     '''
-    sparkConf = init_spark_conf().setMaster("local[1]").setAppName("testNNClassifer")
+    sparkConf = init_spark_conf().setAppName("testNNClassifer")
     sc = init_nncontext(sparkConf)
     sqlContext = SQLContext(sc)
     if demo:

--- a/python/dllib/examples/nnframes/xgboost/xgboost_regressor.py
+++ b/python/dllib/examples/nnframes/xgboost/xgboost_regressor.py
@@ -42,7 +42,7 @@ def Processdata(filepath, demo):
     :param filepath:
     :return: assembledf:
     '''
-    sparkConf = init_spark_conf().setMaster("local[1]").setAppName("testNNClassifer")
+    sparkConf = init_spark_conf().setAppName("testNNClassifer")
     sc = init_nncontext(sparkConf)
     sqlContext = SQLContext(sc)
     if demo:


### PR DESCRIPTION
## Description
Remove hard coded spark mode in xgboost examples.

When submitting tasks, the spark mode specified by the user through the --deploy-mode option will be overwrote by the hard-coded "local[1]" in the .py files. 

### 1. Why the change?
To enable user to specify the deploy mode they want.

### 2. User API changes
None.

### 3. Summary of the change 
Remove hard coded spark deploy mode in all of the .py files under the **xgboost** folder.

### 4. How to test?
- [x] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
