### PR TITLE
[PPML] add bigdl jars into classpath in bigdl-ppml-submit.sh

### DIFF
--- a/ppml/trusted-big-data-ml/python/docker-gramine/base/bigdl-ppml-submit.sh
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/base/bigdl-ppml-submit.sh
@@ -113,7 +113,7 @@ else
 fi
 
 spark_submit_command="${JAVA_HOME}/bin/java \
-        -cp ${SPARK_HOME}/conf/:${SPARK_HOME}/jars/* \
+        -cp ${BIGDL_HOME}/jars/*:${SPARK_HOME}/conf/:${SPARK_HOME}/jars/* \
         -Xmx${RUNTIME_DRIVER_MEMORY} \
         org.apache.spark.deploy.SparkSubmit \
         $SSL \

--- a/ppml/trusted-big-data-ml/python/docker-graphene/bigdl-ppml-submit.sh
+++ b/ppml/trusted-big-data-ml/python/docker-graphene/bigdl-ppml-submit.sh
@@ -125,7 +125,7 @@ else
 fi
 
 spark_submit_command="${JAVA_HOME}/bin/java \
-        -cp ${SPARK_HOME}/conf/:${SPARK_HOME}/jars/* \
+        -cp ${BIGDL_HOME}/jars/*:${SPARK_HOME}/conf/:${SPARK_HOME}/jars/* \
         -Xmx${RUNTIME_DRIVER_MEMORY} \
         org.apache.spark.deploy.SparkSubmit \
         $SSL \


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?
The versions of some libraries of bigdl and spark are in conflict, bigdl-ppml-submit.sh is to load the library of spark first, so Azure API cannot be called successfully. This submission is to add bigdl into classpath so that bidl jars can be loaded first.
<!-- Provide the related github issue link if available -->

