### PR TITLE
Orca: Add a ResNet50 inference example

### DIFF
--- a/python/orca/example/learn/pytorch/resnet50/inference.py
+++ b/python/orca/example/learn/pytorch/resnet50/inference.py
@@ -161,7 +161,7 @@ class DummyData(torch.utils.data.Dataset):
         super(DummyData, self).__init__()
         self.len = size
         self.features = torch.randn(self.len, 3, 224, 224)
-        self.labels = torch.randint(1, 256, size=(self.len, )).long()
+        self.labels = torch.randint(1, 1000, size=(self.len, )).long()
 
     def __len__(self):
         return self.len

--- a/python/orca/example/learn/pytorch/resnet50/inference.py
+++ b/python/orca/example/learn/pytorch/resnet50/inference.py
@@ -122,7 +122,6 @@ class ResNetPerfOperator(TrainingOperator):
                     _progress_bar.set_postfix(postfix)
                 from bigdl.orca.learn.pytorch.utils import get_batchsize
                 num_samples = get_batchsize(target)
-                print('n',num_samples)
                 total_samples += num_samples
                 losses.append(loss.item() * num_samples)
                 for metric in metrics.values():
@@ -157,8 +156,7 @@ class ResNetPerfOperator(TrainingOperator):
 
 class DummyData(torch.utils.data.Dataset):
 
-    def __init__(self, size, use_ipex, use_bf16):
-        super(DummyData, self).__init__()
+    def __init__(self, size):
         self.len = size
         self.features = torch.randn(self.len, 3, 224, 224)
         self.labels = torch.randint(1, 1000, size=(self.len, )).long()
@@ -223,7 +221,7 @@ def validate(args):
             # TODO: dummy data may not need dataloader?
             # dummy data, always running channel last for fp32, bf16, int8
             val_loader = torch.utils.data.DataLoader(
-                DummyData(config["number_iter"] * batch_size, args.ipex, args.bf16),
+                DummyData(config["number_iter"] * batch_size),
                 batch_size=batch_size, shuffle=False,
                 num_workers=args.workers, pin_memory=True)
         return val_loader
@@ -344,7 +342,8 @@ def validate(args):
     mean_validation_s = result['profile']['mean_validation_s']
     mean_eval_fwd_s = result['profile']['mean_eval_fwd_s']
     print('avg_val_time for each worker:', mean_validation_s)
-    print('avg_forward_time for each batch:', mean_eval_fwd_s)
+for
+    print('avg_forward_time  each batch:', mean_eval_fwd_s)
     latency = mean_eval_fwd_s / batch_size * 1000
     perf = batch_size / mean_eval_fwd_s
     print('inference latency %.3f ms' % latency)

--- a/python/orca/example/learn/pytorch/resnet50/inference.py
+++ b/python/orca/example/learn/pytorch/resnet50/inference.py
@@ -342,8 +342,7 @@ def validate(args):
     mean_validation_s = result['profile']['mean_validation_s']
     mean_eval_fwd_s = result['profile']['mean_eval_fwd_s']
     print('avg_val_time for each worker:', mean_validation_s)
-for
-    print('avg_forward_time  each batch:', mean_eval_fwd_s)
+    print('avg_forward_time for each batch:', mean_eval_fwd_s)
     latency = mean_eval_fwd_s / batch_size * 1000
     perf = batch_size / mean_eval_fwd_s
     print('inference latency %.3f ms' % latency)

--- a/python/orca/example/learn/pytorch/resnet50/inference.py
+++ b/python/orca/example/learn/pytorch/resnet50/inference.py
@@ -13,29 +13,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-# Most of the pytorch code is adapted from IntelAI's ResNet50 FP32 inference for
-# imagenet dataset.
+# Most of the pytorch code is adapted from:
 # https://github.com/IntelAI/models/blob/master/quickstart/image_recognition/
 # pytorch/resnet50/inference/cpu
 #
 
-import argparse
 import os
-import random
-import time
+import argparse
+
 import torch
 import torch.nn as nn
 import torch.utils.data
 import torchvision.transforms as transforms
 import torchvision.datasets as datasets
 import torchvision.models as models
-from bigdl.dllib.utils.log4Error import *
 
