### PR TITLE
[backport] add spark313 test script

### DIFF
--- a/python/dev/release_default_linux_spark313.sh
+++ b/python/dev/release_default_linux_spark313.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is the default script with maven parameters to release all the bigdl sub-packages
+# built on top of Spark 3.1.2 for linux.
+
+set -e
+RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
+echo $RUN_SCRIPT_DIR
+BIGDL_DIR="$(cd ${RUN_SCRIPT_DIR}/../..; pwd)"
+echo $BIGDL_DIR
+
+if (( $# < 3)); then
+  echo "Usage: release_default_linux_spark313.sh version quick_build upload suffix mvn_pa                    rameters"
+  echo "Usage example: bash release_default_linux_spark313.sh default false true true"
+  echo "Usage example: bash release_default_linux_spark313.sh 0.14.0.dev1 false false tru                    e"
+  echo "Usage example: bash release_default_linux_spark313.sh 0.14.0.dev1 false false fal                    se -Ddata-store-url=.."
+  exit -1
+fi
+
+version=$1
+quick=$2
+upload=$3
+if (( $# < 4)); then
+  suffix=true
+  profiles=${*:4}
+else
+  suffix=$4
+  profiles=${*:5}
+fi
+
+bash ${RUN_SCRIPT_DIR}/release_default_spark.sh linux ${version} ${quick} ${upload} 3.1.3                     ${suffix} ${profiles}

--- a/python/dev/release_default_linux_spark313.sh
+++ b/python/dev/release_default_linux_spark313.sh
@@ -26,10 +26,10 @@ BIGDL_DIR="$(cd ${RUN_SCRIPT_DIR}/../..; pwd)"
 echo $BIGDL_DIR
 
 if (( $# < 3)); then
-  echo "Usage: release_default_linux_spark313.sh version quick_build upload suffix mvn_pa                    rameters"
+  echo "Usage: release_default_linux_spark313.sh version quick_build upload suffix mvn_parameters"
   echo "Usage example: bash release_default_linux_spark313.sh default false true true"
-  echo "Usage example: bash release_default_linux_spark313.sh 0.14.0.dev1 false false tru                    e"
-  echo "Usage example: bash release_default_linux_spark313.sh 0.14.0.dev1 false false fal                    se -Ddata-store-url=.."
+  echo "Usage example: bash release_default_linux_spark313.sh 0.14.0.dev1 false false true"
+  echo "Usage example: bash release_default_linux_spark313.sh 0.14.0.dev1 false false false -Ddata-store-url=.."
   exit -1
 fi
 
@@ -44,4 +44,4 @@ else
   profiles=${*:5}
 fi
 
-bash ${RUN_SCRIPT_DIR}/release_default_spark.sh linux ${version} ${quick} ${upload} 3.1.3                     ${suffix} ${profiles}
+bash ${RUN_SCRIPT_DIR}/release_default_spark.sh linux ${version} ${quick} ${upload} 3.1.3 ${suffix} ${profiles}

--- a/python/dev/release_default_linux_spark313.sh
+++ b/python/dev/release_default_linux_spark313.sh
@@ -43,5 +43,4 @@ else
   suffix=$4
   profiles=${*:5}
 fi
-
 bash ${RUN_SCRIPT_DIR}/release_default_spark.sh linux ${version} ${quick} ${upload} 3.1.3 ${suffix} ${profiles}

--- a/python/dev/release_default_mac_spark313.sh
+++ b/python/dev/release_default_mac_spark313.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is the default script with maven parameters to release all the bigdl sub-packages
+# built on top of Spark 3.1.2 for mac.
+
+set -e
+RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
+echo $RUN_SCRIPT_DIR
+BIGDL_DIR="$(cd ${RUN_SCRIPT_DIR}/../..; pwd)"
+echo $BIGDL_DIR
+
+if (( $# < 3)); then
+  echo "Usage: release_default_mac_spark312.sh version quick_build upload suffix mvn_parameters"
+  echo "Usage example: bash release_default_mac_spark313.sh default false true true"
+  echo "Usage example: bash release_default_mac_spark313.sh 0.14.0.dev1 false false true"
+  echo "Usage example: bash release_default_mac_spark246.sh 0.14.0.dev1 false false false -Ddata-store-url=.."
+  exit -1
+fi
+
+version=$1
+quick=$2
+upload=$3
+if (( $# < 4)); then
+  suffix=true
+  profiles=${*:4}
+else
+  suffix=$4
+  profiles=${*:5}
+fi
+
+bash ${RUN_SCRIPT_DIR}/release_default_spark.sh mac ${version} ${quick} ${upload} 3.1.3 ${suffix} ${profiles}

--- a/python/dev/release_default_mac_spark313.sh
+++ b/python/dev/release_default_mac_spark313.sh
@@ -43,5 +43,4 @@ else
   suffix=$4
   profiles=${*:5}
 fi
-
 bash ${RUN_SCRIPT_DIR}/release_default_spark.sh mac ${version} ${quick} ${upload} 3.1.3 ${suffix} ${profiles}


### PR DESCRIPTION
## Description

add release_default_linux_spark313.sh and release_default_mac_spark313.sh

### 1. Why the change?

bash: python/dev/release_default_linux_spark313.sh: No such file or directory
http://10.112.231.51:18888/job/ZOO-NB-BigDL-Python-Spark-3.1-py36/404/console
