### PR TITLE
Chronos : fix check and repair of time interval

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -38,7 +38,7 @@ _DEFAULT_ID_PLACEHOLDER = "0"
 
 
 class TSDataset:
-    def __init__(self, data, repair=True, **schema):
+    def __init__(self, data, repair=False, **schema):
         '''
         TSDataset is an abstract of time series dataset.
         Cascade call is supported for most of the transform methods.
@@ -88,7 +88,7 @@ class TSDataset:
                     with_split=False,
                     val_ratio=0,
                     test_ratio=0.1,
-                    repair=True):
+                    repair=False):
         '''
         Initialize tsdataset(s) from pandas dataframe.
 
@@ -111,6 +111,7 @@ class TSDataset:
                is set to True. The value defaults to 0.1.
         :param repair: a bool indicates whether automaticly repair low quality data,
                which may call .impute()/.resample() or modify datetime column on dataframe.
+               The value defaults to False.
 
         :return: a TSDataset instance when with_split is set to False,
                  three TSDataset instances when with_split is set to True.
@@ -167,7 +168,7 @@ class TSDataset:
                      with_split=False,
                      val_ratio=0,
                      test_ratio=0.1,
-                     repair=True,
+                     repair=False,
                      **kwargs):
         """
         Initialize tsdataset(s) from path of parquet file.
@@ -194,6 +195,7 @@ class TSDataset:
                is set to True. The value defaults to 0.1.
         :param repair: a bool indicates whether automaticly repair low quality data,
                which may call .impute()/.resample() or modify datetime column on dataframe.
+               The value defaults to False.
         :param kwargs: Any additional kwargs are passed to the pd.read_parquet
                and pyarrow.parquet.read_table.
 
@@ -241,6 +243,7 @@ class TSDataset:
                         with_split=False,
                         val_ratio=0,
                         test_ratio=0.1,
+                        repair=False,
                         **kwargs):
         """
         Initialize tsdataset(s) from Prometheus data for specified time period via url.
@@ -270,6 +273,9 @@ class TSDataset:
                with_split is set to True. The value defaults to 0.
         :param test_ratio: (optional) float, test ratio. Only effective when with_split
                is set to True. The value defaults to 0.1.
+        :param repair: a bool indicates whether automaticly repair low quality data,
+               which may call .impute()/.resample() or modify datetime column on dataframe.
+               The value defaults to False.
         :param kwargs: Any additional kwargs are passed to the Prometheus query, such as
                timeout.
 
@@ -300,7 +306,8 @@ class TSDataset:
                                      extra_feature_col=df_columns["extra_feature_col"],
                                      with_split=with_split,
                                      val_ratio=val_ratio,
-                                     test_ratio=test_ratio)
+                                     test_ratio=test_ratio,
+                                     repair=repair)
 
     def impute(self, mode="last", const_num=0):
         '''

--- a/python/chronos/src/bigdl/chronos/data/utils/public_dataset.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/public_dataset.py
@@ -256,7 +256,7 @@ class PublicDataset:
                    target_col,
                    extra_feature=None,
                    id_col=None,
-                   repair=True):
+                   repair=False):
         """
         param dt_col: same as tsdata.from_pandas.
         param target_col: same as tsdata.from_pandas.

--- a/python/chronos/src/bigdl/chronos/data/utils/quality_inspection.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/quality_inspection.py
@@ -36,7 +36,8 @@ def quality_check_timeseries_dataframe(df, dt_col, id_col=None, repair=True):
     :return: a bool indicates df whether contains low-quality data.
     '''
     invalidInputError(dt_col in df.columns, f"dt_col {dt_col} can not be found in df.")
-    invalidInputError(id_col in df.columns, f"id_col {id_col} can not be found in df.")
+    if id_col is not None:
+        invalidInputError(id_col in df.columns, f"id_col {id_col} can not be found in df.")
     invalidInputError(pd.isna(df[dt_col]).sum() == 0, "There is N/A in datetime col")
     if df.empty is True:
         return True, df

--- a/python/chronos/test/bigdl/chronos/data/test_tsdataset.py
+++ b/python/chronos/test/bigdl/chronos/data/test_tsdataset.py
@@ -1283,6 +1283,24 @@ class TestTSDataset(TestCase):
         unique_intervals = interval[:-1].unique()
         assert len(unique_intervals) == 1
 
+    def test_tsdataset_interval_repair_for_single_and_multi_id(self):
+        df = get_multi_id_ts_df_interval()
+        tsdata = TSDataset.from_pandas(df, dt_col="datetime",
+                                       target_col=['value'],
+                                       extra_feature_col=None,
+                                       repair=True)
+        dt_col = tsdata.df["datetime"]
+        assert len(dt_col) == 366
+        df = get_multi_id_ts_df_interval()
+        tsdata = TSDataset.from_pandas(df,
+                                       id_col="id",
+                                       dt_col="datetime",
+                                       target_col=['value'],
+                                       extra_feature_col=None,
+                                       repair=True)
+        dt_col = tsdata.df["datetime"]
+        assert len(dt_col) == 366*2
+
     def test_tsdataset_interval_check_and_repair_for_multi_id(self):
         df_multi_id = get_multi_id_ts_df()
         horizon = 10
