### PR TITLE
fix DBFS file path problem on Dataricks

### DIFF
--- a/python/orca/src/bigdl/orca/data/file.py
+++ b/python/orca/src/bigdl/orca/data/file.py
@@ -540,12 +540,11 @@ def get_remote_files_with_prefix_to_local(remote_path_prefix, local_dir):
     return os.path.join(local_dir, prefix)
 
 
-def multi_fs_load(load_func):
+def enable_multi_fs_load_static(load_func):
     """
-
     Enable loading file or directory in multiple file systems.
     It supports local, hdfs, s3 file systems.
-    Note: this decorator is different from dllib decorator @enable_multi_fs_load.
+    Note: this decorator is different from dllib decorator @enable_multi_fs_load_static.
     This decorator can load on each worker while @enable_multi_fs_load can only load on driver.
 
     :param load_func: load file or directory function

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -29,8 +29,8 @@ from bigdl.orca.learn.utils import maybe_dataframe_to_xshards, dataframe_to_xsha
 from bigdl.orca.data import SparkXShards
 from bigdl.orca import OrcaContext
 from bigdl.orca.learn.base_estimator import BaseEstimator
-from bigdl.dllib.utils.file_utils import enable_multi_fs_load, enable_multi_fs_save, \
-    get_remote_file_to_local
+from bigdl.dllib.utils.file_utils import enable_multi_fs_load, enable_multi_fs_save
+from bigdl.orca.data.file import get_remote_file_to_local
 from bigdl.dllib.utils.common import get_node_and_core_number
 from bigdl.orca.learn.log_monitor import start_log_server, stop_log_server
 
@@ -40,7 +40,6 @@ from bigdl.dllib.utils.log4Error import *
 
 
 def partition_to_creator(partition):
-
     def data_creator(config, batch_size):
         from bigdl.orca.data.utils import ray_partition_get_data_label, index_data, get_size
         from torch.utils.data import Dataset, DataLoader
@@ -71,6 +70,12 @@ def partition_to_creator(partition):
         return data_loader
 
     return data_creator
+
+
+def parse_model_dir(model_dir):
+    if model_dir and model_dir.startswith("dbfs:/"):
+        model_dir = "/dbfs/" + model_dir[len("dbfs:/"):]
+    return model_dir
 
 
 class PyTorchPySparkEstimator(BaseEstimator):
@@ -115,7 +120,7 @@ class PyTorchPySparkEstimator(BaseEstimator):
                               "If a loss_creator is not provided, you must "
                               "provide a custom training operator.")
 
-        self.model_dir = model_dir
+        self.model_dir = parse_model_dir(model_dir)
 
         self.model_creator = model_creator
         self.initialization_hook = initialization_hook
@@ -277,7 +282,7 @@ class PyTorchPySparkEstimator(BaseEstimator):
 
                 train_rdd = data.rdd.mapPartitions(lambda iter: [list(iter)])
                 val_rdd = validation_data.rdd.mapPartitions(lambda iter: [list(iter)])
-                res = train_rdd.zip(val_rdd).repartition(self.num_workers).barrier()\
+                res = train_rdd.zip(val_rdd).repartition(self.num_workers).barrier() \
                     .mapPartitions(
                     lambda iter: transform_func(iter, init_params, params)).collect()
 
@@ -319,8 +324,7 @@ class PyTorchPySparkEstimator(BaseEstimator):
         try:
             temp_dir = tempfile.mkdtemp()
             get_remote_file_to_local(os.path.join(remote_dir, "state.pkl"),
-                                     os.path.join(temp_dir, "state.pkl"),
-                                     over_write=True)
+                                     os.path.join(temp_dir, "state.pkl"))
             import pickle
             with open(os.path.join(temp_dir, "state.pkl"), 'rb') as f:
                 state_dicts = pickle.load(f)
@@ -350,7 +354,7 @@ class PyTorchPySparkEstimator(BaseEstimator):
             return PytorchPysparkWorker(**init_param).predict(**params)
 
         pred_shards = SparkXShards(xshards.rdd.mapPartitions(
-                                   lambda iter: transform_func(iter, init_params, params)))
+            lambda iter: transform_func(iter, init_params, params)))
         return pred_shards
 
     def predict(self,

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -29,7 +29,8 @@ from bigdl.orca.learn.utils import maybe_dataframe_to_xshards, dataframe_to_xsha
 from bigdl.orca.data import SparkXShards
 from bigdl.orca import OrcaContext
 from bigdl.orca.learn.base_estimator import BaseEstimator
-from bigdl.orca.data.file import get_remote_file_to_local, enable_multi_fs_save, enable_multi_fs_load
+from bigdl.orca.data.file import get_remote_file_to_local, enable_multi_fs_save, \
+    enable_multi_fs_load
 from bigdl.dllib.utils.common import get_node_and_core_number
 from bigdl.orca.learn.log_monitor import start_log_server, stop_log_server
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -29,8 +29,7 @@ from bigdl.orca.learn.utils import maybe_dataframe_to_xshards, dataframe_to_xsha
 from bigdl.orca.data import SparkXShards
 from bigdl.orca import OrcaContext
 from bigdl.orca.learn.base_estimator import BaseEstimator
-from bigdl.dllib.utils.file_utils import enable_multi_fs_load, enable_multi_fs_save
-from bigdl.orca.data.file import get_remote_file_to_local
+from bigdl.orca.data.file import get_remote_file_to_local, enable_multi_fs_save, enable_multi_fs_load
 from bigdl.dllib.utils.common import get_node_and_core_number
 from bigdl.orca.learn.log_monitor import start_log_server, stop_log_server
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -30,7 +30,7 @@ from bigdl.orca.learn.utils import maybe_dataframe_to_xshards, dataframe_to_xsha
     process_xshards_of_pandas_dataframe
 from bigdl.orca.ray import OrcaRayContext
 from bigdl.orca.learn.ray_estimator import Estimator as OrcaRayEstimator
-from bigdl.dllib.utils.file_utils import enable_multi_fs_load, enable_multi_fs_save
+from bigdl.orca.data.file import enable_multi_fs_save, enable_multi_fs_load
 from bigdl.orca.learn.pytorch.utils import find_free_port
 
 import ray

--- a/python/orca/test/bigdl/orca/data/test_file.py
+++ b/python/orca/test/bigdl/orca/data/test_file.py
@@ -18,7 +18,7 @@ import os.path
 import shutil
 import tempfile
 
-from bigdl.orca.data.file import open_image, open_text, load_numpy, exists, makedirs, write_text, multi_fs_load
+from bigdl.orca.data.file import open_image, open_text, load_numpy, exists, makedirs, write_text, enable_multi_fs_load_static
 
 
 class TestFile:
@@ -163,7 +163,7 @@ class TestFile:
 
     def test_multi_fs_load_local(self):
 
-        @multi_fs_load
+        @enable_multi_fs_load_static
         def mock_func(path):
             assert exists(path)
 
@@ -172,7 +172,7 @@ class TestFile:
 
     def test_multi_fs_load_s3(self):
 
-        @multi_fs_load
+        @enable_multi_fs_load_static
         def mock_func(path):
             assert exists(path)
 


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->
when using pytorch on Databricks, there are some problems.
- driver don't  support loading `state.pkl` from DBFS 
- don't support saving pytorch model to DBFS
- don't support loading pytorch model from DBFS

when call
```python
orca_estimator = Estimator.from_torch(model=model_creator,
                                      optimizer=optimizer_creator,
                                      loss=criterion,
                                      metrics=[Accuracy()],
                                      model_dir=model_dir',
                                      use_tqdm=True,
                                      backend=backend)
```
on Databricks cluster, model_dir should be a shared path to save files, which is a path starts with /dbfs or dbfs:/ on Databricks. but currently, the DBFS format path is not support yet, the same problem happens when call `orca_estimator.save()` or `orca_estimator.load()`

### 1. Why the change?

<!-- Provide the related github issue link if available -->
To fix the mentioned problems above.
-  support loading `state.pkl` from DBFS 
- support saving pytorch model to DBFS
- support loading pytorch model from DBFS
### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->
make sure the model save/load path starts with `/dbfs` on databricks.
### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
Fix pytorch model save/load problems on Databricks.
### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

Verified on Databricks.