### PR TITLE
Chronos: modify examples of forecaster.evaluate() and Evaluator.evaluate()

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -602,12 +602,6 @@ class BasePytorchForecaster(Forecaster):
         if you want to evaluate on a single node(which is common practice), please call
         .to_local().evaluate(data, ...)
 
-        >>> from bigdl.orca.automl.metrics import Evaluator
-        >>> y_hat = forecaster.predict(x)
-        >>> y_hat_unscaled = tsdata.unscale_numpy(y_hat) # or other customized unscale methods
-        >>> y_unscaled = tsdata.unscale_numpy(y) # or other customized unscale methods
-        >>> Evaluator.evaluate(metric=..., y_unscaled, y_hat_unscaled, multioutput=...)
-
         :param data: The data support following formats:
 
                | 1. a numpy ndarray tuple (x, y):
@@ -640,6 +634,11 @@ class BasePytorchForecaster(Forecaster):
         :param quantize: if use the quantized model to predict.
 
         :return: A list of evaluation results. Each item represents a metric.
+
+        Example:
+            >>> # to evaluate using a trained forecaster
+            >>> for x, y in test_loader:
+            >>>     test_eval = forecaster.evaluate((x.numpy(), y.numpy()))
         """
         from bigdl.chronos.pytorch.utils import _pytorch_fashion_inference
 
@@ -699,12 +698,6 @@ class BasePytorchForecaster(Forecaster):
         your data (e.g. use .scale() on the TSDataset) please follow the following code
         snap to evaluate your result if you need to evaluate on unscaled data.
 
-        >>> from bigdl.orca.automl.metrics import Evaluator
-        >>> y_hat = forecaster.predict(x)
-        >>> y_hat_unscaled = tsdata.unscale_numpy(y_hat) # or other customized unscale methods
-        >>> y_unscaled = tsdata.unscale_numpy(y) # or other customized unscale methods
-        >>> Evaluator.evaluate(metric=..., y_unscaled, y_hat_unscaled, multioutput=...)
-
         :param data: The data support following formats:
 
                | 1. a numpy ndarray tuple (x, y):
@@ -733,6 +726,11 @@ class BasePytorchForecaster(Forecaster):
         :param quantize: if use the quantized onnx model to evaluate.
 
         :return: A list of evaluation results. Each item represents a metric.
+
+        Example:
+            >>> # to evaluate using a trained forecaster with onnxruntime
+            >>> for x, y in test_loader:
+            >>>     test_eval = forecaster.evaluate_with_onnx((x.numpy(), y.numpy()))
         """
         from bigdl.chronos.pytorch.utils import _pytorch_fashion_inference
         from bigdl.nano.utils.log4Error import invalidInputError

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -595,12 +595,18 @@ class BasePytorchForecaster(Forecaster):
         """
         Evaluate using a trained forecaster.
 
+        If you want to evaluate on a single node(which is common practice), please call
+        .to_local().evaluate(data, ...)
+
         Please note that evaluate result is calculated by scaled y and yhat. If you scaled
-        your data (e.g. use .scale() on the TSDataset) please follow the following code
+        your data (e.g. use .scale() on the TSDataset), please follow the following code
         snap to evaluate your result if you need to evaluate on unscaled data.
 
-        if you want to evaluate on a single node(which is common practice), please call
-        .to_local().evaluate(data, ...)
+        >>> from bigdl.chronos.metric.forecast_metrics import Evaluator
+        >>> y_hat = forecaster.predict(x)
+        >>> y_hat_unscaled = tsdata.unscale_numpy(y_hat) # or other customized unscale methods
+        >>> y_unscaled = tsdata.unscale_numpy(y) # or other customized unscale methods
+        >>> Evaluator.evaluate(metric=..., y_unscaled, y_hat_unscaled, multioutput=...)
 
         :param data: The data support following formats:
 
@@ -634,11 +640,6 @@ class BasePytorchForecaster(Forecaster):
         :param quantize: if use the quantized model to predict.
 
         :return: A list of evaluation results. Each item represents a metric.
-
-        Example:
-            >>> # to evaluate using a trained forecaster
-            >>> for x, y in test_loader:
-            >>>     test_eval = forecaster.evaluate((x.numpy(), y.numpy()))
         """
         from bigdl.chronos.pytorch.utils import _pytorch_fashion_inference
 
