### PR TITLE
Nano: add specify cpu cores for each process in TorchNano

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
+++ b/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
@@ -173,6 +173,7 @@ class RayStrategy(DDPSpawnStrategy):
 
     def __init__(self,
                  num_processes: int = 1,
+                 cpu_for_each_process: Optional[List[List[int]]] = None,
                  num_cpus_per_worker: int = 1,
                  use_gpu: bool = False,
                  use_ipex: bool = False,

--- a/python/nano/src/bigdl/nano/pytorch/torch_nano.py
+++ b/python/nano/src/bigdl/nano/pytorch/torch_nano.py
@@ -164,6 +164,7 @@ class TorchNano(LightningLite):
         elif strategy in backends_class_map:
             cls = backends_class_map[strategy]
             strategy = cls(num_processes=self.num_processes,   # type: ignore
+                           cpu_for_each_process=self.cpu_for_each_process,
                            use_ipex=self.use_ipex,
                            dtype=self.dtype)
         else:

--- a/python/nano/src/bigdl/nano/pytorch/torch_nano.py
+++ b/python/nano/src/bigdl/nano/pytorch/torch_nano.py
@@ -14,7 +14,8 @@
 # limitations under the License.
 #
 
-from typing import Any, List, Optional, Union
+
+from typing import Any, Union, List, Optional
 from logging import warning
 from functools import partial
 from abc import abstractmethod
@@ -107,6 +108,7 @@ class TorchNano(LightningLite):
                  use_ipex: bool = False,
                  strategy: str = "subprocess",
                  precision: Union[str, int] = 32,
+                 cpu_for_each_process: Optional[List[List[int]]] = None,
                  channels_last: bool = False,
                  *args, **kwargs) -> None:
         """
@@ -119,13 +121,18 @@ class TorchNano(LightningLite):
         :param precision: Double precision (64), full precision (32), half precision (16)
             or bfloat16 precision (bf16), defaults to 32.
             Enable ipex bfloat16 weight prepack when `use_ipex=True` and `precision='bf16'`
+        :param cpu_for_each_process: specify the cpu cores which will be used by each process,
+            if `None`, cpu cores will be distributed evenly by all processes,
+            only take effect when `num_processes` > 1
         :param channels_last: whether convert input to channels last memory formats, \
             defaults to False.
         """
         self.num_processes = num_processes
         self.use_ipex = use_ipex
         self.dtype = None
+        self.cpu_for_each_process = cpu_for_each_process
         self.channels_last = channels_last
+
         if self.use_ipex and precision == 'bf16':
             # Enable ipex bfloat16 weight prepack and disable native AMP
             self.dtype = torch.bfloat16

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -147,17 +147,11 @@ class Trainer(pl.Trainer):
                                       f"distributed training backend work incorrect")
 
             strategy_cls = backends_class_map[distributed_backend]
-
-            strategy_args = dict(num_processes=num_processes,
-                                 cpu_for_each_process=cpu_for_each_process,
-                                 use_ipex=self.use_ipex,
-                                 dtype=dtype,
-                                 auto_lr=auto_lr)
-
-            if distributed_backend == "ray":
-                del strategy_args["cpu_for_each_process"]
-
-            strategy = strategy_cls(**strategy_args)
+            strategy = strategy_cls(num_processes=num_processes,
+                                    cpu_for_each_process=cpu_for_each_process,
+                                    use_ipex=self.use_ipex,
+                                    dtype=dtype,
+                                    auto_lr=auto_lr)
 
             kwargs["strategy"] = strategy
             super().__init__(*args, **kwargs)

--- a/python/nano/test/pytorch/tests/test_torch_nano.py
+++ b/python/nano/test/pytorch/tests/test_torch_nano.py
@@ -198,6 +198,9 @@ class TestLite(TestCase):
     def test_torch_nano_subprocess(self):
         MyNano(num_processes=2, strategy="subprocess").train()
 
+    def test_torch_nano_specify_cpu_cores(self):
+        MyNano(num_processes=2, cpu_for_each_process=[[0,1], [2,3]]).train()
+
     def test_torch_nano_correctness(self):
         MyNanoCorrectness().train(0.25)
 


### PR DESCRIPTION
## Description

`TorchNano` now has a parameter `cpu_for_each_process` to specify the cpu cores which will be used by each process, fix #6103