### PR TITLE
Chronos: base_forecaster: add_predict_with_jit

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -1454,7 +1454,7 @@ class BasePytorchForecaster(Forecaster):
                                                       accelerator="openvino",
                                                       thread_num=thread_num)
 
-    def build_jit(self, thread_num=None):
+    def build_jit(self, thread_num=None, use_ipex=False):
         '''
          Build jit model to speed up inference and reduce latency.
          The method is Not required to call before predict_with_jit
@@ -1466,6 +1466,9 @@ class BasePytorchForecaster(Forecaster):
          | 2. Alleviate the cold start problem when you call predict_with_jit
          |    for the first time.
 
+         :param use_ipex: if to use intel-pytorch-extension for acceleration. Typically,
+                intel-pytorch-extension will bring some acceleration while causing some
+                unexpected error as well.
          :param thread_num: int, the num of thread limit. The value is set to None by
                 default where no limit is set.
          '''
@@ -1482,7 +1485,7 @@ class BasePytorchForecaster(Forecaster):
         self.jit_fp32 = InferenceOptimizer.trace(self.internal,
                                                  input_sample=dummy_input,
                                                  accelerator="jit",
-                                                 use_ipex=True,
+                                                 use_ipex=use_ipex,
                                                  channels_last=False,
                                                  thread_num=thread_num)
 

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -882,7 +882,7 @@ class BasePytorchForecaster(Forecaster):
         :param batch_size: predict batch size. The value will not affect predict
                result but will affect resources cost(e.g. memory and time). Defaults
                to 32. None for all-data-single-time inference.
