### PR TITLE
 Fix the problem that cannot find or load SparkSubmit in gramine image.

### DIFF
--- a/ppml/trusted-big-data-ml/python/docker-gramine/base/start-scripts/start-python-fgboost-server-sgx.sh
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/base/start-scripts/start-python-fgboost-server-sgx.sh
@@ -15,7 +15,7 @@ do
 done
 cd /ppml/trusted-big-data-ml
 export sgx_command="/opt/jdk8/bin/java\
-        -cp '/ppml/trusted-big-data-ml/work/bigdl-${BIGDL_VERSION}/jars/bigdl-ppml-spark_${SPARK_VERSION}-${BIGDL_VERSION}.jar:/ppml/trusted-big-data-ml/work/spark-${SPARK_VERSION}/jars/commons-lang3-3.10.jar:/ppml/trusted-big-data-ml/work/bigdl-${BIGDL_VERSION}/jars/*:/ppml/trusted-big-data-ml/work/spark-${SPARK_VERSION}/conf/:/ppml/trusted-big-data-ml/work/spark-${SPARK_VERSION}/jars/*:/ppml/trusted-big-data-ml/work/spark-${SPARK_VERSION}/examples/jars/*'\
+        -cp '/ppml/trusted-big-data-ml/work/bigdl-2.2.0-SNAPSHOT/jars/bigdl-ppml-spark_3.1.2-2.2.0-SNAPSHOT.jar:/ppml/trusted-big-data-ml/work/spark-3.1.2/jars/commons-lang3-3.10.jar:/ppml/trusted-big-data-ml/work/bigdl-2.2.0-SNAPSHOT/jars/*:/ppml/trusted-big-data-ml/work/spark-3.1.2/conf/:/ppml/trusted-big-data-ml/work/spark-3.1.2/jars/*:/ppml/trusted-big-data-ml/work/spark-3.1.2/examples/jars/*'\
         -Xmx10g org.apache.spark.deploy.SparkSubmit\
         --master local[4]\
         /ppml/trusted-big-data-ml/fl/start-fgboost-server.py --port $port --client_num $client_num"

--- a/ppml/trusted-big-data-ml/python/docker-gramine/base/start-scripts/start-python-fgboost-server-sgx.sh
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/base/start-scripts/start-python-fgboost-server-sgx.sh
@@ -15,9 +15,8 @@ do
 done
 cd /ppml/trusted-big-data-ml
 export sgx_command="/opt/jdk8/bin/java\
-        -cp '/ppml/trusted-big-data-ml/work/bigdl-${BIGDL_VERSION}/jars/bigdl-ppml-spark_${SPARK_VERSION}-${BIGDL_VERSION}.jar:/ppml/trusted-big-data-ml/work/spark-${SPARK_VERSION}/jars/commons-lang3-3.10.jar:/ppml/trusted-big-data-ml/work/bigdl-${BIGDL_VERSION}/jars/*:/ppml/trusted-big-data-ml/work/spark-${SPARK_VERSION}/conf/:/ppml/trusted-big-data-ml/work/spark-${SPARK_VERSION}/jars/*'\
+        -cp '/ppml/trusted-big-data-ml/work/bigdl-${BIGDL_VERSION}/jars/bigdl-ppml-spark_${SPARK_VERSION}-${BIGDL_VERSION}.jar:/ppml/trusted-big-data-ml/work/spark-${SPARK_VERSION}/jars/commons-lang3-3.10.jar:/ppml/trusted-big-data-ml/work/bigdl-${BIGDL_VERSION}/jars/*:/ppml/trusted-big-data-ml/work/spark-${SPARK_VERSION}/conf/:/ppml/trusted-big-data-ml/work/spark-${SPARK_VERSION}/jars/*:/ppml/trusted-big-data-ml/work/spark-${SPARK_VERSION}/examples/jars/*'\
         -Xmx10g org.apache.spark.deploy.SparkSubmit\
-        --master 'local[4]'\
+        --master local[4]\
         /ppml/trusted-big-data-ml/fl/start-fgboost-server.py --port $port --client_num $client_num"
 gramine-sgx bash 2>&1 | tee fgboost-server-sgx.log
-

--- a/ppml/trusted-big-data-ml/python/docker-gramine/base/start-scripts/start-python-fl-server-sgx.sh
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/base/start-scripts/start-python-fl-server-sgx.sh
@@ -14,10 +14,9 @@ do
     esac
 done
 cd /ppml/trusted-big-data-ml
