### PR TITLE
fix Vulnerabilities dllib and orca

### DIFF
--- a/scala/common/spark-version/2.0/pom.xml
+++ b/scala/common/spark-version/2.0/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
-            <version>2.7.3</version>
+            <version>2.10.2</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>2.7.7</version>
+            <version>3.2.3</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/scala/common/spark-version/3.0/pom.xml
+++ b/scala/common/spark-version/3.0/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>2.10.2</version>
+            <version>3.2.3</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/scala/common/spark-version/3.0/pom.xml
+++ b/scala/common/spark-version/3.0/pom.xml
@@ -55,6 +55,38 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>3.3.3</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jetty</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.12</artifactId>
             <version>${spark.version}</version>

--- a/scala/common/spark-version/3.0/pom.xml
+++ b/scala/common/spark-version/3.0/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>2.7.7</version>
+            <version>3.3.3</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/scala/common/spark-version/3.0/pom.xml
+++ b/scala/common/spark-version/3.0/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
-            <version>2.7.3</version>
+            <version>2.10.2</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -51,38 +51,6 @@
                 <exclusion>
                     <groupId>org.codehaus.jackson</groupId>
                     <artifactId>jackson-mapper-asl</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-            <version>3.3.3</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.zookeeper</groupId>
-                    <artifactId>zookeeper</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.jackson</groupId>
-                    <artifactId>jackson-mapper-asl</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protobuf-java</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.code.gson</groupId>
-                    <artifactId>gson</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.mortbay.jetty</groupId>
-                    <artifactId>jetty</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/scala/common/spark-version/3.0/pom.xml
+++ b/scala/common/spark-version/3.0/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>3.3.3</version>
+            <version>2.10.2</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/scala/dllib/pom.xml
+++ b/scala/dllib/pom.xml
@@ -67,10 +67,6 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty</artifactId>
 	        </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-common</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/scala/dllib/pom.xml
+++ b/scala/dllib/pom.xml
@@ -202,6 +202,10 @@
                 <exclusion>
                     <groupId>org.codehaus.jackson</groupId>
                     <artifactId>jackson-mapper-asl</artifactId>
+	        </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -234,6 +238,11 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>${commons-io.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>org.apache.commons</artifactId>
+            <version>1.21.1</version>
         </dependency>
 	<dependency>
             <groupId>org.scalanlp</groupId>

--- a/scala/dllib/pom.xml
+++ b/scala/dllib/pom.xml
@@ -65,6 +65,42 @@
                 <exclusion>
                     <groupId>io.netty</groupId>
                     <artifactId>netty</artifactId>
+	        </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-common</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>3.3.3</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jetty</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/scala/dllib/pom.xml
+++ b/scala/dllib/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>3.2.0</version>
+            <version>3.2.3</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -241,7 +241,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
-            <artifactId>org.apache.commons</artifactId>
+            <artifactId>commons-compress</artifactId>
             <version>1.21.1</version>
         </dependency>
 	<dependency>

--- a/scala/dllib/pom.xml
+++ b/scala/dllib/pom.xml
@@ -67,6 +67,42 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty</artifactId>
 	        </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-common</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>3.2.0</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jetty</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/scala/dllib/pom.xml
+++ b/scala/dllib/pom.xml
@@ -39,7 +39,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-client</artifactId>
+	    <artifactId>hadoop-client</artifactId>
+	    <version>2.10.2</version>
             <scope>${spark-scope}</scope>
             <exclusions>
                 <exclusion>
@@ -69,38 +70,6 @@
                 <exclusion>
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-common</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-            <version>3.3.3</version>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.zookeeper</groupId>
-                    <artifactId>zookeeper</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.codehaus.jackson</groupId>
-                    <artifactId>jackson-mapper-asl</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.protobuf</groupId>
-                    <artifactId>protobuf-java</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.code.gson</groupId>
-                    <artifactId>gson</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.mortbay.jetty</groupId>
-                    <artifactId>jetty</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/scala/dllib/pom.xml
+++ b/scala/dllib/pom.xml
@@ -242,7 +242,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.21.1</version>
+            <version>1.21</version>
         </dependency>
 	<dependency>
             <groupId>org.scalanlp</groupId>

--- a/scala/friesian/pom.xml
+++ b/scala/friesian/pom.xml
@@ -115,7 +115,7 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
+	        </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.15.8</version>
+            <version>3.19.2</version>
             <scope>${serving.scope}</scope>
         </dependency>
         <dependency>
@@ -151,7 +151,7 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.major.version}</artifactId>
             <version>${spark.version}</version>
