### PR TITLE
Chronos : Support val data in autoformer fit

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -432,7 +432,7 @@ class AutoformerForecaster(Forecaster):
                     shuffle=False)
             # transform a TSDataset instance to dataloader
             if isinstance(validation_data, TSDataset):
-                _rolled = data.numpy_x is None
+                _rolled = validation_data.numpy_x is None
                 validation_data = validation_data.to_torch_data_loader(
                     batch_size=batch_size,
                     roll=_rolled,
@@ -443,6 +443,7 @@ class AutoformerForecaster(Forecaster):
                     feature_col=validation_data.roll_feature,
                     target_col=validation_data.roll_target,
                     shuffle=False)
+
             self.trainer.fit(self.internal, data, validation_data)
             self.fitted = True
             fit_out = read_csv('./forecaster_tmp_log/version_0/metrics.csv', loss_name='val_loss')

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -451,6 +451,11 @@ class AutoformerForecaster(Forecaster):
             if validation_mode == 'best_epoch':
                 self.load('validation/best.ckpt')
                 delete_folder("./validation")
+            # modify logger attr in trainer, otherwise predict will report error
+            self.trainer._logger_connector.on_trainer_init(False,
+                                                           self.trainer.flush_logs_every_n_steps,
+                                                           self.trainer.log_every_n_steps,
+                                                           self.trainer.move_metrics_to_cpu)
             return fit_out
 
     def predict(self, data, batch_size=32):

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -18,7 +18,7 @@ import torch
 import numpy as np
 from pandas import Timedelta
 from bigdl.chronos.forecaster.abstract import Forecaster
-from bigdl.chronos.forecaster.utils import *
+from bigdl.chronos.forecaster.utils import read_csv, delete_folder
 from bigdl.chronos.metric.forecast_metrics import Evaluator
 from bigdl.chronos.model.autoformer import model_creator, loss_creator
 from torch.utils.data import TensorDataset, DataLoader

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -583,7 +583,6 @@ class AutoformerForecaster(Forecaster):
                               "You must call fit or restore first before calling predict_interval!")
 
         # step1, according to validation dataset, calculate inherent noise
