### PR TITLE
refactor assmbly deploy

### DIFF
--- a/scala/assembly/pom.xml
+++ b/scala/assembly/pom.xml
@@ -100,12 +100,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>${maven-assembly-plugin.version}</version>
-                <configuration>
-                    <descriptors>
-                        <descriptor>src/main/assembly/assembly.xml</descriptor>
-                        <descriptor>src/main/assembly/fat-assembly.xml</descriptor>
-                    </descriptors>
-                </configuration>
                 <executions>
                     <execution>
                         <id>make-dist-all</id>
@@ -114,6 +108,24 @@
                         <goals>
                             <goal>assembly</goal>
                         </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/assembly.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>make-fat-assembly</id>
+                        <inherited>false</inherited>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/fat-assembly.xml</descriptor>
+                            </descriptors>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -143,7 +155,6 @@
                             <artifacts>
                                 <artifact>
                                     <file>target/${pom.artifactId}-${pom.version}-dist-all.zip</file>
-                                    <file>target/${pom.artifactId}-${pom.version}-fat-jars.zip</file>
                                     <type>zip</type>
                                 </artifact>
                             </artifacts>


### PR DESCRIPTION
## Description

Refactor deploy assembly zip

Currently, we have two assembly zip. One keeps the same as previous assembly zip. The other has a all-in-one-assembly-jar in jars.
The issue is that only one assembly is released in ossh nightly. To fix this issue, this pr refactor the part and add a new execution for our second assembly zip.