-            <scope>${spark-scope}</scope>
+	    <scope>${spark-scope}</scope>
         </dependency>
         <dependency>
             <groupId>io.lettuce</groupId>

--- a/scala/friesian/pom.xml
+++ b/scala/friesian/pom.xml
@@ -115,7 +115,7 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
-	        </exclusion>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.19.2</version>
+            <version>3.15.8</version>
             <scope>${serving.scope}</scope>
         </dependency>
         <dependency>
@@ -151,7 +151,7 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.major.version}</artifactId>
             <version>${spark.version}</version>
-	    <scope>${spark-scope}</scope>
+            <scope>${spark-scope}</scope>
         </dependency>
         <dependency>
             <groupId>io.lettuce</groupId>

--- a/scala/orca/pom.xml
+++ b/scala/orca/pom.xml
@@ -145,7 +145,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.21.1</version>
+            <version>1.21</version>
             <scope>${spark-scope}</scope>
         </dependency>
         <dependency>

--- a/scala/orca/pom.xml
+++ b/scala/orca/pom.xml
@@ -140,7 +140,33 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>3.2.3</version>
-            <scope>${spark-scope}</scope>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jetty</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/scala/orca/pom.xml
+++ b/scala/orca/pom.xml
@@ -127,7 +127,6 @@
                     <artifactId>protobuf-java</artifactId>
                 </exclusion>
             </exclusions>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
@@ -151,7 +150,6 @@
                     <groupId>com.google.protobuf</groupId>
                     <artifactId>protobuf-java</artifactId>
                 </exclusion>
-            </exclusions>
             </exclusions>
         </dependency>
         <dependency>

--- a/scala/orca/pom.xml
+++ b/scala/orca/pom.xml
@@ -125,8 +125,28 @@
                 <exclusion>
                     <groupId>com.google.protobuf</groupId>
                     <artifactId>protobuf-java</artifactId>
+	        </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-common</artifactId>
+	        </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>3.2.3</version>
+            <scope>${spark-scope}</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.21.1</version>
+            <scope>${spark-scope}</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/scala/orca/pom.xml
+++ b/scala/orca/pom.xml
@@ -121,7 +121,12 @@
                 <exclusion>
                     <groupId>xerces</groupId>
                     <artifactId>xercesImpl</artifactId>
+	        </exclusion>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
                 </exclusion>
+            </exclusions>
             </exclusions>
         </dependency>
         <dependency>
@@ -141,8 +146,19 @@
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
+	        </exclusion>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
                 </exclusion>
             </exclusions>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+	    <artifactId>protobuf-java</artifactId>
+	    <version>3.19.2</version>
+	    <scope>${spark-scope}</scope>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -769,7 +769,7 @@
                 <java.version>1.8</java.version>
                 <javac.version>1.8</javac.version>
                 <spark-version.project>3.0</spark-version.project>
-                <spark.version>3.1.2</spark.version>
+                <spark.version>3.1.3</spark.version>
                 <scala.major.version>2.12</scala.major.version>
                 <scala.version>2.12.10</scala.version>
                 <scala.macros.version>2.1.0</scala.macros.version>


### PR DESCRIPTION
## Description
1. org.apache.spark:spark-core_2.12@3.1.2 Upgrade to 3.1.3
![image](https://user-images.githubusercontent.com/30695225/190967636-5997f8ee-b94c-46d2-aadc-a84b8818b55c.png)
2. Upgrade to org.apache.hadoop:hadoop-client@2.7.7  Upgrade to 2.10.2
![image](https://user-images.githubusercontent.com/30695225/190967930-d1ea1afa-34fc-4ae7-a22f-e823939822c6.png)
3. org.apache.hadoop:hadoop-common@2.7.7 Upgrade to 3.2.0 (medium)
![image](https://user-images.githubusercontent.com/30695225/191146528-dc827163-42ae-4a42-a79e-1524245d5bf2.png)
4. com.google.protobuf:protobuf-java@3.5.1  Upgrade to 3.19.2
![image](https://user-images.githubusercontent.com/30695225/190968208-c24be2f9-bf32-4184-aacb-9d67afc77e6b.png)
5. org.apache.commons:commons-compress@1.8.1
![image](https://user-images.githubusercontent.com/30695225/191153908-2673e7c9-8f85-4e60-b07a-d277790301e0.png)
### 1. Why the change?
Vulnerabilities


### 4. How to test?
- [x] N/A

### 5. New dependencies
 No