### PR TITLE
Orca: Add data loader and xshards examples to NCF with merged features

### DIFF
--- a/python/orca/tutorial/NCF/process_xshards.py
+++ b/python/orca/tutorial/NCF/process_xshards.py
@@ -12,89 +12,127 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# ==============================================================================
+# Some of the code is adapted from
+# https://github.com/guoyang9/NCF/blob/master/data_utils.py
 #
 
-# Step 0: Import necessary libraries
-import torch.nn as nn
-import torch.optim as optim
+import os
+import numpy as np
+import pandas as pd
+import scipy.sparse as sp
+from sklearn.model_selection import train_test_split
 
-from process_xshards import prepare_data
-from pytorch_model import NCF
-
-from bigdl.orca import init_orca_context, stop_orca_context
-from bigdl.orca.learn.pytorch import Estimator
-from bigdl.orca.learn.metrics import Accuracy, Precision, Recall
+from bigdl.orca.data.pandas import read_csv
+from bigdl.orca.data.transformer import StringIndexer
 
 
-# Step 1: Init Orca Context
-sc = init_orca_context()
+def ng_sampling(data, user_num, item_num, num_ng):
+    clms = ['user', 'item']
+    data = data.loc[:, clms]
+    data_values = data.values.tolist()
+
+    # calculate a dok matrix
+    train_mat = sp.dok_matrix((user_num, item_num), dtype=np.int64)
+    for row in data_values:
+        train_mat[row[0], row[1]] = 1
+
+    # negative sampling
+    features_ps = data_values
+    features_ng = []
+    for x in features_ps:
+        u = x[0]
+        for t in range(num_ng):
+            j = np.random.randint(item_num)
+            while (u, j) in train_mat:
+                j = np.random.randint(item_num)
+            features_ng.append([u, j])
+
+    labels_ps = [1 for _ in range(len(features_ps))]
+    labels_ng = [0 for _ in range(len(features_ng))]
+
+    features_fill = features_ps + features_ng
+    labels_fill = labels_ps + labels_ng
+    data_XY = pd.DataFrame(data=features_fill, columns=clms, dtype=np.int64)
+    data_XY["label"] = labels_fill
+    data_XY["label"] = data_XY["label"].astype(np.float)
+    return data_XY
 
 
-# Step 2: Define train and test datasets using Orca XShards
-dataset_dir = "./ml-1m"
-feature_cols = ['user', 'item',
-                'gender', 'occupation', 'zipcode', 'category',  # categorical feature
-                'age']  # numerical feature
-label_cols = ["label"]
-total_cols = feature_cols + label_cols
-train_data, test_data, num_embed_cat_feats = prepare_data(dataset_dir,
-                                                          num_ng=4, total_cols=total_cols)
+def split_dataset(data, total_cols):
+    data = data.loc[:, total_cols]
+    train_data, test_data = train_test_split(data, test_size=0.2, random_state=100)
+    return train_data, test_data
 
 
-# Step 3: Define the model, optimizer and loss
-def model_creator(config):
-    model = NCF(factor_num=config['factor_num'],
-                num_layers=config['num_layers'],
-                dropout=config['dropout'],
-                model=config['model'],
-                cat_feats_dim=config['cat_feats_dim'],
-                numeric_feats_dim=config['numeric_feats_dim'],
-                num_embed_cat_feats=num_embed_cat_feats)
-    model.train()
-    return model
+def prepare_data(dataset_dir, num_ng=4, total_cols=['user', 'item', "label"]):
+    # Load the train and test datasets
+    data_1 = read_csv(
+        os.path.join(dataset_dir, 'users.dat'),
+        sep="::", header=None, names=['user', 'gender', 'age', 'occupation', 'zipcode'],
+        usecols=[0, 1, 2, 3, 4])
+    data_2 = read_csv(
+        os.path.join(dataset_dir, 'ratings.dat'),
+        sep="::", header=None, names=['user', 'item'],
+        usecols=[0, 1])
+    data_3 = read_csv(
+        os.path.join(dataset_dir, 'movies.dat'),
+        sep="::", header=None, names=['item', 'category'],
+        usecols=[0, 2])
+
+    # calculate numbers of user and item
+    user_set = set(data_2["user"].unique())
+    item_set = set(data_2["item"].unique())
+    user_num = max(user_set) + 1
+    item_num = max(item_set) + 1
+
+    # Negative sampling
+    data_2 = data_2.transform_shard(lambda shard: ng_sampling(shard, user_num, item_num, num_ng))
+
+    # Merge XShards
+    data = data_1.merge(data_2, on='user')
+    data = data.merge(data_3, on='item')
+    data = data.partition_by("user", data.num_partitions())
+
+    # Category encoding
+    strid = StringIndexer('gender')
+    data = strid.fit_transform(data)
+    strid.setInputCol('zipcode')
+    data = strid.fit_transform(data)
+    strid.setInputCol('category')
+    data = strid.fit_transform(data)
+
+    # Calculate num_embeddings for each categorical features
+    num_embed_cat_feats = []
+    num_embed_cat_feats.append(user_num)
+    num_embed_cat_feats.append(item_num)
+    cat_feat_set = set(data["gender"].unique())
+    num_embed_cat_feats.append(max(cat_feat_set)+1)
+    cat_feat_set = set(data["occupation"].unique())
+    num_embed_cat_feats.append(max(cat_feat_set)+1)
+    cat_feat_set = set(data["zipcode"].unique())
+    num_embed_cat_feats.append(max(cat_feat_set)+1)
+    cat_feat_set = set(data["category"].unique())
+    num_embed_cat_feats.append(max(cat_feat_set)+1)
+
+    # Split dataset
+    train_data, test_data = data.transform_shard(
+        lambda shard: split_dataset(shard, total_cols)).split()
+    return train_data, test_data, num_embed_cat_feats
 
 
-def optimizer_creator(model, config):
-    return optim.Adam(model.parameters(), lr=config['lr'])
+if __name__ == "__main__":
+    from bigdl.orca import init_orca_context, stop_orca_context
 
