### PR TITLE
[Doc] Add collapsing functionality to the quicklink titles in landing page

### DIFF
--- a/docs/readthedocs/source/_static/css/custom.css
+++ b/docs/readthedocs/source/_static/css/custom.css
@@ -60,10 +60,10 @@ code span.pre {
 
 /* for landing page side bar */
 .bigdl-quicklinks-section-nav {
-    padding-bottom: 0.5rem;
     padding-left: 1rem;
 }
 
 .bigdl-quicklinks-section-title {
     color: var(--pst-color-primary);
+    padding: 0.25rem 0rem;
 }

--- a/docs/readthedocs/source/_templates/sidebar_quicklinks.html
+++ b/docs/readthedocs/source/_templates/sidebar_quicklinks.html
@@ -1,68 +1,97 @@
 <nav class="bd-links">
     <p class="bd-links__title">Quick Links</p>
     <div class="navbar-nav">
-        <strong class="bigdl-quicklinks-section-title">Orca QuickStart</Q></strong>
-        <ul class="nav bigdl-quicklinks-section-nav">
+        <ul class="nav">
             <li>
-                <a href="doc/UseCase/spark-dataframe.html">Use Spark Dataframe for Deep Learning</a>
+                <strong class="bigdl-quicklinks-section-title">Orca QuickStart</strong>
+                <input id="quicklink-clsuter-orca" type="checkbox" class="toctree-checkbox" />
+                <label for="quicklink-clsuter-orca" class="toctree-toggle">
+                    <i class="fa-solid fa-chevron-down"></i>
+                </label>
+                <ul class="bigdl-quicklinks-section-nav">
+                    <li>
+                        <a href="doc/UseCase/spark-dataframe.html">Use Spark Dataframe for Deep Learning</a>
+                    </li>
+                    <li>
+                        <a href="doc/Orca/QuickStart/orca-pytorch-distributed-quickstart.html">Distributed PyTorch using Orca</a>
+                    </li>
+                    <li>
+                        <a href="doc/Orca/QuickStart/orca-autoxgboost-quickstart.html">Use AutoXGBoost to tune XGBoost parameters automatically</a>
+                    </li>
+                </ul>
             </li>
             <li>
-                <a href="doc/Orca/QuickStart/orca-pytorch-distributed-quickstart.html">Distributed PyTorch using Orca</a>
+                <strong class="bigdl-quicklinks-section-title">Nano QuickStart</strong>
+                <input id="quicklink-clsuter-nano" type="checkbox" class="toctree-checkbox" />
+                <label for="quicklink-clsuter-nano" class="toctree-toggle">
+                    <i class="fa-solid fa-chevron-down"></i>
+                </label>
+                <ul class="nav bigdl-quicklinks-section-nav">
+                    <li>
+                        <a href="doc/Nano/QuickStart/pytorch_train_quickstart.html">PyTorch Training Acceleration</a>
+                    </li>
+                    <li>
+                        <a href="doc/Nano/QuickStart/pytorch_quantization_inc_onnx.html">PyTorch Inference Quantization with ONNXRuntime Acceleration </a>
+                    </li>
+                    <li>
+                        <a href="doc/Nano/QuickStart/pytorch_openvino.html">PyTorch Inference Acceleration using OpenVINO</a>
+                    </li>
+                    <li>
+                        <a href="doc/Nano/QuickStart/tensorflow_train_quickstart.html">Tensorflow Training Acceleration</a>
+                    </li>
+                    <li>
+                        <a href="doc/Nano/QuickStart/tensorflow_quantization_quickstart.html">Tensorflow Quantization Acceleration</a>
+                    </li>
+                </ul>
             </li>
             <li>
-                <a href="doc/Orca/QuickStart/orca-autoxgboost-quickstart.html">Use AutoXGBoost to tune XGBoost parameters automatically</a>
+                <strong class="bigdl-quicklinks-section-title">DLlib QuickStart</strong>
+                <input id="quicklink-clsuter-dllib" type="checkbox" class="toctree-checkbox" />
+                <label for="quicklink-clsuter-dllib" class="toctree-toggle">
+                    <i class="fa-solid fa-chevron-down"></i>
+                </label>
+                <ul class="nav bigdl-quicklinks-section-nav">
+                    <li>
+                        <a href="doc/DLlib/QuickStart/python-getting-started.html">Python QuickStart</a>
+                    </li>
+                    <li>
+                        <a href="doc/DLlib/QuickStart/scala-getting-started.html">Scala QuickStart</a>
+                    </li>
+                </ul>
             </li>
-
+            <li>
+                <strong class="bigdl-quicklinks-section-title">Chronos QuickStart</strong>
+                <input id="quicklink-clsuter-chronos" type="checkbox" class="toctree-checkbox" />
+                <label for="quicklink-clsuter-chronos" class="toctree-toggle">
+                    <i class="fa-solid fa-chevron-down"></i>
+                </label>
+                <ul class="nav bigdl-quicklinks-section-nav">
+                    <li>
+                        <a href="doc/Chronos/QuickStart/chronos-tsdataset-forecaster-quickstart.html">Basic Forecasting</a>
+                    </li>
+                    <li>
+                        <a href="doc/Chronos/QuickStart/chronos-autotsest-quickstart.html">Forecasting using AutoML</a>
+                    </li>
+                    <li>
+                        <a href="doc/Chronos/QuickStart/chronos-anomaly-detector.html">Anomaly Detection</a>
+                    </li>
+                </ul>
+            </li>
+            <li>
+                <strong class="bigdl-quicklinks-section-title">PPML QuickStart</strong>
+                <input id="quicklink-clsuter-ppml" type="checkbox" class="toctree-checkbox" />
+                <label for="quicklink-clsuter-ppml" class="toctree-toggle">
+                    <i class="fa-solid fa-chevron-down"></i>
+                </label>
+                <ul class="nav bigdl-quicklinks-section-nav">
+                    <li>
+                        <a href="doc/PPML/Overview/quicktour.html">Hello World Example</a>
+                    </li>
+                    <li>
+                        <a href="doc/PPML/QuickStart/end-to-end.html">End-to-End Example</a>
+                    </li>
+                </ul>
+            </li>
         </ul>
-        <strong class="bigdl-quicklinks-section-title">Nano QuickStart</strong>
-        <ul class="nav bigdl-quicklinks-section-nav" >
-            <li>
-                <a href="doc/Nano/QuickStart/pytorch_train_quickstart.html">PyTorch Training Acceleration</a>
-            </li>
-            <li>
-                <a href="doc/Nano/QuickStart/pytorch_quantization_inc_onnx.html">PyTorch Inference Quantization with ONNXRuntime Acceleration </a>
-            </li>
-            <li>
-                <a href="doc/Nano/QuickStart/pytorch_openvino.html">PyTorch Inference Acceleration using OpenVINO</a>
-            </li>
-            <li>
-                <a href="doc/Nano/QuickStart/tensorflow_train_quickstart.html">Tensorflow Training Acceleration</a>
-            </li>
-            <li>
-                <a href="doc/Nano/QuickStart/tensorflow_quantization_quickstart.html">Tensorflow Quantization Acceleration</a>
-            </li>
-        </ul>
-        <strong class="bigdl-quicklinks-section-title">DLlib QuickStart</strong>
-        <ul class="nav bigdl-quicklinks-section-nav" >
-            <li>
-                <a href="doc/DLlib/QuickStart/python-getting-started.html">Python QuickStart</a>
-            </li>
-            <li>
-                <a href="doc/DLlib/QuickStart/scala-getting-started.html">Scala QuickStart</a>
-            </li>
-        </ul>
-        <strong class="bigdl-quicklinks-section-title">Chronos QuickStart</strong>
-        <ul class="nav bigdl-quicklinks-section-nav" >
-            <li>
-                <a href="doc/Chronos/QuickStart/chronos-tsdataset-forecaster-quickstart.html">Basic Forecasting</a>
-            </li>
-            <li>
-                <a href="doc/Chronos/QuickStart/chronos-autotsest-quickstart.html">Forecasting using AutoML</a>
-            </li>
-            <li>
-                <a href="doc/Chronos/QuickStart/chronos-anomaly-detector.html">Anomaly Detection</a>
-            </li>
-        </ul>
-
-        <strong class="bigdl-quicklinks-section-title">PPML QuickStart</strong>
-        <ul class="nav bigdl-quicklinks-section-nav" >
-            <li>
-                <a href="doc/PPML/Overview/quicktour.html">Hello World Example</a>
-            </li>
-            <li>
-                <a href="doc/PPML/QuickStart/end-to-end.html">End-to-End Example</a>
-            </li>
-        </ul>
-
     </div>
 </nav>

--- a/docs/readthedocs/source/doc/UserGuide/win.md
+++ b/docs/readthedocs/source/doc/UserGuide/win.md
@@ -94,12 +94,7 @@ This error may appear when you try to import torch. This is caused by Ubuntu 14.
 sudo apt-get install libgomp1
 ```
 
-### 2. Slow PyTorch training with BF16
-
-Using BFloat16 mixed precision in PyTorch or PyTorch-Lightning training may be much slower than FP32.
-
-
-### 3. ERROR: Could not build wheels for pycocotools, which is required to install pyproject.toml-based projects
+### 2. ERROR: Could not build wheels for pycocotools, which is required to install pyproject.toml-based projects
 
 pycocotools is a dependency of Intel neural-compressor which is used for inference quantization in BigDL-Nano. This error is usually caused by GCC library not installed in system.  Just install gcc to resolve it:
 
@@ -107,7 +102,7 @@ pycocotools is a dependency of Intel neural-compressor which is used for inferen
 sudo apt-get install gcc
 ```
 
-### 4. ValueError: After taking into account object store and redis memory usage, the amount of memory on this node available for tasks and actors is less than -75% of total.
+### 3. ValueError: After taking into account object store and redis memory usage, the amount of memory on this node available for tasks and actors is less than -75% of total.
 
 When running ray applications, you need to set the `memory` and `object_store_memory` properly according to your system memory capacity. This error indicates you have used too large memory configurations and you need to decrease them. For example on a laptop with 8G memory, you may set the memory configurations as below:
 


### PR DESCRIPTION
## Description

- Add collapsing functionality to the quicklink titles in landing page to avoid too long landing page side bar.
- Romve "Slow PyTorch training with BF16" section in windows user guide

Before
![image](https://user-images.githubusercontent.com/54161268/196916578-d607ec9b-9e1a-441a-8d91-0188bd5fe8c0.png)

After
![image](https://user-images.githubusercontent.com/54161268/196916717-7d7099f4-135d-4b05-b567-ad7cf58aa33c.png)


### How to test?
- [x] Document test: https://yuwentestdocs.readthedocs.io/en/collapse-landing-sidebar/