### PR TITLE
Chronos: automatic repair low quality data after detection

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -45,14 +45,10 @@ class TSDataset:
         '''
         self.df = data
         # detect low-quality data and automatic repair (optional)
-        flag, self.df = quality_check_timeseries_dataframe(df=self.df,
-                                                           dt_col=schema["dt_col"],
-                                                           id_col=schema["id_col"],
-                                                           repair=repair)
-        if flag is True:
-            logging.info("Now that there is no low quality data here.")
-        else:
-            logging.warn("There are still some low quality data.")
+        _, self.df = quality_check_timeseries_dataframe(df=self.df,
+                                                        dt_col=schema["dt_col"],
+                                                        id_col=schema["id_col"],
+                                                        repair=repair)
         self.id_col = schema["id_col"]
         self.dt_col = schema["dt_col"]
         self.feature_col = schema["feature_col"].copy()

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -17,6 +17,7 @@
 import pandas as pd
 import numpy as np
 import functools
+import logging
 
 from bigdl.chronos.data.utils.feature import generate_dt_features, generate_global_features
 from bigdl.chronos.data.utils.impute import impute_timeseries_dataframe
@@ -48,6 +49,10 @@ class TSDataset:
                                                            dt_col=schema["dt_col"],
                                                            id_col=schema["id_col"],
                                                            repair=repair)
+        if flag is True:
+            logging.info("Now that there is no low quality data here.")
+        else:
+            logging.warn("There are still some low quality data.")
         self.id_col = schema["id_col"]
         self.dt_col = schema["dt_col"]
         self.feature_col = schema["feature_col"].copy()

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -44,8 +44,10 @@ class TSDataset:
         '''
         self.df = data
         # detect low-quality data and automatic repair (optional)
-        quality_check_timeseries_dataframe(df=self.df, dt_col=schema["dt_col"],
-                                           repair=repair)
+        flag, self.df = quality_check_timeseries_dataframe(df=self.df,
+                                                           dt_col=schema["dt_col"],
+                                                           id_col=schema["id_col"],
+                                                           repair=repair)
         self.id_col = schema["id_col"]
         self.dt_col = schema["dt_col"]
         self.feature_col = schema["feature_col"].copy()

--- a/python/chronos/src/bigdl/chronos/data/utils/public_dataset.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/public_dataset.py
@@ -243,12 +243,14 @@ class PublicDataset:
                    dt_col,
                    target_col,
                    extra_feature=None,
-                   id_col=None):
+                   id_col=None,
+                   repair=True):
         """
         param dt_col: same as tsdata.from_pandas.
         param target_col: same as tsdata.from_pandas.
         param extra_feature: same as tsdata.from_pandas.
         param id_col: same as tsdata.from_pandas.
+        param repair: same as tsdata.from_pandas.
         return tsdata.
         """
         if self.with_split:
@@ -259,13 +261,15 @@ class PublicDataset:
                                          id_col=id_col,
                                          with_split=self.with_split,
                                          val_ratio=self.val_ratio,
-                                         test_ratio=self.test_ratio)
+                                         test_ratio=self.test_ratio,
+                                         repair=repair)
         else:
             return TSDataset.from_pandas(self.df,
                                          dt_col=dt_col,
                                          target_col=target_col,
                                          extra_feature_col=extra_feature,
-                                         id_col=id_col)
+                                         id_col=id_col,
+                                         repair=repair)
 
 
 def download(url, path, chunk_size):

--- a/python/chronos/src/bigdl/chronos/data/utils/quality_inspection.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/quality_inspection.py
@@ -86,10 +86,9 @@ def _timestamp_type_repair(df, dt_col):
     to datetime dtype.
     '''
     try:
-        df[dt_col].astype('datetime64')
+        df[dt_col] = df[dt_col].astype('datetime64')
     except:
         return False
-    df[dt_col] = df[dt_col].astype('datetime64')
     logging.warning("Datetime colomn has be modified to datetime64 dtype.")
     return True
 

--- a/python/chronos/src/bigdl/chronos/data/utils/quality_inspection.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/quality_inspection.py
@@ -19,8 +19,7 @@ from bigdl.nano.utils.log4Error import invalidInputError
 import logging
 
 
-def quality_check_timeseries_dataframe(df,
-                                       dt_col):
+def quality_check_timeseries_dataframe(df, dt_col, repair=True):
     '''
     detect the low-quality data and provide suggestion (e.g. call .impute or .resample).
 
