### PR TITLE
Chronos : provide tsdataset and loader support for partial method of Forecaster

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -795,11 +795,20 @@ class TSDataset:
                 invalidInputError(False,
                                   "Please call 'roll' method before transforming a TSDataset to "
                                   "torch DataLoader if roll is False!")
-            x, y = self.to_numpy()
-            return DataLoader(TensorDataset(torch.from_numpy(x).float(),
-                                            torch.from_numpy(y).float()),
-                              batch_size=batch_size,
-                              shuffle=shuffle)
+            if self.numpy_x_timeenc is None:
+                x, y = self.to_numpy()
+                return DataLoader(TensorDataset(torch.from_numpy(x).float(),
+                                                torch.from_numpy(y).float()),
+                                  batch_size=batch_size,
+                                  shuffle=shuffle)
+            else:
+                x, y, x_enc, y_enc = self.to_numpy()
+                return DataLoader(TensorDataset(torch.from_numpy(x).float(),
+                                                torch.from_numpy(y).float(),
+                                                torch.from_numpy(x_enc).float(),
+                                                torch.from_numpy(y_enc).float()),
+                                  batch_size=batch_size,
+                                  shuffle=shuffle)
 
     def to_tf_dataset(self, batch_size=32, shuffle=False):
         """

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -246,6 +246,7 @@ class BasePytorchForecaster(Forecaster):
 
         :param validation_data: Validation sample for validation loop. Defaults to 'None'.
                If you do not input data for 'validation_data', the validation_step will be skipped.
+               Validation data will be ignored under distributed mode.
                The validation_data support following formats:
 
                | 1. a numpy ndarray tuple (x, y):

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -254,14 +254,18 @@ class BasePytorchForecaster(Forecaster):
                | y's shape is (num_samples, horizon, target_dim), where horizon and target_dim
                | should be the same as future_seq_len and output_feature_num.
                |
-               | 2. pytorch dataloader:
+               | 2. a xshard item:
+               | each partition can be a dictionary of {'x': x, 'y': y}, where x and y's shape
+               | should follow the shape stated before.
+               |
+               | 3. pytorch dataloader:
                | the dataloader should return x, y in each iteration with the shape as following:
                | x's shape is (num_samples, lookback, feature_dim) where lookback and feature_dim
                | should be the same as past_seq_len and input_feature_num.
                | y's shape is (num_samples, horizon, target_dim), where horizon and target_dim
                | should be the same as future_seq_len and output_feature_num.
                |
-               | 3. A bigdl.chronos.data.tsdataset.TSDataset instance:
+               | 4. A bigdl.chronos.data.tsdataset.TSDataset instance:
                | Forecaster will automatically process the TSDataset.
                | By default, TSDataset will be transformed to a pytorch dataloader,
                | which is memory-friendly while a little bit slower.
@@ -314,6 +318,10 @@ class BasePytorchForecaster(Forecaster):
                 warnings.warn("Xshards is collected to local since the "
                               "forecaster is non-distribued.")
                 data = xshard_to_np(data)
+            if isinstance(validation_data, SparkXShards) and not self.distributed:
+                warnings.warn("Xshards is collected to local since the "
+                              "forecaster is non-distribued.")
+                validation_data = xshard_to_np(validation_data)
         except ImportError:
             pass
 

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -196,6 +196,21 @@ class TestChronosModelLSTMForecaster(TestCase):
             ckpt_name_q = os.path.join(tmp_dir_name, "int_openvino")
             forecaster.export_openvino_file(dirname=ckpt_name, quantized_dirname=ckpt_name_q)
 
+    def test_lstm_forecaster_openvino_methods_loader(self):
+        train_data, _, test_data = create_data(loader=True)
+        forecaster = LSTMForecaster(past_seq_len=24,
+                                    input_feature_num=2,
+                                    output_feature_num=2,
+                                    loss="mae",
+                                    lr=0.01)
+        forecaster.fit(train_data, epochs=2)
+        try:
+            pred = forecaster.predict(test_data)
+            pred_openvino = forecaster.predict_with_openvino(test_data)
+            np.testing.assert_almost_equal(pred, pred_openvino, decimal=5)
+        except ImportError:
+            pass
+
     def test_lstm_forecaster_quantization(self):
         train_data, val_data, test_data = create_data()
         forecaster = LSTMForecaster(past_seq_len=24,

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -568,7 +568,7 @@ class TestChronosModelLSTMForecaster(TestCase):
                                     lr=0.01)
         forecaster.fit(train_data, epochs=2)
         y_pred, std = forecaster.predict_interval(data=test_data[0],
-                                                  val_data=val_data,
+                                                  validation_data=val_data,
                                                   repetition_times=5)
         assert y_pred.shape == test_data[1].shape
         assert y_pred.shape == std.shape

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -533,7 +533,7 @@ class TestChronosNBeatsForecaster(TestCase):
                                       lr=0.01)
         forecaster.fit(train_data, epochs=2)
         y_pred, std = forecaster.predict_interval(data=test_data[0],
-                                                  val_data=val_data,
+                                                  validation_data=val_data,
                                                   repetition_times=5)
         assert y_pred.shape == test_data[1].shape
         assert y_pred.shape == std.shape

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -493,7 +493,7 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
                                        lr=0.01)
         forecaster.fit(train_data, epochs=2)
         y_pred, std = forecaster.predict_interval(data=test_data[0],
-                                                  val_data=val_data,
+                                                  validation_data=val_data,
                                                   repetition_times=5)
         assert y_pred.shape == test_data[1].shape
         assert y_pred.shape == std.shape

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-from symbol import test_nocond
 import numpy as np
 import tempfile
 import os
@@ -341,7 +340,7 @@ class TestChronosModelTCNForecaster(TestCase):
         forecaster.quantize(calib_data=train,
                             framework="openvino")
         openvino_yhat = forecaster.predict_with_openvino(test)
-        q_openvino_yhat = forecaster.predict_with_openvino(test_nocond, quantize=True)
+        q_openvino_yhat = forecaster.predict_with_openvino(test, quantize=True)
         assert openvino_yhat.shape == q_openvino_yhat.shape
 
     def test_tcn_forecaster_quantization_dynamic(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -729,9 +729,9 @@ class TestChronosModelTCNForecaster(TestCase):
                                    metrics=["mse"],
                                    lr=0.01)
         forecaster.fit(train_data, epochs=2)
-        # only the first time needs val_data
+        # only the first time needs validation_data
         y_pred, std = forecaster.predict_interval(data=test_data[0],
-                                                  val_data=val_data,
+                                                  validation_data=val_data,
                                                   repetition_times=5)
         assert y_pred.shape == test_data[1].shape
         assert y_pred.shape == std.shape
@@ -749,9 +749,9 @@ class TestChronosModelTCNForecaster(TestCase):
                                    metrics=["mse"],
                                    lr=0.01)
         forecaster.fit(train_loader, epochs=2)
-        # only the first time needs val_data
+        # only the first time needs validation_data
         y_pred, std = forecaster.predict_interval(data=test_loader,
-                                                  val_data=val_loader,
+                                                  validation_data=val_loader,
                                                   repetition_times=5)
         assert y_pred.shape == std.shape
         y_pred, std = forecaster.predict_interval(data=test_loader)
@@ -761,9 +761,9 @@ class TestChronosModelTCNForecaster(TestCase):
         forecaster = TCNForecaster.from_tsdataset(train,
                                            num_channels=[16]*3)
         forecaster.fit(train, epochs=2, batch_size=32)
-        # only the first time needs val_data
+        # only the first time needs validation_data
         y_pred, std = forecaster.predict_interval(data=test,
-                                                  val_data=val,
+                                                  validation_data=val,
                                                   repetition_times=5)
         assert y_pred.shape == std.shape
         y_pred, std = forecaster.predict_interval(data=test)


### PR DESCRIPTION
## Description

provide tsdataset and loader support for partial method of Forecaster

### 1. Why the change?

https://github.com/intel-analytics/BigDL/issues/5834

### 2. User API changes

No change.

### 3. Summary of the change 

- [x] support loader and tsdataset in BaseForecaster.predict_with_openvino
- [x] support tsdataset for Autoformer.fit
- [x] support tsdataset for Autoformer.evaluate
- [x] support tsdataset for Autoformer.predict
- [x] support tsdataset for data and val data in Autoformer.predict_interval
- [x] support xshard for validation_data in BaseForecaster.predict_interval
- [x] support tsdataset for calib_data and val_data in BaseForecaster.quantize
- [x] code refactor

### 4. How to test?

- [x] Unit test
- [x] Application test