### PR TITLE
fix spark2.3 compile issue

### DIFF
--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nnframes/TreeModel.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nnframes/TreeModel.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.SparkSession
 import ml.dmlc.xgboost4j.scala.spark._
 import org.apache.spark.ml.feature.VectorAssembler
 import org.apache.spark.sql.DataFrame
+import org.apache.spark.SparkContext
 import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMClassificationModel => MLightGBMClassificationModel}
 import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMClassifier => MLightGBMClassifier}
 import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMRegressionModel => MLightGBMRegressionModel}

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nnframes/TreeModel.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nnframes/TreeModel.scala
@@ -28,7 +28,7 @@ import com.microsoft.azure.synapse.ml.lightgbm.{LightGBMRegressor => MLightGBMRe
 
 
 class XGBClassifier (val xgboostParams: Map[String, Any] = Map()) {
-  val sc = SparkSession.active.sparkContext
+  val sc = SparkContext.getOrCreate()
   sc.getConf.set("spark.task.cpus", Engine.coreNumber().toString)
   private val estimator = new XGBoostClassifier(xgboostParams)
   estimator.setNthread(Engine.coreNumber())
@@ -430,7 +430,7 @@ object XGBRegressorModel {
  */
 class LightGBMClassifier (val lgbmParams: Map[String, Any] = Map()) {
 
-  val sc = SparkSession.active.sparkContext
+  val sc = SparkContext.getOrCreate()
   sc.getConf.set("spark.task.cpus", Engine.coreNumber().toString)
 
   private val estimator = new MLightGBMClassifier()
@@ -617,7 +617,7 @@ object LightGBMClassifierModel {
  */
 class LightGBMRegressor (val lgbmParams: Map[String, Any] = Map()) {
 
-  val sc = SparkSession.active.sparkContext
+  val sc = SparkContext.getOrCreate()
   sc.getConf.set("spark.task.cpus", Engine.coreNumber().toString)
 
   private val estimator = new MLightGBMRegressor()


### PR DESCRIPTION
## Description
Fix compile on Spark2.3
```
[ERROR] /var/jenkins_home/workspace/BigDL2.0-NB-Deploy-SCALA/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nnframes/TreeModel.scala:31: value active is not a member of object org.apache.spark.sql.SparkSession
[ERROR]   val sc = SparkSession.active.sparkContext
[ERROR]                         ^
[ERROR] /var/jenkins_home/workspace/BigDL2.0-NB-Deploy-SCALA/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nnframes/TreeModel.scala:433: value active is not a member of object org.apache.spark.sql.SparkSession
[ERROR]   val sc = SparkSession.active.sparkContext
[ERROR]                         ^
[ERROR] /var/jenkins_home/workspace/BigDL2.0-NB-Deploy-SCALA/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nnframes/TreeModel.scala:620: value active is not a member of object org.apache.spark.sql.SparkSession
[ERROR]   val sc = SparkSession.active.sparkContext
[ERROR]                         ^
[WARNING] /var/jenkins_home/workspace/BigDL2.0-NB-Deploy-SCALA/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/caffe/CaffeLoader.scala:578: This catches all Throwables. If this is really intended, use `case e : Throwable` to clear this warning.
```
