### PR TITLE
[Orca] Support save model weights in tf2 ray estimator

### DIFF
--- a/python/orca/src/bigdl/orca/data/file.py
+++ b/python/orca/src/bigdl/orca/data/file.py
@@ -517,7 +517,7 @@ def get_remote_dir_to_local(remote_dir, local_dir):
 def get_remote_files_with_prefix_to_local(remote_path_prefix, local_dir):
     prefix = os.path.basename(remote_path_prefix)
     if remote_path_prefix.startswith("hdfs"):  # hdfs://url:port/file_path
-        cmd = 'hdfs dfs -get -f {}* {}'.format(remote_path_prefix, local_dir)
+        cmd = 'hdfs dfs -get {}* {}'.format(remote_path_prefix, local_dir)
         process = subprocess.Popen(cmd, shell=True)
         return process.wait()
     elif remote_path_prefix.startswith("s3"):   # s3://bucket/file_path

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -427,7 +427,8 @@ class SparkTFEstimator():
                 model.save_weights(temp_path, overwrite, save_format)
                 if save_format == 'h5' or filepath.endswith('.h5') or filepath.endswith('.keras'):
                     # hdf5 format
-                    put_local_file_to_remote(temp_path, filepath, over_write=overwrite
+                    put_local_file_to_remote(temp_path, filepath)
+                else:
                     # tf format
                     remote_dir = os.path.dirname(filepath)
                     put_local_files_with_prefix_to_remote(temp_path, remote_dir)

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -427,12 +427,10 @@ class SparkTFEstimator():
                 model.save_weights(temp_path, overwrite, save_format)
                 if save_format == 'h5' or filepath.endswith('.h5') or filepath.endswith('.keras'):
                     # hdf5 format
-                    put_local_file_to_remote(temp_path, filepath, over_write=overwrite)
-                else:
+                    put_local_file_to_remote(temp_path, filepath, over_write=overwrite
                     # tf format
                     remote_dir = os.path.dirname(filepath)
-                    put_local_files_with_prefix_to_remote(temp_path, remote_dir,
-                                                          over_write=overwrite)
+                    put_local_files_with_prefix_to_remote(temp_path, remote_dir)
             finally:
                 shutil.rmtree(temp_dir)
 

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -598,7 +598,7 @@ class TensorFlow2Estimator(OrcaRayEstimator):
         else:
             ray.get([worker.load_remote_model.remote(**params)
                      for worker in self.remote_workers])
-    
+
     def save_weights(self, filepath, overwrite=True, save_format=None, options=None):
         """
         Save the model weights at the provided filepath.
@@ -626,7 +626,7 @@ class TensorFlow2Estimator(OrcaRayEstimator):
             try:
                 model.save_weights(temp_path, overwrite, save_format, options)
                 if save_format == 'h5' or filepath.endswith('.h5') or filepath.endswith('.keras'):
-                # hdf5 format
+                    # hdf5 format
                     put_local_file_to_remote(temp_path, filepath)
                 else:
                     # tf format
@@ -634,7 +634,7 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                     put_local_files_with_prefix_to_remote(temp_path, remote_dir)
             finally:
                 shutil.rmtree(temp_dir)
-    
+
     def load_weights(self, filepath, by_name=False, skip_mismatch=False, options=None):
         """
         Load tensorflow keras model weights from the provided path.

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -624,15 +624,14 @@ class TensorFlow2Estimator(OrcaRayEstimator):
             temp_dir = tempfile.mkdtemp()
             temp_path = os.path.join(temp_dir, file_name)
             try:
-                model.save_weights(filepath, overwrite, save_format, options)
+                model.save_weights(temp_path, overwrite, save_format, options)
                 if save_format == 'h5' or filepath.endswith('.h5') or filepath.endswith('.keras'):
                 # hdf5 format
-                    put_local_file_to_remote(temp_path, filepath, over_write=overwrite)
+                    put_local_file_to_remote(temp_path, filepath)
                 else:
                     # tf format
                     remote_dir = os.path.dirname(filepath)
-                    put_local_files_with_prefix_to_remote(temp_path, remote_dir,
-                                                          over_write=overwrite)
+                    put_local_files_with_prefix_to_remote(temp_path, remote_dir)
             finally:
                 shutil.rmtree(temp_dir)
     

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -34,7 +34,8 @@ from bigdl.orca.learn.ray_estimator import Estimator as OrcaRayEstimator
 from bigdl.orca.learn.utils import maybe_dataframe_to_xshards, dataframe_to_xshards, \
     convert_predict_xshards_to_dataframe, update_predict_xshards, \
     process_xshards_of_pandas_dataframe, make_data_creator
-from bigdl.orca.data.file import put_local_file_to_remote, put_local_dir_tree_to_remote
+from bigdl.orca.data.file import put_local_file_to_remote, put_local_dir_tree_to_remote, \
+    put_local_files_with_prefix_to_remote
 from bigdl.orca.data.utils import process_spark_xshards
 from bigdl.dllib.utils.log4Error import *
 from bigdl.orca.ray import OrcaRayContext
@@ -596,6 +597,71 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                      for worker in self.remote_workers])
         else:
             ray.get([worker.load_remote_model.remote(**params)
+                     for worker in self.remote_workers])
+    
+     def save_weights(self, filepath, overwrite=True, save_format=None, options=None):
+        """
+        Save the model weights at the provided filepath.
+        param filepath: String or PathLike, path to the file to save the weights to.
+              When saving in TensorFlow format, this is the prefix used for checkpoint files
+              (multiple files are generated). Note that the '.h5' suffix causes weights to be
+              saved in HDF5 format.
+        param overwrite: Whether to silently overwrite any existing file at the target location,
+              or provide the user with a manual prompt.
+        param save_format: Either 'tf' or 'h5'.
+              A filepath ending in '.h5' or '.keras' will default to HDF5 if save_format is None.
+              Otherwise None defaults to 'tf'.
+        param options: Optional tf.train.CheckpointOptions object that specifies options for saving
+              weights.
+        :return:
+        """
+        model = self.get_model()
+
+        if is_local_path(filepath):
+            model.save_weights(filepath, overwrite, save_format, options)
+        else:
+            file_name = os.path.basename(filepath)
+            temp_dir = tempfile.mkdtemp()
+            temp_path = os.path.join(temp_dir, file_name)
+            try:
+                model.save_weights(filepath, overwrite, save_format, options)
+                if save_format == 'h5' or filepath.endswith('.h5') or filepath.endswith('.keras'):
+                # hdf5 format
+                    put_local_file_to_remote(temp_path, filepath, over_write=overwrite)
+                else:
+                    # tf format
+                    remote_dir = os.path.dirname(filepath)
+                    put_local_files_with_prefix_to_remote(temp_path, remote_dir,
+                                                          over_write=overwrite)
+            finally:
+                shutil.rmtree(temp_dir)
+    
+    def load_weights(self, filepath, by_name=False, skip_mismatch=False, options=None):
+        """
+        Load tensorflow keras model weights from the provided path.
+        param filepath: String, path to the weights file to load. For weight files in TensorFlow
+              format, this is the file prefix (the same as was passed to save_weights). This can
+              also be a path to a SavedModel saved from model.save.
+        param by_name: Boolean, whether to load weights by name or by topological order.
+              Only topological loading is supported for weight files in TensorFlow format.
+        param skip_mismatch: Boolean, whether to skip loading of layers where there is a mismatch
+              in the number of weights, or a mismatch in the shape of the weight
+              (only valid when by_name=True).
+        param options: Optional tf.train.CheckpointOptions object that specifies options for loading
+              weights.
+        :return:
+        """
+        params = dict(
+            filepath=filepath,
+            by_name=by_name,
+            skip_mismatch=skip_mismatch,
+            options=options
+        )
+        if is_local_path(filepath):
+            ray.get([worker.load_weights.remote(**params)
+                     for worker in self.remote_workers])
+        else:
+            ray.get([worker.load_remote_weights.remote(**params)
                      for worker in self.remote_workers])
 
     def shutdown(self):

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -599,7 +599,7 @@ class TensorFlow2Estimator(OrcaRayEstimator):
             ray.get([worker.load_remote_model.remote(**params)
                      for worker in self.remote_workers])
     
