### PR TITLE
Lazy import BarrierTaskContext in tf spark runner

### DIFF
--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -350,7 +350,7 @@ class SparkTFEstimator():
             size=self.num_workers,
             model_weights=weights,
             mode="predict",
-            cluster_info=self._get_cluster_info(sc),
+            cluster_info=None,
             model_dir=self.model_dir,
             application_id=self.application_id,
             need_to_log_to_driver=self.need_to_log_to_driver,

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -350,7 +350,7 @@ class SparkTFEstimator():
             size=self.num_workers,
             model_weights=weights,
             mode="predict",
-            cluster_info=None,
+            cluster_info=None,  # cluster_info is not needed for predict
             model_dir=self.model_dir,
             application_id=self.application_id,
             need_to_log_to_driver=self.need_to_log_to_driver,

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -14,21 +14,15 @@
 # limitations under the License.
 #
 
-import logging
 import os
-
-from pyspark.sql.dataframe import DataFrame
+import logging
 import tempfile
 import shutil
-import glob
 
-import pickle
-
-import tensorflow as tf
+from pyspark.sql.dataframe import DataFrame
 
 from bigdl.dllib.utils.common import get_node_and_core_number
-from bigdl.dllib.utils.file_utils import enable_multi_fs_load, enable_multi_fs_save, \
-    is_local_path, append_suffix
+from bigdl.dllib.utils.file_utils import is_local_path
 from bigdl.dllib.utils.utils import get_node_ip
 
 from bigdl.orca.data.file import is_file, exists, get_remote_file_to_local, \

--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 import json
-import logging
 import os
 import tempfile
 import shutil
@@ -22,13 +21,10 @@ import copy
 
 import tensorflow as tf
 
-from pyspark import BarrierTaskContext, TaskContext
-
 from bigdl.orca.data.utils import ray_partition_get_data_label
 from bigdl.orca.data.file import exists
 from bigdl.orca.learn.utils import save_pkl, duplicate_stdout_stderr_to_file,\
-    get_specific_object_from_callbacks, get_replaced_path, get_rank, \
-    process_tensorboard_in_callbacks, save_model, load_model, \
+    get_rank, process_tensorboard_in_callbacks, save_model, load_model, \
     replace_specific_object_from_callbacks
 from bigdl.orca.learn.log_monitor import LogMonitor
 from bigdl.orca.learn.tf2.callbacks import ModelCheckpoint
@@ -215,8 +211,10 @@ class SparkRunner:
         self.setup()
         self.cluster = cluster_info
         if mode == "fit" or mode == "evaluate":
+            from pyspark import BarrierTaskContext
             self.partition_id = BarrierTaskContext.get().partitionId()
         else:
+            from pyspark import TaskContext
             self.partition_id = TaskContext.get().partitionId()
         self.need_to_log_to_driver = need_to_log_to_driver
         if need_to_log_to_driver:


### PR DESCRIPTION
So that when use predict only, no need to have the constraint of BarrierTaskContext for Spark2.4+

Tested after the modification, spark 2.3.1 works.

@jason-dai @jenniew Take a look.