### PR TITLE
[Orca] Refacor `model_dir` as optional in pytorch pyspark estimator

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -113,9 +113,7 @@ class PyTorchPySparkEstimator(BaseEstimator):
             invalidInputError(False,
                               "If a loss_creator is not provided, you must "
                               "provide a custom training operator.")
-        if not model_dir:
-            invalidInputError(False,
-                              "Please specify model directory when using spark backend")
+
         self.model_dir = model_dir
 
         self.model_creator = model_creator

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -297,8 +297,12 @@ class PyTorchPySparkEstimator(BaseEstimator):
             res = self.workerRDD.barrier().mapPartitions(
                 lambda iter: transform_func(iter, init_params, params)).collect()
 
-        self.state_dict = PyTorchPySparkEstimator._get_state_dict_from_remote(self.model_dir)
-        worker_stats = res
+        if self.model_dir is not None:
+            self.state_dict = PyTorchPySparkEstimator._get_state_dict_from_remote(self.model_dir)
+            worker_stats = res
+        else:
+            self.state_dict = res[0]
+            worker_stats = res[1]
 
         epoch_stats = list(map(list, zip(*worker_stats)))
         if reduce_results:

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
@@ -83,7 +83,6 @@ class PytorchPysparkWorker(TorchRunner):
         self.mode = mode
         self.backend = backend
         self.cluster_info = cluster_info
-        invalidInputError(model_dir, "model_dir cannot be null")
         self.model_dir = model_dir
         self.log_to_driver = log_to_driver
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
@@ -141,9 +141,13 @@ class PytorchPysparkWorker(TorchRunner):
             LogMonitor.stop_log_monitor(self.log_path, self.logger_thread, self.thread_stop)
 
         if self.rank == 0:
-            save_pkl(state_dict, os.path.join(self.model_dir, "state.pkl"))
-
-        return [stats_list]
+            if self.model_dir is not None:
+                save_pkl(state_dict, os.path.join(self.model_dir, "state.pkl"))
+        
+        if self.model_dir is not None:
+            return [stats_list]
+        else:
+            return [stats_list], state_dict
 
     def validate(self, data_creator, batch_size=32, num_steps=None, profile=False,
                  info=None, wrap_dataloader=None):

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
@@ -146,7 +146,7 @@ class PytorchPysparkWorker(TorchRunner):
         if self.model_dir is not None:
             return [stats_list]
         else:
-            return [stats_list], state_dict
+            return state_dict, [stats_list]
 
     def validate(self, data_creator, batch_size=32, num_steps=None, profile=False,
                  info=None, wrap_dataloader=None):

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
@@ -143,7 +143,7 @@ class PytorchPysparkWorker(TorchRunner):
         if self.rank == 0:
             if self.model_dir is not None:
                 save_pkl(state_dict, os.path.join(self.model_dir, "state.pkl"))
-        
+
         if self.model_dir is not None:
             return [stats_list]
         else:

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
@@ -171,7 +171,7 @@ def get_optimizer(model, config):
 
 
 def get_estimator(workers_per_node=1, model_fn=get_model, sync_stats=False,
-                  log_level=logging.INFO, model_dir=None):
+                  log_level=logging.INFO):
     estimator = Estimator.from_torch(model=model_fn,
                                      optimizer=get_optimizer,
                                      loss=nn.BCELoss(),
@@ -180,8 +180,7 @@ def get_estimator(workers_per_node=1, model_fn=get_model, sync_stats=False,
                                      workers_per_node=workers_per_node,
                                      backend="spark",
                                      sync_stats=sync_stats,
-                                     log_level=log_level,
-                                     model_dir=model_dir)
+                                     log_level=log_level)
     return estimator
 
 
@@ -193,7 +192,7 @@ class TestPyTorchEstimator(TestCase):
         shutil.rmtree(self.model_dir)
 
     def test_data_creator_convergence(self):
