### PR TITLE
Nano: add inference benchmark

### DIFF
--- a/python/nano/benchmark/resnet_inference/pytorch-resnet-inference.py
+++ b/python/nano/benchmark/resnet_inference/pytorch-resnet-inference.py
@@ -1,0 +1,68 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import torch
+import argparse
+import time
+import json
+from torchvision.models import resnet50
+from torch.utils.data import TensorDataset, DataLoader
+
+parser = argparse.ArgumentParser(description='PyTorch Inference Benchmark')
+parser.add_argument('--name', default='Raw inference benchmark', type=str)
+parser.add_argument('--accelerator', default=None, type=str)
+parser.add_argument('--precision', default='fp32', type=str)
+
+
+if __name__ == "__main__":
+
+    args = parser.parse_args()
+    model_ft = resnet50(pretrained=True)
+
+    if args.precision == 'fp32' and args.accelerator is None:
+        x = torch.rand(2, 3, 224, 224)
+        start_time = time.time()
+        for _ in range(100):
+            y_hat = model_ft(x)
+        end_time = time.time()
+        output = json.dumps({
+            "config": args.name,
+            "inference_time": end_time - start_time,
+        })
+
+    else:
+        from bigdl.nano.pytorch import InferenceOptimizer
+
+        x = torch.rand(2, 3, 224, 224)
+        if args.precision != 'fp32':
+            optimized_model = InferenceOptimizer.quantize(model_ft,
+                                    precision = args.precision,
+                                    accelerator = args.accelerator,
+                                    calib_dataloader = DataLoader(TensorDataset(torch.rand(10, 3, 224, 224), torch.rand(10))))
+        else:
+            optimized_model = InferenceOptimizer.trace(model_ft,
+                                                accelerator=args.accelerator,
+                                                input_sample=torch.rand(1, 3, 224, 224))
+        start_time = time.time()
+        for _ in range(100):
+            y_hat = optimized_model(x)
+        end_time = time.time()
+        output = json.dumps({
+            "config": args.name,
+            "inference_time": end_time - start_time,
+        })
+    
+    print(f'>>>{output}<<<')

--- a/python/nano/benchmark/resnet_inference/pytorch_resnet_benchmark.sh
+++ b/python/nano/benchmark/resnet_inference/pytorch_resnet_benchmark.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+bash $ANALYTICS_ZOO_ROOT/python/nano/dev/build_and_install.sh linux default false pytorch
+
+cd $ANALYTICS_ZOO_ROOT/python/nano/benchmark/resnet_inference/
+
+echo "Nano_Perf: Running PyTorch Inference Baseline"
+python pytorch-resnet-inference.py --name "PyTorch Inference Baseline"
+
+source bigdl-nano-init
+echo "Nano_Perf: Running Nano Inference Default"
+python pytorch-resnet-inference.py --name "Nano Inference Baseline"
+source bigdl-nano-unset-env
+
+source bigdl-nano-init
+echo "Nano_Perf: Running Nano Inference Default with int8"
+python pytorch-resnet-inference.py --precision "int8" --name "Nano Inference with int8"
+source bigdl-nano-unset-env
+
+source bigdl-nano-init
+echo "Nano_Perf: Running Nano Inference Default with onnxruntime"
+python pytorch-resnet-inference.py --accelerator "onnxruntime" --name "Nano Inference with onnxruntime"
+source bigdl-nano-unset-env
+
+source bigdl-nano-init
+echo "Nano_Perf: Running Nano Inference Default with openvino"
+python pytorch-resnet-inference.py --accelerator "openvino" --name "Nano Inference with openvino"
+source bigdl-nano-unset-env
+
+source bigdl-nano-init
+echo "Nano_Perf: Running Nano Inference Default with jit"
+python pytorch-resnet-inference.py --accelerator "jit" --name "Nano Inference with jit"
+source bigdl-nano-unset-env
+
+source bigdl-nano-init
+echo "Nano_Perf: Running Nano Inference with openvino and int8"
+python pytorch-resnet-inference.py --accelerator "openvino" --precision "int8" --name "Nano Inference with openvino and int8"
+source bigdl-nano-unset-env
+
+source bigdl-nano-init
+echo "Nano_Perf: Running Nano Inference with onnxruntime and int8"
+python pytorch-resnet-inference.py --accelerator "onnxruntime" --precision "int8" --name "Nano Inference with onnxruntime and int8"
+source bigdl-nano-unset-env

--- a/python/nano/benchmark/resnet_inference/run.sh
+++ b/python/nano/benchmark/resnet_inference/run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Enviroment Settings
+export ANALYTICS_ZOO_ROOT=${ANALYTICS_ZOO_ROOT}
+export NANO_HOME=${ANALYTICS_ZOO_ROOT}/python/nano/src
+export NANO_BENCHMARK_DIR=${ANALYTICS_ZOO_ROOT}/python/nano/benchmark
+
+set -e
+echo "# Start testing"
+start=$(date "+%s")
+
+# Boot-up commands 
+# e.g. python benchmark_program.py 
+bash $NANO_BENCHMARK_DIR/resnet_inference/pytorch_resnet_benchmark.sh
+#
+
+now=$(date "+%s")
+time=$((now-start))
+echo ">> All Benchmark test finished"
+echo ">> Time used:$time sec"


### PR DESCRIPTION
Add pytorch inference benchmark for performance suite.
It tests inference speed of ['fp32','int8']*['None','JIT','onnxruntime','openvino'] except for int8*JIT.