### PR TITLE
Fix orca.pandas.read_csv() only return top 10k rows issue

### DIFF
--- a/python/orca/test/bigdl/orca/data/test_spark_backend.py
+++ b/python/orca/test/bigdl/orca/data/test_spark_backend.py
@@ -223,6 +223,12 @@ class TestSparkBackend(TestCase):
         df = data_shard.to_spark_df()
         df.show()
 
+    def test_read_large_csv(self):
+        file_path = os.path.join(self.resource_path, "orca/data/10010.csv")
+        data_shard = bigdl.orca.data.pandas.read_csv(file_path)
+        res = data_shard.collect()
+        assert len(res[0]) == 10009, "number of records should be 10009"
+
     def test_spark_df_to_shards(self):
         file_path = os.path.join(self.resource_path, "orca/data/csv")
         from pyspark.sql import SparkSession


### PR DESCRIPTION
### 1. Why the change?

Fix https://github.com/intel-analytics/BigDL/issues/5759, however there is performance downgrade(E2E downgrade from 1.2s to 5s). Still investigate the performance issue, but suppose we can merge this pr first to fix correctness issue.

### 2. How to test?
- [ ] N/A
- [x] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...