-parser = argparse.ArgumentParser(description='PyTorch ImageNet Training')
+from bigdl.dllib.utils.log4Error import *
+from bigdl.orca import init_orca_context, stop_orca_context
+from bigdl.orca.learn.pytorch import TrainingOperator
+
+parser = argparse.ArgumentParser(description='PyTorch ImageNet Inference')
 parser.add_argument('data', metavar='DIR',
                     help='path to dataset')
-parser.add_argument('--workers', default=1, type=int,
-                    help='number of workers for orca estimator (default: 1)')
+parser.add_argument("--cluster_mode", type=str, default="local",
+                    help="The cluster mode, such as local, yarn or standalone.")
+parser.add_argument("--master", type=str, default=None,
+                    help="The master url, only used when cluster mode is standalone.")
+parser.add_argument("--cores", type=int, default=4,
+                    help="The number of cores on each node.")
+parser.add_argument("--num_nodes", type=int, default=1,
+                    help="The number of nodes to use.")
+parser.add_argument('--workers_per_node', default=1, type=int,
+                    help='number of torch workers on each node (default: 1)')
 parser.add_argument('--ipex', action='store_true', default=False,
                     help='use intel pytorch extension')
 parser.add_argument('--jit', action='store_true', default=False,
@@ -45,27 +54,119 @@ parser.add_argument('--int8', action='store_true', default=False,
 parser.add_argument('--bf16', action='store_true', default=False,
                     help='enable ipex bf16 path')
 parser.add_argument('-b', '--batch_size', default=256, type=int)
-parser.add_argument('--d_workers', default=4, type=int,
-                    help='number of workers for dataloader (default: 4)')
+parser.add_argument('--workers', default=4, type=int,
+                    help='number of data loading workers (default: 4)')
 parser.add_argument("--dummy", action='store_true',
-                    help="using  dummu data to test the performance of inference")
+                    help="using dummy data to test the performance of inference")
+parser.add_argument('--hub', action='store_true', default=False,
+                    help='use model with torch hub')
+parser.add_argument('--pretrained', dest='pretrained', action='store_true',
+                    help='use pre-trained model')
+parser.add_argument('--steps', default=-1, type=int,
+                    help='steps for validation')
+parser.add_argument('--calibration', action='store_true', default=False,
+                    help='doing calibration step for int8 path')
+parser.add_argument('--configure_dir', default='configure.json', type=str, metavar='PATH',
+                    help='path to int8 configures, default file name is configure.json')
+
+
+class ResNetPerfOperator(TrainingOperator):
+    def validate(self, val_iterator, info, metrics, num_steps=None):
+        self.model.eval()
+        from bigdl.orca.learn.metrics import Metric
+        metrics = Metric.convert_metrics_dict(metrics, backend="pytorch")
+        losses = []
+        total_samples = 0
+
+        # TODO: not sure if this is needed
+        if self.config["ipex"] and self.config["int8"] and self.config["calibration"]:
+            print("running int8 calibration step\n")
+            import intel_extension_for_pytorch as ipex
+            from torch.ao.quantization import MinMaxObserver, PerChannelMinMaxObserver, QConfig
+            qconfig = QConfig(
+                activation=MinMaxObserver.with_args(qscheme=torch.per_tensor_symmetric,
+                                                    dtype=torch.qint8),
+                weight=PerChannelMinMaxObserver.with_args(dtype=torch.qint8,
+                                                          qscheme=torch.per_channel_symmetric))
+            x = torch.randn(1, 3, 224, 224)
+            prepared_model = ipex.quantization.prepare(self.model, qconfig, x, inplace=True)
+            with torch.no_grad():
+                for i, (images, target) in enumerate(val_iterator):
+                    images = images.contiguous(memory_format=torch.channels_last)
+                    prepared_model(images)
+                    if i == 4:
+                        print(i)
+                        break
+                prepared_model.save_qconf_summary(self.config["configure_dir"])
+                print(".........calibration step done..........")
+
+        if self.use_tqdm and self.world_rank == 0:
+            from tqdm import tqdm
+            _progress_bar = tqdm(
+                total=len(val_iterator),
+                unit="batch",
+                leave=False)
+
+        # TODO: support warmup
+        with torch.no_grad():
+            for batch_idx, batch in enumerate(val_iterator):
+                if num_steps and batch_idx == num_steps:
+                    break
+                batch_info = {"batch_idx": batch_idx}
+                batch_info.update(info)
+                output, target, loss = self.forward_batch(batch, batch_info)
+                if self.use_tqdm and self.world_rank == 0:
+                    _progress_bar.n = batch_idx + 1
+                    postfix = {}
+                    # postfix.update(loss=loss)
+                    _progress_bar.set_postfix(postfix)
+                from bigdl.orca.learn.pytorch.utils import get_batchsize
+                num_samples = get_batchsize(target)
+                print('n',num_samples)
+                total_samples += num_samples
+                losses.append(loss.item() * num_samples)
+                for metric in metrics.values():
+                    metric(output, target)
+
+        result = {name: metric.compute() for name, metric in metrics.items()}
+        result["val_loss"] = sum(losses) / total_samples
+        result["num_samples"] = total_samples
+        return result
+
+    def forward_batch(self, batch, batch_info):
+        images, target = batch
+
+        # compute output
+        with self.timers.record("eval_fwd"):
+            if self.config["ipex"]:
+                images = images.contiguous(memory_format=torch.channels_last)
+            if self.config["bf16"]:
+                images = images.to(torch.bfloat16)
+            if not self.config["jit"] and self.config["bf16"]:
+                with torch.cpu.amp.autocast():
+                    output = self.model(images)
+            else:
+                output = self.model(images)
+
+        if self.config["bf16"]:
+            output = output.to(torch.float32)
+        loss = self.criterion(output, target)
+
+        return output, target, loss
 
 
 class DummyData(torch.utils.data.Dataset):
 
-    def __init__(self):
+    def __init__(self, size, use_ipex, use_bf16):
         super(DummyData, self).__init__()
-        self.len = 1000
+        self.len = size
         self.features = torch.randn(self.len, 3, 224, 224)
-        self.labels = torch.arange(1, self.len + 1).long()
-        if args.ipex:
-            self.features = self.features.contiguous(memory_format=torch.channels_last)
-        if args.bf16:
-            self.features = self.features.to(torch.bfloat16)
+        self.labels = torch.randint(1, 256, size=(self.len, )).long()
 
     def __len__(self):
         return self.len
 
+    # TODO: This may not be efficient
     def __getitem__(self, idx):
         return self.features[idx], self.labels[idx]
 
@@ -81,17 +182,31 @@ def main():
         invalidInputError(not args.int8, "int8 path is not enabled for offical pytorch")
         invalidInputError(not args.jit, "jit path is not enabled for offical pytorch")
 
-    from bigdl.orca import init_orca_context, stop_orca_context
-    init_orca_context(cluster_mode="local")
-
+    if args.cluster_mode == "local":
+        init_orca_context("local", cores=args.cores, memory="10g")
+    elif args.cluster_mode == "standalone":
+        init_orca_context("standalone", master=args.master,
+                          cores=args.cores, num_nodes=args.num_nodes,
+                          memory="10g", driver_cores=4, driver_memory="2g")
+    elif args.cluster_mode == "yarn":
+        init_orca_context("yarn-client", cores=args.cores,
+                          num_nodes=args.num_nodes, memory="10g",
+                          driver_cores=4, driver_memory="2g")
+    else:
+        invalidInputError(False,
+                          "cluster_mode should be one of 'local', 'yarn' and 'standalone', "
+                          "but got " + args.cluster_mode)
     validate(args)
-    return
+    stop_orca_context()
 
 
 def validate(args):
 
     def val_loader_func(config, batch_size):
         if not args.dummy:
+            # Data loading code
+            invalidInputError(args.data is not None,
+                              "please set dataset path if you want to using real data")
             valdir = os.path.join(args.data, 'val')
             normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],
                                              std=[0.229, 0.224, 0.225])
