### PR TITLE
bigdl-submit support submit a pod template

### DIFF
--- a/python/nano/src/bigdl/nano/k8s/bigdl_submit.py
+++ b/python/nano/src/bigdl/nano/k8s/bigdl_submit.py
@@ -170,7 +170,7 @@ def _create_pod(pod_name: str,
 
     if pod_file_template_str is not None:
         pod_body = _deserialize_pod_object(pod_file_template_str,
-                                      api_client)
+                                           api_client)
         pod_body.metadata.name = pod_name
         pod_body.metadata.labels.update(pod_labels)
         pod_body.spec.containers[0].env.extend(envs)
@@ -181,17 +181,17 @@ def _create_pod(pod_name: str,
                 client.V1EnvVar(name=env[0], value=env[1]),
             )
         resource = client.V1ResourceRequirements(limits={"cpu": pod_cpu,
-                                                        "memory": pod_memory},
-                                                requests={"cpu": pod_cpu,
-                                                        "memory": pod_memory})
+                                                         "memory": pod_memory},
+                                                 requests={"cpu": pod_cpu,
+                                                           "memory": pod_memory})
         volumn_mounts = [_deserialize_volume_mounts_object(json_str, api_client)
-                        for json_str in volume_mount_strs]
+                         for json_str in volume_mount_strs]
         container = client.V1Container(name="pytorch",
-                                    image=image,
-                                    env=envs,
-                                    command=command,
-                                    resources=resource,
-                                    volume_mounts=volumn_mounts)
+                                       image=image,
+                                       env=envs,
+                                       command=command,
+                                       resources=resource,
+                                       volume_mounts=volumn_mounts)
 
         volumes = [_deserialize_volume_object(json_str, api_client) for json_str in volume_strs]
 
@@ -202,7 +202,6 @@ def _create_pod(pod_name: str,
                                 metadata=metadata,
                                 kind='Pod',
                                 spec=pod_spec)
-    
 
     return pod_body
 

--- a/python/nano/src/bigdl/nano/k8s/bigdl_submit.py
+++ b/python/nano/src/bigdl/nano/k8s/bigdl_submit.py
@@ -23,6 +23,7 @@ from typing import Dict, List, Callable, Optional
 import yaml
 import json
 from os import path
+from bigdl.nano.utils.log4Error import invalidInputError
 
 
 def _get_args_parser() -> ArgumentParser:
@@ -135,11 +136,13 @@ def _deserialize_pod_object(json_str: str, api_client: ApiClient) -> object:
     return api_client.deserialize(res, 'V1Pod')
 
 
-def _get_json_str_from_yaml_file(file_name):
+def _get_json_str_from_yaml_file(file_name: str) -> str:
     with open(path.abspath(file_name)) as f:
         yml_document_all = yaml.safe_load_all(f)
         for obj in yml_document_all:
             return json.dumps(obj)
+    
+    invalidInputError(False, "submitted yaml file is empty")
 
 
 def _create_pod(pod_name: str,
@@ -169,8 +172,8 @@ def _create_pod(pod_name: str,
     ]
 
     if pod_file_template_str is not None:
-        pod_body = _deserialize_pod_object(pod_file_template_str,
-                                           api_client)
+        pod_body: client.V1Pod = _deserialize_pod_object(pod_file_template_str,
+                                                         api_client)
         pod_body.metadata.name = pod_name
         pod_body.metadata.labels.update(pod_labels)
         pod_body.spec.containers[0].env.extend(envs)

--- a/python/nano/src/bigdl/nano/k8s/bigdl_submit.py
+++ b/python/nano/src/bigdl/nano/k8s/bigdl_submit.py
@@ -141,7 +141,7 @@ def _get_json_str_from_yaml_file(file_name: str) -> str:
         yml_document_all = yaml.safe_load_all(f)
         for obj in yml_document_all:
             return json.dumps(obj)
-    
+
     invalidInputError(False, "submitted yaml file is empty")
 
 

--- a/python/nano/src/bigdl/nano/k8s/bigdl_submit.py
+++ b/python/nano/src/bigdl/nano/k8s/bigdl_submit.py
@@ -136,13 +136,14 @@ def _deserialize_pod_object(json_str: str, api_client: ApiClient) -> object:
     return api_client.deserialize(res, 'V1Pod')
 
 
-def _get_json_str_from_yaml_file(file_name: str) -> str:
+def _get_json_str_from_yaml_file(file_name: str) -> Optional[str]:
     with open(path.abspath(file_name)) as f:
         yml_document_all = yaml.safe_load_all(f)
         for obj in yml_document_all:
             return json.dumps(obj)
 
     invalidInputError(False, "submitted yaml file is empty")
+    return None
 
 
 def _create_pod(pod_name: str,


### PR DESCRIPTION
## Description

bigdl-submit support submit a pod template

### 1. Why the change?

1. sometimes it is more convenient to define a yaml file than writing lone command
2. support k8s feature that is not directly supported in bigdl-submit 

### 2. User API changes

Users can user `--submit_pod_template` option to indicate that the main_script is a pod template yaml file.

e.g.
```bash
bigdl-submit --submit_pod_template --nnodes 2 pod_template.yaml
```
pod_template.yaml can be written as:
```yaml
kind: Pod
metadata:
  name: some-name
  labels:
    role: myrole
spec:
  containers:
    - name: pytorch-train
      image: docker.io/kubeflowkatib/pytorch-mnist:v1beta1-45c5727
      command: ["python"]
      args: ["/opt/pytorch-mnist/mnist.py", "--epochs=1"]
      env:
      - name: http_proxy
        value: http://host:port
      - name: https_proxy
        value: http://host:port
      resources:
        requests:
          memory: "40G"
          cpu: "40"
        limits:
          memory: "40G"
          cpu: "40"
    
```

bigdl-submit command will override `metadata.name` and append appropriate values in `metadata.labels` and `spec.containers[0].env`

### 3. Summary of the change 

local changes in `bigdl_submit.py`

### 4. How to test?
- [x] manually tested it

### 5. New dependencies
None