### PR TITLE
Chronos: fix spark 3.1 bug in xshards unscale

### DIFF
--- a/python/chronos/test/bigdl/chronos/data/experimental/test_xshardstsdataset.py
+++ b/python/chronos/test/bigdl/chronos/data/experimental/test_xshardstsdataset.py
@@ -217,8 +217,8 @@ class TestXShardsTSDataset(TestCase):
         scalers = [{0: StandardScaler(), 1: StandardScaler()}]
         df = pd.read_csv(os.path.join(self.resource_path, "multiple.csv"))
         for scaler in scalers:
-            shards_multiple = read_csv(os.path.join(self.resource_path, "multiple.csv"))
-            shards_multiple_test = read_csv(os.path.join(self.resource_path, "multiple.csv"))
+            shards_multiple = read_csv(os.path.join(self.resource_path, "multiple.csv"), dtype={"id": np.int64})
+            shards_multiple_test = read_csv(os.path.join(self.resource_path, "multiple.csv"), dtype={"id": np.int64})
 
             tsdata = XShardsTSDataset.from_xshards(shards_multiple, dt_col="datetime",
                                                    target_col="value",


### PR DESCRIPTION
## Description

This bug should be involved in https://github.com/intel-analytics/BigDL/pull/5558

http://10.112.231.51:18889/job/BigDL-PRVN-chronos-Python-Spark-3.1-py37-ray-part2/794/
