### PR TITLE
Add Nano openvino async api

### DIFF
--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -157,10 +157,9 @@ class OpenVINOModel:
             model.reshape(orig_shape)
         return model
 
-<<<<<<< HEAD
     def _model_exists_or_err(self):
         invalidInputError(self.ie_network is not None, "self.ie_network shouldn't be None.")
-=======
+
     def async_predict(self, inputs, jobs):
         """
         Perfrom model inference using async mode.
@@ -186,6 +185,5 @@ class OpenVINOModel:
             infer_queue.start_async([model_input], userdata=id)
 
         infer_queue.wait_all()
- 
+
         return results
->>>>>>> add openvino async_predict api

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -19,7 +19,7 @@ from openvino.runtime import Core
 from bigdl.nano.utils.log4Error import invalidInputError
 from openvino.runtime import Model
 from .utils import save
-
+from openvino.runtime import AsyncInferQueue
 
 class OpenVINOModel:
     def __init__(self, ie_network: str, device='CPU', thread_num=None):
@@ -157,5 +157,35 @@ class OpenVINOModel:
             model.reshape(orig_shape)
         return model
 
+<<<<<<< HEAD
     def _model_exists_or_err(self):
         invalidInputError(self.ie_network is not None, "self.ie_network shouldn't be None.")
+=======
+    def async_predict(self, inputs, jobs):
+        """
+        Perfrom model inference using async mode.
+        
+        :param inputs: List of input data
+        :type List[numpy.array]
+        :param jobs: numer of infer requests in the AsyncInferQueue
+        :type int
+        
+        :return A List containing result of each input
+        :rtype List[Dict[openvino.runtime.ConstOutput, numpy.array]]
+        """
+        results = [0 for _ in range(len(inputs))]
+
+        # call back function is called when a infer_request in the infer_queue finishes the inference
+        def call_back(requests, idx):
+            results[idx] = requests.results
+
+        infer_queue = AsyncInferQueue(self._compiled_model, jobs=jobs)
+        infer_queue.set_callback(call_back)
+
+        for id, model_input in enumerate(inputs):
+            infer_queue.start_async([model_input], userdata=id)
+
+        infer_queue.wait_all()
+ 
+        return results
+>>>>>>> add openvino async_predict api

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -23,6 +23,7 @@ from .utils import save
 from openvino.runtime import AsyncInferQueue
 import numpy as np
 
+
 class OpenVINOModel:
     def __init__(self, ie_network: str, device='CPU', thread_num=None):
         self._ie = Core()
@@ -198,7 +199,8 @@ class OpenVINOModel:
         """
         results = [0 for _ in range(len(input_data))]
 
-        # call back function is called when a infer_request in the infer_queue finishes the inference
+        # call back function is called when a infer_request in the infer_queue
+        # finishes the inference
         def call_back(requests, idx):
             results[idx] = self.on_forward_end(requests.results)
 

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -32,8 +32,7 @@ class OpenVINOModel:
         self.ie_network = ie_network
 
     def on_forward_start(self, inputs):
-        invalidInputError(self.ie_network,
-                          "self.ie_network shouldn't be None.")
+        self._model_exists_or_err()
         return inputs
 
     def forward_step(self, *inputs):

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -26,6 +26,7 @@ from bigdl.nano.utils.log4Error import invalidInputError
 from ..core.utils import save
 from torch.utils.data.dataloader import DataLoader
 
+
 class PytorchOpenVINOModel(AcceleratedLightningModule):
     def __init__(self, model, input_sample=None, thread_num=None,
                  logging=True, **export_kwargs):

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -120,13 +120,13 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
     def async_predict(self, inputs, jobs):
         """
         Perfrom model inference using async mode.
-        
-        :param inputs: input data, should be a torch.utils.data.dataloader.DataLoader object or List of torch.Tensor
+
+        :param inputs: input data, can be a DataLoader object or List of torch.Tensor
         :type Union[torch.utils.data.dataloader.DataLoader, List[torch.Tensor]]
 
         :param jobs: numer of infer requests in the AsyncInferQueue
         :type int
-        
+
         :return A List containing result of each input
         :rtype List[torch.Tensor]
         """

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -41,7 +41,7 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
                 export(model, str(dir / 'tmp.xml'))
                 ov_model_path = dir / 'tmp.xml'
             self.ov_model = OpenVINOModel(ov_model_path)
