### PR TITLE
make all grpc the same version 1.48.1, and merge META/services files with duplicate names

### DIFF
--- a/scala/assembly/src/main/assembly/all-in-one.xml
+++ b/scala/assembly/src/main/assembly/all-in-one.xml
@@ -20,4 +20,15 @@
             <scope>runtime</scope>
         </dependencySet>
     </dependencySets>
+    <containerDescriptorHandlers>
+        <containerDescriptorHandler>
+            <handlerName>metaInf-services</handlerName>
+        </containerDescriptorHandler>
+        <containerDescriptorHandler>
+            <handlerName>metaInf-spring</handlerName>
+        </containerDescriptorHandler>
+        <containerDescriptorHandler>
+            <handlerName>plexus</handlerName>
+        </containerDescriptorHandler>
+    </containerDescriptorHandlers>
 </assembly>

--- a/scala/assembly/src/main/assembly/fat-assembly.xml
+++ b/scala/assembly/src/main/assembly/fat-assembly.xml
@@ -100,5 +100,16 @@
       </includes>
     </fileSet>
   </fileSets>
+  <containerDescriptorHandlers>
+    <containerDescriptorHandler>
+      <handlerName>metaInf-services</handlerName>
+    </containerDescriptorHandler>
+    <containerDescriptorHandler>
+      <handlerName>metaInf-spring</handlerName>
+    </containerDescriptorHandler>
+    <containerDescriptorHandler>
+      <handlerName>plexus</handlerName>
+    </containerDescriptorHandler>
+  </containerDescriptorHandlers>
 </assembly>
 

--- a/scala/friesian/pom.xml
+++ b/scala/friesian/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <scoverage.plugin.version>1.1.1</scoverage.plugin.version>
         <scoverage.scalacPluginVersion>1.1.1</scoverage.scalacPluginVersion>
-        <grpc.version>1.48.1</grpc.version>
         <scoverage.aggregate>true</scoverage.aggregate>
         <runSpecsInParallel>false</runSpecsInParallel>
         <tagsToExclude>com.intel.analytics.bigdl.tags.Integration</tagsToExclude>
@@ -331,19 +330,16 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-api</artifactId>
-            <version>${grpc.version}</version>
             <scope>${serving.scope}</scope>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-services</artifactId>
-            <version>${grpc.version}</version>
             <scope>${serving.scope}</scope>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
-            <version>${grpc.version}</version>
             <scope>${serving.scope}</scope>
         </dependency>
         <dependency>

--- a/scala/grpc/pom.xml
+++ b/scala/grpc/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <grpc.version>1.47.0</grpc.version>
         <bigdl.basedir>${project.parent.basedir}</bigdl.basedir>
     </properties>
 
@@ -23,7 +22,6 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-api</artifactId>
-            <version>${grpc.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -47,7 +45,6 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
-            <version>${grpc.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -186,6 +186,7 @@
 	    <bigdl-core-all-scope>compile</bigdl-core-all-scope>
         <data-store-url>http://download.tensorflow.org</data-store-url>
         <lightgbm.scope>provided</lightgbm.scope>
+        <grpc.version>1.48.1</grpc.version>
 
     </properties>
 
@@ -273,6 +274,31 @@
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-core</artifactId>
                 <version>3.4.19</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-api</artifactId>
+                <version>${grpc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-netty-shaded</artifactId>
+                <version>${grpc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-protobuf</artifactId>
+                <version>${grpc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-stub</artifactId>
+                <version>${grpc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-services</artifactId>
+                <version>${grpc.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/scala/ppml/pom.xml
+++ b/scala/ppml/pom.xml
@@ -12,7 +12,6 @@
     <packaging>jar</packaging>
 
     <properties>
-        <grpc.version>1.47.0</grpc.version>
         <bigdl.basedir>${project.parent.basedir}</bigdl.basedir>
         <parquet.version>1.12.2</parquet.version>
     </properties>
@@ -119,12 +118,10 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-api</artifactId>
-            <version>1.37.0</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
-            <version>1.37.0</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
@@ -140,12 +137,10 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
-            <version>${grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
-            <version>${grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>
@@ -417,7 +412,6 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>python</id>
                         <inherited>false</inherited>
                         <configuration>
                             <descriptors>

--- a/scala/ppml/pom.xml
+++ b/scala/ppml/pom.xml
@@ -412,7 +412,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
-			<id>python</id>
+                        <id>python</id>
                         <inherited>false</inherited>
                         <configuration>
                             <descriptors>

--- a/scala/ppml/pom.xml
+++ b/scala/ppml/pom.xml
@@ -412,6 +412,7 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
+			<id>python</id>
                         <inherited>false</inherited>
                         <configuration>
                             <descriptors>


### PR DESCRIPTION
## Description

1. Set all grpc package to 1.48.1 in pom.xml 
2. merge the files with deplicate names in META/services in assembly jar. origin behavior is choosing one of them randomly.

### 1. Why the change?

GRPC have multi versions 1.37.0, 1.47.0, 1.48.1. 
Files in META/services in assembly jar is lossing some meta information, we will get the following error:
```
ava.lang.IllegalStateException: Could not find policy 'pick_first'. Make sure its implementation is either registered to LoadBalancerRegistry or included in META-INF/services/io.grpc.LoadBalancerProvider from your jar files.
```

### 2. User API changes

None

### 3. Summary of the change 

1. Set all grpc package to 1.48.1 in pom.xml 
2. merge the files with deplicate names in META/services in assembly jar. origin behavior is choosing one of them randomly.  

files with duplicate names: 
```
(base) xin@xin-dev:/tmp$ cat ./grpc-services/META-INF/services/io.grpc.LoadBalancerProvider
io.grpc.protobuf.services.internal.HealthCheckingRoundRobinLoadBalancerProvider
(base) xin@xin-dev:/tmp$ cat ./grpc-core/META-INF/services/io.grpc.LoadBalancerProvider
io.grpc.internal.PickFirstLoadBalancerProvider
io.grpc.util.SecretRoundRobinLoadBalancerProvider$Provider
```
Merged: 
```
[root@xin-dev META-INF]# cat services/io.grpc.LoadBalancerProvider 
io.grpc.protobuf.services.internal.HealthCheckingRoundRobinLoadBalancerProvider
io.grpc.internal.PickFirstLoadBalancerProvider
io.grpc.util.SecretRoundRobinLoadBalancerProvider$Provider
```

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...