@@ -28,16 +27,31 @@ def quality_check_timeseries_dataframe(df,
     :param dt_col: a str indicates the col name of datetime
             column in the input data frame, the dt_col must be sorted
             from past to latest respectively for each id.
+    :param repair: a bool indicates whether automaticly repair low quality data.
+
+    :return: a bool indicates df whether contains low-quality data.
     '''
     flag = True
     # 1. timestamp check
-    flag = flag and _timestamp_type_check(df[dt_col])
+    if _timestamp_type_check(df[dt_col]) is False:
+        if repair is True:
+            flag = flag and _timestamp_type_repair(df, dt_col)
+        else:
+            flag = False
 
     # 2. irregular interval check
-    flag = flag and _time_interval_check(df[dt_col])
+    if _time_interval_check(df[dt_col]) is False:
+        if repair is True:
+            flag = flag and _time_interval_repair(df, dt_col)
+        else:
+            flag = False
 
     # 3. missing value check
-    flag = flag and _missing_value_check(df, dt_col)
+    if _missing_value_check(df, dt_col) is False:
+        if repair is True:
+            flag = flag and _missing_value_repair(df)
+        else:
+            flag = False
 
     # 4. pattern check and noise check
     # TODO:
@@ -57,6 +71,10 @@ def _timestamp_type_check(df_column):
     return True
 
 
+def _timestamp_type_repair(df, dt_col):
+    pass
+
+
 def _time_interval_check(df_column):
     '''
     This check is used to verify whether all the time intervals of datetime column
@@ -70,6 +88,10 @@ def _time_interval_check(df_column):
                         "first to clean the data.")
         return False
     return True
+
+
+def _time_interval_repair(df, dt_col):
+    pass
 
 
 def _missing_value_check(df, dt_col, threshold=0):
@@ -87,3 +109,7 @@ def _missing_value_check(df, dt_col, threshold=0):
                             f"please call .impute() fisrt to remove N/A number")
             return False
     return True
+
+
+def _missing_value_repair(df):
+    pass

--- a/python/chronos/test/bigdl/chronos/data/test_tsdataset.py
+++ b/python/chronos/test/bigdl/chronos/data/test_tsdataset.py
@@ -204,7 +204,8 @@ class TestTSDataset(TestCase):
         df = get_multi_id_ts_df()
         # legal input
         tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="value",
-                                       extra_feature_col=["extra feature"], id_col="id")
+                                       extra_feature_col=["extra feature"],
+                                       id_col="id", repair=False)
         assert tsdata._id_list == ['00', '01']
         assert tsdata.feature_col == ["extra feature"]
         assert tsdata.target_col == ["value"]
@@ -212,7 +213,8 @@ class TestTSDataset(TestCase):
         assert tsdata._is_pd_datetime
 
         tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col=["value"],
-                                       extra_feature_col="extra feature", id_col="id")
+                                       extra_feature_col="extra feature",
+                                       id_col="id", repair=False)
         assert tsdata._id_list == ['00', '01']
         assert tsdata.feature_col == ["extra feature"]
         assert tsdata.target_col == ["value"]
@@ -220,7 +222,8 @@ class TestTSDataset(TestCase):
         assert tsdata._is_pd_datetime
 
         tsdata = TSDataset.from_pandas(df.drop(columns=["id"]), dt_col="datetime",
-                                       target_col=["value"], extra_feature_col="extra feature")
+                                       target_col=["value"],
+                                       extra_feature_col="extra feature", repair=False)
         assert tsdata._id_list == ['0']
         assert tsdata.feature_col == ["extra feature"]
         assert tsdata.target_col == ["value"]
@@ -230,19 +233,24 @@ class TestTSDataset(TestCase):
         # illegael input
         with pytest.raises(RuntimeError):
             tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col=["value"],
-                                           extra_feature_col="extra feature", id_col=0)
+                                           extra_feature_col="extra feature",
+                                           id_col=0, repair=False)
         with pytest.raises(RuntimeError):
             tsdata = TSDataset.from_pandas(df, dt_col=0, target_col=["value"],
-                                           extra_feature_col="extra feature", id_col="id")
+                                           extra_feature_col="extra feature",
+                                           id_col="id", repair=False)
         with pytest.raises(RuntimeError):
             tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col=0,
