### PR TITLE
Nano : support ONNX Simplifier in Nano's inference

### DIFF
--- a/.github/workflows/chronos-prvn-python-spark-2.4-py37-onnxrt.yml
+++ b/.github/workflows/chronos-prvn-python-spark-2.4-py37-onnxrt.yml
@@ -62,6 +62,7 @@ jobs:
           pip install onnxruntime==1.11.1
           pip install onnx==1.11.0
           pip install onnxruntime-extensions==0.4.2
+          pip install onnxsim==0.4.8
           pip install scipy==1.5.4
           pip install cloudpickle
           apt-get update

--- a/.github/workflows/chronos-prvn-python-spark-2.4-py37-ray.yml
+++ b/.github/workflows/chronos-prvn-python-spark-2.4-py37-ray.yml
@@ -63,6 +63,7 @@ jobs:
           pip install onnx==1.11.0
           pip install onnxruntime==1.11.1
           pip install openvino-dev==2022.2.0
+          pip install onnxsim==0.4.8
           pip install scipy==1.5.4
           pip install cloudpickle
           pip install matplotlib

--- a/.github/workflows/chronos-prvn-python-spark-3.1-py37-onnxrt.yml
+++ b/.github/workflows/chronos-prvn-python-spark-3.1-py37-onnxrt.yml
@@ -62,6 +62,7 @@ jobs:
           pip install onnxruntime==1.11.1
           pip install onnx==1.11.0
           pip install onnxruntime-extensions==0.4.2
+          pip install onnxsim==0.4.8
           pip install scipy==1.5.4
           pip install cloudpickle
           apt-get update

--- a/.github/workflows/chronos-prvn-python-spark-3.1-py37-ray.yml
+++ b/.github/workflows/chronos-prvn-python-spark-3.1-py37-ray.yml
@@ -63,6 +63,7 @@ jobs:
           pip install onnx==1.11.0
           pip install onnxruntime==1.11.1
           pip install openvino-dev==2022.2.0
+          pip install onnxsim==0.4.8
           pip install scipy==1.5.4
           pip install cloudpickle
           pip install matplotlib

--- a/.github/workflows/nano_howto_guides_tests.yml
+++ b/.github/workflows/nano_howto_guides_tests.yml
@@ -49,7 +49,7 @@ jobs:
           source bigdl-nano-init
           pip install pytest nbmake
           pip install neural-compressor==1.11.0
-          pip install onnx onnxruntime onnxruntime-extensions
+          pip install onnx onnxruntime onnxruntime-extensions onnxsim
           bash python/nano/tutorial/notebook/inference/pytorch/run-nano-howto-guides-inference-pytorch-tests.sh onnx
           source $CONDA/bin/deactivate
           $CONDA/bin/conda remove -n howto-guides-inference-pytorch-onnx --all

--- a/.github/workflows/nano_notebooks_tests.yml
+++ b/.github/workflows/nano_notebooks_tests.yml
@@ -65,7 +65,7 @@ jobs:
             source bigdl-nano-init
             pip install pytest nbmake
             pip install neural-compressor==1.11
-            pip install onnx onnxruntime onnxruntime-extensions
+            pip install onnx onnxruntime onnxruntime-extensions onnxsim
             pip install lightning-bolts
             bash python/nano/notebooks/pytorch/tutorial/run-nano-notebooks-pytorch-tutorial-tests.sh false
             bash python/nano/tutorial/inference/pytorch/run_nano_pytorch_inference_tests_onnx.sh

--- a/.github/workflows/nano_unit_tests_pytorch.yml
+++ b/.github/workflows/nano_unit_tests_pytorch.yml
@@ -181,7 +181,7 @@ jobs:
           fi
           pip install pytest
           pip install neural-compressor==1.11
-          pip install onnxruntime onnxruntime-extensions onnx
+          pip install onnxruntime onnxruntime-extensions onnx onnxsim
           source bigdl-nano-init
           bash python/nano/test/run-nano-pytorch-onnx-tests.sh
           source $CONDA/bin/deactivate

--- a/python/nano/notebooks/pytorch/cifar10/requirements.txt
+++ b/python/nano/notebooks/pytorch/cifar10/requirements.txt
@@ -5,3 +5,4 @@ neural-compressor==1.11
 onnxruntime==1.10.0
 onnx==1.11.0
 openvino-dev==2022.1.0