-            super().__init__(self.ov_model)
+            super().__init__(None)
 
     def forward_step(self, *inputs):
         return self.ov_model.forward_step(*inputs)

--- a/python/nano/test/mypy.ini
+++ b/python/nano/test/mypy.ini
@@ -24,3 +24,6 @@ ignore_errors = True
 
 [mypy-bigdl.nano.pytorch.inference.*]
 ignore_errors = True
+
+[mypy-bigdl.nano.deps.openvino.*]
+ignore_errors = True

--- a/python/nano/test/openvino/basic/test_openvino.py
+++ b/python/nano/test/openvino/basic/test_openvino.py
@@ -25,12 +25,12 @@ class TestOpenVINO(TestCase):
         openvino_model = OpenVINOModel("./intel/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.xml")
         x = np.random.randn(1, 3, 224, 224)
         y_hat = openvino_model(x)
-        assert tuple(next(iter(y_hat)).shape) == (1, 1000)
+        assert y_hat.shape == (1, 1000)
 
     def test_openvino_model_async_predict(self):
         openvino_model = OpenVINOModel("./intel/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.xml")
         x = [np.random.randn(1, 3, 224, 224) for i in range(5)]
 
-        result = openvino_model.async_predict(x,jobs=5)
+        result = openvino_model.async_predict(x, num_infer_requests=5)
         for res in result:
-            assert tuple(next(iter(res)).shape) == (1, 1000)
+            assert res.shape == (1, 1000)

--- a/python/nano/test/openvino/basic/test_openvino.py
+++ b/python/nano/test/openvino/basic/test_openvino.py
@@ -26,3 +26,11 @@ class TestOpenVINO(TestCase):
         x = np.random.randn(1, 3, 224, 224)
         y_hat = openvino_model(x)
         assert tuple(next(iter(y_hat)).shape) == (1, 1000)
+
+    def test_openvino_model_async_predict(self):
+        openvino_model = OpenVINOModel("./intel/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.xml")
+        x = [np.random.randn(1, 3, 224, 224) for i in range(5)]
+
+        result = openvino_model.async_predict(x,jobs=5)
+        for res in result:
+            assert tuple(next(iter(res)).shape) == (1, 1000)

--- a/python/nano/test/openvino/basic/test_openvino.py
+++ b/python/nano/test/openvino/basic/test_openvino.py
@@ -31,6 +31,6 @@ class TestOpenVINO(TestCase):
         openvino_model = OpenVINOModel("./intel/resnet18-xnor-binary-onnx-0001/FP16-INT1/resnet18-xnor-binary-onnx-0001.xml")
         x = [np.random.randn(1, 3, 224, 224) for i in range(5)]
 
-        result = openvino_model.async_predict(x, num_infer_requests=5)
+        result = openvino_model.async_predict(x, num_requests=5)
         for res in result:
             assert res.shape == (1, 1000)

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -82,12 +82,12 @@ class TestOpenVINO(TestCase):
         dataloader = DataLoader(ds, batch_size=2)
 
         # do async_predict use dataloader as input
-        result = openvino_model.async_predict(dataloader, num_infer_requests=3)
+        result = openvino_model.async_predict(dataloader, num_requests=3)
         for res in result:
             assert res.shape == (2, 10)
 
         # do async_predict use List of Tensor as input
         x = [torch.rand((10, 3, 256, 256)) for i in range(3)]
-        result = openvino_model.async_predict(x, num_infer_requests=3)
+        result = openvino_model.async_predict(x, num_requests=3)
         for res in result:
             assert res.shape == (10, 10)

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -69,3 +69,25 @@ class TestOpenVINO(TestCase):
             assert y_hat.shape == (3, 10)
             y_hat = loaded_openvino_model(x)
             assert y_hat.shape == (10, 10)
