### PR TITLE
Add nano torch support for channels last

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/torch_nano.py
+++ b/python/nano/src/bigdl/nano/pytorch/torch_nano.py
@@ -162,13 +162,13 @@ class TorchNano(LightningLite):
 
     def _setup(
         self,
-        model: nn.Module,  # type: ignore[override]
+        model: nn.Module,
         optimizers: List[Optimizer],
         move_to_device: bool = True,
     ) -> Any:
         """Used to replace LightningLite's setup method."""
         if self.channels_last:
-            model = model.to(memory_format=torch.channels_last)
+            model = model.to(memory_format=torch.channels_last)  # type: ignore
         # LightningLite won't call `Strategy.setup()` method,
         # in which we add IPEX's optimization when using `trainer`.
 

--- a/python/nano/src/bigdl/nano/pytorch/torch_nano.py
+++ b/python/nano/src/bigdl/nano/pytorch/torch_nano.py
@@ -75,7 +75,7 @@ class _TorchNanoModule(_LiteModule):
             return getattr(self.module, name)
 
     def forward(self, *args: Any, **kwargs: Any) -> Any:
-        """Casts all inputs to the right memory format"""
+        """Casts all inputs to the right memory format."""
         if self.channels_last:
             def _convert_to_channels_last(t: torch.Tensor) -> torch.Tensor:
                 if t.dim() == 4:

--- a/python/nano/src/bigdl/nano/pytorch/torch_nano.py
+++ b/python/nano/src/bigdl/nano/pytorch/torch_nano.py
@@ -80,7 +80,7 @@ class _TorchNanoModule(_LiteModule):
                 return t.to(memory_format=torch.channels_last) if t.dim() == 4 else t
             args, kwargs = apply_to_collection([args, kwargs], function=_convert_to_channels_last,
                                                dtype=torch.Tensor)
-        return super().forward(args, kwargs)
+        return super().forward(*args, **kwargs)
 
 
 class TorchNano(LightningLite):
@@ -106,6 +106,8 @@ class TorchNano(LightningLite):
         :param precision: Double precision (64), full precision (32), half precision (16)
             or bfloat16 precision (bf16), defaults to 32.
             Enable ipex bfloat16 weight prepack when `use_ipex=True` and `precision='bf16'`
+        :param channels_last: whether convert input to channels last memory formats, \
+            defaults to False
         """
         self.num_processes = num_processes
         self.use_ipex = use_ipex

--- a/python/nano/src/bigdl/nano/pytorch/torch_nano.py
+++ b/python/nano/src/bigdl/nano/pytorch/torch_nano.py
@@ -110,7 +110,7 @@ class TorchNano(LightningLite):
             or bfloat16 precision (bf16), defaults to 32.
             Enable ipex bfloat16 weight prepack when `use_ipex=True` and `precision='bf16'`
         :param channels_last: whether convert input to channels last memory formats, \
-            defaults to False
+            defaults to False.
         """
         self.num_processes = num_processes
         self.use_ipex = use_ipex

--- a/python/nano/src/bigdl/nano/pytorch/torch_nano.py
+++ b/python/nano/src/bigdl/nano/pytorch/torch_nano.py
@@ -162,7 +162,7 @@ class TorchNano(LightningLite):
 
     def _setup(
         self,
-        model: nn.Module,
+        model: nn.Module,  # type: ignore[override]
         optimizers: List[Optimizer],
         move_to_device: bool = True,
     ) -> Any:

--- a/python/nano/src/bigdl/nano/pytorch/torch_nano.py
+++ b/python/nano/src/bigdl/nano/pytorch/torch_nano.py
@@ -26,6 +26,7 @@ from torch.utils.data import DataLoader
 from torch.nn.parallel.distributed import DistributedDataParallel
 from pytorch_lightning.lite import LightningLite
 from pytorch_lightning.lite.wrappers import _LiteModule, _LiteOptimizer
+from pytorch_lightning.utilities.apply_func import apply_to_collection
 
 from bigdl.nano.common import check_avx512
 from bigdl.nano.utils.log4Error import invalidInputError
@@ -36,6 +37,10 @@ from bigdl.nano.pytorch.strategies import create_IPEXStrategy, DDPSpawnStrategy,
 
 
 class _TorchNanoModule(_LiteModule):
+    def __init__(self, module, precision_plugin, channels_last) -> None:
+        super().__init__(module, precision_plugin)
+        self.channels_last = channels_last
+
     def state_dict(self, *args, **kwargs):
         if isinstance(self.module, DistributedDataParallel):
             return self.module.module.state_dict(*args, **kwargs)
@@ -69,6 +74,14 @@ class _TorchNanoModule(_LiteModule):
         else:
             return getattr(self.module, name)
 
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        if self.channels_last:
+            def _convert_to_channels_last(t: torch.Tensor) -> torch.Tensor:
+                return t.to(memory_format=torch.channels_last)
+            args, kwargs = apply_to_collection([args, kwargs], function=_convert_to_channels_last,
+                                               dtype=torch.Tensor)
+        return super().forward(args, kwargs)
+
 
 class TorchNano(LightningLite):
     """
@@ -81,6 +94,7 @@ class TorchNano(LightningLite):
                  use_ipex: bool = False,
                  strategy: str = "subprocess",
                  precision: Union[str, int] = 32,
+                 channels_last: bool = False,
                  *args, **kwargs) -> None:
         """
         Create a TorchNano with nano acceleration.
@@ -96,6 +110,7 @@ class TorchNano(LightningLite):
         self.num_processes = num_processes
         self.use_ipex = use_ipex
         self.dtype = None