-     def save_weights(self, filepath, overwrite=True, save_format=None, options=None):
+    def save_weights(self, filepath, overwrite=True, save_format=None, options=None):
         """
         Save the model weights at the provided filepath.
         param filepath: String or PathLike, path to the file to save the weights to.

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -522,6 +522,31 @@ class TFRunner:
                 shutil.rmtree(temp_path)
             else:
                 os.remove(temp_path)
+    
+    def load_weights(self, filepath, by_name, skip_mismatch, options):
+        """Loads all layer weights from a TensorFlow or an HDF5 weight file."""
+        self.model.load_weights(filepath, by_name, skip_mismatch, options)
+
+    def load_remote_weights(self, filepath, by_name, skip_mismatch, options):\
+        """Loads all layer weights from a remote weight file (Tensorflow or HDF5 format)."""
+        file_name = os.path.basename(filepath)
+        temp_dir = tempfile.mkdtemp()
+        if is_file(filepath):
+            # h5 format
+            temp_path = os.path.join(temp_dir, file_name)
+            get_remote_file_to_local(filepath, temp_path)
+        else:
+            # tensorflow format
+            prefix = os.path.basename(filepath)
+            get_remote_files_with_prefix_to_local(filepath, temp_dir)
+            temp_path = os.path.join(temp_dir, prefix)
+        try:
+            self.model.load_weights(temp_path, by_name, skip_mismatch, options)
+        finally:
+            if os.path.isdir(temp_path):
+                shutil.rmtree(temp_path)
+            else:
+                os.remove(temp_path)
 
     def shutdown(self):
         """Attempts to shut down the worker."""

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -42,7 +42,8 @@ from contextlib import closing
 
 from bigdl.dllib.utils import log4Error
 from bigdl.orca.data.utils import ray_partitions_get_data_label, ray_partitions_get_tf_dataset
-from bigdl.orca.data.file import is_file, get_remote_file_to_local, get_remote_dir_to_local
+from bigdl.orca.data.file import is_file, get_remote_file_to_local, get_remote_dir_to_local, \
+    get_remote_files_with_prefix_to_local
 from bigdl.dllib.utils.log4Error import *
 
 logger = logging.getLogger(__name__)
@@ -543,10 +544,7 @@ class TFRunner:
         try:
             self.model.load_weights(temp_path, by_name, skip_mismatch, options)
         finally:
-            if os.path.isdir(temp_path):
-                shutil.rmtree(temp_path)
-            else:
-                os.remove(temp_path)
+            shutil.rmtree(temp_dir)
 
     def shutdown(self):
         """Attempts to shut down the worker."""

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -523,7 +523,7 @@ class TFRunner:
                 shutil.rmtree(temp_path)
             else:
                 os.remove(temp_path)
-    
+
     def load_weights(self, filepath, by_name, skip_mismatch, options):
         """Loads all layer weights from a TensorFlow or an HDF5 weight file."""
         self.model.load_weights(filepath, by_name, skip_mismatch, options)

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -528,7 +528,7 @@ class TFRunner:
         """Loads all layer weights from a TensorFlow or an HDF5 weight file."""
         self.model.load_weights(filepath, by_name, skip_mismatch, options)
 
-    def load_remote_weights(self, filepath, by_name, skip_mismatch, options):\
+    def load_remote_weights(self, filepath, by_name, skip_mismatch, options):
         """Loads all layer weights from a remote weight file (Tensorflow or HDF5 format)."""
         file_name = os.path.basename(filepath)
         temp_dir = tempfile.mkdtemp()


### PR DESCRIPTION
## Description

Support saving and load model weights in tf2 ray estimator. 

### 1. Why the change?

For estimator consistency and improve user experience.

### 2. User API changes

```python
# save model weights
estimator.save_weights(filepath, overwrite, save_format, options)
```

```python
estimator.load_weights(filepath, by_name, skip_mismatch, options)
```

### 3. Summary of the change 

Support saving and load model weights in tf2 ray estimator. 

### 4. How to test?
- [x] Yarn
- [x] Unit test

