### PR TITLE
[PPML] Create Dockerfile for ppml gramine base image

### DIFF
--- a/ppml/base/Dockerfile
+++ b/ppml/base/Dockerfile
@@ -85,6 +85,6 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
 
 
 
-ENV PYTHONPATH                          /usr/lib/python3.7:/usr/lib/python3.7/lib-dynload:/usr/local/lib/python3.7/dist-packages:/usr/lib/python3/dist-packages
+ENV PYTHONPATH   /usr/lib/python3.7:/usr/lib/python3.7/lib-dynload:/usr/local/lib/python3.7/dist-packages:/usr/lib/python3/dist-packages
 WORKDIR /ppml
 ENTRYPOINT [ "/bin/bash" ]

--- a/ppml/base/Dockerfile
+++ b/ppml/base/Dockerfile
@@ -12,29 +12,8 @@ ENV SGX_LOG_LEVEL                       error
 ENV LC_ALL                              C.UTF-8
 ENV LANG                                C.UTF-8
 
-
-
-# TODO: remove these directories
-# RUN mkdir -p /ppml/trusted-big-data-ml/work && \
-#     mkdir -p /ppml/trusted-big-data-ml/work/lib && \
-#     mkdir -p /ppml/trusted-big-data-ml/work/keys && \
-#     mkdir -p /ppml/trusted-big-data-ml/work/password && \
-#     mkdir -p /ppml/trusted-big-data-ml/work/data && \
-#     mkdir -p /ppml/trusted-big-data-ml/work/models && \
-#     mkdir -p /ppml/trusted-big-data-ml/work/apps && \
-#     mkdir -p /ppml/trusted-big-data-ml/work/examples/bigdl && \
-#     mkdir -p /root/.keras/datasets && \
-#     mkdir -p /root/.zinc && \
-#     mkdir -p /root/.m2 && \
-#     mkdir -p /root/.kube/
-#     mkdir -p /ppml/trusted-big-data-ml/fl
-
-# SOLVED: change to use /ppml
 RUN mkdir -p /ppml/
 
-# /ppml/work/lib is the folder for gramine to load libraries, check loader.env.LD_LIBRARY_PATH
-
-# SOLVED: check these four files, resolve any bad paths
 ADD ./bash.manifest.template /ppml/bash.manifest.template
 ADD ./Makefile /ppml/Makefile
 ADD ./init.sh /ppml/init.sh
@@ -84,8 +63,6 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     chmod a+x /ppml/init.sh && \
     chmod a+x /ppml/clean.sh
 
-
 ENV PYTHONPATH                          /usr/lib/python3.7:/usr/lib/python3.7/lib-dynload:/usr/local/lib/python3.7/dist-packages:/usr/lib/python3/dist-packages
-# Change WORKDIR to /ppml/ later images can overwrite this
 WORKDIR /ppml
 ENTRYPOINT [ "/bin/bash" ]

--- a/ppml/base/Dockerfile
+++ b/ppml/base/Dockerfile
@@ -5,6 +5,7 @@ ARG http_proxy
 ARG https_proxy
 ARG no_proxy
 ARG BIGDL_VERSION
+
 ENV BIGDL_VERSION                       ${BIGDL_VERSION}
 ENV LOCAL_IP                            127.0.0.1
 ENV SGX_MEM_SIZE                        32G
@@ -18,6 +19,10 @@ ADD ./bash.manifest.template /ppml/bash.manifest.template
 ADD ./Makefile /ppml/Makefile
 ADD ./init.sh /ppml/init.sh
 ADD ./clean.sh /ppml/clean.sh
+
+# These files ared used for attestation service and register MREnclave
+ADD ./register-mrenclave.py /ppml/register-mrenclave.py
+ADD ./verify-attestation-service.sh /ppml/verify-attestation-service.sh
 
 ADD ./_dill.py.patch /_dill.py.patch
 ADD ./python-uuid.patch /python-uuid.patch
@@ -61,7 +66,24 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     patch /usr/local/lib/python3.7/dist-packages/psutil/_pslinux.py /python-pslinux.patch && \
     cp /usr/lib/x86_64-linux-gnu/libpython3.7m.so.1 /usr/lib/libpython3.7m.so.1 && \
     chmod a+x /ppml/init.sh && \
-    chmod a+x /ppml/clean.sh
+    chmod a+x /ppml/clean.sh && \
+    chmod +x /ppml/verify-attestation-service.sh && \
+# Install sgxsdk and dcap, which is used for remote attestation
+    mkdir -p /opt/intel/ && \
+    cd /opt/intel && \
+    wget https://download.01.org/intel-sgx/sgx-dcap/1.13/linux/distro/ubuntu20.04-server/sgx_linux_x64_sdk_2.16.100.4.bin && \
+    chmod a+x ./sgx_linux_x64_sdk_2.16.100.4.bin && \
+    printf "no\n/opt/intel\n"|./sgx_linux_x64_sdk_2.16.100.4.bin && \
+    . /opt/intel/sgxsdk/environment && \
+    cd /opt/intel && \
+    wget https://download.01.org/intel-sgx/sgx-dcap/1.13/linux/distro/ubuntu20.04-server/sgx_debian_local_repo.tgz && \
+    tar xzf sgx_debian_local_repo.tgz && \
+    echo 'deb [trusted=yes arch=amd64] file:///opt/intel/sgx_debian_local_repo focal main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
+    wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - && \
+    apt-get update && \
+    apt-get install -y libsgx-enclave-common-dev  libsgx-ae-qe3 libsgx-ae-qve libsgx-urts libsgx-dcap-ql libsgx-dcap-default-qpl libsgx-dcap-quote-verify-dev libsgx-dcap-ql-dev libsgx-dcap-default-qpl-dev libsgx-quote-ex-dev libsgx-uae-service libsgx-ra-network libsgx-ra-uefi
+
+
 
 ENV PYTHONPATH                          /usr/lib/python3.7:/usr/lib/python3.7/lib-dynload:/usr/local/lib/python3.7/dist-packages:/usr/lib/python3/dist-packages
 WORKDIR /ppml