+onnxsim==0.4.8

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
@@ -17,7 +17,7 @@
 
 def PytorchONNXRuntimeModel(model, input_sample=None,
                             onnxruntime_session_options=None,
-                            **export_kwargs):
+                            simplification=True, **export_kwargs):
     """
         Create a ONNX Runtime model from pytorch.
 
@@ -27,13 +27,16 @@ def PytorchONNXRuntimeModel(model, input_sample=None,
                              model is a LightningModule with any dataloader attached,
                              defaults to None.
         :param onnxruntime_session_options: A session option for onnxruntime accelerator.
+        :param simplification: whether we use onnxsim to simplify the ONNX model, only valid when
+                               accelerator='onnxruntime', otherwise will be ignored. If this option
+                               is set to True, new dependency 'onnxsim' need to be installed.
         :param **export_kwargs: will be passed to torch.onnx.export function.
         :return: A PytorchONNXRuntimeModel instance
         """
     from .pytorch.pytorch_onnxruntime_model import PytorchONNXRuntimeModel
     return PytorchONNXRuntimeModel(model, input_sample,
                                    onnxruntime_session_options=onnxruntime_session_options,
-                                   **export_kwargs)
+                                   simplification=simplification, **export_kwargs)
 
 
 def load_onnxruntime_model(path):

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -51,6 +51,9 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
             export_to_onnx(model, input_sample=input_sample, onnx_path='tmp.onnx',
                            **export_kwargs)
             onnx_path = 'tmp.onnx'
+            # simplify model
+            from bigdl.nano.deps.onnxsim.onnxsim_api import onnx_simplify
+            onnx_simplify(onnx_path)
         AcceleratedLightningModule.__init__(self, None)
         ONNXRuntimeModel.__init__(self, onnx_path, session_options=onnxruntime_session_options)
         if os.path.exists('tmp.onnx'):

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -57,8 +57,11 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
             onnx_path = 'tmp.onnx'
             if simplification is True:
                 # simplify model
-                from bigdl.nano.deps.onnxsim.onnxsim_api import onnx_simplify
-                onnx_simplify(onnx_path)
+                try:
+                    from bigdl.nano.deps.onnxsim.onnxsim_api import onnx_simplify
+                    onnx_simplify(onnx_path)
+                except Exception:
+                    pass
         AcceleratedLightningModule.__init__(self, None)
         ONNXRuntimeModel.__init__(self, onnx_path, session_options=onnxruntime_session_options)
         if os.path.exists('tmp.onnx'):

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -48,7 +48,6 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
         onnx_path = model
         if isinstance(model, torch.nn.Module):
             # Typically, when model is fp32, we use this path
