### PR TITLE
Chronos:  Make `TSDataset` more friendly

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -71,6 +71,7 @@ class TSDataset:
         self._freq_certainty = False
         self._freq = None
         self._is_pd_datetime = pd.api.types.is_datetime64_any_dtype(self.df[self.dt_col].dtypes)
+        self.is_predict = False
         if self._is_pd_datetime:
             if len(self.df[self.dt_col]) < 2:
                 self._freq = None
@@ -629,7 +630,7 @@ class TSDataset:
                                                        dt_col=self.dt_col,
                                                        freq=self._freq,
                                                        horizon_time=horizon_time,
-                                                       is_predict=is_predict,
+                                                       is_predict=self.is_predict,
                                                        lookback=lookback,
                                                        label_len=label_len))
             self.numpy_x_timeenc = np.concatenate([time_enc_arr[i][0]

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -66,6 +66,7 @@ class TSDataset:
         self._freq_certainty = False
         self._freq = None
         self._is_pd_datetime = pd.api.types.is_datetime64_any_dtype(self.df[self.dt_col].dtypes)
+        self.is_predict = False
         if self._is_pd_datetime:
             if len(self.df[self.dt_col]) < 2:
                 self._freq = None
@@ -590,7 +591,8 @@ class TSDataset:
         # horizon_time is only for time_enc, the time_enc numpy ndarray won't have any
         # shape change when the dataset is for prediction.
         horizon_time = self.horizon
-        if is_predict:
+        self.is_predict = is_predict
+        if self.is_predict:
             self.horizon = 0
 
         if self.lookback == 'auto':
@@ -774,6 +776,7 @@ class TSDataset:
                                   "of lookback and horizon, while get lookback+horizon="
                                   f"{need_dflen} and the length of dataset is {len(self.df)}.")
 
+            self.is_predict = is_predict
             torch_dataset = RollDataset(self.df,
                                         dt_col=self.dt_col,
                                         freq=self._freq,
@@ -784,7 +787,7 @@ class TSDataset:
                                         id_col=self.id_col,
                                         time_enc=time_enc,
                                         label_len=label_len,
-                                        is_predict=is_predict)
+                                        is_predict=self.is_predict)
             # TODO gen_rolling_feature and gen_global_feature will be support later
             self.roll_target = target_col
             self.roll_feature = feature_col

--- a/python/chronos/src/bigdl/chronos/data/utils/utils.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/utils.py
@@ -15,6 +15,8 @@
 #
 
 
+from bigdl.nano.utils.log4Error import invalidInputError
+
 def _to_list(item, name, expect_type=str):
     if isinstance(item, list):
         return item
@@ -66,3 +68,48 @@ def _check_dt_is_sorted(df, dt_col):
                               f"{dt_col} must be sorted.")
     except (ValueError, TypeError):
         warnings.warn(f"{dt_col} may not be sorted.", Warning)
+
+class BooleanDescriptor:
+    def __init__(self):
+        self._is_predict = False
+
+    def __get__(self, instance, type):
+        if instance is None:
+            return self
+        return self._is_predict
+
+    def __set__(self, instance, value):
+        invalidInputError(isinstance(value, bool),
+                          "value must be boolean.")
+        self._is_predict = value
+
+class CycleDescriptor:
+    def __init__(self):
+        self._aggregate = "mode"
+    
+    def __get__(self, instance, type):
+        if instance is None:
+            return self
+        return self._aggregate
+
+    def __set__(self, instance, value: str):
+        invalidInputError(isinstance(value, str),
+                          f"value type must be str, but found {type(value)}")
+        invalidInputError(value.lower().strip() in ['min', 'max', 'mode', 'median', 'mean'],
+                          f"We Only support 'min' 'max' 'mode' 'median' 'mean',"
+                          f" but found {self._aggregate}.")
+        self._aggregate = value.lower().strip()
+
+class IntDescriptor:
+    def __init__(self, val: int=3):
+        self._value = val
+    
+    def __get__(self, instance, type):
+        if instance is None:
+            return self
+        return self._value
+    
+    def __set__(self, instance, value: int):
+        invalidInputError(instance(value, int),
+                          f"value type must be int, but found {type(value)}")
+        self._value = value

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -486,7 +486,8 @@ class BasePytorchForecaster(Forecaster):
                                              horizon=self.data_config['future_seq_len'],
                                              feature_col=data.roll_feature,
                                              target_col=data.roll_target,
-                                             shuffle=False)
+                                             shuffle=False,
+                                             is_predict=data.is_predict)
         # data transform
         is_local_data = isinstance(data, (np.ndarray, DataLoader))
         if is_local_data and self.distributed:
@@ -579,7 +580,8 @@ class BasePytorchForecaster(Forecaster):
                                              horizon=self.data_config['future_seq_len'],
                                              feature_col=data.roll_feature,
                                              target_col=data.roll_target,
-                                             shuffle=False)
+                                             shuffle=False,
+                                             is_predict=data.is_predict)
         if quantize:
             return _pytorch_fashion_inference(model=self.onnxruntime_int8,
                                               input_data=data,
@@ -718,7 +720,8 @@ class BasePytorchForecaster(Forecaster):
                                              horizon=self.data_config['future_seq_len'],
                                              feature_col=data.roll_feature,
                                              target_col=data.roll_target,
-                                             shuffle=False)
+                                             shuffle=False,
+                                             is_predict=False)
         is_local_data = isinstance(data, (tuple, DataLoader))
         if not is_local_data and not self.distributed:
             data = xshard_to_np(data, mode="fit")
@@ -818,7 +821,8 @@ class BasePytorchForecaster(Forecaster):
                                              horizon=self.data_config['future_seq_len'],
                                              feature_col=data.roll_feature,
                                              target_col=data.roll_target,
-                                             shuffle=False)
+                                             shuffle=False,
+                                             is_predict=False)
         if isinstance(data, DataLoader):
             input_data = data
             target = np.concatenate(tuple(val[1] for val in data), axis=0)


### PR DESCRIPTION
## Description

Before that, since the horizon is not 0, the length of the predicted data will be less than the actual demand data.
Now if `is_predict` set to True, then horizon will be set to 0, which avoids the prediction data being split.

### Usage
```python

test = TSDataset.from_pandas(...)
test.is_predict = True
yhat = forecaster.predict(test)
```