### PR TITLE
[PPML] Fix gbt example spark config error

### DIFF
--- a/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/run_spark_gbt_criteo.sh
+++ b/ppml/trusted-big-data-ml/scala/docker-occlum/kubernetes/run_spark_gbt_criteo.sh
@@ -31,7 +31,7 @@ ${SPARK_HOME}/bin/spark-submit \
     --executor-memory 1g \
     --conf spark.executorEnv.SGX_EXECUTOR_JVM_MEM_SIZE="5G" \
     --conf spark.kubernetes.driverEnv.SGX_DRIVER_JVM_MEM_SIZE="3G" \
-    --conf spark.rpc.askTimeout=600 \
-    --conf spark.executor.heartbeatInterval=120s \
+    --conf spark.rpc.askTimeout=600s \
+    --conf spark.executor.heartbeatInterval=100s \
     local:/opt/spark/examples/jars/spark-examples_2.12-3.1.2.jar \
     -i /host/data/gbt_data -s /host/data/path_to_save -I 20 -d 5


### PR DESCRIPTION
## Description
The default value of spark.network.timeout=120000ms must be greater than the value of spark.executor.heartbeatInterval=120000ms, should reduce spark.executor.heartbeatInterval.
<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?
Need to reduce spark.executor.heartbeatInterval.
<!-- Provide the related github issue link if available -->

### 2. User API changes
No.
<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 
Reduce spark.executor.heartbeatInterval to 100s.
<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
