### PR TITLE
Chronos: add `from_prometheus` to initialize tsdataset(s) from Prometheus data

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -213,6 +213,79 @@ class TSDataset:
                                      val_ratio=val_ratio,
                                      test_ratio=test_ratio)
 
+    @staticmethod
+    def from_prometheus(prometheus_url,
+                        query,
+                        starttime,
+                        endtime,
+                        step,
+                        target_col=None,
+                        id_col=None,
+                        extra_feature_col=None,
+                        with_split=False,
+                        val_ratio=0,
+                        test_ratio=0.1,
+                        **kwargs):
+        """
+        Initialize tsdataset(s) from Prometheus data for specified time period via url.
+
+        :param prometheus_url: a str indicates url of a Prometheus server.
+        :param query: str, Prometheus expression query string.
+        :param starttime: start timestamp of the specified time period, RFC-3339 string
+               or as a Unix timestamp in seconds.
+        :param endtime: end timestamp of the specified time period, RFC-3339 string
+               or as a Unix timestamp in seconds.
+        :param step: a str indicates query resolution step width in Prometheus duration format
+               or float number of seconds. More information about Prometheus time durations
+               are here:
+               https://prometheus.io/docs/prometheus/latest/querying/basics/#time-durations
+        :param target_col: (optional) a Prometheus expression query str or list indicates the
+               col name of target column in the input data frame. If it is not explicitly stated,
+               then target column is automatically specified according to the Prometheus data.
+        :param id_col: (optional) a Prometheus expression query str indicates the col name of
+               dataframe id. If it is not explicitly stated, then the data is interpreted as
+               only containing a single id.
+        :param extra_feature_col: (optional) a Prometheus expression query str or list indicates
+               the col name of extra feature columns that needs to predict the target column.
+               If it is not explicitly stated, then extra feature column is None.
+        :param with_split: (optional) bool, states if we need to split the dataframe
+               to train, validation and test set. The value defaults to False.
+        :param val_ratio: (optional) float, validation ratio. Only effective when
+               with_split is set to True. The value defaults to 0.
+        :param test_ratio: (optional) float, test ratio. Only effective when with_split
+               is set to True. The value defaults to 0.1.
+        :param kwargs: Any additional kwargs are passed to the Prometheus query, such as
+               timeout.
+
+        :return: a TSDataset instance when with_split is set to False,
+                 three TSDataset instances when with_split is set to True.
+
+        Create a tsdataset instance by:
+
+        >>> # Here is an example:
+        >>> tsdataset = TSDataset.from_prometheus(prometheus_url="http://localhost:9090",
+        >>>                                       query="collectd_cpufreq{cpufreq="0"}",
+        >>>                                       starttime="2022-09-01T00:00:00Z",
+        >>>                                       endtime="2022-10-01T00:00:00Z",
+        >>>                                       step="1h")
+        """
+        # TODO: Corresponding unit test should be added
+        # Only test locally at present
+        from bigdl.chronos.data.utils.prometheus_df import GetRangeDataframe
+        columns = {"target_col": _to_list(target_col, name="target_col"),
+                   "id_col": _to_list(id_col, name="id_col"),
+                   "extra_feature_col": _to_list(extra_feature_col, name="extra_feature_col")}
+        df, df_columns = GetRangeDataframe(prometheus_url, query, starttime, endtime,
+                                           step, columns=columns, **kwargs)
+        return TSDataset.from_pandas(df,
+                                     dt_col=df_columns["dt_col"],
+                                     target_col=df_columns["target_col"],
+                                     id_col=df_columns["id_col"],
+                                     extra_feature_col=df_columns["extra_feature_col"],
+                                     with_split=with_split,
+                                     val_ratio=val_ratio,
+                                     test_ratio=test_ratio)
+
     def impute(self, mode="last", const_num=0):
         '''
         Impute the tsdataset by imputing each univariate time series

--- a/python/chronos/src/bigdl/chronos/data/utils/prometheus_df.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/prometheus_df.py
@@ -46,7 +46,7 @@ import requests
 
 from bigdl.nano.utils.log4Error import invalidInputError
 
-Timestamp = Union[str, float, datetime.datetime]  # RFC-3339 string or as a Unix timestamp in seconds
+Timestamp = Union[str, float, datetime.datetime]  # RFC-3339 string or a Unix timestamp in seconds
 Duration = Union[str, datetime.timedelta]  # Prometheus duration string
 Matrix = pd.DataFrame
 Vector = pd.Series
@@ -71,7 +71,8 @@ class Prometheus:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.http.close()
 
-    def query_range(self, query: str, start: Timestamp, end: Timestamp, step: Union[Duration, float],
+    def query_range(self, query: str, start: Timestamp, end: Timestamp,
+                    step: Union[Duration, float],
                     timeout: Optional[Duration] = None) -> Matrix:
         """
         Evaluates an expression query over a range of time.
@@ -83,7 +84,8 @@ class Prometheus:
         :param timeout: Evaluation timeout. Optional.
         :return: Pandas DataFrame.
         """
-        params = {'query': query, 'start': _timestamp(start), 'end': _timestamp(end), 'step': _duration(step)}
+        params = {'query': query, 'start': _timestamp(start), 'end': _timestamp(end),
+                  'step': _duration(step)}
 
         if timeout is not None:
             params['timeout'] = _duration(timeout)
@@ -126,7 +128,8 @@ def to_pandas(data: dict) -> Union[Matrix, Vector, Scalar, String]:
 def metric_name(metric: dict) -> str:
     """Convert metric labels to standard form."""
     name = metric.get('__name__', '')
-    labels = ','.join(('{}={}'.format(k, json.dumps(v)) for k, v in metric.items() if k != '__name__'))
+    labels = ','.join(('{}={}'.format(k, json.dumps(v)) for k, v in metric.items() \
+                      if k != '__name__'))
     return '{0}{{{1}}}'.format(name, labels)
 
 
@@ -177,7 +180,7 @@ def GetRangeDataframe(prometheus_url, query, starttime, endtime, step, columns, 
                           "The input " + col + " is not found in collected Prometheus data.")
         if columns[col] != []:
             if len(columns[col]) == 1:
-                output_columns[col] = columns[col][0] # id_col is str
+                output_columns[col] = columns[col][0]  # id_col is str
             else:
                 output_columns[col] = columns[col]
         if output_columns[col] is not None:

--- a/python/chronos/src/bigdl/chronos/data/utils/prometheus_df.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/prometheus_df.py
@@ -128,7 +128,7 @@ def to_pandas(data: dict) -> Union[Matrix, Vector, Scalar, String]:
 def metric_name(metric: dict) -> str:
     """Convert metric labels to standard form."""
     name = metric.get('__name__', '')
-    labels = ','.join(('{}={}'.format(k, json.dumps(v)) for k, v in metric.items() \
+    labels = ','.join(('{}={}'.format(k, json.dumps(v)) for k, v in metric.items()
                       if k != '__name__'))
     return '{0}{{{1}}}'.format(name, labels)
 

--- a/python/chronos/src/bigdl/chronos/data/utils/prometheus_df.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/prometheus_df.py
@@ -1,0 +1,190 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# The MIT License (MIT)
+
+# Copyright (c) 2015 David Coles
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import datetime
+import json
+from typing import Optional, Union
+from urllib.parse import urljoin
+import numpy as np
+import pandas as pd
+import requests
+
+from bigdl.nano.utils.log4Error import invalidInputError
+
+Timestamp = Union[str, float, datetime.datetime]  # RFC-3339 string or as a Unix timestamp in seconds
+Duration = Union[str, datetime.timedelta]  # Prometheus duration string
+Matrix = pd.DataFrame
+Vector = pd.Series
+Scalar = np.float64
+String = str
+
+
+class Prometheus:
+    def __init__(self, api_url: str, http: Optional[requests.Session] = None):
+        """
+        Create Prometheus client.
+
+        :param api_url: URL of Prometheus server.
+        :param http: Requests Session to use for requests. Optional.
+        """
+        self.http = http or requests.Session()
+        self.api_url = api_url
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.http.close()
+
+    def query_range(self, query: str, start: Timestamp, end: Timestamp, step: Union[Duration, float],
+                    timeout: Optional[Duration] = None) -> Matrix:
+        """
+        Evaluates an expression query over a range of time.
+
+        :param query: Prometheus expression query string.
+        :param start: Start timestamp.
+        :param end: End timestamp.
+        :param step: Query resolution step width in `duration` format or float number of seconds.
+        :param timeout: Evaluation timeout. Optional.
+        :return: Pandas DataFrame.
+        """
+        params = {'query': query, 'start': _timestamp(start), 'end': _timestamp(end), 'step': _duration(step)}
+
+        if timeout is not None:
+            params['timeout'] = _duration(timeout)
+
+        return to_pandas(self._do_query('api/v1/query_range', params))
+
+    def _do_query(self, path: str, params: dict) -> dict:
+        resp = self.http.get(urljoin(self.api_url, path), params=params)
+        if resp.status_code not in [400, 422, 503]:
+            resp.raise_for_status()
+
+        response = resp.json()
+        if response['status'] != 'success':
+            invalidInputError(False, "Fail to collect data from Prometheus! "
+                              "{errorType}: {error}".format_map(response))
+
+        return response['data']
+
+
+def to_pandas(data: dict) -> Union[Matrix, Vector, Scalar, String]:
+    """Convert Prometheus data object to Pandas object."""
+    result_type = data['resultType']
+    if result_type == 'vector':
+        return pd.Series((np.float64(r['value'][1]) for r in data['result']),
+                         index=(metric_name(r['metric']) for r in data['result']))
+    elif result_type == 'matrix':
+        return pd.DataFrame({
+            metric_name(r['metric']):
+                pd.Series((np.float64(v[1]) for v in r['values']),
+                          index=(pd.Timestamp(v[0], unit='s') for v in r['values']))
+            for r in data['result']})
+    elif result_type == 'scalar':
+        return np.float64(data['result'])
+    elif result_type == 'string':
+        return data['result']
+    else:
+        invalidInputError(False, f"The collected Prometheus data is unknown type {result_type}.")
+
+
+def metric_name(metric: dict) -> str:
+    """Convert metric labels to standard form."""
+    name = metric.get('__name__', '')
+    labels = ','.join(('{}={}'.format(k, json.dumps(v)) for k, v in metric.items() if k != '__name__'))
+    return '{0}{{{1}}}'.format(name, labels)
+
+
+def _timestamp(value):
+    if isinstance(value, datetime.datetime):
+        return value.timestamp()
+    else:
+        return value
+
+
+def _duration(value):
+    if isinstance(value, datetime.timedelta):
+        return value.total_seconds()
+    else:
+        return value
+
+
+def GetRangeDataframe(prometheus_url, query, starttime, endtime, step, columns, **kwargs):
+    '''
+    Convert the Prometheus data over the specified time period to dataframe and confirm
+    dt_col, target_col, id_col and extra_feature_col.
+
+    Return dataframe and col names.
+    '''
+    from bigdl.chronos.data.utils.utils import _check_type
+    _check_type(prometheus_url, "prometheus_url", str)
+    _check_type(query, "query", str)
+    _check_type(starttime, "starttime", (str, float))
+    _check_type(endtime, "endtime", (str, float))
+    _check_type(step, "step", (str, float))
+
+    # Generate dateframe
+    Pro_client = Prometheus(prometheus_url)
+    Pro_df = Pro_client.query_range(query, starttime, endtime, step, **kwargs)
+    df = pd.DataFrame(columns=Pro_df.columns.tolist())
+    df.insert(0, "datetime", Pro_df.index)
+    for col in Pro_df.columns.tolist():
+        df[col] = Pro_df[col].values
+
+    # Clean columns
+    output_columns = {"dt_col": "datetime",
+                      "target_col": Pro_df.columns.tolist(),
+                      "id_col": None,
+                      "extra_feature_col": None}
+    output_col_list = ["datetime"]
+    for col in ["target_col", "id_col", "extra_feature_col"]:
+        invalidInputError(columns[col] == [] or set(columns[col]).issubset(df.columns.tolist()),
+                          "The input " + col + " is not found in collected Prometheus data.")
+        if columns[col] != []:
+            if len(columns[col]) == 1:
+                output_columns[col] = columns[col][0] # id_col is str
+            else:
+                output_columns[col] = columns[col]
+        if output_columns[col] is not None:
+            if isinstance(output_columns[col], list):
+                output_col_list = output_col_list + output_columns[col]
+            else:
+                output_col_list.append(output_columns[col])
+
+    df = df.loc[:, output_col_list]
+    return df, output_columns

--- a/python/chronos/src/bigdl/chronos/data/utils/prometheus_df.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/prometheus_df.py
@@ -176,13 +176,18 @@ def GetRangeDataframe(prometheus_url, query, starttime, endtime, step, columns, 
                       "extra_feature_col": None}
     output_col_list = ["datetime"]
     for col in ["target_col", "id_col", "extra_feature_col"]:
-        invalidInputError(columns[col] == [] or set(columns[col]).issubset(df.columns.tolist()),
+        # Check whether columns specified by user exist
+        invalidInputError(len(columns[col]) == 0 or
+                          set(columns[col]).issubset(df.columns.tolist()),
                           "The input " + col + " is not found in collected Prometheus data.")
-        if columns[col] != []:
-            if len(columns[col]) == 1:
-                output_columns[col] = columns[col][0]  # id_col is str
-            else:
-                output_columns[col] = columns[col]
+
+        # If users specify target_col/id_col/extra_feature_col, update values in output_columns[]
+        if len(columns[col]) == 1:
+            output_columns[col] = columns[col][0]  # id_col must be str
+        elif len(columns[col]) > 1:
+            output_columns[col] = columns[col]
+
+        # According to output_columns, confirm columns to be remained in df
         if output_columns[col] is not None:
             if isinstance(output_columns[col], list):
                 output_col_list = output_col_list + output_columns[col]


### PR DESCRIPTION
## Description

Provide with new API to initialize tsdataset(s) from Prometheus data for specified time period via url.

### 1. Why the change?

https://github.com/intel-analytics/BigDL/issues/5896

### 2. User API changes

```python
def from_prometheus(prometheus_url, query, starttime, endtime, step,
                    target_col=None, id_col=None, extra_feature_col=None,
                    with_split=False, val_ratio=0, test_ratio=0.1, **kwargs):
```

Example:
```python
tsdata = TSDataset.from_prometheus(prometheus_url='http://10.105.191.163:30000/',
                                   query='collectd_cpufreq{cpufreq="0"}',
                                   starttime="2022-09-27T00:00:00Z",
                                   endtime="2022-09-28T00:00:00Z",
                                   step="1m")
```

### 3. Summary of the change 
- [x] Generate dataframe from Prometheus data.
- [x] If columns are not explicitly stated, `target_col` is automatically specified according to the Prometheus data, `id_col` is interpreted as only containing a single id and `extra_feature_col` is None.
- [x] Users can also customize columns.


### 4. How to test?
- [ ] Unit test
(Considering the inconvenience of obtaining data from Prometheus server, the API is only tested locally.)
