### PR TITLE
Nano: fix the issue of `bigdl-nano-init`

### DIFF
--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -221,6 +221,10 @@ if [ -z "${CONDA_DEFAULT_ENV:-}" ]; then
 else
     if [ -f $CONDA_PREFIX/etc/conda/activate.d/nano_vars.sh ];then
         echo "nano_vars.sh already exists"
+	elif [ ! -f $CONDA_PREFIX/bin/bigdl-nano-init]; then
+		echo "you are sourcing bigdl-nano-init which is not in current conda environment,"
+		echo "maybe you have installed bigdl-nano using system's pip, if so, please uninstall"
+		echo "it and install bigdl-nano in the current conda environment instead."
     else
         echo "Setting environment variables in current conda env"
         ACTIVATED_PATH=$CONDA_PREFIX/etc/conda/activate.d

--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -221,10 +221,10 @@ if [ -z "${CONDA_DEFAULT_ENV:-}" ]; then
 else
     if [ -f $CONDA_PREFIX/etc/conda/activate.d/nano_vars.sh ];then
         echo "nano_vars.sh already exists"
-	elif [ ! -f $CONDA_PREFIX/bin/bigdl-nano-init]; then
-		echo "you are sourcing bigdl-nano-init which is not in current conda environment,"
-		echo "maybe you have installed bigdl-nano using system's pip, if so, please uninstall"
-		echo "it and install bigdl-nano in the current conda environment instead."
+    elif [ ! -f $CONDA_PREFIX/bin/bigdl-nano-init]; then
+        echo "you are sourcing bigdl-nano-init which is not in current conda environment,"
+        echo "maybe you have installed bigdl-nano using system's pip, if so, please uninstall"
+        echo "it and install bigdl-nano in the current conda environment instead."
     else
         echo "Setting environment variables in current conda env"
         ACTIVATED_PATH=$CONDA_PREFIX/etc/conda/activate.d

--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -222,9 +222,9 @@ else
     if [ -f $CONDA_PREFIX/etc/conda/activate.d/nano_vars.sh ];then
         echo "nano_vars.sh already exists"
     elif [ ! -f $CONDA_PREFIX/bin/bigdl-nano-init]; then
-        echo "you are sourcing bigdl-nano-init which is not in current conda environment,"
-        echo "maybe you have installed bigdl-nano using system's pip, if so, please uninstall"
-        echo "it and install bigdl-nano in the current conda environment instead."
+        echo "It seems that you are using bidl-nano installed by system's pip, "
+        echo "you may need to 'source bgidl-nano-init' before using bigdl-nano "
+        echo "and 'source bigdl-nano-unset-env' after using bigdl-nano yourself"
     else
         echo "Setting environment variables in current conda env"
         ACTIVATED_PATH=$CONDA_PREFIX/etc/conda/activate.d

--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -221,7 +221,7 @@ if [ -z "${CONDA_DEFAULT_ENV:-}" ]; then
 else
     if [ -f $CONDA_PREFIX/etc/conda/activate.d/nano_vars.sh ];then
         echo "nano_vars.sh already exists"
-    elif [ ! -f $CONDA_PREFIX/bin/bigdl-nano-init]; then
+    elif [ ! -f $CONDA_PREFIX/bin/bigdl-nano-init ]; then
         echo "It seems that you are using bidl-nano installed by system's pip, "
         echo "you may need to 'source bgidl-nano-init' before using bigdl-nano "
         echo "and 'source bigdl-nano-unset-env' after using bigdl-nano yourself"

--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -263,6 +263,6 @@ echo "NANO_TF_INTER_OP"=${NANO_TF_INTER_OP}
 echo "+++++++++++++++++++++++++"
 # Run the commands after bigdl-nano-init
 echo "Complete."
-if [ ! $1 = "activate" ];then
+if [ ! $1 = "activate" ] && [ ! $1 = "deactivate" ];then
     ${@:1}
 fi


### PR DESCRIPTION
## Description

If user has installed `bigdl-nano` using system's pip, then he can source `bigdl-nano-init` in any conda environment, and this script will mistakenly think that current conda environment has installed `bigdl-nano`, fix this issue: #6199

And, fix another small issue, which will cause `bash: deactivate: command not found`