### PR TITLE
Nano: support specify method_name in get_model of InferenceOptimizer

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -136,7 +136,7 @@ class InferenceOptimizer:
         The available methods are "original", "fp32_ipex", "bf16", "bf16_ipex","int8",
         "jit_fp32", "jit_fp32_ipex", "jit_fp32_ipex_channels_last", "openvino_fp32",
         "openvino_int8", "onnxruntime_fp32", "onnxruntime_int8_qlinear"
-        and "onnxruntime_int8_integer"
+        and "onnxruntime_int8_integer".
 
         :param model: A torch.nn.Module to be optimized
         :param training_data: A torch.utils.data.dataloader.DataLoader object for training
@@ -363,6 +363,30 @@ class InferenceOptimizer:
                               "There is no optimization result. You should call .optimize() "
                               "before summary()")
         print(self._optimize_result)
+
+    def get_model(self, method_name: str):
+        """
+        According to results of `optimize`, obtain the model with method_name.
+
+        The available methods are "original", "fp32_ipex", "bf16", "bf16_ipex","int8",
+        "jit_fp32", "jit_fp32_ipex", "jit_fp32_ipex_channels_last", "openvino_fp32",
+        "openvino_int8", "onnxruntime_fp32", "onnxruntime_int8_qlinear"
+        and "onnxruntime_int8_integer".
+
+        :param method_name: (optional) Obtain specific model according to method_name.
+        :return: Model with different acceleration.
+        """
+        invalidOperationError(len(self.optimized_model_dict) > 0,
+                              "There is no optimized model. You should call .optimize() "
+                              "before get_model()")
+        invalidInputError(method_name in ALL_INFERENCE_ACCELERATION_METHOD.keys(),
+                          f"The model name you passed does not exist in the existing method "
+                          f"list{list(ALL_INFERENCE_ACCELERATION_METHOD.keys())}, please re-enter "
+                          f"the model name again.")
+        invalidInputError("model" in self.optimized_model_dict[method_name],
+                          "Unable to get the specified model as it doesn't exist in "
+                          "optimized_model_dict.")
+        return self.optimized_model_dict[method_name]["model"]
 
     def get_best_model(self,
                        accelerator: Optional[str] = None,

--- a/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
+++ b/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
@@ -232,3 +232,30 @@ class TestInferencePipeline(TestCase):
                                metric=metric,
                                direction="max",
                                thread_num=1)
+
+    def test_get_model_with_wrong_method_name(self):
+        inference_opt = InferenceOptimizer()
+        inference_opt.optimize(model=self.model,
+                               training_data=self.train_loader,
+                               validation_data=self.test_loader,
+                               metric=self.metric,
+                               direction="max",
+                               thread_num=1)
+
+        with pytest.raises(RuntimeError):
+            inference_opt.get_model(method_name="fp16_ipex")
+
+    def test_get_model_with_method_name(self):
+        inference_opt = InferenceOptimizer()
+        inference_opt.optimize(model=self.model,
+                               training_data=self.train_loader,
+                               validation_data=self.test_loader,
+                               metric=self.metric,
+                               direction="max",
+                               thread_num=1)
+        try:
+            model = inference_opt.get_model(method_name="fp32_ipex")
+            from bigdl.nano.deps.ipex.ipex_inference_model import PytorchIPEXJITModel
+            assert isinstance(model, PytorchIPEXJITModel)
+        except:
+            pass


### PR DESCRIPTION
## Description

Some users want to directly obtain and store a specific model based on certain information. So this PR try to support specify model_name in get_best_model of InferenceOptimizer.

### 1. Why the change?

Some users want to directly obtain and store a specific model based on certain information. 

### 2. User API changes
New function `get_model`  for InferenceOptimizer
```
inference_opt = InferenceOptimizer()
inference_opt.optimize(model=self.model,
                       training_data=self.train_loader,
                       validation_data=self.test_loader,
                       metric=self.metric,
                       direction="max",
                       thread_num=1)
model, option = inference_opt.get_model(method_name="fp32_ipex")
```


### 3. Summary of the change 

 support specify model_name in get_best_model of InferenceOptimizer.

### 4. How to test?
- [x] Unit test
- [x] Application test
- [x] Document test
https://ruonantetdoc.readthedocs.io/en/support_specify_model_in_get_best_model/doc/PythonAPI/Nano/pytorch.html#bigdl-nano-pytorch-inferenceoptimizer