-        estimator = get_estimator(workers_per_node=2, model_dir=self.model_dir)
+        estimator = get_estimator(workers_per_node=2)
         start_val_stats = estimator.evaluate(val_data_loader, batch_size=64)
         print(start_val_stats)
         train_stats = estimator.fit(train_data_loader, epochs=4, batch_size=128,
@@ -215,7 +214,7 @@ class TestPyTorchEstimator(TestCase):
     def test_spark_xshards(self):
         from bigdl.dllib.nncontext import init_nncontext
         from bigdl.orca.data import SparkXShards
-        estimator = get_estimator(workers_per_node=1, model_dir=self.model_dir)
+        estimator = get_estimator(workers_per_node=1)
         sc = init_nncontext()
         x_rdd = sc.parallelize(np.random.rand(4000, 1, 50).astype(np.float32))
         # torch 1.7.1+ requires target size same as output size, which is (batch, 1)
@@ -238,7 +237,7 @@ class TestPyTorchEstimator(TestCase):
                                 [int(np.random.randint(0, 2, size=()))])
                      ).toDF(["feature", "label"])
 
-        estimator = get_estimator(workers_per_node=2, model_dir=self.model_dir)
+        estimator = get_estimator(workers_per_node=2)
         estimator.fit(df, batch_size=4, epochs=2,
                       validation_data=df,
                       feature_cols=["feature"],
@@ -257,7 +256,7 @@ class TestPyTorchEstimator(TestCase):
                                 [int(np.random.randint(0, 2, size=()))])
                      ).toDF(["feature", "label"])
 
-        estimator = get_estimator(workers_per_node=2, model_dir=self.model_dir)
+        estimator = get_estimator(workers_per_node=2)
         estimator.fit(df, batch_size=4, epochs=2,
                       feature_cols=["feature"],
                       label_cols=["label"])
@@ -272,7 +271,7 @@ class TestPyTorchEstimator(TestCase):
                                 [int(np.random.randint(0, 2, size=()))])
                      ).toDF(["feature", "label"])
 
-        estimator = get_estimator(workers_per_node=2, model_dir=self.model_dir)
+        estimator = get_estimator(workers_per_node=2)
         assert df.rdd.getNumPartitions() < estimator.num_workers
 
         estimator.fit(df, batch_size=4, epochs=2,
@@ -293,8 +292,7 @@ class TestPyTorchEstimator(TestCase):
                      ).toDF(["feature", "label"])
 
         estimator = get_estimator(workers_per_node=2,
-                                  model_fn=lambda config: IdentityNet(),
-                                  model_dir=self.model_dir)
+                                  model_fn=lambda config: IdentityNet())
         result = estimator.predict(df, batch_size=4,
                                    feature_cols=["feature"])
         expr = "sum(cast(feature <> to_array(prediction) as int)) as error"
@@ -308,8 +306,7 @@ class TestPyTorchEstimator(TestCase):
         shards = SparkXShards(shards)
 
         estimator = get_estimator(workers_per_node=2,
-                                  model_fn=lambda config: IdentityNet(),
-                                  model_dir=self.model_dir)
+                                  model_fn=lambda config: IdentityNet())
         result_shards = estimator.predict(shards, batch_size=4)
         result_before = np.concatenate([shard["prediction"] for shard in result_shards.collect()])
         expected_result = np.concatenate([shard["x"] for shard in result_shards.collect()])
@@ -358,8 +355,7 @@ class TestPyTorchEstimator(TestCase):
                      ).toDF(["f1", "f2", "label"])
 
         estimator = get_estimator(workers_per_node=2,
-                                  model_fn=lambda config: MultiInputNet(),
-                                  model_dir=self.model_dir)
+                                  model_fn=lambda config: MultiInputNet())
         estimator.fit(df, batch_size=4, epochs=2,
                       validation_data=df,
                       feature_cols=["f1", "f2"],
@@ -403,8 +399,7 @@ class TestPyTorchEstimator(TestCase):
                                          config={},
                                          workers_per_node=2,
                                          backend="spark",
-                                         sync_stats=False,
-                                         model_dir=self.model_dir)
+                                         sync_stats=False)
 
         stats = estimator.fit(df, batch_size=4, epochs=2,
                               validation_data=df,
@@ -425,8 +420,7 @@ class TestPyTorchEstimator(TestCase):
                      ).toDF(["feature", "label"])
         df = df.cache()
 
