### PR TITLE
cicd: add debug info to license-scan workflow

### DIFF
--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -2,7 +2,7 @@ name: license-scan
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "wip/shaojun/debug" ]
   #pull_request:
     #branches: [ "main" ]
   schedule:

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -2,7 +2,7 @@ name: license-scan
 
 on:
   push:
-    branches: [ "wip/shaojun/debug" ]
+    branches: [ "main" ]
   #pull_request:
     #branches: [ "main" ]
   schedule:

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         secret: ${{ secrets.GIST_SECRET }}
         gist-id: f91eb10af4d9dbe216ba0f0da71cace9
-        is-self-hosted-runner: false
+        is-self-hosted-runner: true
         file-name: fossa-scan.json
         type: job
         job-name: fossa-scan

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -56,7 +56,10 @@ jobs:
         sed -i 's/<artifactId>bigdl-parent-spark_${spark.version}<\/artifactId>/<artifactId>bigdl-parent-spark_3.1.2<\/artifactId>/' scala/assembly/pom.xml
         mvn dependency:tree -Dhttp.proxyHost=${{ secrets.HTTP_PROXY_HOST_2 }} -Dhttp.proxyPort=${{ secrets.HTTP_PROXY_PORT_2 }} -Dhttps.proxyHost=${{ secrets.HTTP_PROXY_HOST_2 }} -Dhttps.proxyPort=${{ secrets.HTTP_PROXY_PORT_3 }} -Dspark.version=3.1.2 -DSPARK_PLATFORM=SPARK_3.1 -P spark_3.x --file scala/pom.xml
         mvn clean package -Dhttp.proxyHost=${{ secrets.HTTP_PROXY_HOST_2 }} -Dhttp.proxyPort=${{ secrets.HTTP_PROXY_PORT_2 }} -Dhttps.proxyHost=${{ secrets.HTTP_PROXY_HOST_2 }} -Dhttps.proxyPort=${{ secrets.HTTP_PROXY_PORT_3 }} -DskipTests -Dspark.version=3.1.2 -DSPARK_PLATFORM=SPARK_3.1 -P spark_3.x --file scala/pom.xml
+        echo "ls -d scala/assembly/target/*"
         ls -d scala/assembly/target/*
+        echo ""
+        echo "zipinfo -1 scala/assembly/target/bigdl-assembly-spark_3.1.2-2.1.0-SNAPSHOT-dist-all.zip 'jars/*.jar'"
         zipinfo -1 scala/assembly/target/bigdl-assembly-spark_3.1.2-2.1.0-SNAPSHOT-dist-all.zip 'jars/*.jar'
     
     - name: Create Job Badge

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   fossa-scan:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, Bree]
     steps:
     - name: "Checkout Code"
       uses: actions/checkout@v3
@@ -28,10 +28,20 @@ jobs:
       with:
         api-key: ${{ secrets.FOSSAAPIKEY }}
         run-tests: true
-        
-    - name: "Filter the Dependency Tree"
+    
+    - name: Set up JDK8
+      if: ${{ failure() }}
+      uses: ./.github/actions/jdk-setup-action
+
+    - name: Set up maven
+      if: ${{ failure() }}
+      uses: ./.github/actions/maven-setup-action
+
+    - name: "Debug Failure"
       if: ${{ failure() }}
       run: |
+        ls
+        #spark3.1.2
         sed -i 's/<artifactId>${spark-version.project}<\/artifactId>/<artifactId>${spark-version.project}-${SPARK_PLATFORM}<\/artifactId>/' scala/dllib/pom.xml
         sed -i 's/<artifactId>3.0<\/artifactId>/<artifactId>3.0-${SPARK_PLATFORM}<\/artifactId>/' scala/common/spark-version/3.0/pom.xml
         sed -i 's/<artifactId>bigdl-parent-spark_${spark.version}<\/artifactId>/<artifactId>bigdl-parent-spark_3.1.2<\/artifactId>/' scala/pom.xml
@@ -44,9 +54,11 @@ jobs:
         sed -i 's/<artifactId>bigdl-parent-spark_${spark.version}<\/artifactId>/<artifactId>bigdl-parent-spark_3.1.2<\/artifactId>/' scala/serving/pom.xml
         sed -i 's/<artifactId>bigdl-parent-spark_${spark.version}<\/artifactId>/<artifactId>bigdl-parent-spark_3.1.2<\/artifactId>/' scala/ppml/pom.xml
         sed -i 's/<artifactId>bigdl-parent-spark_${spark.version}<\/artifactId>/<artifactId>bigdl-parent-spark_3.1.2<\/artifactId>/' scala/assembly/pom.xml
-        cd scala
-        mvn -P spark_3.x dependency:tree -Dspark.version=3.1.2 -DSPARK_PLATFORM=SPARK_3.1
-
+        mvn dependency:tree -Dhttp.proxyHost=${{ secrets.HTTP_PROXY_HOST_2 }} -Dhttp.proxyPort=${{ secrets.HTTP_PROXY_PORT_2 }} -Dhttps.proxyHost=${{ secrets.HTTP_PROXY_HOST_2 }} -Dhttps.proxyPort=${{ secrets.HTTP_PROXY_PORT_3 }} -Dspark.version=3.1.2 -DSPARK_PLATFORM=SPARK_3.1 -P spark_3.x --file scala/pom.xml
+        mvn clean package -Dhttp.proxyHost=${{ secrets.HTTP_PROXY_HOST_2 }} -Dhttp.proxyPort=${{ secrets.HTTP_PROXY_PORT_2 }} -Dhttps.proxyHost=${{ secrets.HTTP_PROXY_HOST_2 }} -Dhttps.proxyPort=${{ secrets.HTTP_PROXY_PORT_3 }} -DskipTests -Dspark.version=3.1.2 -DSPARK_PLATFORM=SPARK_3.1 -P spark_3.x --file scala/pom.xml
+        ls -d scala/assembly/target/*
+        zipinfo -1 scala/assembly/target/bigdl-assembly-spark_3.1.2-2.1.0-SNAPSHOT-dist-all.zip 'jars/*.jar'
+    
     - name: Create Job Badge
       if: ${{ always() }}
       uses: ./.github/actions/create-job-status-badge


### PR DESCRIPTION
## Description

This submission add debug steps to license-scan.yml, if fossa scan failed, the debug steps will be executed and filter the dependency tree and list jars under assembly zip to help debug.
![image](https://user-images.githubusercontent.com/61072813/190036222-6cc6e216-f573-4312-8d12-922d155fdfd8.png)

![image](https://user-images.githubusercontent.com/61072813/190036033-ec1f0a67-7c9a-4e64-8b91-462dc83c13d3.png)
