### PR TITLE
[Orca] Support load model instead of  `model_creator` in tf2 ray estimator

### DIFF
--- a/python/orca/src/bigdl/orca/learn/tf2/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/estimator.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class Estimator(object):
     @staticmethod
     def from_keras(*,
-                   model_creator,
+                   model_creator=None,
                    config=None,
                    verbose=False,
                    workers_per_node=1,
@@ -64,9 +64,10 @@ class Estimator(object):
         """
         if backend in {"ray", "horovod"}:
             from bigdl.orca.learn.tf2.ray_estimator import TensorFlow2Estimator
-            return TensorFlow2Estimator(model_creator=model_creator, config=config,
-                                        verbose=verbose, workers_per_node=workers_per_node,
-                                        backend=backend, compile_args_creator=compile_args_creator,
+            return TensorFlow2Estimator(model_creator=model_creator,
+                                        config=config, verbose=verbose,
+                                        workers_per_node=workers_per_node, backend=backend,
+                                        compile_args_creator=compile_args_creator,
                                         cpu_binding=cpu_binding)
         elif backend == "spark":
             if cpu_binding:

--- a/python/orca/src/bigdl/orca/learn/tf2/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/estimator.py
@@ -64,10 +64,9 @@ class Estimator(object):
         """
         if backend in {"ray", "horovod"}:
             from bigdl.orca.learn.tf2.ray_estimator import TensorFlow2Estimator
-            return TensorFlow2Estimator(model_creator=model_creator,
-                                        config=config, verbose=verbose,
-                                        workers_per_node=workers_per_node, backend=backend,
-                                        compile_args_creator=compile_args_creator,
+            return TensorFlow2Estimator(model_creator=model_creator, config=config,
+                                        verbose=verbose, workers_per_node=workers_per_node,
+                                        backend=backend, compile_args_creator=compile_args_creator,
                                         cpu_binding=cpu_binding)
         elif backend == "spark":
             if cpu_binding:

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -87,7 +87,6 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                 "config": self.config,
                 "verbose": self.verbose,
             }
-        
 
         if backend == "ray":
             cores_per_node = ray_ctx.ray_node_cpu_cores // workers_per_node

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -74,12 +74,20 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                               "compile_args_creator should not be None,"
                               " when backend is set to horovod")
 
-        params = {
-            "model_creator": model_creator,
-            "compile_args_creator": compile_args_creator,
-            "config": self.config,
-            "verbose": self.verbose,
-        }
+        if self.model_creator is not None:
+            params = {
+                "model_creator": self.model_creator,
+                "compile_args_creator": self.compile_args_creator,
+                "config": self.config,
+                "verbose": self.verbose,
+            }
+        else:
+            params = {
+                "compile_args_creator": self.compile_args_creator,
+                "config": self.config,
+                "verbose": self.verbose,
+            }
+        
 
         if backend == "ray":
             cores_per_node = ray_ctx.ray_node_cpu_cores // workers_per_node

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -57,6 +57,10 @@ class TensorFlow2Estimator(OrcaRayEstimator):
         self.config = {} if config is None else config
         self.verbose = verbose
 
+        if self.model_creator is None:
+            logger.warning("Please use load function of the estimator to load model when"
+                           " model_creator is None.")
+
         ray_ctx = OrcaRayContext.get()
         if "batch_size" in self.config:
             invalidInputError(False,
@@ -72,21 +76,14 @@ class TensorFlow2Estimator(OrcaRayEstimator):
         if backend == "horovod":
             invalidInputError(compile_args_creator is not None,
                               "compile_args_creator should not be None,"
-                              " when backend is set to horovod")
+                              " when backend is set to horovod.")
 
-        if self.model_creator is not None:
-            params = {
-                "model_creator": self.model_creator,
-                "compile_args_creator": self.compile_args_creator,
-                "config": self.config,
-                "verbose": self.verbose,
-            }
-        else:
-            params = {
-                "compile_args_creator": self.compile_args_creator,
-                "config": self.config,
-                "verbose": self.verbose,
-            }
+        params = {
+            "model_creator": self.model_creator,
+            "compile_args_creator": self.compile_args_creator,
+            "config": self.config,
+            "verbose": self.verbose,
+        }
 
         if backend == "ray":
             cores_per_node = ray_ctx.ray_node_cpu_cores // workers_per_node

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -379,7 +379,7 @@ class TFRunner:
         invalidInputError(hasattr(self, "model"),
                           "The model has not yet been created. "
                           "Please input a model_creator when creating estimator "
-                          "or use load function of the estimator to load a model")
+                          "or use load function of the estimator to load a model.")
 
         history = self.model.fit(train_dataset,
                                  epochs=self.epoch + epochs,
@@ -441,7 +441,7 @@ class TFRunner:
         invalidInputError(hasattr(self, "model"),
                           "The model has not yet been created. "
                           "Please input a model_creator when creating estimator "
-                          "or use load function of the estimator to load a model")
+                          "or use load function of the estimator to load a model.")
 
         results = self.model.evaluate(dataset, **params)
         if results is None:
