### PR TITLE
bigdl all in one jar

### DIFF
--- a/scala/assembly/pom.xml
+++ b/scala/assembly/pom.xml
@@ -151,42 +151,10 @@
                 </executions>
 	    </plugin>
             <plugin>
-                <!--Please don't merge this shade plugin with spark-version's shade plugin to spark/pom.xml,
-                 or shade plugin will be executed after assembly plugin. -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.2.1</version>
-                <configuration>
-                    <filters>
-                        <filter>
-                            <artifact>com.google.protobuf</artifact>
-                            <excludes>
-                                <exclude>META-INF/maven/com.google.protobuf/protobuf-java/*</exclude>
-                            </excludes>
-                        </filter>
-                    </filters>
-                    <relocations>
-                        <relocation>
-                            <pattern>com.google.protobuf</pattern>
-                            <shadedPattern>com.intel.analytics.shaded.protobuf_v_3_5_1</shadedPattern>
-                        </relocation>
-                    </relocations>
-                </configuration>
                 <executions>
-                    <execution>
-                        <id>shade</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <artifactSet>
-                                <includes>
-                                    <include>com.google.protobuf</include>
-                                </includes>
-                            </artifactSet>
-                        </configuration>
-                    </execution>
                     <execution>
                         <id>without-spark</id>
                         <phase>package</phase>

--- a/scala/assembly/pom.xml
+++ b/scala/assembly/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>bigdl-assembly-spark_${spark.version}</artifactId>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
 
     <properties>
         <bigdl.basedir>${project.parent.basedir}</bigdl.basedir>
@@ -146,6 +146,56 @@
                                     <type>zip</type>
                                 </artifact>
                             </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+	    </plugin>
+            <plugin>
+                <!--Please don't merge this shade plugin with spark-version's shade plugin to spark/pom.xml,
+                 or shade plugin will be executed after assembly plugin. -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <configuration>
+                    <filters>
+                        <filter>
+                            <artifact>com.google.protobuf</artifact>
+                            <excludes>
+                                <exclude>META-INF/maven/com.google.protobuf/protobuf-java/*</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                    <relocations>
+                        <relocation>
+                            <pattern>com.google.protobuf</pattern>
+                            <shadedPattern>com.intel.analytics.shaded.protobuf_v_3_5_1</shadedPattern>
+                        </relocation>
+                    </relocations>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>shade</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.google.protobuf</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>without-spark</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
                         </configuration>
                     </execution>
                 </executions>

--- a/scala/assembly/src/main/assembly/fat-assembly.xml
+++ b/scala/assembly/src/main/assembly/fat-assembly.xml
@@ -94,23 +94,9 @@
     </fileSet>
     <fileSet>
       <outputDirectory>/jars</outputDirectory>
-      <directory>${project.parent.basedir}/dllib/target</directory>
+      <directory>${project.parent.basedir}/assembly/target</directory>
       <includes>
-          <include>bigdl-dllib*-jar-with-dependencies.jar</include>
-      </includes>
-    </fileSet>
-    <fileSet>
-      <outputDirectory>/jars</outputDirectory>
-      <directory>${project.parent.basedir}/orca/target</directory>
-      <includes>
-          <include>bigdl-orca*-jar-with-dependencies.jar</include>
-      </includes>
-    </fileSet>
-    <fileSet>
-      <outputDirectory>/jars</outputDirectory>
-      <directory>${project.parent.basedir}/friesian/target</directory>
-      <includes>
-          <include>bigdl-friesian*-jar-with-dependencies.jar</include>
+          <include>bigdl-assembly*-jar-with-dependencies.jar</include>
       </includes>
     </fileSet>
   </fileSets>


### PR DESCRIPTION
## Description

Build one jar `bigdl-assembly-spark_2.4.6-2.1.0-SNAPSHOT-jar-with-dependencies.jar`
1. change bigdl-assembly packaging as jar
2. add plugin to append all dependencies and build one jar
3. remove single *jar-with-dependency in fat-assembly, and add all in one jar in fat-assembly
![image](https://user-images.githubusercontent.com/30695225/189262473-691a6978-86d1-4504-a1f2-79198d582e59.png)