-                                           extra_feature_col="extra feature", id_col="id")
+                                           extra_feature_col="extra feature",
+                                           id_col="id", repair=False)
         with pytest.raises(RuntimeError):
             tsdata = TSDataset.from_pandas(0, dt_col="datetime", target_col=["value"],
-                                           extra_feature_col="extra feature", id_col="id")
+                                           extra_feature_col="extra feature",
+                                           id_col="id", repair=False)
         with pytest.raises(RuntimeError):
             tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col=["value1"],
-                                           extra_feature_col="extra feature", id_col="id")
+                                           extra_feature_col="extra feature",
+                                           id_col="id", repair=False)
 
     def test_tsdataset_roll_single_id(self):
         df = get_ts_df()
@@ -310,7 +318,8 @@ class TestTSDataset(TestCase):
         lookback = random.randint(1, 20)
 
         tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="value",
-                                       extra_feature_col=["extra feature"], id_col="id")
+                                       extra_feature_col=["extra feature"],
+                                       id_col="id", repair=False)
 
         # test train
         tsdata.roll(lookback=lookback, horizon=horizon, id_sensitive=True)
@@ -340,7 +349,8 @@ class TestTSDataset(TestCase):
         tsdata = TSDataset.from_pandas(df,
                                        dt_col="datetime",
                                        target_col=["value", "extra feature"],
-                                       id_col="id")
+                                       id_col="id",
+                                       repair=False)
         tsdata.roll(lookback=lookback, horizon=horizon, id_sensitive=False)
         x, y = tsdata.to_numpy()
         assert x.shape == ((50-lookback-horizon+1)*2, lookback, 2)
@@ -631,7 +641,8 @@ class TestTSDataset(TestCase):
         for val in ["last", "const", "linear"]:
             df = get_ugly_ts_df()
             tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="e",
-                                           extra_feature_col=["a", "b", "c", "d"], id_col="id")
+                                           extra_feature_col=["a", "b", "c", "d"],
+                                           id_col="id", repair=False)
             tsdata.impute(mode=val)
             assert tsdata.to_pandas().isna().sum().sum() == 0
             assert len(tsdata.to_pandas()) == 100
@@ -643,7 +654,8 @@ class TestTSDataset(TestCase):
             df.loc[len(df)] = df.loc[np.random.randint(0, 99)]
         assert len(df) == 120
         tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="e",
-                                       extra_feature_col=["a", "b", "c", "d"], id_col="id")
+                                       extra_feature_col=["a", "b", "c", "d"],
+                                       id_col="id", repair=False)
         tsdata.deduplicate()
         assert len(tsdata.to_pandas()) == 100
         tsdata._check_basic_invariants()
@@ -882,12 +894,14 @@ class TestTSDataset(TestCase):
     def test_tsdataset_resample_multiple(self):
         df = get_multi_id_ts_df()
         tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="value",
-                                       extra_feature_col=["extra feature"], id_col="id")
+                                       extra_feature_col=["extra feature"],
+                                       id_col="id", repair=False)
         tsdata.resample('2D', df["datetime"][0], df["datetime"][df.shape[0]-1])
         assert len(tsdata.to_pandas()) == df.shape[0] // 2
         tsdata._check_basic_invariants()
         tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="value",
-                                       extra_feature_col=["extra feature"], id_col="id")
+                                       extra_feature_col=["extra feature"],
+                                       id_col="id", repair=False)
         tsdata.resample('2D')
         assert len(tsdata.to_pandas()) == 50
         tsdata._check_basic_invariants()
@@ -899,7 +913,8 @@ class TestTSDataset(TestCase):
         df["datetime"] = pd.date_range('1/1/2019', periods=100)
         df.loc[50:100, "datetime"] = pd.date_range('1/1/2019', periods=50)
         tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="value",
-                                       extra_feature_col=["extra feature"], id_col="id")
+                                       extra_feature_col=["extra feature"],
+                                       id_col="id", repair=False)
         with pytest.raises(RuntimeError):
             tsdata.resample('2S', df.datetime[0], df.datetime[df.shape[0]-1])
         tsdata._check_basic_invariants()
@@ -909,7 +924,8 @@ class TestTSDataset(TestCase):
         df.value = df.value.astype(np.object)
         df['extra feature'] = df['extra feature'].astype(np.object)
         tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="value",
-                                       extra_feature_col=["extra feature"], id_col="id")
+                                       extra_feature_col=["extra feature"],
+                                       id_col="id", repair=False)
         before_sampling = tsdata.df.columns
         tsdata.resample('2S', df.datetime[0], df.datetime[df.shape[0]-1])
         assert set(before_sampling) == set(tsdata.df.columns)
