### PR TITLE
Update PPML scala SimpleQueryExample

### DIFF
--- a/python/ppml/src/bigdl/ppml/api/simple_query_example.py
+++ b/python/ppml/src/bigdl/ppml/api/simple_query_example.py
@@ -42,8 +42,10 @@ parser.add_argument("--input_encrypt_mode", type=str, required=True, help="input
 parser.add_argument("--output_encrypt_mode", type=str, required=True, help="output encrypt mode")
 parser.add_argument("--input_path", type=str, required=True, help="input path")
 parser.add_argument("--output_path", type=str, required=True, help="output path")
+parser.add_argument("--azure_vault", type=str, help="Azure vault")
+parser.add_argument("--azure_client_id", type=str, help="Azure client id")
 parser.add_argument("--kms_type", type=str, default="SimpleKeyManagementService",
-                    help="SimpleKeyManagementService or EHSMKeyManagementService")
+                    help="SimpleKeyManagementService or EHSMKeyManagementService or AzureKeyManagementService")
 args = parser.parse_args()
 arg_dict = vars(args)
 

--- a/python/ppml/src/bigdl/ppml/api/simple_query_example.py
+++ b/python/ppml/src/bigdl/ppml/api/simple_query_example.py
@@ -42,10 +42,8 @@ parser.add_argument("--input_encrypt_mode", type=str, required=True, help="input
 parser.add_argument("--output_encrypt_mode", type=str, required=True, help="output encrypt mode")
 parser.add_argument("--input_path", type=str, required=True, help="input path")
 parser.add_argument("--output_path", type=str, required=True, help="output path")
-parser.add_argument("--azure_vault", type=str, help="Azure vault")
-parser.add_argument("--azure_client_id", type=str, help="Azure client id")
 parser.add_argument("--kms_type", type=str, default="SimpleKeyManagementService",
-                    help="SimpleKeyManagementService or EHSMKeyManagementService or AzureKeyManagementService")
+                    help="SimpleKeyManagementService or EHSMKeyManagementService")
 args = parser.parse_args()
 arg_dict = vars(args)
 

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/examples/SimpleQuerySparkExample.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/examples/SimpleQuerySparkExample.scala
@@ -46,7 +46,7 @@ object SimpleQuerySparkExample extends Supportive {
       // load csv file to data frame with ppmlcontext.
       val df = timing("1/3 loadInputs") {
         sc.read(cryptoMode = arguments.inputEncryptMode).option("header", "true")
-          .csv(arguments.inputPath + "/people.csv")
+          .csv(arguments.inputPath)
       }
 
       val developers = timing("2/3 doSQLOperations") {


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

related issue: https://github.com/intel-analytics/BigDL/issues/5699

Now, the encrypted file name has to end with .cbc, this extension file name will trigger the decrypt process, but the required input file name in SimpleQuerySparkExample is fixed to `people.csv`, so this pr remove the fixed file name in SimpleQuerySparkExample, let user provide the input file name.

