### PR TITLE
[Nano] Reduce Github Action Testing Time for TensorFlow Multi-Instance Training Fundamental Example/How-to Guides

### DIFF
--- a/python/nano/tutorial/notebook/training/tensorflow/run-nano-howto-guides-training-tensorflow-tests.sh
+++ b/python/nano/tutorial/notebook/training/tensorflow/run-nano-howto-guides-training-tensorflow-tests.sh
@@ -9,6 +9,9 @@ set -e
 # the number of epoch to run is limited for testing purposes
 sed -i 's/epochs=10/epochs=1/' $NANO_HOWTO_GUIDES_TEST_DIR/*.ipynb
 
+# the number of batches to run is limited for testing purposes
+sed -i "s/steps_per_epoch=(ds_info.splits\['train'].num_examples \/\/ 32)/steps_per_epoch=(ds_info.splits\['train'].num_examples \/\/ 32 \/\/ 10)/" $NANO_HOWTO_GUIDES_TEST_DIR/accelerate_tensorflow_training_multi_instance.ipynb
+
 # comment out the install commands
 sed -i 's/!pip install/#!pip install/' $NANO_HOWTO_GUIDES_TEST_DIR/*.ipynb
 
@@ -19,7 +22,7 @@ echo 'Start testing'
 start=$(date "+%s")
 
 # use nbconvert to test here; nbmake may cause some errors
-jupyter nbconvert --ExecutePreprocessor.timeout=700 --to notebook --execute ${NANO_HOWTO_GUIDES_TEST_DIR}/*.ipynb
+jupyter nbconvert --ExecutePreprocessor.timeout=600 --to notebook --execute ${NANO_HOWTO_GUIDES_TEST_DIR}/*.ipynb
 
 now=$(date "+%s")
 time=$((now-start))

--- a/python/nano/tutorial/training/tensorflow/run-nano-tensorflow-test.sh
+++ b/python/nano/tutorial/training/tensorflow/run-nano-tensorflow-test.sh
@@ -5,5 +5,9 @@ export NANO_TUTORIAL_TEST_DIR=${ANALYTICS_ZOO_ROOT}/python/nano/tutorial/trainin
 set -e
 
 export NUM_EPOCHS=1
+
+# the number of batches to run is limited for testing purposes
+sed -i 's/steps_per_epoch=steps_per_epoch/steps_per_epoch=(steps_per_epoch \/\/ 10)/' $NANO_TUTORIAL_TEST_DIR/tensorflow_train_multi_instance.py
+
 python $NANO_TUTORIAL_TEST_DIR/tensorflow_sparse_embedding.py
 python $NANO_TUTORIAL_TEST_DIR/tensorflow_train_multi_instance.py


### PR DESCRIPTION
## Description

### 1. Why the change?

For GitHub action testing on TensorFlow multi-instance how-to guides, the training time sometimes will exceed 700s (defined maximum time for testing one code cell in notebook) for one ephco, which cause failed testing job

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
