### PR TITLE
Chronos: numpy and python version in pr validation Github Action is fixed

### DIFF
--- a/.github/workflows/chronos-prvn-python-spark-2.4-py37-ray.yml
+++ b/.github/workflows/chronos-prvn-python-spark-2.4-py37-ray.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run Chronos python test
         shell: bash
         run: |
-          pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-nano-spark3 bigdl-friesian bigdl-friesian-spark3
+          pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           sed -i "s/'bigdl-core=='+VERSION/'bigdl-core==2.1.0b20220811'/g" python/dllib/src/setup.py
           bash python/dev/release_default_linux_spark246.sh default false false
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U

--- a/.github/workflows/chronos-prvn-python-spark-2.4-py37-ray.yml
+++ b/.github/workflows/chronos-prvn-python-spark-2.4-py37-ray.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7.6"]
+        python-version: ["3.7.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 8
@@ -48,6 +48,11 @@ jobs:
           pip install optuna==2.10.1
           pip install onnxruntime==1.11.1
           pip install onnx==1.11.0
+          pip uninstall -y intel-tensorflow
+          pip install intel-tensorflow==2.9.1
+          pip uninstall -y numpy
+          pip install numpy==1.21.5
+          pip install scipy==1.5.4
           apt-get update
           apt-get install patchelf
 
@@ -65,9 +70,6 @@ jobs:
           pip install python/chronos/src/dist/bigdl_chronos-*-py3-none-manylinux1_x86_64.whl
           export SPARK_LOCAL_HOSTNAME=localhost
           export KERAS_BACKEND=tensorflow
-          pip uninstall -y numpy
-          pip install numpy==1.19.5
-          pip install scipy==1.5.4
           bash python/chronos/dev/test/run-pytests.sh
         env:
           BIGDL_ROOT: ${{ github.workspace }}

--- a/.github/workflows/chronos-prvn-python-spark-2.4-py37-ray.yml
+++ b/.github/workflows/chronos-prvn-python-spark-2.4-py37-ray.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.7.6"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 8

--- a/.github/workflows/chronos-prvn-python-spark-2.4-py37-ray.yml
+++ b/.github/workflows/chronos-prvn-python-spark-2.4-py37-ray.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7.13"]
+        python-version: ["3.7.6"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 8
@@ -48,10 +48,8 @@ jobs:
           pip install optuna==2.10.1
           pip install onnxruntime==1.11.1
           pip install onnx==1.11.0
-          pip uninstall -y intel-tensorflow
-          pip install intel-tensorflow==2.9.1
           pip uninstall -y numpy
-          pip install numpy==1.21.5
+          pip install numpy==1.19.5
           pip install scipy==1.5.4
           apt-get update
           apt-get install patchelf

--- a/.github/workflows/chronos-prvn-python-spark-2.4-py37-ray.yml
+++ b/.github/workflows/chronos-prvn-python-spark-2.4-py37-ray.yml
@@ -22,36 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 8
-        uses: actions/setup-java@v3
-        with:
-          java-version: '8'
-          distribution: 'temurin'
-          #server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          settings-path: ${{ github.workspace }} # location for the settings.xml file
-
+        uses: ./.github/actions/jdk-setup-action
       - name: Set up Maven
-        uses: stCarolas/setup-maven@v4.4
-        with:
-          maven-version: 3.8.2
-
-      - name: Set up Maven Settings
-        uses: s4u/maven-settings-action@v2.6.0
-        with:
-          sonatypeSnapshots: true
-          apacheSnapshots: true
-          servers: |
-            [{
-              "id": "central",
-              "configuration": {
-                "httpConfiguration": {
-                  "all": {
-                    "connectionTimeout": "3600000",
-                    "readTimeout": "3600000"
-                    }    
-                  }
-                }
-            }]
-          mirrors: '[{"id": "ardaNexus", "name": "ardaNexus", "mirrorOf": "*", "url": "${NEXUS_URL}" }]'
+        uses: ./.github/actions/maven-setup-action
 
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -75,6 +48,8 @@ jobs:
           pip install optuna==2.10.1
           pip install onnxruntime==1.11.1
           pip install onnx==1.11.0
+          pip uninstall -y numpy
+          pip install numpy==1.21.5
           apt-get update
           apt-get install patchelf
 
@@ -92,8 +67,8 @@ jobs:
           pip install python/chronos/src/dist/bigdl_chronos-*-py3-none-manylinux1_x86_64.whl
           export SPARK_LOCAL_HOSTNAME=localhost
           export KERAS_BACKEND=tensorflow
-          python --version
           pip install scipy==1.5.4
           bash python/chronos/dev/test/run-pytests.sh
         env:
+          BIGDL_ROOT: ${{ github.workspace }}
           ANALYTICS_ZOO_ROOT: ${{ github.workspace }}

--- a/.github/workflows/chronos-prvn-python-spark-2.4-py37-ray.yml
+++ b/.github/workflows/chronos-prvn-python-spark-2.4-py37-ray.yml
@@ -48,15 +48,13 @@ jobs:
           pip install optuna==2.10.1
           pip install onnxruntime==1.11.1
           pip install onnx==1.11.0
-          pip uninstall -y numpy
-          pip install numpy==1.21.5
           apt-get update
           apt-get install patchelf
 
       - name: Run Chronos python test
         shell: bash
         run: |
-          pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-friesian bigdl-friesian-spark3
+          pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-nano-spark3 bigdl-friesian bigdl-friesian-spark3
           sed -i "s/'bigdl-core=='+VERSION/'bigdl-core==2.1.0b20220811'/g" python/dllib/src/setup.py
           bash python/dev/release_default_linux_spark246.sh default false false
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
@@ -67,6 +65,8 @@ jobs:
           pip install python/chronos/src/dist/bigdl_chronos-*-py3-none-manylinux1_x86_64.whl
           export SPARK_LOCAL_HOSTNAME=localhost
           export KERAS_BACKEND=tensorflow
+          pip uninstall -y numpy
+          pip install numpy==1.19.5
           pip install scipy==1.5.4
           bash python/chronos/dev/test/run-pytests.sh
         env:


### PR DESCRIPTION
## Description

1) Considering all tf1 related tests are deleted, the numpy version in pr validation action now can be fixed to 1.19.5.
2) Python version are set to be 3.7.6 to fix "ImportError: cannot import name 'get_config' from 'tensorflow.python.eager.context' "
3) Besides, because existing workflows have been re-organized, some changes are made accordingly.
