### PR TITLE
Chronos : support confidence interval for forecaster

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -499,8 +499,6 @@ class AutoformerForecaster(Forecaster):
             yhat = np.concatenate(_yhat, axis=0)
             y_hat_list.append(yhat)
         y_hat_mean = np.mean(np.stack(y_hat_list, axis=0), axis=0)
-        invalidInputError(y_hat_mean.shape == y_hat_list[0].shape,
-                          "dismatch shape between y_hat_mean and y_hat")
 
         model_bias = np.zeros_like(y_hat_mean)  # 3d array
         for i in range(repetition_times):

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -161,6 +161,9 @@ class AutoformerForecaster(Forecaster):
         self.use_amp = False
         self.use_hpo = True
 
+        # Model preparation
+        self.fitted = False
+
         has_space = _config_has_search_space(
             config={**self.model_config, **self.optim_config,
                     **self.loss_config, **self.data_config})
@@ -350,6 +353,7 @@ class AutoformerForecaster(Forecaster):
                 self.internal = self.tune_internal._model_build(trial)
 
         self.trainer.fit(self.internal, data)
+        self.fitted = True
 
     def predict(self, data, batch_size=32):
         """
@@ -440,7 +444,7 @@ class AutoformerForecaster(Forecaster):
         """
         from bigdl.chronos.pytorch.utils import _pytorch_fashion_inference
 
-        if not self.fitted:
+        if self.fitted is not True:
             invalidInputError(False,
                               "You must call fit or restore first before calling predict_interval!")
 

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -915,7 +915,7 @@ class BasePytorchForecaster(Forecaster):
         invalidInputError(y_hat_mean.shape == y_hat.shape,
                           "dismatch shape between y_hat_mean and y_hat")
 
-        model_bias = np.zeros_like(y_hat_mean) # 2d array
+        model_bias = np.zeros_like(y_hat_mean) # 3d array
         for i in range(repetition_times):
             model_bias += (y_hat_list[i] - y_hat_mean)**2
         model_bias /= repetition_times

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -802,7 +802,7 @@ class BasePytorchForecaster(Forecaster):
                | which is memory-friendly while a little bit slower.
                | Users may call `roll` on the TSDataset before calling `fit`
                | Then the training speed will be faster but will consume more memory.
-    
+
         :param validation_data: The validation_data support following formats:
 
                | 1. a numpy ndarray tuple (x, y):
@@ -828,7 +828,7 @@ class BasePytorchForecaster(Forecaster):
 
         :param batch_size: predict batch size. The value will not affect predict
                result but will affect resources cost(e.g. memory and time).
-        :param repetition_times : Defines repeate how many times to calculate model 
+        :param repetition_times : Defines repeate how many times to calculate model
                                   uncertainty based on MC Dropout.
 
         :return: A numpy array with shape (num_samples, horizon, target_dim)

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -871,7 +871,8 @@ class BasePytorchForecaster(Forecaster):
         for i in range(B):
             y_hat_list.append(calculate(data, self.internal))
         y_hat_mean = np.mean(y_hat_list)
-        invalidInputError(y_hat_mean.shape == y_hat.shape, "dismatch shape between y_hat_mean and y_hat")
+        invalidInputError(y_hat_mean.shape == y_hat.shape, 
+                          "dismatch shape between y_hat_mean and y_hat")
 
         sig2 = np.zeros_like(y_hat_mean)
         for i in range(B):

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -870,8 +870,8 @@ class BasePytorchForecaster(Forecaster):
         y_hat_list = []
         for i in range(B):
             y_hat_list.append(calculate(data, self.internal))
-        y_hat_mean = np.mean(y_hat_list)
-        invalidInputError(y_hat_mean.shape == y_hat.shape, 
+        y_hat_mean = np.mean(np.stack(y_hat_list, axis=0), axis=0)
+        invalidInputError(y_hat_mean.shape == y_hat.shape,
                           "dismatch shape between y_hat_mean and y_hat")
 
         sig2 = np.zeros_like(y_hat_mean)

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -846,6 +846,7 @@ class BasePytorchForecaster(Forecaster):
                     yhat = xshard_to_np(yhat, mode="yhat", expand_dim=expand_dim)
                 else:
                     yhat = yhat.transform_shard(xshard_expand_dim, expand_dim)
+                return yhat
             else:
                 if not self.fitted:
                     from bigdl.nano.utils.log4Error import invalidInputError
@@ -857,6 +858,7 @@ class BasePytorchForecaster(Forecaster):
                                                   batch_size=batch_size)
                 if not is_local_data:
                     yhat = np_to_xshard(yhat, prefix="prediction")
