### PR TITLE
[PPML] Fix EHSM 0.3.0 create enclave failure

### DIFF
--- a/ppml/services/pccs-ehsm/kubernetes/templates/bigdl-pccs-ehsm-kms.yaml
+++ b/ppml/services/pccs-ehsm/kubernetes/templates/bigdl-pccs-ehsm-kms.yaml
@@ -130,8 +130,10 @@ spec:
       containers:
       - name: dkeyserver
         image: {{ .Values.dkeyserverImageName }}
+        securityContext:
+          privileged: true
         imagePullPolicy: IfNotPresent
-        command: ['sh' , '-c','if [ -c "/dev/sgx/enclave" ]; then echo "/dev/sgx/enclave is ready";elif [ -c "/dev/sgx_enclave" ]; then echo "/dev/sgx/enclave not ready, try to link to /dev/sgx_enclave"; mkdir -p /dev/sgx; ln -s /dev/sgx_enclave /dev/sgx/enclave; else echo "both /dev/sgx/enclave /dev/sgx_enclave are not ready, please check the kernel and driver";fi; if [ -c "/dev/sgx/provision" ]; then echo "/dev/sgx/provision is ready";elif [ -c "/dev/sgx_provision" ]; then echo "/dev/sgx/provision not ready, try to link to /dev/sgx_provision";mkdir -p /dev/sgx;ln -s /dev/sgx_provision /dev/sgx/provision;else echo "both /dev/sgx/provision /dev/sgx_provision are not ready, please check the kernel and driver";fi;sleep 30; curl -v -k -G -w "%{http_code}" "http://{{ .Values.pccsIP }}:18081/sgx/certification/v3/rootcacrl";  bash /home/start_dkeyserver.sh']
+        command: ['sh' , '-c','if [ -c "/dev/sgx/enclave" ]; then echo "/dev/sgx/enclave is ready";elif [ -c "/dev/sgx_enclave" ]; then echo "/dev/sgx/enclave not ready, try to link to /dev/sgx_enclave"; mkdir -p /dev/sgx; ln -s /dev/sgx_enclave /dev/sgx/enclave; else echo "both /dev/sgx/enclave /dev/sgx_enclave are not ready, please check the kernel and driver";fi; if [ -c "/dev/sgx/provision" ]; then echo "/dev/sgx/provision is ready";elif [ -c "/dev/sgx_provision" ]; then echo "/dev/sgx/provision not ready, try to link to /dev/sgx_provision";mkdir -p /dev/sgx;ln -s /dev/sgx_provision /dev/sgx/provision;else echo "both /dev/sgx/provision /dev/sgx_provision are not ready, please check the kernel and driver";fi;sleep 30; curl -v -k -G -w "%{http_code}" "https://{{ .Values.pccsIP }}:18081/sgx/certification/v3/rootcacrl";  bash /home/start_dkeyserver.sh']
         volumeMounts:
         - mountPath: /dev/sgx/enclave
           name: dev-enclave


### PR DESCRIPTION
## Description

Enable privileged securityContext in the statefulset of dkeyserver.

### 1. Why the change?

The 0.3.0 EHSM enables SGX for domainkey generation (which is dummy in 0.2.1), it needs a privileged kubernetes mode and otherwise it will fail to open SGX devices.

### 2. Summary of the change 

Fix EHSM 0.3.0 create enclave failure

### 4. How to test?
Application test.