-loss = nn.BCEWithLogitsLoss()
+    sc = init_orca_context()
 
+    feature_cols = ['user', 'item',
+                    'gender', 'occupation', 'zipcode', 'category',  # categorical feature
+                    'age']  # numerical feature
+    label_cols = ["label"]
+    total_cols = feature_cols + label_cols
+    train_data, test_data, num_embed_cat_feats = prepare_data("./ml-1m", total_cols=total_cols)
+    train_data.save_pickle("train_xshards")
+    test_data.save_pickle("test_xshards")
 
-# Step 4: Distributed training with Orca PyTorch Estimator
-backend = "spark"  # "ray" or "spark"
-
-est = Estimator.from_torch(model=model_creator,
-                           optimizer=optimizer_creator,
-                           loss=loss,
-                           metrics=[Accuracy(), Precision(), Recall()],
-                           backend=backend,
-                           config={'dataset_dir': dataset_dir,
-                                   'factor_num': 16,
-                                   'num_layers': 3,
-                                   'dropout': 0.0,
-                                   'lr': 0.001,
-                                   'model': "NeuMF-end",
-                                   'cat_feats_dim': 6,
-                                   'numeric_feats_dim': 1})
-est.fit(data=train_data, epochs=10,
-        feature_cols=feature_cols,
-        label_cols=label_cols,
-        batch_size=1024)
-
-
-# Step 5: Distributed evaluation of the trained model
-result = est.evaluate(data=test_data,
-                      feature_cols=feature_cols,
-                      label_cols=label_cols,
-                      batch_size=1024)
-print('Evaluation results:')
-for r in result:
-    print(r, ":", result[r])
-
-
-# Step 6: Save the trained PyTorch model
-est.save("NCF_model")
-
-
-# Step 7: Stop Orca Context when program finishes
-stop_orca_context()
+    stop_orca_context()

