### PR TITLE
Chronos: change import path of `get_public_dataset`

### DIFF
--- a/docs/readthedocs/source/doc/Chronos/Overview/data_processing_feature_engineering.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/data_processing_feature_engineering.md
@@ -256,7 +256,7 @@ About `TSDataset`, more details, please refer to [here](../../PythonAPI/Chronos/
 
 ```python
 # load built-in dataset
-from bigdl.chronos.data.repo_dataset import get_public_dataset
+from bigdl.chronos.data import get_public_dataset
 from sklearn.preprocessing import StandardScaler
 tsdata_train, tsdata_val, \
     tsdata_test = get_public_dataset(name='nyc_taxi',

--- a/docs/readthedocs/source/doc/Chronos/Overview/quick-tour.rst
+++ b/docs/readthedocs/source/doc/Chronos/Overview/quick-tour.rst
@@ -133,7 +133,7 @@ To import a specific forecaster, you may use {algorithm name} + "Forecaster", an
 .. code-block:: python
 
     from bigdl.chronos.forecaster import TCNForecaster  # TCN is algorithm name
-    from bigdl.chronos.data.repo_dataset import get_public_dataset
+    from bigdl.chronos.data import get_public_dataset
 
     if __name__ == "__main__":
         # use nyc_taxi public dataset
@@ -159,7 +159,7 @@ For time series forecasting, we also provide an ``AutoTSEstimator`` for distribu
 .. code-block:: python
 
     from bigdl.orca.automl import hp
-    from bigdl.chronos.data.repo_dataset import get_public_dataset
+    from bigdl.chronos.data import get_public_dataset
     from bigdl.chronos.autots import AutoTSEstimator
     from bigdl.orca import init_orca_context, stop_orca_context
     from sklearn.preprocessing import StandardScaler
@@ -230,7 +230,7 @@ To import a specific detector, you may use {algorithm name} + "Detector", and ca
 .. code-block:: python
 
     from bigdl.chronos.detector.anomaly import DBScanDetector  # DBScan is algorithm name
-    from bigdl.chronos.data.repo_dataset import get_public_dataset
+    from bigdl.chronos.data import get_public_dataset
 
     if __name__ == "__main__":
         # use nyc_taxi public dataset

--- a/python/chronos/colab-notebook/howto/how-to-create-forecaster.ipynb
+++ b/python/chronos/colab-notebook/howto/how-to-create-forecaster.ipynb
@@ -178,7 +178,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.4 64-bit",
+   "display_name": "Python 3.7.13 ('chronos-deps')",
    "language": "python",
    "name": "python3"
   },
@@ -192,11 +192,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.7.13"
   },
   "vscode": {
    "interpreter": {
-    "hash": "767d51c1340bd893661ea55ea3124f6de3c7a262a8b4abca0554b478b1e2ff90"
+    "hash": "1a7f5d41b94c9ba67b8a1438ec071a63464312bab4ac0991ee31faebf1c9c228"
    }
   }
  },

--- a/python/chronos/colab-notebook/howto/how-to-create-forecaster.ipynb
+++ b/python/chronos/colab-notebook/howto/how-to-create-forecaster.ipynb
@@ -113,7 +113,7 @@
    "outputs": [],
    "source": [
     "# create a TSDataset\n",
-    "from bigdl.chronos.data.repo_dataset import get_public_dataset\n",
+    "from bigdl.chronos.data import get_public_dataset\n",
     "\n",
     "tsdataset = get_public_dataset('nyc_taxi', with_split=False)"
    ]
@@ -178,7 +178,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.13 ('chronos-deps')",
+   "display_name": "Python 3.9.4 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -192,11 +192,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.9.4"
   },
   "vscode": {
    "interpreter": {
-    "hash": "1a7f5d41b94c9ba67b8a1438ec071a63464312bab4ac0991ee31faebf1c9c228"
+    "hash": "767d51c1340bd893661ea55ea3124f6de3c7a262a8b4abca0554b478b1e2ff90"
    }
   }
  },

--- a/python/chronos/colab-notebook/howto/how_to_evaluate_a_forecaster.ipynb
+++ b/python/chronos/colab-notebook/howto/how_to_evaluate_a_forecaster.ipynb
@@ -85,7 +85,7 @@
    "source": [
     "# data preparation\n",
     "def get_data():\n",
-    "    from bigdl.chronos.data.repo_dataset import get_public_dataset\n",
+    "    from bigdl.chronos.data import get_public_dataset\n",
     "    from sklearn.preprocessing import StandardScaler\n",
     "\n",
     "    # load the nyc taxi dataset\n",

--- a/python/chronos/colab-notebook/howto/how_to_generate_confidence_interval_for_prediction.ipynb
+++ b/python/chronos/colab-notebook/howto/how_to_generate_confidence_interval_for_prediction.ipynb
@@ -180,18 +180,18 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.4 64-bit",
+   "display_name": "Python 3.7.12 ('nano')",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "name": "python",
-   "version": "3.9.4"
+   "version": "3.7.12"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "767d51c1340bd893661ea55ea3124f6de3c7a262a8b4abca0554b478b1e2ff90"
+    "hash": "75c4387adfc215da0f2d9d02c27ad9a4df553a9f0187eec0365fe565a2e50216"
    }
   }
  },

--- a/python/chronos/colab-notebook/howto/how_to_generate_confidence_interval_for_prediction.ipynb
+++ b/python/chronos/colab-notebook/howto/how_to_generate_confidence_interval_for_prediction.ipynb
@@ -87,7 +87,7 @@
    "source": [
     "# data preparation\n",
     "def get_data():\n",
-    "    from bigdl.chronos.data.repo_dataset import get_public_dataset\n",
+    "    from bigdl.chronos.data import get_public_dataset\n",
     "    from sklearn.preprocessing import StandardScaler\n",
     "\n",
     "    # load the nyc taxi dataset\n",
@@ -180,18 +180,18 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.12 ('nano')",
+   "display_name": "Python 3.9.4 64-bit",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "name": "python",
-   "version": "3.7.12"
+   "version": "3.9.4"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "75c4387adfc215da0f2d9d02c27ad9a4df553a9f0187eec0365fe565a2e50216"
+    "hash": "767d51c1340bd893661ea55ea3124f6de3c7a262a8b4abca0554b478b1e2ff90"
    }
   }
  },

--- a/python/chronos/colab-notebook/howto/how_to_speedup_inference_of_forecaster_through_ONNXRuntime.ipynb
+++ b/python/chronos/colab-notebook/howto/how_to_speedup_inference_of_forecaster_through_ONNXRuntime.ipynb
@@ -103,7 +103,7 @@
    "source": [
     "# data preparation\n",
     "def get_data():\n",
-    "    from bigdl.chronos.data.repo_dataset import get_public_dataset\n",
+    "    from bigdl.chronos.data import get_public_dataset\n",
     "    from sklearn.preprocessing import StandardScaler\n",
     "\n",
     "    # load the nyc taxi dataset\n",

--- a/python/chronos/colab-notebook/howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.ipynb
+++ b/python/chronos/colab-notebook/howto/how_to_speedup_inference_of_forecaster_through_OpenVINO.ipynb
@@ -101,7 +101,7 @@
    "source": [
     "# data preparation\n",
     "def get_data():\n",
-    "    from bigdl.chronos.data.repo_dataset import get_public_dataset\n",
+    "    from bigdl.chronos.data import get_public_dataset\n",
     "    from sklearn.preprocessing import StandardScaler\n",
     "\n",
     "    # load the nyc taxi dataset\n",

--- a/python/chronos/colab-notebook/howto/how_to_train_forecaster_on_one_node.ipynb
+++ b/python/chronos/colab-notebook/howto/how_to_train_forecaster_on_one_node.ipynb
@@ -71,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bigdl.chronos.data.repo_dataset import get_public_dataset\n",
+    "from bigdl.chronos.data import get_public_dataset\n",
     "from sklearn.preprocessing import StandardScaler\n",
     "\n",
     "tsdata_train, tsdata_val, _ = get_public_dataset(name='nyc_taxi')\n",
@@ -240,7 +240,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3.7.13 ('chronos')",
+   "display_name": "Python 3.9.4 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -254,11 +254,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.9.4"
   },
   "vscode": {
    "interpreter": {
-    "hash": "f7cbcfcf124497a723b2fc91b0dad8cd6ed41af955928289a9d3478af9690021"
+    "hash": "767d51c1340bd893661ea55ea3124f6de3c7a262a8b4abca0554b478b1e2ff90"
    }
   }
  },

--- a/python/chronos/colab-notebook/howto/how_to_train_forecaster_on_one_node.ipynb
+++ b/python/chronos/colab-notebook/howto/how_to_train_forecaster_on_one_node.ipynb
@@ -240,7 +240,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3.9.4 64-bit",
+   "display_name": "Python 3.7.13 ('chronos')",
    "language": "python",
    "name": "python3"
   },
@@ -254,11 +254,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.7.13"
   },
   "vscode": {
    "interpreter": {
-    "hash": "767d51c1340bd893661ea55ea3124f6de3c7a262a8b4abca0554b478b1e2ff90"
+    "hash": "f7cbcfcf124497a723b2fc91b0dad8cd6ed41af955928289a9d3478af9690021"
    }
   }
  },

--- a/python/chronos/colab-notebook/howto/how_to_tune_forecaster_model.ipynb
+++ b/python/chronos/colab-notebook/howto/how_to_tune_forecaster_model.ipynb
@@ -78,7 +78,7 @@
    "outputs": [],
    "source": [
     "from sklearn.preprocessing import StandardScaler\n",
-    "from bigdl.chronos.data.repo_dataset import get_public_dataset\n",
+    "from bigdl.chronos.data import get_public_dataset\n",
     "\n",
     "def get_tsdata():\n",
     "    name = 'nyc_taxi'\n",
@@ -287,7 +287,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.6.9"
   },
   "vscode": {
    "interpreter": {

--- a/python/chronos/colab-notebook/howto/how_to_tune_forecaster_model.ipynb
+++ b/python/chronos/colab-notebook/howto/how_to_tune_forecaster_model.ipynb
@@ -287,7 +287,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.8.10"
   },
   "vscode": {
    "interpreter": {

--- a/python/chronos/example/auto_model/autolstm_nyc_taxi.py
+++ b/python/chronos/example/auto_model/autolstm_nyc_taxi.py
@@ -18,7 +18,7 @@ import numpy as np
 import argparse
 from sklearn.preprocessing import StandardScaler
 
-from bigdl.chronos.data.repo_dataset import get_public_dataset
+from bigdl.chronos.data import get_public_dataset
 from bigdl.chronos.autots.model.auto_lstm import AutoLSTM
 from bigdl.orca.automl import hp
 from bigdl.orca import init_orca_context, stop_orca_context

--- a/python/chronos/example/distributed/distributed_training_network_traffic.py
+++ b/python/chronos/example/distributed/distributed_training_network_traffic.py
@@ -20,7 +20,7 @@ from sklearn.preprocessing import MinMaxScaler
 from bigdl.orca.automl.metrics import Evaluator
 from bigdl.orca import init_orca_context, stop_orca_context
 from bigdl.chronos.forecaster.seq2seq_forecaster import Seq2SeqForecaster
-from bigdl.chronos.data.repo_dataset import get_public_dataset
+from bigdl.chronos.data import get_public_dataset
 
 
 def get_tsdata():

--- a/python/chronos/example/hpo/muti_objective_hpo_with_builtin_latency_tutorial.ipynb
+++ b/python/chronos/example/hpo/muti_objective_hpo_with_builtin_latency_tutorial.ipynb
@@ -68,7 +68,7 @@
    "source": [
     "from bigdl.chronos.data import TSDataset\n",
     "from sklearn.preprocessing import StandardScaler\n",
-    "from bigdl.chronos.data.repo_dataset import get_public_dataset\n",
+    "from bigdl.chronos.data import get_public_dataset\n",
     "import pandas as pd\n",
     "\n",
     "look_back = 96\n",
@@ -2133,7 +2133,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.12 ('nano')",
+   "display_name": "Python 3.9.4 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -2147,11 +2147,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.9.4"
   },
   "vscode": {
    "interpreter": {
-    "hash": "75c4387adfc215da0f2d9d02c27ad9a4df553a9f0187eec0365fe565a2e50216"
+    "hash": "767d51c1340bd893661ea55ea3124f6de3c7a262a8b4abca0554b478b1e2ff90"
    }
   }
  },

--- a/python/chronos/example/hpo/muti_objective_hpo_with_builtin_latency_tutorial.ipynb
+++ b/python/chronos/example/hpo/muti_objective_hpo_with_builtin_latency_tutorial.ipynb
@@ -2133,7 +2133,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.4 64-bit",
+   "display_name": "Python 3.7.12 ('nano')",
    "language": "python",
    "name": "python3"
   },
@@ -2147,11 +2147,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.7.12"
   },
   "vscode": {
    "interpreter": {
-    "hash": "767d51c1340bd893661ea55ea3124f6de3c7a262a8b4abca0554b478b1e2ff90"
+    "hash": "75c4387adfc215da0f2d9d02c27ad9a4df553a9f0187eec0365fe565a2e50216"
    }
   }
  },

--- a/python/chronos/example/inference-acceleration/cpu_inference_acceleration.py
+++ b/python/chronos/example/inference-acceleration/cpu_inference_acceleration.py
@@ -17,7 +17,7 @@ import torch
 from bigdl.chronos.pytorch import TSTrainer as Trainer
 from bigdl.chronos.model.tcn import model_creator
 from bigdl.chronos.metric.forecast_metrics import Evaluator
-from bigdl.chronos.data.repo_dataset import get_public_dataset
+from bigdl.chronos.data import get_public_dataset
 from sklearn.preprocessing import StandardScaler
 
 def gen_dataloader():

--- a/python/chronos/example/loss/penalize_underestimation.ipynb
+++ b/python/chronos/example/loss/penalize_underestimation.ipynb
@@ -328,7 +328,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.4 64-bit",
+   "display_name": "Python 3.7.12 ('nano')",
    "language": "python",
    "name": "python3"
   },
@@ -342,12 +342,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.7.12"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "767d51c1340bd893661ea55ea3124f6de3c7a262a8b4abca0554b478b1e2ff90"
+    "hash": "75c4387adfc215da0f2d9d02c27ad9a4df553a9f0187eec0365fe565a2e50216"
    }
   }
  },

--- a/python/chronos/example/loss/penalize_underestimation.ipynb
+++ b/python/chronos/example/loss/penalize_underestimation.ipynb
@@ -105,7 +105,7 @@
     "import torch\n",
     "import numpy as np\n",
     "from sklearn.preprocessing import StandardScaler\n",
-    "from bigdl.chronos.data.repo_dataset import get_public_dataset\n",
+    "from bigdl.chronos.data import get_public_dataset\n",
     "\n",
     "\n",
     "def get_tsdata():\n",
@@ -328,7 +328,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.12 ('nano')",
+   "display_name": "Python 3.9.4 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -342,12 +342,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.9.4"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "75c4387adfc215da0f2d9d02c27ad9a4df553a9f0187eec0365fe565a2e50216"
+    "hash": "767d51c1340bd893661ea55ea3124f6de3c7a262a8b4abca0554b478b1e2ff90"
    }
   }
  },

--- a/python/chronos/example/onnx/onnx_autotsestimator_nyc_taxi.py
+++ b/python/chronos/example/onnx/onnx_autotsestimator_nyc_taxi.py
@@ -20,7 +20,7 @@ from sklearn.preprocessing import StandardScaler
 
 from bigdl.orca import init_orca_context, stop_orca_context
 from bigdl.chronos.autots.autotsestimator import AutoTSEstimator
-from bigdl.chronos.data.repo_dataset import get_public_dataset
+from bigdl.chronos.data import get_public_dataset
 
 
 def get_tsdata():

--- a/python/chronos/example/onnx/onnx_forecaster_network_traffic.py
+++ b/python/chronos/example/onnx/onnx_forecaster_network_traffic.py
@@ -19,7 +19,7 @@ import numpy as np
 from sklearn.preprocessing import MinMaxScaler
 
 from bigdl.chronos.forecaster.seq2seq_forecaster import Seq2SeqForecaster
-from bigdl.chronos.data.repo_dataset import get_public_dataset
+from bigdl.chronos.data import get_public_dataset
 
 
 def get_tsdata():

--- a/python/chronos/example/quantization/quantization_tcnforecaster_nyc_taxi.py
+++ b/python/chronos/example/quantization/quantization_tcnforecaster_nyc_taxi.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from bigdl.chronos.data.repo_dataset import get_public_dataset
+from bigdl.chronos.data import get_public_dataset
 from bigdl.chronos.forecaster import TCNForecaster
 from sklearn.preprocessing import StandardScaler
 from bigdl.chronos.metric.forecast_metrics import Evaluator

--- a/python/chronos/use-case/network_traffic/network_traffic_autots_customized_model.ipynb
+++ b/python/chronos/use-case/network_traffic/network_traffic_autots_customized_model.ipynb
@@ -76,7 +76,7 @@
    "outputs": [],
    "source": [
     "from sklearn.preprocessing import StandardScaler\n",
-    "from bigdl.chronos.data.repo_dataset import get_public_dataset"
+    "from bigdl.chronos.data import get_public_dataset"
    ]
   },
   {
@@ -907,11 +907,8 @@
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "5fd0d186da03a3cc4467b80ade5453b676349bbfc4f1af2284fe352fa0ffaaf6"
-  },
   "kernelspec": {
-   "display_name": "bigdl",
+   "display_name": "Python 3.9.4 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -925,7 +922,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.9.4"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "767d51c1340bd893661ea55ea3124f6de3c7a262a8b4abca0554b478b1e2ff90"
+   }
   }
  },
  "nbformat": 4,

--- a/python/chronos/use-case/network_traffic/network_traffic_autots_customized_model.ipynb
+++ b/python/chronos/use-case/network_traffic/network_traffic_autots_customized_model.ipynb
@@ -907,8 +907,11 @@
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "5fd0d186da03a3cc4467b80ade5453b676349bbfc4f1af2284fe352fa0ffaaf6"
+  },
   "kernelspec": {
-   "display_name": "Python 3.9.4 64-bit",
+   "display_name": "bigdl",
    "language": "python",
    "name": "python3"
   },
@@ -922,12 +925,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "767d51c1340bd893661ea55ea3124f6de3c7a262a8b4abca0554b478b1e2ff90"
-   }
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description

For users, `from bigdl.chronos.data.repo_dataset import get_public_dataset` is quite hard to remember.
In https://github.com/intel-analytics/BigDL/pull/5983, `from .repo_dataset import get_public_dataset` has been add in init.py.
Therefore, the import path of `get_public_dataset` are all changed in this PR.


### 2. User API changes

If users want to use `get_public_dataset`
```python
from bigdl.chronos.data import get_public_dataset
```
