### PR TITLE
[Nano] Add openvino tutorial test scripts and add them into workflow

### DIFF
--- a/.github/workflows/nano_notebooks_tests.yml
+++ b/.github/workflows/nano_notebooks_tests.yml
@@ -126,6 +126,25 @@ jobs:
             $CONDA/bin/conda remove -n notebooks-tutorial-pytorch --all
         env:
             ANALYTICS_ZOO_ROOT: ${{ github.workspace }}  
+    
+    - name: Run tutorial notebooks OpenVINO unit tests
+        shell: bash
+        run: |
+            $CONDA/bin/conda create -n notebooks-tutorial-openvino -y python==3.7.10 setuptools=58.0.4
+            source $CONDA/bin/activate notebooks-tutorial-openvino
+            $CONDA/bin/conda info
+            bash python/nano/dev/release_default_linux.sh default false
+            whl_name=`ls python/nano/dist`
+            pip install python/nano/dist/${whl_name}
+            source bigdl-nano-init
+            pip install pytest nbmake
+            pip install ipykernel==5.5.6
+            pip install openvino-dev
+            bash python/nano/tutorial/inference/openvino/run_nano_openvino_inference_tests.sh
+            source $CONDA/bin/deactivate
+            $CONDA/bin/conda remove -n notebooks-tutorial-openvino --all
+        env:
+            ANALYTICS_ZOO_ROOT: ${{ github.workspace }}  
 
   nano-notebooks-tensorflow-test:
     # The type of runner that the job will run on

--- a/.github/workflows/nano_notebooks_tests.yml
+++ b/.github/workflows/nano_notebooks_tests.yml
@@ -126,23 +126,6 @@ jobs:
             $CONDA/bin/conda remove -n notebooks-tutorial-pytorch --all
         env:
             ANALYTICS_ZOO_ROOT: ${{ github.workspace }}  
-    
-      - name: Run tutorial notebooks OpenVINO unit tests
-        shell: bash
-        run: |
-            $CONDA/bin/conda create -n notebooks-tutorial-openvino -y python==3.7.10 setuptools=58.0.4
-            source $CONDA/bin/activate notebooks-tutorial-openvino
-            $CONDA/bin/conda info
-            bash python/nano/dev/release_default_linux.sh default false
-            whl_name=`ls python/nano/dist`
-            pip install python/nano/dist/${whl_name}
-            source bigdl-nano-init
-            pip install openvino-dev
-            bash python/nano/tutorial/inference/openvino/run_nano_openvino_inference_tests.sh
-            source $CONDA/bin/deactivate
-            $CONDA/bin/conda remove -n notebooks-tutorial-openvino --all
-        env:
-            ANALYTICS_ZOO_ROOT: ${{ github.workspace }}  
 
   nano-notebooks-tensorflow-test:
     # The type of runner that the job will run on
@@ -197,5 +180,45 @@ jobs:
             bash python/nano/notebooks/tensorflow/tutorial/run-nano-notebooks-tensorflow-tutorial-tests.sh
             source $CONDA/bin/deactivate
             $CONDA/bin/conda remove -n notebooks-tutorial-tensorflow --all
+        env:
+            ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
+
+  nano-notebooks-OpenVINO-test:
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-20.04"]
+        python-version: ["3.7"]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools==58.0.4
+          python -m pip install --upgrade wheel  
+    
+      - name: Run tutorial notebooks OpenVINO unit tests
+        shell: bash
+        run: |
+            $CONDA/bin/conda create -n notebooks-tutorial-openvino -y python==3.7.10 setuptools=58.0.4
+            source $CONDA/bin/activate notebooks-tutorial-openvino
+            $CONDA/bin/conda info
+            bash python/nano/dev/release_default_linux.sh default false
+            whl_name=`ls python/nano/dist`
+            pip install python/nano/dist/${whl_name}
+            source bigdl-nano-init
+            pip install openvino-dev
+            bash python/nano/tutorial/inference/openvino/run_nano_openvino_inference_tests.sh
+            source $CONDA/bin/deactivate
+            $CONDA/bin/conda remove -n notebooks-tutorial-openvino --all
         env:
             ANALYTICS_ZOO_ROOT: ${{ github.workspace }}

