### PR TITLE
Chronos : Fix a bug of readthedocs about get_public_dataset

### DIFF
--- a/docs/readthedocs/source/doc/Chronos/Overview/data_processing_feature_engineering.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/data_processing_feature_engineering.md
@@ -251,7 +251,7 @@ Built-in Dataset supports the function of data downloading, preprocessing, and r
 
 Specify the `name`, the raw data file will be saved in the specified `path` (defaults to ~/.chronos/dataset). `redownload` can help you re-download the files you need.
 
-When `with_split` is set to True, the length of the data set will be divided according to the specified `val_ratio` and `test_ratio`, and three `TSDataset` will be returned. `with_split` defaults to False, that is, only one `TSDataset` is returned.
+When `with_split` is set to True, the length of the data set will be divided according to the specified `val_ratio` and `test_ratio`, and three `TSDataset` will be returned. `with_split` defaults to True, `val_ratio` and `test_ratio` defaults to **0.1**. If you need only one `TSDataset`, just specify `with_split` to False.
 About `TSDataset`, more details, please refer to [here](../../PythonAPI/Chronos/tsdataset.html).
 
 ```python


### PR DESCRIPTION
## Description
https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/data_processing_feature_engineering.html?highlight=get_public_dataset#built-in-dataset
fix the wrong default value of with_split.

![image](https://user-images.githubusercontent.com/105281011/190604618-e387555c-beb5-44ed-9b6d-06a7302325b4.png)

