### PR TITLE
Orca: Support flexable config object in estimator

### DIFF
--- a/python/orca/src/bigdl/orca/automl/model/base_keras_model.py
+++ b/python/orca/src/bigdl/orca/automl/model/base_keras_model.py
@@ -17,6 +17,7 @@ from bigdl.orca.automl.model.abstract import BaseModel, ModelBuilder
 import numpy as np
 from bigdl.orca.automl.metrics import Evaluator
 import pickle
+from copy import copy
 import tensorflow as tf
 from tensorflow.keras import backend as K
 import types
@@ -87,7 +88,7 @@ class KerasBaseModel(BaseModel):
             update_config()
             self.build(config)
         else:
-            tmp_config = self.config.copy()
+            tmp_config = copy(self.config)
             tmp_config.update(config)
             self._check_config(**tmp_config)
             self.config.update(config)

--- a/python/orca/src/bigdl/orca/automl/model/base_pytorch_model.py
+++ b/python/orca/src/bigdl/orca/automl/model/base_pytorch_model.py
@@ -22,6 +22,7 @@ import math
 import pandas as pd
 import tempfile
 import os
+from copy import copy
 
 from bigdl.orca.automl.model.abstract import BaseModel, ModelBuilder
 from bigdl.orca.automl.metrics import Evaluator
@@ -143,7 +144,7 @@ class PytorchBaseModel(BaseModel):
             update_config()
             self.build(config)
         else:
-            tmp_config = self.config.copy()
+            tmp_config = copy(self.config)
             tmp_config.update(config)
             self._check_config(**tmp_config)
             self.config.update(config)

--- a/python/orca/src/bigdl/orca/learn/mxnet/mxnet_runner.py
+++ b/python/orca/src/bigdl/orca/learn/mxnet/mxnet_runner.py
@@ -21,6 +21,7 @@ import subprocess
 import ray._private.services
 import mxnet as mx
 from mxnet import gluon
+from copy import copy
 from bigdl.orca.ray.utils import to_list
 from bigdl.dllib.utils.log4Error import *
 
@@ -83,7 +84,7 @@ class MXNetRunner(object):
         """Train the model and update the model parameters."""
         stats = dict()
         if self.is_worker:
-            config = self.config.copy()
+            config = copy(self.config)
             if "batch_size" not in config:
                 config["batch_size"] = batch_size
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/wandb.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/wandb.py
@@ -15,7 +15,7 @@
 #
 from bigdl.orca.learn.pytorch.callbacks import Callback
 from bigdl.dllib.utils.log4Error import invalidInputError
-
+from copy import copy
 
 try:
     import wandb
@@ -86,7 +86,7 @@ class WandbLoggerCallback(Callback):
         else:
             config = {}
         if self.log_config:
-            trainer_config = self.trainer.config.copy()
+            trainer_config = copy(self.trainer.config)
             config.update(trainer_config)
 
         if is_rank_zero:

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -19,6 +19,7 @@ import logging
 import numbers
 import torch
 import numpy as np
+from copy import copy
 
 from bigdl.orca.learn.pytorch.training_operator import TrainingOperator
 from bigdl.orca.learn.pytorch.pytorch_pyspark_worker import PytorchPysparkWorker
@@ -146,7 +147,7 @@ class PyTorchPySparkEstimator(BaseEstimator):
             training_operator_cls=training_operator_cls,
             scheduler_step_freq=scheduler_step_freq,
             use_tqdm=use_tqdm,
-            config=self.config.copy(),
+            config=copy(self.config),
             metrics=metrics,
             size=self.num_workers,
             cores_per_worker=self.cores_per_worker,

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
@@ -37,6 +37,7 @@ import logging
 from bigdl.orca.learn.utils import save_pkl
 import os
 import tempfile
+from copy import copy
 
 from pyspark import BarrierTaskContext, TaskContext
 from bigdl.orca.learn.utils import save_pkl, duplicate_stdout_stderr_to_file, get_rank
@@ -157,7 +158,7 @@ class PytorchPysparkWorker(TorchRunner):
 
     def predict(self, data_creator, batch_size=32, profile=False):
         """Evaluates the model on the validation data set."""
-        config = self.config.copy()
+        config = copy(self.config)
         self._toggle_profiling(profile=profile)
 
         partition = data_creator(config, batch_size)

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -20,6 +20,7 @@ import logging
 import numbers
 import torch
 import numpy as np
+from copy import copy
 
 from bigdl.orca.data.ray_xshards import RayXShards
 from bigdl.orca.learn.pytorch.training_operator import TrainingOperator
@@ -148,7 +149,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
 
         self.initialization_hook = initialization_hook
         self.config = {} if config is None else config