--- a/ppml/base/Dockerfile
+++ b/ppml/base/Dockerfile
@@ -1,0 +1,91 @@
+ARG BIGDL_VERSION=2.2.0-SNAPSHOT
+
+FROM ubuntu:20.04
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+ARG BIGDL_VERSION
+ENV BIGDL_VERSION                       ${BIGDL_VERSION}
+ENV LOCAL_IP                            127.0.0.1
+ENV SGX_MEM_SIZE                        32G
+ENV SGX_LOG_LEVEL                       error
+ENV LC_ALL                              C.UTF-8
+ENV LANG                                C.UTF-8
+
+
+
+# TODO: remove these directories
+# RUN mkdir -p /ppml/trusted-big-data-ml/work && \
+#     mkdir -p /ppml/trusted-big-data-ml/work/lib && \
+#     mkdir -p /ppml/trusted-big-data-ml/work/keys && \
+#     mkdir -p /ppml/trusted-big-data-ml/work/password && \
+#     mkdir -p /ppml/trusted-big-data-ml/work/data && \
+#     mkdir -p /ppml/trusted-big-data-ml/work/models && \
+#     mkdir -p /ppml/trusted-big-data-ml/work/apps && \
+#     mkdir -p /ppml/trusted-big-data-ml/work/examples/bigdl && \
+#     mkdir -p /root/.keras/datasets && \
+#     mkdir -p /root/.zinc && \
+#     mkdir -p /root/.m2 && \
+#     mkdir -p /root/.kube/
+#     mkdir -p /ppml/trusted-big-data-ml/fl
+
+# SOLVED: change to use /ppml
+RUN mkdir -p /ppml/
+
+# /ppml/work/lib is the folder for gramine to load libraries, check loader.env.LD_LIBRARY_PATH
+
+# SOLVED: check these four files, resolve any bad paths
+ADD ./bash.manifest.template /ppml/bash.manifest.template
+ADD ./Makefile /ppml/Makefile
+ADD ./init.sh /ppml/init.sh
+ADD ./clean.sh /ppml/clean.sh
+
+ADD ./_dill.py.patch /_dill.py.patch
+ADD ./python-uuid.patch /python-uuid.patch
+ADD ./python-pslinux.patch /python-pslinux.patch
+
+# Python3.7
+RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt install software-properties-common -y && \
+    add-apt-repository ppa:deadsnakes/ppa -y && \
+    apt-get install -y python3.7-minimal build-essential python3.7-distutils python3.7 python3-setuptools python3.7-dev python3-wheel python3-pip libpython3.7 && \
+    rm /usr/bin/python3 && \
+    ln -s /usr/bin/python3.7 /usr/bin/python3 && \
+    pip3 install --upgrade pip && \
+    pip install setuptools==58.4.0 && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
+# Gramine
+    apt-get update --fix-missing && \
+    env DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y apt-utils wget unzip protobuf-compiler && \
+    pip install --no-cache-dir meson==0.63.2 cmake==3.24.1.1 toml==0.10.2 pyelftools cffi dill==0.3.4 psutil && \
+# Create a link to cmake, upgrade cmake version so that it is compatible with latest meson build (require version >= 3.17)
+    ln -s /usr/local/bin/cmake /usr/bin/cmake && \
+    env DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential autoconf bison gawk git ninja-build python3-click python3-jinja2 wget pkg-config cmake libcurl4-openssl-dev libprotobuf-c-dev protobuf-c-compiler python3-cryptography python3-pip python3-protobuf nasm && \
+    git clone https://github.com/analytics-zoo/gramine.git /gramine && \
+    git clone https://github.com/intel/SGXDataCenterAttestationPrimitives.git /opt/intel/SGXDataCenterAttestationPrimitives && \
+    cd /gramine && \
+    git checkout devel-v1.3.1-2022-10-08 && \
+    meson setup build/ --buildtype=release  -Dsgx=enabled   -Dsgx_driver=dcap1.10 && \
+    ninja -C build/ && \
+    ninja -C build/ install && \
+    cd /ppml/ && \
+# meson will copy the original file instead of the symlink, which enable us to delete the gramine directory entirely
+    rm -rf /gramine && \
+    apt-get update --fix-missing && \
+    env DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y tzdata && \
+    apt-get install -y apt-utils vim curl nano wget unzip git tree zip && \
+    apt-get install -y libsm6 make build-essential && \
+    apt-get install -y autoconf gawk bison libcurl4-openssl-dev python3-protobuf libprotobuf-c-dev protobuf-c-compiler && \
+    apt-get install -y netcat net-tools && \
+    patch /usr/local/lib/python3.7/dist-packages/dill/_dill.py /_dill.py.patch && \
+    patch /usr/lib/python3.7/uuid.py /python-uuid.patch && \
+    patch /usr/local/lib/python3.7/dist-packages/psutil/_pslinux.py /python-pslinux.patch && \
+    cp /usr/lib/x86_64-linux-gnu/libpython3.7m.so.1 /usr/lib/libpython3.7m.so.1 && \
+    chmod a+x /ppml/init.sh && \
+    chmod a+x /ppml/clean.sh
+
+
+ENV PYTHONPATH                          /usr/lib/python3.7:/usr/lib/python3.7/lib-dynload:/usr/local/lib/python3.7/dist-packages:/usr/lib/python3/dist-packages
+# Change WORKDIR to /ppml/ later images can overwrite this
+WORKDIR /ppml
+ENTRYPOINT [ "/bin/bash" ]

