### PR TITLE
Nano: fix a bug of `TorchNano`'s multi-instance training

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
+++ b/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
@@ -357,6 +357,8 @@ class RayStrategy(DDPSpawnStrategy):
     def _setup_model(self, model: torch.nn.Module) -> DistributedDataParallel:
         """Wraps the model into a 'DistributedDataParallel' module."""
         # we should override this method to change the creation of `DistributedDataParallel`
+        # we need to set `find_unused_parameters` to True to fix mult-instance training,
+        # `Trainer` will set it automatically, but `TorchNano` won't, so we set it manually
         self._ddp_kwargs['find_unused_parameters'] = True
         return DistributedDataParallel(model, **self._ddp_kwargs)
 

--- a/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
+++ b/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
@@ -357,7 +357,8 @@ class RayStrategy(DDPSpawnStrategy):
     def _setup_model(self, model: torch.nn.Module) -> DistributedDataParallel:
         """Wraps the model into a 'DistributedDataParallel' module."""
         # we should override this method to change the creation of `DistributedDataParallel`
-        return DistributedDataParallel(model, find_unused_parameters=True, **self._ddp_kwargs)
+        self._ddp_kwargs['find_unused_parameters'] = True
+        return DistributedDataParallel(model, **self._ddp_kwargs)
 
     @property
     def distributed_sampler_kwargs(self):

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -351,7 +351,8 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
     def _setup_model(self, model: nn.Module) -> DistributedDataParallel:
         """Wraps the model into a 'DistributedDataParallel' module."""
         # we should override this method to change the creation of `DistributedDataParallel`
-        return DistributedDataParallel(model, find_unused_parameters=True, **self._ddp_kwargs)
+        self._ddp_kwargs['find_unused_parameters'] = True
+        return DistributedDataParallel(model, **self._ddp_kwargs)
 
     def reduce(self, tensor, group: Optional[Any] = None,   # type: ignore[override]
                reduce_op: Union[ReduceOp, str] = "mean") -> Tensor:

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -351,7 +351,7 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
     def _setup_model(self, model: nn.Module) -> DistributedDataParallel:
         """Wraps the model into a 'DistributedDataParallel' module."""
         # we should override this method to change the creation of `DistributedDataParallel`
-        return DistributedDataParallel(model, **self._ddp_kwargs)
+        return DistributedDataParallel(model, find_unused_parameters=True, **self._ddp_kwargs)
 
     def reduce(self, tensor, group: Optional[Any] = None,   # type: ignore[override]
                reduce_op: Union[ReduceOp, str] = "mean") -> Tensor:

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -351,6 +351,8 @@ class DDPSpawnStrategy(_DDPSpawnStrategy):
     def _setup_model(self, model: nn.Module) -> DistributedDataParallel:
         """Wraps the model into a 'DistributedDataParallel' module."""
         # we should override this method to change the creation of `DistributedDataParallel`
+        # we need to set `find_unused_parameters` to True to fix mult-instance training,
+        # `Trainer` will set it automatically, but `TorchNano` won't, so we set it manually
         self._ddp_kwargs['find_unused_parameters'] = True
         return DistributedDataParallel(model, **self._ddp_kwargs)
 

--- a/python/nano/src/bigdl/nano/pytorch/strategies/k8s.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/k8s.py
@@ -195,5 +195,5 @@ class DDPK8sStrategy(DDPStrategy):
     def _setup_model(self, model: nn.Module) -> DistributedDataParallel:
         """Wraps the model into a 'DistributedDataParallel' module."""
         # we should override this method to change the creation of `DistributedDataParallel`
-        return DistributedDataParallel(model, find_unused_parameters=True,
-                                       **self._ddp_kwargs)  # type: ignore
+        self._ddp_kwargs['find_unused_parameters'] = True
+        return DistributedDataParallel(model, **self._ddp_kwargs) # type: ignore

--- a/python/nano/src/bigdl/nano/pytorch/strategies/k8s.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/k8s.py
@@ -195,4 +195,5 @@ class DDPK8sStrategy(DDPStrategy):
     def _setup_model(self, model: nn.Module) -> DistributedDataParallel:
         """Wraps the model into a 'DistributedDataParallel' module."""
         # we should override this method to change the creation of `DistributedDataParallel`
-        return DistributedDataParallel(model, **self._ddp_kwargs)  # type: ignore
+        return DistributedDataParallel(model, find_unused_parameters=True,
+                                       **self._ddp_kwargs)  # type: ignore

--- a/python/nano/src/bigdl/nano/pytorch/strategies/k8s.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/k8s.py
@@ -195,5 +195,7 @@ class DDPK8sStrategy(DDPStrategy):
     def _setup_model(self, model: nn.Module) -> DistributedDataParallel:
         """Wraps the model into a 'DistributedDataParallel' module."""
         # we should override this method to change the creation of `DistributedDataParallel`
