### PR TITLE
Support decimal for Spark DataFrame

### DIFF
--- a/python/dllib/src/bigdl/dllib/utils/utils.py
+++ b/python/dllib/src/bigdl/dllib/utils/utils.py
@@ -194,6 +194,8 @@ def _is_scalar_type(dtype, accept_str_col=False):
         return True
     if isinstance(dtype, df_types.TimestampType):
         return True
+    if isinstance(dtype, df_types.DecimalType):
+        return True
     if accept_str_col and isinstance(dtype, df_types.StringType):
         return True
     return False
@@ -212,6 +214,8 @@ def convert_row_to_numpy(row, schema, feature_cols, label_cols, accept_str_col=F
                     result.append(np.array(row[name]).astype('datetime64[ns]'))
                 elif isinstance(feature_type, df_types.IntegerType):
                     result.append(np.array(row[name]).astype(np.int32))
+                elif isinstance(feature_type, df_types.DecimalType):
+                    result.append(np.array(row[name]).astype(np.float64))
                 else:
                     result.append(np.array(row[name]))
             elif isinstance(feature_type, df_types.ArrayType):

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
@@ -348,6 +348,37 @@ class TestTFRayEstimator(TestCase):
                          label_cols=["label"])
         trainer.predict(df, feature_cols=["feature"]).collect()
 
+    def test_dataframe_decimal_input(self):
+
+        from pyspark.sql.types import StructType, StructField, IntegerType, FloatType
+        from pyspark.sql.functions import col
+        from bigdl.orca import OrcaContext
+
+        spark = OrcaContext.get_spark_session()
+        schema = StructType([
+            StructField("feature", FloatType(), True),
+            StructField("label", IntegerType(), True)
+        ])
+        data = [(30.2222, 1), (40.0, 0), (15.1, 1),
+                (-2.456, 1), (3.21, 0), (11.28, 1)]
+        df = spark.createDataFrame(data=data, schema=schema)
+        df = df.withColumn("feature", col("feature").cast("decimal(38,2)"))
+        res = df.collect()
+        features = [x[0] for x in res]
+
+        config = {
+            "lr": 0.8
+        }
+        trainer = Estimator.from_keras(
+            model_creator=model_creator,
+            verbose=True,
+            config=config,
+            workers_per_node=2)
+
+        trainer.fit(df, epochs=1, batch_size=4, steps_per_epoch=25,
+                    feature_cols=["feature"],
+                    label_cols=["label"])
+
     def test_dataframe_with_empty_partition(self):
         from bigdl.orca import OrcaContext
         sc = OrcaContext.get_spark_context()

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
@@ -363,8 +363,6 @@ class TestTFRayEstimator(TestCase):
                 (-2.456, 1), (3.21, 0), (11.28, 1)]
         df = spark.createDataFrame(data=data, schema=schema)
         df = df.withColumn("feature", col("feature").cast("decimal(38,2)"))
-        res = df.collect()
-        features = [x[0] for x in res]
 
         config = {
             "lr": 0.8


### PR DESCRIPTION
Support transforming to XShards when a Spark DataFrame column is DecimalType, requested by the customer.

numpy has higher-precision types e.g. float128 (i.e. longdouble) and even float256, which may be equivalent to decimal. But tensorflow tensor doesn't support such type (probably pytorch doesn't either):
```
E                         File "/home/kai/anaconda3/envs/py37-tf2/lib/python3.7/site-packages/tensorflow/python/data/ops/dataset_ops.py", line 793, in from_tensor_slices
E                           return TensorSliceDataset(tensors, name=name)
E                         File "/home/kai/anaconda3/envs/py37-tf2/lib/python3.7/site-packages/tensorflow/python/data/ops/dataset_ops.py", line 4477, in __init__
E                           element = structure.normalize_element(element)
E                         File "/home/kai/anaconda3/envs/py37-tf2/lib/python3.7/site-packages/tensorflow/python/data/util/structure.py", line 107, in normalize_element
E                           ops.convert_to_tensor(t, name="component_%d" % i))
E                         File "/home/kai/anaconda3/envs/py37-tf2/lib/python3.7/site-packages/tensorflow/python/profiler/trace.py", line 183, in wrapped
E                           return func(*args, **kwargs)
E                         File "/home/kai/anaconda3/envs/py37-tf2/lib/python3.7/site-packages/tensorflow/python/framework/ops.py", line 1695, in convert_to_tensor
E                           ret = conversion_func(value, dtype=dtype, name=name, as_ref=as_ref)
E                         File "/home/kai/anaconda3/envs/py37-tf2/lib/python3.7/site-packages/tensorflow/python/framework/tensor_conversion_registry.py", line 48, in _default_conversion_function
E                           return constant_op.constant(value, dtype, name=name)
E                         File "/home/kai/anaconda3/envs/py37-tf2/lib/python3.7/site-packages/tensorflow/python/framework/constant_op.py", line 268, in constant
E                           allow_broadcast=True)
E                         File "/home/kai/anaconda3/envs/py37-tf2/lib/python3.7/site-packages/tensorflow/python/framework/constant_op.py", line 279, in _constant_impl
E                           return _constant_eager_impl(ctx, value, dtype, shape, verify_shape)
E                         File "/home/kai/anaconda3/envs/py37-tf2/lib/python3.7/site-packages/tensorflow/python/framework/constant_op.py", line 304, in _constant_eager_impl
E                           t = convert_to_eager_tensor(value, ctx, dtype)
E                         File "/home/kai/anaconda3/envs/py37-tf2/lib/python3.7/site-packages/tensorflow/python/framework/constant_op.py", line 102, in convert_to_eager_tensor
E                           return ops.EagerTensor(value, ctx.device_name, dtype)
E                       ValueError: Failed to convert a NumPy array to a Tensor (Unsupported numpy type: NPY_LONGDOUBLE).
```

So as a workaround, decimal can only be converted to np.float64, though some precision may be lost.
@jason-dai Is it OK for you?