-export sgx_command"/opt/jdk8/bin/java\
-        -cp '/ppml/trusted-big-data-ml/work/spark-${SPARK_VERSION}/conf/:/ppml/trusted-big-data-ml/work/spark-${SPARK_VERSION}/jars/*'\
+export sgx_command="/opt/jdk8/bin/java\
+        -cp '/ppml/trusted-big-data-ml/work/spark-3.1.2/conf/:/ppml/trusted-big-data-ml/work/spark-3.1.2/jars/*:/ppml/trusted-big-data-ml/work/spark-3.1.2/examples/jars/*'\
         -Xmx10g org.apache.spark.deploy.SparkSubmit\
-        --master 'local[4]'\
-        /ppml/trusted-big-data-ml/fl/start-fl-server.py -p $port -c $client_num" 
+        --master local[4] \
+        /ppml/trusted-big-data-ml/fl/start-fl-server.py -p $port -c $client_num"
 gramine-sgx bash 2>&1 | tee fl-server-sgx.log
-

--- a/python/ppml/scripts/start-fgboost-server.py
+++ b/python/ppml/scripts/start-fgboost-server.py
@@ -18,10 +18,13 @@ import click
 import fnmatch
 import sys
 
-for files in os.listdir('/ppml/trusted-big-data-ml/work/bigdl-2.1.0-SNAPSHOT/python/'):
-    if fnmatch.fnmatch(files, 'bigdl-ppml-*-python-api.zip'):
-        sys.path.append('/ppml/trusted-big-data-ml/work/bigdl-2.1.0-SNAPSHOT/python/' + files)
-        sys.path.append('/ppml/trusted-big-data-ml/work/bigdl-2.1.0-SNAPSHOT/python/' + files + '/bigdl/ppml/fl/nn/generated')
+for dirs in os.listdir('/ppml/trusted-big-data-ml/work'):
+    if fnmatch.fnmatch(dirs, 'bigdl-*'):
+        path = '/ppml/trusted-big-data-ml/work/' + dirs + '/python/'
+        for files in os.listdir(path):
+            if fnmatch.fnmatch(files, 'bigdl-ppml-*-python-api.zip'):
+                sys.path.append(path + files)
+                sys.path.append(path + files + '/bigdl/ppml/fl/nn/generated')
 
 from bigdl.ppml.fl.fl_server import FLServer
 

--- a/python/ppml/scripts/start-fl-server.py
+++ b/python/ppml/scripts/start-fl-server.py
@@ -19,24 +19,26 @@ import os
 import fnmatch
 import getopt
 
-for files in os.listdir('/ppml/trusted-big-data-ml/work/bigdl-2.1.0-SNAPSHOT/python/'):
-    if fnmatch.fnmatch(files, 'bigdl-ppml-*-python-api.zip'):
-        sys.path.append('/ppml/trusted-big-data-ml/work/bigdl-2.1.0-SNAPSHOT/python/' + files)
-        sys.path.append('/ppml/trusted-big-data-ml/work/bigdl-2.1.0-SNAPSHOT/python/' + files + '/bigdl/ppml/fl/nn/generated')
+for dirs in os.listdir('/ppml/trusted-big-data-ml/work'):
+    if fnmatch.fnmatch(dirs, 'bigdl-*'):
+        path = '/ppml/trusted-big-data-ml/work/' + dirs + '/python/'
+        for files in os.listdir(path):
+            if fnmatch.fnmatch(files, 'bigdl-ppml-*-python-api.zip'):
+                sys.path.append(path + files)
+                sys.path.append(path + files + '/bigdl/ppml/fl/nn/generated')
 
 from bigdl.ppml.fl.nn.fl_server import FLServer
 
 if __name__ == '__main__':
 
     client_num = 2
-    port = 8980
-    
+
     try:
         opts, args = getopt.getopt(sys.argv[1:], "hc:p:", ["client-num=", "port="])
     except getopt.GetoptError:
         print("start_fl_server.py -c <client-num> -p <port>")
         sys.exit(2)
-    
+
     for opt, arg in opts:
         if opt == '-h':
             print("start_fl_server.py -c <client-num> -p <port>")
@@ -51,3 +53,4 @@ if __name__ == '__main__':
     fl_server.start()
 
     fl_server.wait_for_termination()
+


### PR DESCRIPTION
## Description

 Fix the problem that cannot find or load SparkSubmit.

### 1. Why the change?

Run FL in SGX with gramine image will lead to the problem that cannot find or load SparkSubmit. This is caused by one import jar is not included in the classpath.

### 2. User API changes

None.

### 3. Summary of the change 

Add /ppml/trusted-big-data-ml/work/spark-3.1.2/examples/jars/* into classpath.