+        self.channels_last = channels_last
         if self.use_ipex and precision == 'bf16':
             # Enable ipex bfloat16 weight prepack and disable native AMP
             self.dtype = torch.bfloat16
@@ -150,6 +165,8 @@ class TorchNano(LightningLite):
         move_to_device: bool = True,
     ) -> Any:
         """Used to replace LightningLite's setup method."""
+        if self.channels_last:
+            model = model.to(memory_format=torch.channels_last)
         # LightningLite won't call `Strategy.setup()` method,
         # in which we add IPEX's optimization when using `trainer`.
 
@@ -187,7 +204,7 @@ class TorchNano(LightningLite):
 
         if move_to_device:
             model = self._move_model_to_device(model=model, optimizers=optimizers)
-        model = _TorchNanoModule(model, self._precision_plugin)
+        model = _TorchNanoModule(model, self._precision_plugin, self.channels_last)
         optimizers = [_LiteOptimizer(optimizer=optimizer, strategy=self._strategy)  # type: ignore
                       for optimizer in optimizers]
         self._models_setup += 1

--- a/python/nano/src/bigdl/nano/pytorch/torch_nano.py
+++ b/python/nano/src/bigdl/nano/pytorch/torch_nano.py
@@ -75,9 +75,12 @@ class _TorchNanoModule(_LiteModule):
             return getattr(self.module, name)
 
     def forward(self, *args: Any, **kwargs: Any) -> Any:
+        """Casts all inputs to the right memory format"""
         if self.channels_last:
             def _convert_to_channels_last(t: torch.Tensor) -> torch.Tensor:
-                return t.to(memory_format=torch.channels_last) if t.dim() == 4 else t
+                if t.dim() == 4:
+                    return t.to(memory_format=torch.channels_last)  # type: ignore
+                return t
             args, kwargs = apply_to_collection([args, kwargs], function=_convert_to_channels_last,
                                                dtype=torch.Tensor)
         return super().forward(*args, **kwargs)

--- a/python/nano/src/bigdl/nano/pytorch/torch_nano.py
+++ b/python/nano/src/bigdl/nano/pytorch/torch_nano.py
@@ -77,7 +77,7 @@ class _TorchNanoModule(_LiteModule):
     def forward(self, *args: Any, **kwargs: Any) -> Any:
         if self.channels_last:
             def _convert_to_channels_last(t: torch.Tensor) -> torch.Tensor:
-                return t.to(memory_format=torch.channels_last)
+                return t.to(memory_format=torch.channels_last) if t.dim() == 4 else t
             args, kwargs = apply_to_collection([args, kwargs], function=_convert_to_channels_last,
                                                dtype=torch.Tensor)
         return super().forward(args, kwargs)

--- a/python/nano/test/pytorch/tests/test_channels_last.py
+++ b/python/nano/test/pytorch/tests/test_channels_last.py
@@ -120,7 +120,16 @@ class MyNanoChannelsLastCorrectness(TorchNano):
 
         model, optimizer, train_loader = self.setup(model, optimizer, train_loader)
 
-        
+        model.train()
+
+        for X, y in train_loader:
+            optimizer.zero_grad()
+            loss = loss_fuc(model(X), y)
+            self.backward(loss)
+            optimizer.step()
+
+        result = torch.tensor([[[[0.0, -1.0]], [[-1.25, 0.5]]]])
+        assert model.conv1.weight.equal(result)
 
 
 class TestChannelsLast(TestCase):

--- a/python/nano/test/pytorch/tests/test_channels_last.py
+++ b/python/nano/test/pytorch/tests/test_channels_last.py
@@ -19,6 +19,7 @@ import pytest
 import torch
 from unittest import TestCase
 from bigdl.nano.pytorch import Trainer
+from bigdl.nano.pytorch import TorchNano
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_12
 from torchvision.models.resnet import ResNet, BasicBlock
 from torchmetrics.functional import accuracy
@@ -101,6 +102,25 @@ class ConvModel(torch.nn.Module):
             assert x.is_contiguous(memory_format=torch.channels_last)
         output = torch.flatten(x, 1)
         return output
+
+class MyNanoChannelsLastCorrectness(TorchNano):
+    def train(self, lr):
+        x = torch.Tensor([
+            [[[1, 0]], [[1, 0]]],
+            [[[1, 0]], [[2, 0]]],
+            [[[0, 3]], [[1, 0]]],
+            [[[1, 1]], [[2, 1]]]
+        ])
+        y = torch.Tensor([[0.0], [1.0], [0.0], [1.0]])
+        train_dataset = torch.utils.data.TensorDataset(x, y)
+        train_loader = torch.utils.data.DataLoader(train_dataset, batch_size=4, shuffle=False)
+        model = ConvModel()
+        loss_fuc = torch.nn.MSELoss()
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.25)
+
+        model, optimizer, train_loader = self.setup(model, optimizer, train_loader)
+
+        
 
 
 class TestChannelsLast(TestCase):


### PR DESCRIPTION
## Description

Add support for automatically converting model and data's memory_format to channels_last.

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

Channels Last improves the throughput of convolution operations in networks for computer vision.  It's
necessary to provide user a simple way to apply torch.channels to both of the model object and data.

<!-- Provide the related github issue link if available -->

### 2. User API changes
```python
MyNano(TorchNano):
    def train(self):
        ...

MyNano(channels_last=True).train()
```
<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change
N/A
<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [x] Unit test
- [x] Jenkins
http://10.112.231.51:18889/job/BigDL-Chronos-PR-Validation/801/
