### PR TITLE
[PPML] Remove remaining enclave key in k8s yaml

### DIFF
--- a/ppml/trusted-big-data-ml/python/docker-gramine/kubernetes/bigdl-ppml-helm/templates/spark-job.yaml
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/kubernetes/bigdl-ppml-helm/templates/spark-job.yaml
@@ -77,9 +77,6 @@ spec:
             mountPath: /dev/gsgx
           - name: aesm-socket
             mountPath: /var/run/aesmd/aesm.socket
-          - name: enclave-key
-            mountPath: /root/.config/gramine/enclave-key.pem
-            subPath: enclave-key.pem
           - name: secure-keys
             mountPath: /ppml/trusted-big-data-ml/work/keys
           - name: secure-password


### PR DESCRIPTION
## Description

There is still a encalve-key section remained in spark k8s job yaml, which is outdated in gramine now.

### 1. Why the change?

Fix bug.

### 2. User API changes

None.

### 3. Summary of the change 

Remove remaining enclave key in k8s yaml

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...