+
+    def test_pytorch_openvino_model_async_predict(self):
+        trainer = Trainer(max_epochs=1)
+        model = mobilenet_v3_small(num_classes=10)
+
+        x = torch.rand((10, 3, 256, 256))
+        y = torch.ones((10, ), dtype=torch.long)
+
+        openvino_model = trainer.trace(model, input_sample=x, accelerator='openvino')
+        ds = TensorDataset(x, y)
+        dataloader = DataLoader(ds, batch_size=2)
+
+        # do async_predict use dataloader as input
+        result = openvino_model.async_predict(dataloader, jobs=3)
+        for res in result:
+            assert res.shape == (2, 10)
+
+        # do async_predict use List of Tensor as input
+        x = [torch.rand((10, 3, 256, 256)) for i in range(3)]
+        result = openvino_model.async_predict(x, jobs=3)
+        for res in result:
+            assert res.shape == (10, 10)

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -82,12 +82,12 @@ class TestOpenVINO(TestCase):
         dataloader = DataLoader(ds, batch_size=2)
 
         # do async_predict use dataloader as input
-        result = openvino_model.async_predict(dataloader, jobs=3)
+        result = openvino_model.async_predict(dataloader, num_infer_requests=3)
         for res in result:
             assert res.shape == (2, 10)
 
         # do async_predict use List of Tensor as input
         x = [torch.rand((10, 3, 256, 256)) for i in range(3)]
-        result = openvino_model.async_predict(x, jobs=3)
+        result = openvino_model.async_predict(x, num_infer_requests=3)
         for res in result:
             assert res.shape == (10, 10)


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->
Add OpenVINO API for Async Inference

### 1. Why the change?

<!-- Provide the related github issue link if available -->
Releated issue: [issue#5507](https://github.com/intel-analytics/BigDL/issues/5507)

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->
**For OpenVINOModel**
```python
# input data should be List of numpy array
x = [np.random.randn(1, 3, 224, 224) for i in range(5)]

# do async inference
# async inference api usage: openvino_model.async_predict(input_data, num_requests)
# param input_data: Input data to be inferenced.
#                  Users can put multiple input data in a list to infer them together.
#                  Can be List[numpy.ndarray] or
#                  List[List[numpy.ndarray]] if the model has multiple inputs.
# param num_requests: Number of requests in the asynchronous infer requests pool.
#                     Defaults to 0.
#                     If 0, it will be set automatically to the optimal number.
# return value: a List containing the infer result of each input array in x
# return value type: List[numpy.array]
result = openvino_model.async_predict(input_data=x, num_requests=5)
```
**For PytorchOpenVINOModel**
```python
from torch.utils.data.dataloader import DataLoader

trainer = Trainer()

x = torch.rand((10, 3, 256, 256))
y = torch.ones((10, ), dtype=torch.long)

pytorch_openvino_model = trainer.trace(model, input_sample=x, accelerator='openvino')

# async inference api usage: pytorch_openvino_model.async_predict(input_data, num_requests)
# param input_data: Input data to be inferenced.
#                   Users can put multiple input data in a list or
#                   put all data in a DataLoader to infer and get results of all input data
#                   Can be torch.utils.data.dataloader.DataLoader and
#                   List[torch.Tensor] or
#                   List[List[torch.Tensor]] if the model has multiple inputs.
#                   If input_data is a DataLoader object,the format in DataLoader should be
#                   (x1, x2, ..., xn, y).
# param jobs: same as OpenVINOModel
# return value: List of output Tensor of each input data (same as sync inference)
# return value type: List[torch.Tensor]

# do async_predict use dataloader as input

# wrap data as a torch.utils.data.dataloader.DataLoader object
ds = TensorDataset(x, y)
dataloader = DataLoader(ds, batch_size=2)

# will infer all data in dataloader batch by batch
result = pytorch_openvino_model.async_predict(dataloader,num_requests=3)

# do async_predict use List of torch.Tensor as input
x = [torch.rand((10, 3, 256, 256)) for i in range(3)]
result = openvino_model.async_predict(x, num_requests=3)


```
### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
- use openvino `AsyncInferQueue` api to implement async inference.
- user can put multiple input data in a list or a dataloader to infer and get results of all input data.
- make the output format same as `PytorchOpenVINOModel` when doing inference with `OpenVINOModel` 

### 4. How to test?
- [x] Unit test
