### PR TITLE
Nano : add API for InferenceOptimizer and deprecated some Trainer APIs

### DIFF
--- a/docs/readthedocs/source/doc/PythonAPI/Nano/pytorch.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Nano/pytorch.rst
@@ -9,6 +9,14 @@ bigdl.nano.pytorch.Trainer
     :undoc-members:
     :exclude-members: accelerator_connector, checkpoint_connector, reload_dataloaders_every_n_epochs, limit_val_batches, logger, logger_connector, state
 
+bigdl.nano.pytorch.InferenceOptimizer
+---------------------------
+
+.. autoclass:: bigdl.nano.pytorch.InferenceOptimizer
+    :members:
+    :undoc-members:
+    :exclude-members: 
+
 bigdl.nano.pytorch.TorchNano
 ---------------------------
 

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -65,7 +65,7 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         status.update({"xml_path": 'ov_saved_model.xml', "weight_path": 'ov_saved_model.bin'})
         return status
 
-    @property
+    @property  # type: ignore
     def forward_args(self):
         return self.ov_model.forward_args
 

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -109,6 +109,7 @@ class InferenceOptimizer:
     def __init__(self):
         '''
         InferenceOptimizer for BigDL-Nano pytorch.
+
         It can be used to accelerate inference pipeline with very few code changes.
         '''
         # optimized_model_dict handles the optimized model and some metadata

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -108,7 +108,7 @@ class InferenceOptimizer:
 
     def __init__(self):
         '''
-        InferenceOptimizer for BigDL-Nano pytorch.
+        InferenceOptimizer for Pytorch Model.
 
         It can be used to accelerate inference pipeline with very few code changes.
         '''

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -108,7 +108,8 @@ class InferenceOptimizer:
 
     def __init__(self):
         '''
-        initialize an optimizer
+        InferenceOptimizer for BigDL-Nano pytorch.
+        It can be used to accelerate inference pipeline with very few code changes.
         '''
         # optimized_model_dict handles the optimized model and some metadata
         # in {"method_name": {"latency": ..., "accuracy": ..., "model": ...}}

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -265,7 +265,8 @@ class Trainer(pl.Trainer):
         return self.hposearcher.search_summary()
 
     @staticmethod
