### PR TITLE
[Document] Add API docs for `bigdl.nano.tf.keras.layers.Embedding` and `bigdl.nano.tf.optimizers.SparseAdam`

### DIFF
--- a/docs/readthedocs/source/doc/PythonAPI/Nano/tensorflow.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Nano/tensorflow.rst
@@ -12,3 +12,13 @@ bigdl.nano.tf.keras
     :members:
     :undoc-members:
     :inherited-members: Sequential
+
+.. autoclass:: bigdl.nano.tf.keras.layers.Embedding
+    :members:
+    :undoc-members:
+
+bigdl.nano.tf.optimizers
+---------------------------
+.. autoclass:: bigdl.nano.tf.optimizers.SparseAdam
+    :members: 
+    :undoc-members:

--- a/python/nano/src/bigdl/nano/tf/keras/layers/embeddings.py
+++ b/python/nano/src/bigdl/nano/tf/keras/layers/embeddings.py
@@ -40,11 +40,6 @@ class Embedding(TFEmbedding):
         """
         Create a slightly modified version of tf.keras.Embedding layer.
 
-        :param input_sample: torch.Tensor or a list for the model tracing.
-        :param file_path: The path to save onnx model file.
-        :param sess_options: ortsess options in ort.SessionOptions type
-        :param **kwargs: will be passed to torch.onnx.export function.
-
         :param input_dim: Integer. Size of the vocabulary,
             i.e. maximum integer index + 1.
         :param output_dim: Integer. Dimension of the dense embedding.

--- a/python/nano/src/bigdl/nano/tf/keras/layers/embeddings.py
+++ b/python/nano/src/bigdl/nano/tf/keras/layers/embeddings.py
@@ -40,9 +40,6 @@ class Embedding(TFEmbedding):
         """
         Create a slightly modified version of tf.keras.Embedding layer.
 
-        This embedding layer only applies regularizer to the output of the embedding
-        layer, so that the gradient to embeddings is sparse.
-
         :param input_sample: torch.Tensor or a list for the model tracing.
         :param file_path: The path to save onnx model file.
         :param sess_options: ortsess options in ort.SessionOptions type
@@ -69,7 +66,7 @@ class Embedding(TFEmbedding):
             If mask_zero is set to True, as a consequence, index 0 cannot be
             used in the vocabulary (input_dim should equal size of
             vocabulary + 1).
-        param: input_length: Length of input sequences, when it is constant.
+        :param input_length: Length of input sequences, when it is constant.
             This argument is required if you are going to connect
             `Flatten` then `Dense` layers upstream
             (without it, the shape of the dense outputs cannot be computed).

--- a/python/nano/src/bigdl/nano/tf/keras/layers/embeddings.py
+++ b/python/nano/src/bigdl/nano/tf/keras/layers/embeddings.py
@@ -23,7 +23,7 @@ class Embedding(TFEmbedding):
     """
     A slightly modified version of tf.keras Embedding layer.
 
-    This embedding layer only apply regularizer to the output of the embedding
+    This embedding layer only applies regularizer to the output of the embedding
     layers, so that the gradient to embeddings is sparse.
     """
 

--- a/python/nano/src/bigdl/nano/tf/keras/layers/embeddings.py
+++ b/python/nano/src/bigdl/nano/tf/keras/layers/embeddings.py
@@ -21,7 +21,7 @@ from tensorflow.keras.layers import Embedding as TFEmbedding
 
 class Embedding(TFEmbedding):
     """
-    A slightly modified version of tf.keras.Embedding layer.
+    A slightly modified version of tf.keras Embedding layer.
 
     This embedding layer only apply regularizer to the output of the embedding
     layers, so that the gradient to embeddings is sparse.
@@ -38,7 +38,7 @@ class Embedding(TFEmbedding):
                  input_length=None,
                  **kwargs):
         """
-        Create a slightly modified version of tf.keras.Embedding layer.
+        Create a slightly modified version of tf.keras Embedding layer.
 
         :param input_dim: Integer. Size of the vocabulary,
             i.e. maximum integer index + 1.
@@ -65,6 +65,7 @@ class Embedding(TFEmbedding):
             This argument is required if you are going to connect
             `Flatten` then `Dense` layers upstream
             (without it, the shape of the dense outputs cannot be computed).
+        :param kwargs: Keyword arguments passed to tf.keras.layers.Embedding
         """
         if embeddings_regularizer is not None and activity_regularizer is None:
             warnings.warn(

--- a/python/nano/tutorial/notebook/training/tensorflow/tensorflow_training_embedding_sparseadam.ipynb
+++ b/python/nano/tutorial/notebook/training/tensorflow/tensorflow_training_embedding_sparseadam.ipynb
@@ -227,7 +227,7 @@
     ">\n",
     "> If you would like to apply a regularizer function to the embedding matrix through setting `embeddings_regularizer`, Nano will apply the regularizer to the output tensors of the embedding layer instead to avoid making the sparse gradient dense (if `activity_regularize=None`).\n",
     ">\n",
-    "> Please refer to [here](https://github.com/intel-analytics/BigDL/blob/main/python/nano/src/bigdl/nano/tf/keras/layers/embeddings.py) for more information on `bigdl.nano.tf.keras.layers.Embedding`."
+    "> Please refer to [API document](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/tensorflow.html#bigdl.nano.tf.keras.layers.Embedding) for more information on `bigdl.nano.tf.keras.layers.Embedding`."
    ]
   },
   {
@@ -290,7 +290,7 @@
     ">\n",
     "> `SparseAdam` optimizer is a variant of `tf.keras.optimizers.Adam`. This method only updates moments that show up in the gradient, and applies only those portions of gradient to the trainable variables.\n",
     ">\n",
-    "> Please refer to [here](https://github.com/intel-analytics/BigDL/blob/main/python/nano/src/bigdl/nano/tf/optimizers/sparse_adam.py) for more information on `bigdl.nano.tf.optimizers.SparseAdam`."
+    "> Please refer to [API document](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/tensorflow.html#bigdl.nano.tf.optimizers.SparseAdam) for more information on `bigdl.nano.tf.optimizers.SparseAdam`."
    ]
   },
   {


### PR DESCRIPTION
## Description

Add api docs for `bigdl.nano.tf.keras.layers.Embedding` and `bigdl.nano.tf.optimizers.SparseAdam`, and change the api document link for related how-to guides

### 1. Why the change?
#5939 

### 2. How to test?
- [x] Document test: https://yuwentestdocs.readthedocs.io/en/nano-api-docs-embedding-sparseadam/doc/PythonAPI/Nano/index.html
- `bigdl.nano.tf.keras.layers.Embedding`: https://yuwentestdocs.readthedocs.io/en/nano-api-docs-embedding-sparseadam/doc/PythonAPI/Nano/tensorflow.html#bigdl.nano.tf.keras.layers.Embedding
- `bigdl.nano.tf.optimizers.SparseAdam`: https://yuwentestdocs.readthedocs.io/en/nano-api-docs-embedding-sparseadam/doc/PythonAPI/Nano/tensorflow.html#bigdl.nano.tf.optimizers.SparseAdam
