### PR TITLE
[Doc] Revise tooltips on decision tree and small fixes

### DIFF
--- a/docs/readthedocs/source/doc/DLlib/Overview/visualization.md
+++ b/docs/readthedocs/source/doc/DLlib/Overview/visualization.md
@@ -3,38 +3,38 @@ With the summary info generated, we can then use [TensorBoard](https://pypi.pyth
 
 * **Installing TensorBoard**
 
-Prerequisites:
+  Prerequisites:
 
-1. Python verison: 2.7, 3.4, 3.5, or 3.6
-2. Pip version >= 9.0.1
+  1. Python verison: 2.7, 3.4, 3.5, or 3.6
+  2. Pip version >= 9.0.1
 
-To install TensorBoard using Python 2, you may run the command:
-```bash
-pip install tensorboard==1.0.0a4
-```
+     To install TensorBoard using Python 2, you may run the command:
+     ```bash
+     pip install tensorboard==1.0.0a4
+     ```
 
-To install TensorBoard using Python 3, you may run the command:
-```bash
-pip3 install tensorboard==1.0.0a4
-```
+     To install TensorBoard using Python 3, you may run the command:
+     ```bash
+     pip3 install tensorboard==1.0.0a4
+     ```
 
-Please refer to [this page](https://github.com/intel-analytics/BigDL/tree/master/spark/dl/src/main/scala/com/intel/analytics/bigdl/visualization#known-issues) for possible issues when installing TensorBoard.
+     Please refer to [this page](https://github.com/intel-analytics/BigDL/tree/master/spark/dl/src/main/scala/com/intel/analytics/bigdl/visualization#known-issues) for possible issues when installing TensorBoard.
 
 * **Launching TensorBoard**
 
-You can launch TensorBoard using the command below:
-```bash
-tensorboard --logdir=/tmp/bigdl_summaries
-```
-After that, navigate to the TensorBoard dashboard using a browser. You can find the URL in the console output after TensorBoard is successfully launched; by default the URL is http://your_node:6006
+  You can launch TensorBoard using the command below:
+  ```bash
+  tensorboard --logdir=/tmp/bigdl_summaries
+  ```
+  After that, navigate to the TensorBoard dashboard using a browser. You can find the URL in the console output after TensorBoard is successfully launched; by default the URL is http://your_node:6006
 
 * **Visualizations in TensorBoard**
 
-Within the TensorBoard dashboard, you will be able to read the visualizations of each run, including the “Loss” and “Throughput” curves under the SCALARS tab (as illustrated below):
-![](../Image/tensorboard-scalar.png)
+  Within the TensorBoard dashboard, you will be able to read the visualizations of each run, including the “Loss” and “Throughput” curves under the SCALARS tab (as illustrated below):
+  ![](../Image/tensorboard-scalar.png)
 
-And “weights”, “bias”, “gradientWeights” and “gradientBias” under the DISTRIBUTIONS and HISTOGRAMS tabs (as illustrated below):
-![](../Image/tensorboard-histo1.png)
-![](../Image/tensorboard-histo2.png)
+  And “weights”, “bias”, “gradientWeights” and “gradientBias” under the DISTRIBUTIONS and HISTOGRAMS tabs (as illustrated below):
+  ![](../Image/tensorboard-histo1.png)
+  ![](../Image/tensorboard-histo2.png)
 
 ---

--- a/docs/readthedocs/source/index.rst
+++ b/docs/readthedocs/source/index.rst
@@ -18,21 +18,22 @@ Choosing the right BigDL library
 .. graphviz::
 
     digraph BigDLDecisionTree {
-        graph [pad=0.1 ranksep=0.3]
-        node [color="#0171c3" shape=box fontname="Arial" fontsize=14]
+        graph [pad=0.1 ranksep=0.3 tooltip=" "]
+        node [color="#0171c3" shape=box fontname="Arial" fontsize=14 tooltip=" "]
+        edge [tooltip=" "]
         
         Feature1 [label="Hardware Secured Big Data & AI?"]
         Feature2 [label="Python vs. Scala/Java?"]
         Feature3 [label="What type of application?"]
         Feature4 [label="Domain?"]
         
-        Orca[href="../doc/Orca/index.html" target="_blank" target="_blank" style="rounded,filled" fontcolor="#ffffff"]
-        Nano[href="../doc/Nano/index.html" target="_blank" target="_blank" style="rounded,filled" fontcolor="#ffffff"]
-        DLlib1[label="DLlib" href="../doc/DLlib/index.html" target="_blank" style="rounded,filled" fontcolor="#ffffff"]
-        DLlib2[label="DLlib" href="../doc/DLlib/index.html" target="_blank" style="rounded,filled" fontcolor="#ffffff"]
-        Chronos[href="../doc/Chronos/index.html" target="_blank" style="rounded,filled" fontcolor="#ffffff"]
-        Friesian[href="../doc/Friesian/index.html" target="_blank" style="rounded,filled" fontcolor="#ffffff"]
-        PPML[href="../doc/PPML/index.html" target="_blank" style="rounded,filled" fontcolor="#ffffff"]
+        Orca[href="../doc/Orca/index.html" target="_blank" target="_blank" style="rounded,filled" fontcolor="#ffffff" tooltip="Go to BigDL-Orca document"]
+        Nano[href="../doc/Nano/index.html" target="_blank" target="_blank" style="rounded,filled" fontcolor="#ffffff" tooltip="Go to BigDL-Nano document"]
+        DLlib1[label="DLlib" href="../doc/DLlib/index.html" target="_blank" style="rounded,filled" fontcolor="#ffffff" tooltip="Go to BigDL-DLlib document"]
+        DLlib2[label="DLlib" href="../doc/DLlib/index.html" target="_blank" style="rounded,filled" fontcolor="#ffffff" tooltip="Go to BigDL-DLlib document"]
+        Chronos[href="../doc/Chronos/index.html" target="_blank" style="rounded,filled" fontcolor="#ffffff" tooltip="Go to BigDL-Chronos document"]
+        Friesian[href="../doc/Friesian/index.html" target="_blank" style="rounded,filled" fontcolor="#ffffff" tooltip="Go to BigDL-Friesian document"]
+        PPML[href="../doc/PPML/index.html" target="_blank" style="rounded,filled" fontcolor="#ffffff" tooltip="Go to BigDL-PPML document"]
         
         ArrowLabel1[label="No" fontsize=12 width=0.1 height=0.1 style=filled color="#c9c9c9"]
         ArrowLabel2[label="Yes" fontsize=12 width=0.1 height=0.1 style=filled color="#c9c9c9"]


### PR DESCRIPTION
## Description

- Remove useless tooltips in decision tree
- Add tooltips “Go to BigDL-[library name] document” to each leaf node
- Small fixes to list indent problem of DLlib/Overview/visualization.md

### How to test?
- [x] Document test: https://yuwentestdocs.readthedocs.io/en/doc-improve/