@@ -489,7 +489,7 @@ class TFRunner:
         invalidInputError(hasattr(self, "model"),
                           "The model has not yet been created. "
                           "Please input a model_creator when creating estimator "
-                          "or use load function of the estimator to load a model")
+                          "or use load function of the estimator to load a model.")
 
         if self.backend == "tf-distributed" and self.model_creator is not None:
             local_model = self.model_creator(self.config)
@@ -523,7 +523,7 @@ class TFRunner:
         invalidInputError(hasattr(self, "model"),
                           "The model has not yet been created. "
                           "Please input a model_creator when creating estimator "
-                          "or use load function of the estimator to load a model")
+                          "or use load function of the estimator to load a model.")
         return {
             "epoch": self.epoch,
             "weights": self.model.get_weights(),

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -376,6 +376,12 @@ class TFRunner:
         if callbacks:
             replaced_log_dir = process_tensorboard_in_callbacks(callbacks, "fit", self.rank)
 
+        if self.model is None:
+            invalidInputError(False,
+                              "The model has not yet been created. "
+                              "Please input a model_creator when creating estimator "
+                              "or use load function of the estimator to load a model")
+
         history = self.model.fit(train_dataset,
                                  epochs=self.epoch + epochs,
                                  verbose=verbose,
@@ -432,6 +438,13 @@ class TFRunner:
             steps=steps,
             callbacks=callbacks,
         )
+
+        if self.model is None:
+            invalidInputError(False,
+                              "The model has not yet been created. "
+                              "Please input a model_creator when creating estimator "
+                              "or use load function of the estimator to load a model")
+
         results = self.model.evaluate(dataset, **params)
         if results is None:
             # Using local Model since model.evaluate() returns None
@@ -475,6 +488,12 @@ class TFRunner:
             callbacks=callbacks,
         )
 
+        if self.model is None:
+            invalidInputError(False,
+                              "The model has not yet been created. "
+                              "Please input a model_creator when creating estimator "
+                              "or use load function of the estimator to load a model")
+
         if self.backend == "tf-distributed" and self.model_creator is not None:
             local_model = self.model_creator(self.config)
             try:
@@ -504,6 +523,11 @@ class TFRunner:
 
     def get_state(self):
         """Returns the state of the runner."""