--- a/python/orca/tutorial/NCF/process_xshards.py
+++ b/python/orca/tutorial/NCF/process_xshards.py
@@ -12,77 +12,89 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
-# Some of the code is adapted from
-# https://github.com/guoyang9/NCF/blob/master/data_utils.py
 #
 
-import os
-import numpy as np
-import pandas as pd
-import scipy.sparse as sp
-from sklearn.model_selection import train_test_split
+# Step 0: Import necessary libraries
+import torch.nn as nn
+import torch.optim as optim
 
-from bigdl.orca.data.pandas import read_csv
+from process_xshards import prepare_data
+from pytorch_model import NCF
 
-
-def ng_sampling(data, user_num, item_num):
-    data_X = data.values.tolist()
-
-    # calculate a dok matrix
-    train_mat = sp.dok_matrix((user_num, item_num), dtype=np.int64)
-    for row in data_X:
-        train_mat[row[0], row[1]] = 1
-
-    # negative sampling
-    num_ng = 4  # sample 4 negative items for training
-    features_ps = data_X
-    features_ng = []
-    for x in features_ps:
-        u = x[0]
-        for t in range(num_ng):
-            j = np.random.randint(item_num)
-            while (u, j) in train_mat:
-                j = np.random.randint(item_num)
-            features_ng.append([u, j])
-
-    labels_ps = [1 for _ in range(len(features_ps))]
-    labels_ng = [0 for _ in range(len(features_ng))]
-
-    features_fill = features_ps + features_ng
-    labels_fill = labels_ps + labels_ng
-    data_XY = pd.DataFrame(data=features_fill, columns=["user", "item"], dtype=np.int64)
-    data_XY["label"] = labels_fill
-    data_XY["label"] = data_XY["label"].astype(np.float)
-    return data_XY
+from bigdl.orca import init_orca_context, stop_orca_context
+from bigdl.orca.learn.pytorch import Estimator
+from bigdl.orca.learn.metrics import Accuracy, Precision, Recall
 
 
-def split_dataset(data):
-    train_data, test_data = train_test_split(data, test_size=0.2, random_state=100)
-    return train_data, test_data
+# Step 1: Init Orca Context
+sc = init_orca_context()
 
 
-def prepare_data(dataset_dir):
-    data = read_csv(os.path.join(dataset_dir, 'ratings.dat'),
-                    sep="::", header=None, names=['user', 'item'],
-                    usecols=[0, 1], dtype={0: np.int64, 1: np.int64})
-    data = data.partition_by("user")
-
-    user_set = set(data["user"].unique())
-    item_set = set(data["item"].unique())
-    user_num = max(user_set) + 1
-    item_num = max(item_set) + 1
-
-    data = data.transform_shard(lambda shard: ng_sampling(shard, user_num, item_num))
-    train_data, test_data = data.transform_shard(split_dataset).split()
-    return train_data, test_data, user_num, item_num
+# Step 2: Define train and test datasets using Orca XShards
+dataset_dir = "./ml-1m"
+feature_cols = ['user', 'item',
+                'gender', 'occupation', 'zipcode', 'category',  # categorical feature
+                'age']  # numerical feature
+label_cols = ["label"]
+total_cols = feature_cols + label_cols
+train_data, test_data, num_embed_cat_feats = prepare_data(dataset_dir,
+                                                          num_ng=4, total_cols=total_cols)
 
 
-if __name__ == "__main__":
-    from bigdl.orca import init_orca_context, stop_orca_context
+# Step 3: Define the model, optimizer and loss
+def model_creator(config):
+    model = NCF(factor_num=config['factor_num'],
+                num_layers=config['num_layers'],
+                dropout=config['dropout'],
+                model=config['model'],
+                cat_feats_dim=config['cat_feats_dim'],
+                numeric_feats_dim=config['numeric_feats_dim'],
+                num_embed_cat_feats=num_embed_cat_feats)
+    model.train()
+    return model
 
