### PR TITLE
Chronos: fix install cmd in Chronos User Guide document

### DIFF
--- a/docs/readthedocs/source/_static/js/chronos_installation_guide.js
+++ b/docs/readthedocs/source/_static/js/chronos_installation_guide.js
@@ -85,7 +85,7 @@ function refresh_cmd(){
         disable(packages);
         disable(hardwares);
         disable(automls);
-        cmd="Please refer to <a href='https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/windows_guide.html'>windows_guide.</a>";
+        cmd="Please refer to <a href='https://bigdl.readthedocs.io/en/latest/doc/Chronos/Howto/windows_guide.html'>windows_guide.</a>";
     }else{
         enable(functionalities);
         enable(models);


### PR DESCRIPTION
## Description

In Chronos User Guide, the install cmd for `Windows` option is updated.

### 1. How to test?
- [x] Document test
https://binbin-winguide.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html