-        :param quantize: if use the quantized jit model to predict.
+        :param quantize: if use the quantized jit model to predict. Not support yet.
 
         :return: A numpy array with shape (num_samples, horizon, target_dim).
         """
@@ -908,7 +908,7 @@ class BasePytorchForecaster(Forecaster):
                                              target_col=data.roll_target,
                                              shuffle=False)
 
-        if quantize:
+        if quantize and False:
             return _pytorch_fashion_inference(model=self.jit_int8,
                                               input_data=data,
                                               batch_size=batch_size)
@@ -1614,7 +1614,7 @@ class BasePytorchForecaster(Forecaster):
         :param conf: A path to conf yaml file for quantization. Default to None,
                using default config.
         :param framework: string or list. [{'pytorch_fx'|'pytorch_ipex'},
-               {'onnxrt_integerops'|'onnxrt_qlinearops'}, {'openvino'}, {'jit'}]
+               {'onnxrt_integerops'|'onnxrt_qlinearops'}, {'openvino'}]
                Default: 'pytorch_fx'. Consistent with Intel Neural Compressor.
         :param approach: str, 'static' or 'dynamic'. Default to 'static'.
                OpenVINO supports static mode only, if set to 'dynamic',
@@ -1707,9 +1707,6 @@ class BasePytorchForecaster(Forecaster):
             elif accelerator == 'openvino':
                 method = None
                 approach = "static"
-            elif accelerator == 'jit':
-                method = 'ipex'
-                approach = "static"
             else:
                 accelerator = 'onnxruntime'
                 method = method[:-3]
@@ -1730,8 +1727,6 @@ class BasePytorchForecaster(Forecaster):
                 self.onnxruntime_int8 = q_model
             if accelerator == 'openvino':
                 self.openvino_int8 = q_model
-            if accelerator == 'jit':
-                self.jit_int8 = q_model
             if accelerator is None:
                 self.pytorch_int8 = q_model
 

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -1464,7 +1464,7 @@ class BasePytorchForecaster(Forecaster):
 
          | 1. Strictly control the thread to be used during inferencing.
          | 2. Alleviate the cold start problem when you call predict_with_jit
-              for the first time.
+         |    for the first time.
 
          :param thread_num: int, the num of thread limit. The value is set to None by
                 default where no limit is set.

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -1458,7 +1458,7 @@ class BasePytorchForecaster(Forecaster):
         '''
          Build jit model to speed up inference and reduce latency.
          The method is Not required to call before predict_with_jit
-         or export_jit_file.
+         or export_torchscript_file.
 
          It is recommended to use when you want to:
 

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -85,8 +85,10 @@ class BasePytorchForecaster(Forecaster):
                                                 optimizer=optimizer)
             self.onnxruntime_fp32 = None  # onnxruntime session for fp32 precision
             self.openvino_fp32 = None  # placeholader openvino session for fp32 precision
+            self.jit_fp32 = None  # placeholader jit session for fp32 precision
             self.onnxruntime_int8 = None  # onnxruntime session for int8 precision
             self.openvino_int8 = None  # placeholader openvino session for int8 precision
+            self.jit_int8 = None  # placeholader jit session for int8 precision
             self.pytorch_int8 = None  # pytorch model for int8 precision
             self.optim_model = None  # accelarated model obtained from .optimize()
             self.metadata = None  # str indicates model type of optim_model
@@ -849,6 +851,74 @@ class BasePytorchForecaster(Forecaster):
                                               input_data=data,
                                               batch_size=batch_size)
 
+    def predict_with_jit(self, data, batch_size=32, quantize=False):
+        """
+        Predict using a trained forecaster with jit. The method can only be
+        used when forecaster is a non-distributed version.
+
+        Directly call this method without calling build_jit is valid and Forecaster will
+        automatically build an jit session with default settings.
+
+       :param data: The data support following formats:
+
+               | 1. a numpy ndarray x:
+               | x's shape is (num_samples, lookback, feature_dim) where lookback and feature_dim
+               | should be the same as past_seq_len and input_feature_num.
+               |
+               | 2. pytorch dataloader:
+               | the dataloader needs to return at least x in each iteration
+               | with the shape as following:
+               | x's shape is (num_samples, lookback, feature_dim) where lookback and feature_dim
+               | should be the same as past_seq_len and input_feature_num.
+               | If returns x and y only get x.
+               |
+               | 3. A bigdl.chronos.data.tsdataset.TSDataset instance:
+               | Forecaster will automatically process the TSDataset.
+               | By default, TSDataset will be transformed to a pytorch dataloader,
+               | which is memory-friendly while a little bit slower.
+               | Users may call `roll` on the TSDataset before calling `fit`
+               | Then the training speed will be faster but will consume more memory.
+
+        :param batch_size: predict batch size. The value will not affect predict
+               result but will affect resources cost(e.g. memory and time). Defaults
+               to 32. None for all-data-single-time inference.
+        :param quantize: if use the quantized jit model to predict.
+
+        :return: A numpy array with shape (num_samples, horizon, target_dim).
+        """
+        from bigdl.chronos.pytorch.utils import _pytorch_fashion_inference
+        from bigdl.nano.utils.log4Error import invalidInputError
+
+        if self.distributed:
+            invalidInputError(False,
+                              "Jit inference has not been supported for distributed "
+                              "forecaster. You can call .to_local() to transform the "
+                              "forecaster to a non-distributed version.")
+        if not self.fitted:
+            invalidInputError(False,
+                              "You must call fit or restore first before calling predict!")
+
+        if isinstance(data, TSDataset):
+            _rolled = data.numpy_x is None
+            data = data.to_torch_data_loader(batch_size=batch_size,
+                                             roll=_rolled,
+                                             lookback=self.data_config['past_seq_len'],
+                                             horizon=self.data_config['future_seq_len'],
+                                             feature_col=data.roll_feature,
+                                             target_col=data.roll_target,
+                                             shuffle=False)
+
+        if quantize:
+            return _pytorch_fashion_inference(model=self.jit_int8,
+                                              input_data=data,
+                                              batch_size=batch_size)
+        else:
+            if self.jit_fp32 is None:
+                self.build_jit()
+            return _pytorch_fashion_inference(model=self.jit_fp32,
+                                              input_data=data,
+                                              batch_size=batch_size)
+
     def evaluate(self, data, batch_size=32, multioutput="raw_values", quantize=False,
                  acceleration: bool = True):
         """
