### PR TITLE
[Friesian] Fix pom cause the test cases not found

### DIFF
--- a/scala/friesian/pom.xml
+++ b/scala/friesian/pom.xml
@@ -369,10 +369,19 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${junit5-maven-surefire-plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit-platform</artifactId>
+                        <version>${junit5-maven-surefire-plugin.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${junit5-maven-failsafe-plugin.version}</version>
             </plugin>


### PR DESCRIPTION
## Description

[Issue](https://github.com/analytics-zoo/friesian/issues/313)
Add the surefire provider setting to fix the bug that test cases cannot be found during maven test.

Due to the new dependencies in `spark_3.x`, if the surefire provider is not specified, the default provider is replaced by `surefire-testng`. The test cases of junit5 cannot be found.
[This link](https://issues.apache.org/jira/browse/SUREFIRE-1527) shows a similar case.
In addition to specifying the provider, this issue can also be solved by upgrading `maven-surefire-plugin`.
In `3.0.0-M5` and later, the default provider reverts to `surefire-junit-platform`. However, to avoid same issues in the future, I decide to solve it by specifying a provider.