### PR TITLE
Add resource_quota to limit namespace resource

### DIFF
--- a/docker/bigdl/deployment-k8s.yaml
+++ b/docker/bigdl/deployment-k8s.yaml
@@ -178,6 +178,20 @@ roleRef:
 
 ---
 apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: bigdl-resources
+  namespace: bigdl
+spec:
+  hard:
+    pods: "10"
+    requests.cpu: "10"
+    requests.memory: 10Gi
+    limits.cpu: "20"
+    limits.memory: 20Gi
+
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: bigdl-notebook-config


### PR DESCRIPTION
## Description

Apply resource_quota to limit the total amount of compute resources that may be consumed by resources in that namespace.

### 1. Why the change?

The current deployment scheme does not limit resources and the resource footprint will expand.

### 2. User API changes

N/A

### 3. Summary of the change 

Add resource_quota in deployment-k8s.yml to limit computing resource.

### 4. How to test?
- [ ] K8s test