-        worker_config = self.config.copy()
+        worker_config = copy(self.config)
         params = dict(
             model_creator=self.model_creator,
             optimizer_creator=self.optimizer_creator,

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
@@ -29,6 +29,7 @@
 # limitations under the License.
 
 import ray
+from copy import copy
 from bigdl.orca.learn.pytorch.utils import find_free_port
 from bigdl.orca.learn.pytorch.torch_runner import TorchRunner
 import torch.nn as nn
@@ -118,7 +119,7 @@ class PytorchRayWorker(TorchRunner):
 
     def predict(self, data_creator, batch_size=32, profile=False):
         """Evaluates the model on the validation data set."""
-        config = self.config.copy()
+        config = copy(self.config)
         self._toggle_profiling(profile=profile)
 
         shards_ref = data_creator(config, batch_size)

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -36,6 +36,7 @@ import logging
 import io
 import itertools
 import os
+from copy import copy
 import tempfile
 import torch
 import torch.nn as nn
@@ -255,7 +256,7 @@ class TorchRunner:
     def train_epochs(self, data_creator, epochs=1, batch_size=32, profile=False,
                      info=None, wrap_dataloader=None, callbacks=None,
                      validation_data_creator=None):
-        config = self.config.copy()
+        config = copy(self.config)
         if OrcaContext.serialize_data_creator:
             with FileLock(
                     os.path.join(tempfile.gettempdir(), ".orcadata.lock")):
@@ -382,7 +383,7 @@ class TorchRunner:
     def validate(self, data_creator, batch_size=32, num_steps=None, profile=False,
                  info=None, wrap_dataloader=None):
         """Evaluates the model on the validation data set."""
-        config = self.config.copy()
+        config = copy(self.config)
         info = info or {}
         self._toggle_profiling(profile=profile)
 
@@ -411,7 +412,7 @@ class TorchRunner:
 
     def predict(self, partition, batch_size=32, profile=False):
         """Evaluates the model on the validation data set."""
-        config = self.config.copy()
+        config = copy(self.config)
         self._toggle_profiling(profile=profile)
 
         params = {"batch_size": batch_size, "shuffle": False}

--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -18,6 +18,7 @@ import logging
 import os
 import tempfile
 import shutil
+from copy import copy
 
 import tensorflow as tf
 
@@ -318,7 +319,7 @@ class SparkRunner:
         """
         Get model training results and new model.
         """
-        config = self.config.copy()
+        config = copy(self.config)
         if data_config is not None:
             config.update(data_config)
         config["batch_size"] = batch_size
@@ -372,7 +373,7 @@ class SparkRunner:
         """
         Evaluates the model on the validation data set.
         """
-        config = self.config.copy()
+        config = copy(self.config)
         if data_config is not None:
             config.update(data_config)
         config["batch_size"] = batch_size
@@ -430,7 +431,7 @@ class SparkRunner:
             return []
 
     def predict(self, data_creator, batch_size, verbose, steps, callbacks, data_config):
-        config = self.config.copy()
+        config = copy(self.config)
         if data_config is not None:
             config.update(data_config)
 

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -35,6 +35,7 @@ import socket
 import shutil
 import tempfile
 import subprocess
+from copy import copy
 
 import ray
 import numpy as np
@@ -333,7 +334,7 @@ class TFRunner:
              steps_per_epoch=None, validation_steps=None, validation_freq=1,
              data_config=None):
         """Runs a training epoch and updates the model parameters."""
-        config = self.config.copy()
+        config = copy(self.config)
         if data_config is not None:
             config.update(data_config)
         config["batch_size"] = batch_size
@@ -383,7 +384,7 @@ class TFRunner:
     def validate(self, data_creator, batch_size=32, verbose=1, sample_weight=None,
                  steps=None, callbacks=None, data_config=None):
         """Evaluates the model on the validation data set."""
-        config = self.config.copy()
+        config = copy(self.config)
         if data_config is not None:
             config.update(data_config)
         config["batch_size"] = batch_size
@@ -431,7 +432,7 @@ class TFRunner:
         return [stats]
 
     def predict(self, data_creator, batch_size, verbose, steps, callbacks, data_config):
-        config = self.config.copy()
+        config = copy(self.config)
         if data_config is not None:
             config.update(data_config)
 


### PR DESCRIPTION
## Description

For now we only support dict as config in estimator like
```
config={`batchsize`:16}
```
Actually there are many other types in third-party implementations that can also function as configuration like CfgNode, and it's completely exploited by user code, so may we extend config type to NameSpace type like CfgNode object here, intead of only dict?

### 1. Why the change?

https://github.com/intel-analytics/BigDL/issues/5729
config.copy() only returns a dict. so we call copy.copy() on it.

### 2. User API changes

We now support more type as configs now, like NameSpace and CfgNode even customized class.

### 3. Summary of the change 

self.config.copy() -> copy(self.config)

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...
