### PR TITLE
Fix the conflict of `KMP_AFFINITY` and onnxruntime 

### DIFF
--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -144,9 +144,9 @@ if [ -f "${LIB_DIR}/libiomp5.so" ]; then
 
 	echo "Setting KMP_AFFINITY..."
 	if [[ $threads_per_core -gt 1 ]]; then
-		export KMP_AFFINITY=granularity=fine,compact,1,0
+		export KMP_AFFINITY=granularity=fine,1,0
 	else
-		export KMP_AFFINITY=granularity=fine,compact
+		export KMP_AFFINITY=granularity=fine
 	fi
 
 

--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -143,12 +143,7 @@ if [ -f "${LIB_DIR}/libiomp5.so" ]; then
 	fi
 
 	echo "Setting KMP_AFFINITY..."
-	if [[ $threads_per_core -gt 1 ]]; then
-		export KMP_AFFINITY=granularity=fine,1,0
-	else
-		export KMP_AFFINITY=granularity=fine
-	fi
-
+	export KMP_AFFINITY=granularity=fine
 
 	echo "Setting KMP_BLOCKTIME..."
 	export KMP_BLOCKTIME=1


### PR DESCRIPTION
## Description

The default value of `KMP_AFFINITY` has some conflict with onnxruntime, change the default value from `granularity=fine,compact,1,0` to `granularity=fine,1,0` to avoid the conflict