### PR TITLE
Nano : reduce time cost for InferenceOptimizer and update demo

### DIFF
--- a/python/nano/example/pytorch/inference_pipeline/resnet/README.md
+++ b/python/nano/example/pytorch/inference_pipeline/resnet/README.md
@@ -29,18 +29,23 @@ unset KMP_AFFINITY
 ``` 
 You may find environment variables set like follows:
 ```
+OpenMP library found...
 Setting OMP_NUM_THREADS...
 Setting OMP_NUM_THREADS specified for pytorch...
 Setting KMP_AFFINITY...
 Setting KMP_BLOCKTIME...
 Setting MALLOC_CONF...
+Setting LD_PRELOAD...
+nano_vars.sh already exists
 +++++ Env Variables +++++
-LD_PRELOAD=./../lib/libjemalloc.so
-MALLOC_CONF=oversize_threshold:1,background_thread:true,metadata_thp:auto,dirty_decay_ms:-1,muzzy_decay_ms:-1
+LD_PRELOAD=/opt/anaconda3/envs/nano/bin/../lib/libiomp5.so /opt/anaconda3/envs/nano/lib/python3.7/site-packages/bigdl/nano//libs/libtcmalloc.so
+MALLOC_CONF=
 OMP_NUM_THREADS=112
 KMP_AFFINITY=granularity=fine,compact,1,0
 KMP_BLOCKTIME=1
-TF_ENABLE_ONEDNN_OPTS=
+TF_ENABLE_ONEDNN_OPTS=1
+ENABLE_TF_OPTS=1
+NANO_TF_INTER_OP=1
 +++++++++++++++++++++++++
 Complete.
 ```
@@ -60,27 +65,25 @@ python inference_pipeline.py
 It will take about 1 minute to run inference optimization. Then you may find the result for inference as follows:
 ```
 ==========================Optimization Results==========================
- -------------------------------- ---------------------- -------------- ------------
-|             method             |        status        | latency(ms)  |  accuracy  |
- -------------------------------- ---------------------- -------------- ------------
-|            original            |      successful      |    43.447    |   0.994    |
-|           fp32_ipex            |      successful      |    32.827    |   0.994    |
-|              bf16              |   fail to forward    |     None     |    None    |
-|           bf16_ipex            |        pruned        |   201.702    |    None    |
-|              int8              |      successful      |    10.992    |   0.994    |
-|            jit_fp32            |      successful      |    36.741    |   0.994    |
-|         jit_fp32_ipex          |      successful      |    33.293    |   0.994    |
-|  jit_fp32_ipex_channels_last   |      successful      |    19.523    |   0.994    |
-|         openvino_fp32          |      successful      |    10.51     |   0.994    |
-|         openvino_int8          |      successful      |    6.637     |   0.994    |
-|        onnxruntime_fp32        |      successful      |    20.55     |   0.994    |
-|    onnxruntime_int8_qlinear    |      successful      |     8.15     |   0.994    |
-|    onnxruntime_int8_integer    |   fail to convert    |     None     |    None    |
- -------------------------------- ---------------------- -------------- ------------
+ -------------------------------- ---------------------- -------------- ----------------------
+|             method             |        status        | latency(ms)  |       accuracy       |
+ -------------------------------- ---------------------- -------------- ----------------------
+|            original            |      successful      |    43.688    |        0.969         |
+|           fp32_ipex            |      successful      |    33.383    |    not recomputed    |
+|              bf16              |   fail to forward    |     None     |         None         |
+|           bf16_ipex            |    early stopped     |   203.897    |         None         |
+|              int8              |      successful      |    10.74     |        0.969         |
+|            jit_fp32            |      successful      |    38.732    |    not recomputed    |
+|         jit_fp32_ipex          |      successful      |    35.205    |    not recomputed    |
+|  jit_fp32_ipex_channels_last   |      successful      |    19.327    |    not recomputed    |
+|         openvino_fp32          |      successful      |    10.215    |    not recomputed    |
+|         openvino_int8          |      successful      |    8.192     |        0.969         |
+|        onnxruntime_fp32        |      successful      |    20.931    |    not recomputed    |
+|    onnxruntime_int8_qlinear    |      successful      |    8.274     |        0.969         |
+|    onnxruntime_int8_integer    |   fail to convert    |     None     |         None         |
+ -------------------------------- ---------------------- -------------- ----------------------
 
 Optimization cost 64.3s at all.
 ===========================Stop Optimization===========================
