### PR TITLE
Friesian serving recommender http server add prometheus client

### DIFF
--- a/scala/friesian/src/main/java/com/intel/analytics/bigdl/friesian/serving/recommender/HTTP/RecommenderHTTP.java
+++ b/scala/friesian/src/main/java/com/intel/analytics/bigdl/friesian/serving/recommender/HTTP/RecommenderHTTP.java
@@ -59,6 +59,20 @@ public class RecommenderHTTP {
     public static void main(String[] args) throws IOException {
         final HttpServer server = startServer(args);
 
+        if (Utils.runMonitor()) {
+            logger.info("Starting prometheus client HTTPServer at port " +
+                    Utils.helper().monitorPort() + "....");
+            final io.prometheus.client.exporter.HTTPServer monitorServer =
+                    new io.prometheus.client.exporter.HTTPServer.Builder()
+                            .withPort(Utils.helper().monitorPort())
+                            .build();
+            // register shutdown hook
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                logger.info("Stopping prometheus client HTTPServer....");
+                monitorServer.close();
+            }, "prometheusShutdownHook"));
+        }
+
         // register shutdown hook
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             logger.info("Stopping server..");

--- a/scala/friesian/src/main/java/com/intel/analytics/bigdl/friesian/serving/recommender/HTTP/RecommenderHTTPService.java
+++ b/scala/friesian/src/main/java/com/intel/analytics/bigdl/friesian/serving/recommender/HTTP/RecommenderHTTPService.java
@@ -2,7 +2,10 @@ package com.intel.analytics.bigdl.friesian.serving.recommender.HTTP;
 
 import com.intel.analytics.bigdl.friesian.serving.recommender.IDProbList;
 import com.intel.analytics.bigdl.friesian.serving.recommender.RecommenderImpl;
+import com.intel.analytics.bigdl.friesian.serving.utils.Utils;
 import com.intel.analytics.bigdl.grpc.JacksonJsonSerializer;
+import io.prometheus.client.Counter;
+import io.prometheus.client.Histogram;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
@@ -10,6 +13,19 @@ import javax.ws.rs.core.MediaType;
 @Path("recommender")
 public class RecommenderHTTPService {
     private final RecommenderImpl impl = RecommenderImpl.getInstance();
+    private static final Histogram requestLatency = Histogram.build()
+            .namespace("http")
+            .name("requests_latency_seconds")
+            .help("Request latency in seconds.")
+            .buckets(Utils.getPromBuckets())
+            .labelNames("http_service", "http_method")
+            .register();
+    private static final Counter requests = Counter.build()
+            .namespace("http")
+            .name("requests_total")
+            .help("Total requests.")
+            .labelNames("http_service", "http_method")
+            .register();
 
     @GET
     @Path("recommend/{id}")
@@ -17,16 +33,23 @@ public class RecommenderHTTPService {
     public String getRecommendIDs(@PathParam("id") int id,
                                   @DefaultValue("50") @QueryParam("canK") int canK,
                                   @DefaultValue("10") @QueryParam("k") int k) {
-        JacksonJsonSerializer jacksonJsonSerializer = new JacksonJsonSerializer();
-        IDProbList recommendList = impl.getRecommendIDs(id, canK, k);
-//        System.out.println(recommendList.toString());
-        return jacksonJsonSerializer.serialize(recommendList);
+        requests.labels("recommender", "getRecommendIDs").inc();
+        Histogram.Timer requestTimer = requestLatency.
+                labels("recommender", "getRecommendIDs").startTimer();
+        try {
+            JacksonJsonSerializer jacksonJsonSerializer = new JacksonJsonSerializer();
+            IDProbList recommendList = impl.getRecommendIDs(id, canK, k);
+            return jacksonJsonSerializer.serialize(recommendList);
+        } finally {
+            requestTimer.observeDuration();
+        }
     }
 
     @GET
     @Path("metrics")
     @Produces(MediaType.APPLICATION_JSON)
     public String getMetrics() {
+        requests.labels("recommender", "getMetrics").inc();
         return impl.getMetrics(null);
     }
 
@@ -34,6 +57,7 @@ public class RecommenderHTTPService {
     @Path("resetMetrics")
     @Produces(MediaType.APPLICATION_JSON)
     public String resetMetrics() {
+        requests.labels("recommender", "resetMetrics").inc();
         impl.resetMetrics();
         return "{success: true}";
     }
@@ -42,12 +66,14 @@ public class RecommenderHTTPService {
     @Path("clientMetrics")
     @Produces(MediaType.APPLICATION_JSON)
     public String getClientMetrics() {
+        requests.labels("recommender", "getClientMetrics").inc();
         return impl.getClientMetrics();
     }
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)
-    public String test(){
+    public String hello(){
+        requests.labels("recommender", "hello").inc();
         return "Hello";
     }
 }


### PR DESCRIPTION
## Description

Friesian serving recommender HTTP server add Prometheus client.

### 1. Why the change?

The recommender HTTP server lacks the monitoring information needed by Prometheus.

### 3. Summary of the change 

Friesian serving recommender HTTP server add Prometheus client. Now the user/Prometheus can read the metrics by accessing http://localhost:monitor_port.
Optimize error messages.

### 4. How to test?
- [ ] Unit test
- [ ] Application test

