### PR TITLE
Chronos: add serving forecaster example in document

### DIFF
--- a/docs/readthedocs/source/_static/js/chronos_tutorial.js
+++ b/docs/readthedocs/source/_static/js/chronos_tutorial.js
@@ -65,7 +65,7 @@ $(".checkboxes").click(function(){
             "MultvarWIDE","MultstepWIDE","LSTMF","AutoPr","AnomalyDetection",
             "DeepARmodel","TFTmodel","hyperparameter","taxiDataset","distributedFashion",
             "ONNX","Quantize","TCMF","PenalizeUnderestimation",
-            "GPUtrainingCPUacceleration"];
+            "GPUtrainingCPUacceleration","ServeForecaster"];
             showTutorials(ids);
             var disIds = ["simulation"];
             disCheck(disIds);

--- a/docs/readthedocs/source/doc/Chronos/QuickStart/index.md
+++ b/docs/readthedocs/source/doc/Chronos/QuickStart/index.md
@@ -353,6 +353,19 @@
         </details>
         <hr>
 
+        <details id="ServeForecaster">
+            <summary>
+                <a href="https://github.com/intel-analytics/BigDL/tree/main/python/chronos/example/serving">Serve Chronos forecaster and predict through TorchServe</a>
+                <p>Tag: 
+                    <button value="forecast">forecast</button>&nbsp;
+                    <button value="TCNForecaster" class="roundbutton">TCNForecaster</button>
+                </p>
+            </summary>
+            <img src="../../../_images/GitHub-Mark-32px.png"><a href="https://github.com/intel-analytics/BigDL/tree/main/python/chronos/example/serving">View source on GitHub</a>
+            <p>In this example, we show how to serve Chronos forecaster and predict through TorchServe.</p>
+        </details>
+        <hr>
+
     </div>
 
     <script src="../../../_static/js/chronos_tutorial.js"></script> 


### PR DESCRIPTION
## Description

Code and readme of serving forecaster has been added in https://github.com/intel-analytics/BigDL/pull/6140.
In this PR, enable this example displayed in document.

### 4. How to test?
- [x] Document test
https://binbin-doc.readthedocs.io/en/serve-example-html/doc/Chronos/QuickStart/index.html