@@ -102,47 +217,71 @@ def validate(args):
                     transforms.ToTensor(),
                     normalize,
                 ])),
-                batch_size=args.batch_size, shuffle=False,
-                num_workers=args.d_workers, pin_memory=True)
+                batch_size=batch_size, shuffle=False,
+                num_workers=args.workers, pin_memory=True)
         else:
-            # dummy data, always running channle last for fp32, bf16, int8
+            # TODO: dummy data may not need dataloader?
+            # dummy data, always running channel last for fp32, bf16, int8
             val_loader = torch.utils.data.DataLoader(
-                DummyData(),
-                batch_size=args.batch_size, shuffle=False,
-                num_workers=args.d_workers, pin_memory=True)
+                DummyData(config["number_iter"] * batch_size, args.ipex, args.bf16),
+                batch_size=batch_size, shuffle=False,
+                num_workers=args.workers, pin_memory=True)
         return val_loader
 
     def model_creator(config):
-        print("=> using pre-trained model '{}'".format('resnet50'))
-        model = models.__dict__['resnet50'](pretrained=True)
+        arch = 'resnet50'
+        if args.hub:
+            torch.set_flush_denormal(True)
+            model = torch.hub.load('facebookresearch/WSL-Images', arch)
+        else:
+            # create model
+            if args.pretrained:
+                print("=> using pre-trained model '{}'".format(arch))
+                model = models.__dict__[arch](pretrained=True)
+            else:
+                print("=> creating model '{}'".format(arch))
+                model = models.__dict__[arch]()
 
         if args.ipex:
             print("using ipex model to do inference\n")
             import intel_extension_for_pytorch as ipex
 
             if args.int8:
-                import torch.fx.experimental.optimization as optimization
-
-                model = optimization.fuse(model, inplace=True)
-                conf = ipex.quantization.QuantConf(args.configure_dir)
-                x = torch.randn(args.batch_size, 3, 224, 224) \
-                    .contiguous(memory_format=torch.channels_last)
-                model = ipex.quantization.convert(model, conf, x)
-                with torch.no_grad():
+                model.eval()
+                if not args.calibration:
+                    from torch.ao.quantization import MinMaxObserver, \
+                        PerChannelMinMaxObserver, QConfig
+                    x = torch.randn(args.batch_size, 3, 224, 224) \
+                        .contiguous(memory_format=torch.channels_last)
+                    qconfig = QConfig(
+                        activation=MinMaxObserver.with_args(qscheme=torch.per_tensor_symmetric,
+                                                            dtype=torch.qint8),
+                        weight=PerChannelMinMaxObserver.with_args(
+                            dtype=torch.qint8,
+                            qscheme=torch.per_channel_symmetric))
+                    prepared_model = ipex.quantization.prepare(model, qconfig, x, inplace=True)
+                    prepared_model.load_qconf_summary(qconf_summary=args.configure_dir)
+                    model = ipex.quantization.convert(prepared_model)
+                    model = torch.jit.trace(model, x)
+                    model = torch.jit.freeze(model.eval())
                     y = model(x)
-                    print(model.graph_for(x))
-                print("running int8 evalation step\n")
+                    y = model(x)
+                    print("running int8 evaluation step\n")
             else:
                 # for ipex path, always convert model to channels_last for bf16, fp32.
                 # TODO: int8 path: https://jira.devtools.intel.com/browse/MFDNN-6103
                 model = model.to(memory_format=torch.channels_last)
+                model.eval()
 
-                if args.bf16:
+                if args.bf32:
+                    ipex.set_fp32_math_mode(mode=ipex.FP32MathMode.BF32, device="cpu")
+                    print("using bf32 fmath mode\n")
+                elif args.bf16:
                     model = ipex.optimize(model, dtype=torch.bfloat16, inplace=True)
-                    print("running bfloat16 evalation step\n")
+                    print("running bfloat16 evaluation step\n")
                 else:
                     model = ipex.optimize(model, dtype=torch.float32, inplace=True)
-                    print("running fp32 evalation step\n")
+                    print("running fp32 evaluation step\n")
 
                 if args.jit:
                     x = torch.randn(args.batch_size, 3, 224, 224) \
@@ -156,7 +295,7 @@ def validate(args):
                             model = torch.jit.trace(model, x).eval()
                     model = torch.jit.freeze(model)
         else:
-            print("using offical pytorch model to do inference\n")
+            print("using official pytorch model to do inference\n")
 
         model.eval()
         return model