@@ -950,7 +966,8 @@ class TestTSDataset(TestCase):
         tsdata_train, tsdata_valid, tsdata_test =\
             TSDataset.from_pandas(df, dt_col="datetime", target_col="value",
                                   extra_feature_col=["extra feature"], id_col="id",
-                                  with_split=True, val_ratio=0.1, test_ratio=0.1)
+                                  with_split=True, val_ratio=0.1, test_ratio=0.1,
+                                  repair=False)
 
         assert set(np.unique(tsdata_train.to_pandas()["id"])) == {"00", "01"}
         assert set(np.unique(tsdata_valid.to_pandas()["id"])) == {"00", "01"}
@@ -999,11 +1016,13 @@ class TestTSDataset(TestCase):
         horizon = random.randint(2, 10)
         lookback = random.randint(2, 20)
         tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="value",
-                                       extra_feature_col=["extra feature"], id_col="id")
+                                       extra_feature_col=["extra feature"],
+                                       id_col="id", repair=False)
         tsdata.gen_rolling_feature(settings="minimal", window_size=lookback)
         tsdata._check_basic_invariants()
         tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="value",
-                                       extra_feature_col=["extra feature"], id_col="id")
+                                       extra_feature_col=["extra feature"],
+                                       id_col="id", repair=False)
         tsdata.gen_rolling_feature(settings="minimal", window_size=lookback, n_jobs=2)
         tsdata._check_basic_invariants()
 
@@ -1065,7 +1084,8 @@ class TestTSDataset(TestCase):
         tsdata = TSDataset.from_pandas(df, target_col="value",
                                        dt_col="datetime",
                                        extra_feature_col="extra feature",
-                                       id_col="id")
+                                       id_col="id",
+                                       repair=False)
         with pytest.raises(RuntimeError):
             tsdata.roll(lookback=5, horizon=2, id_sensitive=True)
         tsdata._check_basic_invariants()
@@ -1227,7 +1247,7 @@ class TestTSDataset(TestCase):
                                        target_col=['a', 'b', 'c', 'd', 'e'],
                                        extra_feature_col=None,
                                        repair=True)
-        missing_value = tsdata.df.isna().sum()
+        missing_value = tsdata.df.isna().sum().sum()
         assert missing_value == 0
     
     def test_tsdataset_non_std_dt_check_and_repair(self):
@@ -1240,7 +1260,7 @@ class TestTSDataset(TestCase):
         assert _is_pd_datetime is True
 
     def test_tsdataset_interval_check_and_repair(self):
-        df = get_multi_id_ts_df()
+        df = get_multi_interval_df()
         tsdata = TSDataset.from_pandas(df, dt_col="datetime",
                                        target_col=['a', 'b', 'c', 'd', 'e'],
                                        extra_feature_col=None,
@@ -1248,4 +1268,4 @@ class TestTSDataset(TestCase):
         dt_col = tsdata.df["datetime"]
         interval = dt_col.shift(-1) - dt_col
         unique_intervals = interval[:-1].unique()
-        assert unique_intervals == 1
+        assert len(unique_intervals) == 1

--- a/python/chronos/test/bigdl/chronos/data/utils/test_public_dataset.py
+++ b/python/chronos/test/bigdl/chronos/data/utils/test_public_dataset.py
@@ -63,7 +63,8 @@ class TestPublicDataset(TestCase):
                                                                   if x.endswith("Mbps")
                                                                   else float(x[:-4])*1000)
 
-            tsdata = public_data.get_tsdata(target_col=['AvgRate', 'total'], dt_col='StartTime')
+            tsdata = public_data.get_tsdata(target_col=['AvgRate', 'total'],
+                                            dt_col='StartTime', repair=False)
             assert tsdata.df.shape == (8760, 5)
             assert set(tsdata.df.columns) == {'StartTime', 'EndTime', 'AvgRate', 'total', 'id'}
             tsdata._check_basic_invariants()
@@ -82,7 +83,8 @@ class TestPublicDataset(TestCase):
             public_data.df.time_step = pd.to_datetime(public_data.df.time_step,
                                                       unit='s',
                                                       origin=pd.Timestamp('2018-01-01'))