+                return yhat
 
         # step3: calculate y_hat
         y_hat = calculate(data, self.internal)

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -839,7 +839,7 @@ class BasePytorchForecaster(Forecaster):
         """
         from bigdl.chronos.pytorch.utils import _pytorch_fashion_inference
         from bigdl.orca.data.shard import SparkXShards
-        # TODO: how to judge fitted in distributed state?
+        # TODO: fitted when distributed?
         if not self.distributed and not self.fitted:
             invalidInputError(False,
                               "You must call fit or restore first before calling predict_interval!")

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-from tkinter.messagebox import NO
 from bigdl.chronos.forecaster.abstract import Forecaster
 from bigdl.chronos.forecaster.utils import *
 from bigdl.chronos.metric.forecast_metrics import Evaluator

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -885,7 +885,8 @@ class BasePytorchForecaster(Forecaster):
                 target = np.concatenate(tuple(val[1] for val in val_data), axis=0)
             elif isinstance(val_data, SparkXShards):
                 input_data = val_data
-                target = np.concatenate([val_data[i]['y'] for i in range(len(val_data['y']))], axis=0)
+                target = np.concatenate([val_data[i]['y'] for i in range(len(val_data['y']))],
+                                        axis=0)
             else:
                 input_data, target = val_data
 

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -802,11 +802,38 @@ class BasePytorchForecaster(Forecaster):
                | which is memory-friendly while a little bit slower.
                | Users may call `roll` on the TSDataset before calling `fit`
                | Then the training speed will be faster but will consume more memory.
+    
+        :param validation_data: The validation_data support following formats:
+
+               | 1. a numpy ndarray tuple (x, y):
+               | x's shape is (num_samples, lookback, feature_dim) where lookback and feature_dim
+               | should be the same as past_seq_len and input_feature_num.
+               | y's shape is (num_samples, horizon, target_dim), where horizon and target_dim
+               | should be the same as future_seq_len and output_feature_num.
+               | 2. a xshard item:
+               | each partition can be a dictionary of {'x': x, 'y': y}, where x and y's shape
+               | should follow the shape stated before.
+               | 3. pytorch dataloader:
+               | the dataloader should return x, y in each iteration with the shape as following:
+               | x's shape is (num_samples, lookback, feature_dim) where lookback and feature_dim
+               | should be the same as past_seq_len and input_feature_num.
+               | y's shape is (num_samples, horizon, target_dim), where horizon and target_dim
+               | should be the same as future_seq_len and output_feature_num.
+               | 4. A bigdl.chronos.data.tsdataset.TSDataset instance:
+               | Forecaster will automatically process the TSDataset.
+               | By default, TSDataset will be transformed to a pytorch dataloader,
+               | which is memory-friendly while a little bit slower.
+               | Users may call `roll` on the TSDataset before calling `fit`
+               | Then the training speed will be faster but will consume more memory.
 
         :param batch_size: predict batch size. The value will not affect predict
                result but will affect resources cost(e.g. memory and time).
-        :repetition_times : Defines repeate how many times to calculate model uncertainty
-                            based MC Dropout.
+        :param repetition_times : Defines repeate how many times to calculate model 
+                                  uncertainty based on MC Dropout.
+
+        :return: A numpy array with shape (num_samples, horizon, target_dim)
+                 if data is a numpy ndarray or a dataloader and a variance value.
+
         """
         from bigdl.chronos.pytorch.utils import _pytorch_fashion_inference
 

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -850,11 +850,11 @@ class BasePytorchForecaster(Forecaster):
                 if not self.fitted:
                     from bigdl.nano.utils.log4Error import invalidInputError
                     invalidInputError(False,
-                                    "You must call fit or restore first before calling predict!")
+                                      "You must call fit or restore first before calling predict!")
                 self.internal.eval()
                 yhat = _pytorch_fashion_inference(model=model,
-                                                input_data=data,
-                                                batch_size=batch_size)
+                                                  input_data=data,
+                                                  batch_size=batch_size)
                 if not is_local_data:
                     yhat = np_to_xshard(yhat, prefix="prediction")
 