--- a/.github/workflows/nano_notebooks_tests.yml
+++ b/.github/workflows/nano_notebooks_tests.yml
@@ -137,8 +137,6 @@ jobs:
             whl_name=`ls python/nano/dist`
             pip install python/nano/dist/${whl_name}
             source bigdl-nano-init
-            pip install pytest nbmake
-            pip install ipykernel==5.5.6
             pip install openvino-dev
             bash python/nano/tutorial/inference/openvino/run_nano_openvino_inference_tests.sh
             source $CONDA/bin/deactivate

--- a/.github/workflows/nano_notebooks_tests.yml
+++ b/.github/workflows/nano_notebooks_tests.yml
@@ -212,9 +212,7 @@ jobs:
             $CONDA/bin/conda create -n notebooks-tutorial-openvino -y python==3.7.10 setuptools=58.0.4
             source $CONDA/bin/activate notebooks-tutorial-openvino
             $CONDA/bin/conda info
-            bash python/nano/dev/release_default_linux.sh default false
-            whl_name=`ls python/nano/dist`
-            pip install python/nano/dist/${whl_name}
+            bash python/nano/dev/build_and_install.sh linux default false basic
             source bigdl-nano-init
             pip install openvino-dev
             bash python/nano/tutorial/inference/openvino/run_nano_openvino_inference_tests.sh

--- a/.github/workflows/nano_notebooks_tests.yml
+++ b/.github/workflows/nano_notebooks_tests.yml
@@ -127,7 +127,7 @@ jobs:
         env:
             ANALYTICS_ZOO_ROOT: ${{ github.workspace }}  
     
-    - name: Run tutorial notebooks OpenVINO unit tests
+      - name: Run tutorial notebooks OpenVINO unit tests
         shell: bash
         run: |
             $CONDA/bin/conda create -n notebooks-tutorial-openvino -y python==3.7.10 setuptools=58.0.4

--- a/python/nano/tutorial/inference/openvino/run_nano_openvino_inference_tests.sh
+++ b/python/nano/tutorial/inference/openvino/run_nano_openvino_inference_tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+export ANALYTICS_ZOO_ROOT=${ANALYTICS_ZOO_ROOT}
+export NANO_HOME=${ANALYTICS_ZOO_ROOT}/python/nano/src
+export NANO_TUTORIAL_TEST_DIR=${ANALYTICS_ZOO_ROOT}/python/nano/tutorial/inference/openvino/
+
+set -e
+
+python $NANO_TUTORIAL_TEST_DIR/openvino_inference_sync.py
+
+python $NANO_TUTORIAL_TEST_DIR/openvino_inference_async.py
+

--- a/python/nano/tutorial/inference/openvino/run_nano_openvino_inference_tests.sh
+++ b/python/nano/tutorial/inference/openvino/run_nano_openvino_inference_tests.sh
@@ -6,6 +6,10 @@ export NANO_TUTORIAL_TEST_DIR=${ANALYTICS_ZOO_ROOT}/python/nano/tutorial/inferen
 
 set -e
 
+# Download model
+
+omz_downloader --name resnet18-xnor-binary-onnx-0001 -o ./model
+
 python $NANO_TUTORIAL_TEST_DIR/openvino_inference_sync.py
 
 python $NANO_TUTORIAL_TEST_DIR/openvino_inference_async.py


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->
Add OpenVINO tutorial test scripts and add them to github workflow as part of nano-notebook-tests.
### 1. Why the change?

<!-- Provide the related github issue link if available -->
As mentioned in PR #5832, the OpenVINO fundamental examples need test scripts and the test scripts should be added to github workflow.
### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->
N/A
### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
- Add OpenVINO tutorial test scripts
- Add a new job (nano-notebooks-OpenVINO-test) in `Nano Unit Tests for Notebooks` workflow
### 4. How to test?
- [ ] Unit test