-    @deprecated('Please use `bigdl.nano.pytorch.InferenceOptimizer.trace` instead.')
+    @deprecated(func_name="bigdl.nano.pytorch.Trainer.trace",
+                message="Please use `bigdl.nano.pytorch.InferenceOptimizer.trace` instead.")
     def trace(model: nn.Module,
               input_sample=None,
               accelerator: str = None,
@@ -301,9 +302,9 @@ class Trainer(pl.Trainer):
         :return: Model with different acceleration.
 
         .. warning::
-             bigdl.nano.pytorch.Trainer.trace will be deprecated in future release.
+             ``bigdl.nano.pytorch.Trainer.trace`` will be deprecated in future release.
 
-             Please use `bigdl.nano.pytorch.InferenceOptimizer.trace` instead.
+             Please use ``bigdl.nano.pytorch.InferenceOptimizer.trace`` instead.
         """
         return InferenceOptimizer.trace(model=model,
                                         input_sample=input_sample,
@@ -315,7 +316,8 @@ class Trainer(pl.Trainer):
                                         **export_kwargs)
 
     @staticmethod
-    @deprecated('Please use `bigdl.nano.pytorch.InferenceOptimizer.quantize` instead.')
+    @deprecated(func_name="bigdl.nano.pytorch.Trainer.quantize",
+                message="Please use `bigdl.nano.pytorch.InferenceOptimizer.quantize` instead.")
     def quantize(model: nn.Module,
                  precision: str = 'int8',
                  accelerator: str = None,
@@ -386,9 +388,9 @@ class Trainer(pl.Trainer):
         :return:            A accelerated Pytorch-Lightning Model if quantization is sucessful.
 
         .. warning::
-             bigdl.nano.pytorch.Trainer.quantize will be deprecated in future release.
+             ``bigdl.nano.pytorch.Trainer.quantize`` will be deprecated in future release.
 
-             Please use `bigdl.nano.pytorch.InferenceOptimizer.quantize` instead.
+             Please use ``bigdl.nano.pytorch.InferenceOptimizer.quantize`` instead.
         """
         return InferenceOptimizer.quantize(model=model,
                                            precision=precision,

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -299,7 +299,6 @@ class Trainer(pl.Trainer):
                          data to be channels last according to the setting. Defaultly, channels_last
                          will be set to True if use_ipex=True.
         :return: Model with different acceleration.
-        
         .. deprecated:: 2.2.0
             Use :func:`bigdl.nano.pytorch.InferenceOptimizer.trace` instead.
         """

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -40,6 +40,7 @@ from bigdl.nano.deps.ipex.ipex_api import load_ipexjit_model
 from bigdl.nano.deps.onnxruntime.onnxruntime_api import load_onnxruntime_model
 from bigdl.nano.deps.neural_compressor.inc_api import load_inc_model
 from bigdl.nano.common import check_avx512
+from bigdl.nano.utils import deprecated
 
 distributed_backends = ["spawn", "ray", "subprocess"]
 
@@ -264,6 +265,8 @@ class Trainer(pl.Trainer):
         return self.hposearcher.search_summary()
 
     @staticmethod
+    @deprecated('bigdl.nano.pytorch.Trainer.trace is now deprecated. '
+                'Please use `bigdl.nano.pytorch.InferenceOptimizer.trace` instead.')
     def trace(model: nn.Module,
               input_sample=None,
               accelerator: str = None,
@@ -308,6 +311,8 @@ class Trainer(pl.Trainer):
                                         **export_kwargs)
 
     @staticmethod
+    @deprecated('bigdl.nano.pytorch.Trainer.quantize is now deprecated. '
+                'Please use `bigdl.nano.pytorch.InferenceOptimizer.quantize` instead.')
     def quantize(model: nn.Module,
                  precision: str = 'int8',
                  accelerator: str = None,

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -264,8 +264,8 @@ class Trainer(pl.Trainer):
             return None
         return self.hposearcher.search_summary()
 
-    @deprecated('Please use `bigdl.nano.pytorch.InferenceOptimizer.trace` instead.')
     @staticmethod
+    @deprecated('Please use `bigdl.nano.pytorch.InferenceOptimizer.trace` instead.')
     def trace(model: nn.Module,
               input_sample=None,
               accelerator: str = None,
@@ -299,6 +299,9 @@ class Trainer(pl.Trainer):
                          data to be channels last according to the setting. Defaultly, channels_last
                          will be set to True if use_ipex=True.
         :return: Model with different acceleration.
+        
+        .. deprecated:: 2.2.0
+            Use :func:`bigdl.nano.pytorch.InferenceOptimizer.trace` instead.
         """
         return InferenceOptimizer.trace(model=model,
                                         input_sample=input_sample,
@@ -309,8 +312,8 @@ class Trainer(pl.Trainer):
                                         logging=logging,
                                         **export_kwargs)
 
-    @deprecated('Please use `bigdl.nano.pytorch.InferenceOptimizer.quantize` instead.')
     @staticmethod
+    @deprecated('Please use `bigdl.nano.pytorch.InferenceOptimizer.quantize` instead.')
     def quantize(model: nn.Module,
                  precision: str = 'int8',
                  accelerator: str = None,
@@ -379,6 +382,8 @@ class Trainer(pl.Trainer):
                         accelerator='openvino', otherwise will be ignored. default: True.
         :param **export_kwargs: will be passed to torch.onnx.export function.
         :return:            A accelerated Pytorch-Lightning Model if quantization is sucessful.
+        .. deprecated:: 2.2.0
+            Use :func:`bigdl.nano.pytorch.InferenceOptimizer.quantize` instead.
         """
         return InferenceOptimizer.quantize(model=model,
                                            precision=precision,

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -264,8 +264,6 @@ class Trainer(pl.Trainer):
             return None
         return self.hposearcher.search_summary()
 
-    @deprecated('bigdl.nano.pytorch.Trainer.trace is now deprecated. '
-                'Please use `bigdl.nano.pytorch.InferenceOptimizer.trace` instead.')
     @staticmethod
     def trace(model: nn.Module,
               input_sample=None,
@@ -301,6 +299,10 @@ class Trainer(pl.Trainer):
                          will be set to True if use_ipex=True.
         :return: Model with different acceleration.
         """
+        import warnings
+        warnings.warn('bigdl.nano.pytorch.Trainer.trace is now deprecated. '
+                      'Please use `bigdl.nano.pytorch.InferenceOptimizer.trace` instead.',
+                      category=DeprecationWarning)
         return InferenceOptimizer.trace(model=model,
                                         input_sample=input_sample,
                                         accelerator=accelerator,
@@ -310,8 +312,6 @@ class Trainer(pl.Trainer):
                                         logging=logging,
                                         **export_kwargs)
 
-    @deprecated('bigdl.nano.pytorch.Trainer.quantize is now deprecated. '
-                'Please use `bigdl.nano.pytorch.InferenceOptimizer.quantize` instead.')
     @staticmethod
     def quantize(model: nn.Module,
                  precision: str = 'int8',
@@ -382,6 +382,10 @@ class Trainer(pl.Trainer):
         :param **export_kwargs: will be passed to torch.onnx.export function.
         :return:            A accelerated Pytorch-Lightning Model if quantization is sucessful.
         """
+        import warnings
+        warnings.warn('bigdl.nano.pytorch.Trainer.quantize is now deprecated. '
+                      'Please use `bigdl.nano.pytorch.InferenceOptimizer.quantize` instead.',
+                      category=DeprecationWarning)
         return InferenceOptimizer.quantize(model=model,
                                            precision=precision,
                                            accelerator=accelerator,

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -264,6 +264,7 @@ class Trainer(pl.Trainer):
             return None
         return self.hposearcher.search_summary()
 
+    @deprecated('Please use `bigdl.nano.pytorch.InferenceOptimizer.trace` instead.')
     @staticmethod
     def trace(model: nn.Module,
               input_sample=None,
@@ -299,10 +300,6 @@ class Trainer(pl.Trainer):
                          will be set to True if use_ipex=True.
         :return: Model with different acceleration.
         """
-        import warnings
-        warnings.warn('bigdl.nano.pytorch.Trainer.trace is now deprecated. '
-                      'Please use `bigdl.nano.pytorch.InferenceOptimizer.trace` instead.',
-                      category=DeprecationWarning)
         return InferenceOptimizer.trace(model=model,
                                         input_sample=input_sample,
                                         accelerator=accelerator,
@@ -312,6 +309,7 @@ class Trainer(pl.Trainer):
                                         logging=logging,
                                         **export_kwargs)
 
+    @deprecated('Please use `bigdl.nano.pytorch.InferenceOptimizer.quantize` instead.')
     @staticmethod
     def quantize(model: nn.Module,
                  precision: str = 'int8',
@@ -382,10 +380,6 @@ class Trainer(pl.Trainer):
         :param **export_kwargs: will be passed to torch.onnx.export function.
         :return:            A accelerated Pytorch-Lightning Model if quantization is sucessful.
         """
-        import warnings
-        warnings.warn('bigdl.nano.pytorch.Trainer.quantize is now deprecated. '
-                      'Please use `bigdl.nano.pytorch.InferenceOptimizer.quantize` instead.',
-                      category=DeprecationWarning)
         return InferenceOptimizer.quantize(model=model,
                                            precision=precision,
                                            accelerator=accelerator,

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -264,7 +264,7 @@ class Trainer(pl.Trainer):
             return None
         return self.hposearcher.search_summary()
 
-    @deprecated('Please use `bigdl.nano.pytorch.InferenceOptimizer.trace` instead.')
+    # @deprecated('Please use `bigdl.nano.pytorch.InferenceOptimizer.trace` instead.')
     @staticmethod
     def trace(model: nn.Module,
               input_sample=None,
@@ -309,7 +309,7 @@ class Trainer(pl.Trainer):
                                         logging=logging,
                                         **export_kwargs)
 
-    @deprecated('Please use `bigdl.nano.pytorch.InferenceOptimizer.quantize` instead.')
+    # @deprecated('Please use `bigdl.nano.pytorch.InferenceOptimizer.quantize` instead.')
     @staticmethod
     def quantize(model: nn.Module,
                  precision: str = 'int8',

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -264,9 +264,9 @@ class Trainer(pl.Trainer):
             return None
         return self.hposearcher.search_summary()
 
-    @staticmethod
     @deprecated('bigdl.nano.pytorch.Trainer.trace is now deprecated. '
                 'Please use `bigdl.nano.pytorch.InferenceOptimizer.trace` instead.')
+    @staticmethod
     def trace(model: nn.Module,
               input_sample=None,
               accelerator: str = None,
@@ -310,9 +310,9 @@ class Trainer(pl.Trainer):
                                         logging=logging,
                                         **export_kwargs)
 
-    @staticmethod
     @deprecated('bigdl.nano.pytorch.Trainer.quantize is now deprecated. '
                 'Please use `bigdl.nano.pytorch.InferenceOptimizer.quantize` instead.')
+    @staticmethod
     def quantize(model: nn.Module,
                  precision: str = 'int8',
                  accelerator: str = None,

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -299,8 +299,11 @@ class Trainer(pl.Trainer):
                          data to be channels last according to the setting. Defaultly, channels_last
                          will be set to True if use_ipex=True.
         :return: Model with different acceleration.
-        .. deprecated:: 2.2.0
-            Use :func:`bigdl.nano.pytorch.InferenceOptimizer.trace` instead.
+
+        .. warning::
+             bigdl.nano.pytorch.Trainer.trace will be deprecated in future release.
+
+             Please use `bigdl.nano.pytorch.InferenceOptimizer.trace` instead.
         """
         return InferenceOptimizer.trace(model=model,
                                         input_sample=input_sample,
@@ -381,8 +384,11 @@ class Trainer(pl.Trainer):
                         accelerator='openvino', otherwise will be ignored. default: True.
         :param **export_kwargs: will be passed to torch.onnx.export function.
         :return:            A accelerated Pytorch-Lightning Model if quantization is sucessful.
-        .. deprecated:: 2.2.0
-            Use :func:`bigdl.nano.pytorch.InferenceOptimizer.quantize` instead.
+
+        .. warning::
+             bigdl.nano.pytorch.Trainer.quantize will be deprecated in future release.
+
+             Please use `bigdl.nano.pytorch.InferenceOptimizer.quantize` instead.
         """
         return InferenceOptimizer.quantize(model=model,
                                            precision=precision,

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -264,7 +264,7 @@ class Trainer(pl.Trainer):
             return None
         return self.hposearcher.search_summary()
 
-    # @deprecated('Please use `bigdl.nano.pytorch.InferenceOptimizer.trace` instead.')
+    @deprecated('Please use `bigdl.nano.pytorch.InferenceOptimizer.trace` instead.')
     @staticmethod
     def trace(model: nn.Module,
               input_sample=None,
@@ -309,7 +309,7 @@ class Trainer(pl.Trainer):
                                         logging=logging,
                                         **export_kwargs)
 
-    # @deprecated('Please use `bigdl.nano.pytorch.InferenceOptimizer.quantize` instead.')
+    @deprecated('Please use `bigdl.nano.pytorch.InferenceOptimizer.quantize` instead.')
     @staticmethod
     def quantize(model: nn.Module,
                  precision: str = 'int8',

--- a/python/nano/src/bigdl/nano/utils/__init__.py
+++ b/python/nano/src/bigdl/nano/utils/__init__.py
@@ -1,0 +1,18 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from .util import deprecated

--- a/python/nano/src/bigdl/nano/utils/util.py
+++ b/python/nano/src/bigdl/nano/utils/util.py
@@ -1,3 +1,19 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import warnings
 from functools import wraps
 

--- a/python/nano/src/bigdl/nano/utils/util.py
+++ b/python/nano/src/bigdl/nano/utils/util.py
@@ -18,13 +18,14 @@ import warnings
 from functools import wraps
 
 
-def deprecated(message=""):
+def deprecated(func_name=None, message=""):
     def deprecated_decorator(function):
         @wraps(function)
         def wrapped(*args, **kwargs):
             warnings.simplefilter('always', DeprecationWarning)
-            warnings.warn("{} will be deprecated in future release. {}"
-                          .format(function.__name__, message),
+            funcname = function.__name__ if func_name is None else func_name
+            warnings.warn("`{}` will be deprecated in future release. {}"
+                          .format(funcname, message),
                           category=DeprecationWarning)
             warnings.simplefilter('default', DeprecationWarning)
             return function(*args, **kwargs)

--- a/python/nano/src/bigdl/nano/utils/util.py
+++ b/python/nano/src/bigdl/nano/utils/util.py
@@ -1,0 +1,15 @@
+import warnings
+from functools import wraps
+
+def deprecated(message=""):
+    def deprecated_decorator(function):
+        @wraps(function)
+        def wrapped(*args, **kwargs):
+            warnings.simplefilter('always', DeprecationWarning)
+            warnings.warn("{} will be deprecated in future release. {}"
+                          .format(function.__name__, message),
+                          category=DeprecationWarning)
+            warnings.simplefilter('default', DeprecationWarning)
+            return function(*args, **kwargs)
+        return wrapped
+    return deprecated_decorator

--- a/python/nano/src/bigdl/nano/utils/util.py
+++ b/python/nano/src/bigdl/nano/utils/util.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 #
 
-
 import warnings
 from functools import wraps
+
 
 def deprecated(message=""):
     def deprecated_decorator(function):

--- a/python/nano/src/bigdl/nano/utils/util.py
+++ b/python/nano/src/bigdl/nano/utils/util.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+
 import warnings
 from functools import wraps
 


### PR DESCRIPTION
## Description
Add InferenceOptimizer to Nano PyTorch API.
Deprecate Trainer.trace and Trainer.quantize(https://github.com/intel-analytics/BigDL/pull/5667)

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

No change.

### 3. Summary of the change 

- Add InferenceOptimizer to Nano PyTorch API.
- Deprecate Trainer.trace and Trainer.quantize

### 4. How to test?
- [x] Unit test
- [x] Application test
http://10.112.231.51:18889/view/BigDL-PR-Validation/job/ZOO-PR-NanoTests/399/
- [x] Document test
https://ruonantetdoc.readthedocs.io/en/add_api_for_optimizer/doc/PythonAPI/Nano/index.html
https://ruonantetdoc.readthedocs.io/en/add_api_for_optimizer/doc/PythonAPI/Nano/pytorch.html#bigdl-nano-pytorch-inferenceoptimizer