### PR TITLE
Chronos: change get_latency to a static method

### DIFF
--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -131,6 +131,7 @@ class Evaluator(object):
                     res_list.append(res.numpy())
         return res_list
 
+    @staticmethod
     def get_latency(func, *args, num_running=100, **kwargs):
         """
         Return the time cost in milliseconds of a specific function by running multiple times.


### PR DESCRIPTION
## Description

Change `Evaluator.get_latency` to be a static method.

http://10.112.231.51:18889/job/BigDL-Chronos-PR-Validation/783/