@@ -698,6 +699,12 @@ class BasePytorchForecaster(Forecaster):
         your data (e.g. use .scale() on the TSDataset) please follow the following code
         snap to evaluate your result if you need to evaluate on unscaled data.
 
+        >>> from bigdl.chronos.metric.forecast_metrics import Evaluator
+        >>> y_hat = forecaster.predict_with_onnx(x)
+        >>> y_hat_unscaled = tsdata.unscale_numpy(y_hat) # or other customized unscale methods
+        >>> y_unscaled = tsdata.unscale_numpy(y) # or other customized unscale methods
+        >>> Evaluator.evaluate(metric=..., y_unscaled, y_hat_unscaled, multioutput=...)
+
         :param data: The data support following formats:
 
                | 1. a numpy ndarray tuple (x, y):
@@ -726,11 +733,6 @@ class BasePytorchForecaster(Forecaster):
         :param quantize: if use the quantized onnx model to evaluate.
 
         :return: A list of evaluation results. Each item represents a metric.
-
-        Example:
-            >>> # to evaluate using a trained forecaster with onnxruntime
-            >>> for x, y in test_loader:
-            >>>     test_eval = forecaster.evaluate_with_onnx((x.numpy(), y.numpy()))
         """
         from bigdl.chronos.pytorch.utils import _pytorch_fashion_inference
         from bigdl.nano.utils.log4Error import invalidInputError

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -182,11 +182,6 @@ class Evaluator(object):
         :return: Float or ndarray of floats.
                  A floating point value, or an
                  array of floating point values, one for each individual target.
-
-        Example:
-            >>> for x, y in test_loader:
-            >>>     yhat = forecaster.predict(x.numpy())
-            >>>     metric = Evaluator.evaluate("mse", y.numpy(), yhat)
         """
         metrics, y_true, y_pred, original_shape = _standard_input(metrics, y_true, y_pred)
 

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -182,6 +182,11 @@ class Evaluator(object):
         :return: Float or ndarray of floats.
                  A floating point value, or an
                  array of floating point values, one for each individual target.
+        
+        Example:
+            >>> for x, y in test_loader:
+            >>>     yhat = forecaster.predict(x.numpy())
+            >>>     metric = Evaluator.evaluate("mse", y.numpy(), yhat)
         """
         metrics, y_true, y_pred, original_shape = _standard_input(metrics, y_true, y_pred)
 
@@ -222,7 +227,7 @@ class Evaluator(object):
             >>> # run forecaster.predict(x.numpy()) for len(tsdata_test.df) times
             >>> # to evaluate the time cost
             >>> latency = Evaluator.get_latency(forecaster.predict, x.numpy(),\
-                          num_running = len(tsdata_test.df))
+num_running = len(tsdata_test.df))
             >>> # an example output:
             >>> # {"p50": 3.853, "p90": 3.881, "p95": 3.933, "p99": 4.107}
         """

--- a/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
+++ b/python/chronos/src/bigdl/chronos/metric/forecast_metrics.py
@@ -182,7 +182,7 @@ class Evaluator(object):
         :return: Float or ndarray of floats.
                  A floating point value, or an
                  array of floating point values, one for each individual target.
-        
+
         Example:
             >>> for x, y in test_loader:
             >>>     yhat = forecaster.predict(x.numpy())


### PR DESCRIPTION
## Description

In Chronos API doc, examples of forecaster.evaluate() and forecaster.evaluate_with_onnx() are incorrect. And example of Evaluator.evaluate() is added.

