### PR TITLE
Chronos: update openvino-dev version in Chronos prvn action

### DIFF
--- a/.github/workflows/chronos-prvn-python-spark-2.4-py37-ray.yml
+++ b/.github/workflows/chronos-prvn-python-spark-2.4-py37-ray.yml
@@ -61,9 +61,7 @@ jobs:
           pip install optuna==2.10.1
           pip install onnx==1.11.0
           pip install onnxruntime==1.11.1
-          pip install openvino-dev==2022.1.0
-          pip uninstall -y numpy
-          pip install numpy==1.19.5
+          pip install openvino-dev==2022.2.0
           pip install scipy==1.5.4
           pip install cloudpickle
           pip install matplotlib

--- a/.github/workflows/chronos-prvn-python-spark-3.1-py37-ray.yml
+++ b/.github/workflows/chronos-prvn-python-spark-3.1-py37-ray.yml
@@ -61,9 +61,7 @@ jobs:
           pip install optuna==2.10.1
           pip install onnx==1.11.0
           pip install onnxruntime==1.11.1
-          pip install openvino-dev==2022.1.0
-          pip uninstall -y numpy
-          pip install numpy==1.19.5
+          pip install openvino-dev==2022.2.0
           pip install scipy==1.5.4
           pip install cloudpickle
           pip install matplotlib


### PR DESCRIPTION
## Description

Use 2022.2.0 instead of 2022.1.0 version openvino-dev, so that we don't need to solve complex numpy related issue.

### 4. How to test?
- [x] Unit test
