### PR TITLE
Fix the access of custom attributes when using `TorchNano` and multi-instance training

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/torch_nano.py
+++ b/python/nano/src/bigdl/nano/pytorch/torch_nano.py
@@ -55,7 +55,12 @@ class _TorchNanoModule(_LiteModule):
         except AttributeError:
             pass
 
+        # When using multi-instance training, self.module will be DistributedDataParallel(DDP),
+        # otherwise, `self.module` will be original module.
         if isinstance(self.module, DistributedDataParallel):
+            # just in case that users try to access an attribute of DDP
+            # or an attribute of both DDP and original model,
+            # we should first try to find it in DDP
             try:
                 return getattr(self.module, name)
             except AttributeError:

--- a/python/nano/src/bigdl/nano/pytorch/torch_nano.py
+++ b/python/nano/src/bigdl/nano/pytorch/torch_nano.py
@@ -48,7 +48,7 @@ class _TorchNanoModule(_LiteModule):
 
     def __getattr__(self, name: str):
         # automatically unwrap attributes access of _LiteModule,
-        # always raise a single-level exception when the attribute doesn't exist
+        # always throw a single-level exception when the attribute doesn't exist
         # for a more user-friendly exception message
         try:
             return super().__getattr__(name)

--- a/python/nano/test/pytorch/tests/test_torch_nano.py
+++ b/python/nano/test/pytorch/tests/test_torch_nano.py
@@ -106,12 +106,7 @@ class MyNanoCorrectness(TorchNano):
                 self.backward(loss)
                 optimizer.step()
 
-        try:
-            assert model._module.fc1.weight.data == 0.25, \
-                f"wrong weights: {model._module.fc1.weight.data}"
-        except:
-            assert model._module.module.fc1.weight.data == 0.25, \
-                f"wrong weights: {model._module.module.fc1.weight.data}"
+        assert model.fc1.weight.data == 0.25, f"wrong weights: {model.fc1.weight.data}"
 
 
 class MyNanoAccess(TorchNano):
@@ -183,8 +178,7 @@ class MyNanoLoadStateDict(TorchNano):
         model.train()
         train_one_epoch(model, optimizer, loss_func, train_loader)
 
-        assert model._module.fc1.weight.data == 0.25, \
-            f"wrong weights: {model._module.fc1.weight.data}"
+        assert model.fc1.weight.data == 0.25, f"wrong weights: {model.fc1.weight.data}"
 
 
 class TestLite(TestCase):
@@ -216,11 +210,17 @@ class TestLite(TestCase):
     def test_torch_nano_attribute_access(self):
         MyNanoAccess().train()
 
+    def test_torch_nano_attribute_access_ddp(self):
+        MyNanoAccess(num_processes=2).train()
+
     def test_torch_nano_multi_optimizer(self):
         MyNanoMultiOptimizer().train()
 
     def test_torch_nano_load_state_dict(self):
         MyNanoLoadStateDict().train(0.25)
+
+    def test_torch_nano_load_state_dict_ddp(self):
+        MyNanoLoadStateDict(num_processes=2).train(0.5)
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/python/nano/test/pytorch/tests/test_torch_nano_ipex.py
+++ b/python/nano/test/pytorch/tests/test_torch_nano_ipex.py
@@ -104,12 +104,7 @@ class MyNanoCorrectness(TorchNano):
                 self.backward(loss)
                 optimizer.step()
 
-        try:
-            assert model._module.fc1.weight.data == 0.25, \
-                f"wrong weights: {model._module.fc1.weight.data}"
-        except:
-            assert model._module.module.fc1.weight.data == 0.25, \
-                f"wrong weights: {model._module.module.fc1.weight.data}"
+        assert model.fc1.weight.data == 0.25, f"wrong weights: {model.fc1.weight.data}"
 
 
 class MyNanoLoadStateDict(TorchNano):
@@ -142,8 +137,7 @@ class MyNanoLoadStateDict(TorchNano):
         model.train()
         train_one_epoch(model, optimizer, loss_func, train_loader)
 
-        assert model._module.fc1.weight.data == 0.25, \
-            f"wrong weights: {model._module.fc1.weight.data}"
+        assert model.fc1.weight.data == 0.25, f"wrong weights: {model.fc1.weight.data}"
 
 
 class TestLite(TestCase):

--- a/python/nano/test/ray/test_torch_nano_ray.py
+++ b/python/nano/test/ray/test_torch_nano_ray.py
@@ -102,8 +102,7 @@ class MyNanoCorrectness(TorchNano):
                 self.backward(loss)
                 optimizer.step()
 
-        assert model._module.module.fc1.weight.data == 0.25, \
-            f"wrong weights: {model._module.module.fc1.weight.data}"
+        assert model.fc1.weight.data == 0.25, f"wrong weights: {model.fc1.weight.data}"
 
 
 class TestLite(TestCase):


### PR DESCRIPTION
## Description

- Fix the access of custom attributes when using `TorchNano` and multi-instance training.
- Fix the state dict saved by multi-instance training cannot be loaded in single-instance training.

### 1. Why the change?

Before this PR, when user runs multi-instance training(i.e. set `num_processes=n`, where n>1), he cannot access the custom properties of the model. For example:

```python
class MyNano(TorchNano):
    def train():
        origin_model = ModelClass(...)
        model = self.setup(origin_model)
        model.xxx
``` 

Here `model` is an instance of `_TorchNanoModule`.
If `xxx` attribute doesn't exist in `_TorchNanoModule`, `_TorchNanoModule` will find `xxx` attribute in `model.module`, which is the original model in non-multi-instance training. 
However, when using multi-instance training, `model.module` will be DDP(DistributedDataParallel), instead, `model.module.module` will be the original model.

Before this PR, user cannot load the state dict saved by multi-instance training.

### 2. User API changes

Before this PR, user can only use `model.custom_attribute` to access custom attributes in single-instance training, he must use `model.module.custom_attribute` in multi-instance training.

Now user can use `model.custom_attribute` in both single-instance and multi-instance training.

Now user can load the state dict saved by multi-instance training.

### 3. Summary of the change 

- Fix the access of custom attributes when using `TorchNano` and multi-instance training
- Fix the state dict saved by multi-instance training cannot be loaded in single-instance training
- Add and fix UT

### 4. How to test?
- [ ] N/A
- [X] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

