### PR TITLE
Move dirs required by bash.manifest to first layer

### DIFF
--- a/ppml/base/Dockerfile
+++ b/ppml/base/Dockerfile
@@ -94,8 +94,13 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     rm jdk-$JDK_VERSION-linux-x64.tar && \
     mv /opt/jdk* /opt/jdk8 && \
     ln -s /opt/jdk8 /opt/jdk && \
-# related dirs
-    mkdir -p /root/.cache/
+# related dirs required by bash.manifest
+    mkdir -p /root/.cache/ && \
+    mkdir -p /root/.keras/datasets && \
+    mkdir -p /root/.zinc && \
+    mkdir -p /root/.m2 && \
+    mkdir -p /root/.kube/
+
 
 ADD ./download_jars.sh /ppml
 

--- a/ppml/trusted-deep-learning/base/Dockerfile
+++ b/ppml/trusted-deep-learning/base/Dockerfile
@@ -16,13 +16,8 @@ ARG CMAKE_PREFIX_PATH="/usr/local/lib/python3.7/dist-packages/:/usr/local/lib/"
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin/tini
 ADD ./entrypoint.sh /opt/entrypoint.sh
 
-# Folders required by bash.menifest.template
-RUN mkdir -p /root/.keras/datasets && \
-    mkdir -p /root/.zinc && \
-    mkdir -p /root/.m2 && \
-    mkdir -p /root/.kube/ && \
-    # PyTorch dependencies
-    env DEBIAN_FRONTEND=noninteractive apt-get update && \
+# PyTorch Dependencies
+RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get install -y libssl-dev && \
     pip install --no-cache-dir astunparse numpy ninja pyyaml setuptools cmake cffi typing_extensions future six requests dataclasses mkl mkl-include intel-openmp && \
     pip install --no-cache-dir torchvision==0.13.1 && \


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

Move the following four folders from second layer into the first layer.
```bash
    mkdir -p /root/.keras/datasets && \
    mkdir -p /root/.zinc && \
    mkdir -p /root/.m2 && \
    mkdir -p /root/.kube/
```
So that when we want to add folders into the bash.manifest.template, we do not need to modify Dockerfile in second layer.
