### PR TITLE
[Chronos] Add install options in chronos-nightly docker image

### DIFF
--- a/docker/chronos-nightly/Dockerfile
+++ b/docker/chronos-nightly/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /opt/work
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Asia/Shanghai
 
-# model: select from pytorch, tensorflow, prophet, arima
+# model: select from pytorch, tensorflow, prophet, arima, ml
 ARG model
 # auto_tuning: y (for yes) or n (for no)
 ARG auto_tuning

--- a/docker/chronos-nightly/Dockerfile
+++ b/docker/chronos-nightly/Dockerfile
@@ -20,15 +20,15 @@ WORKDIR /opt/work
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Asia/Shanghai
 
-# model: select from pytorch, tensorflow, prophet, arima, ml
-ARG model
-# auto_tuning: y (for yes) or n (for no)
-ARG auto_tuning
-# hardware: single or cluster
-ARG hardware
+# model: select from pytorch (default), tensorflow, prophet, arima, ml
+ARG model=pytorch
+# auto_tuning: y (for yes) or n (default, for no)
+ARG auto_tuning=n
+# hardware: single (default) or cluster
+ARG hardware=single
 # extra_dep: install extra dependencies(e.g. onnxruntime, jupyter, ...)
-#            y (for yes) or n (for no)
-ARG extra_dep 
+#            y (for yes) or n (default, for no)
+ARG extra_dep=n
 
 ADD ./docker/chronos-nightly/install-python-env.sh /opt
 ADD ./python/chronos/colab-notebook /opt/work/colab-notebook
@@ -54,4 +54,3 @@ RUN apt-get update --fix-missing && \
 RUN echo "source activate chronos" > ~/.bashrc
 RUN echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/" >> ~/.bashrc
 ENV PATH /usr/local/envs/chronos/bin:$PATH
-

--- a/docker/chronos-nightly/Dockerfile
+++ b/docker/chronos-nightly/Dockerfile
@@ -26,6 +26,9 @@ ARG model
 ARG auto_tuning
 # hardware: single or cluster
 ARG hardware
+# extra_dep: install extra dependencies(e.g. onnxruntime, jupyter, ...)
+#            y (for yes) or n (for no)
+ARG extra_dep 
 
 ADD ./docker/chronos-nightly/install-python-env.sh /opt
 ADD ./python/chronos/colab-notebook /opt/work/colab-notebook
@@ -46,7 +49,7 @@ RUN apt-get update --fix-missing && \
     ./Miniconda3-py37_4.12.0-Linux-x86_64.sh -b -f -p /usr/local && \
     rm Miniconda3-py37_4.12.0-Linux-x86_64.sh && \
 # python
-    /opt/install-python-env.sh ${model} ${auto_tuning} ${hardware}
+    /opt/install-python-env.sh ${model} ${auto_tuning} ${hardware} ${extra_dep}
 
 RUN echo "source activate chronos" > ~/.bashrc
 RUN echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/" >> ~/.bashrc

--- a/docker/chronos-nightly/Dockerfile
+++ b/docker/chronos-nightly/Dockerfile
@@ -20,6 +20,13 @@ WORKDIR /opt/work
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Asia/Shanghai
 
+# model: select from pytorch, tensorflow, prophet, arima
+ARG model
+# auto_tuning: y (for yes) or n (for no)
+ARG auto_tuning
+# hardware: single or cluster
+ARG hardware
+
 ADD ./docker/chronos-nightly/install-python-env.sh /opt
 ADD ./python/chronos/colab-notebook /opt/work/colab-notebook
 RUN chmod a+x /opt/install-python-env.sh
@@ -39,7 +46,7 @@ RUN apt-get update --fix-missing && \
     ./Miniconda3-py37_4.12.0-Linux-x86_64.sh -b -f -p /usr/local && \
     rm Miniconda3-py37_4.12.0-Linux-x86_64.sh && \
 # python
-    /opt/install-python-env.sh
+    /opt/install-python-env.sh ${model} ${auto_tuning} ${hardware}
 
 RUN echo "source activate chronos" > ~/.bashrc
 RUN echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/" >> ~/.bashrc

--- a/docker/chronos-nightly/README.md
+++ b/docker/chronos-nightly/README.md
@@ -13,7 +13,31 @@ cp docker/chronos-nightly/Dockerfile ./Dockerfile
 ```
 Then build your docker image with Dockerfile:
 ```bash
