### PR TITLE
Nano : update installation guide to nightly-build version

### DIFF
--- a/docs/readthedocs/source/doc/Nano/Overview/install.md
+++ b/docs/readthedocs/source/doc/Nano/Overview/install.md
@@ -10,7 +10,7 @@ For PyTorch Users, you can install bigdl-nano along with some dependencies speci
 ```bash
 conda create -n env
 conda activate env
-pip install bigdl-nano[pytorch]
+pip install --pre --upgrade bigdl-nano[pytorch]
 ```
 
 For TensorFlow users, you can install bigdl-nano along with some dependencies specific to TensorFlow using the following commands.
@@ -18,7 +18,12 @@ For TensorFlow users, you can install bigdl-nano along with some dependencies sp
 ```bash
 conda create -n env
 conda activate env
-pip install bigdl-nano[tensorflow]
+pip install --pre --upgrade bigdl-nano[tensorflow]
+```
+
+```eval_rst
+.. note::
+    Since bigdl-nano is still in the process of rapid iteration, we highly recommend that you install nightly build version through the above command to facilitate your use of the latest features, rather than installing the latest release version such as 2.1.0 by ``pip install bigdl-nano[pytorch]``.
 ```
 
 After installing bigdl-nano, you can run the following command to setup a few environment variables.

--- a/docs/readthedocs/source/doc/Nano/Overview/install.md
+++ b/docs/readthedocs/source/doc/Nano/Overview/install.md
@@ -23,7 +23,7 @@ pip install --pre --upgrade bigdl-nano[tensorflow]
 
 ```eval_rst
 .. note::
-    Since bigdl-nano is still in the process of rapid iteration, we highly recommend that you install nightly build version through the above command to facilitate your use of the latest features, rather than installing the latest release version such as 2.1.0 by ``pip install bigdl-nano[pytorch]``.
+    Since bigdl-nano is still in the process of rapid iteration, we highly recommend that you install nightly build version through the above command to facilitate your use of the latest features. For stable version, please refer to the document and installation guide [here](https://bigdl.readthedocs.io/en/v2.1.0/doc/Nano/Overview/nano.html).
 ```
 
 After installing bigdl-nano, you can run the following command to setup a few environment variables.

--- a/docs/readthedocs/source/doc/Nano/Overview/install.md
+++ b/docs/readthedocs/source/doc/Nano/Overview/install.md
@@ -23,7 +23,9 @@ pip install --pre --upgrade bigdl-nano[tensorflow]
 
 ```eval_rst
 .. note::
-    Since bigdl-nano is still in the process of rapid iteration, we highly recommend that you install nightly build version through the above command to facilitate your use of the latest features. For stable version, please refer to the document and installation guide [here](https://bigdl.readthedocs.io/en/v2.1.0/doc/Nano/Overview/nano.html).
+    Since bigdl-nano is still in the process of rapid iteration, we highly recommend that you install nightly build version through the above command to facilitate your use of the latest features.
+
+    For stable version, please refer to the document and installation guide `here <https://bigdl.readthedocs.io/en/v2.1.0/doc/Nano/Overview/nano.html>`_ .
 ```
 
 After installing bigdl-nano, you can run the following command to setup a few environment variables.

--- a/python/nano/example/pytorch/inference_optimizer/export_model/README.md
+++ b/python/nano/example/pytorch/inference_optimizer/export_model/README.md
@@ -8,10 +8,10 @@ For the sake of this example, we take ResNet50 for an example. First, by calling
 ## Prepare the environment
 We recommend you to use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to prepare the environment.
 **Note**: during your installation, there may be some warnings or errors about version, just ignore them.
-```
+```bash
 conda create -n nano python=3.7 setuptools=58.0.4  # "nano" is conda environment name, you can use any name you like.
 conda activate nano
-pip install --pre --upgrade bigdl-nano[pytorch]
+pip install --pre --upgrade bigdl-nano[pytorch] # install the nightly-bulit version
 
 # bf16 is available only on torch1.12
 pip install torch==1.12.0 torchvision --extra-index-url https://download.pytorch.org/whl/cpu 

--- a/python/nano/example/pytorch/inference_optimizer/resnet/README.md
+++ b/python/nano/example/pytorch/inference_optimizer/resnet/README.md
@@ -7,10 +7,10 @@ For the sake of this example, we first train the proposed network(by default, a 
 ## Prepare the environment
 We recommend you to use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to prepare the environment.
 **Note**: during your installation, there may be some warnings or errors about version, just ignore them.
-```
+```bash
 conda create -n nano python=3.7 setuptools=58.0.4  # "nano" is conda environment name, you can use any name you like.
 conda activate nano
-pip install --pre --upgrade bigdl-nano[pytorch]
+pip install --pre --upgrade bigdl-nano[pytorch] # install the nightly-bulit version
 
 # bf16 is available only on torch1.12
 pip install torch==1.12.0 torchvision --extra-index-url https://download.pytorch.org/whl/cpu 

--- a/python/nano/example/pytorch/inference_optimizer/vision_transformers/vision_transformer.ipynb
+++ b/python/nano/example/pytorch/inference_optimizer/vision_transformers/vision_transformer.ipynb
@@ -55,7 +55,7 @@
     "```bash\n",
     "conda create -n nano python=3.7 setuptools=58.0.4 # \"nano\" is conda environment name, you can use any name you like.\n",
     "conda activate nano\n",
