### PR TITLE
Chronos: add `gen_synthetic_data` to provide users with offline dataset

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/__init__.py
+++ b/python/chronos/src/bigdl/chronos/data/__init__.py
@@ -15,3 +15,4 @@
 #
 
 from .tsdataset import TSDataset
+from .repo_dataset import get_public_dataset, gen_synthetic_data

--- a/python/chronos/src/bigdl/chronos/data/repo_dataset.py
+++ b/python/chronos/src/bigdl/chronos/data/repo_dataset.py
@@ -122,7 +122,7 @@ def gen_synthetic_data(len=10000, **kwargs):
     endtime = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())
     df.insert(0, "datetime", pd.date_range(end=endtime, periods=len, freq="T"))
 
-    if not 'with_split' in kwargs or not kwargs['with_split']:
+    if 'with_split' not in kwargs or not kwargs['with_split']:
         tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="target")
         return tsdata
     else:

--- a/python/chronos/src/bigdl/chronos/data/repo_dataset.py
+++ b/python/chronos/src/bigdl/chronos/data/repo_dataset.py
@@ -139,7 +139,7 @@ def gen_synthetic_data(len=10000, sine_amplitude=10.0, angular_freq=0.01,
     gen_x = np.linspace(0, len*angular_freq, len)
     np.random.seed(seed)
     gen_y = sine_amplitude * np.sin(gen_x) + \
-              noise_amplitude * np.random.normal(0, noise_scale, len)
+noise_amplitude * np.random.normal(0, noise_scale, len)
     df = pd.DataFrame(gen_y, columns=["target"])
     endtime = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())
     df.insert(0, "datetime", pd.date_range(end=endtime, periods=len, freq=time_freq))

--- a/python/chronos/src/bigdl/chronos/data/repo_dataset.py
+++ b/python/chronos/src/bigdl/chronos/data/repo_dataset.py
@@ -139,7 +139,7 @@ def gen_synthetic_data(len=10000, sine_amplitude=10.0, angular_freq=0.01,
     gen_x = np.linspace(0, len*angular_freq, len)
     np.random.seed(seed)
     gen_y = sine_amplitude * np.sin(gen_x) + \
-       noise_amplitude * np.random.normal(0, noise_scale, len)
+              noise_amplitude * np.random.normal(0, noise_scale, len)
     df = pd.DataFrame(gen_y, columns=["target"])
     endtime = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())
     df.insert(0, "datetime", pd.date_range(end=endtime, periods=len, freq=time_freq))

--- a/python/chronos/src/bigdl/chronos/data/repo_dataset.py
+++ b/python/chronos/src/bigdl/chronos/data/repo_dataset.py
@@ -98,7 +98,8 @@ def get_public_dataset(name, path='~/.chronos/dataset', redownload=False, **kwar
                           f"are supported in Chronos built-in dataset, while get {name}.")
 
 
-def gen_synthetic_data(len=10000, amplitude=10.0, angular_freq=0.01, scale=1.0, time_freq="D", **kwargs):
+def gen_synthetic_data(len=10000, amplitude=10.0, angular_freq=0.01, scale=1.0,
+                       time_freq="D", **kwargs):
     """
     Generate dataset according to sine function with a Gaussian noise.
     Datetime is generated according to `time_freq` with the current time as endtime.

--- a/python/chronos/src/bigdl/chronos/data/repo_dataset.py
+++ b/python/chronos/src/bigdl/chronos/data/repo_dataset.py
@@ -98,7 +98,8 @@ def get_public_dataset(name, path='~/.chronos/dataset', redownload=False, **kwar
                           f"are supported in Chronos built-in dataset, while get {name}.")
 
 
-def gen_synthetic_data(len=10000, amplitude=10.0, angular_freq=0.01, scale=1.0,
+def gen_synthetic_data(len=10000, sine_amplitude=10.0, angular_freq=0.01,
+                       noise_amplitude=0.01, noise_scale=1.0, seed=1,
                        time_freq="D", **kwargs):
     """
     Generate dataset according to sine function with a Gaussian noise.