@@ -871,16 +871,15 @@ class BasePytorchForecaster(Forecaster):
         for i in range(B):
             y_hat_list.append(calculate(data, self.internal))
         y_hat_mean = np.mean(y_hat_list)
-        assert y_hat_mean.shape == y_hat.shape
-        
+        invalidInputError(y_hat_mean.shape == y_hat.shape, "dismatch shape between y_hat_mean and y_hat")
+
         sig2 = np.zeros_like(y_hat_mean)
-        for i in  range(B):
+        for i in range(B):
             sig2 += (y_hat_list[i] - y_hat_mean)**2
         sig2 /= B
         sig = np.sqrt(sig1 + sig2)
 
         return y_hat, sig
-
 
     def save(self, checkpoint_file, quantize_checkpoint_file=None):
         """

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -810,7 +810,8 @@ class BasePytorchForecaster(Forecaster):
 
         # step1, according to validation dataset, calculate inherent noise
         output = self.evaluate(data=validation_data, multioutput='uniform_average')
-        sig1 = output["mse"]
+        # TODO: index for mse
+        sig1 = output[0]
 
         # step2: data preprocess
         if isinstance(data, TSDataset):

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -782,7 +782,7 @@ class BasePytorchForecaster(Forecaster):
     def predict_interval(self, data, validation_data, batch_size=None, repetition_times=5):
         """
         Calculate confidence interval of data based on Monte Carlo dropout(MC dropout).
-        
+
         :param data: The data support following formats:
 
                | 1. a numpy ndarray x:

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -909,7 +909,7 @@ class BasePytorchForecaster(Forecaster):
         for i in range(repetition_times):
             y_hat_list.append(calculate(data, self.internal))
         y_hat_mean = np.mean(np.stack(y_hat_list, axis=0), axis=0)
