### PR TITLE
Chronos: fix `ZooTestCase` in tensorflow unit tests

### DIFF
--- a/python/chronos/test/bigdl/chronos/model/tf2/test_Seq2Seq_keras.py
+++ b/python/chronos/test/bigdl/chronos/model/tf2/test_Seq2Seq_keras.py
@@ -19,7 +19,7 @@ import tensorflow as tf
 
 import pytest
 
-from bigdl.orca.test_zoo_utils import ZooTestCase
+from unittest import TestCase
 from bigdl.chronos.model.tf2.Seq2Seq_keras import LSTMSeq2Seq, model_creator
 import numpy as np
 
@@ -42,7 +42,7 @@ def create_data():
 
 
 @pytest.mark.skipif(tf.__version__ < '2.0.0', reason="Run only when tf>2.0.0.")
-class TestSeq2Seq(ZooTestCase):
+class TestSeq2Seq(TestCase):
 
     train_data, test_data = create_data()
     model = model_creator(config={

--- a/python/chronos/test/bigdl/chronos/model/tf2/test_tcn_keras.py
+++ b/python/chronos/test/bigdl/chronos/model/tf2/test_tcn_keras.py
@@ -19,7 +19,7 @@ import numpy as np
 import pytest
 import tensorflow as tf
 
-from bigdl.orca.test_zoo_utils import ZooTestCase
+from unittest import TestCase
 from bigdl.chronos.model.tf2.TCN_keras import model_creator, TemporalConvNet, TemporalBlock
 
 
@@ -40,7 +40,7 @@ def create_data():
     return train_data, test_data
 
 @pytest.mark.skipif(tf.__version__ < '2.0.0', reason="Run only when tf>2.0.0.")
-class TestTcnKeras(ZooTestCase):
+class TestTcnKeras(TestCase):
 
     train_data, test_data = create_data()
     model = model_creator(config={


### PR DESCRIPTION
## Description

`ZooTestCase` are modified to `TestCase` in unit tests to reduce unnecessary `import orca`.

### 1. How to test?
- [x] Unit test
http://10.112.231.51:18889/view/BigDL-PR-Validation/job/BigDL-Chronos-PR-Validation/851/