### PR TITLE
Chronos: More autoformer bug fix and enhancement

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -606,7 +606,7 @@ class TSDataset:
         roll_feature_df = None if self.roll_feature_df is None \
             else self.roll_feature_df[additional_feature_col]
 
-        if time_enc and label_len==0:
+        if time_enc and label_len == 0:
             label_len = lookback // 2
 
         self.lookback, self.horizon, self.label_len = lookback, horizon, label_len
@@ -767,7 +767,7 @@ class TSDataset:
             target_col = _to_list(target_col, "target_col") if target_col is not None \
                 else self.target_col
 
-            if time_enc and label_len==0:
+            if time_enc and label_len == 0:
                 label_len = lookback // 2
 
             # set scaler index for unscale_numpy

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -51,6 +51,7 @@ class TSDataset:
         self.numpy_y = None
         self.lookback = None  # lookback stated by users if they called roll, to_torch_data_loader
         self.horizon = None  # horizon stated by users if they called roll, to_torch_data_loader
+        self.label_len = None
         self.roll_feature = None  # contains feature_col requested by roll/to_torch_data_loader
         self.roll_target = None  # contains target_col requested by roll/to_torch_data_loader
         self.roll_feature_df = None

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -21,8 +21,8 @@ import functools
 from bigdl.chronos.data.utils.feature import generate_dt_features, generate_global_features
 from bigdl.chronos.data.utils.impute import impute_timeseries_dataframe
 from bigdl.chronos.data.utils.deduplicate import deduplicate_timeseries_dataframe
-from bigdl.chronos.data.utils.roll import roll_timeseries_dataframe, _roll_timeseries_ndarray
-from bigdl.chronos.data.utils.time_feature import time_features
+from bigdl.chronos.data.utils.roll import roll_timeseries_dataframe
+from bigdl.chronos.data.utils.time_feature import time_features, gen_time_enc_arr
 from bigdl.chronos.data.utils.scale import unscale_timeseries_numpy
 from bigdl.chronos.data.utils.resample import resample_timeseries_dataframe
 from bigdl.chronos.data.utils.split import split_timeseries_dataframe
@@ -606,7 +606,10 @@ class TSDataset:
         roll_feature_df = None if self.roll_feature_df is None \
             else self.roll_feature_df[additional_feature_col]
 
-        self.lookback, self.horizon = lookback, horizon
+        if time_enc and label_len==0:
+            label_len = lookback // 2
+
+        self.lookback, self.horizon, self.label_len = lookback, horizon, label_len
         # horizon_time is only for time_enc, the time_enc numpy ndarray won't have any
         # shape change when the dataset is for prediction.
         horizon_time = self.horizon
@@ -639,22 +642,21 @@ class TSDataset:
 
         # time_enc
         if time_enc:
-            df_stamp = pd.DataFrame(columns=[self.dt_col])
-            if is_predict:
-                pred_dates = pd.date_range(self.df[self.dt_col].values[-1],
-                                           periods=horizon_time + 1, freq=self._freq)
-                df_stamp.loc[:, self.dt_col] =\
-                    list(self.df[self.dt_col].values) + list(pred_dates[1:])
-            else:
-                df_stamp.loc[:, self.dt_col] = list(self.df[self.dt_col].values)
-            data_stamp = time_features(pd.to_datetime(df_stamp[self.dt_col].values),
-                                       freq=self._freq)
-            self.data_stamp = data_stamp.transpose(1, 0)
-            max_horizon = horizon_time if isinstance(horizon_time, int) else max(horizon_time)
-            self.numpy_x_timeenc, _ = _roll_timeseries_ndarray(self.data_stamp[:-max_horizon],
-                                                               lookback)
-            self.numpy_y_timeenc, _ = _roll_timeseries_ndarray(self.data_stamp[lookback-label_len:],
-                                                               horizon_time+label_len)
+            time_enc_arr = \
+                self.df.groupby([self.id_col]) \
+                    .apply(lambda df: gen_time_enc_arr(df=df,
+                                                       dt_col=self.dt_col,
+                                                       freq=self._freq,
+                                                       horizon_time=horizon_time,
+                                                       is_predict=is_predict,
+                                                       lookback=lookback,
+                                                       label_len=label_len))
+            self.numpy_x_timeenc = np.concatenate([time_enc_arr[i][0]
+                                                   for i in self._id_list],
+                                                  axis=0).astype(np.float32)
+            self.numpy_y_timeenc = np.concatenate([time_enc_arr[i][1]
+                                                   for i in self._id_list],
+                                                  axis=0).astype(np.float32)
         else:
             self.numpy_x_timeenc = None
             self.numpy_y_timeenc = None