-        invalidInputError(y_hat_mean.shape == y_hat.shape,
+        invalidInputError(y_hat_mean.shape == y_hat_list[0].shape,
                           "dismatch shape between y_hat_mean and y_hat")
 
         model_bias = np.zeros_like(y_hat_mean)  # 3d array

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -851,8 +851,8 @@ class BasePytorchForecaster(Forecaster):
             else:
                 input_data, target = validation_data
             val_yhat = self.predict(input_data)
-            self.data_noise = Evaluator.evaluate(["mse"], target, # a scalar
-                                                 val_yhat, aggregate='uniform_average')[0]
+            self.data_noise = Evaluator.evaluate(["mse"], target,
+                                                 val_yhat, aggregate=None)[0]  # 3d-array
 
         # step2: data preprocess
         if isinstance(data, TSDataset):
@@ -915,10 +915,11 @@ class BasePytorchForecaster(Forecaster):
         invalidInputError(y_hat_mean.shape == y_hat.shape,
                           "dismatch shape between y_hat_mean and y_hat")
 
-        model_bias = np.zeros_like(y_hat_mean) # 3d array
+        model_bias = np.zeros_like(y_hat_mean)  # 3d array
         for i in range(repetition_times):
             model_bias += (y_hat_list[i] - y_hat_mean)**2
         model_bias /= repetition_times
+        assert self.data_noise.shape == model_bias.shape
         std_deviation = np.sqrt(self.data_noise + model_bias)
 
         return y_hat, std_deviation

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -916,7 +916,8 @@ class BasePytorchForecaster(Forecaster):
         for i in range(repetition_times):
             model_bias += (y_hat_list[i] - y_hat_mean)**2
         model_bias /= repetition_times
-        assert self.data_noise.shape == model_bias.shape
+        invalidInputError(self.data_noise.shape == model_bias.shape,
+                          "dismatch shape between validation_data and data")
         std_deviation = np.sqrt(self.data_noise + model_bias)
 
         return y_hat_mean, std_deviation

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -885,10 +885,9 @@ class BasePytorchForecaster(Forecaster):
                 target = np.concatenate(tuple(val[1] for val in val_data), axis=0)
             elif isinstance(val_data, SparkXShards):
                 input_data = val_data
-                target = np.concatenate([val_data[i]['y'] for i
-                         in range(len(val_data['y']))], axis=0)
+                target = np.concatenate([val_data[i]['y'] for i in range(len(val_data['y']))], axis=0)
             else:
-                input_data, target = data
+                input_data, target = val_data
 
             val_yhat = calculate(input_data, self.internal)
             self.data_noise = Evaluator.evaluate(["mse"], target,
@@ -933,7 +932,8 @@ class BasePytorchForecaster(Forecaster):
             model_bias += (y_hat_list[i] - y_hat_mean)**2
         model_bias /= repetition_times
         invalidInputError(self.data_noise.shape == model_bias.shape,
-                          "dismatch shape between validation_data and data")
+                          "dismatch shape between val_data and data, the front is {}, "
+                          "the later is {}".format(self.data_noise.shape, model_bias.shape))
         std_deviation = np.sqrt(self.data_noise + model_bias)
 
         return y_hat_mean, std_deviation

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -827,7 +827,6 @@ class BasePytorchForecaster(Forecaster):
         is_local_data = isinstance(data, (np.ndarray, DataLoader))
         if is_local_data and self.distributed:
             if isinstance(data, DataLoader):
-                from bigdl.nano.utils.log4Error import invalidInputError
                 invalidInputError(False,
                                   "We will be support input dataloader later.")
             data = np_to_xshard(data)
@@ -849,7 +848,6 @@ class BasePytorchForecaster(Forecaster):
                 return yhat
             else:
                 if not self.fitted:
-                    from bigdl.nano.utils.log4Error import invalidInputError
                     invalidInputError(False,
                                       "You must call fit or restore first before calling predict!")
                 self.internal.eval()

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -899,10 +899,7 @@ class BasePytorchForecaster(Forecaster):
                     yhat = np_to_xshard(yhat, prefix="prediction")
                 return yhat
 
-        # step3: calculate y_hat
-        y_hat = calculate(data, self.internal)
-
-        # step4: calculate model uncertainty based MC Dropout
+        # step3: calculate model uncertainty based MC Dropout
         def apply_dropout(m):
             if type(m) == torch.nn.Dropout:
                 m.train()
@@ -922,7 +919,7 @@ class BasePytorchForecaster(Forecaster):
         assert self.data_noise.shape == model_bias.shape
         std_deviation = np.sqrt(self.data_noise + model_bias)
 
-        return y_hat, std_deviation
+        return y_hat_mean, std_deviation
 
     def save(self, checkpoint_file, quantize_checkpoint_file=None):
         """

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -779,7 +779,7 @@ class BasePytorchForecaster(Forecaster):
         aggregate = 'mean' if multioutput == 'uniform_average' else None
         return Evaluator.evaluate(self.metrics, target, yhat, aggregate=aggregate)
 
-    def predict_interval(self, data, validation_data, batch_size=None, repetition_times=5):
+    def predict_interval(self, data, validation_data=None, batch_size=None, repetition_times=5):
         """
         Calculate confidence interval of data based on Monte Carlo dropout(MC dropout).
 

--- a/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
@@ -261,3 +261,39 @@ class TestChronosModelAutoformerForecaster(TestCase):
         evaluate = forecaster.evaluate(val_loader)
         pred = forecaster.predict(test_loader)
         evaluate_list.append(evaluate)
+
+    def test_autoformer_forecaster_confidence_interval_with_loader(self):
+        train_loader, val_loader, test_loader = create_data(loader=True)
+        forecaster = AutoformerForecaster(past_seq_len=24,
+                                          future_seq_len=5,
+                                          input_feature_num=2,
+                                          output_feature_num=2,
+                                          label_len=12,
+                                          freq='s',
+                                          seed=0,
+                                          moving_avg=20) # even
+        forecaster.fit(train_loader, epochs=3, batch_size=32)
+        # only the first time needs val_data
+        y_pred, std = forecaster.predict_interval(data=test_loader,
+                                                  val_data=val_loader,
+                                                  repetition_times=5)
+        assert y_pred.shape == std.shape
+        y_pred, std = forecaster.predict_interval(data=test_loader)
+
+    def test_autoformer_forecaster_confidence_interval_with_numpy(self):
+        train_data, val_data, test_data = create_data(loader=False)
+        forecaster = AutoformerForecaster(past_seq_len=24,
+                                          future_seq_len=5,
+                                          input_feature_num=2,
+                                          output_feature_num=2,
+                                          label_len=12,
+                                          freq='s',
+                                          seed=0,
+                                          moving_avg=20) # even
+        forecaster.fit(train_data, epochs=3, batch_size=32)
+        # only the first time needs val_data
+        y_pred, std = forecaster.predict_interval(data=test_data,
+                                                  val_data=val_data,
+                                                  repetition_times=5)
+        assert y_pred.shape == std.shape
+        y_pred, std = forecaster.predict_interval(data=test_data)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -542,7 +542,7 @@ class TestChronosModelLSTMForecaster(TestCase):
                                     lr=0.01)
         forecaster.fit(train_data, epochs=2)
         y_pred, std = forecaster.predict_interval(data=test_data[0],
-                                                  validation_data=val_data,
+                                                  val_data=val_data,
                                                   repetition_times=5)
         assert y_pred.shape == test_data[1].shape
         assert y_pred.shape == std.shape

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -532,12 +532,12 @@ class TestChronosModelLSTMForecaster(TestCase):
     def test_predict_interval(self):
         train_data, val_data, test_data = create_data()
         forecaster = LSTMForecaster(past_seq_len=24,
-                                    future_seq_len=5,
-                                    input_feature_num=1,
-                                    output_feature_num=1,
-                                    kernel_size=4,
-                                    num_channels=[16, 16, 16],
-                                    loss="mse",
+                                    input_feature_num=2,
+                                    output_feature_num=2,
+                                    hidden_dim=16,
+                                    layer_num=1,
+                                    dropout=0.1,
+                                    loss="mae",
                                     metrics=["mse"],
                                     lr=0.01)
         forecaster.fit(train_data, epochs=2)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -528,3 +528,21 @@ class TestChronosModelLSTMForecaster(TestCase):
                         n_trials=3, target_metric="mse",
                         direction="minimize")
         forecaster.fit(train_data, epochs=10)