-sudo docker build -t chronos-nightly:b1 . # You may choose any NAME:TAG you want.
+sudo docker build \
+    --build-arg model=pytorch \
+    --build-arg auto_tuning=y \
+    --build-arg hardware=single \
+    --build-arg extra_dep=n \
+     -t chronos-nightly:b1 . # You may choose any NAME:TAG you want.
+```
+You may specify some build args to install chronos with necessary dependencies according to your own needs.
+The build args are similar to the install options in [Chronos documentation](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install).
+
+```
+model: which model or framework you want. 
+       value: pytorch or tensorflow or prophet or arima.
+
+auto_tuning: whether to enable auto tuning.
+             value: y (for yes) or n (for no).
+
+hardware: run chronos on a single machine or a cluster.
+          value: single or cluster
+
+extra_dep: whether to install some extra dependencies like onnx and jupyter.
+           value: y (for yes) or n (for no).
+           if specified to y, the following dependencies will be installed:
+           neural_compressor, onnxruntime, onnx, tsfresh, 
+           prometheus_pandas, xgboost, jupyter
 ```
 (Optional) Or build with a proxy:
 ```bash
@@ -21,6 +45,10 @@ sudo docker build -t chronos-nightly:b1 . # You may choose any NAME:TAG you want
 sudo docker build \
     --build-arg http_proxy=http://<your_proxy_ip>:<your_proxy_port> \ #optional
     --build-arg https_proxy=http://<your_proxy_ip>:<your_proxy_port> \ #optional
+    --build-arg model=pytorch \
+    --build-arg auto_tuning=y \
+    --build-arg hardware=single \
+    --build-arg extra_dep=n \
     -t chronos-nightly:b1 . # You may choose any NAME:TAG you want.
 ```
 According to your network status, this building will cost **15-30 mins**. 
@@ -33,12 +61,14 @@ sudo docker run -it --rm --net=host chronos-nightly:b1 bash
 ```
 
 ## Use Chronos
-A conda environment is created for you automatically. `bigdl-chronos` and all of its depenencies are installed inside this environment.
+A conda environment is created for you automatically. `bigdl-chronos` and the necessary depenencies (based on the build args) are installed inside this environment.
 ```bash
 (chronos) root@cpx-3:/opt/work#
 ```
 
 ## Run unitest examples on Jupyter Notebook for a quick use
+>To use jupyter notebook, you need to specify the build arg `extra_dep` to `y`.
+
 You can run these on Jupyter Notebook on single node server if you pursue a quick use on Chronos.
 ```bash
 (chronos) root@cpx-3:/opt/work# cd /opt/work/colab-notebook #Unitest examples are here.

--- a/docker/chronos-nightly/README.md
+++ b/docker/chronos-nightly/README.md
@@ -11,7 +11,39 @@ Then `cd` to the root directory of `BigDL`, and copy the Dockerfile to it.
 cd BigDL
 cp docker/chronos-nightly/Dockerfile ./Dockerfile
 ```
-Then build your docker image with Dockerfile:
+When building image, you can specify some build args to install chronos with necessary dependencies according to your own needs.
+The build args are similar to the install options in [Chronos documentation](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install).
+
+```
+model: which model or framework you want. 
+       value: pytorch (default)
+              tensorflow
+              prophet
+              arima
+              ml (for machine learning models).
+
+auto_tuning: whether to enable auto tuning.
+             value: y (for yes)
+                    n (default, for no).
+
+hardware: run chronos on a single machine or a cluster.
+          value: single (default)
+                 cluster
+
+extra_dep: whether to install some extra dependencies like onnx and jupyter.
+           value: y (for yes)
+                  n (default, for no)
+           if specified to y, the following dependencies will be installed:
+           neural_compressor, onnxruntime, onnx, tsfresh, 
+           prometheus_pandas, xgboost, jupyter
+```
+
+If you want to build image with the default options, you can simply use the following command:
+```bash
+sudo docker build -t chronos-nightly:b1 . # You may choose any NAME:TAG you want.
+```
+
+You can also build with other options by specifying the build args:
 ```bash
 sudo docker build \
     --build-arg model=pytorch \
@@ -20,42 +52,13 @@ sudo docker build \
     --build-arg extra_dep=n \
      -t chronos-nightly:b1 . # You may choose any NAME:TAG you want.
 ```
