### PR TITLE
[PPML] Modify settings in trusted-big-data-ml remote attestation settings

### DIFF
--- a/ppml/trusted-big-data-ml/python/docker-gramine/base/bash.manifest.template
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/base/bash.manifest.template
@@ -10,8 +10,10 @@ loader.env.LD_PRELOAD  = ""
 loader.insecure_disable_aslr = true
 loader.argv_src_file = "file:/ppml/trusted-big-data-ml/secured_argvs"
 
-sgx.remote_attestation = true
+sgx.remote_attestation = "dcap"
 sgx.ra_client_spid = ""
+
+sys.enable_extra_runtime_domain_names_conf = true
 
 sgx.allow_file_creation = true
 sgx.debug = false


### PR DESCRIPTION
## Description
Add the following settings to bash.manifest.template:
1. sgx.remote_attestation = "dcap"
2. sys.enable_extra_runtime_domain_names_conf = true

The original setting in first one will generate a warning.

The second one will ensure the gethostname() works correctly in gramine.