@@ -765,9 +767,12 @@ class TSDataset:
             target_col = _to_list(target_col, "target_col") if target_col is not None \
                 else self.target_col
 
+            if time_enc and label_len==0:
+                label_len = lookback // 2
+
             # set scaler index for unscale_numpy
             self.scaler_index = [self.target_col.index(t) for t in target_col]
-            self.lookback, self.horizon = lookback, horizon
+            self.lookback, self.horizon, self.label_len = lookback, horizon, label_len
 
             if self.lookback == 'auto':
                 self.lookback = self.get_cycle_length('mode', top_k=3)

--- a/python/chronos/src/bigdl/chronos/data/utils/roll_dataset.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/roll_dataset.py
@@ -20,7 +20,7 @@ import torch
 import pandas as pd
 
 from bigdl.chronos.data.utils.utils import _check_cols_no_na, _to_list
-from bigdl.chronos.data.utils.time_feature import time_features
+from bigdl.chronos.data.utils.time_feature import time_features, gen_time_enc_arr
 
 
 def get_roll_start_idx(df, id_col, window_size):

--- a/python/chronos/src/bigdl/chronos/data/utils/time_feature.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/time_feature.py
@@ -127,18 +127,18 @@ def time_features_from_frequency_str(offset) -> List[TimeFeature]:
             HourOfDay,
             DayOfWeek,
             DayOfMonth,
-            DayOfYear]),
+            DayOfYear]),  # 6 for second - minutes
         (Timedelta(minutes=60), [
             MinuteOfHour,
             HourOfDay,
             DayOfWeek,
             DayOfMonth,
             DayOfYear,
-        ]),
-        (Timedelta(hours=24), [HourOfDay, DayOfWeek, DayOfMonth, DayOfYear]),
-        (Timedelta(days=7), [DayOfWeek, DayOfMonth, DayOfYear]),
-        (Timedelta(days=30), [DayOfMonth, WeekOfYear]),
-        (Timedelta(days=365), [MonthOfYear]),
+        ]),  # 5 for minutes - hour
+        (Timedelta(hours=24), [HourOfDay, DayOfWeek, DayOfMonth, DayOfYear]),  # 4 for hour - day
+        (Timedelta(days=7), [DayOfWeek, DayOfMonth, DayOfYear]),  # 3 for day - week
+        (Timedelta(days=30), [DayOfMonth, WeekOfYear]),  # 2 for week - month
+        (Timedelta(days=365), [MonthOfYear]),  # 1 for month - year
     )
 
     for offset_type, feature_classes in features_by_offsets:

--- a/python/chronos/src/bigdl/chronos/data/utils/time_feature.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/time_feature.py
@@ -156,17 +156,17 @@ def gen_time_enc_arr(df, dt_col, freq, horizon_time, is_predict, lookback, label
     df_stamp = pd.DataFrame(columns=[dt_col])
     if is_predict:
         pred_dates = pd.date_range(df[dt_col].values[-1],
-                                    periods=horizon_time + 1, freq=freq)
+                                   periods=horizon_time + 1, freq=freq)
         df_stamp.loc[:, dt_col] =\
             list(df[dt_col].values) + list(pred_dates[1:])
     else:
         df_stamp.loc[:, dt_col] = list(df[dt_col].values)
     data_stamp = time_features(pd.to_datetime(df_stamp[dt_col].values),
-                                freq=freq)
+                               freq=freq)
     data_stamp = data_stamp.transpose(1, 0)
     max_horizon = horizon_time if isinstance(horizon_time, int) else max(horizon_time)
     numpy_x_timeenc, _ = _roll_timeseries_ndarray(data_stamp[:-max_horizon],
-                                                        lookback)
+                                                  lookback)
     numpy_y_timeenc, _ = _roll_timeseries_ndarray(data_stamp[lookback-label_len:],
-                                                        horizon_time+label_len)
+                                                  horizon_time+label_len)
     return numpy_x_timeenc, numpy_y_timeenc

--- a/python/chronos/src/bigdl/chronos/data/utils/time_feature.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/time_feature.py
@@ -42,6 +42,7 @@ import numpy as np
 import pandas as pd
 from pandas import Timedelta
 from pandas.tseries.frequencies import to_offset
+from bigdl.chronos.data.utils.roll import _roll_timeseries_ndarray
 
 
 class TimeFeature:
@@ -149,3 +150,23 @@ def time_features_from_frequency_str(offset) -> List[TimeFeature]:
 
 def time_features(dates, freq='h'):
     return np.vstack([feat(dates) for feat in time_features_from_frequency_str(freq)])
+
+
+def gen_time_enc_arr(df, dt_col, freq, horizon_time, is_predict, lookback, label_len):
+    df_stamp = pd.DataFrame(columns=[dt_col])
+    if is_predict:
+        pred_dates = pd.date_range(df[dt_col].values[-1],
+                                    periods=horizon_time + 1, freq=freq)
+        df_stamp.loc[:, dt_col] =\
+            list(df[dt_col].values) + list(pred_dates[1:])
+    else:
+        df_stamp.loc[:, dt_col] = list(df[dt_col].values)
+    data_stamp = time_features(pd.to_datetime(df_stamp[dt_col].values),
+                                freq=freq)
+    data_stamp = data_stamp.transpose(1, 0)
+    max_horizon = horizon_time if isinstance(horizon_time, int) else max(horizon_time)
+    numpy_x_timeenc, _ = _roll_timeseries_ndarray(data_stamp[:-max_horizon],
+                                                        lookback)
+    numpy_y_timeenc, _ = _roll_timeseries_ndarray(data_stamp[lookback-label_len:],
+                                                        horizon_time+label_len)
+    return numpy_x_timeenc, numpy_y_timeenc

--- a/python/chronos/src/bigdl/chronos/forecaster/__init__.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/__init__.py
@@ -57,6 +57,7 @@ if torch_available:
     TCNForecaster = LazyImport(PREFIXNAME+'tcn_forecaster.TCNForecaster')
     Seq2SeqForecaster = LazyImport(PREFIXNAME+'seq2seq_forecaster.Seq2SeqForecaster')
     NBeatsForecaster = LazyImport(PREFIXNAME+'nbeats_forecaster.NBeatsForecaster')
+    AutoformerForecaster = LazyImport(PREFIXNAME+'autoformer_forecaster.AutoformerForecaster')
     if orca_available:
         TCMFForecaster = LazyImport(PREFIXNAME+'tcmf_forecaster.TCMFForecaster')
 if tf_available and orca_available:

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -591,11 +591,11 @@ class AutoformerForecaster(Forecaster):
             invalidInputError(False,
                               "Forecaster requires 'past_seq_len' and 'future_seq_len' to specify "
                               "the history time step and output time step.")
-        
+
         if label_len is None:
             label_len = past_seq_len//2
 
