### PR TITLE
Nano : add sample size for quantize

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -188,6 +188,10 @@ class InferenceOptimizer:
             invalidInputError(False,
                               "training_data is incompatible with your model input.")
         baseline_time = time.perf_counter() - st
+        if baseline_time > 0.1:  # 100ms
+            sample_size_for_pot = 15
+        else:
+            sample_size_for_pot = 100
 
         print("==========================Start Optimization==========================")
         start_time = time.perf_counter()
@@ -243,6 +247,7 @@ class InferenceOptimizer:
                                                         calib_dataloader=training_data,
                                                         method=ort_method,
                                                         thread_num=thread_num,
+                                                        sample_size=sample_size_for_pot,
                                                         # remove output of openvino
                                                         logging=logging)
                     except Exception as e:
@@ -404,6 +409,7 @@ class InferenceOptimizer:
                  input_sample=None,
                  thread_num: int = None,
                  onnxruntime_session_options=None,
+                 sample_size: int = 100,
                  logging: bool = True,
                  **export_kwargs):
         """
@@ -452,6 +458,9 @@ class InferenceOptimizer:
                            or accelerator='openvino'.
         :param onnxruntime_session_options: The session option for onnxruntime, only valid when
                                             accelerator='onnxruntime', otherwise will be ignored.
+        :param sample_size: (optional) a int represents how many samples will be used for
+                            Post-training Optimization Tools (POT) from OpenVINO toolkit,
+                            only valid for accelerator='openvino'. default to 100.
         :param logging: whether to log detailed information of model conversion, only valid when
                         accelerator='openvino', otherwise will be ignored. default: True.
         :param **export_kwargs: will be passed to torch.onnx.export function.
@@ -558,7 +567,7 @@ class InferenceOptimizer:
                     "max_iter_num": max_trials,
                     # TODO following two keys are optional, if there is need, we can add them
                     # "n_requests": None,
-                    # "sample_size": 300
+                    "sample_size": sample_size
                 }
                 return model.pot(calib_dataloader, **kwargs)
             else:


### PR DESCRIPTION
## Description

During demo writing, we find in some cases, openvino pot process cost too much time (more than 10 minutes).
So plan to expose `sample_size` paramter of pot to quantize, and manully change it in optimize().

### 1. Why the change?

Reduce time cost of openvino pot process.

### 2. User API changes

new parameter of quantize : 
`InferenceOptimizer.quantize(..., sample_size=15)`

### 3. Summary of the change 

expose `sample_size` paramter of pot to quantize, and manully change it in optimize()

### 4. How to test?
- [ ] Unit test
- [ ] Application test

case : binary_classification_for_defect_detection
After this change: 
![image](https://user-images.githubusercontent.com/105281011/191906472-d7249b20-5743-4c4e-bd73-848622ce4336.png)