+        if self.model is None:
+            invalidInputError(False,
+                              "The model has not yet been created. "
+                              "Please input a model_creator when creating estimator "
+                              "or use load function of the estimator to load a model")
         return {
             "epoch": self.epoch,
             "weights": self.model.get_weights(),

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -350,7 +350,7 @@ class TFRunner:
         config["batch_size"] = batch_size
 
         with self.strategy.scope():
-            dataset_handler = DatasetHandler.ge1t_handler(self.backend, self.rank, self.size)
+            dataset_handler = DatasetHandler.get_handler(self.backend, self.rank, self.size)
             train_dataset, test_dataset = dataset_handler \
                 .handle_datasets_train(data_creator,
                                        validation_data_creator,
@@ -439,9 +439,6 @@ class TFRunner:
             logger.warning("Running a local model to get validation score.")
             if self.model_creator is not None:
                 self.local_model = self.model_creator(self.config)
-                self.local_model.set_weights(self.model.get_weights())
-            else:
-                self.local_model = self.tf_model
                 self.local_model.set_weights(self.model.get_weights())
             results = self.local_model.evaluate(dataset, **params)
 

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -236,8 +236,8 @@ class TFRunner:
     """Manages a TensorFlow model for training."""
 
     def __init__(self,
-                 model_creator,
-                 compile_args_creator,
+                 model_creator=None,
+                 compile_args_creator=None,
                  config=None,
                  verbose=False):
         """Initializes the runner.

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -376,11 +376,10 @@ class TFRunner:
         if callbacks:
             replaced_log_dir = process_tensorboard_in_callbacks(callbacks, "fit", self.rank)
 
-        if self.model is None:
-            invalidInputError(False,
-                              "The model has not yet been created. "
-                              "Please input a model_creator when creating estimator "
-                              "or use load function of the estimator to load a model")
+        invalidInputError(hasattr(self, "model"),
+                          "The model has not yet been created. "
+                          "Please input a model_creator when creating estimator "
+                          "or use load function of the estimator to load a model")
 
         history = self.model.fit(train_dataset,
                                  epochs=self.epoch + epochs,
@@ -439,11 +438,10 @@ class TFRunner:
             callbacks=callbacks,
         )
 
-        if self.model is None:
-            invalidInputError(False,
-                              "The model has not yet been created. "
-                              "Please input a model_creator when creating estimator "
-                              "or use load function of the estimator to load a model")
+        invalidInputError(hasattr(self, "model"),
+                          "The model has not yet been created. "
+                          "Please input a model_creator when creating estimator "
+                          "or use load function of the estimator to load a model")
 
         results = self.model.evaluate(dataset, **params)
         if results is None:
@@ -488,11 +486,10 @@ class TFRunner:
             callbacks=callbacks,
         )
 
-        if self.model is None:
-            invalidInputError(False,
-                              "The model has not yet been created. "
-                              "Please input a model_creator when creating estimator "
-                              "or use load function of the estimator to load a model")
+        invalidInputError(hasattr(self, "model"),
+                          "The model has not yet been created. "
+                          "Please input a model_creator when creating estimator "
+                          "or use load function of the estimator to load a model")
 
         if self.backend == "tf-distributed" and self.model_creator is not None:
             local_model = self.model_creator(self.config)
@@ -523,11 +520,10 @@ class TFRunner:
 
     def get_state(self):
         """Returns the state of the runner."""
-        if self.model is None:
-            invalidInputError(False,
-                              "The model has not yet been created. "
-                              "Please input a model_creator when creating estimator "
-                              "or use load function of the estimator to load a model")
+        invalidInputError(hasattr(self, "model"),
+                          "The model has not yet been created. "
+                          "Please input a model_creator when creating estimator "
+                          "or use load function of the estimator to load a model")
         return {
             "epoch": self.epoch,
             "weights": self.model.get_weights(),

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
@@ -737,7 +737,7 @@ class TestTFRayEstimator(TestCase):
         finally:
             shutil.rmtree(temp_dir)
     
-    def test_load_model(self):   
+    def test_optional_model_creator(self):   
         sc = OrcaContext.get_spark_context()
         rdd = sc.range(0, 100)
         spark = OrcaContext.get_spark_session()

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
@@ -770,6 +770,7 @@ class TestTFRayEstimator(TestCase):
 
             before_res = trainer.predict(df, feature_cols=["feature"]).collect()
             expect_res = np.concatenate([part["prediction"] for part in before_res])
+            trainer.shutdown()
 
             est = Estimator.from_keras(
                 verbose=True,

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
@@ -736,6 +736,55 @@ class TestTFRayEstimator(TestCase):
             assert np.array_equal(expect_res, pred_res)
         finally:
             shutil.rmtree(temp_dir)
+    
+    def test_load_model(self):   
+        sc = OrcaContext.get_spark_context()
+        rdd = sc.range(0, 100)
+        spark = OrcaContext.get_spark_session()
+
+        from pyspark.ml.linalg import DenseVector
+        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float)),
+                                int(np.random.randint(0, 2, size=())))).toDF(["feature", "label"])
+
+        config = {
+            "lr": 0.2
+        }
+
+        try:
+            temp_dir = tempfile.mkdtemp()
+
+            trainer = Estimator.from_keras(
+                model_creator=model_creator,
+                verbose=True,
+                config=config,
+                workers_per_node=3,
+                backend="ray")
+
+            res = trainer.fit(df, epochs=5, batch_size=4, steps_per_epoch=25,
+                              feature_cols=["feature"],
+                              label_cols=["label"],
+                              validation_data=df,
+                              validation_steps=1)
+
+            trainer.save(os.path.join(temp_dir, "cifar10.h5"))
+
+            before_res = trainer.predict(df, feature_cols=["feature"]).collect()
+            expect_res = np.concatenate([part["prediction"] for part in before_res])
+
+            est = Estimator.from_keras(
+                verbose=True,
+                config=config,
+                workers_per_node=3,
+                backend="ray")
+
+            est.load(os.path.join(temp_dir, "cifar10.h5"))
+
+            after_res = est.predict(df, feature_cols=["feature"]).collect()
+            pred_res = np.concatenate([part["prediction"] for part in after_res])
+
+            assert np.array_equal(expect_res, pred_res)
+        finally:
+            shutil.rmtree(temp_dir)
 
     def test_save_load_model_weights_h5(self):
         sc = OrcaContext.get_spark_context()


### PR DESCRIPTION
## Description
This PR refactor tf2 ray estimator to support users loading a saved model instead of defining a `model_creator`.


### 1. Why the change?
Some users want to load the model directly but not define a `model_creator`, we could only provide a workaround solution to them and that's really not user-friendly.


### 2. User API changes
The new API accepts `moedl_creator` as None, which will not create a model until users load the model through `load()` API.
```python
trainer= estimator.from_keras(
    workers_per_node=3,
    backend="ray")

trainer.load("/path/to/model.h5")

trainer.predict(df,  feature_cols)
```

### 3. Summary of the change 
Refactor `model_creator` as an optional, users could load their saved model through `estimator.load()`.

### 4. How to test?
- [x] Unit test
- [x] Application test

