### PR TITLE
[Doc] Move in-file toc to yml file except for API related toc

### DIFF
--- a/docs/readthedocs/source/_toc.yml
+++ b/docs/readthedocs/source/_toc.yml
@@ -94,6 +94,23 @@ subtrees:
                   - file: doc/Nano/QuickStart/tensorflow_quantization_quickstart
             - file: doc/Nano/Howto/index
               title: "How-to Guides"
+              subtrees:
+                - entries:
+                  - file: doc/Nano/Howto/Training/PyTorchLightning/accelerate_pytorch_lightning_training_ipex
+                  - file: doc/Nano/Howto/Training/PyTorchLightning/accelerate_pytorch_lightning_training_multi_instance
+                  - file: doc/Nano/Howto/Training/PyTorchLightning/pytorch_lightning_training_channels_last
+                  - file: doc/Nano/Howto/Training/PyTorchLightning/pytorch_lightning_training_bf16
+                  - file: doc/Nano/Howto/Training/PyTorchLightning/pytorch_lightning_cv_data_pipeline
+                  - file: doc/Nano/Howto/Training/TensorFlow/accelerate_tensorflow_training_multi_instance
+                  - file: doc/Nano/Howto/Training/TensorFlow/tensorflow_training_embedding_sparseadam
+                  - file: doc/Nano/Howto/Training/General/choose_num_processes_training
+                  - file: doc/Nano/Howto/Inference/PyTorch/accelerate_pytorch_inference_onnx
+                  - file: doc/Nano/Howto/Inference/PyTorch/accelerate_pytorch_inference_openvino
+                  - file: doc/Nano/Howto/Inference/PyTorch/quantize_pytorch_inference_inc
+                  - file: doc/Nano/Howto/Inference/PyTorch/quantize_pytorch_inference_pot
+                  - file: doc/Nano/Howto/Inference/PyTorch/inference_optimizer_optimize
+                  - file: doc/Nano/Howto/install_in_colab
+                  - file: doc/Nano/Howto/windows_guide
             - file: doc/Nano/Overview/known_issues
               title: "Tips and Known Issues"
             - file: doc/PythonAPI/Nano/index
@@ -140,8 +157,27 @@ subtrees:
             title: "Installation"
           - file: doc/Chronos/Overview/deep_dive
             title: "Key Features"
+            subtrees:
+              - entries:
+                - file: doc/Chronos/Overview/data_processing_feature_engineering
+                - file: doc/Chronos/Overview/forecasting
+                - file: doc/Chronos/Overview/anomaly_detection
+                - file: doc/Chronos/Overview/simulation
+                - file: doc/Chronos/Overview/speed_up
+                - file: doc/Chronos/Overview/useful_functionalities
           - file: doc/Chronos/Howto/index
             title: "How-to Guides"
+            subtrees:
+              - entries:
+                - file: doc/Chronos/Howto/windows_guide
+                - file: doc/Chronos/Howto/docker_guide_single_node
+                - file: doc/Chronos/Howto/how_to_create_forecaster
+                - file: doc/Chronos/Howto/how_to_train_forecaster_on_one_node
+                - file: doc/Chronos/Howto/how_to_tune_forecaster_model
+                - file: doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_ONNXRuntime
+                - file: doc/Chronos/Howto/how_to_speedup_inference_of_forecaster_through_OpenVINO
+                - file: doc/Chronos/Howto/how_to_evaluate_a_forecaster
+                - file: doc/Chronos/Howto/how_to_generate_confidence_interval_for_prediction
           - file: doc/Chronos/QuickStart/index
             title: "Tutorials"
             subtrees:

--- a/docs/readthedocs/source/doc/Chronos/Howto/index.rst
+++ b/docs/readthedocs/source/doc/Chronos/Howto/index.rst
@@ -8,13 +8,6 @@ Install
 * `Install Chronos on Windows <windows_guide.html>`__
 * `Use Chronos in container(docker) <docker_guide_single_node.html>`__
 
-.. toctree::
-    :maxdepth: 1
-    :hidden:
-
-    windows_guide
-    docker_guide_single_node
-
 Forecasting
 -------------------------
 * `Create a forecaster <how_to_create_forecaster.html>`__
@@ -24,16 +17,3 @@ Forecasting
 * `Speed up inference of forecaster through OpenVINO <how_to_speedup_inference_of_forecaster_through_OpenVINO.html>`__
 * `Evaluate a forecaster <how_to_evaluate_a_forecaster.html>`__
 * `Generate confidence interval for prediction <how_to_generate_confidence_interval_for_prediction.html>`__
