### PR TITLE
[Document] Reword "Edit on Github" Button

### DIFF
--- a/docs/readthedocs/source/_templates/breadcrumbs.html
+++ b/docs/readthedocs/source/_templates/breadcrumbs.html
@@ -1,0 +1,5 @@
+{%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
+
+<!--Remove "Edit on Github" button on top-right corner in every page-->
+{% block breadcrumbs_aside %}
+{% endblock %}

--- a/docs/readthedocs/source/_templates/breadcrumbs.html
+++ b/docs/readthedocs/source/_templates/breadcrumbs.html
@@ -1,5 +1,21 @@
 {%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
 
-<!--Remove "Edit on Github" button on top-right corner in every page-->
-{% block breadcrumbs_aside %}
-{% endblock %}
+<!--Change "Edit on Github" button on top-right corner to "Edit this page" in every page-->
+{%- block breadcrumbs_aside %}
+<li class="wy-breadcrumbs-aside">
+  {%- if hasdoc(pagename) and display_vcs_links %}
+    {%- if display_github %}
+      {%- if check_meta and 'github_url' in meta %}
+        <!-- User defined GitHub URL -->
+        <a href="{{ meta['github_url'] }}" class="fa fa-github"> {{ _('Edit this page') }}</a>
+      {%- else %}
+        <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode or "blob" }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ page_source_suffix }}" class="fa fa-github"> {{ _('Edit this page') }}</a>
+      {%- endif %}
+    {%- elif show_source and source_url_prefix %}
+      <a href="{{ source_url_prefix }}{{ pagename }}{{ page_source_suffix }}">{{ _('View page source') }}</a>
+    {%- elif show_source and has_source and sourcename %}
+      <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> {{ _('View page source') }}</a>
+    {%- endif %}
+  {%- endif %}
+</li>
+{%- endblock %}

--- a/docs/readthedocs/source/_templates/breadcrumbs.html
+++ b/docs/readthedocs/source/_templates/breadcrumbs.html
@@ -1,3 +1,42 @@
+<!--
+Copyright 2016 The BigDL Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+the following code is adapted from https://github.com/readthedocs/sphinx_rtd_theme/
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2018 Dave Snider, Read the Docs, Inc. & contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-->
+
 {%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
 
 <!--Change "Edit on Github" button on top-right corner to "Edit this page" in every page-->


### PR DESCRIPTION
## Description

Reword "Edit on Github" button (which will lead user to the GitHub source file of each web page) on the top-right corner of each web page to "Edit this page"

### 1. Why the change?

The "Edit on Github" button in some pages ncould be misleading. For example, in Nano How-to Guides, the "Edit on Github" button and "View the runnable example on Github" link together could make readers confused.
<img width="562" alt="image" src="https://user-images.githubusercontent.com/54161268/190565907-5e198599-b221-4e18-8f31-b9800ca4f94d.png">

### 2. Summary of the change 

For each ReadtheDocs web page:
- Before
![image](https://user-images.githubusercontent.com/54161268/191171727-26c63b90-adfe-4f54-9b97-aaec7dc3bd01.png)
- After
![image](https://user-images.githubusercontent.com/54161268/191171993-59062895-8ea3-42ac-b0c4-288fd988bdfb.png)

Realized through overwriting `sphinx_rtd_theme`'s template. (Refer to https://github.com/readthedocs/sphinx_rtd_theme/blob/master/sphinx_rtd_theme/breadcrumbs.html#L31)

### 3. How to test?
- [x] Document test: https://yuwentestdocs.readthedocs.io/en/remove-readthedocs-edit-on-github-button/