-When accelerator is onnxruntime, the model with minimal latency is:  inc + onnxruntime + qlinear 
-When accuracy drop less than 5%, the model with minimal latency is:  openvino + pot 
-The model with minimal latency is:  openvino + pot 
+When accuracy drop less than 5%, the model with minimal latency is:  openvino + int8 
 ```

--- a/python/nano/example/pytorch/inference_pipeline/resnet/README.md
+++ b/python/nano/example/pytorch/inference_pipeline/resnet/README.md
@@ -1,7 +1,7 @@
 # Bigdl-nano InferenceOptimizer example on Cat vs. Dog dataset
 
 This example illustrates how to apply InferenceOptimizer to quickly find acceleration method with the minimum inference latency under specific restrictions or without restrictions for a trained model. 
-For the sake of this example, we first train the proposed network(by default, a ResNet18 is used) on the [cats and dogs dataset](https://storage.googleapis.com/mledu-datasets/cats_and_dogs_filtered.zip), which consists both [frozen and unfrozen stages](https://github.com/PyTorchLightning/pytorch-lightning/blob/495812878dfe2e31ec2143c071127990afbb082b/pl_examples/domain_templates/computer_vision_fine_tuning.py#L21-L35). Then, by calling `optimize()`, we can obtain all available accelaration combinations provided by BigDL-Nano for inference. By calling `get_best_mdoel()` , we could get an accelerated model whose inference is 7.5x times faster.
+For the sake of this example, we first train the proposed network(by default, a ResNet18 is used) on the [cats and dogs dataset](https://storage.googleapis.com/mledu-datasets/cats_and_dogs_filtered.zip), which consists both [frozen and unfrozen stages](https://github.com/PyTorchLightning/pytorch-lightning/blob/495812878dfe2e31ec2143c071127990afbb082b/pl_examples/domain_templates/computer_vision_fine_tuning.py#L21-L35). Then, by calling `optimize()`, we can obtain all available accelaration combinations provided by BigDL-Nano for inference. By calling `get_best_mdoel()` , we could get an accelerated model whose inference is 5.5x times faster.
 
 
 ## Prepare the environment
@@ -25,6 +25,7 @@ pip install --upgrade numpy==1.21.6
 Initialize environment variables with script `bigdl-nano-init` installed with bigdl-nano.
 ```
 source bigdl-nano-init
+unset KMP_AFFINITY
 ``` 
 You may find environment variables set like follows:
 ```