-    sc = init_orca_context()
-    train_data, test_data, user_num, item_num = prepare_data("./ml-1m")
-    train_data.save_pickle("train_xshards")
-    test_data.save_pickle("test_xshards")
-    stop_orca_context()
+
+def optimizer_creator(model, config):
+    return optim.Adam(model.parameters(), lr=config['lr'])
+
+loss = nn.BCEWithLogitsLoss()
+
+
+# Step 4: Distributed training with Orca PyTorch Estimator
+backend = "spark"  # "ray" or "spark"
+
+est = Estimator.from_torch(model=model_creator,
+                           optimizer=optimizer_creator,
+                           loss=loss,
+                           metrics=[Accuracy(), Precision(), Recall()],
+                           backend=backend,
+                           config={'dataset_dir': dataset_dir,
+                                   'factor_num': 16,
+                                   'num_layers': 3,
+                                   'dropout': 0.0,
+                                   'lr': 0.001,
+                                   'model': "NeuMF-end",
+                                   'cat_feats_dim': 6,
+                                   'numeric_feats_dim': 1})
+est.fit(data=train_data, epochs=10,
+        feature_cols=feature_cols,
+        label_cols=label_cols,
+        batch_size=1024)
+
+
+# Step 5: Distributed evaluation of the trained model
+result = est.evaluate(data=test_data,
+                      feature_cols=feature_cols,
+                      label_cols=label_cols,
+                      batch_size=1024)
+print('Evaluation results:')
+for r in result:
+    print(r, ":", result[r])
+
+
+# Step 6: Save the trained PyTorch model
+est.save("NCF_model")
+
+
+# Step 7: Stop Orca Context when program finishes
+stop_orca_context()

--- a/python/orca/tutorial/NCF/pytorch_dataset.py
+++ b/python/orca/tutorial/NCF/pytorch_dataset.py
@@ -26,66 +26,87 @@ import torch.utils.data as data
 
 
 class NCFData(data.Dataset):
-    def __init__(self, features,
-                 num_item=0, train_mat=None, num_ng=0):
-        super(NCFData, self).__init__()
-        """ Note that the labels are only useful when training, we thus
-            add them in the ng_sample() function.
-        """
-        self.features_ps = features
-        self.num_item = num_item
-        self.train_mat = train_mat
-        self.num_ng = num_ng
-        self.is_sampling = False
-        self.labels = [1 for _ in range(len(features))]
-
-    def ng_sample(self):
-        self.is_sampling = True
-        self.features_ng = []
-        for x in self.features_ps:
-            u = x[0]
-            for t in range(self.num_ng):
-                j = np.random.randint(self.num_item)
-                while (u, j) in self.train_mat:
-                    j = np.random.randint(self.num_item)
-                self.features_ng.append([u, j])
-
-        labels_ps = [1 for _ in range(len(self.features_ps))]
-        labels_ng = [0 for _ in range(len(self.features_ng))]
-
-        self.features_fill = self.features_ps + self.features_ng
-        self.labels_fill = labels_ps + labels_ng
+    def __init__(self, data):
+        self.data = list(map(lambda row: list(row[1:]), data.itertuples()))
 
     def __len__(self):
-        return (self.num_ng + 1) * len(self.labels)
+        return len(self.data)
 
     def __getitem__(self, idx):