-            # TODO: expose ONNX export parameters to users
             export_to_onnx(model, input_sample=input_sample, onnx_path='tmp.onnx',
                            **export_kwargs)
             onnx_path = 'tmp.onnx'

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -32,7 +32,7 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
     '''
 
     def __init__(self, model, input_sample=None, onnxruntime_session_options=None,
-                 **export_kwargs):
+                 simplification=True, **export_kwargs):
         """
         Create a ONNX Runtime model from pytorch.
 
@@ -41,6 +41,10 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
         :param input_sample: A set of inputs for trace, defaults to None if you have trace before or
                              model is a LightningModule with any dataloader attached,
                              defaults to None.
+        :param onnxruntime_session_options: A session option for onnxruntime accelerator.
+        :param simplification: whether we use onnxsim to simplify the ONNX model, only valid when
+                               accelerator='onnxruntime', otherwise will be ignored. If this option
+                               is set to True, new dependency 'onnxsim' need to be installed.
         :param **export_kwargs: will be passed to torch.onnx.export function.
         """
         # Typically, when model is int8, we use this path
@@ -51,9 +55,10 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
             export_to_onnx(model, input_sample=input_sample, onnx_path='tmp.onnx',
                            **export_kwargs)
             onnx_path = 'tmp.onnx'
-            # simplify model
-            from bigdl.nano.deps.onnxsim.onnxsim_api import onnx_simplify
-            onnx_simplify(onnx_path)
+            if simplification is True:
+                # simplify model
+                from bigdl.nano.deps.onnxsim.onnxsim_api import onnx_simplify
+                onnx_simplify(onnx_path)
         AcceleratedLightningModule.__init__(self, None)
         ONNXRuntimeModel.__init__(self, onnx_path, session_options=onnxruntime_session_options)
         if os.path.exists('tmp.onnx'):

--- a/python/nano/src/bigdl/nano/deps/onnxsim/__init__.py
+++ b/python/nano/src/bigdl/nano/deps/onnxsim/__init__.py
@@ -1,0 +1,15 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/nano/src/bigdl/nano/deps/onnxsim/onnxsim_api.py
+++ b/python/nano/src/bigdl/nano/deps/onnxsim/onnxsim_api.py
@@ -1,0 +1,35 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from onnxsim import simplify
+import onnx
+
+
+def onnx_simplify(onnx_path: str):
+    """
+    Simplify the ONNX model based on onnxsim.
+    If simplification is successful, will overwrite new ONNX model to onnx_path
+
+    :param onnx_path: File path of of onnx ModelProto object.
+    """
+    # load your predefined ONNX model
+    model = onnx.load(onnx_path)
+
+    # convert model
+    model_simp, check = simplify(model)
+
+    # overwrite model_simp to onnx_path
+    if check is True:
+        onnx.save(model_simp, onnx_path)

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -492,6 +492,7 @@ class InferenceOptimizer:
                  input_sample=None,
                  thread_num: Optional[int] = None,
                  onnxruntime_session_options=None,
+                 simplification: bool = True,
                  sample_size: int = 100,
                  logging: bool = True,
                  **export_kwargs):
@@ -541,6 +542,9 @@ class InferenceOptimizer:
                            or accelerator='openvino'.
         :param onnxruntime_session_options: The session option for onnxruntime, only valid when
                                             accelerator='onnxruntime', otherwise will be ignored.
+        :param simplification: whether we use onnxsim to simplify the ONNX model, only valid when
+                               accelerator='onnxruntime', otherwise will be ignored. If this option
+                               is set to True, new dependency 'onnxsim' need to be installed.
         :param sample_size: (optional) a int represents how many samples will be used for
                             Post-training Optimization Tools (POT) from OpenVINO toolkit,
                             only valid for accelerator='openvino'. Default to 100.
@@ -600,6 +604,7 @@ class InferenceOptimizer:
                             input_sample=input_sample,
                             accelerator='onnxruntime',
                             onnxruntime_session_options=onnxruntime_session_options,
+                            simplification=simplification,
                             **export_kwargs)
                 """
                 If accelerator==None, quantized model returned should be an object of PytorchModel
@@ -668,6 +673,7 @@ class InferenceOptimizer:
               use_ipex: bool = False,
               thread_num: Optional[int] = None,
               onnxruntime_session_options=None,
+              simplification: bool = True,
               logging: bool = True,
               **export_kwargs):
         """
@@ -686,6 +692,9 @@ class InferenceOptimizer:
                            or accelerator='openvino'.
         :param onnxruntime_session_options: The session option for onnxruntime, only valid when
                                             accelerator='onnxruntime', otherwise will be ignored.
+        :param simplification: whether we use onnxsim to simplify the ONNX model, only valid when
+                               accelerator='onnxruntime', otherwise will be ignored. If this option
+                               is set to True, new dependency 'onnxsim' need to be installed.
         :param logging: whether to log detailed information of model conversion, only valid when
                         accelerator='openvino', otherwise will be ignored. Default: ``True``.
         :param **kwargs: other extra advanced settings include
@@ -711,7 +720,7 @@ class InferenceOptimizer:
                     onnxruntime_session_options.intra_op_num_threads = thread_num
                     onnxruntime_session_options.inter_op_num_threads = thread_num
             return PytorchONNXRuntimeModel(model, input_sample, onnxruntime_session_options,
-                                           **export_kwargs)
+                                           simplification=simplification, **export_kwargs)
         if accelerator == 'jit' or use_ipex:
             if use_ipex:
                 invalidInputError(not TORCH_VERSION_LESS_1_10,

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
@@ -19,7 +19,6 @@ import inspect
 from torch.utils.data import DataLoader
 import torch
 from bigdl.nano.utils.log4Error import invalidInputError
-from bigdl.nano.deps.onnxsim import onnx_simplify
 
 
 def get_forward_args(model):
@@ -107,4 +106,3 @@ def export_to_onnx(model, input_sample=None, onnx_path="model.onnx", dynamic_axe
                                 }
     default_onnx_export_args.update(kwargs)
     torch.onnx.export(model, input_sample, onnx_path, **default_onnx_export_args)
-    onnx_simplify(onnx_path)

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
@@ -19,6 +19,7 @@ import inspect
 from torch.utils.data import DataLoader
 import torch
 from bigdl.nano.utils.log4Error import invalidInputError
+from bigdl.nano.deps.onnxsim import onnx_simplify
 
 
 def get_forward_args(model):
@@ -106,3 +107,4 @@ def export_to_onnx(model, input_sample=None, onnx_path="model.onnx", dynamic_axe
                                 }
     default_onnx_export_args.update(kwargs)
     torch.onnx.export(model, input_sample, onnx_path, **default_onnx_export_args)
+    onnx_simplify(onnx_path)


### PR DESCRIPTION
## Description

We are considering integrating ONNX Simplifier into Nano's InferenceOptimizer.

### 1. Why the change?

https://github.com/intel-analytics/BigDL/issues/5975

### 2. User API changes

No change.

### 3. Summary of the change 

support onnxsim in Nano

### 4. How to test?
- [ ] Unit test
- [ ] Application test

### 5. New dependencies

- [x] New Python dependencies
       - onnxsim