+
+    def test_predict_interval(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = LSTMForecaster(past_seq_len=24,
+                                    future_seq_len=5,
+                                    input_feature_num=1,
+                                    output_feature_num=1,
+                                    kernel_size=4,
+                                    num_channels=[16, 16, 16],
+                                    loss="mse",
+                                    metrics=["mse"],
+                                    lr=0.01)
+        forecaster.fit(train_data, epochs=2)
+        y_pred, std = forecaster.predict_interval(data=test_data[0],
+                                                  validation_data=val_data,
+                                                  repetition_times=5)
+        assert y_pred.shape == test_data[1].shape
+        assert y_pred.shape == std.shape

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -506,7 +506,7 @@ class TestChronosNBeatsForecaster(TestCase):
                                       lr=0.01)
         forecaster.fit(train_data, epochs=2)
         y_pred, std = forecaster.predict_interval(data=test_data[0],
-                                                  validation_data=val_data,
+                                                  val_data=val_data,
                                                   repetition_times=5)
         assert y_pred.shape == test_data[1].shape
         assert y_pred.shape == std.shape

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -494,3 +494,19 @@ class TestChronosNBeatsForecaster(TestCase):
                                       lr=0.01)
         val_loss = forecaster.fit((train_data[0], train_data[1]), val_data,
                                   validation_mode='best_epoch', epochs=10)
+
+    def test_predict_interval(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = NBeatsForecaster(past_seq_len=24,
+                                      future_seq_len=5,
+                                      stack_types=('generic', 'generic'),
+                                      nb_blocks_per_stack=3,
+                                      hidden_layer_units=256,
+                                      metrics=['mse'],
+                                      lr=0.01)
+        forecaster.fit(train_data, epochs=2)
+        y_pred, std = forecaster.predict_interval(data=test_data[0],
+                                                  validation_data=val_data,
+                                                  repetition_times=5)
+        assert y_pred.shape == test_data[1].shape
+        assert y_pred.shape == std.shape

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -467,7 +467,7 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
                                        lr=0.01)
         forecaster.fit(train_data, epochs=2)
         y_pred, std = forecaster.predict_interval(data=test_data[0],
-                                                  validation_data=val_data,
+                                                  val_data=val_data,
                                                   repetition_times=5)
         assert y_pred.shape == test_data[1].shape
         assert y_pred.shape == std.shape

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -455,3 +455,21 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
                         n_trials=3, target_metric="mse",
                         direction="minimize")
         forecaster.fit(train_data, epochs=10)
