### PR TITLE
[PPML] Remove redundant value-assignment for JDK_URL

### DIFF
--- a/ppml/trusted-big-data-ml/python/docker-gramine/build-docker-image.sh
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/build-docker-image.sh
@@ -14,7 +14,6 @@ Proxy_Modified="sudo docker build \
     --build-arg HTTPS_PROXY_PORT=${HTTPS_PROXY_PORT} \
     --build-arg JDK_VERSION=8u192 \
     --build-arg JDK_URL=${JDK_URL} \
-    --build-arg JDK_URL=${SPARK_JAR_REPO_URL} \
     --build-arg SPARK_JAR_REPO_URL=${SPARK_JAR_REPO_URL} \
     --build-arg no_proxy=x.x.x.x \
     -t intelanalytics/bigdl-ppml-trusted-big-data-ml-python-gramine:2.1.0-SNAPSHOT -f ./Dockerfile ."
@@ -22,7 +21,6 @@ Proxy_Modified="sudo docker build \
 No_Proxy_Modified="sudo docker build \
     --build-arg JDK_VERSION=8u192 \
     --build-arg JDK_URL=${JDK_URL} \
-    --build-arg JDK_URL=${SPARK_JAR_REPO_URL} \
     --build-arg SPARK_JAR_REPO_URL=${SPARK_JAR_REPO_URL} \
     --build-arg no_proxy=x.x.x.x \
     -t intelanalytics/bigdl-ppml-trusted-big-data-ml-python-gramine:2.1.0-SNAPSHOT -f ./Dockerfile ."


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?
Remove the redundant value-assignment for JDK_URL in the build script
It will cause error because the value of SPARK_JAR_URL will be assigned to JDK_URL

### 2. User API changes
None.

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 
Remove the redundant value-assignment for JDK_URL in the build script
<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [x] Docker build test
