### PR TITLE
CICD: add image tag to Github Action workflow nightly_test 

### DIFF
--- a/.github/actions/ppml-spark-local-example-tests-on-gramine-action/action.yml
+++ b/.github/actions/ppml-spark-local-example-tests-on-gramine-action/action.yml
@@ -1,5 +1,10 @@
 name: 'PPML-spark-Local-Example-Tests-on-Gramine'
 description: 'PPML-spark-Local-Example-Tests-on-Gramine'
+inputs:
+  image-tag:
+    description: 'image tag'
+    required: true
+    default: 'latest'
 runs:
   using: "composite"
   steps:
@@ -8,7 +13,7 @@ runs:
       shell: bash
       env:
         DEFAULT_SGX_MEM_SIZE: 32G
-        DEFAULT_IMAGE: 10.239.45.10/arda/intelanalytics/bigdl-ppml-trusted-big-data-ml-python-gramine:latest
+        DEFAULT_IMAGE: 10.239.45.10/arda/intelanalytics/bigdl-ppml-trusted-big-data-ml-python-gramine:${{ inputs.image-tag }}
       run: |
         echo "CONTAINER_NAME=spark-exmaples-test-gramine" >> $GITHUB_ENV
         echo "SGX_MEM_SIZE=${{ env.DEFAULT_SGX_MEM_SIZE }}" >> $GITHUB_ENV

--- a/.github/actions/ppml/ppml-pyspark-k8s-example-on-gramine-action/action.yml
+++ b/.github/actions/ppml/ppml-pyspark-k8s-example-on-gramine-action/action.yml
@@ -1,5 +1,10 @@
 name: 'PPML-PySpark-K8S-Example-on-Gramine'
 description: 'PPML-PySpark-K8S-Example-on-Gramine'
+inputs:
+  image-tag:
+    description: 'image tag'
+    required: true
+    default: 'latest'
 runs:
   using: "composite"
   steps:
@@ -7,7 +12,7 @@ runs:
     - name: Set Variable
       shell: bash
       env:
-        DEFAULT_IMAGE: 10.239.45.10/arda/intelanalytics/bigdl-ppml-trusted-big-data-ml-python-gramine:latest
+        DEFAULT_IMAGE: 10.239.45.10/arda/intelanalytics/bigdl-ppml-trusted-big-data-ml-python-gramine:${{ inputs.image-tag }}
       run: |
         echo "CONTAINER_NAME=pyspark-exmaples-test-gramine" >> $GITHUB_ENV
         echo "SGX_MEM_SIZE=${{ env.DEFAULT_SGX_MEM_SIZE }}" >> $GITHUB_ENV

--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -28,6 +28,11 @@ on:
         - PPML-PySpark-K8S-EXAMPLE
         - PPML-Occlum-ExampleTests
         - PPML-spark-Local-Example-Tests-on-Gramine
+      tag:
+        description: 'docker image tag'
+        required: true
+        default: 'latest'
+        type: string
 
 permissions:
   contents: read
@@ -373,9 +378,16 @@ jobs:
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
       uses: ./.github/actions/maven-setup-action
+    - name: set env
+      env:
+        DEFAULT_TAG: 'latest'
+      run: |
+        echo "TAG=${{ github.event.inputs.bigdlTag || env.DEFAULT_TAG }} " >> $GITHUB_ENV
     - name: Run test
       uses: ./.github/actions/ppml/ppml-pyspark-k8s-example-on-gramine-action
-
+      with:
+        image-tag: ${TAG}
+        
   create-workflow-badge:
     runs-on: ubuntu-latest
     steps:
@@ -423,8 +435,15 @@ jobs:
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
       uses: ./.github/actions/maven-setup-action
+    - name: set env
+      env:
+        DEFAULT_TAG: 'latest'
+      run: |
+        echo "TAG=${{ github.event.inputs.bigdlTag || env.DEFAULT_TAG }} " >> $GITHUB_ENV
     - name: Run test
       uses: ./.github/actions/ppml-spark-local-example-tests-on-gramine-action
+      with:
+        image-tag: ${TAG}
     - name: Create Job Badge
       uses: ./.github/actions/create-job-status-badge
       if: ${{ always() }}


### PR DESCRIPTION
## Description

This submission adds the ability to manually specify the image tag for the docker related jobs in nightly test workflow on GitHub action.