-        estimator = get_estimator(workers_per_node=2, model_dir=self.model_dir,
-                                  log_level=logging.DEBUG)
+        estimator = get_estimator(workers_per_node=2, log_level=logging.DEBUG)
 
         callbacks = [
             ModelCheckpoint(filepath=os.path.join(self.model_dir, "test-{epoch}"),
@@ -446,8 +440,7 @@ class TestPyTorchEstimator(TestCase):
         latest_checkpoint_path = Estimator.latest_checkpoint(self.model_dir)
         assert os.path.isfile(latest_checkpoint_path)
         estimator.shutdown()
-        new_estimator = get_estimator(workers_per_node=2,  model_dir=self.model_dir,
-                                      log_level=logging.DEBUG)
+        new_estimator = get_estimator(workers_per_node=2, log_level=logging.DEBUG)
         new_estimator.load_checkpoint(latest_checkpoint_path)
         eval_after = new_estimator.evaluate(df, batch_size=4,
                                             feature_cols=["feature"],
@@ -466,8 +459,7 @@ class TestPyTorchEstimator(TestCase):
                      ).toDF(["feature", "label"])
         df = df.cache()
 
-        estimator = get_estimator(workers_per_node=2, model_dir=self.model_dir,
-                                  log_level=logging.DEBUG)
+        estimator = get_estimator(workers_per_node=2, log_level=logging.DEBUG)
         estimator.fit(df, batch_size=4, epochs=epochs,
                       feature_cols=["feature"],
                       label_cols=["label"])
@@ -480,8 +472,7 @@ class TestPyTorchEstimator(TestCase):
             ckpt_file = os.path.join(temp_dir, "manual.ckpt")
             estimator.save_checkpoint(ckpt_file)
             estimator.shutdown()
-            new_estimator = get_estimator(workers_per_node=2, model_dir=self.model_dir,
-                                          log_level=logging.DEBUG)
+            new_estimator = get_estimator(workers_per_node=2, log_level=logging.DEBUG)
             new_estimator.load_checkpoint(ckpt_file)
             eval_after = new_estimator.evaluate(df, batch_size=4,
                                                 feature_cols=["feature"],
@@ -492,7 +483,7 @@ class TestPyTorchEstimator(TestCase):
             shutil.rmtree(temp_dir)
 
     def test_custom_callback(self):
-        estimator = get_estimator(workers_per_node=2, model_dir=self.model_dir)
+        estimator = get_estimator(workers_per_node=2)
         callbacks = [CustomCallback()]
         estimator.fit(train_data_loader, epochs=4, batch_size=128, 
                       validation_data=val_data_loader, callbacks=callbacks)


### PR DESCRIPTION
## Description
This PR mainly refactors pytorch pyspark estimator to support users ignoring `model_dir` when creating estimator, which could improve user experience.

### 1. Why the change?
Pyspark estimator requires users to specify `model_dir` when creating estimator, since ray estimator does not.  This discontinuity may make users feel annoyed.

### 2. User API changes
Pytorch pyspark estimator supports whether users specify `model_dir` or not; it's basically an optional but not a requirement now.

#### option 1.  Non `model_dir`
```python
estimator = Estimator.from_torch(
              model_creator=model_creator,
              workers_per_node=2,
              backend="spark")
```

####  option 2. Setting `model_dir`
```python
estimator = Estimator.from_torch(
              model_creator=model_creator,
              workers_per_node=2,
              backend="spark",
              model_dir="/tmp")
```

### 3. Summary of the change 
Refactor `model_dir` to an option and not a must requirement anymore.

### 4. How to test?
- [x] Unit test
- [x] Test on YARN