### PR TITLE
[PPML] Attestation policy ID kubernetes secret

### DIFF
--- a/ppml/README.md
+++ b/ppml/README.md
@@ -367,7 +367,7 @@ To build your own Big Data & AI applications, refer to [develop your own Big Dat
               secretKeyRef:
                 name: kms-secret
                 key: app_key
-          - name: POLICY_ID
+          - name: ATTESTATION_POLICYID
             valueFrom:
               secretKeyRef:
                 name: policy-id-secret

--- a/ppml/README.md
+++ b/ppml/README.md
@@ -248,7 +248,7 @@ To build your own Big Data & AI applications, refer to [develop your own Big Dat
 
 2. Enable attestation
     The bi-attestation gurantees that the MREnclave in runtime containers is a secure one made by you. Its workflow is as below:
-    ![image](https://user-images.githubusercontent.com/60865256/197942524-85a52f73-cf1a-49b3-bd1c-175d130f93e4.png)
+    ![image](https://user-images.githubusercontent.com/60865256/198168194-d62322f8-60a3-43d3-84b3-a76b57a58470.png)
     
     To enable attestation, first you should have a running Attestation Service in your environment. 
 

--- a/ppml/README.md
+++ b/ppml/README.md
@@ -7,12 +7,11 @@ Protecting privacy and confidentiality is critical for large-scale data analysis
 &ensp;&ensp;[3.1 BigDL PPML Hello World](#31-bigdl-ppml-hello-world) \
 &ensp;&ensp;[3.2 BigDL PPML End-to-End Workflow](#32-bigdl-ppml-end-to-end-workflow) \
 &ensp;&ensp;&ensp;&ensp;&ensp;&ensp;[Step 0. Preparation your environment](#step-0-preparation-your-environment): detailed steps in [Prepare Environment](https://github.com/liu-shaojun/BigDL/blob/ppml_doc/ppml/docs/prepare_environment.md) \
-&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;[Step 1. Build your PPML image for production environment](#step-1-build-your-ppml-image-for-production-environment) \
-&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;[Step 2. Encrypt and Upload Data](#step-2-encrypt-and-upload-data) \
-&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;[Step 3. Build Big Data & AI applications](#step-3-build-big-data--ai-applications) \
-&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;[Step 4. Attestation ](#step-4-attestation) \
-&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;[Step 5. Submit Job](#step-5-submit-job): 4 deploy modes and 2 options to submit job  \
-&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;[Step 6. Decrypt and Read Result](#step-6-decrypt-and-read-result) \
+&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;[Step 1. Encrypt and Upload Data](#step-1-encrypt-and-upload-data) \
+&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;[Step 2. Build Big Data & AI applications](#step-2-build-big-data--ai-applications) \
+&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;[Step 3. Attestation ](#step-3-attestation) \
+&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;[Step 4. Submit Job](#step-4-submit-job): 4 deploy modes and 2 options to submit job  \
+&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;[Step 5. Decrypt and Read Result](#step-5-decrypt-and-read-result) \
 &ensp;&ensp;[3.3 More BigDL PPML Examples](#33-more-bigdl-ppml-examples) \
 [4. Develop your own Big Data & AI applications with BigDL PPML](#4-develop-your-own-big-data--ai-applications-with-bigdl-ppml) \
 &ensp;&ensp;[4.1 Create PPMLContext](#41-create-ppmlcontext) \
@@ -68,7 +67,7 @@ In this section, you can get started with running a simple native python HelloWo
 
 For demo purpose, we will skip building the custom image here and use the public reference image provided by BigDL PPML `intelanalytics/bigdl-ppml-trusted-big-data-ml-python-gramine-reference:2.2.0-SNAPSHOT` to have a quick start.
 
-Note: This public image is only for demo purposes, it is non-production. For security concern, you are strongly recommended to generate your encalve key and build your own custom image for your production environment. Refer to [How to Build Your PPML image for production environment](#step-1-build-your-ppml-image-for-production-environment).
+Note: This public image is only for demo purposes, it is non-production. For security concern, you are strongly recommended to generate your encalve key and build your own custom image for your production environment. Refer to How to Build Your PPML image for production environment.
 
 **b. Prepare Keys**
 
@@ -159,23 +158,14 @@ https://user-images.githubusercontent.com/61072813/184758702-4b9809f9-50ac-425e-
 #### Step 0. Preparation your environment
 To secure your Big Data & AI applications in BigDL PPML manner, you should prepare your environment first, including K8s cluster setup, K8s-SGX plugin setup, key/password preparation, key management service (KMS) and attestation service (AS) setup, BigDL PPML client container preparation. **Please follow the detailed steps in** [Prepare Environment](./docs/prepare_environment.md). 
 
-Next, you are going to build a base image, and a custom image on top of it in order to avoid leaving secrets e.g. enclave key in images/containers. After that, you need to register the mrenclave in your custom image to Attestation Service Before running your application, and PPML will verify the runtime MREnclave automatically at the backend. The below chart illustrated the whole workflow:
-![PPML Workflow with MREnclave](https://user-images.githubusercontent.com/60865256/197942436-7e40d40a-3759-49b4-aab1-826f09760ab1.png)
+Next, you are going to build a base image and a custom image on top of it in order to avoid leaving secrets e.g. enclave key in images/containers. Before running your application, you need to register the mrenclave in your custom image to Attestation Service, and PPML will verify the runtime MREnclave automatically at the backend. The below chart illustrated the whole workflow:
 
 Start your application with the following guide step by step:
 
 #### Step 1. Build your PPML image for production environment
 To build a secure PPML image which can be used in production environment, BigDL prepared a public base image that does not contain any secrets. You can customize your own image on top of this base image.
 
-1. Prepare BigDL Base Image
-
-    Users can pull the base image or build it by themselves. 
-
-    Pull the base image
-    ```bash
-    docker pull 10.239.45.10/arda/intelanalytics/bigdl-ppml-trusted-big-data-ml-python-gramine-reference-32g-all:2.2.0-SNAPSHOT
-    ```
-    or
+1. Build BigDL Base Image
 
     Running the following command to build the BigDL base image first. Please update the parameters in `./base/build-base-image.sh` first. 
 
@@ -185,7 +175,6 @@ To build a secure PPML image which can be used in production environment, BigDL 
     ./build-base-image.sh
     cd ..
     ```
-
 2. Build Custom Image
 
     When the base image is ready, you need to generate your enclave key which will be used when building custom image, keep the enclave key safely for future remote attestations.
@@ -214,7 +203,7 @@ To build a secure PPML image which can be used in production environment, BigDL 
     mr_signer        : 6f0627955......
     ````
 
-    Note: you can also customize the image  according to your own needs, e.g. install extra python library, add code, jars.
+    Note: you can also customize the image according to your own needs, e.g. install extra python library, add code, jars.
     
 
 #### Step 2. Encrypt and Upload Data
@@ -239,19 +228,16 @@ To build your own Big Data & AI applications, refer to [develop your own Big Dat
     apiVersion: v1
     kind: Pod
     spec:
-      containers:
-      - name: spark-driver
-        securityContext:
-          privileged: true
+      ...
         env:
           - name: ATTESTATION
             value: false
+      ...
     ```
 
 2. Enable attestation
     The bi-attestation gurantees that the MREnclave in runtime containers is a secure one made by you. Its workflow is as below:
-    ![image](https://user-images.githubusercontent.com/60865256/197942524-85a52f73-cf1a-49b3-bd1c-175d130f93e4.png)
-
+  
     To enable attestation, first you should have a running Attestation Service in your environment. 
 
     **2.1. Deploy EHSM KMS & AS**
@@ -333,9 +319,16 @@ To build your own Big Data & AI applications, refer to [develop your own Big Dat
                                 --mr_enclave <your_mrenclave_hash_value> \
                                 --mr_signer <your_mrensigner_hash_value>
     ```
+    You will receive a response containing a `policyID` and save it which will be used to attest runtime MREnclave when running distributed kubernetes application.
 
     **3.5. Enable Attestation in configuration**
 
+    First, upload `policyID` obtained to kubernetes as a secret when registering MREnclave before:
+    
+    ```bash
+    kubectl create secret generic policy-id-secret --from-literal=policy_id=YOUR_POLICY_ID
+    ```
+    
     Configure `spark-driver-template.yaml` and `spark-executor-template.yaml` to enable Attestation as follows:
     ``` yaml
     apiVersion: v1
@@ -348,8 +341,8 @@ To build your own Big Data & AI applications, refer to [develop your own Big Dat
         env:
           - name: ATTESTATION
             value: true
-          - name: ATTESTATION_URL
-            value: your_attestation_url
+          - name: PCCS_URL
+            value: your_pccs_url  -----> <set_the_value_to_your_pccs_url>
           - name: ATTESTATION_ID
             valueFrom:
               secretKeyRef:
@@ -359,7 +352,12 @@ To build your own Big Data & AI applications, refer to [develop your own Big Dat
             valueFrom:
               secretKeyRef:
                 name: kms-secret
-                key: api_key
+                key: app_key
+          - name: POLICY_ID
+            valueFrom:
+              secretKeyRef:
+                name: policy-id-secret
+                key: policy_id
     ...
     ```
     You should get `Attestation Success!` in logs after you [submit a PPML job](#step-4-submit-job) if the quote generated with user report is verified successfully by Attestation Service, or you will get `Attestation Fail! Application killed!` and the job will be stopped.

--- a/ppml/trusted-big-data-ml/python/docker-gramine/README.md
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/README.md
@@ -150,6 +150,7 @@ python register-mrenclave.py --appid <your_appid> \
                              --mr_enclave <your_mrenclave_hash_value> \
                              --mr_signer <your_mrensigner_hash_value>
 ```
+You will receive a response containing a `policyID` and please save it which will be used to attest runtime MREnclave of distributed kubernetes application.
 
 ## Run Your PySpark Program
 
@@ -270,7 +271,8 @@ kubectl config view --flatten --minify > /YOUR_DIR/kubeconfig
 #### 1.2.3 Create k8s secret
 ```bash
 kubectl create secret generic spark-secret --from-literal secret=YOUR_SECRET
-kubectl create secret generic kms-secret --from-literal=app_id=your-kms-app-id --from-literal=api_key=your-kms-api-key
+kubectl create secret generic kms-secret --from-literal=app_id=YOUR_KMS_APP_ID --from-literal=api_key=YOUR_KMS_API_KEY
+kubectl create secret generic policy-id-secret --from-literal=policy_id=YOUR_POLICY_ID
 ```
 **The secret created (`YOUR_SECRET`) should be the same as the password you specified in section 1.1**
 

--- a/ppml/trusted-big-data-ml/python/docker-gramine/base/entrypoint.sh
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/base/entrypoint.sh
@@ -100,7 +100,7 @@ elif [ "$ATTESTATION" = "true" ]; then
     echo "[INFO] PPML Application Exit!"
     exit 1
   fi
-  ATTESTATION_COMMAND="/opt/jdk8/bin/java -Xmx1g -cp $SPARK_CLASSPATH:$BIGDL_HOME/jars/* com.intel.analytics.bigdl.ppml.attestation.AttestationCLI -u ${ATTESTATION_URL} -i ${ATTESTATION_ID}  -k ${ATTESTATION_KEY}"
+  ATTESTATION_COMMAND="/opt/jdk8/bin/java -Xmx1g -cp $SPARK_CLASSPATH:$BIGDL_HOME/jars/* com.intel.analytics.bigdl.ppml.attestation.AttestationCLI -u ${ATTESTATION_URL} -i ${ATTESTATION_ID}  -k ${ATTESTATION_KEY} -o ${POLICY_ID}"
 fi
 
 

--- a/ppml/trusted-big-data-ml/python/docker-gramine/base/entrypoint.sh
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/base/entrypoint.sh
@@ -100,7 +100,7 @@ elif [ "$ATTESTATION" = "true" ]; then
     echo "[INFO] PPML Application Exit!"
     exit 1
   fi
-  ATTESTATION_COMMAND="/opt/jdk8/bin/java -Xmx1g -cp $SPARK_CLASSPATH:$BIGDL_HOME/jars/* com.intel.analytics.bigdl.ppml.attestation.AttestationCLI -u ${ATTESTATION_URL} -i ${ATTESTATION_ID}  -k ${ATTESTATION_KEY} -o ${POLICY_ID}"
+  ATTESTATION_COMMAND="/opt/jdk8/bin/java -Xmx1g -cp $SPARK_CLASSPATH:$BIGDL_HOME/jars/* com.intel.analytics.bigdl.ppml.attestation.AttestationCLI -u ${ATTESTATION_URL} -i ${ATTESTATION_ID}  -k ${ATTESTATION_KEY}"
 fi
 
 

--- a/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-driver-template.yaml
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-driver-template.yaml
@@ -22,6 +22,11 @@ spec:
       #    secretKeyRef:
       #      name: kms-secret
       #      key: app_key
+      #- name: POLICY_ID
+      #  valueFrom:
+      #    secretKeyRef:
+      #      name: policy-id-secret
+      #      key: policy_id
     volumeMounts:
       - name: device-plugin
         mountPath: /var/lib/kubelet/device-plugins

--- a/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-driver-template.yaml
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-driver-template.yaml
@@ -22,7 +22,7 @@ spec:
       #    secretKeyRef:
       #      name: kms-secret
       #      key: app_key
-      #- name: POLICY_ID
+      #- name: ATTESTATION_POLICYID
       #  valueFrom:
       #    secretKeyRef:
       #      name: policy-id-secret

--- a/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-executor-template.yaml
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-executor-template.yaml
@@ -22,6 +22,11 @@ spec:
       #    secretKeyRef:
       #      name: kms-secret
       #      key: app_key
+      #- name: POLICY_ID
+      #  valueFrom:
+      #    secretKeyRef:
+      #      name: policy-id-secret
+      #      key: policy_id
     volumeMounts:
       - name: device-plugin
         mountPath: /var/lib/kubelet/device-plugins

--- a/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-executor-template.yaml
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-executor-template.yaml
@@ -22,7 +22,7 @@ spec:
       #    secretKeyRef:
       #      name: kms-secret
       #      key: app_key
-      #- name: POLICY_ID
+      #- name: ATTESTATION_POLICYID
       #  valueFrom:
       #    secretKeyRef:
       #      name: policy-id-secret

--- a/ppml/trusted-big-data-ml/python/docker-gramine/kubernetes/policy-id-secret.yaml
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/kubernetes/policy-id-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  policy_id: YOUR_POLICY_ID
+kind: Secret
+metadata:
+ name: policy-id-secret
+type: Opaque


### PR DESCRIPTION
## Description

Support for new Attestation API.
Pass policy ID to k8s as a secret.

### 1. Why the change?

Adopt to EHSMVerify API upgrade.

### 2. User API changes

Create policy ID k8s secret.

### 3. Summary of the change 

Attestation policy ID kubernetes secret

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [x] Document test
- [ ] ...