+
+    def test_predict_interval(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = Seq2SeqForecaster(past_seq_len=24,
+                                       future_seq_len=5,
+                                       input_feature_num=1,
+                                       output_feature_num=1,
+                                       kernel_size=4,
+                                       num_channels=[16, 16, 16],
+                                       loss="mse",
+                                       metrics=["mse"],
+                                       lr=0.01)
+        forecaster.fit(train_data, epochs=2)
+        y_pred, std = forecaster.predict_interval(data=test_data[0],
+                                                  validation_data=val_data,
+                                                  repetition_times=5)
+        assert y_pred.shape == test_data[1].shape
+        assert y_pred.shape == std.shape

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -462,8 +462,6 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
                                        future_seq_len=5,
                                        input_feature_num=1,
                                        output_feature_num=1,
-                                       kernel_size=4,
-                                       num_channels=[16, 16, 16],
                                        loss="mse",
                                        metrics=["mse"],
                                        lr=0.01)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -696,7 +696,3 @@ class TestChronosModelTCNForecaster(TestCase):
                                                 B=5)
         assert y_pred.shape == test_data[1].shape
         assert y_pred.shape == sigma.shape
-
-if __name__ == "__main__":
-    test = TestChronosModelTCNForecaster()
-    test.test_predict_interval()

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -721,7 +721,6 @@ class TestChronosModelTCNForecaster(TestCase):
     def test_predict_interval_with_xshard_input(self):
         from bigdl.orca import init_orca_context, stop_orca_context
         train_data, val_data, test_data = create_data()
-        print("original", train_data[0].dtype)
         init_orca_context(cores=4, memory="2g")
         from bigdl.orca.data import XShards
 

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -693,6 +693,6 @@ class TestChronosModelTCNForecaster(TestCase):
         forecaster.fit(train_data, epochs=2)
         y_pred, sigma = forecaster.predict_interval(data=test_data[0],
                                                 validation_data=val_data,
-                                                B=5)
+                                                repetition_times=5)
         assert y_pred.shape == test_data[1].shape
         assert y_pred.shape == sigma.shape

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -691,9 +691,9 @@ class TestChronosModelTCNForecaster(TestCase):
                                    metrics=["mse"],
                                    lr=0.01)
         forecaster.fit(train_data, epochs=2)
-        # only the first time needs validation_data
+        # only the first time needs val_data
         y_pred, std = forecaster.predict_interval(data=test_data[0],
-                                                  validation_data=val_data,
+                                                  val_data=val_data,
                                                   repetition_times=5)
         assert y_pred.shape == test_data[1].shape
         assert y_pred.shape == std.shape
@@ -711,9 +711,9 @@ class TestChronosModelTCNForecaster(TestCase):
                                    metrics=["mse"],
                                    lr=0.01)
         forecaster.fit(train_loader, epochs=2)
-        # only the first time needs validation_data
+        # only the first time needs val_data
         y_pred, std = forecaster.predict_interval(data=test_loader,
-                                                  validation_data=val_loader,
+                                                  val_data=val_loader,
                                                   repetition_times=5)
         assert y_pred.shape == std.shape
         y_pred, std = forecaster.predict_interval(data=test_loader)
@@ -744,10 +744,10 @@ class TestChronosModelTCNForecaster(TestCase):
                                        lr=0.01,
                                        distributed=distributed)
             forecaster.fit(train_data, epochs=2)
