### PR TITLE
Orca: fix port variable name.

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -569,4 +569,4 @@ class PyTorchPySparkEstimator(BaseEstimator):
         Shutdown estimator and release resources.
         """
         if self.need_to_log_to_driver:
-            stop_log_server(self.log_server_thread, self.ip, self.port)
+            stop_log_server(self.log_server_thread, self.ip, self.log_port)


### PR DESCRIPTION
## Description

This PR is to hotfix port variable name. `self.port` -> `self.log_port`
