### PR TITLE
Chronos: a new API called `export_openvino_file`

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -1127,7 +1127,7 @@ class BasePytorchForecaster(Forecaster):
                                            accelerator="openvino",
                                            thread_num=thread_num)
 
-    def export_onnx_file(self, dirname="fp32_onnx", quantized_dirname="quantized_onnx"):
+    def export_onnx_file(self, dirname="fp32_onnx", quantized_dirname=None):
         """
         Save the onnx model file to the disk.
 
@@ -1149,7 +1149,7 @@ class BasePytorchForecaster(Forecaster):
             Trainer.save(self.onnxruntime_fp32, dirname)
 
     def export_openvino_file(self, dirname="fp32_openvino",
-                             quantized_dirname="quantized_openvino"):
+                             quantized_dirname=None):
         """
         Save the openvino model file to the disk.
 

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -1127,11 +1127,12 @@ class BasePytorchForecaster(Forecaster):
                                            accelerator="openvino",
                                            thread_num=thread_num)
 
-    def export_onnx_file(self, dirname="model.onnx", quantized_dirname="qmodel.onnx"):
+    def export_onnx_file(self, dirname="fp32_onnx", quantized_dirname="quantized_onnx"):
         """
         Save the onnx model file to the disk.
 
         :param dirname: The dir location you want to save the onnx file.
+        :param quantized_dirname: The dir location you want to save the quantized onnx file.
         """
         from bigdl.chronos.pytorch import TSTrainer as Trainer
         from bigdl.nano.utils.log4Error import invalidInputError
@@ -1140,14 +1141,34 @@ class BasePytorchForecaster(Forecaster):
                               "export_onnx_file has not been supported for distributed "
                               "forecaster. You can call .to_local() to transform the "
                               "forecaster to a non-distributed version.")
-        dummy_input = torch.rand(1, self.data_config["past_seq_len"],
-                                 self.data_config["input_feature_num"])
         if quantized_dirname:
             Trainer.save(self.onnxruntime_int8, dirname)
         if dirname:
             if self.onnxruntime_fp32 is None:
                 self.build_onnx()
             Trainer.save(self.onnxruntime_fp32, dirname)
