### PR TITLE
Nano : support save and load for InferenceOptimizer

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -643,7 +643,7 @@ class InferenceOptimizer:
         :return: Model with different acceleration(None/OpenVINO/ONNX Runtime/JIT) or
                  precision(FP32/FP16/BF16/INT8).
         """
-        load_model(path, model)
+        return load_model(path, model)
 
 
 def _inc_checker():

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -428,7 +428,7 @@ class Trainer(pl.Trainer):
         :return: Model with different acceleration(None/OpenVINO/ONNX Runtime/JIT) or
                  precision(FP32/FP16/BF16/INT8).
         """
-        load_model(path, model)
+        return load_model(path, model)
 
     def save_checkpoint(    # type: ignore[override]
         self, filepath, weights_only: bool = False, storage_options: Optional[Any] = None

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -15,7 +15,6 @@
 #
 import copy
 from logging import warning
-from pathlib import Path
 from typing import Any, List, Optional, Union
 import pytorch_lightning as pl
 import torch
@@ -24,10 +23,9 @@ from torch.nn.modules.loss import _Loss
 from torch.utils.data import DataLoader
 from torchmetrics.metric import Metric
 from torch.optim.lr_scheduler import _LRScheduler
-import yaml
 from bigdl.nano.pytorch import InferenceOptimizer
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10, TORCH_VERSION_LESS_1_11
-from bigdl.nano.pytorch.utils import ChannelsLastCallback
+from bigdl.nano.pytorch.utils import ChannelsLastCallback, save_model, load_model
 from bigdl.nano.pytorch.algorithms import SelectiveBackprop
 from bigdl.nano.pytorch.lightning import LightningModule
 from bigdl.nano.pytorch.plugins.ddp_spawn import DDPSpawnPlugin
@@ -35,10 +33,6 @@ from bigdl.nano.pytorch.plugins.ddp_subprocess import DDPSubprocessPlugin
 from bigdl.nano.deps.automl.hpo_api import create_hpo_searcher, check_hpo_status
 from bigdl.nano.deps.ray.ray_api import distributed_ray
 from bigdl.nano.utils.log4Error import invalidInputError
-from bigdl.nano.deps.openvino.openvino_api import load_openvino_model
-from bigdl.nano.deps.ipex.ipex_api import load_ipexjit_model
-from bigdl.nano.deps.onnxruntime.onnxruntime_api import load_onnxruntime_model
-from bigdl.nano.deps.neural_compressor.inc_api import load_inc_model
 from bigdl.nano.common import check_avx512
 from bigdl.nano.utils import deprecated
 
@@ -420,21 +414,7 @@ class Trainer(pl.Trainer):
                Trainer.trace/Trainer.quantize.
         :param path: Path to saved model. Path should be a directory.
         """
-        path = Path(path)
-        path.mkdir(parents=path.parent, exist_ok=True)
-        if hasattr(model, '_save'):
-            model._save(path)
-        else:
-            # typically for models of nn.Module, pl.LightningModule type
-            meta_path = Path(path) / "nano_model_meta.yml"
-            with open(meta_path, 'w+') as f:
-                metadata = {
-                    'ModelType': 'PytorchModel',
-                    'checkpoint': 'saved_weight.pt'
-                }
-                yaml.safe_dump(metadata, f)
-            checkpoint_path = path / metadata['checkpoint']
-            torch.save(model.state_dict(), checkpoint_path)
+        save_model(model, path)
 
     @staticmethod
     def load(path, model: pl.LightningModule = None):
@@ -448,42 +428,7 @@ class Trainer(pl.Trainer):
         :return: Model with different acceleration(None/OpenVINO/ONNX Runtime/JIT) or
                  precision(FP32/FP16/BF16/INT8).
         """
-        path = Path(path)
-        if not path.exists():
-            invalidInputError(False, "{} doesn't exist.".format(path))
-        meta_path = path / "nano_model_meta.yml"
-        if not meta_path.exists():
-            invalidInputError(False, "File {} is required to load model.".format(str(meta_path)))
-        with open(meta_path, 'r') as f:
-            metadata = yaml.safe_load(f)
-        model_type = metadata.get('ModelType', None)
-        if model_type == 'PytorchOpenVINOModel':
-            invalidInputError(model is None,
-                              "Argument 'model' must be None for OpenVINO loading.")
-            return load_openvino_model(path)
-        if model_type == 'PytorchONNXRuntimeModel':
-            invalidInputError(model is None,
-                              "Argument 'model' must be None for ONNX Runtime loading.")
-            return load_onnxruntime_model(path)
-        if model_type == 'PytorchQuantizedModel':
-            return load_inc_model(path, model, 'pytorch')
-        if model_type == 'PytorchIPEXJITModel':
-            return load_ipexjit_model(path, model)
-        if isinstance(model, nn.Module):
-            # typically for models of nn.Module, pl.LightningModule type
-            model = copy.deepcopy(model)
-            checkpoint_path = metadata.get('checkpoint', None)
-            if checkpoint_path:
-                checkpoint_path = path / metadata['checkpoint']
-                state_dict = torch.load(checkpoint_path, map_location='cpu')
-                model.load_state_dict(state_dict)
-                return model
-            else:
-                invalidInputError(False, "Key 'checkpoint' must be specified.")
-        else:
-            invalidInputError(False,
-                              "ModelType {} or argument 'model={}' is not acceptable for pytorch"
-                              " loading.".format(model_type, type(model)))
+        load_model(path, model)
 
     def save_checkpoint(    # type: ignore[override]
         self, filepath, weights_only: bool = False, storage_options: Optional[Any] = None


### PR DESCRIPTION
## Description

- Currently, if a user just want to optimize inference pipeline, after using InferenceOptimizer API, he needs to import Trainer to save and load model, which is inconvenient and unnatural.
- So this PR try to support save and load for InferenceOptimizer.
- To facilitate the synchronization of save and load between Trainer and InferenceOptimizer, save and load function is stored separately as a function in nano.pytorch.utils.

### 1. Why the change?

To support save and load for InferenceOptimizer.

### 2. User API changes

Before : 
```
from bigdl.nano.pytorch import InferenceOptimizer
optimizer = InferenceOptimizer()
optimizer.optimize(model, ...)
accelarate_model = optimizer.get_best_model()

from bigdl.nano.pytorch import Trainer
Trainer.save(accelarate_model, path)
Trainer.load(path)
```

Now:
```
from bigdl.nano.pytorch import InferenceOptimizer
optimizer = InferenceOptimizer()
optimizer.optimize(model, ...)
accelarate_model = optimizer.get_best_model()
optimizer.save(accelarate_model, path)
optimizer.load(path)
```

### 3. Summary of the change 

- Support save and load for InferenceOptimizer
- To facilitate the synchronization of save and load between Trainer and InferenceOptimizer, save and load function is stored separately as a function

### 4. How to test?
- [x] Unit test
- [x] Application test
http://10.112.231.51:18889/job/BigDL-Chronos-PR-Validation/853/