### PR TITLE
Nano : remove redundant code in resnet18 example

### DIFF
--- a/python/nano/example/pytorch/inference_pipeline/resnet/README.md
+++ b/python/nano/example/pytorch/inference_pipeline/resnet/README.md
@@ -59,6 +59,7 @@ python inference_pipeline.py
 
 It will take about 2 minutes to run inference optimization. Then you may find the result for inference as follows:
 ```
+==========================Optimization Results==========================
 accleration option: original, latency: 54.2669ms, accuracy: 0.9937
 accleration option: fp32_ipex, latency: 40.3075ms, accuracy: 0.9937
 accleration option: bf16_ipex, latency: 115.6182ms, accuracy: 0.9937

--- a/python/nano/example/pytorch/inference_pipeline/resnet/inference_pipeline.py
+++ b/python/nano/example/pytorch/inference_pipeline/resnet/inference_pipeline.py
@@ -36,7 +36,6 @@ if __name__ == "__main__":
         return Accuracy()(pred, target)
 
     # 3. Accelaration inference using InferenceOptimizer
-    model.eval()
     optimizer = InferenceOptimizer()
     # optimize may take about 2 minutes to run all possible accelaration combinations
     optimizer.optimize(model=model,
@@ -48,9 +47,6 @@ if __name__ == "__main__":
                        direction="max",
                        cpu_num=1,
                        latency_sample_num=30)
-
-    for key, value in optimizer.optimized_model_dict.items():
-        print("accleration option: {}, latency: {:.4f}ms, accuracy: {:.4f}".format(key, value["latency"], value["accuracy"]))
 
     # 4. Get the best model under specific restrictions or without restrictions
     acc_model, option = optimizer.get_best_model(accelerator="onnxruntime")


### PR DESCRIPTION
## Description

Based on update of InferenceOptimizer, remove some redundant code in https://github.com/intel-analytics/BigDL/tree/main/python/nano/example/pytorch/inference_pipeline/resnet
