### PR TITLE
Nano: remove unsupported accelerator in doc string of `bigdl.nano.tf.keras.Model.quantize`

### DIFF
--- a/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
@@ -47,7 +47,7 @@ class InferenceUtils:
                                 static quantization. It's also used as validation dataloader.
         :param precision:       Global precision of quantized model,
                                 supported type: 'int8', 'bf16', 'fp16', defaults to 'int8'.
-        :param accelerator:     Use accelerator 'None', 'onnxruntime', 'openvino', defaults to None.
+        :param accelerator:     Use accelerator 'None', defaults to None.
                                 None means staying in tensorflow.
         :param metric:          A tensorflow.keras.metrics.Metric object for evaluation.
         :param accuracy_criterion:  Tolerable accuracy drop.


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

<!-- Provide the related github issue link if available -->
In `bigdl.nano.tf.keras.Model.quantize`, accelerator is only support `None` now, we need to remove `onnxruntime` and `openvino`.
https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/tensorflow.html#bigdl.nano.tf.keras.Model.quantize
### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->
N/A
### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
remove `onnxruntime` and `openvino` in doc string.
preview API doc: https://zhaojie-doc.readthedocs.io/en/tf-quantization-doc-update/doc/PythonAPI/Nano/tensorflow.html#bigdl.nano.tf.keras.Model.quantize