@@ -167,43 +306,50 @@ def validate(args):
                                     weight_decay=1e-4)
         return optimizer
 
-    loss_function = nn.CrossEntropyLoss()
+    if args.dummy:
+        number_iter = args.steps if args.steps > 0 else 200
+    else:
+        number_iter = args.steps if args.steps > 0 else None
+    if args.calibration:
+        number_iter = 100
 
     from bigdl.orca.learn.pytorch import Estimator
     from bigdl.orca.learn.metrics import Accuracy
 
+    config = vars(args)
+    config["number_iter"] = number_iter
+    batch_size = config.pop("batch_size")
     backend = "ray"
     est = Estimator.from_torch(model=model_creator,
                                optimizer=optimizer_creator,
-                               loss=loss_function,
+                               loss=nn.CrossEntropyLoss(),
                                metrics=[Accuracy()],
                                backend=backend,
-                               workers_per_node=args.workers
-                               )
-    if not args.jit and args.bf16:
-        with torch.cpu.amp.autocast():
-            result = est.evaluate(data=val_loader_func, profile=True)
-    else:
-        result = est.evaluate(data=val_loader_func, profile=True)
+                               config=config,
+                               workers_per_node=args.workers_per_node,
+                               training_operator_cls=ResNetPerfOperator,
+                               use_tqdm=True)
+
+    result = est.evaluate(data=val_loader_func, batch_size=batch_size,
+                          num_steps=number_iter, profile=True)
     for r in result:
-        print(r, ":", result[r])
+        print("{}: {}".format(r, result[r]))
 
     print('---------')
-    print('total num_samples:', result['num_samples'])
-    print('num_workers:', args.workers)
-    print('batch_size:', args.batch_size)
-    num_samples = result['num_samples'] / args.workers
-    print('num_samples for each worker:', num_samples)
-    print('num_batches for each worker:', num_samples / args.batch_size)
+    print('total number of records:', result['num_samples'])
+    print('batch_size for each worker:', batch_size)
+    num_samples_per_worker = result['num_samples'] / (args.workers_per_node * args.num_nodes)
+    print('num_samples for each worker: around', num_samples_per_worker)
+    print('num_batches for each worker: around', num_samples_per_worker // batch_size)
     mean_validation_s = result['profile']['mean_validation_s']
     mean_eval_fwd_s = result['profile']['mean_eval_fwd_s']
-    print('ave_val_time for each worker:', mean_validation_s)
-    print('ave_val_time for each batch:', mean_eval_fwd_s)
-    latency = mean_eval_fwd_s / args.batch_size * 1000
-    perf = args.batch_size / mean_eval_fwd_s
+    print('avg_val_time for each worker:', mean_validation_s)
+    print('avg_forward_time for each batch:', mean_eval_fwd_s)
+    latency = mean_eval_fwd_s / batch_size * 1000
+    perf = batch_size / mean_eval_fwd_s
     print('inference latency %.3f ms' % latency)
-    print("throughput: {:.3f} fps".format(perf))
-    return
+    print("Throughput: {:.3f} fps".format(perf))
+    print("Accuracy: {top1:.3f} ".format(top1=result["Accuracy"]))
 
 if __name__ == '__main__':
     main()

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -400,12 +400,11 @@ class TorchRunner:
         elif wrap_dataloader is True:
             loader = self.with_sampler(loader)
         loader = iter(loader)
-        if num_steps:
-            loader = itertools.islice(loader, num_steps)
         with self.timers.record("validation"):
             validation_stats = self.training_operator.validate(loader,
                                                                info=info,
-                                                               metrics=self.metrics)
+                                                               metrics=self.metrics,
+                                                               num_steps=num_steps)
         if profile:
             validation_stats.update(profile=self.timers.stats())
         return validation_stats


### PR DESCRIPTION
## Description

Add a ResNet50 inference example

### 1. Details of change

1.The `inference.py`  takes `data_loader` as the input of the model, supporting fitting the estimator with `ray` backend.


### 2. User API changes

Use command line `python inference.py path_to_dataset/imagenet-small --pretrained`. 
Ensure that `imagenet-small` contains the subdirectory `val`.
