### PR TITLE
[PPML] Modify image to support pert model

### DIFF
--- a/.github/workflows/manually_build.yml
+++ b/.github/workflows/manually_build.yml
@@ -155,6 +155,7 @@ jobs:
           --build-arg https_proxy=${HTTPS_PROXY} \
           --build-arg no_proxy=${NO_PROXY} \
           --build-arg BASE_IMAGE_NAME=${base_image} \
+          --build-arg SGX_MEM_SIZE=64G \
           --build-arg BASE_IMAGE_TAG=${TAG} \
           -t ${image}:${TAG} -f ./Dockerfile .
         sudo docker push ${image}:${TAG}

--- a/ppml/trusted-deep-learning/ref/Dockerfile
+++ b/ppml/trusted-deep-learning/ref/Dockerfile
@@ -27,12 +27,16 @@ COPY --from=temp /ppml/bash.manifest /ppml/bash.manifest
 ADD ./mnist.py /ppml/mnist.py
 ADD ./pert.py  /ppml/pert.py
 
+# Small patch to fix dataasets
+ADD ./filelock.patch /filelock.patch
+
 # 2.2 output mr_enclave and mr_signer to customer
 RUN cd /ppml && \
     echo "[INFO] Use the below hash values of mr_enclave and mr_signer to register enclave:" && \
     gramine-sgx-quote-dump -m bash.sig|grep mr_enclave && \
     gramine-sgx-quote-dump -m bash.sig|grep mr_signer && \
-    pip3 install --no-cache datasets transformers
+    pip3 install --no-cache datasets==2.6.1 transformers pyarrow==6.0.1 && \
+    patch /usr/local/lib/python3.7/dist-packages/datasets/utils/filelock.py /filelock.patch
 
 WORKDIR /ppml
 

--- a/ppml/trusted-deep-learning/ref/filelock.patch
+++ b/ppml/trusted-deep-learning/ref/filelock.patch
@@ -1,0 +1,9 @@
+407c407
+<             fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+---
+>             fcntl.lockf(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+421c421
+<         fcntl.flock(fd, fcntl.LOCK_UN)
+---
+>         fcntl.lockf(fd, fcntl.LOCK_UN)
+


### PR DESCRIPTION
## Description

Modify bigdl-ppml-trusted-deep-learning-gramine-ref image to support training PERT model

### 1. Why the change?
There are three changes required in total:
1. Change FileLock to use lockf instead of flock.
2. Change to use pyarrow 6.0.1
3. Increase SGX_MEM_SIZE

Gramine only supports **fnctl** file lock.  However, the load_datasets function in the huggingface **datasets** interface choose to use the **flock** file lock.  This is done by applying a patch


The reason why we need pyarrow version 6.0.1 is related to this issue:
`https://github.com/huggingface/datasets/issues/3310`
There are two ways to solve this problem:

Pin aws-sdk-cpp=1.8.186, but only works in Conda
Or downgrade pyarrow to 6.0.1.

We choose the second.


The reason why we need to increase SGX_MEM_SIZE is that the memory is not enough when batch-size is 16. 
However, it works when batch size is 8.  We want to change this and check again see if it works in batch-size 16.

### 2. User API changes
None.


### 3. How to test?
- [x] Manually build
- [ ] Unit test
- [ ] Application test
- [ ] Document test