-
-.. toctree::
-    :maxdepth: 1
-    :hidden:
-
-    how_to_create_forecaster
-    how_to_train_forecaster_on_one_node
-    how_to_tune_forecaster_model
-    how_to_speedup_inference_of_forecaster_through_ONNXRuntime
-    how_to_speedup_inference_of_forecaster_through_OpenVINO
-    how_to_evaluate_a_forecaster
-    how_to_generate_confidence_interval_for_prediction
-

--- a/docs/readthedocs/source/doc/Chronos/Overview/deep_dive.rst
+++ b/docs/readthedocs/source/doc/Chronos/Overview/deep_dive.rst
@@ -7,14 +7,3 @@ Chronos Deep Dive
 * `Generate Synthetic Sequential Data <simulation.html>`__ introduces how to build a series data generation application.
 * `Speed up Chronos built-in/customized models <speed_up.html>`__ introduces how to speed up chronos built-in models/customized time-series models
 * `Useful Functionalities <useful_functionalities.html>`__ introduces some functionalities provided by Chronos that can help you improve accuracy/performance or scale the application to a larger data. 
-
-.. toctree::
-    :maxdepth: 1
-    :hidden:
-
-    data_processing_feature_engineering.md
-    forecasting.md
-    anomaly_detection.md
-    simulation.md
-    speed_up.md
-    useful_functionalities.md

--- a/docs/readthedocs/source/doc/Nano/Howto/index.rst
+++ b/docs/readthedocs/source/doc/Nano/Howto/index.rst
@@ -16,16 +16,6 @@ PyTorch Lightning
 * `How to conduct BFloat16 Mixed Precision training in your PyTorch Lightning application <Training/PyTorchLightning/pytorch_lightning_training_bf16.html>`_
 * `How to accelerate a computer vision data processing pipeline <Training/PyTorchLightning/pytorch_lightning_cv_data_pipeline.html>`_
 
-.. toctree::
-    :maxdepth: 1
-    :hidden:
-
-    Training/PyTorchLightning/accelerate_pytorch_lightning_training_ipex
-    Training/PyTorchLightning/accelerate_pytorch_lightning_training_multi_instance
-    Training/PyTorchLightning/pytorch_lightning_training_channels_last
-    Training/PyTorchLightning/pytorch_lightning_training_bf16
-    Training/PyTorchLightning/pytorch_lightning_cv_data_pipeline
-
 TensorFlow
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 * `How to accelerate a TensorFlow Keras application on training workloads through multiple instances <Training/TensorFlow/accelerate_tensorflow_training_multi_instance.html>`_
@@ -34,23 +24,9 @@ TensorFlow
 .. |tensorflow_training_embedding_sparseadam_link| replace:: How to optimize your model with a sparse ``Embedding`` layer and ``SparseAdam`` optimizer
 .. _tensorflow_training_embedding_sparseadam_link: Training/TensorFlow/tensorflow_training_embedding_sparseadam.html
 
-.. toctree::
-    :maxdepth: 1
-    :hidden:
-
-    Training/TensorFlow/accelerate_tensorflow_training_multi_instance
-    Training/TensorFlow/tensorflow_training_embedding_sparseadam
-
 General
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 * `How to choose the number of processes for multi-instance training <Training/General/choose_num_processes_training.html>`_
-
-.. toctree::
-    :maxdepth: 1
-    :hidden:
-
-    Training/General/choose_num_processes_training
-
 
 Inference Optimization
 -------------------------
@@ -64,24 +40,7 @@ PyTorch
 * `How to quantize your PyTorch model for inference using OpenVINO Post-training Optimization Tools <Inference/PyTorch/quantize_pytorch_inference_pot.html>`_
 * `How to find accelerated method with minimal latency using InferenceOptimizer <Inference/PyTorch/inference_optimizer_optimize.html>`_
 
-.. toctree::
-    :maxdepth: 1
-    :hidden:
-
-    Inference/PyTorch/accelerate_pytorch_inference_onnx
-    Inference/PyTorch/accelerate_pytorch_inference_openvino
-    Inference/PyTorch/quantize_pytorch_inference_inc
-    Inference/PyTorch/quantize_pytorch_inference_pot
-    Inference/PyTorch/inference_optimizer_optimize
-
 Install
 -------------------------
 * `How to install BigDL-Nano in Google Colab <install_in_colab.html>`_
 * `How to install BigDL-Nano on Windows <windows_guide.html>`_
-
-.. toctree::
-    :maxdepth: 1
-    :hidden:
-
-    install_in_colab
-    windows_guide


### PR DESCRIPTION
Move in-file toc to _toc.yml files for better maintenance purposes.

For API docs, toc are still in corresponding files as these toc lists are needed to shown in API index pages.

Document test: https://yuwentestdocs.readthedocs.io/en/move-toc-to-yml/