### PR TITLE
Add attribute sys.stdout.fileno when it is missed on Databricks

### DIFF
--- a/python/orca/src/bigdl/orca/ray/raycontext.py
+++ b/python/orca/src/bigdl/orca/ray/raycontext.py
@@ -30,6 +30,9 @@ class OrcaRayContext(object):
                  cores=2,
                  num_nodes=1,
                  **kwargs):
+        import sys
+        if not hasattr(sys.stdout, 'fileno'):
+            sys.stdout.fileno = lambda: 1
 
         self.runtime = runtime
         self.initialized = False

--- a/python/orca/src/bigdl/orca/ray/raycontext.py
+++ b/python/orca/src/bigdl/orca/ray/raycontext.py
@@ -30,9 +30,10 @@ class OrcaRayContext(object):
                  cores=2,
                  num_nodes=1,
                  **kwargs):
-        # Add sys.stdout.fileno for Databricks. In Databricks notebook, sys.stdout is redirected to a ConsoleBuffer
-        # object, this object has no attribute fileno, and cause ray init crash. Normally, sys.stdout should have
-        # attribute fileno and is set to 1. So set sys.stdout.fileno to 1 when this attribute is missing.
+        # Add sys.stdout.fileno for Databricks. In Databricks notebook, sys.stdout is redirected to
+        # a ConsoleBuffer object, this object has no attribute fileno, and cause ray init crash.
+        # Normally, sys.stdout should have attribute fileno and is set to 1.
+        # So set sys.stdout.fileno to 1 when this attribute is missing.
         import sys
         if not hasattr(sys.stdout, 'fileno'):
             sys.stdout.fileno = lambda: 1

--- a/python/orca/src/bigdl/orca/ray/raycontext.py
+++ b/python/orca/src/bigdl/orca/ray/raycontext.py
@@ -30,6 +30,9 @@ class OrcaRayContext(object):
                  cores=2,
                  num_nodes=1,
                  **kwargs):
+        # Add sys.stdout.fileno for Databricks. In Databricks notebook, sys.stdout is redirect to a ConsoleBuffer
+        # object, this object has no attribute fileno, and cause ray init crash. Normally, sys.stdout should have
+        # attribute fileno and is set to 1. So set sys.stdout.fileno to 1 when this attribute is missed
         import sys
         if not hasattr(sys.stdout, 'fileno'):
             sys.stdout.fileno = lambda: 1

--- a/python/orca/src/bigdl/orca/ray/raycontext.py
+++ b/python/orca/src/bigdl/orca/ray/raycontext.py
@@ -30,9 +30,9 @@ class OrcaRayContext(object):
                  cores=2,
                  num_nodes=1,
                  **kwargs):
-        # Add sys.stdout.fileno for Databricks. In Databricks notebook, sys.stdout is redirect to a ConsoleBuffer
+        # Add sys.stdout.fileno for Databricks. In Databricks notebook, sys.stdout is redirected to a ConsoleBuffer
         # object, this object has no attribute fileno, and cause ray init crash. Normally, sys.stdout should have
-        # attribute fileno and is set to 1. So set sys.stdout.fileno to 1 when this attribute is missed
+        # attribute fileno and is set to 1. So set sys.stdout.fileno to 1 when this attribute is missing.
         import sys
         if not hasattr(sys.stdout, 'fileno'):
             sys.stdout.fileno = lambda: 1


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->
In [Databricks RayDemo](https://www.databricks.com/notebooks/raydemo.html) mentioned:
```python
# Ray will crash unless sys.stdout is modified.
import sys
 
sys.stdout.fileno = lambda: 0
```
This is because in Databricks notebook, sys.stdout is redirect to a `ConsoleBuffer` object, this object has no attribute fileno, and cause ray init crash. Normally, sys.stdout should have attribute fileno and is set to 1. So set sys.stdout.fileno to 1 when this attribute is missed, this should fix the bug when run BigDL ray backend on Databricks, and should not affect non-Databricks env.

This is verified on Databricks.