### PR TITLE
Chronos: add test script and Github action for How-to Guides

### DIFF
--- a/.github/workflows/chronos-howto-guides-test.yml
+++ b/.github/workflows/chronos-howto-guides-test.yml
@@ -1,0 +1,71 @@
+name: Chronos Tests for How-to Guides
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on pull request events but only for the main branch
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'python/chronos/colab-notebook/howto/**'
+      - '.github/workflows/chronos-howto-guides-test.yml'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  chronos-howto-guides-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-20.04"]
+        python-version: ["3.7.10"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: ./.github/actions/jdk-setup-action
+      - name: Set up Maven
+        uses: ./.github/actions/maven-setup-action
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools==58.0.4
+          python -m pip install --upgrade wheel
+
+      - name: Run tests for Chronos How-to Guides
+        shell: bash
+        run: |
+          if conda info --env | grep "chronos-howto-env"; then
+            source deactivate
+            conda remove -n chronos-howto-env -y --all
+          fi
+          conda create -n chronos-howto-env -y python==3.7.10 setuptools==58.0.4
+          source activate chronos-howto-env
+          pip install pytest nbmake
+          pip install neural-compressor==1.11
+          pip install onnx==1.11.0
+          pip install onnxruntime==1.11.1
+          pip install openvino-dev==2022.1.0
+          pip uninstall -y numpy
+          pip install numpy==1.19.5
+          pip install ipykernel==5.5.6
+          pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
+          bash python/dev/release_default_linux_spark246.sh default false false
+          bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
+          whl_name=`ls python/nano/dist/`
+          pip install python/nano/dist/${whl_name}[tensorflow,pytorch]
+          pip install python/chronos/src/dist/bigdl_chronos-*-py3-none-manylinux1_x86_64.whl
+          export SPARK_LOCAL_HOSTNAME=localhost
+          export KERAS_BACKEND=tensorflow
+          bash python/chronos/dev/test/run-pytests-howto-guides.sh
+          source deactivate
+          conda remove -n chronos-howto-env -y --all
+        env:
+          BIGDL_ROOT: ${{ github.workspace }}
+          ANALYTICS_ZOO_ROOT: ${{ github.workspace }}

--- a/python/chronos/dev/test/run-pytests-howto-guides.sh
+++ b/python/chronos/dev/test/run-pytests-howto-guides.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+export Chronos_Howto_Guides_dir=${ANALYTICS_ZOO_ROOT}/python/chronos/colab-notebook/howto
+
+echo "Running tests for Chronos How-to Guides"
+python -m pytest -v  --nbmake --nbmake-timeout=6000 --nbmake-kernel=python3 ${Chronos_Howto_Guides_dir}
+
+echo "Tests for Chronos How-to Guides finished."


### PR DESCRIPTION
## Description

Currently we have a bunch of notebook as how to guide in Chronos, they need a test script that can be triggered during validation.

### 1. Why the change?

https://github.com/intel-analytics/BigDL/issues/6121
