### PR TITLE
cicd: scan dependency tree to help debug if fossa scan failed

### DIFF
--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -2,7 +2,7 @@ name: license-scan
 
 on:
   push:
-    branches: [ "wip/shaojun/licensescan" ]
+    branches: [ "main" ]
   #pull_request:
     #branches: [ "main" ]
   schedule:

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -29,8 +29,8 @@ jobs:
           api-key: ${{ secrets.FOSSAAPIKEY }}
           run-tests: true
 
-      - name: "Scan Dependency"
-        if: always()
+      - name: "Filter the Dependency Tree"
+        if: ${{ failure() }}
         run: |
           sed -i 's/<artifactId>${spark-version.project}<\/artifactId>/<artifactId>${spark-version.project}-${SPARK_PLATFORM}<\/artifactId>/' scala/dllib/pom.xml
           sed -i 's/<artifactId>3.0<\/artifactId>/<artifactId>3.0-${SPARK_PLATFORM}<\/artifactId>/' scala/common/spark-version/3.0/pom.xml

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -45,4 +45,4 @@ jobs:
           sed -i 's/<artifactId>bigdl-parent-spark_${spark.version}<\/artifactId>/<artifactId>bigdl-parent-spark_3.1.2<\/artifactId>/' scala/ppml/pom.xml
           sed -i 's/<artifactId>bigdl-parent-spark_${spark.version}<\/artifactId>/<artifactId>bigdl-parent-spark_3.1.2<\/artifactId>/' scala/assembly/pom.xml
           cd scala
-          mvn -P spark_3.x dependency:tree
+          mvn -P spark_3.x dependency:tree -Dspark.version=3.1.2 -DSPARK_PLATFORM=SPARK_3.1

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -2,7 +2,7 @@ name: license-scan
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "wip/shaojun/licensescan" ]
   #pull_request:
     #branches: [ "main" ]
   schedule:
@@ -28,3 +28,20 @@ jobs:
         with:
           api-key: ${{ secrets.FOSSAAPIKEY }}
           run-tests: true
+
+      - name: "Scan Dependency"
+        run: |
+          sed -i 's/<artifactId>${spark-version.project}<\/artifactId>/<artifactId>${spark-version.project}-${SPARK_PLATFORM}<\/artifactId>/' scala/dllib/pom.xml
+          sed -i 's/<artifactId>3.0<\/artifactId>/<artifactId>3.0-${SPARK_PLATFORM}<\/artifactId>/' scala/common/spark-version/3.0/pom.xml
+          sed -i 's/<artifactId>bigdl-parent-spark_${spark.version}<\/artifactId>/<artifactId>bigdl-parent-spark_3.1.2<\/artifactId>/' scala/pom.xml
+          sed -i 's/<artifactId>bigdl-parent-spark_${spark.version}<\/artifactId>/<artifactId>bigdl-parent-spark_3.1.2<\/artifactId>/' scala/common/spark-version/pom.xml
+          sed -i 's/<artifactId>bigdl-parent-spark_${spark.version}<\/artifactId>/<artifactId>bigdl-parent-spark_3.1.2<\/artifactId>/' scala/common/spark-version/3.0/pom.xml
+          sed -i 's/<artifactId>bigdl-parent-spark_${spark.version}<\/artifactId>/<artifactId>bigdl-parent-spark_3.1.2<\/artifactId>/' scala/dllib/pom.xml
+          sed -i 's/<artifactId>bigdl-parent-spark_${spark.version}<\/artifactId>/<artifactId>bigdl-parent-spark_3.1.2<\/artifactId>/' scala/orca/pom.xml
+          sed -i 's/<artifactId>bigdl-parent-spark_${spark.version}<\/artifactId>/<artifactId>bigdl-parent-spark_3.1.2<\/artifactId>/' scala/friesian/pom.xml
+          sed -i 's/<artifactId>bigdl-parent-spark_${spark.version}<\/artifactId>/<artifactId>bigdl-parent-spark_3.1.2<\/artifactId>/' scala/grpc/pom.xml
+          sed -i 's/<artifactId>bigdl-parent-spark_${spark.version}<\/artifactId>/<artifactId>bigdl-parent-spark_3.1.2<\/artifactId>/' scala/serving/pom.xml
+          sed -i 's/<artifactId>bigdl-parent-spark_${spark.version}<\/artifactId>/<artifactId>bigdl-parent-spark_3.1.2<\/artifactId>/' scala/ppml/pom.xml
+          sed -i 's/<artifactId>bigdl-parent-spark_${spark.version}<\/artifactId>/<artifactId>bigdl-parent-spark_3.1.2<\/artifactId>/' scala/assembly/pom.xml
+          cd scala
+          mvn -P spark_3.x dependency:tree

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -30,6 +30,7 @@ jobs:
           run-tests: true
 
       - name: "Scan Dependency"
+        if: always()
         run: |
           sed -i 's/<artifactId>${spark-version.project}<\/artifactId>/<artifactId>${spark-version.project}-${SPARK_PLATFORM}<\/artifactId>/' scala/dllib/pom.xml
           sed -i 's/<artifactId>3.0<\/artifactId>/<artifactId>3.0-${SPARK_PLATFORM}<\/artifactId>/' scala/common/spark-version/3.0/pom.xml


### PR DESCRIPTION
## Description

This submission
- add a step in license-scan workflow to filter the dependency tree, this step will be executed only if the previous fossa scan and fossa test failed. This is to help debug when license scan failed.