### PR TITLE
Chronos: add description about thread_num control for openvino in how-to guide

### DIFF
--- a/python/chronos/colab-notebook/howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.ipynb
+++ b/python/chronos/colab-notebook/howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.ipynb
@@ -147,7 +147,10 @@
    "source": [
     "> 📝**Note**\n",
     "> \n",
-    "> `build_openvino` is recommended to use when you want to alleviate the cold start problem when `predict_with_openvino` is called for the first time.\n",
+    "> `build_openvino` is recommended to use in following cases:\n",
+    "> \n",
+    "> 1. To strictly control the thread to be used during inferencing.\n",
+    "> 2. To alleviate the cold start problem when `predict_with_openvino` is called for the first time.\n",
     "> \n",
     "> Please refer to [API documentation](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Chronos/forecasters.html#bigdl.chronos.forecaster.tcn_forecaster.TCNForecaster.build_openvino) for more information on `build_openvino`."
    ]


### PR DESCRIPTION
## Description

Since we have now supported thread_num control for openvino in forecaster, we should add this description in how-to guide.

### 4. How to test?
- [x] Document test
https://binbin-5901.readthedocs.io/en/latest/doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.html