-    "pip install --pre --upgrade bigdl-nano[pytorch]\n",
+    "pip install --pre --upgrade bigdl-nano[pytorch] # install the nightly-bulit version\n",
     "\n",
     "# bf16 is available only on torch1.12\n",
     "pip install torch==1.12.0 torchvision --extra-index-url https://download.pytorch.org/whl/cpu \n",

--- a/python/nano/example/pytorch/pl-finetune/README.md
+++ b/python/nano/example/pytorch/pl-finetune/README.md
@@ -5,12 +5,12 @@ This example illustrates how to apply bigdl-nano optimizations on a fine-tuning 
 
 ## Prepare the environment
 We recommend you to use [Anaconda](https://www.anaconda.com/distribution/#linux) to prepare the environment.
-```
+```bash
 conda create -n nano python=3.7  # "nano" is conda environment name, you can use any name you like.
 conda activate nano
 pip install jsonargparse[signatures]
 
-pip install bigdl-nano[pytorch]
+pip install --pre --upgrade bigdl-nano[pytorch] # install the nightly-bulit version
 ```
 Initialize environment variables with script `bigdl-nano-init` installed with bigdl-nano.
 ```

--- a/python/nano/example/pytorch/semantic_segmentation/README.md
+++ b/python/nano/example/pytorch/semantic_segmentation/README.md
@@ -5,11 +5,11 @@ This example illustrates how to apply bigdl-nano optimizations on a semantic seg
 
 ## Prepare the environment
 We recommend you to use [Anaconda](https://www.anaconda.com/distribution/#linux) to prepare the environment.
-```
+```bash
 conda create -n nano python=3.7  # "nano" is conda environment name, you can use any name you like.
 conda activate nano
 
-pip install bigdl-nano[pytorch]
+pip install --pre --upgrade bigdl-nano[pytorch] # install the nightly-bulit version
 ```
 Initialize environment variables with script `bigdl-nano-init` installed with bigdl-nano.
 ```

--- a/python/nano/example/quantization/neural-compressor/pytorch-lightning/cifar_resnet18/README.md
+++ b/python/nano/example/quantization/neural-compressor/pytorch-lightning/cifar_resnet18/README.md
@@ -3,7 +3,7 @@ This example shows the usage of pytorch quantization based on Intel Neural Compr
 
 ## Environment Setup
 ```shell
-pip install bigdl-nano[pytorch]
+pip install --pre --upgrade bigdl-nano[pytorch] # install the nightly-bulit version
 pip install lightning-bolts
 ```
 

--- a/python/nano/example/tensorflow/segmentation/Readme.md
+++ b/python/nano/example/tensorflow/segmentation/Readme.md
@@ -9,7 +9,7 @@ This example describes how to use BigDL Nano to optimize a TensorFlow image segm
     Install the BigDL-Nano with Tensorflow support with `pip` in a conda environment. 
 
     ```
-    pip install bigdl-nano[tensorflow]
+    pip install --pre --upgrade bigdl-nano[tensorflow] # install the nightly-bulit version
     ```
 
     Then install Tensorflow Examples for `pix2pix` model and Tensorflow Datasets for `oxford_iiit_pet` dataset support. 

--- a/python/nano/example/tensorflow/transfer_learning/Readme.md
+++ b/python/nano/example/tensorflow/transfer_learning/Readme.md
@@ -11,7 +11,7 @@ https://github.com/tensorflow/docs/blob/r2.4/site/en/tutorials/images/transfer_l
     You can install the necessary packages with the following command
     
     ```
-    pip install bigdl-nano[tensorflow]
+    pip install --pre --upgrade bigdl-nano[tensorflow] # install the nightly-bulit version
     ```
 
     Then setup the environment with the script `bigdl-nano-init`:


### PR DESCRIPTION
## Description

As BigDL-Nano is still in the process of rapid iteration, if users are based on the 2.1 version of Nano, they may encounter some problems, or they cannot use some of the latest functions or parameters, so we should always recommend users to install the nightly build version of Nano in all relevant documents.

### 1. Why the change?

https://github.com/intel-analytics/BigDL/issues/6201

### 2. User API changes

No change.

### 3. Summary of the change 

- [x] installation page(https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html) 
- [x] related examples

### 4. How to test?
- [x] Application test
- [x] Document test
https://ruonantetdoc.readthedocs.io/en/recommand_nb_version_for_user/doc/Nano/Overview/install.html