@@ -59,24 +60,25 @@ python inference_pipeline.py
 It will take about 1 minute to run inference optimization. Then you may find the result for inference as follows:
 ```
 ==========================Optimization Results==========================
-    -------------------------------- ---------------------- -------------- ------------
+ -------------------------------- ---------------------- -------------- ------------
 |             method             |        status        | latency(ms)  |  accuracy  |
-    -------------------------------- ---------------------- -------------- ------------
-|            original            |      successful      |    43.52     |    1.0     |
-|           fp32_ipex            |      successful      |    33.316    |    1.0     |
+ -------------------------------- ---------------------- -------------- ------------
+|            original            |      successful      |    43.447    |   0.994    |
+|           fp32_ipex            |      successful      |    32.827    |   0.994    |
 |              bf16              |   fail to forward    |     None     |    None    |
-|           bf16_ipex            |        pruned        |   206.862    |    None    |
-|              int8              |      successful      |    10.815    |    1.0     |
-|            jit_fp32            |      successful      |    33.066    |    1.0     |
-|         jit_fp32_ipex          |      successful      |    34.361    |    1.0     |
-|  jit_fp32_ipex_channels_last   |      successful      |    19.313    |    1.0     |
-|         openvino_fp32          |      successful      |    11.65     |    1.0     |
-|         openvino_int8          |      successful      |    7.931     |   0.994    |
-|        onnxruntime_fp32        |      successful      |    20.652    |    1.0     |
-|    onnxruntime_int8_qlinear    |      successful      |    8.504     |   0.988    |
+|           bf16_ipex            |        pruned        |   201.702    |    None    |
+|              int8              |      successful      |    10.992    |   0.994    |
+|            jit_fp32            |      successful      |    36.741    |   0.994    |
+|         jit_fp32_ipex          |      successful      |    33.293    |   0.994    |
+|  jit_fp32_ipex_channels_last   |      successful      |    19.523    |   0.994    |
+|         openvino_fp32          |      successful      |    10.51     |   0.994    |
+|         openvino_int8          |      successful      |    6.637     |   0.994    |
+|        onnxruntime_fp32        |      successful      |    20.55     |   0.994    |
+|    onnxruntime_int8_qlinear    |      successful      |     8.15     |   0.994    |
 |    onnxruntime_int8_integer    |   fail to convert    |     None     |    None    |
-    -------------------------------- ---------------------- -------------- ------------
-Optimization cost 67.1s at all.
+ -------------------------------- ---------------------- -------------- ------------
+
+Optimization cost 64.3s at all.
 ===========================Stop Optimization===========================
 When accelerator is onnxruntime, the model with minimal latency is:  inc + onnxruntime + qlinear 
 When accuracy drop less than 5%, the model with minimal latency is:  openvino + pot 

--- a/python/nano/example/pytorch/inference_pipeline/resnet/README.md
+++ b/python/nano/example/pytorch/inference_pipeline/resnet/README.md
@@ -1,7 +1,7 @@
 # Bigdl-nano InferenceOptimizer example on Cat vs. Dog dataset
 
 This example illustrates how to apply InferenceOptimizer to quickly find acceleration method with the minimum inference latency under specific restrictions or without restrictions for a trained model. 
-For the sake of this example, we first train the proposed network(by default, a ResNet18 is used) on the [cats and dogs dataset](https://storage.googleapis.com/mledu-datasets/cats_and_dogs_filtered.zip), which consists both [frozen and unfrozen stages](https://github.com/PyTorchLightning/pytorch-lightning/blob/495812878dfe2e31ec2143c071127990afbb082b/pl_examples/domain_templates/computer_vision_fine_tuning.py#L21-L35). Then, by calling `optimize()`, we can obtain all available accelaration combinations provided by BigDL-Nano for inference. By calling `get_best_mdoel()` , we could get an accelerated model whose inference is 6.5x times faster.
+For the sake of this example, we first train the proposed network(by default, a ResNet18 is used) on the [cats and dogs dataset](https://storage.googleapis.com/mledu-datasets/cats_and_dogs_filtered.zip), which consists both [frozen and unfrozen stages](https://github.com/PyTorchLightning/pytorch-lightning/blob/495812878dfe2e31ec2143c071127990afbb082b/pl_examples/domain_templates/computer_vision_fine_tuning.py#L21-L35). Then, by calling `optimize()`, we can obtain all available accelaration combinations provided by BigDL-Nano for inference. By calling `get_best_mdoel()` , we could get an accelerated model whose inference is 5x times faster.
 
 
 ## Prepare the environment
@@ -25,7 +25,6 @@ pip install --upgrade numpy==1.21.6
 Initialize environment variables with script `bigdl-nano-init` installed with bigdl-nano.
 ```
 source bigdl-nano-init
-unset KMP_AFFINITY
 ``` 
 You may find environment variables set like follows:
 ```
@@ -41,7 +40,7 @@ nano_vars.sh already exists
 LD_PRELOAD=/opt/anaconda3/envs/nano/bin/../lib/libiomp5.so /opt/anaconda3/envs/nano/lib/python3.7/site-packages/bigdl/nano//libs/libtcmalloc.so
 MALLOC_CONF=
 OMP_NUM_THREADS=112