-        features = self.features_fill if self.is_sampling \
-            else self.features_ps
-        labels = self.labels_fill if self.is_sampling \
-            else self.labels
-
-        user = features[idx][0]
-        item = features[idx][1]
-        label = float(labels[idx])
-        return user, item, label
+        return tuple(self.data[idx])
 
 
-def load_dataset(dataset_dir):
-    data_X = pd.read_csv(
+def load_dataset(dataset_dir, num_ng=4, total_cols=['user', 'item', "label"],
+                 cal_num_embed=False):
+    """
+    dataset_dir: the path of the datasets;
+    num_ng: number of negative samples to be sampled here;
+    total_cols: the list of total features;
+    cal_num_embed: if True, will calculate num_embed_cat_feats.
+    """
+    data_1 = pd.read_csv(
+        os.path.join(dataset_dir, 'users.dat'),
+        sep="::", header=None, names=['user', 'gender', 'age', 'occupation', 'zipcode'],
+        usecols=[0, 1, 2, 3, 4],
+        dtype={0: np.int64, 1: np.object, 2: np.int64, 3: np.int64, 4: np.object})
+    data_2 = pd.read_csv(
         os.path.join(dataset_dir, 'ratings.dat'),
         sep="::", header=None, names=['user', 'item'],
         usecols=[0, 1], dtype={0: np.int64, 1: np.int64})
+    data_3 = pd.read_csv(
+        os.path.join(dataset_dir, 'movies.dat'),
+        sep="::", header=None, names=['item', 'category'],
+        usecols=[0, 2], dtype={0: np.int64, 1: np.object})
 
-    user_num = data_X['user'].max() + 1
-    item_num = data_X['item'].max() + 1
+    user_num = data_2['user'].max() + 1
+    item_num = data_2['item'].max() + 1
 
-    # load ratings as a dok matrix
-    train_mat = sp.dok_matrix((user_num, item_num), dtype=np.int64)
-    for x in data_X.values.tolist():
-        train_mat[x[0], x[1]] = 1
+    # category encoding
+    data_1.gender, _ = pd.Series(data_1.gender).factorize()
+    data_1.zipcode, _ = pd.Series(data_1.zipcode).factorize()
+    data_3.category, _ = pd.Series(data_3.category).factorize()
 
-    return data_X, user_num, item_num, train_mat
+    # sample negative items for training datasets
+    if num_ng > 0:
+        # load ratings as a dok matrix
+        features_ps = data_2.values.tolist()
+        train_mat = sp.dok_matrix((user_num, item_num), dtype=np.int64)
+        for x in features_ps:
+            train_mat[x[0], x[1]] = 1
+
+        features_ng = []
+        for x in features_ps:
+            u = x[0]
+            for t in range(num_ng):
+                j = np.random.randint(item_num)
+                while (u, j) in train_mat:
+                    j = np.random.randint(item_num)
+                features_ng.append([u, j])
+        features = features_ps + features_ng
+        labels_ps = [1 for _ in range(len(features_ps))]
+        labels_ng = [0 for _ in range(len(features_ng))]
+        labels = labels_ps + labels_ng
+        data_2 = pd.DataFrame(features, columns=["user", "item"], dtype=np.int64)
+        data_2["label"] = labels
+    else:
+        data_2["label"] = [1 for _ in range(len(data_2))]
+
+    # merge dataframes
+    data_X = data_1.merge(data_2, on='user')
+    data_X = data_X.merge(data_3, on='item')
+    data_X = data_X.loc[:, total_cols]
+
+    # Calculate num_embeddings for each categorical features
+    num_embed_cat_feats = []
+    if cal_num_embed:
+        num_embed_cat_feats.append(user_num)
+        num_embed_cat_feats.append(item_num)
+        num_embed_cat_feats.append(data_1['gender'].max()+1)
+        num_embed_cat_feats.append(data_1['occupation'].max()+1)
+        num_embed_cat_feats.append(data_1['zipcode'].max()+1)
+        num_embed_cat_feats.append(data_3['category'].max()+1)
+
+    return data_X, num_embed_cat_feats
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Add data loader and xshards examples to NCF. These 2 files `train_data_loader_add_features.py` and `train_xshards_add_features.py` merge other features to datasets besides `user` and `item`.

### 1. Why the change?

To show how to use `SparkXShards.merge` and `pandas.dataframe.merge` API to add features to datasets.

### 2. User API changes

No change.