@@ -1288,8 +1358,10 @@ class BasePytorchForecaster(Forecaster):
         self.fitted = True
         self.onnxruntime_fp32 = None  # onnxruntime session for fp32 precision
         self.openvino_fp32 = None  # openvino session for fp32 precision
+        self.jit_fp32 = None  # jit session for fp32 precision
         self.onnxruntime_int8 = None  # onnxruntime session for int8 precision
         self.openvino_int8 = None  # openvino session for int8 precision
+        self.jit_int8 = None  # jit session for int8 precision
         self.pytorch_int8 = None  # pytorch model for int8 precision
         return self
 
@@ -1382,6 +1454,37 @@ class BasePytorchForecaster(Forecaster):
                                                       accelerator="openvino",
                                                       thread_num=thread_num)
 
+    def build_jit(self, thread_num=None):
+        '''
+         Build jit model to speed up inference and reduce latency.
+         The method is Not required to call before predict_with_jit
+         or export_jit_file.
+
+         It is recommended to use when you want to:
+
+         | 1. Strictly control the thread to be used during inferencing.
+         | 2. Alleviate the cold start problem when you call predict_with_jit
+              for the first time.
+
+         :param thread_num: int, the num of thread limit. The value is set to None by
+                default where no limit is set.
+         '''
+        from bigdl.nano.pytorch import InferenceOptimizer
+        from bigdl.nano.utils.log4Error import invalidInputError
+
+        if self.distributed:
+            invalidInputError(False,
+                              "build_jit has not been supported for distributed "
+                              "forecaster. You can call .to_local() to transform the "
+                              "forecaster to a non-distributed version.")
+        dummy_input = torch.rand(1, self.data_config["past_seq_len"],
+                                 self.data_config["input_feature_num"])
+        self.jit_fp32 = InferenceOptimizer.trace(self.internal,
+                                                 input_sample=dummy_input,
+                                                 accelerator="jit",
+                                                 use_ipex=True,
+                                                 thread_num=thread_num)
+
     def export_onnx_file(self, dirname="fp32_onnx", quantized_dirname=None):
         """
         Save the onnx model file to the disk.
@@ -1424,6 +1527,28 @@ class BasePytorchForecaster(Forecaster):
             if self.openvino_fp32 is None:
                 self.build_openvino()
             InferenceOptimizer.save(self.openvino_fp32, dirname)
+
+    def export_jit_file(self, dirname="fp32_jit",
+                             quantized_dirname=None):
+        """
+        Save the jit model file to the disk.
+
+        :param dirname: The dir location you want to save the jit file.
+        :param quantized_dirname: The dir location you want to save the quantized jit file.
+        """
+        from bigdl.nano.pytorch import InferenceOptimizer
+        from bigdl.nano.utils.log4Error import invalidInputError
+        if self.distributed:
+            invalidInputError(False,
+                              "export_jit_file has not been supported for distributed "
+                              "forecaster. You can call .to_local() to transform the "
+                              "forecaster to a non-distributed version.")
+        if quantized_dirname and self.jit_int8:
+            InferenceOptimizer.save(self.jit_int8, dirname)
+        if dirname:
+            if self.jit_fp32 is None:
+                self.build_jit()
+            InferenceOptimizer.save(self.jit_fp32, dirname)
 
     def quantize(self, calib_data=None,
                  val_data=None,
@@ -1489,7 +1614,7 @@ class BasePytorchForecaster(Forecaster):
         :param conf: A path to conf yaml file for quantization. Default to None,
                using default config.
         :param framework: string or list. [{'pytorch_fx'|'pytorch_ipex'},
-               {'onnxrt_integerops'|'onnxrt_qlinearops'}, {'openvino'}]
+               {'onnxrt_integerops'|'onnxrt_qlinearops'}, {'openvino'}, {'jit'}]
                Default: 'pytorch_fx'. Consistent with Intel Neural Compressor.
         :param approach: str, 'static' or 'dynamic'. Default to 'static'.
                OpenVINO supports static mode only, if set to 'dynamic',
@@ -1582,6 +1707,9 @@ class BasePytorchForecaster(Forecaster):
             elif accelerator == 'openvino':
                 method = None
                 approach = "static"
+            elif accelerator == 'jit':
+                method = 'ipex'
+                approach = "static"
             else:
                 accelerator = 'onnxruntime'
                 method = method[:-3]
@@ -1602,6 +1730,8 @@ class BasePytorchForecaster(Forecaster):
                 self.onnxruntime_int8 = q_model
             if accelerator == 'openvino':
                 self.openvino_int8 = q_model
+            if accelerator == 'jit':
+                self.jit_int8 = q_model
             if accelerator is None:
                 self.pytorch_int8 = q_model
 

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -1483,6 +1483,7 @@ class BasePytorchForecaster(Forecaster):
                                                  input_sample=dummy_input,
                                                  accelerator="jit",
                                                  use_ipex=True,
+                                                 channels_last=False,
                                                  thread_num=thread_num)
 
     def export_onnx_file(self, dirname="fp32_onnx", quantized_dirname=None):
@@ -1528,23 +1529,23 @@ class BasePytorchForecaster(Forecaster):
                 self.build_openvino()
             InferenceOptimizer.save(self.openvino_fp32, dirname)
 
-    def export_jit_file(self, dirname="fp32_jit",
-                             quantized_dirname=None):
+    def export_torchscript_file(self, dirname="fp32_torchscript",
+                                quantized_dirname=None):
         """