--- a/ppml/base/Makefile
+++ b/ppml/base/Makefile
@@ -1,0 +1,91 @@
+SGX_SIGNER_KEY ?= /root/.config/gramine/enclave-key.pem
+ARCH_LIBDIR ?= /lib/$(shell $(CC) -dumpmachine)
+
+G_JAVA_XMX ?= "2G"
+G_SGX_SIZE ?= "16G"
+G_LOG_LEVEL ?= all
+G_SGX_THREAD_NUM ?= 1024
+
+THIS_DIR ?= /ppml
+WORK_DIR ?= $(THIS_DIR)/work
+JDK_HOME ?= /opt/jdk8
+PYTHON_HOME ?= /usr/lib/python3.8
+SPARK_HOME ?= $(THIS_DIR)/work/spark-3.1.2
+SPARK_USER ?= root
+SPARK_LOCAL_IP ?= 127.0.0.1
+
+
+.PHONY: all
+all: bash.manifest
+ifeq ($(SGX),1)
+all: bash.manifest.sgx bash.sig bash.token
+endif
+
+ifeq ($(DEBUG),1)
+GRAMINE_LOG_LEVEL = all
+endif
+#                -D=$() \
+
+bash.manifest: bash.manifest.template
+	gramine-manifest \
+                -Dlog_level=$(G_LOG_LEVEL) \
+                -Dexecdir=$(shell dirname $(shell which bash)) \
+                -Darch_libdir=$(ARCH_LIBDIR) \
+                -Dpython_home=$(PYTHON_HOME) \
+                -Djdk_home=$(JDK_HOME) \
+		-Dg_sgx_size=$(G_SGX_SIZE) \
+		-Dg_sgx_thread_num=$(G_SGX_THREAD_NUM) \
+		-Dspark_home=$(SPARK_HOME) \
+		-Dspark_user=$(SPARK_USER) \
+		-Dspark_local_ip=$(SPARK_LOCAL_IP) \
+                $< >$@
+
+bash.manifest.sgx: bash.manifest
+	gramine-sgx-sign \
+                --manifest bash.manifest \
+                --output $@
+
+bash.sig: bash.manifest.sgx
+
+bash.token: bash.sig
+	gramine-sgx-get-token --output bash.token --sig bash.sig
+
+ifeq ($(SGX),)
+GRAMINE = gramine-direct
+else
+GRAMINE = gramine-sgx
+endif
+
+.PHONY: regression
+regression: all
+	@mkdir -p scripts/testdir
+
+	@mkdir -p scripts/testdir
+
+	$(GRAMINE) ./bash -c "ls" > OUTPUT
+	@grep -q "Makefile" OUTPUT && echo "[ Success 1/7 ]"
+	@rm OUTPUT
+
+	$(GRAMINE) ./bash -c "cd scripts && bash bash_test.sh 1" > OUTPUT
+	@grep -q "hello 1" OUTPUT      && echo "[ Success 2/7 ]"
+	@grep -q "createdfile" OUTPUT  && echo "[ Success 3/7 ]"
+	@grep -q "somefile" OUTPUT     && echo "[ Success 4/7 ]"
+	@grep -q "current date" OUTPUT && echo "[ Success 5/7 ]"
+	@rm OUTPUT
+
+	$(GRAMINE) ./bash -c "cd scripts && bash bash_test.sh 3" > OUTPUT
+	@grep -q "hello 3" OUTPUT      && echo "[ Success 6/7 ]"
+	@rm OUTPUT
+
+	$(GRAMINE) ./bash -c "readlink /proc/self/exe" > OUTPUT
+	@grep -qE "^(/usr)?/bin/readlink" OUTPUT && echo "[ Success 7/7 ]"
+	@rm OUTPUT
+
+	@rm -rf scripts/testdir
+
+.PHONY: clean
+clean:
+	$(RM) *.manifest *.manifest.sgx *.token *.sig OUTPUT scripts/testdir/*
+
+.PHONY: distclean
+distclean: clean

--- a/ppml/base/README.md
+++ b/ppml/base/README.md
@@ -59,6 +59,8 @@ Besides, you may also want to set the `WORKDIR` and the `ENTRYPOINT` in your ima
 
 The image only contains these important components:
 
-1. Python3.7 and some packages
-2. Gramine
+1. Python3.7 and some packages.
+2. Gramine.
 3. Three patches applied to the Python source code and its packages.
+4. Package sgxsdk and dcap, required by remote attestation.
+5. Script for register MREnclave and verify remote EHSM (The jars required are not fully provided).

--- a/ppml/base/README.md
+++ b/ppml/base/README.md
@@ -1,0 +1,64 @@
+# Gramine PPML Base Image
+
+This folder contains the Dockerfile needed to build the Gramine PPML Base Image.
+
+## Build Image
+
+To build the image, setup the proxy settings in the `build-docker-image.sh` if proxy is needed.  Otherwise, just run `./build-docker-image.sh` to build the image.
+
+
+## For those who wants to extend this image:
+
+### New working directory
+
+The working directory is now set to `/ppml/` instead of `/ppml/trusted-big-data-ml/`.
+
+For instance, the `bash.manifest.template` originally loads the library from `/ppml/trusted-big-data-ml/work/lib`.  Now, it will load the library from `/ppml/work/lib`
+
+All the corresponding files including
+
+1. bash.manifest.template
+2. clean.sh
+3. init.sh
+4. Makefile
+
+are changed accordingly.
+
+### Mount files needed by bash.manifest.template
+
+The following four directories required by the `bash.manifest.template` are no longer added to the image.
+```bash
+  { path = "/root/.kube/", uri = "file:/root/.kube/" },
+  { path = "/root/.keras", uri = "file:/root/.keras" },
+  { path = "/root/.m2", uri = "file:/root/.m2" },
+  { path = "/root/.zinc", uri = "file:/root/.zinc" },
+```
+
+
+To ensure that the `bash.manifest.template` works correctly, add the following block into your image's Dockerfile:
+
+```dockerfile
+RUN  mkdir -p /root/.keras/datasets && \
+     mkdir -p /root/.zinc && \
+     mkdir -p /root/.m2 && \
+     mkdir -p /root/.kube/
+```
+
+### Set ENV in your image
+
+The image have Python3.7 installed.  If this is what you needed, put the following command into your image:
+```dockerfile
+ENV PYTHONPATH                          /usr/lib/python3.7:/usr/lib/python3.7/lib-dynload:/usr/local/lib/python3.7/dist-packages:/usr/lib/python3/dist-packages
+```
+
+Otherwise, install your version of Python and set the `PYTHONPATH` accordingly.
+
+Besides, you may also want to set the `WORKDIR` and the `ENTRYPOINT` in your image.
+
+## What is included in the image?
+
+The image only contains these important components:
+
+1. Python3.7 and some packages
+2. Gramine
+3. Three patches applied to the Python source code and its packages.

--- a/ppml/base/README.md
+++ b/ppml/base/README.md
@@ -48,7 +48,7 @@ RUN  mkdir -p /root/.keras/datasets && \
 
 The image have Python3.7 installed.  If this is what you needed, put the following command into your image:
 ```dockerfile
-ENV PYTHONPATH                          /usr/lib/python3.7:/usr/lib/python3.7/lib-dynload:/usr/local/lib/python3.7/dist-packages:/usr/lib/python3/dist-packages
+ENV PYTHONPATH   /usr/lib/python3.7:/usr/lib/python3.7/lib-dynload:/usr/local/lib/python3.7/dist-packages:/usr/lib/python3/dist-packages
 ```
 
 Otherwise, install your version of Python and set the `PYTHONPATH` accordingly.

--- a/ppml/base/_dill.py.patch
+++ b/ppml/base/_dill.py.patch
@@ -1,0 +1,11 @@
+203,206c203,207
+<     open = kwargs.pop("open", __builtin__.open)
+<     f = open(os.devnull, *args, **kwargs)
+<     t = type(f)
+<     f.close()
+---
+>     #open = kwargs.pop("open", __builtin__.open)
+>     #f = open(os.devnull, *args, **kwargs)
+>     #t = type(f)
+>     #f.close()
+>     t=None

--- a/ppml/base/bash.manifest.template
+++ b/ppml/base/bash.manifest.template
@@ -1,0 +1,91 @@
+libos.entrypoint = "{{ execdir }}/bash"
+loader.entrypoint = "file:{{ gramine.libos }}"
+loader.pal_internal_mem_size = "512M"
+loader.log_level = "{{ log_level }}"
+
+#loader.insecure__use_cmdline_argv = true
+loader.insecure_disable_aslr = true
+#loader.argv_src_file = "file:/ppml/trusted-big-data-ml/secured_argvs"
+loader.argv_src_file = "file:/ppml/secured_argvs"
+
+sgx.allow_file_creation = true
+sgx.debug = false
+sgx.nonpie_binary = true
+sgx.enclave_size = "{{ g_sgx_size }}"
+sgx.thread_num = {{ g_sgx_thread_num }}
+sgx.file_check_policy = "allow_all_but_log"
+sgx.static_address = 1
+sgx.isvprodid = 1
+sgx.isvsvn = 3
+
+#loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}:/usr/lib/python3.7/lib:/usr/lib:{{ jdk_home }}:{{ jdk_home }}/lib/amd64/jli:/ppml/trusted-big-data-ml/work/lib"
+loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}:/usr/lib/python3.7/lib:/usr/lib:{{ jdk_home }}:{{ jdk_home }}/lib/amd64/jli:/ppml/work/lib"
+loader.env.PATH = "{{ execdir }}:/usr/lib/python3.7/bin:/:/usr/sbin:/usr/bin:/sbin:/bin:{{ jdk_home }}/bin"
+loader.env.PYTHONHOME = "/usr/lib/python3.7"
+loader.env.PYTHONPATH = "/usr/lib/python3.7:/usr/lib/python3.7/lib-dynload:/usr/local/lib/python3.7/dist-packages:/usr/lib/python3/dist-packages"
+loader.env.JAVA_HOME = "{{ jdk_home }}"
+loader.env.JAVA_OPTS = "'-Djava.library.path={{ jdk_home }}/lib -Dsun.boot.library.path={{ jdk_home }}/lib'"
+loader.env.SPARK_LOCAL_IP = "{{ spark_local_ip }}"
+loader.env.SPARK_USER = "{{ spark_user }}"
+loader.env.SPARK_SCALA_VERSION = "2.12"
+loader.env.SPARK_HOME = "{{ spark_home }}"
+loader.env.SPARK_MASTER_OPTS = "'-Dspark.worker.timeout=60'"
+
+sgx.ioctl_structs.ifconf  =  [ {name = "ifc_len",size = 4, align = 4, type= "inout" }, {size = 4, type= "inout"}, { ptr=[ {name="ifcu_req", size= "ifc_len", type="in"} ] } ]
+sgx.allowed_ioctls.io1.request = 0x8912
+sgx.allowed_ioctls.io1.struct = "ifconf"
+
+sgx.ioctl_structs.ifreq = [ {  name ="ifreq", size=40, type="inout"} ]
+sgx.allowed_ioctls.io2.request = 0x8927
+sgx.allowed_ioctls.io2.struct = "ifreq"
+
+
+fs.mounts = [
+  { path = "{{ arch_libdir }}", uri = "file:{{ arch_libdir }}" },
+  { path = "/usr{{ arch_libdir }}", uri = "file:/usr{{ arch_libdir }}" },
+  { path = "{{ execdir }}", uri = "file:{{ execdir }}" },
+  { path = "/usr/lib", uri = "file:/usr/lib" },
+  { path = "/lib", uri = "file:{{ gramine.runtimedir() }}" },
+  { path = "/usr/local", uri = "file:/usr/local" },
+  { path = "/etc", uri = "file:/etc" },
+  { path = "/usr/local/etc", uri = "file:/etc" },
+  { path = "/opt", uri = "file:/opt" },
+  { path = "/bin", uri = "file:/bin" },
+  { path = "/tmp", uri = "file:/tmp" },
+  { path = "/usr/lib/python3.7", uri = "file:/usr/lib/python3.7" },
+  { path = "/usr/lib/python3/dist-packages", uri = "file:/usr/lib/python3/dist-packages" },
+  { path = "/root/.kube/", uri = "file:/root/.kube/" },
+  { path = "/root/.keras", uri = "file:/root/.keras" },
+  { path = "/root/.m2", uri = "file:/root/.m2" },
+  { path = "/root/.zinc", uri = "file:/root/.zinc" },
+  { path = "/usr/lib/gcc", uri = "file:/usr/lib/gcc" },
+  #{ path = "/ppml/trusted-big-data-ml", uri = "file:/ppml/trusted-big-data-ml" },
+  { path = "/ppml", uri = "file:/ppml" },
+]
+#  { path = "{{ gramine.runtimedir() }}/etc/localtime", uri = "file:/etc" },
+
+sgx.trusted_files = [
+  "file:{{ gramine.libos }}",
+  "file:{{ gramine.runtimedir() }}/",
+  "file:{{ arch_libdir }}/",
+  "file:/usr/{{ arch_libdir }}/",
+  "file:{{ execdir }}/",
+  #"file:/ppml/trusted-big-data-ml/secured_argvs",
+  "file:/ppml/secured_argvs",
+]
+
+sgx.allowed_files = [
+  "file:scripts/",
+  "file:/etc",
+  "file:/tmp",
+  "file:{{ jdk_home }}",
+  "file:/ppml",
+  "file:{{ python_home }}",
+  "file:/usr/local/lib/python3.7/dist-packages",
+  "file:/root/.keras",
+  "file:/root/.m2",
+  "file:/root/.zinc",
+  "file:/usr/lib/gcc",
+  "file:/root/.kube/config",
+  "file:/etc/localtime",
+]

--- a/ppml/base/bash.manifest.template
+++ b/ppml/base/bash.manifest.template
@@ -2,12 +2,18 @@ libos.entrypoint = "{{ execdir }}/bash"
 loader.entrypoint = "file:{{ gramine.libos }}"
 loader.pal_internal_mem_size = "512M"
 loader.log_level = "{{ log_level }}"
+loader.insecure__use_host_env = true
+loader.env.LD_PRELOAD  = ""
+
+sys.enable_extra_runtime_domain_names_conf = true
 
 #loader.insecure__use_cmdline_argv = true
 loader.insecure_disable_aslr = true
 #loader.argv_src_file = "file:/ppml/trusted-big-data-ml/secured_argvs"
 loader.argv_src_file = "file:/ppml/secured_argvs"
 
+sgx.remote_attestation = "dcap"
+sgx.ra_client_spid = ""
 sgx.allow_file_creation = true
 sgx.debug = false
 sgx.nonpie_binary = true

--- a/ppml/base/build-docker-image.sh
+++ b/ppml/base/build-docker-image.sh
@@ -1,0 +1,23 @@
+export HTTP_PROXY_HOST=your_http_proxy_host
+export HTTP_PROXY_PORT=your_http_proxy_port
+export HTTPS_PROXY_HOST=your_https_proxy_host
+export HTTPS_PROXY_PORT=your_https_proxy_port
+
+Proxy_Modified="sudo docker build \
+    --build-arg http_proxy=http://${HTTP_PROXY_HOST}:${HTTP_PROXY_PORT} \
+    --build-arg https_proxy=http://${HTTPS_PROXY_HOST}:${HTTPS_PROXY_PORT} \
+    --build-arg no_proxy=x.x.x.x \
+    -t intelanalytics/bigdl-ppml-gramine-base:2.2.0-SNAPSHOT -f ./Dockerfile ."
+
+No_Proxy_Modified="sudo docker build \
+    --build-arg no_proxy=x.x.x.x \
+    -t intelanalytics/bigdl-ppml-gramine-base:2.2.0-SNAPSHOT -f ./Dockerfile ."
+
+if [[ "$HTTP_PROXY_HOST" == "your_http_proxy_host" ]] || [[ "$HTTP_PROXY_PORT" == "your_http_proxy_port" ]] || [[ "$HTTPS_PROXY_HOST" == "your_https_proxy_host" ]] || [[ "$HTTPS_PROXY_PORT" == "your_https_proxy_port" ]]
+then
+    echo "If your environment don't need to set proxy, please ignore this notice information; if your environment need to set proxy, please delete the image just created and modify the proxy in the script, then rerun this script."
+    $No_Proxy_Modified
+    echo "If your environment don't need to set proxy, please ignore this notice information; if your environment need to set proxy, please delete the image just created and modify the proxy in the script, then rerun this script."
+else
+    $Proxy_Modified
+fi

--- a/ppml/base/clean.sh
+++ b/ppml/base/clean.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -x
+
+sgx_mem_size=$SGX_MEM_SIZE
+
+make SGX=1 THIS_DIR=/ppml G_SGX_SIZE=$sgx_mem_size clean

--- a/ppml/base/init.sh
+++ b/ppml/base/init.sh
@@ -2,10 +2,12 @@
 
 set -x
 
-local_ip=$LOCAL_IP
-sgx_mem_size=$SGX_MEM_SIZE
-sgx_log_level=$SGX_LOG_LEVEL
-
+if [ -f "/ppml/bash.sig" ]; then
+    echo "/ppml/bash.sig is ready"
+else
+    echo "/ppml/bash.sig is not ready, please generate it through building CustomerImageDockfile"
+    exit 1
+fi
 if [ -c "/dev/sgx/enclave" ]; then
     echo "/dev/sgx/enclave is ready"
 elif [ -c "/dev/sgx_enclave" ]; then
@@ -28,13 +30,9 @@ else
     exit 1
 fi
 
-if [ -f "/ppml/secured_argvs" ]; then
-    echo "/ppml/secured_argvs is ready"
-else
-    echo "/ppml/secured_argvs is not ready, please generate it before init.sh"
-    exit 1
-fi
 
 ls -al /dev/sgx
 
-make SGX=1 DEBUG=1 THIS_DIR=/ppml  SPARK_LOCAL_IP=$local_ip SPARK_USER=root G_SGX_SIZE=$sgx_mem_size G_LOG_LEVEL=$sgx_log_level
+gramine-sgx-get-token --output /ppml/bash.token --sig /ppml/bash.sig
+
+chmod +x /ppml/bash.token

--- a/ppml/base/init.sh
+++ b/ppml/base/init.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -x
+
+local_ip=$LOCAL_IP
+sgx_mem_size=$SGX_MEM_SIZE
+sgx_log_level=$SGX_LOG_LEVEL
+
+if [ -c "/dev/sgx/enclave" ]; then
+    echo "/dev/sgx/enclave is ready"
+elif [ -c "/dev/sgx_enclave" ]; then
+    echo "/dev/sgx/enclave not ready, try to link to /dev/sgx_enclave"
+    mkdir -p /dev/sgx
+    ln -s /dev/sgx_enclave /dev/sgx/enclave
+else
+    echo "both /dev/sgx/enclave /dev/sgx_enclave are not ready, please check the kernel and driver"
+    exit 1
+fi
+
+if [ -c "/dev/sgx/provision" ]; then
+    echo "/dev/sgx/provision is ready"
+elif [ -c "/dev/sgx_provision" ]; then
+    echo "/dev/sgx/provision not ready, try to link to /dev/sgx_provision"
+    mkdir -p /dev/sgx
+    ln -s /dev/sgx_provision /dev/sgx/provision
+else
+    echo "both /dev/sgx/provision /dev/sgx_provision are not ready, please check the kernel and driver"
+    exit 1
+fi
+
+if [ -f "/ppml/secured_argvs" ]; then
+    echo "/ppml/secured_argvs is ready"
+else
+    echo "/ppml/secured_argvs is not ready, please generate it before init.sh"
+    exit 1
+fi
+
+ls -al /dev/sgx
+
+make SGX=1 DEBUG=1 THIS_DIR=/ppml  SPARK_LOCAL_IP=$local_ip SPARK_USER=root G_SGX_SIZE=$sgx_mem_size G_LOG_LEVEL=$sgx_log_level

--- a/ppml/base/python-pslinux.patch
+++ b/ppml/base/python-pslinux.patch
@@ -1,0 +1,14 @@
+301,303c301,303
+< try:
+<     set_scputimes_ntuple("/proc")
+< except Exception:  # pragma: no cover
+---
+> #try:
+>     #set_scputimes_ntuple("/proc")
+> #except Exception:  # pragma: no cover
+305,306c305,306
+<     traceback.print_exc()
+<     scputimes = namedtuple('scputimes', 'user system idle')(0.0, 0.0, 0.0)
+---
+>     #traceback.print_exc()
+> scputimes = namedtuple('scputimes', 'user system idle')(0.0, 0.0, 0.0)

--- a/ppml/base/python-uuid.patch
+++ b/ppml/base/python-uuid.patch
@@ -1,0 +1,6 @@
+609c609,611
+<                 lib = ctypes.CDLL(ctypes.util.find_library(libname))
+---
+>                 #lib = ctypes.CDLL(ctypes.util.find_library(libname))
+>                 lib = ctypes.CDLL('/lib/x86_64-linux-gnu/libuuid.so.1')
+>                 print("###INFO lib:" + str(lib))

--- a/ppml/base/register-mrenclave.py
+++ b/ppml/base/register-mrenclave.py
@@ -1,0 +1,100 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import requests
+import json
+import argparse
+import base64
+import time
+import random
+import hmac
+from hashlib import sha256
+from collections import OrderedDict
+import urllib.parse
+from requests.packages import urllib3
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+use_secure_cert = False
+headers = {"Content-Type":"application/json"}
+# below placeholders for global variables, and they will be initalized in the below context
+appid = ''
+apikey = ''
+
+def init_appid_apikey(appid_user, apikey_user):
+    global appid
+    global apikey
+    appid = appid_user
+    apikey = apikey_user
+
+def init_params(payload=False):
+    params = OrderedDict()
+    params["appid"] = appid
+    if payload!=False:
+        ord_payload = OrderedDict(sorted(payload.items(), key=lambda k: k[0]))
+        params["payload"] = urllib.parse.unquote_plus(urllib.parse.urlencode(ord_payload))
+    params["timestamp"] = str(int(time.time() * 1000))
+    sign_string = urllib.parse.unquote_plus(urllib.parse.urlencode(params))
+    sign = str(base64.b64encode(hmac.new(apikey.encode('utf-8'), sign_string.encode('utf-8'), digestmod=sha256).digest()),'utf-8')
+    if payload!=False:
+        params["payload"] = payload
+    params["sign"] = sign
+    return params
+
+def no_bool_convert(pairs):
+  return {k: str(v).casefold() if isinstance(v, bool) else v for k, v in pairs}
+
+def check_result(res, action):
+    res_json = json.loads(res.text)
+    if(res_json['code'] == 200):
+        print("%s successfully \n" %(action))
+        return True
+    else:
+        print("%s failed, error message: %s \n" %(action, res_json["message"]))
+        return False
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--appid', type=str, help='your ehsm appid obtained from enroll', required=True)
+    parser.add_argument('--apikey', type=str, help='your ehsm apikey obtained from enroll', required=True)
+    parser.add_argument('--url', type=str, help='the address of the ehsm_kms_server, fornmat likes https://1.2.3.4:9000', required=True)
+    parser.add_argument('--mr_enclave', type=str, help='mr_enclave you will upload', required=True)
+    parser.add_argument('--mr_signer', type=str, help='mr_signer you will upload', required=True)
+    args = parser.parse_args()
+
+    base_url = args.url + "/ehsm?Action="
+    print(base_url)
+    return base_url, args.mr_enclave, args.mr_signer, args.appid, args.apikey
+
+def register(base_url, mr_enclave, mr_signer, appid, apikey):
+    payload = OrderedDict()
+    payload["mr_enclave"] = mr_enclave
+    payload["mr_signer"] = mr_signer
+    init_appid_apikey(appid, apikey)
+    params = init_params(payload)
+    resp = requests.post(url=base_url + "UploadQuotePolicy", data=json.dumps(params), headers=headers, verify=use_secure_cert)
+    if(check_result(resp, 'UploadQuotePolicy') == False):
+        return
+    print('[INFO] register resp:\n%s\n' %(resp.text))
+
+    policyId = json.loads(resp.text)['result']['policyId']
+    print('[INFO] policyID:\n%s\n' %(policyId))
+    return policyId
+
+if __name__ == "__main__":
+
+    base_url, mr_enclave, mr_signer, appid, apikey = get_args()
+
+    register(base_url, mr_enclave, mr_signer, appid, apikey)

--- a/ppml/base/verify-attestation-service.sh
+++ b/ppml/base/verify-attestation-service.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -x
+
+export ATTESTATION_URL=your_attestation_url
+export ATTESTATION_TYPE=your_attestation_service_type
+export APP_ID=your_app_id
+export API_KEY=your_api_keya
+export CHALLENGE=your_challenge_string
+export SPARK_HOME=$SPARK_HOME
+export BIGDL_PPML_JAR=$BIGDL_HOME/jars/*
+
+if [ "$ATTESTATION_URL" = "your_attestation_url" ]; then
+    echo "[ERROR] ATTESTATION_URL is not set!"
+    echo "[INFO] PPML Application Exit!"
+    exit 1
+fi
+if [ "$ATTESTATION_TYPE" = "your_attestation_service_type" ]; then
+    ATTESTATION_TYPE="EHSMAttestationService"
+fi
+if [ "$APP_ID" = "your_app_id" ]; then
+    echo "[ERROR] APP_ID is not set!"
+    echo "[INFO] PPML Application Exit!"
+    exit 1
+fi
+if [ "$API_KEY" = "your_api_key" ]; then
+    echo "[ERROR] API_KEY is not set!"
+    echo "[INFO] PPML Application Exit!"
+    exit 1
+fi
+if [ "$CHALLENGE" = "your_challenge_string" ]; then
+    echo "[ERROR] CHALLENGE is not set!"
+    echo "[INFO] PPML Application Exit!"
+    exit 1
+fi
+if [ "$SPARK_HOME" = "your_spark_home" ]; then
+    echo "[ERROR] SPARK_HOME is not set!"
+    echo "[INFO] PPML Application Exit!"
+    exit 1
+fi
+if [ "$BIGDL_PPML_JAR" = "your_bigdl_ppml_jar" ]; then
+    echo "[ERROR] BIGDL_PPML_JAR is not set!"
+    echo "[INFO] PPML Application Exit!"
+    exit 1
+fi
+
+JARS="$SPARK_HOME/jars/*:$SPARK_HOME/examples/jars/*:$BIGDL_PPML_JAR"
+
+java -cp $JARS com.intel.analytics.bigdl.ppml.attestation.VerificationCLI -i $APP_ID -k $API_KEY -c $CHALLENGE -u $ATTESTATION_URL -t $ATTESTATION_TYPE


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?
Now nearly all applications using SGX with Gramine use the same image (intelanayltics/bigdl-ppml-trusted-big-data-ml-python-gramine), which can cause the size of the image to become very large.   Besides, each application may only use part of the image.

A better approach should be provide a image for each of the applications.

### 2. For those who wants to extend this image:
Now the working directory is changed from `/ppml/trusted-big-dasta-ml/` to `/ppml/`.
All the corresponding files including
1. bash.manifest.template
2. clean.sh
3. init.sh
4. Makefile

are changed accordingly.

The following four directories required by the `bash.manifest.template` are no longer added to the image.
```bash
  { path = "/root/.kube/", uri = "file:/root/.kube/" },
  { path = "/root/.keras", uri = "file:/root/.keras" },
  { path = "/root/.m2", uri = "file:/root/.m2" },
  { path = "/root/.zinc", uri = "file:/root/.zinc" },
```
For those who wants to use the bash.manifest.template, you need to manually add these four directories into your image.
<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 
Provide a base image which contains only Gramine.

Other applications can extend this base image and install their own dependencies.
<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
Run the following command to boot the container:
```bash
export ENCLAVE_KEY=YOUR_ENCLAVE_KEY
export KEYS_PATH=YOUR_KEY_PATH
export SECURE_PASSWORD_PATH=PASSWORD_PATH
export DOCKER_IMAGE=10.239.45.10/arda/intelanayltics/bigdl-ppml-trusted-big-data-ml-python-gramine:gramine-base
sudo docker run -itd \
--privileged \
--net=host \
--name=gc-test-gramine-base \
--cpuset-cpus="20-24" \
--oom-kill-disable \
--device=/dev/sgx/enclave \
--device=/dev/sgx/provision \
-v /var/run/aesmd/aesm.socket:/var/run/aesmd/aesm.socket \
-v $ENCLAVE_KEY:/root/.config/gramine/enclave-key.pem \
-v $KEYS_PATH:/ppml/trusted-big-data-ml/work/keys \
-v $SECURE_PASSWORD_PATH:/ppml/trusted-big-data-ml/work/password \
-e SGX_ENABLED=true \
-e SGX_LOG_LEVEL=error \
-e LOCAL_IP=$LOCAL_IP \
$DOCKER_IMAGE
```

Then at `/ppml/trusted-big-data-ml/`, execute the `./init.sh` script.

Verify Gramine is working as follows:

```bash
cd /gramine/CI-Examples/helloworld/
make SGX=1
gramine-sgx helloworld
```

The result should be similar to the following figures:

![gramine](https://user-images.githubusercontent.com/110874468/194740015-8ae31605-b921-45b9-b0dd-c854783571a3.PNG)

Test of the bash.manifest.template:
![manifest_test](https://user-images.githubusercontent.com/110874468/194745124-9a1ac127-0a6c-4ff5-94b4-89c9757c865d.PNG)


### 5. TODO List
- [x] Finish Dockerfile
- [x] Solve the TODOs
- [x] Review
- [x] Add README.md
- [x] Remove redundant comments
