### PR TITLE
Nano : Enhancements for InferenceOptimizer to support YOLOX

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -302,7 +302,8 @@ class InferenceOptimizer:
                                 result_map[method]["accuracy"] =\
                                     _accuracy_calculate_helper(acce_model, metric,
                                                                validation_data)
-                            except Exception:
+                            except Exception as e:
+                                print(e)
                                 self._calculate_accuracy = False
                                 invalidInputError(
                                     False,
@@ -794,10 +795,8 @@ def _signature_check(function):
     if len(sig.parameters.values()) != 2:
         return False
     param1_name = list(sig.parameters.values())[0].name
-    param2_name = list(sig.parameters.values())[0].name
-    if "pred" in param1_name:
-        return True
-    if "target" in param2_name:
+    param2_name = list(sig.parameters.values())[1].name
+    if "pred" in param1_name and "target" in param2_name:
         return True
     return False
 
@@ -807,12 +806,17 @@ def _accuracy_calculate_helper(model, metric, data):
     A quick helper to calculate accuracy
     '''
     if isinstance(metric, Metric) or _signature_check(metric) is True:
+        invalidInputError(data is not None,
+                          "Validation data can't be None when you pass a "
+                          "torchmetrics.Metric object or similar callable "
+                          "object which takes prediction and target as input.")
         metric = NanoMetric(metric)
         return metric(model, data)
-    if data is None:
-        return metric(model)
     else:
-        return metric(model, data)
+        if data is None:
+            return metric(model)
+        else:
+            return metric(model, data)
 
 
 def _format_acceleration_option(method_name: str) -> str:

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -795,9 +795,9 @@ def _signature_check(function):
         return False
     param1_name = list(sig.parameters.values())[0].name
     param2_name = list(sig.parameters.values())[0].name
-    if "pred" in param1_name or "pred" in param2_name:
+    if "pred" in param1_name:
         return True
-    if "target" in param2_name or "target" in param2_name:
+    if "target" in param2_name:
         return True
     return False
 

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -144,12 +144,13 @@ class InferenceOptimizer:
         :param metric: (optional) A callable object which is used for calculating accuracy.
                It supports two kinds of callable object:
                1. A torchmetrics.Metric object or similar callable object which takes
-               prediction and target than returns an accuracy value in this calling
+               prediction and target then returns an accuracy value in this calling
                method `metric(pred, target)`. This requires data in validation_data
                is composed of (input_data, target).
-               2. A callable object that takes model and validation_data(which could
-               be None) as input and returns an accuracy value in this calling method
-               `accuracy = metric(model, data_loader)`.
+               2. A callable object that takes model and validation_data (if
+               validation_data is not None) as input, and returns an accuracy value in
+               this calling method metric(model, data_loader) (or metric(model) if
+               validation_data is None).
         :param direction: (optional) A string that indicates the higher/lower
                better for the metric, "min" for the lower the better and "max" for the
                higher the better. Default value is "max".
@@ -303,10 +304,17 @@ class InferenceOptimizer:
                                                                validation_data)
                             except Exception:
                                 self._calculate_accuracy = False
-                                invalidInputError(False,
-                                                  "Your metric is incompatible with "
-                                                  "validation_data or don't follow "
-                                                  "our given pattern.")
+                                invalidInputError(
+                                    False,
+                                    "Your metric is incompatible with validation_data or don't "
+                                    "follow our given pattern. Our expected metric pattern is "
+                                    "as follows:\n1. a torchmetrics.Metric object\n2. a callable "
+                                    "object which takes prediction and target then returns a value"
+                                    " in this calling method `metric(pred, target)`\n3. a callable"
+                                    " object that takes model and validation_data (if "
+                                    "validation_data is not None) as input, and returns an accuracy"
+                                    " value in this calling method metric(model, data_loader) "
+                                    "(or metric(model) if validation_data is None).")
                         else:
                             result_map[method]["accuracy"] =\
                                 _accuracy_calculate_helper(acce_model, metric,

--- a/python/nano/src/bigdl/nano/utils/__init__.py
+++ b/python/nano/src/bigdl/nano/utils/__init__.py
@@ -14,5 +14,4 @@
 # limitations under the License.
 #
 
-
 from .util import deprecated

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/metrics.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/metrics.py
@@ -1,0 +1,36 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from typing import Callable
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+import numpy as np
+
+
+class NanoMetric(object):
+    def __init__(self, metric: Callable):
+        self.metric = metric
+
+    def __call__(self, model: nn.Module, data_loader: DataLoader):
+        with torch.no_grad():
+            metric_list = []
+            sample_num = 0
+            for data_input, target in data_loader:
+                metric_list.append(
+                    self.metric(model(data_input), target).numpy() * data_input.shape[0])
+                sample_num += data_input.shape[0]
+            return np.sum(metric_list) / sample_num

--- a/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
+++ b/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
@@ -152,6 +152,20 @@ class TestInferencePipeline(TestCase):
                                metric=metric,
                                direction="max",
                                thread_num=1)
+    
+    def test_pipeline_with_custom_function_metric_without_data(self):
+        inference_opt = InferenceOptimizer()
+
+        def metric(pred, target):
+            return self.metric(pred, target)
+
+        with pytest.raises(RuntimeError):
+            inference_opt.optimize(model=self.model,
+                                training_data=self.train_loader,
+                                validation_data=None,
+                                metric=metric,
+                                direction="max",
+                                thread_num=1)
 
     def test_pipeline_with_wrong_custom_function_metric(self):
         inference_opt = InferenceOptimizer()

--- a/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
+++ b/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
@@ -130,12 +130,57 @@ class TestInferencePipeline(TestCase):
             transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5)),
             transforms.Resize(64),
         ])
-        fake_train_loader = create_data_loader(self.data_dir, 32, self.num_workers, 
+        fake_train_loader = create_data_loader(self.data_dir, 32, self.num_workers,
                                                fake_transform, subset=10, shuffle=True)
         inference_opt = InferenceOptimizer()
         with pytest.raises(RuntimeError) as e:
             inference_opt.optimize(model=self.model,
-                                    training_data=fake_train_loader,
-                                    thread_num=1)
+                                   training_data=fake_train_loader,
+                                   thread_num=1)
         error_msg = e.value.args[0]
         assert error_msg == "training_data is incompatible with your model input."
+
+    def test_pipeline_with_custom_function_metric(self):
+        inference_opt = InferenceOptimizer()
+
+        def metric(pred, target):
+            return self.metric(pred, target)
+
+        inference_opt.optimize(model=self.model,
+                               training_data=self.train_loader,
+                               validation_data=self.test_loader,
+                               metric=metric,
+                               direction="max",
+                               thread_num=1)
+
+    def test_pipeline_with_wrong_custom_function_metric(self):
+        inference_opt = InferenceOptimizer()
+
+        def metric(x, y):
+            return self.metric(x, y)
+
+        with pytest.raises(RuntimeError):
+            inference_opt.optimize(model=self.model,
+                                training_data=self.train_loader,
+                                validation_data=self.test_loader,
+                                metric=metric,
+                                direction="max",
+                                thread_num=1)
+
+    def test_pipeline_with_custom_function_metric_with_data_loader(self):
+        inference_opt = InferenceOptimizer()
+        import numpy as np
+        def metric(model, data_loader):
+            metrics = []
+            for input_data, target in data_loader:
+                pred = model(input_data)
+                metric = self.metric(pred, target)
+                metrics.append(metric)
+            return np.mean(metrics)
+
+        inference_opt.optimize(model=self.model,
+                               training_data=self.train_loader,
+                               validation_data=self.test_loader,
+                               metric=metric,
+                               direction="max",
+                               thread_num=1)


### PR DESCRIPTION
## Description
To support applying InferenceOptimizer on YOLOX.

### 1. Why the change?

Based on https://github.com/intel-analytics/BigDL/issues/5995, we want to extend `metric` in `InferenceOptimizer.optimize` to support more cases.

### 2. User API changes

Before API supports torchmetrics.Metric object or similar callable object which which takes prediction and target as input.
case1 : torchmetrics.Metric object
```python
inference_opt.optimize(model=model,
                       training_data=train_loader,
                       validation_data=val_loader,
                       metric=torchmetrics.Accuracy(),
                       direction="max",
                       thread_num=1)
```
case2：similar callable object which which takes prediction and target as input. related example: https://github.com/intel-analytics/BigDL/blob/main/python/nano/example/pytorch/inference_optimizer/resnet/inference_pipeline.py
```python
def metric(pred, target):
      value = process(pred, target)
      return value

inference_opt.optimize(model=model,
                       training_data=train_loader,
                       validation_data=val_loader,
                       metric=metric,
                       direction="max",
                       thread_num=1)
```
Now, two additional metric inputs are supported.
case3: A callable object that takes model and validation_data as input
```python
def metric(model, data_loader):
      value = process(model, data_loader)
      return value

inference_opt.optimize(model=model,
                       training_data=train_loader,
                       validation_data=val_loader,
                       metric=metric,
                       direction="max",
                       thread_num=1)
```
case4: A callable object that takes model as input, here validation_data is None, related example: https://github.com/intel-analytics/BigDL/issues/5995
```python
def metric(model):
      value = process(model)
      return value

inference_opt.optimize(model=model,
                       training_data=train_loader,
                       validation_data=None,
                       metric=metric,
                       direction="max",
                       thread_num=1)
```

### 3. Summary of the change

- [x] Extend metric to support more cases
- [x] Add more unittests to test different kinds of metric

### 4. How to test?
- [x] Unit test
- [x] Application test

Inference result of YOLOX：
![image](https://user-images.githubusercontent.com/105281011/192747945-fb05a129-67e4-42f0-ba60-0a427fb654b8.png)

