### PR TITLE
fix syntax error

### DIFF
--- a/python/dllib/src/setup.py
+++ b/python/dllib/src/setup.py
@@ -107,7 +107,7 @@ def setup_package():
         scripts=scripts,
         install_requires=[
             'numpy>=1.19.5', 'pyspark==2.4.6', 'conda-pack==0.3.1',
-            'six>=1.10.0', 'bigdl-core=='2.1.0'],
+            'six>=1.10.0', 'bigdl-core==2.1.0'],
         dependency_links=['https://d3kbcqa49mib13.cloudfront.net/spark-2.0.0-bin-hadoop2.7.tgz'],
         include_package_data=True,
         package_data={"bigdl.share.dllib": ['lib/bigdl-dllib*.jar', 'conf/*',


### PR DESCRIPTION
## Description



### 1. Why the change?
~~~
 File "setup.py", line 110
    'six>=1.10.0', 'bigdl-core=='2.1.0'],
                                   ^
SyntaxError: invalid syntax
~~~
http://10.112.231.51:18888/job/ZOO-NB-BigDL-Python-Spark-2.4-py36-ray/428/console


