### PR TITLE
Chronos: fix ImportError with pytest.mark.tf2

### DIFF
--- a/python/chronos/test/bigdl/chronos/forecaster/tf/__init__.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/__init__.py
@@ -1,0 +1,15 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#


### PR DESCRIPTION
## Description

In order to easily test uts corresponding to different installation options, uts are marked with labels.
But there exists ImportError with op_tf2, the error is fixed.
