### PR TITLE
Document: fix Chronos installation panel line overflow bug.

### DIFF
--- a/docs/readthedocs/source/_static/css/chronos_installation_guide.css
+++ b/docs/readthedocs/source/_static/css/chronos_installation_guide.css
@@ -42,8 +42,11 @@
     cursor: pointer;
 }
 
-#cmd {
-    width: auto;
-    height: 35px;
-    overflow:unset;
+#table-1 #cmd {
+    height: 2em;
+    text-align: left;
+}
+
+#table-1 .taller_tr {
+    height: 71px;
 }

--- a/docs/readthedocs/source/_static/js/chronos_installation_guide.js
+++ b/docs/readthedocs/source/_static/js/chronos_installation_guide.js
@@ -43,7 +43,7 @@ function refresh_cmd(){
     $("#model").empty();
     if(functionality=="Forecasting"){
         $("#model").append("<td colspan='1'>Model</td>\
-        <td colspan='1'><button id='Deep_learning_models' style='font-size: 13px;'>Deep learning models</button></td>\
+        <td colspan='1'><button id='Deep_learning_models'>Deep learning models</button></td>\
         <td colspan='2'><button id='Prophet'>Prophet</button></td>\
         <td colspan='1'><button id='ARIMA'>ARIMA</button></td>");
     }

--- a/docs/readthedocs/source/doc/Chronos/Overview/install.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/install.md
@@ -35,20 +35,20 @@ Select your preferences in the panel below to find the proper install command. T
 
         <table id="table-1">
             <tbody>
-                <tr>
+                <tr class="taller_tr">
                     <td colspan="1">Functionality</td>
                     <td colspan="1"><button id="Forecasting">Forecasting</button></td>
                     <td colspan="2"><button id="Anomaly" style="font-size: 15px">Anomaly Detection</button></td>
                     <td colspan="1"><button id="Simulation">Simulation</button></td>
                 </tr>
-                <tr id="model">
+                <tr id="model" class="taller_tr">
                     <td colspan="1">Model</td>
                     <td colspan="1"><button id="Deep_learning_models" style="font-size: 13px;">Deep learning models</button></td>
                     <td colspan="2"><button id="Prophet">Prophet</button></td>
                     <td colspan="1"><button id="ARIMA">ARIMA</button></td>
                 </tr>
                 <tr>
-                    <td colspan="1">DL<br>framework</td>
+                    <td colspan="1">DL&nbsp;framework</td>
                     <td colspan="2"><button id="pytorch"
                             title="Use PyTorch as deep learning models' backend. Most of the model support and works better under PyTorch.">PyTorch (Recommended)</button>
                     </td>
@@ -92,11 +92,9 @@ Select your preferences in the panel below to find the proper install command. T
                             title="For users would like to deploy chronos in their production">Stable (2.1.0)</button></td>
                 </tr>
 
-                <tr>
+                <tr class="taller_tr">
                     <td colspan="1">Install CMD</td>
-                    <td colspan="4">
-                        <div id="cmd" style="text-align: left;">NA</div>
-                    </td>
+                    <td colspan="4" id="cmd">NA</td>
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
## Description

Fixed an overflow issue that caused by installation prompt given to be too long and needed to wrap when a specific combination of options was selected.

The preview link is [here](https://andytestdoc.readthedocs.io/en/table_issue/doc/Chronos/Overview/install.html), please choose `Forecasting` -- `ARIMA` -- Auto Tuning`Yes` to see the fix of newline overflow.