### PR TITLE
[Document] Fix code format missing problem when rendering executed notebooks

### DIFF
--- a/docs/readthedocs/requirements-doc.txt
+++ b/docs/readthedocs/requirements-doc.txt
@@ -38,5 +38,6 @@ ConfigSpace==0.5.0
 sphinx-design==0.2.0
 sphinx-external-toc==0.3.0
 nbsphinx==0.8.9
+ipython==7.34.0
 sphinx-design==0.2.0
 nbsphinx-link==1.3.0


### PR DESCRIPTION
## Description

Fix issue #5734 through adding `ipython` packages to our ReadtheDocs project.

### 1. How to test?
- [x] Document test (e.g.): https://yuwentestdocs.readthedocs.io/en/correct-codes-format-missing-readthedocs/doc/Chronos/Howto/how_to_create_forecaster.html

After adding `ipython` package, warning in our docs is reduced from [669](https://readthedocs.org/api/v2/build/18066604.txt) to [547](https://readthedocs.org/api/v2/build/18066838.txt)

### 2. New dependencies

- For ReadtheDocs project
	- ipython ([BSD 3-Clause License](https://github.com/ipython/ipython/blob/main/LICENSE))
