### PR TITLE
Orca:  Customized collate_fn in dataloader

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -478,7 +478,7 @@ class PyTorchPySparkEstimator(BaseEstimator):
                 .mapPartitions(lambda iter: transform_func(iter, init_params, params)).collect()
         else:
             params["data_creator"] = reload_dataloader_creator(data,
-                                                               collate_fn=recollate_fn)
+                                                               recollate_fn=recollate_fn)
 
             def transform_func(iter, init_param, param):
                 return PytorchPysparkWorker(**init_param).validate(**param)

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -56,7 +56,7 @@ def partition_to_creator(partition, collate_fn=empty_recollate_fn):
             def __getitem__(self, i):
                 return index_data(self.x, i), index_data(self.y, i)
 
-        params = {"batch_size": batch_size, "shuffle": True}
+        params = {"batch_size": batch_size, "shuffle": True, "collate_fn": collate_fn}
         for arg in ["shuffle", "sampler", "batch_sampler", "num_workers", "collate_fn",
                     "pin_memory", "drop_last", "timeout", "worker_init_fn",
                     "multiprocessing_context"]:
@@ -67,7 +67,7 @@ def partition_to_creator(partition, collate_fn=empty_recollate_fn):
                                                    allow_list=False)
         print("Data size on worker: ", len(label))
         dataset = NDArrayDataset(data, label)
-        data_loader = DataLoader(dataset, **params, collate_fn=collate_fn)
+        data_loader = DataLoader(dataset, **params)
         return data_loader
 
     return data_creator

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -321,8 +321,6 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                     torch_datashard = shard.to_torch(label_column=label_cols,
                                                      feature_columns=feature_cols,
                                                      batch_size=batch_size)
-                    torch_datashard.generator_func = reload_raydataset_generator(
-                        torch_datashard.generator_func)
                     return torch_datashard
                 return data_creator
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -27,8 +27,7 @@ from bigdl.orca.learn.pytorch.training_operator import TrainingOperator
 from bigdl.orca.learn.pytorch.pytorch_ray_worker import PytorchRayWorker
 from bigdl.orca.learn.utils import maybe_dataframe_to_xshards, dataframe_to_xshards, \
     convert_predict_xshards_to_dataframe, update_predict_xshards, \
-    process_xshards_of_pandas_dataframe, reload_dataloader_creator, \
-    reload_raydataset_generator
+    process_xshards_of_pandas_dataframe, reload_dataloader_creator
 from bigdl.orca.ray import OrcaRayContext
 from bigdl.orca.learn.ray_estimator import Estimator as OrcaRayEstimator
 from bigdl.dllib.utils.file_utils import enable_multi_fs_load, enable_multi_fs_save
@@ -343,9 +342,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                 val_shards = validation_data.split(n=self.num_workers,
                                                    locality_hints=self.remote_workers)
                 for shard, val_shard, worker in zip(shards, val_shards, self.num_workers):