-            # only the first time needs validation_data
+            # only the first time needs val_data
             y_pred, std = forecaster.predict_interval(data=test_data,
-                                                    validation_data=val_data,
-                                                    repetition_times=5)
+                                                      val_data=val_data,
+                                                      repetition_times=5)
             assert y_pred.shape == std.shape
             y_pred, std = forecaster.predict_interval(data=test_data)
         stop_orca_context()

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -691,8 +691,8 @@ class TestChronosModelTCNForecaster(TestCase):
                                    metrics=["mse"],
                                    lr=0.01)
         forecaster.fit(train_data, epochs=2)
-        y_pred, sigma = forecaster.predict_interval(data=test_data[0],
+        y_pred, std = forecaster.predict_interval(data=test_data[0],
                                                 validation_data=val_data,
                                                 repetition_times=5)
         assert y_pred.shape == test_data[1].shape
-        assert y_pred.shape == sigma.shape
+        assert y_pred.shape == std.shape

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -678,3 +678,25 @@ class TestChronosModelTCNForecaster(TestCase):
             forecaster.load(ckpt_name)
             test_pred_load = forecaster.predict(test_data[0])
         np.testing.assert_almost_equal(test_pred_save, test_pred_load)
+
+    def test_predict_interval(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = TCNForecaster(past_seq_len=24,
+                                   future_seq_len=5,
+                                   input_feature_num=1,
+                                   output_feature_num=1,
+                                   kernel_size=4,
+                                   num_channels=[16, 16, 16],
+                                   loss="mse",
+                                   metrics=["mse"],
+                                   lr=0.01)
+        forecaster.fit(train_data, epochs=2)
+        y_pred, sigma = forecaster.predict_interval(data=test_data[0],
+                                                validation_data=val_data,
+                                                B=5)
+        assert y_pred.shape == test_data[1].shape
+        assert y_pred.shape == sigma.shape
+
+if __name__ == "__main__":
+    test = TestChronosModelTCNForecaster()
+    test.test_predict_interval()

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -691,8 +691,42 @@ class TestChronosModelTCNForecaster(TestCase):
                                    metrics=["mse"],
                                    lr=0.01)
         forecaster.fit(train_data, epochs=2)
+        # only the first time needs validation_data
         y_pred, std = forecaster.predict_interval(data=test_data[0],
-                                                validation_data=val_data,
-                                                repetition_times=5)
+                                                  validation_data=val_data,
+                                                  repetition_times=5)
         assert y_pred.shape == test_data[1].shape
         assert y_pred.shape == std.shape