-You may specify some build args to install chronos with necessary dependencies according to your own needs.
-The build args are similar to the install options in [Chronos documentation](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install).
 
-```
-model: which model or framework you want. 
-       value: pytorch
-              tensorflow
-              prophet
-              arima
-              ml (for machine learning models).
-
-auto_tuning: whether to enable auto tuning.
-             value: y (for yes)
-                    n (for no).
-
-hardware: run chronos on a single machine or a cluster.
-          value: single
-                 cluster
-
-extra_dep: whether to install some extra dependencies like onnx and jupyter.
-           value: y (for yes)
-                  n (for no)
-           if specified to y, the following dependencies will be installed:
-           neural_compressor, onnxruntime, onnx, tsfresh, 
-           prometheus_pandas, xgboost, jupyter
-```
-(Optional) Or build with a proxy:
+(Optional) If you need a proxy, you can add two additional build args to specify it:
 ```bash
 # typically, you need a proxy for building since there will be some downloading.
 sudo docker build \
     --build-arg http_proxy=http://<your_proxy_ip>:<your_proxy_port> \ #optional
     --build-arg https_proxy=http://<your_proxy_ip>:<your_proxy_port> \ #optional
-    --build-arg model=pytorch \
-    --build-arg auto_tuning=y \
-    --build-arg hardware=single \
-    --build-arg extra_dep=n \
     -t chronos-nightly:b1 . # You may choose any NAME:TAG you want.
 ```
 According to your network status, this building will cost **15-30 mins**. 

