### PR TITLE
split ckks secret to all_secret and compute_secret

### DIFF
--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/example/ckks/GenerateCkksSecret.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/example/ckks/GenerateCkksSecret.scala
@@ -17,14 +17,23 @@ package com.intel.analytics.bigdl.ppml.fl.example.ckks
 
 import com.intel.analytics.bigdl.ckks.CKKS
 
+import java.io.File
+
 // TODO: key should be provided by Key Management System
 object GenerateCkksSecret {
   def main(args: Array[String]): Unit = {
     if (args.length >=  1) {
       val ckks = new CKKS()
       val keys = ckks.createSecrets()
-      CKKS.saveSecret(keys, args(0))
-      println("save secret to " + args(0))
+      val computeKeys = new Array[Array[Byte]](2)
+      computeKeys(0) = keys(0)
+      computeKeys(1) = keys(2)
+      val fullSecretFileName = args(0) + File.separator + "all_secret"
+      val computeSecretFileName = args(0) + File.separator + "compute_secret"
+      CKKS.saveSecret(keys, fullSecretFileName)
+      println("save all secret to " + fullSecretFileName)
+      CKKS.saveSecret(computeKeys, computeSecretFileName)
+      println("save compute secret to " + computeSecretFileName)
     } else {
       println("please provide a path to save secret.")
     }

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/example/ckks/README.md
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/example/ckks/README.md
@@ -18,16 +18,19 @@ The original data has 15 columns. In preprocessing, some new feature are created
 Download BigDL assembly all in one jar from [BigDL-Release](https://bigdl.readthedocs.io/en/latest/doc/release.html), file name is bigdl-assembly-spark_[version]-jar-with-all-dependencies.jar
 
 ### Generate secret
-
+`GenerateCkksSecret` will generate two secret file in given folder, one is `all_secret`, another is `compute_secret`.  
+`all_secret`: contains all secret for both encryption and computing.
+`compute_secret`: contains only computing secret for compute the cipher text, used on FLServer.
 ```bash
-java -cp bigdl-assembly-[version]-jar-with-all-dependencies.jar com.intel.analytics.bigdl.ppml.fl.example.ckks.GenerateCkksSecret ckks.crt
+java -cp bigdl-assembly-[version]-jar-with-all-dependencies.jar com.intel.analytics.bigdl.ppml.fl.example.ckks.GenerateCkksSecret [folder path]
 ```
+This secret generation is not for production use, secret should be protected by Key Management Service.
 
 ### Start FLServer
 Before starting server, modify the config file, `ppml-conf.yaml`, this application has 2 clients globally, and set the absolute path to ckks secret. So use following config:
-```
-worldSize: 2
-ckksSercetPath: /[absolute path]/ckks.crt
+```yaml
+clientNum: 2
+ckksSercetPath: /[absolute folder path]/compute_secret
 ```
 Then start FLServer at server machine
 ```bash
@@ -36,11 +39,11 @@ java -cp bigdl-assembly-[version]-jar-with-all-dependencies.jar com.intel.analyt
 
 ## Start Local Trainers
 Start the local Logistic Regression trainers at 2 training machines
-```
+```bash
 java -cp bigdl-assembly-[version]-jar-with-all-dependencies.jar com.intel.analytics.bigdl.ppml.fl.example.ckks.VflLogisticRegressionCkks
     -d [path to adult dataset]
     -i 1
-    -s [path to ckks.crt]
+    -s [path to all_secret]
 # change -i 1 to -i 2 at client-2
 ```
 

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/example/ckks/README.md
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/example/ckks/README.md
@@ -1,6 +1,6 @@
 # VFL Logistic Regression with CKKS Example
 
-This example show how to create an end-to-end VFL Logistic Regression application with 2 clients and 1 server with CKKS on BigDL PPML.
+This example show you how to create an end-to-end VFL Logistic Regression application with 2 clients and 1 server, using CKKS to protect data passing to FlServer on BigDL PPML.
 The targets and outputs of each clients will be protected by CKKS, server will compute loss and grad using cipherText. 
 
 ### Data

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/example/ckks/README.md
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/example/ckks/README.md
@@ -1,7 +1,7 @@
 # VFL Logistic Regression with CKKS Example
 
-This example show you how to create an end-to-end VFL Logistic Regression application with 2 clients and 1 server, using CKKS to protect data passing to FlServer on BigDL PPML.
-The targets and outputs of each clients will be protected by CKKS, server will compute loss and grad using cipherText. 
+This example show you how to create an end-to-end VFL Logistic Regression application with 2 clients and 1 server, using CKKS to protect data passing to FlServer on BigDL PPML.  
+The targets and outputs of each client's linear will be protected by CKKS, clients will encrypt targets and outputs to cipher text, then send the cipher texts to FL server. FLServer will compute loss and grad using cipher texts, return the cipher-text results back to clients. After receive the cipher texts, Clients can use their private key to decrypt the returned cipher texts to loss and grad. The plain-text loss and grad will be given back linear to compute linear's grad, the rest work is just normal LR training.
 
 ### Data
 We use [Census Income Dataset](https://archive.ics.uci.edu/ml/datasets/Census+Income) data in this example.

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/nn/NNServiceImpl.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/fl/nn/NNServiceImpl.scala
@@ -57,7 +57,7 @@ class NNServiceImpl(clientNum: Int) extends NNServiceGrpc.NNServiceImplBase {
   }
   def initCkksAggregator(secret: Array[Array[Byte]]): Unit = {
     val ckks = new CKKS()
-    val ckksCommonInstance = ckks.createCkksCommonInstance(secret)
+    val ckksCommonInstance = ckks.createCkksCommon(secret)
     val ckksAggregator = new VFLNNAggregatorCkks(ckksCommonInstance)
     ckksAggregator.setClientNum(clientNum)
     aggregatorMap.put("vfl_logistic_regression_ckks", ckksAggregator)

--- a/scala/ppml/src/test/scala/com/intel/analytics/bigdl/ppml/fl/nn/CkksSpec.scala
+++ b/scala/ppml/src/test/scala/com/intel/analytics/bigdl/ppml/fl/nn/CkksSpec.scala
@@ -40,7 +40,7 @@ class CkksSpec extends BigDLSpecHelper {
     val ckks = new CKKS()
     val secrets = ckks.createSecrets()
     val encryptorPtr = ckks.createCkksEncryptor(secrets)
-    val ckksRunnerPtr = ckks.createCkksCommonInstance(secrets)
+    val ckksRunnerPtr = ckks.createCkksCommon(secrets)
 
     val input1 = Array(0.1f, 0.2f, 1.1f, -1f)
     val input2 = Array(-0.1f, 1.2f, 2.1f, 1f)
@@ -82,7 +82,7 @@ class CkksSpec extends BigDLSpecHelper {
     val ckks = new CKKS()
     val secrets = ckks.createSecrets()
     val encryptorPtr = ckks.createCkksEncryptor(secrets)
-    val ckksRunnerPtr = ckks.createCkksCommonInstance(secrets)
+    val ckksRunnerPtr = ckks.createCkksCommon(secrets)
     val enTarget =
       Tensor[Byte](Storage[Byte](ckks.ckksEncrypt(encryptorPtr, target.storage().array())))
         .resize(target.size())
@@ -131,7 +131,7 @@ class CkksSpec extends BigDLSpecHelper {
     val ckks = new CKKS()
     val secrets = ckks.createSecrets()
     val encryptorPtr = ckks.createCkksEncryptor(secrets)
-    val ckksRunnerPtr = ckks.createCkksCommonInstance(secrets)
+    val ckksRunnerPtr = ckks.createCkksCommon(secrets)
     val enInput = ckks.ckksEncrypt(encryptorPtr, input.storage().array())
     val enTarget = ckks.ckksEncrypt(encryptorPtr, target.storage().array())
     val o = ckks.train(ckksRunnerPtr, enInput, enTarget)
@@ -165,7 +165,7 @@ class CkksSpec extends BigDLSpecHelper {
     val ckks = new CKKS()
     val secrets = ckks.createSecrets()
     val encryptorPtr = ckks.createCkksEncryptor(secrets)
-    val ckksRunnerPtr = ckks.createCkksCommonInstance(secrets)
+    val ckksRunnerPtr = ckks.createCkksCommon(secrets)
     val enInput = ckks.ckksEncrypt(encryptorPtr, input.storage().array())
     val enOutput = ckks.sigmoidForward(ckksRunnerPtr, enInput)
     val outputArray = ckks.ckksDecrypt(encryptorPtr, enOutput(0))
@@ -209,7 +209,7 @@ class CkksSpec extends BigDLSpecHelper {
     val ckks = new CKKS()
     val secrets = ckks.createSecrets()
     val encryptorPtr = ckks.createCkksEncryptor(secrets)
-    val ckksRunnerPtr = ckks.createCkksCommonInstance(secrets)
+    val ckksRunnerPtr = ckks.createCkksCommon(secrets)
 
     val epochNum = 2
     val lossArray = new Array[Float](epochNum)


### PR DESCRIPTION
## Description

split ckks secret to all_secret and compute_secret

### 1. Why the change?
FLServer should not hold secret for encrytion.

### 2. User API changes
Some ReadMe changed.

### 3. Summary of the change 

split ckks secret to all_secret and compute_secret

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