-        invalidInputError(tsdataset.label_len == label_len,
+        invalidInputError(tsdataset.label_len == label_len or tsdataset.label_len is None,
                           f"Expected label_len to be {tsdataset.label_len}, "
                           f"but found {label_len}")
 

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -634,14 +634,14 @@ def _str2metric(metric):
 
 def _timedelta_to_delta_str(offset):
     features_by_offsets = (
-        (Timedelta(seconds=60), 's'),  # 6 for second - minutes
-        (Timedelta(minutes=60), 't'),  # 5 for minutes - hour
-        (Timedelta(hours=24), 'h'),  # 4 for hour - day
-        (Timedelta(days=7), 'd'),  # 3 for day - week
-        (Timedelta(days=30), 'w'),  # 2 for week - month
-        (Timedelta(days=365), 'm'),  # 1 for month - year
+        (Timedelta(seconds=60), 's'),
+        (Timedelta(minutes=60), 't'),
+        (Timedelta(hours=24), 'h'),
+        (Timedelta(days=7), 'd'),
+        (Timedelta(days=30), 'w'),
+        (Timedelta(days=365), 'm'),
     )
     for offset_type, offset_str in features_by_offsets:
         if offset < offset_type:
             return offset_str
-    return 'a'  # freq larger than 1 year
+    return 'a'

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -595,6 +595,10 @@ class AutoformerForecaster(Forecaster):
         if label_len is None:
             label_len = past_seq_len//2
 
+        invalidInputError(tsdataset.label_len == label_len,
+                          f"Expected label_len to be {tsdataset.label_len}, "
+                          f"but found {label_len}")
+
         invalidInputError(check_time_steps(tsdataset, past_seq_len, future_seq_len),
                           "tsdataset already has history time steps and "
                           "differs from the given past_seq_len and future_seq_len "

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -16,6 +16,7 @@
 
 import torch
 import numpy as np
+from pandas import Timedelta
 from bigdl.chronos.forecaster.abstract import Forecaster
 from bigdl.chronos.metric.forecast_metrics import Evaluator
 from bigdl.chronos.model.autoformer import model_creator, loss_creator
@@ -537,8 +538,9 @@ class AutoformerForecaster(Forecaster):
     @classmethod
     def from_tsdataset(cls,
                        tsdataset,
-                       past_seq_len,
-                       future_seq_len,
+                       past_seq_len=None,
+                       future_seq_len=None,
+                       label_len=None,
                        freq=None,
                        **kwargs):
         """
@@ -589,6 +591,9 @@ class AutoformerForecaster(Forecaster):
             invalidInputError(False,
                               "Forecaster requires 'past_seq_len' and 'future_seq_len' to specify "
                               "the history time step and output time step.")
+        
+        if label_len is None:
+            label_len = past_seq_len//2
 
         invalidInputError(check_time_steps(tsdataset, past_seq_len, future_seq_len),
                           "tsdataset already has history time steps and "
@@ -608,6 +613,7 @@ class AutoformerForecaster(Forecaster):
                    input_feature_num=input_feature_num,
                    output_feature_num=output_feature_num,
                    freq=freq,
+                   label_len=label_len,
                    **kwargs)
 
 

--- a/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
@@ -306,4 +306,15 @@ class TestChronosModelAutoformerForecaster(TestCase):
                                 with_split=True, test_ratio=0.1, val_ratio=0.1)
         train_loader = tsdata_train.to_torch_data_loader(lookback=24, horizon=5, time_enc=True)
         forecaster = AutoformerForecaster.from_tsdataset(tsdata_train)
-        forecaster.fit(train_loader, epochs=3, batch_size=32)
+        forecaster.fit(train_loader, epochs=1, batch_size=32)
+
+        with pytest.raises(RuntimeError):
+            forecaster = AutoformerForecaster.from_tsdataset(tsdata_train, label_len=30)
+        
+        tsdata_train, tsdata_val, tsdata_test =\
+            TSDataset.from_pandas(df, dt_col="datetime", target_col=target,
+                                with_split=True, test_ratio=0.1, val_ratio=0.1)
+        forecaster = AutoformerForecaster.from_tsdataset(tsdata_train,
+                                                         past_seq_len=24,
+                                                         future_seq_len=5)
+        forecaster.fit(train_loader, epochs=1, batch_size=32)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
@@ -308,9 +308,11 @@ class TestChronosModelAutoformerForecaster(TestCase):
         forecaster = AutoformerForecaster.from_tsdataset(tsdata_train)
         forecaster.fit(train_loader, epochs=1, batch_size=32)
 
+        # conflict param
         with pytest.raises(RuntimeError):
             forecaster = AutoformerForecaster.from_tsdataset(tsdata_train, label_len=30)
-        
+
+        # no data infer
         tsdata_train, tsdata_val, tsdata_test =\
             TSDataset.from_pandas(df, dt_col="datetime", target_col=target,
                                 with_split=True, test_ratio=0.1, val_ratio=0.1)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
@@ -297,3 +297,13 @@ class TestChronosModelAutoformerForecaster(TestCase):
                                                   repetition_times=5)
         assert y_pred.shape == std.shape
         y_pred, std = forecaster.predict_interval(data=test_data)
+
+    def test_autoformer_forecaster_from_tsdataset(self):
+        df = get_ts_df()
+        target = ["value", "extra feature"]
+        tsdata_train, tsdata_val, tsdata_test =\
+            TSDataset.from_pandas(df, dt_col="datetime", target_col=target,
+                                with_split=True, test_ratio=0.1, val_ratio=0.1)
+        train_loader = tsdata_train.to_torch_data_loader(lookback=24, horizon=5, time_enc=True)
+        forecaster = AutoformerForecaster.from_tsdataset(tsdata_train)
+        forecaster.fit(train_loader, epochs=3, batch_size=32)


### PR DESCRIPTION
## Description
This PR brings many enhancement and bug fix to Autoformer 

### 1. Why the change?

- [x] fix `TSDataset.roll` when `id_col` is not `None`, sample num is not aligned between x,y and x_time,y_time
- [x] add a new API `AutoformerForecaster.from_tsdataset()`
- [x] support `from bigdl.chronos.forecaster import AutoformerForecaster`

### 2. User API changes
Currently, users can create a forecaster by:
```python
tsdata = TSDataset.from_pandas(...)
train_loader = tsdata.to_torch_data_loader(lookback=24, horizon=5, time_enc=True)
forecaster = AutoformerForecaster.from_tsdataset(tsdata)
```
### 3. Summary of the change 
TSDataset, AutoformerForecaster and their uts. nothing special

### 4. How to test?
- [ ] Unit test
