### PR TITLE
Chronos : fix bug caused by lookback=1

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -584,7 +584,7 @@ class TSDataset:
             else self.roll_feature_df[additional_feature_col]
 
         if time_enc and label_len == 0:
-            label_len = lookback // 2
+            label_len = max(lookback // 2, 1)
 
         self.lookback, self.horizon, self.label_len = lookback, horizon, label_len
         # horizon_time is only for time_enc, the time_enc numpy ndarray won't have any
@@ -752,7 +752,7 @@ class TSDataset:
                 else self.target_col
 
             if time_enc and label_len == 0:
-                label_len = lookback // 2
+                label_len = max(lookback // 2, 1)
 
             # set scaler index for unscale_numpy
             self.scaler_index = [self.target_col.index(t) for t in target_col]

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -105,6 +105,8 @@ class AutoformerForecaster(Forecaster):
         :param kwargs: other hyperparameter please refer to
                https://github.com/zhouhaoyi/Informer2020#usage
         """
+        invalidInputError(past_seq_len > 1,
+                          "past_seq_len of Autoformer must exceeds one.")
 
         # config setting
         self.data_config = {
@@ -759,7 +761,7 @@ class AutoformerForecaster(Forecaster):
                               "the history time step and output time step.")
 
         if label_len is None:
-            label_len = past_seq_len//2
+            label_len = max(past_seq_len//2, 1)
 
         invalidInputError(tsdataset.label_len == label_len or tsdataset.label_len is None,
                           f"Expected label_len to be {tsdataset.label_len}, "

--- a/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
@@ -365,7 +365,28 @@ class TestChronosModelAutoformerForecaster(TestCase):
                                                          past_seq_len=24,
                                                          future_seq_len=5)
         forecaster.fit(train_loader, epochs=1, batch_size=32)
-        
+
+    def test_autoformer_forecaster_lookback_equals_to_one(self):
+        # from tsdataset
+        df = get_ts_df()
+        target = ["value", "extra feature"]
+        tsdata_train, tsdata_val, tsdata_test =\
+            TSDataset.from_pandas(df, dt_col="datetime", target_col=target,
+                                with_split=True, test_ratio=0.1, val_ratio=0.1)
+        with pytest.raises(RuntimeError):
+            forecaster = AutoformerForecaster.from_tsdataset(tsdata_train,
+                                                             past_seq_len=1,
+                                                             future_seq_len=5)
+
+        # normal definition
+        with pytest.raises(RuntimeError):
+            forecaster = AutoformerForecaster(past_seq_len=1,
+                                            future_seq_len=5,
+                                            input_feature_num=2,
+                                            output_feature_num=2,
+                                            label_len=12,
+                                            freq='s')
+
     def test_autoformer_forecaster_fit_val(self):
         train_data, val_data, _ = create_data()
         forecaster = AutoformerForecaster(past_seq_len=24,


### PR DESCRIPTION
## Description

Found there are two problems when lookback=1 for Autoformer.
1. if time_enc = True and lookback=1, label_len = 0 will cause error in tsdataset.
2. FFT in Autoformer will report error when lookback=1.

We take different solutions for these two cases.

### 1. Why the change?
http://10.112.231.51:18889/job/BigDL-NB-chronos-Python-Spark-3.1-py37-ray-part2/357//console
fix bug when lookback=1.

### 2. User API changes

No change.

### 3. Summary of the change 

- [x] Manually set label_len = 1 when time_enc = True and lookback=1
- [x] Add invalidInputError when past_seq_len = 1 during initialize AutoformerForecaster

### 4. How to test?
- [ ] Unit test
- [ ] Application test

