### PR TITLE
upgrade spark312 to spark313

### DIFF
--- a/python/dev/release_default_linux_spark312.sh
+++ b/python/dev/release_default_linux_spark312.sh
@@ -17,7 +17,7 @@
 #
 
 # This is the default script with maven parameters to release all the bigdl sub-packages
-# built on top of Spark 3.1.2 for mac.
+# built on top of Spark 3.1.2 for linux.
 
 set -e
 RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
@@ -26,10 +26,10 @@ BIGDL_DIR="$(cd ${RUN_SCRIPT_DIR}/../..; pwd)"
 echo $BIGDL_DIR
 
 if (( $# < 3)); then
-  echo "Usage: release_default_mac_spark312.sh version quick_build upload suffix mvn_parameters"
-  echo "Usage example: bash release_default_mac_spark313.sh default false true true"
-  echo "Usage example: bash release_default_mac_spark313.sh 0.14.0.dev1 false false true"
-  echo "Usage example: bash release_default_mac_spark246.sh 0.14.0.dev1 false false false -Ddata-store-url=.."
+  echo "Usage: release_default_linux_spark312.sh version quick_build upload suffix mvn_parameters"
+  echo "Usage example: bash release_default_linux_spark312.sh default false true true"
+  echo "Usage example: bash release_default_linux_spark312.sh 0.14.0.dev1 false false true"
+  echo "Usage example: bash release_default_linux_spark312.sh 0.14.0.dev1 false false false -Ddata-store-url=.."
   exit -1
 fi
 
@@ -44,4 +44,4 @@ else
   profiles=${*:5}
 fi
 
-bash ${RUN_SCRIPT_DIR}/release_default_spark.sh mac ${version} ${quick} ${upload} 3.1.3 ${suffix} ${profiles}
+bash ${RUN_SCRIPT_DIR}/release_default_spark.sh linux ${version} ${quick} ${upload} 3.1.2 ${suffix} ${profiles}

--- a/python/dev/release_default_linux_spark313.sh
+++ b/python/dev/release_default_linux_spark313.sh
@@ -17,7 +17,7 @@
 #
 
 # This is the default script with maven parameters to release all the bigdl sub-packages
-# built on top of Spark 3.1.2 for linux.
+# built on top of Spark 3.1.3 for linux.
 
 set -e
 RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
@@ -44,4 +44,4 @@ else
   profiles=${*:5}
 fi
 
-bash ${RUN_SCRIPT_DIR}/release_default_spark.sh linux ${version} ${quick} ${upload} 3.1.2 ${suffix} ${profiles}
+bash ${RUN_SCRIPT_DIR}/release_default_spark.sh linux ${version} ${quick} ${upload} 3.1.3 ${suffix} ${profiles}

--- a/python/dev/release_default_linux_spark313.sh
+++ b/python/dev/release_default_linux_spark313.sh
@@ -17,7 +17,7 @@
 #
 
 # This is the default script with maven parameters to release all the bigdl sub-packages
-# built on top of Spark 3.1.3 for linux.
+# built on top of Spark 3.1.2 for linux.
 
 set -e
 RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
@@ -26,10 +26,10 @@ BIGDL_DIR="$(cd ${RUN_SCRIPT_DIR}/../..; pwd)"
 echo $BIGDL_DIR
 
 if (( $# < 3)); then
-  echo "Usage: release_default_linux_spark312.sh version quick_build upload suffix mvn_parameters"
-  echo "Usage example: bash release_default_linux_spark312.sh default false true true"
-  echo "Usage example: bash release_default_linux_spark312.sh 0.14.0.dev1 false false true"
-  echo "Usage example: bash release_default_linux_spark312.sh 0.14.0.dev1 false false false -Ddata-store-url=.."
+  echo "Usage: release_default_linux_spark313.sh version quick_build upload suffix mvn_parameters"
+  echo "Usage example: bash release_default_linux_spark313.sh default false true true"
+  echo "Usage example: bash release_default_linux_spark313.sh 0.14.0.dev1 false false true"
+  echo "Usage example: bash release_default_linux_spark313.sh 0.14.0.dev1 false false false -Ddata-store-url=.."
   exit -1
 fi
 

--- a/python/dev/release_default_mac_spark312.sh
+++ b/python/dev/release_default_mac_spark312.sh
@@ -27,8 +27,8 @@ echo $BIGDL_DIR
 
 if (( $# < 3)); then
   echo "Usage: release_default_mac_spark312.sh version quick_build upload suffix mvn_parameters"
-  echo "Usage example: bash release_default_mac_spark313.sh default false true true"
-  echo "Usage example: bash release_default_mac_spark313.sh 0.14.0.dev1 false false true"
+  echo "Usage example: bash release_default_mac_spark312.sh default false true true"
+  echo "Usage example: bash release_default_mac_spark312.sh 0.14.0.dev1 false false true"
   echo "Usage example: bash release_default_mac_spark246.sh 0.14.0.dev1 false false false -Ddata-store-url=.."
   exit -1
 fi
@@ -44,4 +44,4 @@ else
   profiles=${*:5}
 fi
 
-bash ${RUN_SCRIPT_DIR}/release_default_spark.sh mac ${version} ${quick} ${upload} 3.1.3 ${suffix} ${profiles}
+bash ${RUN_SCRIPT_DIR}/release_default_spark.sh mac ${version} ${quick} ${upload} 3.1.2 ${suffix} ${profiles}

--- a/python/dev/release_default_mac_spark313.sh
+++ b/python/dev/release_default_mac_spark313.sh
@@ -17,7 +17,7 @@
 #
 
 # This is the default script with maven parameters to release all the bigdl sub-packages
-# built on top of Spark 3.1.2 for mac.
+# built on top of Spark 3.1.3 for mac.
 
 set -e
 RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
@@ -44,4 +44,4 @@ else
   profiles=${*:5}
 fi
 
-bash ${RUN_SCRIPT_DIR}/release_default_spark.sh mac ${version} ${quick} ${upload} 3.1.2 ${suffix} ${profiles}
+bash ${RUN_SCRIPT_DIR}/release_default_spark.sh mac ${version} ${quick} ${upload} 3.1.3 ${suffix} ${profiles}

--- a/python/dev/release_default_spark.sh
+++ b/python/dev/release_default_spark.sh
@@ -27,7 +27,7 @@ echo $BIGDL_DIR
 
 if (( $# < 4)); then
   echo "Usage: release_default_spark.sh platform version quick_build upload spark_version suffix mvn_parameters"
-  echo "Usage example: bash release_default_spark.sh linux default false true 3.1.3 true"
+  echo "Usage example: bash release_default_spark.sh linux default false true 3.1.2 true"
   echo "Usage example: bash release_default_spark.sh linux 0.14.0.dev1 false false 2.4.6 true"
   echo "Usage example: bash release_default_spark.sh mac 0.14.0.dev1 false false 2.4.6 false -Ddata-store-url=.."
   exit -1
@@ -44,7 +44,7 @@ spark_first_version=${array[0]}
 
 re='^[2-3]+$'
 if ! [[ $spark_first_version =~ $re ]] ; then
-   echo "error: Spark version is not a number like 3.1.3"
+   echo "error: Spark version is not a number like 3.1.2"
    exit 1
 fi
 

--- a/python/dev/release_default_spark.sh
+++ b/python/dev/release_default_spark.sh
@@ -27,7 +27,7 @@ echo $BIGDL_DIR
 
 if (( $# < 4)); then
   echo "Usage: release_default_spark.sh platform version quick_build upload spark_version suffix mvn_parameters"
-  echo "Usage example: bash release_default_spark.sh linux default false true 3.1.2 true"
+  echo "Usage example: bash release_default_spark.sh linux default false true 3.1.3 true"
   echo "Usage example: bash release_default_spark.sh linux 0.14.0.dev1 false false 2.4.6 true"
   echo "Usage example: bash release_default_spark.sh mac 0.14.0.dev1 false false 2.4.6 false -Ddata-store-url=.."
   exit -1
@@ -44,7 +44,7 @@ spark_first_version=${array[0]}
 
 re='^[2-3]+$'
 if ! [[ $spark_first_version =~ $re ]] ; then
-   echo "error: Spark version is not a number like 3.1.2"
+   echo "error: Spark version is not a number like 3.1.3"
    exit 1
 fi
 


### PR DESCRIPTION
## Description
Spark_core_2.12 requires spark 3.1.3 to avoid a high Vulnerability. We  need to upgrade spark 312 to 313
org.apache.spark:spark-core_2.12@3.1.2 Upgrade to 3.1.3
![image](https://user-images.githubusercontent.com/30695225/190967636-5997f8ee-b94c-46d2-aadc-a84b8818b55c.png)