### PR TITLE
Nano: pytorch trace onnx & openvino support user customized dynamic_axes.

### DIFF
--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/utils.py
@@ -34,5 +34,5 @@ def export(model, input_sample=None, xml_path="model.xml", logging=True, **kwarg
     with TemporaryDirectory() as folder:
         folder = Path(folder)
         onnx_path = str(folder / 'tmp.onnx')
-        export_to_onnx(model, input_sample, onnx_path, dynamic_axes=True, **kwargs)
+        export_to_onnx(model, input_sample, onnx_path, **kwargs)
         convert_onnx_to_xml(onnx_path, xml_path, logging)

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
@@ -80,8 +80,7 @@ def export_to_onnx(model, input_sample=None, onnx_path="model.onnx", dynamic_axe
            KEY (str): an input or output name. Each name must also be provided in input_names or
            output_names.
            VALUE (dict or list): If a dict, keys are axis indices and values are axis names. If a
-           list, each element is an axis index. If we set the first dim of each input as a dynamic
-           batch_size.
+           list, each element is an axis index.
     :param **kwargs: will be passed to torch.onnx.export function.
     '''
     forward_args = get_forward_args(model)
@@ -93,7 +92,7 @@ def export_to_onnx(model, input_sample=None, onnx_path="model.onnx", dynamic_axe
                       'or set one of input_sample and model.example_input_array')
     if isinstance(dynamic_axes, dict):
         pass
-    elif dynamic_axes:
+    elif dynamic_axes is True:
         dynamic_axes = {}
         for arg in forward_args:
             dynamic_axes[arg] = {0: 'batch_size'}  # set all dim0 to be dynamic

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
@@ -72,7 +72,16 @@ def export_to_onnx(model, input_sample=None, onnx_path="model.onnx", dynamic_axe
 
     :param input_sample: torch.Tensor or a list for the model tracing.
     :param file_path: The path to save onnx model file.
-    :param dynamic_axes: If we set the first dim of each input as a dynamic batch_size
+    :param dynamic_axes: dict or boolean, default: True. By default the exported model will
+           have the first dim of each input as a dynamic batch_size. If dynamic_axes=False, the
+           exported model will have the shapes of all input and output tensors set to exactly match
+           those given in input_sample. To specify axes of tensors as dynamic (i.e. known only at
+           run-time), set dynamic_axes to a dict with schema:
+           KEY (str): an input or output name. Each name must also be provided in input_names or
+           output_names.
+           VALUE (dict or list): If a dict, keys are axis indices and values are axis names. If a
+           list, each element is an axis index. If we set the first dim of each input as a dynamic
+           batch_size.
     :param **kwargs: will be passed to torch.onnx.export function.
     '''
     forward_args = get_forward_args(model)
@@ -82,7 +91,9 @@ def export_to_onnx(model, input_sample=None, onnx_path="model.onnx", dynamic_axe
                       'model.train_dataloader, model.val_dataloader and '
                       'model.predict_dataloader, '
                       'or set one of input_sample and model.example_input_array')
-    if dynamic_axes:
+    if isinstance(dynamic_axes, dict):
+        pass
+    elif dynamic_axes:
         dynamic_axes = {}
         for arg in forward_args:
             dynamic_axes[arg] = {0: 'batch_size'}  # set all dim0 to be dynamic


### PR DESCRIPTION
## Description

The current implementation ignores the user passed `dynamic_axes` for the `torch.onnx.export` function.

### 2. User API changes

The user can pass dynamic_axes in trace and quantize.

description:
dynamic_axes : dict or boolean, default: True. By default, the exported model will
           have the first dim of each input as a dynamic batch_size. If dynamic_axes=False, the
           exported model will have the shapes of all input and output tensors set to exactly match
           those given in input_sample. To specify axes of tensors as dynamic (i.e. known only at
           run-time), set dynamic_axes to a dict with schema:
           KEY (str): an input or output name. Each name must also be provided in input_names or
           output_names.
           VALUE (dict or list): If a dict, keys are axis indices and values are axis names. If a
           list, each element is an axis index.

### 4. How to test?
- [ ] Unit test

