### PR TITLE
add fillna in xshards

### DIFF
--- a/python/friesian/src/bigdl/friesian/feature/table.py
+++ b/python/friesian/src/bigdl/friesian/feature/table.py
@@ -23,6 +23,7 @@ from functools import reduce
 import numpy as np
 import pyspark.sql.functions as F
 from bigdl.friesian.feature.utils import *
+from bigdl.orca.data.utils import import fill_na, fill_na_int
 from bigdl.dllib.utils.log4Error import *
 from bigdl.orca import OrcaContext
 from py4j.protocol import Py4JError

--- a/python/orca/src/bigdl/orca/data/shard.py
+++ b/python/orca/src/bigdl/orca/data/shard.py
@@ -24,6 +24,16 @@ from bigdl.dllib.utils.log4Error import *
 
 import numpy as np
 
+from typing import (
+    TYPE_CHECKING,
+    TypeVar,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 class XShards(object):
     """
@@ -134,6 +144,7 @@ But got data of type {}
 
 
 class SparkXShards(XShards):
+
     """
 
     A collection of data which can be pre-processed in parallel on Spark
@@ -632,6 +643,19 @@ class SparkXShards(XShards):
             invalidInputError(False,
                               "The two SparkXShards should have the same number of elements "
                               "in each partition")
+
+    def fillna(self, value: Union[int, float, str, bool],
+               columns: Optional[Union[str, List[str]]]):
+        if self._get_class_name() == 'pandas.core.frame.DataFrame':
+            import pandas as pd
+            df = self.to_spark_df()
+            filled_df = fill_na(df, value, columns)
+            data_shards = spark_df_to_pd_sparkxshards(filled_df)
+            return data_shards
+        else:
+            invalidInputError(False,
+                              "Currently only support dedup() on XShards of Pandas DataFrame")
+
 
     def _to_spark_df_without_arrow(self):
         def f(iter):

--- a/python/orca/src/bigdl/orca/data/utils.py
+++ b/python/orca/src/bigdl/orca/data/utils.py
@@ -18,7 +18,16 @@ from bigdl.dllib.utils.file_utils import get_file_list, callZooFunc
 from bigdl.dllib.utils.utils import convert_row_to_numpy
 from bigdl.dllib.utils.common import *
 from bigdl.dllib.utils.log4Error import *
-
+from typing import (
+    TYPE_CHECKING,
+    TypeVar,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 def list_s3_file(file_path, env):
     path_parts = file_path.split('/')
@@ -502,3 +511,15 @@ def check_col_exists(df, columns):
     if len(col_not_exist) > 0:
         invalidInputError(False,
                           str(col_not_exist) + " do not exist in this Table")
+
+
+def fill_na(df: "SparkDataFrame",
+            fill_val: Union[int, str, float],
+            columns: List[str]) -> "SparkDataFrame":
+    return callZooFunc("float", "fillNa", df, fill_val, columns)
+
+
+def fill_na_int(df: "SparkDataFrame",
+                fill_val: int,
+                columns: Optional[List[str]]) -> "SparkDataFrame":
+    return callZooFunc("float", "fillNaInt", df, fill_val, columns)

--- a/scala/friesian/src/test/scala/com/intel/analytics/bigdl/friesian/FriesianSpec.scala
+++ b/scala/friesian/src/test/scala/com/intel/analytics/bigdl/friesian/FriesianSpec.scala
@@ -49,43 +49,6 @@ class FriesianSpec extends ZooSpecHelper {
     }
   }
 
-  "Fill NA int" should "work properly" in {
-    val path = resource.getFile + "/data1.parquet"
-    val df = sqlContext.read.parquet(path)
-    val cols = Array("col_1", "col_2")
-    val dfFilled = friesian.fillNa(df, 0, cols.toList.asJava)
-    TestUtils.conditionFailTest(dfFilled.filter(dfFilled("col_1").isNull).count == 0)
-    TestUtils.conditionFailTest(dfFilled.filter(dfFilled("col_2").isNull).count == 0)
-  }
-
-  "Fill NA string" should "work properly" in {
-    val path = resource.getFile + "/data1.parquet"
-    val df = sqlContext.read.parquet(path)
-    val cols = Array("col_4", "col_5")
-    val dfFilled = friesian.fillNa(df, "bb", cols.toList.asJava)
-    TestUtils.conditionFailTest(dfFilled.filter(dfFilled("col_4").isNull).count == 0)
-    TestUtils.conditionFailTest(dfFilled.filter(dfFilled("col_5").isNull).count == 0)
-  }
-
-  "Fill NA string int" should "throw exception" in {
-    val path = resource.getFile + "/data1.parquet"
-    val df = sqlContext.read.parquet(path)
-    val cols = Array("col_1", "col_4")
-    assertThrows[IllegalArgumentException] {
-      friesian.fillNa(df, "bb", cols.toList.asJava)
-    }
-  }
-
-  "Fill NAInt" should "work properly" in {
-    val path = resource.getFile + "/data1.parquet"
-    val df = sqlContext.read.parquet(path)
-    val dfFilled = friesian.fillNaInt(df, 3)
-    TestUtils.conditionFailTest(dfFilled.filter(dfFilled("col_2").isNull).count == 0)
-    TestUtils.conditionFailTest(dfFilled.filter(dfFilled("col_3").isNull).count == 0)
-    val dfFilled2 = friesian.fillNaInt(df, 4, List("col_3").asJava)
-    TestUtils.conditionFailTest(dfFilled2.filter(dfFilled2("col_2").isNull).count == 1)
-    TestUtils.conditionFailTest(dfFilled2.filter(dfFilled2("col_3").isNull).count == 0)
-  }
 
   "Clip" should "work properly" in {
     val path = resource.getFile + "/data1.parquet"

--- a/scala/orca/src/main/scala/com/intel/analytics/bigdl/orca/utils/DataUtils.scala
+++ b/scala/orca/src/main/scala/com/intel/analytics/bigdl/orca/utils/DataUtils.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.spark.TaskContext
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.sql.functions.{col, udf}
+import org.apache.spark.sql.types.{ArrayType, IntegerType}
+import org.apache.spark.sql.{DataFrame, Row}
+
+import scala.collection.mutable
+import scala.collection.mutable.WrappedArray
+import scala.util.Random
+
+package com.intel.analytics.bigdl.orca.utils
+
+object DataUtils {
+  def fillNaIndex(df: DataFrame, fillVal: Any, columns: Array[Int]): DataFrame = {
+    val targetType = fillVal match {
+      case _: Double | _: Long | _: Int => "numeric"
+      case _: String => "string"
+      case _: Boolean => "boolean"
+      case _ => throw new IllegalArgumentException(
+        s"Unsupported value type ${fillVal.getClass.getName} ($fillVal).")
+    }
+
+    val schema = df.schema
+
+    val fillValList = columns.map(idx => {
+      val matchAndVal = checkTypeAndCast(schema(idx).dataType.typeName, targetType, fillVal)
+      if (!matchAndVal._1) {
+        throw new IllegalArgumentException(s"$targetType does not match the type of column " +
+          s"${schema(idx).name}")
+      }
+      matchAndVal._2
+    })
+
+    val dfUpdated = df.rdd.map(row => {
+      val origin = row.toSeq.toArray
+      for ((idx, fillV) <- columns zip fillValList) {
+        if (row.isNullAt(idx)) {
+          origin.update(idx, fillV)
+        }
+      }
+      Row.fromSeq(origin)
+    })
+
+    val spark = df.sparkSession
+    spark.createDataFrame(dfUpdated, schema)
+  }
+
+  def getIndex(df: DataFrame, columns: Array[String]): Array[Int] = {
+    columns.map(col_n => {
+      val idx = df.columns.indexOf(col_n)
+      if (idx == -1) {
+        throw new IllegalArgumentException(s"The column name $col_n does not exist")
+      }
+      idx
+    })
+  }
+
+
+}

--- a/scala/orca/src/main/scala/com/intel/analytics/bigdl/orca/utils/DataUtils.scala
+++ b/scala/orca/src/main/scala/com/intel/analytics/bigdl/orca/utils/DataUtils.scala
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+package com.intel.analytics.bigdl.orca.utils
+
 import org.apache.spark.TaskContext
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql.functions.{col, udf}
@@ -24,9 +26,24 @@ import scala.collection.mutable
 import scala.collection.mutable.WrappedArray
 import scala.util.Random
 
-package com.intel.analytics.bigdl.orca.utils
-
 object DataUtils {
+  def checkTypeAndCast(schemaType: String, targetType: String, fillVal: Any):
+
+  (Boolean, Any) = {
+    if (schemaType == targetType) {
+      return (true, fillVal)
+    } else if (targetType == "numeric") {
+      val fillNum = fillVal.asInstanceOf[Number]
+      return schemaType match {
+        case "long" => (true, fillNum.longValue)
+        case "integer" => (true, fillNum.intValue)
+        case "double" => (true, fillNum.doubleValue)
+        case _ => (false, fillVal)
+      }
+    }
+    (false, fillVal)
+  }
+
   def fillNaIndex(df: DataFrame, fillVal: Any, columns: Array[Int]): DataFrame = {
     val targetType = fillVal match {
       case _: Double | _: Long | _: Int => "numeric"
@@ -70,6 +87,5 @@ object DataUtils {
       idx
     })
   }
-
-
 }
+

--- a/scala/orca/src/test/scala/com/intel/analytics/bigdl/orca/utils/OrcaSpec.scala
+++ b/scala/orca/src/test/scala/com/intel/analytics/bigdl/orca/utils/OrcaSpec.scala
@@ -29,7 +29,6 @@ import org.apache.spark.{SparkConf, SparkContext, SparkException}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-
 import com.intel.analytics.bigdl.orca.utils._
 
 class OrcaSpec extends ZooSpecHelper {
@@ -87,5 +86,43 @@ class OrcaSpec extends ZooSpecHelper {
     val col5Idx = stringIdxList.get(1).collect().sortBy(_.getInt(1))
     TestUtils.conditionFailTest(col4Idx(0).getString(0) == "abc")
     TestUtils.conditionFailTest(col5Idx(0).getString(0) == "aa")
+  }
+
+  "Fill NA int" should "work properly" in {
+    val path = resource.getFile + "/data1.parquet"
+    val df = sqlContext.read.parquet(path)
+    val cols = Array("col_1", "col_2")
+    val dfFilled = orca.fillNa(df, 0, cols.toList.asJava)
+    TestUtils.conditionFailTest(dfFilled.filter(dfFilled("col_1").isNull).count == 0)
+    TestUtils.conditionFailTest(dfFilled.filter(dfFilled("col_2").isNull).count == 0)
+  }
+
+  "Fill NA string" should "work properly" in {
+    val path = resource.getFile + "/data1.parquet"
+    val df = sqlContext.read.parquet(path)
+    val cols = Array("col_4", "col_5")
+    val dfFilled = orca.fillNa(df, "bb", cols.toList.asJava)
+    TestUtils.conditionFailTest(dfFilled.filter(dfFilled("col_4").isNull).count == 0)
+    TestUtils.conditionFailTest(dfFilled.filter(dfFilled("col_5").isNull).count == 0)
+  }
+
+  "Fill NA string int" should "throw exception" in {
+    val path = resource.getFile + "/data1.parquet"
+    val df = sqlContext.read.parquet(path)
+    val cols = Array("col_1", "col_4")
+    assertThrows[IllegalArgumentException] {
+      orca.fillNa(df, "bb", cols.toList.asJava)
+    }
+  }
+
+  "Fill NAInt" should "work properly" in {
+    val path = resource.getFile + "/data1.parquet"
+    val df = sqlContext.read.parquet(path)
+    val dfFilled = orca.fillNaInt(df, 3)
+    TestUtils.conditionFailTest(dfFilled.filter(dfFilled("col_2").isNull).count == 0)
+    TestUtils.conditionFailTest(dfFilled.filter(dfFilled("col_3").isNull).count == 0)
+    val dfFilled2 = orca.fillNaInt(df, 4, List("col_3").asJava)
+    TestUtils.conditionFailTest(dfFilled2.filter(dfFilled2("col_2").isNull).count == 1)
+    TestUtils.conditionFailTest(dfFilled2.filter(dfFilled2("col_3").isNull).count == 0)
   }
 }


### PR DESCRIPTION
## Description
reuse some code of Friesian Table to support Orca Xshards fillna

### 1. Why the change?
to avoid depleted code in orca xshards and friesian table 

### 2. User API changes
no change in friesian table

### 3. Summary of the change 
move scala Friesian Table fillna related implementation to Orca since Friesian depends on Orca
move python friesian.feature.utils fillna related to orca.data.utils 
add fillna in python orca.data.shard.py

### 4. How to test?
- [ ] Unit test

### 5. New dependencies
no dependencies