### PR TITLE
auto adjust batch_size when multiprocessing training

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -301,6 +301,11 @@ class BasePytorchForecaster(Forecaster):
                in multi-objective search.
         :return: Validation loss if 'validation_data' is not None.
         """
+        # auto adjust batch_size
+        if batch_size // self.num_processes > 0:
+            batch_size = batch_size // self.num_processes
+        else:
+            batch_size = 1
         # input transform
         if isinstance(data, TSDataset):
             _rolled = data.numpy_x is None


### PR DESCRIPTION
## Description

 Auto adjust `batch_size` in `base-forecaster.fit()` to make sure the updating steps is stable when multiprocessing training.