-            tsdata = public_data.get_tsdata(dt_col='time_step', target_col='cpu_usage')
+            tsdata = public_data.get_tsdata(dt_col='time_step', target_col='cpu_usage',
+                                            repair=False)
             assert tsdata.df.shape == (61570, 4)
             assert set(tsdata.df.columns) == {'time_step', 'cpu_usage', 'mem_usage', 'id'}
             tsdata._check_basic_invariants()

--- a/python/chronos/test/bigdl/chronos/data/utils/test_quality_inspection.py
+++ b/python/chronos/test/bigdl/chronos/data/utils/test_quality_inspection.py
@@ -52,7 +52,7 @@ def get_non_dt_df():
     return df
 
 
-class TestImputeTimeSeries(TestCase):
+class TestCheckAndRepairTimeSeries(TestCase):
     def setup_method(self, method):
         pass
 
@@ -62,17 +62,32 @@ class TestImputeTimeSeries(TestCase):
     def test_normal_dataframe(self):
         pass
 
-    def test_missing_check(self):
+    def test_missing_check_and_repair(self):
         df = get_missing_df()
-        flag = quality_check_timeseries_dataframe(df, "datetime")
+        flag, _ = quality_check_timeseries_dataframe(df, "datetime", repair=False)
         assert flag is False
+        flag, _ = quality_check_timeseries_dataframe(df, "datetime", repair=True)
+        assert flag is True
+        # make sure modifiation has been made to df
+        flag, _ = quality_check_timeseries_dataframe(df, "datetime", repair=False)
+        assert flag is True
 
-    def test_time_interval_check(self):
+    def test_time_interval_check_and_repair(self):
         df = get_multi_interval_df()
-        flag = quality_check_timeseries_dataframe(df, "datetime")
+        flag, _ = quality_check_timeseries_dataframe(df, "datetime", repair=False)
         assert flag is False
+        flag, df = quality_check_timeseries_dataframe(df, "datetime", repair=True)
+        assert flag is True
+        # make sure modifiation has been made to df
+        flag, _ = quality_check_timeseries_dataframe(df, "datetime", repair=False)
+        assert flag is True
 
-    def test_non_dt_type_check(self):
+    def test_non_dt_type_check_and_repair(self):
         df = get_non_dt_df()
-        flag = quality_check_timeseries_dataframe(df, "datetime")
+        flag, _ = quality_check_timeseries_dataframe(df, "datetime", repair=False)
         assert flag is False
+        flag, df = quality_check_timeseries_dataframe(df, "datetime", repair=True)
+        assert flag is True
+        # make sure modifiation has been made to df
+        flag, _ = quality_check_timeseries_dataframe(df, "datetime", repair=False)
+        assert flag is True

--- a/python/chronos/test/bigdl/chronos/data/utils/test_roll_dataset.py
+++ b/python/chronos/test/bigdl/chronos/data/utils/test_roll_dataset.py
@@ -52,7 +52,8 @@ class TestRollDataset:
         # get results rolled by tsdata.roll
         extra_feature_col = None if feature_num == 0 else ["extra feature"]
         tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="value",
-                                       extra_feature_col=extra_feature_col, id_col="id")
+                                       extra_feature_col=extra_feature_col,
+                                       id_col="id", repair=False)
         tsdata.roll(lookback=lookback, horizon=horizon)
         if horizon == 0:
             x = tsdata.to_numpy()


### PR DESCRIPTION
## Description

After detecting the low-quality data, we may want to automatic repair part of them according to our experience.

### 1. Why the change?

https://github.com/intel-analytics/BigDL/issues/6023

### 2. User API changes
a new parameter `repair` is supported.
```python
from bigdl.chronos.data import TSDataset
TSDataset.from_pandas(df,
                      dt_col,
                      target_col,
                      id_col=None,
                      extra_feature_col=None,
                      with_split=False,
                      val_ratio=0,
                      test_ratio=0.1,
                      repair=True):
```

```python
from bigdl.chronos.data import TSDataset
TSDataset.from_parquet(path,
                       dt_col,
                       target_col,
                       id_col=None,
                       extra_feature_col=None,
                       with_split=False,
                       val_ratio=0,
                       test_ratio=0.1,
                       repair=True,
                       **kwargs):
```
### 3. Summary of the change 

- [x] repair timestamp type, ut
- [x] repair inconsistent interval, ut
- [x] repair missing data, ut
- [x] add this check_and_repair function to tsdataset initialization
- [x] tsdataset ut

### 4. How to test?
- [x] Unit test
- [x] Application test