-                    params["data_creator"] = make_data_creator(shard,
-                                                               feature_cols,
-                                                               label_cols)
+                    params["data_creator"] = make_data_creator(shard, feature_cols, label_cols)
 
                     params["validation_data_creator"] = make_data_creator(val_shard,
                                                                           feature_cols,

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -60,7 +60,7 @@ def check_for_failure(remote_values):
     return False
 
 
-def partition_refs_to_creator(partition_refs, collate_fn=None):
+def partition_refs_to_creator(partition_refs):
     def data_creator(config, batch_size):
         from bigdl.orca.data.utils import ray_partitions_get_data_label, index_data, get_size
         from torch.utils.data import Dataset, DataLoader
@@ -329,10 +329,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
             remote_worker_stats = []
             if validation_data is None:
                 for shard, worker in zip(shards, self.remote_workers):
-                    params["data_creator"] = make_data_creator(
-                        shard,
-                        feature_cols,
-                        label_cols)
+                    params["data_creator"] = make_data_creator(shard, feature_cols, label_cols)
                     stats = worker.train_epochs.remote(**params)
                     remote_worker_stats.append(stats)
             else:
@@ -502,8 +499,6 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                 torch_datashard = shard.to_torch(label_column=label_cols,
                                                  feature_columns=feature_cols,
                                                  batch_size=batch_size)
-                torch_datashard.generator_func = reload_raydataset_generator(
-                    torch_datashard.generator_func)
                 return torch_datashard
 
             remote_worker_stats = []

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_spark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_spark_estimator.py
@@ -31,6 +31,7 @@ import torch
 import types
 from bigdl.dllib.utils.log4Error import *
 
+
 def dataloader_collate_wrapper(func, recollate_fn):
 
     def new_collate_fn(batch):

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_spark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_spark_estimator.py
@@ -277,6 +277,7 @@ class PyTorchSparkEstimator(OrcaSparkEstimator):
         elif isinstance(data, DataLoader) or callable(data) or isinstance(data, types.FunctionType):
             if isinstance(data, types.FunctionType):
                 data = data(self.config, batch_size)
+            data.collate_fn = dataloader_collate_wrapper(data.collate_fn, recollate_fn)
             val_feature_set = FeatureSet.pytorch_dataloader(data)
             result = self.estimator.evaluate_minibatch(val_feature_set, self.metrics)
         else:

--- a/python/orca/src/bigdl/orca/learn/utils.py
+++ b/python/orca/src/bigdl/orca/learn/utils.py
@@ -485,13 +485,6 @@ def reload_dataloader_creator(dataloader_func, recollate_fn=None):
     return reload_dataloader if dataloader_func else None
 
 
-def reload_raydataset_generator(generator, recollate_fn=None):
-    def reload_dataset():
-        for batch in generator():
-            yield recollate_fn(batch)
-    return reload_dataset if recollate_fn is not None else generator
-
-
 def data_length(data):
     x = data["x"]
     if isinstance(x, np.ndarray):

--- a/python/orca/src/bigdl/orca/learn/utils.py
+++ b/python/orca/src/bigdl/orca/learn/utils.py
@@ -459,10 +459,6 @@ def make_data_creator(refs):
     return data_creator
 
 
-def empty_recollate_fn(batch):
-    return batch
-
-
 def collate_dataloader_wrapper(func, recollate_fn):
     import torch
 

--- a/python/orca/src/bigdl/orca/learn/utils.py
+++ b/python/orca/src/bigdl/orca/learn/utils.py
@@ -489,6 +489,13 @@ def reload_dataloader_creator(dataloader_func, recollate_fn=empty_recollate_fn):
     return reload_dataloader if dataloader_func else None
 
 
+def reload_raydataset_generator(generator, recollate_fn=empty_recollate_fn):
+    def reload_dataset():
+        for batch in generator():
+            yield recollate_fn(batch)
+    return reload_dataset
+
+
 def data_length(data):
     x = data["x"]
     if isinstance(x, np.ndarray):

--- a/python/orca/src/bigdl/orca/learn/utils.py
+++ b/python/orca/src/bigdl/orca/learn/utils.py
@@ -475,7 +475,7 @@ def collate_dataloader_wrapper(func, recollate_fn):
     return make_feature_list
 
 
-def reload_dataloader_creator(dataloader_func, recollate_fn=empty_recollate_fn):
+def reload_dataloader_creator(dataloader_func, recollate_fn=None):
     def reload_dataloader(config, batch_size):
         dataloader = dataloader_func(config, batch_size)
         dataloader.collate_fn = collate_dataloader_wrapper(dataloader.collate_fn,
@@ -485,11 +485,11 @@ def reload_dataloader_creator(dataloader_func, recollate_fn=empty_recollate_fn):
     return reload_dataloader if dataloader_func else None
 
 
-def reload_raydataset_generator(generator, recollate_fn=empty_recollate_fn):
+def reload_raydataset_generator(generator, recollate_fn=None):
     def reload_dataset():
         for batch in generator():
             yield recollate_fn(batch)
-    return reload_dataset
+    return reload_dataset if recollate_fn is not None else generator
 
 
 def data_length(data):

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
@@ -252,29 +252,6 @@ class TestPyTorchEstimator(TestCase):
         val_stats = estimator.evaluate(val_xshards, batch_size=128)
         print(val_stats)
 
-    def test_spark_xshards_collate(self):
-        from bigdl.dllib.nncontext import init_nncontext
-        from bigdl.orca.data import SparkXShards
-        def combine_collate_fn(batch):
-            x1_x2, y = batch['x'], batch['y']
-            return [x1_x2['input1'], x1_x2['input2']], y
-        estimator = get_estimator(workers_per_node=1,
-                                  model_fn=lambda config: MultiInputNet())
-        sc = init_nncontext()
-        x1_rdd = sc.parallelize(np.random.rand(4000, 1, 25).astype(np.float32))
-        x2_rdd = sc.parallelize(np.random.rand(4000, 1, 25).astype(np.float32))
-        # torch 1.7.1+ requires target size same as output size, which is (batch, 1)
-        y_rdd = sc.parallelize(np.random.randint(0, 2, size=(4000, 1, 1)).astype(np.float32))
-        rdd = x1_rdd.zip(x2_rdd).zip(y_rdd).map(lambda x_y: {'x': {"input1":x_y[0][0], "input2":x_y[0][1]}, 'y': x_y[1]})
-        train_rdd, val_rdd = rdd.randomSplit([0.9, 0.1])
-        train_xshards = SparkXShards(train_rdd)
-        val_xshards = SparkXShards(val_rdd)
-        train_stats = estimator.fit(train_xshards, validation_data=val_xshards,
-                                    batch_size=256, epochs=2, recollate_fn=combine_collate_fn)
-        print(train_stats)
-        val_stats = estimator.evaluate(val_xshards, batch_size=128, recollate_fn=combine_collate_fn)
-        print(val_stats)
-
     def test_dataframe_train_eval(self):
 
         sc = init_nncontext()

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_runtime.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_runtime.py
@@ -215,9 +215,6 @@ def get_model(config):
 def get_optimizer(model, config):
     return torch.optim.SGD(model.parameters(), lr=config.get("lr", 1e-2))
 
-def collate_list_input(batch):
-    feature, target = batch
-    return feature[0], feature[1], target
 
 class TestPytorchEstimator(TestCase):
     def setUp(self):


### PR DESCRIPTION
### 1. Why the change?

For third-party dataloader implementations, we can use a `collate_fn` wrapper to implement custom data processing like elements alignment:
```
def reduceWrapper(func):
    def reduceIterElement(batch):
        batch=func(batch)
        assert len(batch)==5, "Should yield inputs, labels, index, time, meta in dataloader"
        return batch[0], batch[1]
    return reduceIterElement

def train_loader_creator(config, batch_size):
    train_loader = loader.construct_loader(config, "train")
    loader.shuffle_dataset(train_loader, 0)
    train_loader.collate_fn = reduceWrapper(train_loader.collate_fn)
    return train_loader
```
It should be more natural than just integrade their code into users' implementation.

~~And it can also collate elements when `data` is dataframe or Xshards for generic usages.~~

https://github.com/intel-analytics/BigDL/issues/4410

### 2. User API changes

We add a new function type argument called `recollate_fn` to estimator.fit(). 

`recollate_fn` takes a batch of dataloader as input and ouput processed batch:
```
def customized_collate_fn(batch):
       *features, labels = batch
       new_features = process_features(features)
       new_labels = process_labels(labels)
       return new_features, new_labels
```

When a dataloader is passed to fit(), it's original `collate_fn` will be wrapped around with `recollate_fn`

By default `recollate_fn` does nothing.

### 3. Summary of the change 

Enable `recollate_fn` in bigdl, ray and spark backend.  

Before this change if we need to collate dataloader manually:
```
def reduceWrapper(func):
    def reduceIterElement(batch):
        batch=func(batch)
        print("reduce called")
        assert len(batch)==5, "Should yield inputs, labels, index, time, meta in dataloader"
        return batch[0], batch[1]
    return reduceIterElement

def train_loader_creator(config, batch_size):
    train_loader = loader.construct_loader(config, "train")
    loader.shuffle_dataset(train_loader, 0)
    train_loader.collate_fn = reduceWrapper(train_loader.collate_fn)
    return train_loader

def validation_data_creator(config, batch_size):
      val_loader = loader.construct_loader(config,"val")
      val_loader.collate_fn = reduceWrapper(val_loader.collate_fn)
      return val_loader

orca_estimator.fit(data=train_loader_creator,
                               validation_data=validation_data_creator,
                               batch_size=cfg.TRAIN.BATCH_SIZE,
                               epochs=cfg.SOLVER.MAX_EPOCH)
```

now:
```
def reduceIterElement(batch):
    print("reduce called")
    assert len(batch)==5, "Should yield inputs, labels, index, time, meta in dataloader"
    return batch[0], batch[1]

orca_estimator.fit(data=train_loader_creator,
                       validation_data=validation_data_creator,
                       batch_size=cfg.TRAIN.BATCH_SIZE,
                       epochs=cfg.SOLVER.MAX_EPOCH,
                       recollate_fn=reduceIterElement)
```

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...