-        # which should be done during fit
         if not hasattr(self, "data_noise"):
             invalidInputError(validation_data is not None,
                               "When call predict_interval for the first time, you must pass in "
@@ -616,7 +615,7 @@ class AutoformerForecaster(Forecaster):
             self.data_noise = Evaluator.evaluate(["mse"], target,
                                                  val_yhat, aggregate=None)[0]  # 2d array
 
-        # step3: calculate model uncertainty based MC Dropout
+        # step2: calculate model uncertainty based MC Dropout
         def apply_dropout(m):
             if type(m) == torch.nn.Dropout:
                 m.train()

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -612,6 +612,14 @@ class AutoformerForecaster(Forecaster):
 
         return y_hat_mean, std_deviation
 
+    def get_model(self):
+        """
+        Returns the learned PyTorch Lightning model.
+
+        :return: a pytorch lightning model instance
+        """
+        return self.internal
+
     def load(self, checkpoint_file):
         """
         restore the forecaster.

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -208,6 +208,9 @@ class BasePytorchForecaster(Forecaster):
             self.tune_trainer.reset_train_val_dataloaders(self.internal)
 
     def search_summary(self):
+        """
+        Return search summary of HPO.
+        """
         # add tuning check
         invalidOperationError(self.use_hpo, "No search summary when HPO is disabled.")
         return self.tune_trainer.search_summary()

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -430,6 +430,12 @@ class BasePytorchForecaster(Forecaster):
                 if validation_mode == 'best_epoch':
                     self.load('validation/best.ckpt')
                     delete_folder("./validation")
+                # modify logger attr in trainer, otherwise predict will report error
+                self.trainer._logger_connector.on_trainer_init(
+                    False,
+                    self.trainer.flush_logs_every_n_steps,
+                    self.trainer.log_every_n_steps,
+                    self.trainer.move_metrics_to_cpu)
                 return fit_out
 
     def predict(self, data, batch_size=32, quantize=False):

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -904,7 +904,6 @@ class BasePytorchForecaster(Forecaster):
                               "You must call fit or restore first before calling predict_interval!")
 
         # step1, according to validation dataset, calculate inherent noise
-        # which should be done during fit
         if not hasattr(self, "data_noise"):
             invalidInputError(validation_data is not None,
                               "When call predict_interval for the first time, you must pass in "
@@ -934,7 +933,7 @@ class BasePytorchForecaster(Forecaster):
             self.data_noise = Evaluator.evaluate(["mse"], target,
                                                  val_yhat, aggregate=None)[0]  # 2d array
 
-        # step2: data preprocess
+        # data preprocess
         if isinstance(data, TSDataset):
             _rolled = data.numpy_x is None
             data = data.to_torch_data_loader(batch_size=batch_size,
@@ -945,7 +944,7 @@ class BasePytorchForecaster(Forecaster):
                                              target_col=data.roll_target,
                                              shuffle=False)
 
-        # step3: calculate model uncertainty based MC Dropout
+        # step2: calculate model uncertainty based MC Dropout
         def apply_dropout(m):
             if type(m) == torch.nn.Dropout:
                 m.train()

--- a/python/chronos/src/bigdl/chronos/forecaster/utils.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/utils.py
@@ -156,14 +156,14 @@ def np_to_dataloader(data, batch_size, num_processes):
                       shuffle=True)
 
 
-def read_csv(filename):
+def read_csv(filename, loss_name='val/loss'):
     import codecs
     import csv
     fit_out = {}
     with codecs.open(filename, encoding='utf-8-sig') as f:
         for row in csv.DictReader(f, skipinitialspace=True):
-            if row['val/loss']:
-                fit_out[row['epoch']] = {'val_loss': row['val/loss']}
+            if row[loss_name]:
+                fit_out[row['epoch']] = {'val_loss': row[loss_name]}
     return fit_out
 
 

--- a/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
@@ -392,3 +392,15 @@ class TestChronosModelAutoformerForecaster(TestCase):
                                           seed=0)
         val_loss = forecaster.fit(train_loader, val_loader, epochs=10,
                                   validation_mode='best_epoch')
+
+    def test_autoformer_forecaster_fit_val_tsdataset(self):
+        train, val, test = create_tsdataset(val_ratio=0.1)
+        forecaster = AutoformerForecaster(past_seq_len=24,
+                                          future_seq_len=5,
+                                          input_feature_num=2,
+                                          output_feature_num=2,
+                                          label_len=12,
+                                          freq='s',
+                                          seed=0)
+        forecaster.fit(train, val, epochs=3, batch_size=32)
+        forecaster.predict(test)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -629,7 +629,7 @@ class TestChronosModelTCNForecaster(TestCase):
         np.testing.assert_almost_equal(test_pred_save, test_pred_load)
    
     def test_tcn_forecaster_fit_val(self):
-        train_data, val_data, _ = create_data()
+        train_data, val_data, test_data = create_data()
         forecaster = TCNForecaster(past_seq_len=24,
                                    future_seq_len=5,
                                    input_feature_num=1,
@@ -639,6 +639,7 @@ class TestChronosModelTCNForecaster(TestCase):
                                    loss="mae",
                                    lr=0.01)
         val_loss = forecaster.fit(train_data, val_data, epochs=10)
+        _ = forecaster.predict(test_data[0])
 
     def test_tcn_forecaster_fit_loader_val(self):
         train_loader, val_loader, _ = create_data(loader=True)


### PR DESCRIPTION
## Description

We need to align function in BaseForecaster and AutoformerForecaster synchronously.

### 1. Why the change?

https://github.com/intel-analytics/BigDL/issues/5834

### 2. User API changes

```
from bigdl.chronos.forecaster import AutoformerForecaster
forecaster = AutoformerForecaster(...)
forecaster.fit(data, validation_data, validation_mode='output', earlystop_patience=1)
```

### 3. Summary of the change 

- [x] support validation_data, validation_mode and earlystop_patience for AutoformerForecaster.fit
- [x] support get_model for AutoformerForecaster
- [x] code refactor

### 4. How to test?
- [ ] Unit test
- [ ] Application test