### PR TITLE
[Nano] Add an option for `framework` parameter in `build_and_install.sh` to install nano without any framework

### DIFF
--- a/.github/workflows/nano_unit_tests_basic.yml
+++ b/.github/workflows/nano_unit_tests_basic.yml
@@ -41,9 +41,7 @@ jobs:
           $CONDA/bin/conda create -n bigdl-init -y python==3.7.10 setuptools==58.0.4
           source $CONDA/bin/activate bigdl-init
           $CONDA/bin/conda info
-          bash python/nano/dev/release_default_linux.sh default false
-          whl_name=`ls python/nano/dist`
-          pip install python/nano/dist/${whl_name}
+          bash python/nano/dev/build_and_install.sh linux default false basic
           source bigdl-nano-init
           if [ 0"$LD_PRELOAD" = "0" ]; then
             exit 1
@@ -74,9 +72,7 @@ jobs:
           $CONDA/bin/conda create -n openvino-basic -y python==3.7.10 setuptools=58.0.4
           source $CONDA/bin/activate openvino-basic
           $CONDA/bin/conda info
-          bash python/nano/dev/release_default_linux.sh default false
-          whl_name=`ls python/nano/dist`
-          pip install python/nano/dist/${whl_name}
+          bash python/nano/dev/build_and_install.sh linux default false basic
           pip install pytest openvino-dev
           source bigdl-nano-init
           bash python/nano/test/run-nano-basic-openvino-tests.sh

--- a/python/nano/dev/build_and_install.sh
+++ b/python/nano/dev/build_and_install.sh
@@ -24,6 +24,8 @@ if (( $# < 4)); then
   echo "Usage: build_and_install.sh platform version upload framework pip_install_options[optional]"
   echo "Usage example: bash build_and_install.sh linux default true pytorch --force-reinstall"
   echo "Usage example: bash build_and_install.sh mac 0.14.0.dev1 false tensorflow"
+  echo "To install Nano without any framework, specify framework to basic"
+  echo "Usage example: bash build_and_install.sh linux default true basic"
   exit -1
 fi
 
@@ -37,6 +39,11 @@ bash ${RUN_SCRIPT_DIR}/release.sh ${platform} ${version} ${upload}
 
 cd ${WHL_DIR}
 whl_name=`ls dist`
-pip install $install_options dist/${whl_name}[${framework}]
-
-
+if [ $framework == "basic" ];
+then
+  # when framework is specified to "basic", nano will be installed without
+  # any framework like Pytorch and TensorFlow
+  pip install $install_options dist/${whl_name}
+else
+  pip install $install_options dist/${whl_name}[${framework}]
+fi


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->
This PR wants to simplify the usage of building and installing Nano when we need to install Nano without any framework.

### 1. Why the change?

<!-- Provide the related github issue link if available -->
resolve #5919 
When inferencing with OpenVINO model using `OpenVINOModel`, we don't need to install Nano with TF or Pytorch. 
When we add test scripts to github workflow, we often use `build_and_install.sh` to build and install Nano. But the `build_and_install.sh` will raise an error when we try to install Nano without any framework, so we have to use more commands to install in this circumstance. For example, in `.github/workflows/nano_unit_tests_basic.yml`:
```bash
bash python/nano/dev/release_default_linux.sh default false
whl_name=`ls python/nano/dist`
pip install python/nano/dist/${whl_name}
```
Since these commands are already in `build_and_install.sh`, so we can add an option for the  `framework` parameter in the script to simplify the usage.
This PR adds an option "basic" to `framework` parameter, if `framework` is specified to "basic", Nano will be installed without any framework.
After this change, the install commands in `.github/workflows/nano_unit_tests_basic.yml` can be changed to:
```bash
bash python/nano/dev/build_and_install.sh linux default false basic
```
### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->
When using `build_and_install.sh` to install Nano, if `framework` is specified to "basic", Nano will be installed without any framework.
### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
- Add an option "basic" for `framework` parameter in `build_and_install.sh` to install Nano without any framework
- Simplify the install command in `.github/workflows/nano_unit_tests_basic.yml` 
### 4. How to test?
- [ ] Unit test
