### PR TITLE
Delete PYTHONHOME when start ray process

### DIFF
--- a/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
+++ b/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
@@ -98,6 +98,7 @@ class RayServiceFuncGenerator(object):
         modified_env.pop("KMP_BLOCKTIME", None)
         modified_env.pop("KMP_AFFINITY", None)
         modified_env.pop("KMP_SETTINGS", None)
+        modified_env.pop("PYTHONHOME", None)
         if self.env:  # Add in env argument if any MKL setting is needed.
             modified_env.update(self.env)
         if self.verbose:


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->
when call `init_orca_context(cluster_mode="spark-submit")`, `PYTHONHOME` will be set inside this method. This environment variable will cause ray process start failed and throw `ModuleNotFoundError: No module named encodings`, delete PYTHONHOME when start ray process will fix this problem.
This is tested on Databricks.