+        y_pred, std = forecaster.predict_interval(data=test_data[0])
+
+    def test_predict_interval_without_validation_data(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = TCNForecaster(past_seq_len=24,
+                                   future_seq_len=5,
+                                   input_feature_num=1,
+                                   output_feature_num=1,
+                                   kernel_size=4,
+                                   num_channels=[16, 16, 16],
+                                   loss="mse",
+                                   metrics=["mse"],
+                                   lr=0.01)
+        forecaster.fit(train_data, epochs=2)
+        with pytest.raises(RuntimeError):
+            y_pred, std = forecaster.predict_interval(data=test_data[0],
+                                                    repetition_times=5)
+
+    def test_predict_interval_without_mse(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = TCNForecaster(past_seq_len=24,
+                                   future_seq_len=5,
+                                   input_feature_num=1,
+                                   output_feature_num=1,
+                                   kernel_size=4,
+                                   num_channels=[16, 16, 16],
+                                   loss="mse",
+                                   metrics=["mae"],
+                                   lr=0.01)
+        forecaster.fit(train_data, epochs=2)
+        with pytest.raises(RuntimeError):
+            y_pred, std = forecaster.predict_interval(data=test_data[0],
+                                                    repetition_times=5)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -679,7 +679,7 @@ class TestChronosModelTCNForecaster(TestCase):
             test_pred_load = forecaster.predict(test_data[0])
         np.testing.assert_almost_equal(test_pred_save, test_pred_load)
 
-    def test_predict_interval(self):
+    def test_predict_interval_with_numpy(self):
         train_data, val_data, test_data = create_data()
         forecaster = TCNForecaster(past_seq_len=24,
                                    future_seq_len=5,
@@ -698,6 +698,25 @@ class TestChronosModelTCNForecaster(TestCase):
         assert y_pred.shape == test_data[1].shape
         assert y_pred.shape == std.shape
         y_pred, std = forecaster.predict_interval(data=test_data[0])
+    
+    def test_predict_interval_with_loader(self):
+        train_loader, val_loader, test_loader = create_data(loader=True)
+        forecaster = TCNForecaster(past_seq_len=24,
+                                   future_seq_len=5,
+                                   input_feature_num=1,
+                                   output_feature_num=1,
+                                   kernel_size=4,
+                                   num_channels=[16, 16, 16],
+                                   loss="mse",
+                                   metrics=["mse"],
+                                   lr=0.01)
+        forecaster.fit(train_loader, epochs=2)
+        # only the first time needs validation_data
+        y_pred, std = forecaster.predict_interval(data=test_loader,
+                                                  validation_data=val_loader,
+                                                  repetition_times=5)
+        assert y_pred.shape == std.shape
+        y_pred, std = forecaster.predict_interval(data=test_loader)
 
     def test_predict_interval_without_validation_data(self):
         train_data, val_data, test_data = create_data()

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -713,20 +713,4 @@ class TestChronosModelTCNForecaster(TestCase):
         forecaster.fit(train_data, epochs=2)
         with pytest.raises(RuntimeError):
             y_pred, std = forecaster.predict_interval(data=test_data[0],
-                                                    repetition_times=5)
-
-    def test_predict_interval_without_mse(self):
-        train_data, val_data, test_data = create_data()
-        forecaster = TCNForecaster(past_seq_len=24,
-                                   future_seq_len=5,
-                                   input_feature_num=1,
-                                   output_feature_num=1,
-                                   kernel_size=4,
-                                   num_channels=[16, 16, 16],
-                                   loss="mse",
-                                   metrics=["mae"],
-                                   lr=0.01)
-        forecaster.fit(train_data, epochs=2)
-        with pytest.raises(RuntimeError):
-            y_pred, std = forecaster.predict_interval(data=test_data[0],
-                                                    repetition_times=5)
+                                                      repetition_times=5)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -741,40 +741,6 @@ class TestChronosModelTCNForecaster(TestCase):
         assert y_pred.shape == std.shape
         y_pred, std = forecaster.predict_interval(data=test)
 
-    def test_predict_interval_with_xshard_input(self):
-        from bigdl.orca import init_orca_context, stop_orca_context
-        train_data, val_data, test_data = create_data()
-        init_orca_context(cores=4, memory="2g")
-        from bigdl.orca.data import XShards
-
-        def transform_to_dict(data):
-            return {'x': data[0], 'y': data[1]}
-
-        def transform_to_dict_x(data):
-            return {'x': data[0]}
-
-        train_data = XShards.partition(train_data).transform_shard(transform_to_dict)
-        val_data = XShards.partition(val_data).transform_shard(transform_to_dict)
-        test_data = XShards.partition(test_data).transform_shard(transform_to_dict_x)
-
-        for distributed in [True, False]:
-            forecaster = TCNForecaster(past_seq_len=24,
-                                       future_seq_len=5,
-                                       input_feature_num=1,
-                                       output_feature_num=1,
-                                       kernel_size=4,
-                                       num_channels=[16, 16, 16],
-                                       lr=0.01,
-                                       distributed=distributed)
-            forecaster.fit(train_data, epochs=2)
-            # only the first time needs val_data
-            y_pred, std = forecaster.predict_interval(data=test_data,
-                                                      val_data=val_data,
-                                                      repetition_times=5)
-            assert y_pred.shape == std.shape
-            y_pred, std = forecaster.predict_interval(data=test_data)
-        stop_orca_context()
-
     def test_predict_interval_without_validation_data(self):
         train_data, _, test_data = create_data()
         forecaster = TCNForecaster(past_seq_len=24,


### PR DESCRIPTION
## Description

Confidence interval to be supported in forecaster (TCN, S2S, NBeats, LSTM, Autoformer).

### 1. Why the change?

To provide confidence interval in forecaster for user.

### 2. User API changes


### 3. Summary of the change 

Confidence interval to be supported in forecaster (TCN, S2S, NBeats, LSTM, Autoformer).

### 4. How to test?
- [x] Unit test
- [x] Jenkins
http://10.112.231.51:18889/view/BigDL-PR-Validation/job/BigDL-Chronos-PR-Validation/862/