### PR TITLE
flip zoo-core/bigdl-core 2.1.0 others

### DIFF
--- a/scala/friesian/pom.xml
+++ b/scala/friesian/pom.xml
@@ -72,13 +72,13 @@
         <dependency>
             <groupId>com.intel.analytics.bigdl.core.dist</groupId>
             <artifactId>all</artifactId>
-            <version>2.1.0-SNAPSHOT</version>
+            <version>2.1.0</version>
             <scope>${bigdl-core-all-scope}</scope>
         </dependency>
         <dependency>
             <groupId>com.intel.analytics.zoo</groupId>
             <artifactId>${core.artifactId}</artifactId>
-            <version>0.12.0-SNAPSHOT</version>
+            <version>2.1.0</version>
             <type>${core.dependencyType}</type>
             <scope>${core.scope}</scope>
         </dependency>

--- a/scala/ppml/pom.xml
+++ b/scala/ppml/pom.xml
@@ -183,7 +183,7 @@
         <dependency>
             <groupId>com.intel.analytics.bigdl.core.dist</groupId>
             <artifactId>all</artifactId>
-            <version>2.1.0-SNAPSHOT</version>
+            <version>2.1.0</version>
             <scope>${bigdl-core-all-scope}</scope>
         </dependency>
         <dependency>

--- a/scala/serving/pom.xml
+++ b/scala/serving/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.intel.analytics.bigdl.core.dist</groupId>
             <artifactId>all</artifactId>
-            <version>2.1.0-SNAPSHOT</version>
+            <version>2.1.0</version>
             <scope>${bigdl-core-all-scope}</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Description

Update BigDL-core/Zoo-core version 2.1.0 in friesian/serving/ppml .
The version control will set as a global variable in further PR.