### PR TITLE
[Chronos] Solve the problem of slow initialization for tf2 seq2seq forecaster

### DIFF
--- a/python/chronos/src/bigdl/chronos/autots/model/auto_seq2seq.py
+++ b/python/chronos/src/bigdl/chronos/autots/model/auto_seq2seq.py
@@ -101,7 +101,7 @@ class AutoSeq2Seq(BaseAutomodel):
         if self.backend.startswith("torch"):
             from bigdl.chronos.model.Seq2Seq_pytorch import model_creator
         elif self.backend.startswith("keras"):
-            from bigdl.chronos.model.tf2.Seq2Seq_keras import model_creator
+            from bigdl.chronos.model.tf2.Seq2Seq_keras import model_creator_auto as model_creator
         else:
             from bigdl.nano.utils.log4Error import invalidInputError
             invalidInputError(False,

--- a/python/chronos/src/bigdl/chronos/model/tf2/Seq2Seq_keras.py
+++ b/python/chronos/src/bigdl/chronos/model/tf2/Seq2Seq_keras.py
@@ -150,6 +150,22 @@ def model_creator(config):
                         lstm_layer_num=config.get("lstm_layer_num", 2),
                         dropout=config.get("dropout", 0.25),
                         teacher_forcing=config.get("teacher_forcing", False))
+    learning_rate = config.get('lr', 1e-3)
+    model.compile(optimizer=getattr(tf.keras.optimizers,
+                                    config.get("optim", "Adam"))(learning_rate),
+                  loss=config.get("loss", "mse"),
+                  metrics=[config.get("metics", "mse")])
+    return model
+
+
+def model_creator_auto(config):
+    model = LSTMSeq2Seq(input_feature_num=config["input_feature_num"],
+                        output_feature_num=config["output_feature_num"],
+                        future_seq_len=config["future_seq_len"],
+                        lstm_hidden_dim=config.get("lstm_hidden_dim", 128),
+                        lstm_layer_num=config.get("lstm_layer_num", 2),
+                        dropout=config.get("dropout", 0.25),
+                        teacher_forcing=config.get("teacher_forcing", False))
     inputs = Input(shape=(None, config['input_feature_num']))
     model(inputs)
     learning_rate = config.get('lr', 1e-3)

--- a/python/chronos/src/bigdl/chronos/model/tf2/Seq2Seq_keras.py
+++ b/python/chronos/src/bigdl/chronos/model/tf2/Seq2Seq_keras.py
@@ -159,6 +159,9 @@ def model_creator(config):
 
 
 def model_creator_auto(config):
+    """
+    Add model(inputs) in this model creator to initialize the weights
+    """
     model = LSTMSeq2Seq(input_feature_num=config["input_feature_num"],
                         output_feature_num=config["output_feature_num"],
                         future_seq_len=config["future_seq_len"],


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?
Solve the problem of slow initialization for tf2 seq2seq forecaster.

<!-- Provide the related github issue link if available -->

### 2. User API changes
Add new API:
bigdl.chronos.model.tf2.Seq2Seq_keras: **model_creator_auto**

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