-        Save the jit model file to the disk.
+        Save the torchscript model file to the disk.
 
-        :param dirname: The dir location you want to save the jit file.
-        :param quantized_dirname: The dir location you want to save the quantized jit file.
+        :param dirname: The dir location you want to save the torchscript file.
+        :param quantized_dirname: The dir location you want to save the quantized torchscript file.
         """
         from bigdl.nano.pytorch import InferenceOptimizer
         from bigdl.nano.utils.log4Error import invalidInputError
         if self.distributed:
             invalidInputError(False,
-                              "export_jit_file has not been supported for distributed "
+                              "export_torchscript_file has not been supported for distributed "
                               "forecaster. You can call .to_local() to transform the "
                               "forecaster to a non-distributed version.")
         if quantized_dirname and self.jit_int8:
-            InferenceOptimizer.save(self.jit_int8, dirname)
+            InferenceOptimizer.save(self.jit_int8, quantized_dirname)
         if dirname:
             if self.jit_fp32 is None:
                 self.build_jit()

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -233,11 +233,10 @@ class TestChronosModelLSTMForecaster(TestCase):
         except ImportError:
             pass
 
-        # test exporting the openvino
+        # test exporting the jit
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             ckpt_name = os.path.join(tmp_dir_name, "fp32_jit")
-            ckpt_name_q = os.path.join(tmp_dir_name, "int_jit")
-            forecaster.export_jit_file(dirname=ckpt_name, quantized_dirname=ckpt_name_q)
+            forecaster.export_jit_file(dirname=ckpt_name)
 
     @op_diff_set_all
     def test_lstm_forecaster_jit_methods_loader(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -236,7 +236,7 @@ class TestChronosModelLSTMForecaster(TestCase):
         # test exporting the jit
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             ckpt_name = os.path.join(tmp_dir_name, "fp32_jit")
-            forecaster.export_jit_file(dirname=ckpt_name)
+            forecaster.export_torchscript_file(dirname=ckpt_name)
 
     @op_diff_set_all
     def test_lstm_forecaster_jit_methods_loader(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -194,6 +194,27 @@ class TestChronosNBeatsForecaster(TestCase):
             forecaster.export_openvino_file(dirname=ckpt_name, quantized_dirname=ckpt_name_q)
 
     @op_diff_set_all
+    def test_nbeats_forecaster_jit_methods(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = NBeatsForecaster(past_seq_len=24,
+                                      future_seq_len=5,
+                                      loss='mae',
+                                      lr=0.01)
+        forecaster.fit(train_data, epochs=2)
+        try:
+            pred = forecaster.predict(test_data[0])
+            pred_jit = forecaster.predict_with_jit(test_data[0])
+            np.testing.assert_almost_equal(pred, pred_jit, decimal=5)
+        except ImportError:
+            pass
+
+        # test exporting the openvino
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            ckpt_name = os.path.join(tmp_dir_name, "fp32_jit")
+            ckpt_name_q = os.path.join(tmp_dir_name, "int_jit")
+            forecaster.export_jit_file(dirname=ckpt_name, quantized_dirname=ckpt_name_q)
+
+    @op_diff_set_all
     def test_nbeats_forecaster_quantization(self):
         train_data, val_data, test_data = create_data()
         forecaster = NBeatsForecaster(past_seq_len=24,

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -208,11 +208,10 @@ class TestChronosNBeatsForecaster(TestCase):
         except ImportError:
             pass
 
-        # test exporting the openvino
+        # test exporting the jit
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             ckpt_name = os.path.join(tmp_dir_name, "fp32_jit")
-            ckpt_name_q = os.path.join(tmp_dir_name, "int_jit")
-            forecaster.export_jit_file(dirname=ckpt_name, quantized_dirname=ckpt_name_q)
+            forecaster.export_jit_file(dirname=ckpt_name)
 
     @op_diff_set_all
     def test_nbeats_forecaster_quantization(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -211,7 +211,7 @@ class TestChronosNBeatsForecaster(TestCase):
         # test exporting the jit
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             ckpt_name = os.path.join(tmp_dir_name, "fp32_jit")
-            forecaster.export_jit_file(dirname=ckpt_name)
+            forecaster.export_torchscript_file(dirname=ckpt_name)
 
     @op_diff_set_all
     def test_nbeats_forecaster_quantization(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -208,11 +208,10 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
         except ImportError:
             pass
 
-        # test exporting the openvino
+        # test exporting the jit
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             ckpt_name = os.path.join(tmp_dir_name, "fp32_jit")
-            ckpt_name_q = os.path.join(tmp_dir_name, "int_jit")
-            forecaster.export_jit_file(dirname=ckpt_name, quantized_dirname=ckpt_name_q)
+            forecaster.export_jit_file(dirname=ckpt_name)
 
     @op_diff_set_all
     def test_s2s_forecaster_quantization(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -192,6 +192,29 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
             forecaster.export_openvino_file(dirname=ckpt_name, quantized_dirname=ckpt_name_q)
 
     @op_diff_set_all
+    def test_s2s_forecaster_jit_methods(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = Seq2SeqForecaster(past_seq_len=24,
+                                       future_seq_len=5,
+                                       input_feature_num=1,
+                                       output_feature_num=1,
+                                       loss="mae",
+                                       lr=0.01)
+        forecaster.fit(train_data, epochs=2)
+        try:
+            pred = forecaster.predict(test_data[0])
+            pred_jit = forecaster.predict_with_jit(test_data[0])
+            np.testing.assert_almost_equal(pred, pred_jit, decimal=5)
+        except ImportError:
+            pass
+
+        # test exporting the openvino
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            ckpt_name = os.path.join(tmp_dir_name, "fp32_jit")
+            ckpt_name_q = os.path.join(tmp_dir_name, "int_jit")
+            forecaster.export_jit_file(dirname=ckpt_name, quantized_dirname=ckpt_name_q)
+
+    @op_diff_set_all
     def test_s2s_forecaster_quantization(self):
         train_data, val_data, test_data = create_data()
         forecaster = Seq2SeqForecaster(past_seq_len=24,

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -211,7 +211,7 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
         # test exporting the jit
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             ckpt_name = os.path.join(tmp_dir_name, "fp32_jit")
-            forecaster.export_jit_file(dirname=ckpt_name)
+            forecaster.export_torchscript_file(dirname=ckpt_name)
 
     @op_diff_set_all
     def test_s2s_forecaster_quantization(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -394,6 +394,84 @@ class TestChronosModelTCNForecaster(TestCase):
         assert openvino_yhat.shape == q_openvino_yhat.shape
 
     @op_diff_set_all
+    def test_tcn_forecaster_jit_methods(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = TCNForecaster(past_seq_len=24,
+                                   future_seq_len=5,
+                                   input_feature_num=1,
+                                   output_feature_num=1,
+                                   kernel_size=4,
+                                   num_channels=[16, 16],
+                                   lr=0.01)
+        forecaster.fit(train_data, epochs=2)
+        try:
+            pred = forecaster.predict(test_data[0])
+            pred_jit = forecaster.predict_with_jit(test_data[0])
+            np.testing.assert_almost_equal(pred, pred_jit, decimal=5)
+        except ImportError:
+            pass
+
+        forecaster.quantize(calib_data=train_data,
+                            framework="jit")
+        jit_yhat = forecaster.predict_with_jit(test_data[0])
+        q_jit_yhat = forecaster.predict_with_jit(test_data[0], quantize=True)
+        assert jit_yhat.shape == q_jit_yhat.shape == test_data[1].shape
+
+        # test exporting the openvino
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            ckpt_name = os.path.join(tmp_dir_name, "fp32_jit")
+            ckpt_name_q = os.path.join(tmp_dir_name, "int_jit")
+            forecaster.export_jit_file(dirname=ckpt_name, quantized_dirname=ckpt_name_q)
+
+    @op_diff_set_all
+    def test_tcn_forecaster_jit_methods_loader(self):
+        train_loader, val_loader, test_loader = create_data(loader=True)
+        forecaster = TCNForecaster(past_seq_len=24,
+                                   future_seq_len=5,
+                                   input_feature_num=1,
+                                   output_feature_num=1,
+                                   kernel_size=4,
+                                   num_channels=[16, 16],
+                                   lr=0.01)
+        forecaster.fit(train_loader, epochs=2)
+        try:
+            pred = forecaster.predict(test_loader)
+            pred_jit = forecaster.predict_with_jit(test_loader)
+            np.testing.assert_almost_equal(pred, pred_jit, decimal=5)
+        except ImportError:
+            pass
+
+        forecaster.quantize(calib_data=train_loader,
+                            framework="jit")
+        jit_yhat = forecaster.predict_with_jit(test_loader)
+        q_jit_yhat = forecaster.predict_with_jit(test_loader, quantize=True)
+        assert jit_yhat.shape == q_jit_yhat.shape
+
+    @op_diff_set_all
+    def test_tcn_forecaster_jit_methods_tsdataset(self):
+        train, test = create_tsdataset(roll=True, horizon=5)
+        forecaster = TCNForecaster(past_seq_len=24,
+                                   future_seq_len=5,
+                                   input_feature_num=2,
+                                   output_feature_num=2,
+                                   kernel_size=4,
+                                   num_channels=[16, 16],
+                                   lr=0.01)
+        forecaster.fit(train, epochs=2)
+        try:
+            pred = forecaster.predict(test)
+            pred_jit = forecaster.predict_with_jit(test)
+            np.testing.assert_almost_equal(pred, pred_jit, decimal=5)
+        except ImportError:
+            pass
+
+        forecaster.quantize(calib_data=train,
+                            framework="jit")
+        jit_yhat = forecaster.predict_with_jit(test)
+        q_jit_yhat = forecaster.predict_with_jit(test, quantize=True)
+        assert jit_yhat.shape == q_jit_yhat.shape
+
+    @op_diff_set_all
     def test_tcn_forecaster_quantization_dynamic(self):
         train_data, val_data, test_data = create_data()
         forecaster = TCNForecaster(past_seq_len=24,

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -411,17 +411,10 @@ class TestChronosModelTCNForecaster(TestCase):
         except ImportError:
             pass
 
-        forecaster.quantize(calib_data=train_data,
-                            framework="jit")
-        jit_yhat = forecaster.predict_with_jit(test_data[0])
-        q_jit_yhat = forecaster.predict_with_jit(test_data[0], quantize=True)
-        assert jit_yhat.shape == q_jit_yhat.shape == test_data[1].shape
-
-        # test exporting the openvino
+        # test exporting the jit
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             ckpt_name = os.path.join(tmp_dir_name, "fp32_jit")
-            ckpt_name_q = os.path.join(tmp_dir_name, "int_jit")
-            forecaster.export_jit_file(dirname=ckpt_name, quantized_dirname=ckpt_name_q)
+            forecaster.export_jit_file(dirname=ckpt_name)
 
     @op_diff_set_all
     def test_tcn_forecaster_jit_methods_loader(self):
@@ -441,12 +434,6 @@ class TestChronosModelTCNForecaster(TestCase):
         except ImportError:
             pass
 
-        forecaster.quantize(calib_data=train_loader,
-                            framework="jit")
-        jit_yhat = forecaster.predict_with_jit(test_loader)
-        q_jit_yhat = forecaster.predict_with_jit(test_loader, quantize=True)
-        assert jit_yhat.shape == q_jit_yhat.shape
-
     @op_diff_set_all
     def test_tcn_forecaster_jit_methods_tsdataset(self):
         train, test = create_tsdataset(roll=True, horizon=5)
@@ -464,12 +451,6 @@ class TestChronosModelTCNForecaster(TestCase):
             np.testing.assert_almost_equal(pred, pred_jit, decimal=5)
         except ImportError:
             pass
-
-        forecaster.quantize(calib_data=train,
-                            framework="jit")
-        jit_yhat = forecaster.predict_with_jit(test)
-        q_jit_yhat = forecaster.predict_with_jit(test, quantize=True)
-        assert jit_yhat.shape == q_jit_yhat.shape
 
     @op_diff_set_all
     def test_tcn_forecaster_quantization_dynamic(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -414,7 +414,7 @@ class TestChronosModelTCNForecaster(TestCase):
         # test exporting the jit
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             ckpt_name = os.path.join(tmp_dir_name, "fp32_jit")
-            forecaster.export_jit_file(dirname=ckpt_name)
+            forecaster.export_torchscript_file(dirname=ckpt_name)
 
     @op_diff_set_all
     def test_tcn_forecaster_jit_methods_loader(self):


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?
Add **add_predict_with_jit** for base_forecaster. 

<!-- Provide the related github issue link if available -->

### 2. User API changes
New API:
forecaster.predict_with_jit()
forecaster.build_jit()
forecaster.export_jit_file()

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 
Add a new **add_predict_with_jit** interface to base_forecaster, add or adjust the corresponding properties and functions, and add some new unit tests.

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [x] Unit test
Add new tests as follows：
- test_lstm_forecaster.py::TestChronosModelLSTMForecaster::test_lstm_forecaster_jit_methods
- test_lstm_forecaster.py::TestChronosModelLSTMForecaster::test_lstm_forecaster_jit_methods_loader
- test_nbeats_forecaster.py::TestChronosNBeatsForecaster::test_nbeats_forecaster_jit_methods
- test_seq2seq_forecaster.py::TestChronosModelSeq2SeqForecaster::test_s2s_forecaster_jit_methods
- test_tcn_forecaster.py::TestChronosModelTCNForecaster::test_tcn_forecaster_jit_methods
- test_tcn_forecaster.py::TestChronosModelTCNForecaster::test_tcn_forecaster_jit_methods_loader
- test_tcn_forecaster.py::TestChronosModelTCNForecaster::test_tcn_forecaster_jit_methods_tsdataset