@@ -108,12 +109,15 @@ def gen_synthetic_data(len=10000, amplitude=10.0, angular_freq=0.01, scale=1.0,
     >>> tsdata_gen = gen_synthetic_data()
 
     :param len: int, the number indicates the dataset size. Default to 10000.
-    :param amplitude: float, the number indicates amplitude of the sine function.
+    :param sine_amplitude: float, the number indicates amplitude of the sine function.
            Default to 10.0.
     :param angular_freq: float, the number indicates angular frequency of the sine function.
            Default to 0.01.
-    :param scale: float, the number indicates the standard deviation of the Gaussian noise
+    :param noise_amplitude: float, the number indicates amplitude of the Gaussian noise.
+           Default to 0.01.
+    :param noise_scale: float, the number indicates the standard deviation of the Gaussian noise
            while the mean is set to 0. Default to 1.0.
+    :param seed: int, random seed for generating Gaussian noise. Default to 1.
     :param time_freq: str, the frequency of the generated dataframe, default to 'D'(calendar day
            frequency). The frequency can be anything from the pandas list of frequency strings here:
            https://pandas.pydata.org/docs/user_guide/timeseries.html#timeseries-offset-aliases
@@ -125,13 +129,17 @@ def gen_synthetic_data(len=10000, amplitude=10.0, angular_freq=0.01, scale=1.0,
     """
     from bigdl.chronos.data.utils.utils import _check_type
     _check_type(len, "len", int)
-    _check_type(amplitude, "amplitude", float)
+    _check_type(sine_amplitude, "sine_amplitude", float)
     _check_type(angular_freq, "angular_freq", float)
-    _check_type(scale, "scale", float)
+    _check_type(noise_amplitude, "noise_amplitude", float)
+    _check_type(noise_scale, "noise_scale", float)
+    _check_type(seed, "seed", int)
     _check_type(time_freq, "time_freq", str)
 
     gen_x = np.linspace(0, len*angular_freq, len)
-    gen_y = amplitude * np.sin(gen_x) + np.random.normal(0, scale, len)
+    np.random.seed(seed)
+    gen_y = sine_amplitude * np.sin(gen_x) + \
+            noise_amplitude * np.random.normal(0, noise_scale, len)
     df = pd.DataFrame(gen_y, columns=["target"])
     endtime = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())
     df.insert(0, "datetime", pd.date_range(end=endtime, periods=len, freq=time_freq))

--- a/python/chronos/src/bigdl/chronos/data/repo_dataset.py
+++ b/python/chronos/src/bigdl/chronos/data/repo_dataset.py
@@ -138,9 +138,8 @@ def gen_synthetic_data(len=10000, sine_amplitude=10.0, angular_freq=0.01,
 
     gen_x = np.linspace(0, len * angular_freq, len)
     np.random.seed(seed)
-    gen_y = \
-       sine_amplitude * np.sin(gen_x) + \
-       noise_amplitude * np.random.normal(0, noise_scale, len)
+    gen_y = (sine_amplitude * np.sin(gen_x)
+             + noise_amplitude * np.random.normal(0, noise_scale, len))
     df = pd.DataFrame(gen_y, columns=["target"])
     endtime = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())
     df.insert(0, "datetime", pd.date_range(end=endtime, periods=len, freq=time_freq))

--- a/python/chronos/src/bigdl/chronos/data/repo_dataset.py
+++ b/python/chronos/src/bigdl/chronos/data/repo_dataset.py
@@ -138,8 +138,7 @@ def gen_synthetic_data(len=10000, sine_amplitude=10.0, angular_freq=0.01,
 
     gen_x = np.linspace(0, len*angular_freq, len)
     np.random.seed(seed)
-    gen_y = sine_amplitude * np.sin(gen_x) + \
-noise_amplitude * np.random.normal(0, noise_scale, len)
+    gen_y = sine_amplitude*np.sin(gen_x) + noise_amplitude*np.random.normal(0, noise_scale, len)
     df = pd.DataFrame(gen_y, columns=["target"])
     endtime = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())
     df.insert(0, "datetime", pd.date_range(end=endtime, periods=len, freq=time_freq))

--- a/python/chronos/src/bigdl/chronos/data/repo_dataset.py
+++ b/python/chronos/src/bigdl/chronos/data/repo_dataset.py
@@ -139,7 +139,7 @@ def gen_synthetic_data(len=10000, sine_amplitude=10.0, angular_freq=0.01,
     gen_x = np.linspace(0, len*angular_freq, len)
     np.random.seed(seed)
     gen_y = sine_amplitude * np.sin(gen_x) + \
-            noise_amplitude * np.random.normal(0, noise_scale, len)
+       noise_amplitude * np.random.normal(0, noise_scale, len)
     df = pd.DataFrame(gen_y, columns=["target"])
     endtime = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())
     df.insert(0, "datetime", pd.date_range(end=endtime, periods=len, freq=time_freq))

--- a/python/chronos/src/bigdl/chronos/data/repo_dataset.py
+++ b/python/chronos/src/bigdl/chronos/data/repo_dataset.py
@@ -138,8 +138,9 @@ def gen_synthetic_data(len=10000, sine_amplitude=10.0, angular_freq=0.01,
 
     gen_x = np.linspace(0, len * angular_freq, len)
     np.random.seed(seed)
-    gen_y = sine_amplitude * np.sin(gen_x) + \
-            noise_amplitude * np.random.normal(0, noise_scale, len)
+    gen_y = \
+       sine_amplitude * np.sin(gen_x) + \
+       noise_amplitude * np.random.normal(0, noise_scale, len)
     df = pd.DataFrame(gen_y, columns=["target"])
     endtime = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())
     df.insert(0, "datetime", pd.date_range(end=endtime, periods=len, freq=time_freq))

--- a/python/chronos/src/bigdl/chronos/data/repo_dataset.py
+++ b/python/chronos/src/bigdl/chronos/data/repo_dataset.py
@@ -122,7 +122,7 @@ def gen_synthetic_data(len=10000, **kwargs):
     endtime = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())
     df.insert(0, "datetime", pd.date_range(end=endtime, periods=len, freq="T"))
 
-    if 'with_split' not in kwargs or kwargs['with_split']==False:
+    if not 'with_split' in kwargs or kwargs['with_split'] == False:
         tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="target")
         return tsdata
     else:

--- a/python/chronos/src/bigdl/chronos/data/repo_dataset.py
+++ b/python/chronos/src/bigdl/chronos/data/repo_dataset.py
@@ -122,7 +122,7 @@ def gen_synthetic_data(len=10000, **kwargs):
     endtime = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())
     df.insert(0, "datetime", pd.date_range(end=endtime, periods=len, freq="T"))
 
-    if not 'with_split' in kwargs or kwargs['with_split'] == False:
+    if not 'with_split' in kwargs or not kwargs['with_split']:
         tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="target")
         return tsdata
     else:

--- a/python/chronos/src/bigdl/chronos/data/repo_dataset.py
+++ b/python/chronos/src/bigdl/chronos/data/repo_dataset.py
@@ -136,9 +136,10 @@ def gen_synthetic_data(len=10000, sine_amplitude=10.0, angular_freq=0.01,
     _check_type(seed, "seed", int)
     _check_type(time_freq, "time_freq", str)
 
-    gen_x = np.linspace(0, len*angular_freq, len)
+    gen_x = np.linspace(0, len * angular_freq, len)
     np.random.seed(seed)
-    gen_y = sine_amplitude*np.sin(gen_x) + noise_amplitude*np.random.normal(0, noise_scale, len)
+    gen_y = sine_amplitude * np.sin(gen_x) + \
+            noise_amplitude * np.random.normal(0, noise_scale, len)
     df = pd.DataFrame(gen_y, columns=["target"])
     endtime = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())
     df.insert(0, "datetime", pd.date_range(end=endtime, periods=len, freq=time_freq))

--- a/python/chronos/test/bigdl/chronos/data/test_repo_dataset.py
+++ b/python/chronos/test/bigdl/chronos/data/test_repo_dataset.py
@@ -47,6 +47,14 @@ class TestRepoDataset(TestCase):
     def test_gen_synthetic_data(self):
         with pytest.raises(RuntimeError):
             gen_synthetic_data(len="10000")
+        with pytest.raises(RuntimeError):
+            gen_synthetic_data(amplitude="10")
+        with pytest.raises(RuntimeError):
+            gen_synthetic_data(angular_freq="0.01")
+        with pytest.raises(RuntimeError):
+            gen_synthetic_data(scale="1.0")
+        with pytest.raises(RuntimeError):
+            gen_synthetic_data(time_freq=1)
 
         tsdata = gen_synthetic_data()
         assert tsdata._id_list == ['0']

--- a/python/chronos/test/bigdl/chronos/data/test_repo_dataset.py
+++ b/python/chronos/test/bigdl/chronos/data/test_repo_dataset.py
@@ -48,11 +48,15 @@ class TestRepoDataset(TestCase):
         with pytest.raises(RuntimeError):
             gen_synthetic_data(len="10000")
         with pytest.raises(RuntimeError):
-            gen_synthetic_data(amplitude="10")
+            gen_synthetic_data(sine_amplitude="10")
         with pytest.raises(RuntimeError):
             gen_synthetic_data(angular_freq="0.01")
         with pytest.raises(RuntimeError):
-            gen_synthetic_data(scale="1.0")
+            gen_synthetic_data(noise_amplitude="0.01")
+        with pytest.raises(RuntimeError):
+            gen_synthetic_data(noise_scale="1.0")
+        with pytest.raises(RuntimeError):
+            gen_synthetic_data(seed=0.01)
         with pytest.raises(RuntimeError):
             gen_synthetic_data(time_freq=1)
 

--- a/python/chronos/test/bigdl/chronos/data/test_repo_dataset.py
+++ b/python/chronos/test/bigdl/chronos/data/test_repo_dataset.py
@@ -18,7 +18,7 @@ import pandas as pd
 import random
 
 from unittest import TestCase
-from bigdl.chronos.data.repo_dataset import get_public_dataset
+from bigdl.chronos.data import get_public_dataset, gen_synthetic_data
 
 
 class TestRepoDataset(TestCase):
@@ -43,3 +43,21 @@ class TestRepoDataset(TestCase):
         path = '~/.chorons/dataset/'
         with pytest.raises(RuntimeError):
             get_public_dataset(name, path=path, redownload=False)
+
+    def test_gen_synthetic_data(self):
+        with pytest.raises(RuntimeError):
+            gen_synthetic_data(len="10000")
+
+        tsdata = gen_synthetic_data()
+        assert tsdata._id_list == ['0']
+        assert tsdata.target_col == ["target"]
+        assert tsdata.dt_col == "datetime"
+
+        tsdata = gen_synthetic_data(len=5000)
+        assert len(tsdata.to_pandas()) == 5000
+
+        tsdata_train, tsdata_val, tsdata_test = gen_synthetic_data(with_split=True,
+                                                                   val_ratio=0.1, test_ratio=0.1)
+        assert len(tsdata_train.to_pandas()) == 10000*0.8
+        assert len(tsdata_val.to_pandas()) == 10000*0.1
+        assert len(tsdata_test.to_pandas()) == 10000*0.1


### PR DESCRIPTION
## Description

Add the new API `gen_synthetic_data` to help users generate dataset to do some tests even with poor Internet connection.
The dataset is generated according to sine function with a Gaussian noise. And the datetime is generated according to `time_freq` with the current time as endtime.

### 1. Why the change?

https://github.com/intel-analytics/BigDL/issues/5934

### 2. User API changes

2.1. if users want to use `get_public_dataset`
```python
from bigdl.chronos.data import get_public_dataset
```
2.2. if users want to use `gen_synthetic_data` to generate TSDataset
```python
def gen_synthetic_data(len=10000, sine_amplitude=10.0, angular_freq=0.01,
                       noise_amplitude=0.01, noise_scale=1.0, seed=1,
                       time_freq="D", **kwargs)
```

```python
from bigdl.chronos.data import gen_synthetic_data
tsdata_gen = gen_synthetic_data()
tsdata_train_gen, tsdata_val_gen, tsdata_test_gen = gen_synthetic_data(with_split=True, val_ratio=0.1, test_ratio=0.1)
```

### 3. Summary of the change 

3.1. Add import in _init_.py
3.2. Add src and ut of `gen_synthetic_data`

### 4. How to test?
- [x] Unit test