### PR TITLE
Chronos: fix `quantize` and `to_torch_data_loader` API doc

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -722,9 +722,9 @@ class TSDataset:
                This parameter should be set to True only when you are using Autoformer model. This
                indicates the length of overlap area of output(y) and input(x) on time axis.
         :param is_predict: bool,
-               This parameter should be set to True only when you are using Autoformer model. This
-               indicates if the dataset will be sampled as a prediction dataset(without groud
-               truth).
+               This parameter should be set to True only when you are processing test data without
+               accuracy evaluation for Autoformer model. This indicates if the dataset will be
+               sampled as a prediction dataset(without groud truth).
 
         :return: A pytorch DataLoader instance.
 

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -1016,7 +1016,7 @@ class BasePytorchForecaster(Forecaster):
         :param conf: A path to conf yaml file for quantization. Default to None,
                using default config.
         :param framework: string or list.
-               [{'pytorch'|'pytorch_fx'|'pytorch_ipex'},
+               [{'pytorch_fx'|'pytorch_ipex'},
                 {'onnxrt_integerops'|'onnxrt_qlinearops'},
                 {'openvino'}] Default: 'pytorch_fx'. Consistent with Intel Neural Compressor.
         :param approach: str, 'static' or 'dynamic'. Default to 'static'.

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -1015,10 +1015,9 @@ class BasePytorchForecaster(Forecaster):
                quantization. You may choose from "mse", "mae", "rmse", "r2", "mape", "smape".
         :param conf: A path to conf yaml file for quantization. Default to None,
                using default config.
-        :param framework: string or list.
-               [{'pytorch_fx'|'pytorch_ipex'},
-                {'onnxrt_integerops'|'onnxrt_qlinearops'},
-                {'openvino'}] Default: 'pytorch_fx'. Consistent with Intel Neural Compressor.
+        :param framework: string or list. [{'pytorch_fx'|'pytorch_ipex'},
+               {'onnxrt_integerops'|'onnxrt_qlinearops'}, {'openvino'}]
+               Default: 'pytorch_fx'. Consistent with Intel Neural Compressor.
         :param approach: str, 'static' or 'dynamic'. Default to 'static'.
                OpenVINO supports static mode only, if set to 'dynamic',
                it will be replaced with 'static'.


### PR DESCRIPTION
## Description

There are some confusing descriptions in `quantize` and `to_torch_data_loader` API documents,

### 1. How to test?
- [x] Document test
https://binbin-apidoc.readthedocs.io/en/latest/doc/PythonAPI/Chronos/tsdataset.html#bigdl.chronos.data.tsdataset.TSDataset.to_torch_data_loader
https://binbin-apidoc.readthedocs.io/en/latest/doc/PythonAPI/Chronos/forecasters.html#bigdl.chronos.forecaster.lstm_forecaster.LSTMForecaster.quantize