@@ -1290,7 +1308,8 @@ class TestTSDataset(TestCase):
         batch_size = 32
 
         tsdata = TSDataset.from_pandas(df_multi_id, dt_col="datetime", target_col="value",
-                                        extra_feature_col=["extra feature"], id_col="id")
+                                        extra_feature_col=["extra feature"], id_col="id",
+                                        repair=True)
 
         # train
         torch_loader = tsdata.to_torch_data_loader(batch_size=batch_size,

--- a/python/chronos/test/bigdl/chronos/data/test_tsdataset.py
+++ b/python/chronos/test/bigdl/chronos/data/test_tsdataset.py
@@ -47,6 +47,19 @@ def get_multi_id_ts_df():
     return train_df
 
 
+def get_multi_id_ts_df_interval():
+    sample_num = 100
+    train_df = pd.DataFrame({"value": np.random.randn(sample_num),
+                             "id": np.array(['00']*50 + ['01']*50),
+                             "extra feature": np.random.randn(sample_num)})
+    train_df["datetime"] = pd.date_range('1/1/2019', periods=sample_num)
+    train_df.loc[49, "datetime"] = '1/1/2020'
+    train_df.loc[50:100, "datetime"] = pd.date_range('1/1/2019', periods=50)
+    train_df.loc[99, "datetime"] = '1/1/2020'
+    train_df["datetime"] = train_df["datetime"].astype('datetime64')
+    return train_df
+
+
 def get_ugly_ts_df():
     data = np.random.random_sample((100, 5))
     mask = np.random.random_sample((100, 5))
@@ -1269,3 +1282,46 @@ class TestTSDataset(TestCase):
         interval = dt_col.shift(-1) - dt_col
         unique_intervals = interval[:-1].unique()
         assert len(unique_intervals) == 1
+
+    def test_tsdataset_interval_check_and_repair_for_multi_id(self):
+        df_multi_id = get_multi_id_ts_df()
+        horizon = 10
+        lookback = 20
+        batch_size = 32
+
+        tsdata = TSDataset.from_pandas(df_multi_id, dt_col="datetime", target_col="value",
+                                        extra_feature_col=["extra feature"], id_col="id")
+
+        # train
+        torch_loader = tsdata.to_torch_data_loader(batch_size=batch_size,
+                                                    lookback=lookback,
+                                                    horizon=horizon)
+        for x_batch, y_batch in torch_loader:
+            assert tuple(x_batch.size()) == (batch_size, lookback, 2)
+            assert tuple(y_batch.size()) == (batch_size, horizon, 1)
+            break
+
+        # test
+        torch_loader = tsdata.to_torch_data_loader(batch_size=batch_size,
+                                                    lookback=lookback,
+                                                    horizon=0)
+        for x_batch in torch_loader:
+            assert tuple(x_batch.size()) == (batch_size, lookback, 2)
+            break
+
+        # specify feature_col
+        torch_loader = tsdata.to_torch_data_loader(batch_size=batch_size,
+                                                    lookback=lookback,
+                                                    horizon=horizon,
+                                                    feature_col=[])
+        for x_batch, y_batch in torch_loader:
+            assert tuple(x_batch.size()) == (batch_size, lookback, 1)
+            assert tuple(y_batch.size()) == (batch_size, horizon, 1)
+            break
+
+        # Non-subset relationship
+        with pytest.raises(ValueError):
+            tsdata.to_torch_data_loader(batch_size=batch_size,
+                                        lookback=lookback,
+                                        horizon=horizon,
+                                        target_col=['value', 'extra feature'])


### PR DESCRIPTION
## Description

We found some errors in check and automatic repair of time interval, this PR will  fix these bugs.

At the same time, set `repair=True` is a little dangerous and may cause some hard to find bugs, so we will set `repair=False` and warn users call `repair=True` if there exists any low quality data.

### 1. Why the change?

We found some errors in check and automatic repair of time interval, this PR will  fix these bugs.

### 2. User API changes
Set  `repair=False`  for `from_pandas` / `from_parquet` / `from_prometheus`
```python
def from_pandas(df,
                dt_col,
                target_col,
                id_col=None,
                extra_feature_col=None,
                with_split=False,
                val_ratio=0,
                test_ratio=0.1,
                repair=False):
```
```python
def from_parquet(path,
                 dt_col,
                 target_col,
                 id_col=None,
                 extra_feature_col=None,
                 with_split=False,
                 val_ratio=0,
                 test_ratio=0.1,
                 repair=False,
                 **kwargs):
```
```python
def from_prometheus(prometheus_url,
                    query,
                    starttime,
                    endtime,
                    step,
                    target_col=None,
                    id_col=None,
                    extra_feature_col=None,
                    with_split=False,
                    val_ratio=0,
                    test_ratio=0.1,
                    repair=False,
                    **kwargs):
```

### 3. Summary of the change 

- [x] fix check and repair to support multi-id dataframe
- [x] fix check and repair to support empty dataframe
- [x] set repair=False when `from_pandas` / `from_parquet` / `from_prometheus`

### 4. How to test?
- [x] Unit test
- [x] Application test