+        # we need to set `find_unused_parameters` to True to fix mult-instance training,
+        # `Trainer` will set it automatically, but `TorchNano` won't, so we set it manually
         self._ddp_kwargs['find_unused_parameters'] = True
         return DistributedDataParallel(model, **self._ddp_kwargs)   # type: ignore

--- a/python/nano/src/bigdl/nano/pytorch/strategies/k8s.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/k8s.py
@@ -196,4 +196,4 @@ class DDPK8sStrategy(DDPStrategy):
         """Wraps the model into a 'DistributedDataParallel' module."""
         # we should override this method to change the creation of `DistributedDataParallel`
         self._ddp_kwargs['find_unused_parameters'] = True
-        return DistributedDataParallel(model, **self._ddp_kwargs) # type: ignore
+        return DistributedDataParallel(model, **self._ddp_kwargs)   # type: ignore


### PR DESCRIPTION
## Description

Fix a bug of `TorchNano`'s multi-instance training, we need to set `find_unused_parameters=True` when creating DDP to fix this issue.

When using `Trainer`, it will set `find_unused_parameters=True` automatically, but `TorchNano` won't, so we set it manually

Some application which can runs in single process may report this error when running multi-instance training:
```
Traceback (most recent call last):
  File "train_nano.py", line 265, in <module>
    MyNano(use_ipex=True, distributed_backend='spawn', num_processes=2).train(ARGS)
  File "/root/miniconda3/envs/nano-dev/lib/python3.7/site-packages/pytorch_lightning/lite/lite.py", line 404, in _run_impl
    return self._strategy.launcher.launch(run_method, *args, **kwargs)
  File "/root/BigDL/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py", line 143, in launch
    while not context.join():
  File "/root/miniconda3/envs/nano-dev/lib/python3.7/site-packages/torch/multiprocessing/spawn.py", line 160, in join
    raise ProcessRaisedException(msg, error_index, failed_process.pid)
torch.multiprocessing.spawn.ProcessRaisedException: 

-- Process 0 terminated with the following error:
Traceback (most recent call last):
  File "/root/miniconda3/envs/nano-dev/lib/python3.7/site-packages/torch/multiprocessing/spawn.py", line 69, in _wrap
    fn(i, *args)
  File "/root/miniconda3/envs/nano-dev/lib/python3.7/site-packages/pytorch_lightning/strategies/launchers/spawn.py", line 101, in _wrapping_function
    results = function(*args, **kwargs)
  File "/root/miniconda3/envs/nano-dev/lib/python3.7/site-packages/pytorch_lightning/lite/lite.py", line 411, in _run_with_strategy_setup
    return run_method(*args, **kwargs)
  File "/root/DeepLearningExamples-nano/PyTorch/Forecasting/TFT/train_nano.py", line 121, in train
    predictions = ipex_model(batch)
  File "/root/miniconda3/envs/nano-dev/lib/python3.7/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/root/BigDL/python/nano/src/bigdl/nano/pytorch/torch_nano.py", line 87, in forward
    return super().forward(*args, **kwargs)
  File "/root/miniconda3/envs/nano-dev/lib/python3.7/site-packages/pytorch_lightning/lite/wrappers.py", line 105, in forward
    output = self.module(*args, **kwargs)
  File "/root/miniconda3/envs/nano-dev/lib/python3.7/site-packages/torch/nn/modules/module.py", line 1110, in _call_impl
    return forward_call(*input, **kwargs)
  File "/root/miniconda3/envs/nano-dev/lib/python3.7/site-packages/torch/nn/parallel/distributed.py", line 947, in forward
    if torch.is_grad_enabled() and self.reducer._rebuild_buckets():
RuntimeError: Expected to have finished reduction in the prior iteration before starting a new one. This error indicates that your module has parameters that were not used in producing loss. You can enable unused parameter detection by passing the keyword argument `find_unused_parameters=True` to `torch.nn.parallel.DistributedDataParallel`, and by 
making sure all `forward` function outputs participate in calculating loss. 
If you already have done the above, then the distributed data parallel module wasn't able to locate the output tensors in the return value of your module's `forward` function. Please include the loss function and the structure of the return value of `forward` of your module when reporting this issue (e.g. list, dict, iterable).
Parameter indices which did not receive grad for rank 0: 7 97 98 99 100 136 137 138 139
 In addition, you can set the environment variable TORCH_DISTRIBUTED_DEBUG to either INFO or DETAIL to print out information about which particular parameters did not receive gradient on this rank as part of this error
```