-KMP_AFFINITY=granularity=fine,compact,1,0
+KMP_AFFINITY=granularity=fine
 KMP_BLOCKTIME=1
 TF_ENABLE_ONEDNN_OPTS=1
 ENABLE_TF_OPTS=1
@@ -85,5 +84,5 @@ It will take about 1 minute to run inference optimization. Then you may find the
 
 Optimization cost 64.3s at all.
 ===========================Stop Optimization===========================
-When accuracy drop less than 5%, the model with minimal latency is:  openvino + int8 
+When accuracy drop less than 5%, the model with minimal latency is:  openvino + int8
 ```

--- a/python/nano/example/pytorch/inference_pipeline/resnet/README.md
+++ b/python/nano/example/pytorch/inference_pipeline/resnet/README.md
@@ -1,7 +1,7 @@
 # Bigdl-nano InferenceOptimizer example on Cat vs. Dog dataset
 
 This example illustrates how to apply InferenceOptimizer to quickly find acceleration method with the minimum inference latency under specific restrictions or without restrictions for a trained model. 
-For the sake of this example, we first train the proposed network(by default, a ResNet18 is used) on the [cats and dogs dataset](https://storage.googleapis.com/mledu-datasets/cats_and_dogs_filtered.zip), which consists both [frozen and unfrozen stages](https://github.com/PyTorchLightning/pytorch-lightning/blob/495812878dfe2e31ec2143c071127990afbb082b/pl_examples/domain_templates/computer_vision_fine_tuning.py#L21-L35). Then, by calling `optimize()`, we can obtain all available accelaration combinations provided by BigDL-Nano for inference. By calling `get_best_mdoel()` , we could get an accelerated model whose inference is 5.5x times faster.
+For the sake of this example, we first train the proposed network(by default, a ResNet18 is used) on the [cats and dogs dataset](https://storage.googleapis.com/mledu-datasets/cats_and_dogs_filtered.zip), which consists both [frozen and unfrozen stages](https://github.com/PyTorchLightning/pytorch-lightning/blob/495812878dfe2e31ec2143c071127990afbb082b/pl_examples/domain_templates/computer_vision_fine_tuning.py#L21-L35). Then, by calling `optimize()`, we can obtain all available accelaration combinations provided by BigDL-Nano for inference. By calling `get_best_mdoel()` , we could get an accelerated model whose inference is 6.5x times faster.
 
 
 ## Prepare the environment

--- a/python/nano/example/pytorch/inference_pipeline/resnet/README.md
+++ b/python/nano/example/pytorch/inference_pipeline/resnet/README.md
@@ -56,22 +56,28 @@ python inference_pipeline.py
 ```
 
 ## Results
