### PR TITLE
Nano: add jit/ipex fund examples

### DIFF
--- a/.github/workflows/nano_notebooks_tests.yml
+++ b/.github/workflows/nano_notebooks_tests.yml
@@ -93,6 +93,21 @@ jobs:
         env:
             ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
 
+      - name: Run tutorial notebooks Pytorch unit tests(JIT+IPEX)
+        shell: bash
+        run: |
+            $CONDA/bin/conda create -n notebooks-tutorial-pytorch -y python==3.7.10 setuptools=58.0.4
+            source $CONDA/bin/activate notebooks-tutorial-pytorch
+            $CONDA/bin/conda info
+            bash python/nano/dev/build_and_install.sh linux default false pytorch
+            pip install intel_extension_for_pytorch==1.11
+            source bigdl-nano-init
+            bash python/nano/tutorial/inference/pytorch/run_nano_pytorch_inference_tests_jit_ipex.sh
+            source $CONDA/bin/deactivate
+            $CONDA/bin/conda remove -n notebooks-tutorial-pytorch --all
+        env:
+            ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
+
       - name: Run realworld notebooks Pytorch unit tests(OpenVINO)
         shell: bash
         run: |

--- a/python/nano/tutorial/inference/pytorch/pytorch_inference_jit_ipex.py
+++ b/python/nano/tutorial/inference/pytorch/pytorch_inference_jit_ipex.py
@@ -1,0 +1,56 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import torch
+from torchvision.models import resnet18
+
+if __name__ == "__main__":
+
+    model_ft = resnet18(pretrained=True)
+
+    # Normal Inference
+    x = torch.rand(2, 3, 224, 224)
+    y_hat = model_ft(x)
+    predictions = y_hat.argmax(dim=1)
+    print(predictions)
+
+    # Accelerated Inference Using JIT/IPEX/JIT+IPEX
+    # it is recommended to use JIT and IPEX together
+    from bigdl.nano.pytorch import InferenceOptimizer
+
+    # JIT
+    jit_model = InferenceOptimizer.trace(model_ft,
+                                         accelerator="jit",
+                                         input_sample=torch.rand(1, 3, 224, 224))
+    y_hat = jit_model(x)
+    predictions = y_hat.argmax(dim=1)
+    print(predictions)
+
+    # IPEX
+    ipex_model = InferenceOptimizer.trace(model_ft,
+                                          use_ipex=True)
+    y_hat = ipex_model(x)
+    predictions = y_hat.argmax(dim=1)
+    print(predictions)
+
+    # IPEX + JIT
+    jit_ipex_model = InferenceOptimizer.trace(model_ft,
+                                              accelerator="jit",
+                                              use_ipex=True,
+                                              input_sample=torch.rand(1, 3, 224, 224))
+    y_hat = jit_ipex_model(x)
+    predictions = y_hat.argmax(dim=1)
+    print(predictions)

--- a/python/nano/tutorial/inference/pytorch/pytorch_save_and_load_ipex.py
+++ b/python/nano/tutorial/inference/pytorch/pytorch_save_and_load_ipex.py
@@ -1,0 +1,43 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import torch
+from torchvision.models import resnet18
+
+if __name__ == "__main__":
+    model_ft = resnet18(pretrained=True)
+
+    x = torch.rand(2, 3, 224, 224)
+
+    # Accelerated Inference Using IPEX
+    from bigdl.nano.pytorch import InferenceOptimizer
+    ipex_model = InferenceOptimizer.trace(model_ft,
+                                          use_ipex=True)
+
+    # Save Optimized IPEX Model
+    # The saved model files will be saved at "./optimized_model_ipex" directory
+    # There are 2 files in optimized_model_ipex, users only need to take "ckpt.pth" file for further usage:
+    #   nano_model_meta.yml: meta information of the saved model checkpoint
+    #   ckpt.pth: pytorch state dict checkpoint for general use, describes model structure
+    InferenceOptimizer.save(ipex_model, "./optimized_model_ipex")
+
+    # Load the Optimized Model
+    loaded_model = InferenceOptimizer.load("./optimized_model_ipex", model=model_ft)
+
+    # Inference with the Loaded Model
+    y_hat = loaded_model(x)
+    predictions = y_hat.argmax(dim=1)
+    print(predictions)

