### PR TITLE
add enginetype nonemkl 

### DIFF
--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/Engine.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/Engine.scala
@@ -36,6 +36,7 @@ sealed trait EngineType
 
 case object MklBlas extends EngineType
 case object MklDnn extends EngineType
+case object NoneMkl extends EngineType
 
 /**
  * define optimizer version trait
@@ -223,6 +224,7 @@ object Engine {
     System.getProperty("bigdl.engineType", "mklblas").toLowerCase(Locale.ROOT) match {
       case "mklblas" => MklBlas
       case "mkldnn" => MklDnn
+      case "nonemkl" => NoneMkl
       case engineType =>
         Log4Error.invalidOperationError(false, s"Unknown engine type $engineType")
         MklDnn
@@ -318,7 +320,10 @@ object Engine {
   private[bigdl] def setCoreNumber(n: Int): Unit = {
     Log4Error.invalidInputError(n > 0, "Engine.init: core number is smaller than zero")
     physicalCoreNumber = n
-    initThreadPool(n)
+    // won't init mkl if EngineType is not mkl.
+    if (getEngineType() != NoneMkl) {
+      initThreadPool(n)
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

Add engineType nonemkl, won't load and init mkl if enginetype is set to `nonemkl`.
Set property `bigdl.engineType` to `NoneMkl` to enable this.

### 1. Why the change?

Some ppml job(sql only) doesn't need mkl.

### 2. User API changes

Add new property `bigdl.engineType`: `NoneMkl` 

### 3. Summary of the change 

Add engineType nonemkl, won't load and init mkl if enginetype is set to `nonemkl`.
Set property `bigdl.engineType` to `NoneMkl` to enable this.

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