-
-It will take about 2 minutes to run inference optimization. Then you may find the result for inference as follows:
+It will take about 1 minute to run inference optimization. Then you may find the result for inference as follows:
 ```
 ==========================Optimization Results==========================
-accleration option: original, latency: 54.2669ms, accuracy: 0.9937
-accleration option: fp32_ipex, latency: 40.3075ms, accuracy: 0.9937
-accleration option: bf16_ipex, latency: 115.6182ms, accuracy: 0.9937
-accleration option: int8, latency: 14.4857ms, accuracy: 0.4750
-accleration option: jit_fp32, latency: 39.3361ms, accuracy: 0.9937
-accleration option: jit_fp32_ipex, latency: 39.2949ms, accuracy: 0.9937
-accleration option: jit_fp32_ipex_clast, latency: 24.5715ms, accuracy: 0.9937
-accleration option: openvino_fp32, latency: 14.5771ms, accuracy: 0.9937
-accleration option: openvino_int8, latency: 7.2186ms, accuracy: 0.9937
-accleration option: onnxruntime_fp32, latency: 44.3872ms, accuracy: 0.9937
-accleration option: onnxruntime_int8_qlinear, latency: 10.1866ms, accuracy: 0.9937
-accleration option: onnxruntime_int8_integer, latency: 18.8731ms, accuracy: 0.9875
+    -------------------------------- ---------------------- -------------- ------------
+|             method             |        status        | latency(ms)  |  accuracy  |
+    -------------------------------- ---------------------- -------------- ------------
+|            original            |      successful      |    43.52     |    1.0     |
+|           fp32_ipex            |      successful      |    33.316    |    1.0     |
+|              bf16              |   fail to forward    |     None     |    None    |
+|           bf16_ipex            |        pruned        |   206.862    |    None    |
+|              int8              |      successful      |    10.815    |    1.0     |
+|            jit_fp32            |      successful      |    33.066    |    1.0     |
+|         jit_fp32_ipex          |      successful      |    34.361    |    1.0     |
+|  jit_fp32_ipex_channels_last   |      successful      |    19.313    |    1.0     |
+|         openvino_fp32          |      successful      |    11.65     |    1.0     |
+|         openvino_int8          |      successful      |    7.931     |   0.994    |
+|        onnxruntime_fp32        |      successful      |    20.652    |    1.0     |
+|    onnxruntime_int8_qlinear    |      successful      |    8.504     |   0.988    |
+|    onnxruntime_int8_integer    |   fail to convert    |     None     |    None    |
+    -------------------------------- ---------------------- -------------- ------------
+Optimization cost 67.1s at all.
+===========================Stop Optimization===========================
 When accelerator is onnxruntime, the model with minimal latency is:  inc + onnxruntime + qlinear 
 When accuracy drop less than 5%, the model with minimal latency is:  openvino + pot 
 The model with minimal latency is:  openvino + pot 

--- a/python/nano/example/pytorch/inference_pipeline/resnet/inference_pipeline.py
+++ b/python/nano/example/pytorch/inference_pipeline/resnet/inference_pipeline.py
@@ -49,14 +49,8 @@ if __name__ == "__main__":
                        latency_sample_num=30)
 
     # 4. Get the best model under specific restrictions or without restrictions
-    acc_model, option = optimizer.get_best_model(accelerator="onnxruntime")
-    print("When accelerator is onnxruntime, the model with minimal latency is: ", option)
-
     acc_model, option = optimizer.get_best_model(accuracy_criterion=0.05)
     print("When accuracy drop less than 5%, the model with minimal latency is: ", option)
-
-    acc_model, option = optimizer.get_best_model()
-    print("The model with minimal latency is: ", option)
 
     # 5. Inference with accelerated model
     x_input = next(iter(datamodule.train_dataloader(batch_size=1)))[0]

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -34,7 +34,7 @@ from bigdl.nano.deps.onnxruntime.onnxruntime_api import PytorchONNXRuntimeModel,
     load_onnxruntime_model
 from bigdl.nano.deps.neural_compressor.inc_api import load_inc_model, quantize as inc_quantize
 from bigdl.nano.utils.inference.pytorch.model import AcceleratedLightningModule
-from bigdl.nano.utils.inference.pytorch.model_utils import get_input_example
+from bigdl.nano.utils.inference.pytorch.model_utils import get_forward_args, get_input_example
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
 import warnings
 # Filter out useless Userwarnings
@@ -173,8 +173,9 @@ class InferenceOptimizer:
         result_map: Dict[str, Dict] = {}
 
         model.eval()  # change model to eval mode
-        # TODO: inspect to get model args
-        input_sample = get_input_example(model, training_data)
+
+        forward_args = get_forward_args(model)
+        input_sample = get_input_example(model, training_data, forward_args)
         st = time.perf_counter()
         try:
             with torch.no_grad():

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -178,7 +178,7 @@ class InferenceOptimizer:
         try:
             with torch.no_grad():
                 model(*input_sample)
-        except:
+        except Exception:
             invalidInputError(False,
                               "training_data is incompatible with your model input.")
             exit(1)

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -175,8 +175,13 @@ class InferenceOptimizer:
 
         input_sample = tuple(next(iter(training_data))[:-1])
         st = time.perf_counter()
-        with torch.no_grad():
-            model(*input_sample)
+        try:
+            with torch.no_grad():
+                model(*input_sample)
+        except:
+            invalidInputError(False,
+                              "training_data is incompatible with your model input.")
+            exit(1)
         baseline_time = time.perf_counter() - st
 
         print("==========================Start Optimization==========================")

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -251,8 +251,7 @@ class InferenceOptimizer:
                 try:
                     result_map[method]["latency"], status =\
                         _throughput_calculate_helper(latency_sample_num, baseline_time,
-	                                                 func_test,
-	                                                 acce_model, input_sample)
+                                                     func_test, acce_model, input_sample)
                     if status is False:
                         result_map[method]["status"] = "pruned"
                         torch.set_num_threads(default_threads)

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -34,6 +34,7 @@ from bigdl.nano.deps.onnxruntime.onnxruntime_api import PytorchONNXRuntimeModel,
     load_onnxruntime_model
 from bigdl.nano.deps.neural_compressor.inc_api import load_inc_model, quantize as inc_quantize
 from bigdl.nano.utils.inference.pytorch.model import AcceleratedLightningModule
+from bigdl.nano.utils.inference.pytorch.model_utils import get_input_example
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
 import warnings
 # Filter out useless Userwarnings
@@ -172,8 +173,8 @@ class InferenceOptimizer:
         result_map: Dict[str, Dict] = {}
 
         model.eval()  # change model to eval mode
-
-        input_sample = tuple(next(iter(training_data))[:-1])
+        # TODO: inspect to get model args
+        input_sample = get_input_example(model, training_data)
         st = time.perf_counter()
         try:
             with torch.no_grad():
@@ -181,7 +182,6 @@ class InferenceOptimizer:
         except Exception:
             invalidInputError(False,
                               "training_data is incompatible with your model input.")
-            exit(1)
         baseline_time = time.perf_counter() - st
 
         print("==========================Start Optimization==========================")

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Any
+from typing import Any, Sequence
 from bigdl.nano.pytorch.lightning import LightningModule
 import inspect
 from torch.utils.data import DataLoader
@@ -31,10 +31,9 @@ def get_forward_args(model):
 
 def get_input_example(model, input_sample, forward_args):
     if isinstance(input_sample, DataLoader):
-        # TODO: This assumpe the last output is y
         input_sample = next(iter(input_sample))
-        if isinstance(input_sample, list):
-            input_sample = input_sample[:len(forward_args)]
+        if isinstance(input_sample, Sequence):
+            input_sample = tuple(list(input_sample)[:len(forward_args)])
     elif input_sample is None:
         if getattr(model, "example_input_array", None) is not None:
             input_sample = model.example_input_array
@@ -45,10 +44,9 @@ def get_input_example(model, input_sample, forward_args):
                                   model.val_dataloader]:
                 try:
                     dataloader = dataloader_fn()
-                    # TODO: This assumpe the last output is y
                     input_sample = next(iter(input_sample))
-                    if isinstance(input_sample, list):
-                        input_sample = input_sample[:len(forward_args)]
+                    if isinstance(input_sample, Sequence):
+                        input_sample = tuple(list(input_sample)[:len(forward_args)])
                     break
                 except Exception as _e:
                     pass

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
@@ -29,10 +29,12 @@ def get_forward_args(model):
     return forward_args
 
 
-def get_input_example(model, input_sample):
+def get_input_example(model, input_sample, forward_args):
     if isinstance(input_sample, DataLoader):
         # TODO: This assumpe the last output is y
-        input_sample = tuple(next(iter(input_sample))[:-1])
+        input_sample = next(iter(input_sample))
+        if isinstance(input_sample, list):
+            input_sample = input_sample[:len(forward_args)]
     elif input_sample is None:
         if getattr(model, "example_input_array", None) is not None:
             input_sample = model.example_input_array
@@ -44,7 +46,9 @@ def get_input_example(model, input_sample):
                 try:
                     dataloader = dataloader_fn()
                     # TODO: This assumpe the last output is y
-                    input_sample = tuple(next(iter(dataloader)))[:-1]
+                    input_sample = next(iter(input_sample))
+                    if isinstance(input_sample, list):
+                        input_sample = input_sample[:len(forward_args)]
                     break
                 except Exception as _e:
                     pass
@@ -73,13 +77,13 @@ def export_to_onnx(model, input_sample=None, onnx_path="model.onnx", dynamic_axe
     :param dynamic_axes: If we set the first dim of each input as a dynamic batch_size
     :param **kwargs: will be passed to torch.onnx.export function.
     '''
-    input_sample = get_input_example(model, input_sample)
+    forward_args = get_forward_args(model)
+    input_sample = get_input_example(model, input_sample, forward_args)
     invalidInputError(input_sample is not None,
                       'You should implement at least one of model.test_dataloader, '
                       'model.train_dataloader, model.val_dataloader and '
                       'model.predict_dataloader, '
                       'or set one of input_sample and model.example_input_array')
-    forward_args = get_forward_args(model)
     if dynamic_axes:
         dynamic_axes = {}
         for arg in forward_args:

--- a/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
+++ b/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
@@ -63,8 +63,6 @@ class TestInferencePipeline(TestCase):
     model = Net()
     test_loader = create_data_loader(data_dir, 1, num_workers, data_transform, subset=10, shuffle=False)
     train_loader = create_data_loader(data_dir, 32, num_workers, data_transform, subset=10, shuffle=True)
-    input_sample = next(iter(test_loader))[0]
-    print(input_sample.shape)
     loss = nn.CrossEntropyLoss()
     optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
 

--- a/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
+++ b/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
@@ -63,6 +63,8 @@ class TestInferencePipeline(TestCase):
     model = Net()
     test_loader = create_data_loader(data_dir, 1, num_workers, data_transform, subset=10, shuffle=False)
     train_loader = create_data_loader(data_dir, 32, num_workers, data_transform, subset=10, shuffle=True)
+    input_sample = next(iter(test_loader))[0]
+    print(input_sample.shape)
     loss = nn.CrossEntropyLoss()
     optimizer = torch.optim.Adam(model.parameters(), lr=0.001)
 
@@ -111,3 +113,31 @@ class TestInferencePipeline(TestCase):
         error_msg = e.value.args[0]
         assert error_msg == "If you want to specify accuracy_criterion, you need "\
                             "to set metric and validation_data when call 'optimize'."
+
+    def test_summary(self):
+        inference_opt = InferenceOptimizer()
+        with pytest.raises(RuntimeError) as e:
+            inference_opt.summary()
+        error_msg = e.value.args[0]
+        assert error_msg == "There is no optimization result. You should call .optimize() "\
+                            "before summary()"
+        inference_opt.optimize(model=self.model,
+                               training_data=self.train_loader,
+                               thread_num=1)
+        inference_opt.summary()
+
+    def test_wrong_data_loader(self):
+        fake_transform = transforms.Compose([
+            transforms.ToTensor(),
+            transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
+            transforms.Resize(64),
+        ])
+        fake_train_loader = create_data_loader(self.data_dir, 32, self.num_workers, 
+                                               fake_transform, subset=10, shuffle=True)
+        inference_opt = InferenceOptimizer()
+        with pytest.raises(RuntimeError) as e:
+            inference_opt.optimize(model=self.model,
+                                    training_data=fake_train_loader,
+                                    thread_num=1)
+        error_msg = e.value.args[0]
+        assert error_msg == "training_data is incompatible with your model input."


### PR DESCRIPTION
## Description

Update resnet18 demo for  InferenceOptimizer and reduce time cost for InferenceOptimizer.

### 1. Why the change?

Make the optimization pipeline faster.

### 2. User API changes

No change.

### 3. Summary of the change 

- modify the example of resnet18 according to recent changes for InferenceOptimizer
- remove accuracy calculation of traced model
- add model pruning for some really slow methods like bf16_ipex
- remove some warnings
- add ut for summary and invaliad input

### 4. How to test?
- [x] Unit test
- [x] Application test
http://10.112.231.51:18889/view/BigDL-PR-Validation/job/ZOO-PR-NanoTests/396/
http://10.112.231.51:18889/job/BigDL-PRVN-chronos-Python-Spark-3.1-py37-ray-part2/818/

### demo output
![image](https://user-images.githubusercontent.com/105281011/190103830-37c515e5-f6f8-4035-a93c-4cd90ebd4fee.png)
