### PR TITLE
Chronos:  Add orca distributed function to TF2Forecaster

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
@@ -75,9 +75,7 @@ class BaseTF2Forecaster(Forecaster):
         if isinstance(data, TSDataset):
             if data.lookback is None:
                 data.roll(lookback=self.model_config['past_seq_len'],
-                          horizon=self.model_config['future_seq_len'],
-                          feature_col=data.roll_feature,
-                          target_col=data.roll_target)
+                          horizon=self.model_config['future_seq_len'])
 
         if self.distributed:
             if isinstance(data, tuple):
@@ -129,9 +127,7 @@ class BaseTF2Forecaster(Forecaster):
         if isinstance(data, TSDataset):
             if data.lookback is None:
                 data.roll(lookback=self.model_config['past_seq_len'],
-                          horizon=self.model_config['future_seq_len'],
-                          target_col=data.roll_target,
-                          feature_col=data.roll_feature)
+                          horizon=self.model_config['future_seq_len'])
 
         invalidInputError(self.fitted,
                           "You must call fit or restore first before calling predict!")
@@ -143,7 +139,7 @@ class BaseTF2Forecaster(Forecaster):
                 input_data, _ = data.to_numpy()
                 data = np_to_xshards(input_data)
             invalidInputError(not isinstance(data, tf.data.Dataset),
-                              "Will support in the future.")
+                              "prediction on tf.data.Dataset will be supported in future.")
             yhat = self.internal.predict(data, batch_size=batch_size)
 
             # pytorch and tf2 have different behavior, when `future_seq_len` and

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
@@ -142,7 +142,7 @@ class BaseTF2Forecaster(Forecaster):
         else:
             if not self.fitted:
                 invalidInputError(False,
-                                "You must call fit or restore first before calling predict!")
+                                  "You must call fit or restore first before calling predict!")
             if isinstance(data, TSDataset):
                 data = data.to_tf_dataset(batch_size, batch_size)
             if batch_size or isinstance(data, tf.data.Dataset):
@@ -207,7 +207,7 @@ class BaseTF2Forecaster(Forecaster):
         else:
             if not self.fitted:
                 invalidInputError(False,
-                                "You must call fit or restore first before calling evaluate!")
+                                  "You must call fit or restore first before calling evaluate!")
             if isinstance(data, tuple):
                 input_data, target = data
             else:

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
@@ -146,6 +146,8 @@ class BaseTF2Forecaster(Forecaster):
                               "Will support in the future.")
             yhat = self.internal.predict(data, batch_size=batch_size)
 
+            # pytorch and tf2 have different behavior, when `future_seq_len` and
+            # `output_feature_num` are equal to 1, they will not squeeze data.
             expand_dim = []
             yhat = xshard_to_np(yhat, mode="yhat", expand_dim=expand_dim)
         else:

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
@@ -77,8 +77,7 @@ class BaseTF2Forecaster(Forecaster):
 
 
         if self.distributed:
-            if isinstance(data, TSDataset):
-                data = rollback_tf_dataset(data)
+            if isinstance(data, tuple):
                 data = np_to_data_creator(data)
             self.internal.fit(data, epochs=epochs, batch_size=batch_size)
         else:

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
@@ -190,9 +190,6 @@ class BaseTF2Forecaster(Forecaster):
         :return: A list of evaluation results. Each item represents a metric.
         """
         from bigdl.nano.utils.log4Error import invalidInputError
-        if not self.fitted:
-            invalidInputError(False,
-                              "You must call fit or restore first before calling evaluate!")
         if isinstance(data, TSDataset):
             if data.lookback is None:
                 data.roll(lookback=self.model_config['past_seq_len'],
@@ -208,6 +205,9 @@ class BaseTF2Forecaster(Forecaster):
                               "please replace with numpy.ndarray or TSDataset instance.")
             return self.internal.evaluate(data, batch_size=batch_size)
         else:
+            if not self.fitted:
+                invalidInputError(False,
+                                "You must call fit or restore first before calling evaluate!")
             if isinstance(data, tuple):
                 input_data, target = data
             else:

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
@@ -273,7 +273,12 @@ class BaseTF2Forecaster(Forecaster):
         :params checkpoint_file: The location you want to save the forecaster.
         """
         if self.distributed:
-            self.internal.save(checkpoint_file)
+            # TODO: can't save and load, temporarily use save_weight instead, will fix later.
+            from bigdl.dllib.utils.file_utils import is_local_path
+            if is_local_path(checkpoint_file):
+                self.internal.save_weights(checkpoint_file)
+            else:
+                self.internal.save(checkpoint_file)
         else:
             if not self.fitted:
                 invalidInputError(False,
@@ -287,7 +292,12 @@ class BaseTF2Forecaster(Forecaster):
         :params checkpoint_file: The checkpoint file location you want to load the forecaster.
         """
         if self.distributed:
-            self.internal.load(checkpoint_file)
+            # TODO: can't save and load, temporarily use load_weights instead, will fix later.
+            from bigdl.dllib.utils.file_utils import is_local_path
+            if is_local_path(checkpoint_file):
+                self.internal.load_weights(checkpoint_file)
+            else:
+                self.internal.load(checkpoint_file)
         else:
             self.internal = keras.models.load_model(checkpoint_file,
                                                     custom_objects=self.custom_objects_config)

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
@@ -148,8 +148,7 @@ class BaseTF2Forecaster(Forecaster):
 
             # pytorch and tf2 have different behavior, when `future_seq_len` and
             # `output_feature_num` are equal to 1, they will not squeeze data.
-            expand_dim = []
-            yhat = xshard_to_np(yhat, mode="yhat", expand_dim=expand_dim)
+            yhat = xshard_to_np(yhat, mode="yhat")
         else:
             if isinstance(data, TSDataset):
                 data = data.to_tf_dataset(batch_size, batch_size)

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/lstm_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/lstm_forecaster.py
@@ -104,8 +104,8 @@ class LSTMForecaster(BaseTF2Forecaster):
 
         # distributed settings
         self.distributed = distributed
+        self.local_distributed_backend = "subprocess"
         self.remote_distributed_backend = distributed_backend
-        # self.local_distributed_backend = "subprocess"
         self.workers_per_node = workers_per_node
 
         # other settings

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/lstm_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/lstm_forecaster.py
@@ -103,15 +103,10 @@ class LSTMForecaster(BaseTF2Forecaster):
         self.custom_objects_config = {"LSTMModel": LSTMModel}
 
         # distributed settings
-        # self.distributed = distributed
-        # self.distributed_backend = distributed_backend
-        # self.workers_per_node = workers_per_node
-        from bigdl.nano.utils.log4Error import invalidInputError
-        if distributed:
-            invalidInputError(False,
-                              "We will add distributed support in subsequent releases, "
-                              "the feature is currently unavailable, "
-                              "Please set distributed=False.")
+        self.distributed = distributed
+        self.remote_distributed_backend = distributed_backend
+        # self.local_distributed_backend = "subprocess"
+        self.workers_per_node = workers_per_node
 
         # other settings
         self.lr = lr

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/seq2seq_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/seq2seq_forecaster.py
@@ -112,8 +112,8 @@ class Seq2SeqForecaster(BaseTF2Forecaster):
 
         # distributed settings
         self.distributed = distributed
-        self.remote_distributed_backend = distributed_backend
         self.local_distributed_backend = "subprocess"
+        self.remote_distributed_backend = distributed_backend
         self.workers_per_node = workers_per_node
 
         # other settings

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/seq2seq_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/seq2seq_forecaster.py
@@ -111,15 +111,10 @@ class Seq2SeqForecaster(BaseTF2Forecaster):
         self.custom_objects_config = {"LSTMSeq2Seq": LSTMSeq2Seq}
 
         # distributed settings
-        # self.distributed = distributed
-        # self.distributed_backend = distributed_backend
-        # self.workers_per_node = workers_per_node
-        from bigdl.nano.utils.log4Error import invalidInputError
-        if distributed:
-            invalidInputError(False,
-                              "We will add distributed support in subsequent releases, "
-                              "the feature is currently unavailable, "
-                              "Please set distributed=False.")
+        self.distributed = distributed
+        self.remote_distributed_backend = distributed_backend
+        self.local_distributed_backend = "subprocess"
+        self.workers_per_node = workers_per_node
 
         # other settings
         self.lr = lr

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/tcn_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/tcn_forecaster.py
@@ -114,14 +114,10 @@ class TCNForecaster(BaseTF2Forecaster):
                                       "TemporalConvNet": TemporalConvNet}
 
         # distributed settings
-        # self.distributed = distributed
-        # self.distributed_backend = distributed_backend
-        # self.workers_per_node = workers_per_node
-        from bigdl.nano.utils.log4Error import invalidInputError
-        if distributed:
-            invalidInputError(False, "We will add distributed support in subsequent releases, "
-                                     "the feature is currently unavailable, "
-                                     "Please set distributed=False.")
+        self.distributed = distributed
+        self.remote_distributed_backend = distributed_backend
+        self.local_distributed_backend = "subprocess"
+        self.workers_per_node = workers_per_node
 
         # other settings
         self.lr = lr

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/tcn_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/tcn_forecaster.py
@@ -115,8 +115,8 @@ class TCNForecaster(BaseTF2Forecaster):
 
         # distributed settings
         self.distributed = distributed
-        self.remote_distributed_backend = distributed_backend
         self.local_distributed_backend = "subprocess"
+        self.remote_distributed_backend = distributed_backend
         self.workers_per_node = workers_per_node
 
         # other settings

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/utils.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/utils.py
@@ -35,8 +35,7 @@ def np_to_data_creator(tuple_data):
 
 def tsdata_to_data_creator(tf_data, shuffle=True):
     def data_creator(config, batch_size):
-        data = tf_data.to_tf_dataset(shuffle=shuffle, batch_size=batch_size)
-        return data
+        return tf_data.to_tf_dataset(shuffle=shuffle, batch_size=batch_size)
     return data_creator
 
 

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/utils.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/utils.py
@@ -50,7 +50,6 @@ def np_to_xshards(data):
     _shards = XShards.partition(data)
 
     def transform_to_dict(data):
-        data = data[0] if isinstance(data, Iterable) else data
         return {"x": data}
     return _shards.transform_shard(transform_to_dict)
 

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/utils.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/utils.py
@@ -53,6 +53,7 @@ def np_to_xshards(data, workers_num):
         warnings.warn("Too many partitions and too few workers will reduce inference performance, "
                       "we recommend setting 'worker_per_node' to a large number and",
                       "not larger than the number of partitions.", category=RuntimeWarning)
+
     def transform_to_dict(data):
         return {"x": data}
     return _shards.transform_shard(transform_to_dict)

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/utils.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/utils.py
@@ -17,18 +17,14 @@ import tensorflow as tf
 import numpy as np
 
 
-__all__ = ['np_to_data_creator',
-           'tsdata_to_data_creator',
-           'np_to_tfdataset',
-           'np_to_xshards',
-           'xshard_to_np']
-
-
-def np_to_data_creator(tuple_data):
+def np_to_data_creator(tuple_data, shuffle=False):
     def data_creator(config, batch_size):
         data_len = tuple_data[0].shape[0]
         data = tf.data.Dataset.from_tensor_slices((tuple_data))
-        data = data.cache().shuffle(data_len).batch(batch_size)
+        if shuffle:
+            data = data.cache().shuffle(data_len).batch(batch_size)
+        else:
+            data = data.bactch(batch_size).cache()
         return data.prefetch(tf.data.AUTOTUNE)
     return data_creator
 

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/utils.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/utils.py
@@ -1,0 +1,33 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import tensorflow as tf
+import numpy as np
+
+
+def rollback_tf_dataset(tf_data):
+    x, y= tf_data.map(lambda x, y: x), tf_data.map(lambda x, y: y)
+    x = np.concatenate(tuple(x.as_numpy_iterator()), axis=0)
+    y = np.concatenate(tuple(y.as_numpy_iterator()), axis=0)
+    return x, y
+
+
+def np_to_data_creator(tf_data):
+    def data_creator(config, batch_size):
+        data_len = tf_data[0].shape[0]
+        data = tf.data.Dataset.from_tensor_slices((tf_data))
+        data = data.cache().shuffle(data_len).batch(batch_size)
+        return data.prefetch(tf.data.AUTOTUNE)
+    return data_creator

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/utils.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/utils.py
@@ -51,7 +51,7 @@ def np_to_xshards(data, workers_num):
     _shards = XShards.partition(data)
     if math.floor(math.sqrt(math.sqrt(_shards.num_partitions()))) > workers_num:
         warnings.warn("Too many partitions and too few workers will reduce inference performance, "
-                      "we recommend setting 'worker_per_node' to a large number and",
+                      "we recommend setting 'workers_per_node' to a large number and",
                       "not larger than the number of partitions.", category=RuntimeWarning)
 
     def transform_to_dict(data):

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_lstm_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_lstm_keras_forecaster.py
@@ -199,6 +199,14 @@ class TestLSTMForecaster(TestCase):
         from bigdl.chronos.model.tf2.VanillaLSTM_keras import LSTMModel
         assert isinstance(model, LSTMModel)
 
+        with tempfile.TemporaryDirectory() as tmp_file_name:
+            name = os.path.join(tmp_file_name, "lstm.ckpt")
+            test_pred_save = forecaster.predict(test_data[0])
+            forecaster.save(name)
+            forecaster.load(name)
+            test_pred_load = forecaster.predict(test_data[0])
+        np.testing.assert_almost_equal(test_pred_save, test_pred_load)
+
         forecaster.to_local()
         local_pred = forecaster.predict(test_data[0])
         local_eval = forecaster.evaluate(val_data)

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_lstm_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_lstm_keras_forecaster.py
@@ -206,6 +206,31 @@ class TestLSTMForecaster(TestCase):
         np.testing.assert_array_almost_equal(distributed_pred, local_pred, decimal=5)
         stop_orca_context()
 
+    def test_lstm_forecaster_distributed_illegal_input(self):
+        from bigdl.orca import init_orca_context, stop_orca_context
+        init_orca_context(cores=2, memory="2g")
+
+        forecaster = LSTMForecaster(past_seq_len=10,
+                                    input_feature_num=2,
+                                    output_feature_num=2,
+                                    loss="mae",
+                                    distributed=True)
+        train_data, _, test_data = create_data(tf_data=True)
+        ts_train, _, ts_test = create_tsdataset(roll=False)
+        _, y_test = ts_test.roll(lookback=24, horizon=1).to_numpy()
+
+        forecaster.fit(ts_train, epochs=2)
+        yhat = forecaster.predict(ts_test)
+        assert yhat.shape == y_test.shape
+        res = forecaster.evaluate(ts_test)
+
+        # illegal input
+        with pytest.raises(RuntimeError):
+            forecaster.fit(train_data)
+        with pytest.raises(RuntimeError):
+            forecaster.evaluate(test_data)
+
+        stop_orca_context()
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_lstm_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_lstm_keras_forecaster.py
@@ -88,6 +88,8 @@ class TestLSTMForecaster(TestCase):
                                          output_feature_num=2)
 
     def tearDown(self):
+        from bigdl.orca import stop_orca_context
+        stop_orca_context()
         del self.forecaster
 
     def test_lstm_forecaster_fit_predict_evaluate(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_seq2seq_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_seq2seq_keras_forecaster.py
@@ -40,6 +40,7 @@ def create_data(tf_data=False, batch_size=32):
         return x, y
 
     train_data = get_x_y(train_num_samples)
+    valid_data = get_x_y(test_num_samples)
     test_data = get_x_y(test_num_samples)
 
     if tf_data:
@@ -48,10 +49,13 @@ def create_data(tf_data=False, batch_size=32):
                                                    .shuffle(train_num_samples)\
                                                    .batch(batch_size)\
                                                    .prefetch(tf.data.AUTOTUNE)
-        test_data = from_tensor_slices(test_data).cache()\
-                                                 .batch(batch_size)\
+        valid_data = from_tensor_slices(valid_data).batch(batch_size)\
+                                                   .cache()\
+                                                   .prefetch(tf.data.AUTOTUNE)
+        test_data = from_tensor_slices(test_data).batch(batch_size)\
+                                                 .cache()\
                                                  .prefetch(tf.data.AUTOTUNE)
-    return train_data, test_data
+    return train_data, valid_data, test_data
 
 def create_tsdataset(roll=True):
     from bigdl.chronos.data import TSDataset
@@ -63,14 +67,15 @@ def create_tsdataset(roll=True):
                       dtype=np.float32)
     df.reset_index(inplace=True)
     df.rename(columns={'index': 'timeseries'}, inplace=True)
-    train, _, test = TSDataset.from_pandas(df=df,
+    train, valid, test = TSDataset.from_pandas(df=df,
                                            dt_col='timeseries',
                                            target_col=['value1', 'value2'],
+                                           val_ratio=0.1,
                                            with_split=True)
     if roll:
-        for tsdata in [train, test]:
+        for tsdata in [train, valid, test]:
             tsdata.roll(lookback=24, horizon=2)
-    return train, test
+    return train, valid, test
 
 
 @op_all
@@ -88,7 +93,7 @@ class TestSeq2SeqForecaster(TestCase):
         del self.forecaster
 
     def test_seq2seq_fit_predict_evaluate(self):
-        train_data, test_data = create_data()
+        train_data, _, test_data = create_data()
         self.forecaster.fit(train_data,
                             epochs=2,
                             batch_size=32)
@@ -98,14 +103,14 @@ class TestSeq2SeqForecaster(TestCase):
         assert mse[0].shape == test_data[-1].shape[1:]
     
     def test_seq2seq_fit_tf_data(self):
-        train_data, test_data = create_data(tf_data=True)
+        train_data, _, test_data = create_data(tf_data=True)
         self.forecaster.fit(train_data,
                             epochs=2)
         yhat = self.forecaster.predict(test_data)
         assert yhat.shape == (400, 2, 2)
 
     def test_seq2seq_save_load(self):
-        train_data, test_data = create_data()
+        train_data, _, test_data = create_data()
         self.forecaster.fit(train_data,
                             epochs=2,
                             batch_size=32)
@@ -121,11 +126,11 @@ class TestSeq2SeqForecaster(TestCase):
         np.testing.assert_almost_equal(yhat, load_model_yhat, decimal=5)
 
     def test_s2s_customized_loss_metric(self):
-        train_data, test_data = create_data(tf_data=True)
+        train_data, _, test_data = create_data(tf_data=True)
         loss = tf.keras.losses.MeanSquaredError()
         def customized_metric(y_true, y_pred):
             return tf.keras.losses.MeanSquaredError(tf.convert_to_tensor(y_pred),
-                                      tf.convert_to_tensor(y_true)).numpy()
+                                                    tf.convert_to_tensor(y_true)).numpy()
         from bigdl.chronos.forecaster.tf.seq2seq_forecaster import Seq2SeqForecaster
         self.forecaster = Seq2SeqForecaster(past_seq_len=10,
                                             future_seq_len=2,
@@ -147,7 +152,7 @@ class TestSeq2SeqForecaster(TestCase):
         np.testing.assert_almost_equal(yhat, load_model_yhat, decimal=5)
 
     def test_s2s_from_tsdataset(self):
-        train, test = create_tsdataset(roll=True)
+        train, _, test = create_tsdataset(roll=True)
         s2s = Seq2SeqForecaster.from_tsdataset(train,
                                                lstm_hidden_dim=16,
                                                lstm_layer_num=2)
@@ -162,7 +167,7 @@ class TestSeq2SeqForecaster(TestCase):
 
         del s2s
 
-        train, test = create_tsdataset(roll=False)
+        train, _, test = create_tsdataset(roll=False)
         s2s = Seq2SeqForecaster.from_tsdataset(train,
                                                past_seq_len=24,
                                                future_seq_len=2,
@@ -177,6 +182,32 @@ class TestSeq2SeqForecaster(TestCase):
         _, y_test = test.to_numpy()
         assert yhat.shape == y_test.shape
 
+    def test_s2s_forecaster_distributed(self):
+        from bigdl.orca import init_orca_context, stop_orca_context
+        train_data, val_data, test_data = create_data()
+
+        init_orca_context(cores=4, memory="4g")
+        forecaster = Seq2SeqForecaster(past_seq_len=10,
+                                       future_seq_len=2,
+                                       input_feature_num=10,
+                                       output_feature_num=2,
+                                       loss="mae",
+                                       distributed=True)
+
+        forecaster.fit(train_data, epochs=2)
+        distributed_pred = forecaster.predict(test_data[0])
+        distributed_eval = forecaster.evaluate(val_data)
+
+        model = forecaster.get_model()
+        from bigdl.chronos.model.tf2.Seq2Seq_keras import LSTMSeq2Seq
+        assert isinstance(model, LSTMSeq2Seq)
+
+        forecaster.to_local()
+        local_pred = forecaster.predict(test_data[0])
+        local_eval = forecaster.evaluate(val_data)
+
+        np.testing.assert_almost_equal(distributed_pred, local_pred, decimal=5)
+        stop_orca_context()
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_seq2seq_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_seq2seq_keras_forecaster.py
@@ -202,6 +202,14 @@ class TestSeq2SeqForecaster(TestCase):
         from bigdl.chronos.model.tf2.Seq2Seq_keras import LSTMSeq2Seq
         assert isinstance(model, LSTMSeq2Seq)
 
+        with tempfile.TemporaryDirectory() as tmp_file_name:
+            name = os.path.join(tmp_file_name, "s2s.ckpt")
+            test_pred_save = forecaster.predict(test_data[0])
+            forecaster.save(name)
+            forecaster.load(name)
+            test_pred_load = forecaster.predict(test_data[0])
+        np.testing.assert_almost_equal(test_pred_save, test_pred_load)
+
         forecaster.to_local()
         local_pred = forecaster.predict(test_data[0])
         local_eval = forecaster.evaluate(val_data)

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_seq2seq_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_seq2seq_keras_forecaster.py
@@ -90,6 +90,8 @@ class TestSeq2SeqForecaster(TestCase):
                                             output_feature_num=2)
 
     def tearDown(self):
+        from bigdl.orca import stop_orca_context
+        stop_orca_context()
         del self.forecaster
 
     def test_seq2seq_fit_predict_evaluate(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
@@ -208,6 +208,14 @@ class TestTCNForecaster(TestCase):
         from bigdl.chronos.model.tf2.TCN_keras import TemporalConvNet
         assert isinstance(model, TemporalConvNet)
 
+        with tempfile.TemporaryDirectory() as tmp_file_name:
+            name = os.path.join(tmp_file_name, "tcn.ckpt")
+            test_pred_save = forecaster.predict(test_data[0])
+            forecaster.save(name)
+            forecaster.load(name)
+            test_pred_load = forecaster.predict(test_data[0])
+        np.testing.assert_almost_equal(test_pred_save, test_pred_load)
+
         forecaster.to_local()
         local_pred = forecaster.predict(test_data[0])
         local_eval = forecaster.evaluate(val_data)

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
@@ -93,6 +93,8 @@ class TestTCNForecaster(TestCase):
                                         num_channels=[15]*7)
 
     def tearDown(self):
+        from bigdl.orca import stop_orca_context
+        stop_orca_context()
         del self.forecaster
 
     def test_tcn_forecaster_fit_predict_evaluate(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
@@ -25,6 +25,7 @@ from bigdl.chronos.utils import LazyImport
 tf = LazyImport('tensorflow')
 TCNForecaster = LazyImport('bigdl.chronos.forecaster.tf.tcn_forecaster.TCNForecaster')
 from test.bigdl.chronos import op_tf2, op_all
+import tensorflow as tf
 
 
 def create_data(tf_data=False, batch_size=32):
@@ -41,6 +42,7 @@ def create_data(tf_data=False, batch_size=32):
         return x, y
     
     train_data = get_x_y(train_num_samples)
+    val_data = get_x_y(test_num_samples)
     test_data = get_x_y(test_num_samples)
 
     if tf_data:
@@ -49,10 +51,13 @@ def create_data(tf_data=False, batch_size=32):
                                                    .shuffle(train_num_samples)\
                                                    .batch(batch_size)\
                                                    .prefetch(tf.data.AUTOTUNE)
-        test_data = from_tensor_slices(test_data).cache()\
-                                                 .batch(batch_size)\
+        val_data = from_tensor_slices(val_data).batch(batch_size)\
+                                               .cache()\
+                                               .prefetch(tf.data.AUTOTUNE)
+        test_data = from_tensor_slices(test_data).batch(batch_size)\
+                                                 .cache()\
                                                  .prefetch(tf.data.AUTOTUNE)
-    return train_data, test_data
+    return train_data, val_data, test_data
 
 
 def create_tsdataset(roll=True):
@@ -65,14 +70,15 @@ def create_tsdataset(roll=True):
                       dtype=np.float32)
     df.reset_index(inplace=True)
     df.rename(columns={'index': 'timeseries'}, inplace=True)
-    train, _, test = TSDataset.from_pandas(df=df,
+    train, valid, test = TSDataset.from_pandas(df=df,
                                            dt_col='timeseries',
                                            target_col=['value1', 'value2'],
+                                           val_ratio=0.1,
                                            with_split=True)
     if roll:
-        for tsdata in [train, test]:
+        for tsdata in [train, valid, test]:
             tsdata.roll(lookback=24, horizon=5)
-    return train, test
+    return train, valid, test
 
 
 @op_all
@@ -90,7 +96,7 @@ class TestTCNForecaster(TestCase):
         del self.forecaster
 
     def test_tcn_forecaster_fit_predict_evaluate(self):
-        train_data, test_data = create_data()
+        train_data, _, test_data = create_data()
         self.forecaster.fit(train_data,
                             epochs=2,
                             batch_size=32)
@@ -103,7 +109,7 @@ class TestTCNForecaster(TestCase):
         assert mse[0].shape == test_data[1].shape[1:]
 
     def test_tcn_forecaster_fit_tf_data(self):
-        train_data, test_data = create_data(tf_data=True)
+        train_data, _, test_data = create_data(tf_data=True)
         self.forecaster.fit(train_data,
                             epochs=2,
                             batch_size=32)
@@ -111,7 +117,7 @@ class TestTCNForecaster(TestCase):
         assert yhat.shape == (400, 2, 2)
 
     def test_tcn_forecaster_save_load(self):
-        train_data, test_data = create_data()
+        train_data, _, test_data = create_data()
         self.forecaster.fit(train_data, epochs=2)
         yhat = self.forecaster.predict(test_data[0])
         with tempfile.TemporaryDirectory() as tmp_dir_file:
@@ -125,11 +131,11 @@ class TestTCNForecaster(TestCase):
         np.testing.assert_almost_equal(yhat, load_model_yhat, decimal=5)
 
     def test_tcn_customized_loss_metric(self):
-        train_data, test_data = create_data(tf_data=True)
+        train_data, _, test_data = create_data(tf_data=True)
         loss = tf.keras.losses.MeanSquaredError()
         def customized_metric(y_true, y_pred):
             return tf.keras.losses.MeanSquaredError(tf.convert_to_tensor(y_pred),
-                                      tf.convert_to_tensor(y_true)).numpy()
+                                                    tf.convert_to_tensor(y_true)).numpy()
         from bigdl.chronos.forecaster.tf.tcn_forecaster import TCNForecaster
         self.forecaster = TCNForecaster(past_seq_len=10,
                                         future_seq_len=2,
@@ -152,7 +158,7 @@ class TestTCNForecaster(TestCase):
         np.testing.assert_almost_equal(yhat, load_model_yhat, decimal=5)
 
     def test_tcn_from_tsdataset(self):
-        train, test = create_tsdataset(roll=True)
+        train, _, test = create_tsdataset(roll=True)
 
         tcn = TCNForecaster.from_tsdataset(train,
                                             num_channels=[16]*2)
@@ -167,7 +173,7 @@ class TestTCNForecaster(TestCase):
 
         del tcn
 
-        train, test = create_tsdataset(roll=False)
+        train, _, test = create_tsdataset(roll=False)
         tcn = TCNForecaster.from_tsdataset(train,
                                             past_seq_len=24,
                                             future_seq_len=5,
@@ -180,6 +186,34 @@ class TestTCNForecaster(TestCase):
                   horizon=tcn.model_config['future_seq_len'])
         _, y_test = test.to_numpy()
         assert yhat.shape == y_test.shape
+
+    def test_tcn_forecaster_distributed(self):
+        from bigdl.orca import init_orca_context, stop_orca_context
+        train_data, val_data, test_data = create_data()
+
+        init_orca_context(cores=4, memory="4g")
+        forecaster = TCNForecaster(past_seq_len=10,
+                                   future_seq_len=2,
+                                   input_feature_num=10,
+                                   output_feature_num=2,
+                                   kernel_size=3,
+                                   lr=1e-3,
+                                   distributed=True)
+
+        forecaster.fit(train_data, epochs=2)
+        distributed_pred = forecaster.predict(test_data[0])
+        distributed_eval = forecaster.evaluate(val_data)
+
+        model = forecaster.get_model()
+        from bigdl.chronos.model.tf2.TCN_keras import TemporalConvNet
+        assert isinstance(model, TemporalConvNet)
+
+        forecaster.to_local()
+        local_pred = forecaster.predict(test_data[0])
+        local_eval = forecaster.evaluate(val_data)
+
+        np.testing.assert_almost_equal(distributed_pred, local_pred, decimal=5)
+        stop_orca_context()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added TF2Forecaster support for orca distributed  and some related unit test.

### New API
 - to_local: Same as `pytorchforecaster.to_local`, convert distributed model to local model.
 - get_model: Reture a keras model, same as `pytorchforecaster.get_model`.

### Known issues
 - input data: `tf.data.Dataset` cannot be entered directly, this issue may not be fixed and is caused by `keras`/`tensorflow` itself.
 - save/load: `TF2Estimator.save` and `TF2Estimator.load` not working properly when model is of type subclass. (Will be fixed in other PRs)
 - error message: Need to improve the Error message

### Solutions: Issue will be raised after PR merge.

### Doc link: https://liangs.readthedocs.io/en/tf2forecaster-distributed/doc/PythonAPI/Chronos/forecasters.html#lstmforecaster