--- a/docker/chronos-nightly/README.md
+++ b/docker/chronos-nightly/README.md
@@ -25,16 +25,23 @@ The build args are similar to the install options in [Chronos documentation](htt
 
 ```
 model: which model or framework you want. 
-       value: pytorch or tensorflow or prophet or arima.
+       value: pytorch
+              tensorflow
+              prophet
+              arima
+              ml (for machine learning models).
 
 auto_tuning: whether to enable auto tuning.
-             value: y (for yes) or n (for no).
+             value: y (for yes)
+                    n (for no).
 
 hardware: run chronos on a single machine or a cluster.
-          value: single or cluster
+          value: single
+                 cluster
 
 extra_dep: whether to install some extra dependencies like onnx and jupyter.
-           value: y (for yes) or n (for no).
+           value: y (for yes)
+                  n (for no)
            if specified to y, the following dependencies will be installed:
            neural_compressor, onnxruntime, onnx, tsfresh, 
            prometheus_pandas, xgboost, jupyter

--- a/docker/chronos-nightly/README.md
+++ b/docker/chronos-nightly/README.md
@@ -76,12 +76,12 @@ A conda environment is created for you automatically. `bigdl-chronos` and the ne
 (chronos) root@cpx-3:/opt/work#
 ```
 
-## Run unitest examples on Jupyter Notebook for a quick use
+## Run unittest examples on Jupyter Notebook for a quick use
 >To use jupyter notebook, you need to specify the build arg `extra_dep` to `y`.
 
 You can run these on Jupyter Notebook on single node server if you pursue a quick use on Chronos.
 ```bash
-(chronos) root@cpx-3:/opt/work# cd /opt/work/colab-notebook #Unitest examples are here.
+(chronos) root@cpx-3:/opt/work# cd /opt/work/colab-notebook #Unittest examples are here.
 ```
 ```bash
 (chronos) root@cpx-3:/opt/work# jupyter notebook --notebook-dir=./ --ip=* --allow-root #Start the Jupyter Notebook services.

--- a/docker/chronos-nightly/install-python-env.sh
+++ b/docker/chronos-nightly/install-python-env.sh
@@ -86,10 +86,8 @@ if [ ${#options[@]} == 0 ];
 then
     pip install --no-cache-dir --pre --upgrade bigdl-chronos
 else
-    echo $options
     str=${options[*]}
     opts=`echo $str | tr ' ' ','`
-    echo $opts
     pip install --no-cache-dir --pre --upgrade bigdl-chronos[$opts]
 fi
 

--- a/docker/chronos-nightly/install-python-env.sh
+++ b/docker/chronos-nightly/install-python-env.sh
@@ -1,22 +1,19 @@
+if (( $# < 4)); then
+    echo "Usage: install-python-env.sh model auto_tuning hardware extra_dep"
+    echo "       model: pytorch|tensorflow|prophet|arima"
+    echo "       auto_tuning: y|n"
+    echo "       hardware: single|cluster"
+    echo "       extra_dep: y|n"
+    exit -1
+fi
+
 conda create -y -n chronos python=3.7 setuptools=58.0.4
 source activate chronos
-pip install --no-cache-dir neural_compressor==1.8.1 && \
-pip install --no-cache-dir onnxruntime==1.6.0 && \
-pip install --no-cache-dir tsfresh==0.17.0 && \
-pip install --no-cache-dir numpy==1.19.5 && \
-pip install --no-cache-dir ray==1.9.2 ray[tune]==1.9.2 ray[default]==1.9.2 && \
-pip install --no-cache-dir pyarrow==6.0.1 && \
-pip install --no-cache-dir --pre bigdl-nano[pytorch] && \
-pip install --no-cache-dir --pre bigdl-nano[tensorflow] && \
-pip install --no-cache-dir torchmetrics==0.7.2 && \
-pip install --no-cache-dir scipy==1.5.4 && \
-pip install --no-cache-dir prometheus_pandas==0.3.1 && \
-pip install --no-cache-dir xgboost==1.2.0 && \
-pip install --no-cache-dir jupyter==1.0.0
 
 model=$1
 auto_tuning=$2
 hardware=$3
+extra_dep=$4
 options=()
 
 if [ $model == "pytorch" ] || [ $model == "tensorflow" ];
@@ -30,7 +27,7 @@ then
     then
         # invalid args
         echo "Invalid argument."
-        echo "Argument auto_tuning can be y (for yes)|n (for no), please check."
+        echo "Argument auto_tuning can be y (for yes) or n (for no), please check."
         exit -1
     fi
 
@@ -41,7 +38,7 @@ then
     then
         # invalid args
         echo "Invalid argument."
-        echo "Argument hardware can be single|cluster, please check."
+        echo "Argument hardware can be single or cluster, please check."
         exit -1
     fi
 elif [ $model == "prophet" ] || [ $model == "arima" ];
@@ -53,7 +50,7 @@ then
     then
         # invalid args
         echo "Invalid argument."
-        echo "Argument auto_tuning can be y (for yes)|n (for no), please check."
+        echo "Argument auto_tuning can be y (for yes) or n (for no), please check."
         exit -1
     fi
 
@@ -67,7 +64,7 @@ then
     then
         # invalid args
         echo "Invalid argument."
-        echo "Argument hardware can be single|cluster, please check."
+        echo "Argument hardware can be single or cluster, please check."
         exit -1
     fi
 
@@ -81,7 +78,7 @@ then
 else
     # invalid args
     echo "Invalid argument."
-    echo "Argument model can be pytorch|tensorflow|prophet|arima, please check."
+    echo "Argument model can be pytorch, tensorflow, prophet, or arima, please check."
     exit -1
 fi
 
@@ -96,5 +93,22 @@ else
     pip install --no-cache-dir --pre --upgrade bigdl-chronos[$opts]
 fi
 
+if [ $extra_dep == "y" ];
+then
+    pip install --no-cache-dir neural_compressor==1.8.1 && \
+    pip install --no-cache-dir onnxruntime==1.6.0 && \
+    pip install --no-cache-dir onnx==1.8.0 && \
+    pip install --no-cache-dir tsfresh==0.17.0 && \
+
+    pip install --no-cache-dir prometheus_pandas==0.3.1 && \
+    pip install --no-cache-dir xgboost==1.2.0 && \
+    pip install --no-cache-dir jupyter==1.0.0
+elif [ $extra_dep != "n" ];
+then
+    # invalid args
+    echo "Invalid argument."
+    echo "Argument extra_dep can be y (for yes) or n (for no), please check."
+    exit -1
+fi
 
 

--- a/docker/chronos-nightly/install-python-env.sh
+++ b/docker/chronos-nightly/install-python-env.sh
@@ -1,7 +1,5 @@
 conda create -y -n chronos python=3.7 setuptools=58.0.4
 source activate chronos
-pip install --no-cache-dir prophet==1.1.0 &&\
-pip install --no-cache-dir pmdarima==1.8.4 && \
 pip install --no-cache-dir neural_compressor==1.8.1 && \
 pip install --no-cache-dir onnxruntime==1.6.0 && \
 pip install --no-cache-dir tsfresh==0.17.0 && \
@@ -10,7 +8,6 @@ pip install --no-cache-dir ray==1.9.2 ray[tune]==1.9.2 ray[default]==1.9.2 && \
 pip install --no-cache-dir pyarrow==6.0.1 && \
 pip install --no-cache-dir --pre bigdl-nano[pytorch] && \
 pip install --no-cache-dir --pre bigdl-nano[tensorflow] && \
-pip install --no-cache-dir --pre bigdl-chronos[all] && \
 pip install --no-cache-dir torchmetrics==0.7.2 && \
 pip install --no-cache-dir scipy==1.5.4 && \
 pip install --no-cache-dir prometheus_pandas==0.3.1 && \
@@ -29,18 +26,35 @@ then
     if [ $auto_tuning == "y" ];
     then
         options[1]="automl"
+    elif [ $auto_tuning != "n" ];
+    then
+        # invalid args
+        echo "Invalid argument."
+        echo "Argument auto_tuning can be y (for yes)|n (for no), please check."
+        exit -1
     fi
 
     if [ $hardware == "cluster" ];
     then
         options[2]="distributed"
+    elif [ $hardware != "single" ];
+    then
+        # invalid args
+        echo "Invalid argument."
+        echo "Argument hardware can be single|cluster, please check."
+        exit -1
     fi
-else
-    # prophet and arima
-
+elif [ $model == "prophet" ] || [ $model == "arima" ];
+then
     if [ $auto_tuning == "y" ];
     then
         options[0]="distributed"
+    elif [ $auto_tuning != "n" ];
+    then
+        # invalid args
+        echo "Invalid argument."
+        echo "Argument auto_tuning can be y (for yes)|n (for no), please check."
+        exit -1
     fi
 
     if [ $hardware == "cluster" ];
@@ -49,15 +63,26 @@ else
         then
             options[0]="distributed"
         fi
+    elif [ $hardware != "single" ];
+    then
+        # invalid args
+        echo "Invalid argument."
+        echo "Argument hardware can be single|cluster, please check."
+        exit -1
     fi
 
-    if [$model == "prophet"];
+    if [ $model == "prophet" ];
     then
         pip install --no-cache-dir prophet==1.1.0
     else
         # ARIMA
         pip install --no-cache-dir pmdarima==1.8.5
     fi
+else
+    # invalid args
+    echo "Invalid argument."
+    echo "Argument model can be pytorch|tensorflow|prophet|arima, please check."
+    exit -1
 fi
 
 if [ ${#options[@]} == 0 ];

--- a/docker/chronos-nightly/install-python-env.sh
+++ b/docker/chronos-nightly/install-python-env.sh
@@ -1,6 +1,6 @@
 if (( $# < 4)); then
     echo "You need to specify four build args when building the image:"
-    echo "model: pytorch|tensorflow|prophet|arima"
+    echo "model: pytorch|tensorflow|prophet|arima|ml"
     echo "auto_tuning: y|n"
     echo "hardware: single|cluster"
     echo "extra_dep: y|n"
@@ -76,10 +76,11 @@ then
         # ARIMA
         pip install --no-cache-dir pmdarima==1.8.5
     fi
-else
+elif [ $model != "ml" ];
+then
     # invalid args
     echo "Invalid argument."
-    echo "Argument model can be pytorch, tensorflow, prophet, or arima, please check."
+    echo "Argument model can be pytorch, tensorflow, prophet, arima or ml, please check."
     exit -1
 fi
 

--- a/docker/chronos-nightly/install-python-env.sh
+++ b/docker/chronos-nightly/install-python-env.sh
@@ -1,13 +1,3 @@
-if (( $# < 4)); then
-    echo "You need to specify four build args when building the image:"
-    echo "model: pytorch|tensorflow|prophet|arima|ml"
-    echo "auto_tuning: y|n"
-    echo "hardware: single|cluster"
-    echo "extra_dep: y|n"
-    echo "Visit https://github.com/intel-analytics/BigDL/blob/main/docker/chronos-nightly/README.md for more information."
-    exit -1
-fi
-
 conda create -y -n chronos python=3.7 setuptools=58.0.4
 source activate chronos
 

--- a/docker/chronos-nightly/install-python-env.sh
+++ b/docker/chronos-nightly/install-python-env.sh
@@ -1,9 +1,10 @@
 if (( $# < 4)); then
-    echo "Usage: install-python-env.sh model auto_tuning hardware extra_dep"
-    echo "       model: pytorch|tensorflow|prophet|arima"
-    echo "       auto_tuning: y|n"
-    echo "       hardware: single|cluster"
-    echo "       extra_dep: y|n"
+    echo "You need to specify four build args when building the image:"
+    echo "model: pytorch|tensorflow|prophet|arima"
+    echo "auto_tuning: y|n"
+    echo "hardware: single|cluster"
+    echo "extra_dep: y|n"
+    echo "Visit https://github.com/intel-analytics/BigDL/blob/main/docker/chronos-nightly/README.md for more information."
     exit -1
 fi
 
@@ -108,5 +109,3 @@ then
     echo "Argument extra_dep can be y (for yes) or n (for no), please check."
     exit -1
 fi
-
-

--- a/docker/chronos-nightly/install-python-env.sh
+++ b/docker/chronos-nightly/install-python-env.sh
@@ -1,5 +1,5 @@
-conda create -y -n chronos python=3.7 setuptools=58.0.4 && \
-source activate chronos && \
+conda create -y -n chronos python=3.7 setuptools=58.0.4
+source activate chronos
 pip install --no-cache-dir prophet==1.1.0 &&\
 pip install --no-cache-dir pmdarima==1.8.4 && \
 pip install --no-cache-dir neural_compressor==1.8.1 && \
@@ -17,6 +17,59 @@ pip install --no-cache-dir prometheus_pandas==0.3.1 && \
 pip install --no-cache-dir xgboost==1.2.0 && \
 pip install --no-cache-dir jupyter==1.0.0
 
+model=$1
+auto_tuning=$2
+hardware=$3
+options=()
+
+if [ $model == "pytorch" ] || [ $model == "tensorflow" ];
+then
+    options[0]=$model
+
+    if [ $auto_tuning == "y" ];
+    then
+        options[1]="automl"
+    fi
+
+    if [ $hardware == "cluster" ];
+    then
+        options[2]="distributed"
+    fi
+else
+    # prophet and arima
+
+    if [ $auto_tuning == "y" ];
+    then
+        options[0]="distributed"
+    fi
+
+    if [ $hardware == "cluster" ];
+    then
+        if [ ${#options[@]} == 0 ];
+        then
+            options[0]="distributed"
+        fi
+    fi
+
+    if [$model == "prophet"];
+    then
+        pip install --no-cache-dir prophet==1.1.0
+    else
+        # ARIMA
+        pip install --no-cache-dir pmdarima==1.8.5
+    fi
+fi
+
+if [ ${#options[@]} == 0 ];
+then
+    pip install --no-cache-dir --pre --upgrade bigdl-chronos
+else
+    echo $options
+    str=${options[*]}
+    opts=`echo $str | tr ' ' ','`
+    echo $opts
+    pip install --no-cache-dir --pre --upgrade bigdl-chronos[$opts]
+fi
 
 
 

--- a/docs/readthedocs/source/doc/Chronos/Howto/docker_guide_single_node.md
+++ b/docs/readthedocs/source/doc/Chronos/Howto/docker_guide_single_node.md
@@ -77,7 +77,7 @@ A conda environment is created for you automatically. `bigdl-chronos` and the ne
 ```
 
 ## Run unittest examples on Jupyter Notebook for a quick use
-> To use jupyter notebook, you need to specify the build arg `extra_dep` to `y`.
+> Note: To use jupyter notebook, you need to specify the build arg `extra_dep` to `y`.
 
 You can run these on Jupyter Notebook on single node server if you pursue a quick use on Chronos.
 ```bash

--- a/docs/readthedocs/source/doc/Chronos/Howto/docker_guide_single_node.md
+++ b/docs/readthedocs/source/doc/Chronos/Howto/docker_guide_single_node.md
@@ -11,11 +11,49 @@ Then `cd` to the root directory of `BigDL`, and copy the Dockerfile to it.
 cd BigDL
 cp docker/chronos-nightly/Dockerfile ./Dockerfile
 ```
-Then build your docker image with Dockerfile:
+When building image, you can specify some build args to install chronos with necessary dependencies according to your own needs.
+The build args are similar to the install options in [Chronos documentation](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install).
+
+```
+model: which model or framework you want. 
+       value: pytorch (default)
+              tensorflow
+              prophet
+              arima
+              ml (for machine learning models).
+
+auto_tuning: whether to enable auto tuning.
+             value: y (for yes)
+                    n (default, for no).
+
+hardware: run chronos on a single machine or a cluster.
+          value: single (default)
+                 cluster
+
+extra_dep: whether to install some extra dependencies like onnx and jupyter.
+           value: y (for yes)
+                  n (default, for no)
+           if specified to y, the following dependencies will be installed:
+           neural_compressor, onnxruntime, onnx, tsfresh, 
+           prometheus_pandas, xgboost, jupyter
+```
+
+If you want to build image with the default options, you can simply use the following command:
 ```bash
 sudo docker build -t chronos-nightly:b1 . # You may choose any NAME:TAG you want.
 ```
-(Optional) Or build with a proxy:
+
+You can also build with other options by specifying the build args:
+```bash
+sudo docker build \
+    --build-arg model=pytorch \
+    --build-arg auto_tuning=y \
+    --build-arg hardware=single \
+    --build-arg extra_dep=n \
+     -t chronos-nightly:b1 . # You may choose any NAME:TAG you want.
+```
+
+(Optional) If you need a proxy, you can add two additional build args to specify it:
 ```bash
 # typically, you need a proxy for building since there will be some downloading.
 sudo docker build \
@@ -33,12 +71,14 @@ sudo docker run -it --rm --net=host chronos-nightly:b1 bash
 ```
 
 ## Use Chronos
-A conda environment is created for you automatically. `bigdl-chronos` and all of its depenencies are installed inside this environment.
+A conda environment is created for you automatically. `bigdl-chronos` and the necessary depenencies (based on the build args) are installed inside this environment.
 ```bash
 (chronos) root@cpx-3:/opt/work#
 ```
 
 ## Run unitest examples on Jupyter Notebook for a quick use
+>To use jupyter notebook, you need to specify the build arg `extra_dep` to `y`.
+
 You can run these on Jupyter Notebook on single node server if you pursue a quick use on Chronos.
 ```bash
 (chronos) root@cpx-3:/opt/work# cd /opt/work/colab-notebook #Unitest examples are here.

--- a/docs/readthedocs/source/doc/Chronos/Howto/docker_guide_single_node.md
+++ b/docs/readthedocs/source/doc/Chronos/Howto/docker_guide_single_node.md
@@ -77,7 +77,7 @@ A conda environment is created for you automatically. `bigdl-chronos` and the ne
 ```
 
 ## Run unittest examples on Jupyter Notebook for a quick use
->To use jupyter notebook, you need to specify the build arg `extra_dep` to `y`.
+> To use jupyter notebook, you need to specify the build arg `extra_dep` to `y`.
 
 You can run these on Jupyter Notebook on single node server if you pursue a quick use on Chronos.
 ```bash

--- a/docs/readthedocs/source/doc/Chronos/Howto/docker_guide_single_node.md
+++ b/docs/readthedocs/source/doc/Chronos/Howto/docker_guide_single_node.md
@@ -76,12 +76,12 @@ A conda environment is created for you automatically. `bigdl-chronos` and the ne
 (chronos) root@cpx-3:/opt/work#
 ```
 
-## Run unitest examples on Jupyter Notebook for a quick use
+## Run unittest examples on Jupyter Notebook for a quick use
 >To use jupyter notebook, you need to specify the build arg `extra_dep` to `y`.
 
 You can run these on Jupyter Notebook on single node server if you pursue a quick use on Chronos.
 ```bash
-(chronos) root@cpx-3:/opt/work# cd /opt/work/colab-notebook #Unitest examples are here.
+(chronos) root@cpx-3:/opt/work# cd /opt/work/colab-notebook #Unittest examples are here.
 ```
 ```bash
 (chronos) root@cpx-3:/opt/work# jupyter notebook --notebook-dir=./ --ip=* --allow-root #Start the Jupyter Notebook services.


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

<!-- Provide the related github issue link if available -->
Add install options in chronos-nightly docker image so that users can install chronos with necessary dependencies according to their needs, like the install options in the [documentation](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install)
### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->
Four build args are added when building the image, the new command could be:
```
sudo docker build \
    --build-arg model=pytorch \
    --build-arg auto_tuning=y \
    --build-arg hardware=single \
    --build-arg extra_dep=n \
     -t chronos-nightly:b1 .
```
The example for building chronos-nightly image can be seen in `BigDL/docker/chronos-nightly/README.md`.
### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
1. Add four build args to choose necessary dependencies when building the image.
2. Update build command in `README.md`.