--- a/python/nano/tutorial/inference/pytorch/pytorch_save_and_load_jit.py
+++ b/python/nano/tutorial/inference/pytorch/pytorch_save_and_load_jit.py
@@ -1,0 +1,64 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import torch
+from torchvision.models import resnet18
+
+if __name__ == "__main__":
+    model_ft = resnet18(pretrained=True)
+
+    x = torch.rand(2, 3, 224, 224)
+
+    # Accelerated Inference Using JIT / JIT+IPEX
+    from bigdl.nano.pytorch import InferenceOptimizer
+    jit_model = InferenceOptimizer.trace(model_ft,
+                                         accelerator="jit",
+                                         input_sample=torch.rand(1, 3, 224, 224))
+
+    # Save Optimized JIT Model
+    # The saved model files will be saved at "./optimized_model_jit" directory
+    # There are 2 files in optimized_model_jit, users only need to take "ckpt.pth" file for further usage:
+    #   nano_model_meta.yml: meta information of the saved model checkpoint
+    #   ckpt.pth: JIT model checkpoint for general use, describes model structure
+    InferenceOptimizer.save(jit_model, "./optimized_model_jit")
+
+    # Load the Optimized Model
+    loaded_model = InferenceOptimizer.load("./optimized_model_jit")
+
+    # Inference with the Loaded Model
+    y_hat = loaded_model(x)
+    predictions = y_hat.argmax(dim=1)
+    print(predictions)
+
+    # Accelerated Inference Using IPEX
+    jit_model = InferenceOptimizer.trace(model_ft,
+                                         use_ipex=True,
+                                         input_sample=torch.rand(1, 3, 224, 224))
+
+    # Save Optimized IPEX Model
+    # The saved model files will be saved at "./optimized_model_ipex" directory
+    # There are 2 files in optimized_model_ipex, users only need to take "ckpt.pth" file for further usage:
+    #   nano_model_meta.yml: meta information of the saved model checkpoint
+    #   ckpt.pth: pytorch state dict checkpoint for general use, describes model structure
+    InferenceOptimizer.save(jit_model, "./optimized_model_ipex")
+
+    # Load the Optimized Model
+    loaded_model = InferenceOptimizer.load("./optimized_model_ipex", model=model_ft)
+
+    # Inference with the Loaded Model
+    y_hat = loaded_model(x)
+    predictions = y_hat.argmax(dim=1)
+    print(predictions)

--- a/python/nano/tutorial/inference/pytorch/pytorch_save_and_load_jit.py
+++ b/python/nano/tutorial/inference/pytorch/pytorch_save_and_load_jit.py
@@ -42,23 +42,3 @@ if __name__ == "__main__":
     y_hat = loaded_model(x)
     predictions = y_hat.argmax(dim=1)
     print(predictions)
-
-    # Accelerated Inference Using IPEX
-    jit_model = InferenceOptimizer.trace(model_ft,
-                                         use_ipex=True,
-                                         input_sample=torch.rand(1, 3, 224, 224))
-
-    # Save Optimized IPEX Model
-    # The saved model files will be saved at "./optimized_model_ipex" directory
-    # There are 2 files in optimized_model_ipex, users only need to take "ckpt.pth" file for further usage:
-    #   nano_model_meta.yml: meta information of the saved model checkpoint
-    #   ckpt.pth: pytorch state dict checkpoint for general use, describes model structure
-    InferenceOptimizer.save(jit_model, "./optimized_model_ipex")
-
-    # Load the Optimized Model
-    loaded_model = InferenceOptimizer.load("./optimized_model_ipex", model=model_ft)
-
-    # Inference with the Loaded Model
-    y_hat = loaded_model(x)
-    predictions = y_hat.argmax(dim=1)
-    print(predictions)

--- a/python/nano/tutorial/inference/pytorch/run_nano_pytorch_inference_tests_jit_ipex.sh
+++ b/python/nano/tutorial/inference/pytorch/run_nano_pytorch_inference_tests_jit_ipex.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+export ANALYTICS_ZOO_ROOT=${ANALYTICS_ZOO_ROOT}
+export NANO_HOME=${ANALYTICS_ZOO_ROOT}/python/nano/src
+export NANO_TUTORIAL_TEST_DIR=${ANALYTICS_ZOO_ROOT}/python/nano/tutorial/inference/pytorch/
+
+set -e
+
+python $NANO_TUTORIAL_TEST_DIR/pytorch_inference_jit_ipex.py
+
+python $NANO_TUTORIAL_TEST_DIR/pytorch_save_and_load_jit.py
+
+python $NANO_TUTORIAL_TEST_DIR/pytorch_save_and_load_ipex.py


### PR DESCRIPTION
## Description

### 1. Why the change?
JIT and ipex are 2 accelerators we support for tracing, we should add examples about them.

### 2. User API changes
Nothing

### 3. Summary of the change 
3 examples are added
1. pytorch_inference_jit_ipex.py (I put them together since jit and ipex are recommended to use together)
2. pytorch_save_and_load_jit.py
3. pytorch_save_and_load_ipex.py

### 4. How to test?
- [x] Application test