+
+    def export_openvino_file(self, dirname="fp32_openvino",
+                             quantized_dirname="quantized_openvino"):
+        """
+        Save the openvino model file to the disk.
+
+        :param dirname: The dir location you want to save the openvino file.
+        :param quantized_dirname: The dir location you want to save the quantized openvino file.
+        """
+        from bigdl.chronos.pytorch import TSTrainer as Trainer
+        from bigdl.nano.utils.log4Error import invalidInputError
+        if self.distributed:
+            invalidInputError(False,
+                              "export_openvino_file has not been supported for distributed "
+                              "forecaster. You can call .to_local() to transform the "
+                              "forecaster to a non-distributed version.")
+        if quantized_dirname:
+            Trainer.save(self.openvino_int8, dirname)
+        if dirname:
+            if self.openvino_fp32 is None:
+                self.build_openvino()
+            Trainer.save(self.openvino_fp32, dirname)
 
     def quantize(self, calib_data=None,
                  val_data=None,

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -190,6 +190,12 @@ class TestChronosModelLSTMForecaster(TestCase):
         except ImportError:
             pass
 
+        # test exporting the openvino
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            ckpt_name = os.path.join(tmp_dir_name, "fp32_openvino")
+            ckpt_name_q = os.path.join(tmp_dir_name, "int_openvino")
+            forecaster.export_openvino_file(dirname=ckpt_name, quantized_dirname=ckpt_name_q)
+
     def test_lstm_forecaster_quantization(self):
         train_data, val_data, test_data = create_data()
         forecaster = LSTMForecaster(past_seq_len=24,
@@ -254,8 +260,8 @@ class TestChronosModelLSTMForecaster(TestCase):
         pred_q = forecaster.predict_with_onnx(test_data[0], quantize=True)
         eval_q = forecaster.evaluate_with_onnx(test_data, quantize=True)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
-            ckpt_name = os.path.join(tmp_dir_name, "ckpt")
-            ckpt_name_q = os.path.join(tmp_dir_name, "ckpt.q")
+            ckpt_name = os.path.join(tmp_dir_name, "fp32_onnx")
+            ckpt_name_q = os.path.join(tmp_dir_name, "int_onnx")
             forecaster.export_onnx_file(dirname=ckpt_name, quantized_dirname=ckpt_name_q)
 
     def test_lstm_forecaster_save_load(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -182,6 +182,12 @@ class TestChronosNBeatsForecaster(TestCase):
         except ImportError:
             pass
 
+        # test exporting the openvino
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            ckpt_name = os.path.join(tmp_dir_name, "fp32_openvino")
+            ckpt_name_q = os.path.join(tmp_dir_name, "int_openvino")
+            forecaster.export_openvino_file(dirname=ckpt_name, quantized_dirname=ckpt_name_q)
+
     def test_nbeats_forecaster_quantization(self):
         train_data, val_data, test_data = create_data()
         forecaster = NBeatsForecaster(past_seq_len=24,
@@ -247,8 +253,8 @@ class TestChronosNBeatsForecaster(TestCase):
         pred_q = forecaster.predict_with_onnx(test_data[0], quantize=True)
         eval_q = forecaster.evaluate_with_onnx(test_data, quantize=True)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
-            ckpt_name = os.path.join(tmp_dir_name, "ckpt")
-            ckpt_name_q = os.path.join(tmp_dir_name, "ckpt.q")
+            ckpt_name = os.path.join(tmp_dir_name, "fp32_onnx")
+            ckpt_name_q = os.path.join(tmp_dir_name, "int_onnx")
             forecaster.export_onnx_file(dirname=ckpt_name, quantized_dirname=ckpt_name_q)
 
     def test_nbeats_forecaster_save_load(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -182,6 +182,12 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
         except ImportError:
             pass
 
+        # test exporting the openvino
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            ckpt_name = os.path.join(tmp_dir_name, "fp32_openvino")
+            ckpt_name_q = os.path.join(tmp_dir_name, "int_openvino")
+            forecaster.export_openvino_file(dirname=ckpt_name, quantized_dirname=ckpt_name_q)
+
     def test_s2s_forecaster_quantization(self):
         train_data, val_data, test_data = create_data()
         forecaster = Seq2SeqForecaster(past_seq_len=24,

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -312,6 +312,12 @@ class TestChronosModelTCNForecaster(TestCase):
         q_openvino_yhat = forecaster.predict_with_openvino(test_data[0], quantize=True)
         assert openvino_yhat.shape == q_openvino_yhat.shape == test_data[1].shape
 
+        # test exporting the openvino
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            ckpt_name = os.path.join(tmp_dir_name, "fp32_openvino")
+            ckpt_name_q = os.path.join(tmp_dir_name, "int_openvino")
+            forecaster.export_openvino_file(dirname=ckpt_name, quantized_dirname=ckpt_name_q)
+
     def test_tcn_forecaster_quantization_dynamic(self):
         train_data, val_data, test_data = create_data()
         forecaster = TCNForecaster(past_seq_len=24,
@@ -402,8 +408,8 @@ class TestChronosModelTCNForecaster(TestCase):
         pred_q = forecaster.predict_with_onnx(test_data[0], quantize=True)
         eval_q = forecaster.evaluate_with_onnx(test_data, quantize=True)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
-            ckpt_name = os.path.join(tmp_dir_name, "ckpt")
-            ckpt_name_q = os.path.join(tmp_dir_name, "ckpt.q")
+            ckpt_name = os.path.join(tmp_dir_name, "fp32_onnx")
+            ckpt_name_q = os.path.join(tmp_dir_name, "int_onnx")
             forecaster.export_onnx_file(dirname=ckpt_name, quantized_dirname=ckpt_name_q)
 
     def test_tcn_forecaster_save_load(self):


### PR DESCRIPTION
## Description

### 1. Why the change?

Need symmetric method `export_openvino_file` for openvino.

### 2. User API changes
Add a new API called `export_openvino_file`, with 2 parameters for fp32 and int8 ckpt.

### 3. Summary of the change 


### 4. How to test?
- [ ] Unit test

