### PR TITLE
[WIP] Orca: add pytorch tensorboard callback.

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/base.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/base.py
@@ -32,12 +32,12 @@ class Callback(object):
         pass
 
     @abstractmethod
-    def on_batch_end(self, batch):
+    def on_batch_end(self, batch, logs=None):
         """
         Called at the end of a training batch in `fit` methods.
         Subclasses should override for any actions to run.
         @param batch: Integer, index of batch within the current epoch.
-        :param logs: Dict. Aggregated metric results up until this batch.
+        @param logs: Dict. Aggregated metric results up until this batch.
         """
         pass
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/model_checkpoint.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/model_checkpoint.py
@@ -59,11 +59,12 @@ class ModelCheckpoint(Callback):
         """
         pass
 
-    def on_batch_end(self, batch):
+    def on_batch_end(self, batch, logs=None):
         """
         Called at the end of a training batch in `fit` methods.
         Subclasses should override for any actions to run.
         @param batch: Integer, index of batch within the current epoch.
+        @param logs: Dict. Aggregated metric results up until this batch.
         """
         pass
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tensorboard.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tensorboard.py
@@ -24,7 +24,6 @@ from bigdl.orca.learn.pytorch.callbacks import Callback
 from bigdl.dllib.utils.log4Error import invalidInputError
 
 
-
 class TensorBoardCallback(Callback):
 
     def __init__(
@@ -36,10 +35,10 @@ class TensorBoardCallback(Callback):
         """
         :param log_dir: Log directory of TensorBoard.
         :param freq: Frequency of logging metrics and loss. 
-            Accept values: 'batch' or 'epoch' or integer. When using 'batch', 
+            Accept values: 'batch' or 'epoch' or integer. When using 'batch',
             writes the losses and metrics to TensorBoard after each batch.
-            The same applies for 'epoch'. If using an integer, let's say 1000, 
-            the callback will write the metrics and losses to TensorBoard every 1000 batches. 
+            The same applies for 'epoch'. If using an integer, let's say 1000,
+            the callback will write the metrics and losses to TensorBoard every 1000 batches.
             Note that writing too frequently to TensorBoard can slow down your training.
         :param **kwargs: The keyword arguments will be pased to ``SummaryWriter``.
         """
@@ -119,7 +118,6 @@ class TensorBoardCallback(Callback):
             put_local_dir_tree_to_remote(self.tmp_dir, self.log_dir)
             if os.path.exists(self.tmp_dir):
                 shutil.rmtree(self.tmp_dir)
-
 
     def set_model(self, model):
         self.model = model

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tensorboard.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tensorboard.py
@@ -69,7 +69,7 @@ class TensorBoardCallback(Callback):
                 writer = SummaryWriter(log_dir=self.tmp_dir, **self.kwargs)
                 for name, value in logs.items():
                     if name not in self.unlog_items:
-                        writer.add_scalar(name, value, epoch)
+                        writer.add_scalar(name, value, batch)
                 writer.close()
 
     def on_epoch_begin(self, epoch):

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tensorboard.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tensorboard.py
@@ -1,0 +1,130 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+import shutil
+import tempfile
+
+from torch.utils.tensorboard import SummaryWriter
+
+from bigdl.orca.data.file import put_local_dir_tree_to_remote
+from bigdl.orca.learn.pytorch.callbacks import Callback
+from bigdl.dllib.utils.log4Error import invalidInputError
+
+
+
+class TensorBoardCallback(Callback):
+
+    def __init__(
+        self,
+        log_dir: str = None,
+        freq: str = "epoch",
+        **kwargs,
+    ):
+        """
+        :param logdir: Log directory of TensorBoard.
+        :param **kwargs: The keyword arguments will be pased to ``SummaryWriter``.
+        """
+        self.log_dir = log_dir
+        self.tmp_dir = os.path.join(tempfile.mkdtemp(), os.path.basename(log_dir))
+        self.freq = freq
+        self.kwargs = kwargs
+        self.unlog_items = ["epoch", "batch_count", "num_samples"]
+        super().__init__()
+
+    def on_batch_begin(self, batch):
+        """
+        Called at the beginning of a training batch in `fit` methods.
+        Subclasses should override for any actions to run.
+        @param batch: Integer, index of batch within the current epoch.
+        """
+        pass
+
+    def on_batch_end(self, batch):
+        """
+        Called at the end of a training batch in `fit` methods.
+        Subclasses should override for any actions to run.
+        @param batch: Integer, index of batch within the current epoch.
+        """
+        if self.freq != "epoch" and self._is_rank_zero():
+            if self.freq == "batch" or batch % int(self.freq) == 0:
+                writer = SummaryWriter(log_dir=self.tmp_dir, **self.kwargs)
+                for name, value in logs.items():
+                    if name not in self.unlog_items:
+                        writer.add_scalar(name, value, epoch)
+                writer.close()
+
+    def on_epoch_begin(self, epoch):
+        """
+        Called at the start of an epoch.
+        Subclasses should override for any actions to run. This function should only
+        be called during TRAIN mode.
+        @param epoch: Integer, index of epoch.
+        @param logs: Dict. Currently, saved stats in last epoch has been passed to this argument
+        for this method but may change in the future.
+        """
+        pass
+
+    def on_epoch_end(self, epoch, logs=None):
+        """
+        Called at the end of an epoch.
+        Subclasses should override for any actions to run. This function should only
+        be called during TRAIN mode.
+        @param epoch:  Integer, index of epoch.
+        @param logs: Dict, metric results for this training epoch, and for the validation epoch if
+            validation is performed. Validation result keys are prefixed with val_. For training
+            epoch, the values of the Model's metrics are returned.
+            Example : {'loss': 0.2, 'accuracy': 0.7}
+        """
+        if self.freq == "epoch" and self._is_rank_zero():
+            writer = SummaryWriter(log_dir=self.tmp_dir, **self.kwargs)
+            for name, value in logs.items():
+                if name not in self.unlog_items:
+                    writer.add_scalar(name, value, epoch)
+            writer.close()
+
+    def on_train_begin(self):
+        """
+        Called at the beginning of training.
+        Subclasses should override for any actions to run.
+        @param logs: Dict. Currently, no data is passed to this argument for this method
+          but that may change in the future.
+        """
+        pass
+
+    def on_train_end(self, logs=None):
+        """
+        Called at the end of training.
+        Subclasses should override for any actions to run.
+        """
+        if self._is_rank_zero():
+            put_local_dir_tree_to_remote(self.tmp_dir, self.log_dir)
+            if os.path.exists(self.tmp_dir):
+                shutil.rmtree(self.tmp_dir)
+
+
+    def set_model(self, model):
+        self.model = model
+
+    def set_param(self, param):
+        self.params = param
+
+    def set_trainer(self, trainer):
+        self.trainer = trainer
+
+    def _is_rank_zero(self):
+        invalidInputError(self.trainer, "Sanity check failed. Must call set_trainer first!")
+        rank = self.trainer.rank
+        return rank == 0

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tensorboard.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tensorboard.py
@@ -29,12 +29,18 @@ class TensorBoardCallback(Callback):
 
     def __init__(
         self,
-        log_dir: str = None,
-        freq: str = "epoch",
+        log_dir=None,
+        freq="epoch",
         **kwargs,
     ):
         """
-        :param logdir: Log directory of TensorBoard.
+        :param log_dir: Log directory of TensorBoard.
+        :param freq: Frequency of logging metrics and loss. 
+            Accept values: 'batch' or 'epoch' or integer. When using 'batch', 
+            writes the losses and metrics to TensorBoard after each batch.
+            The same applies for 'epoch'. If using an integer, let's say 1000, 
+            the callback will write the metrics and losses to TensorBoard every 1000 batches. 
+            Note that writing too frequently to TensorBoard can slow down your training.
         :param **kwargs: The keyword arguments will be pased to ``SummaryWriter``.
         """
         self.log_dir = log_dir

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tensorboard.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tensorboard.py
@@ -34,7 +34,7 @@ class TensorBoardCallback(Callback):
     ):
         """
         :param log_dir: Log directory of TensorBoard.
-        :param freq: Frequency of logging metrics and loss. 
+        :param freq: Frequency of logging metrics and loss.
             Accept values: 'batch' or 'epoch' or integer. When using 'batch',
             writes the losses and metrics to TensorBoard after each batch.
             The same applies for 'epoch'. If using an integer, let's say 1000,

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tensorboard.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tensorboard.py
@@ -62,6 +62,7 @@ class TensorBoardCallback(Callback):
         Called at the end of a training batch in `fit` methods.
         Subclasses should override for any actions to run.
         @param batch: Integer, index of batch within the current epoch.
+        @param logs: Dict. Aggregated metric results up until this batch.
         """
         if self.freq != "epoch" and self._is_rank_zero():
             if self.freq == "batch" or batch % int(self.freq) == 0:

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tensorboard.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tensorboard.py
@@ -57,7 +57,7 @@ class TensorBoardCallback(Callback):
         """
         pass
 
-    def on_batch_end(self, batch):
+    def on_batch_end(self, batch, logs=None):
         """
         Called at the end of a training batch in `fit` methods.
         Subclasses should override for any actions to run.

--- a/python/orca/src/bigdl/orca/learn/pytorch/training_operator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/training_operator.py
@@ -232,7 +232,7 @@ class TrainingOperator:
             self.global_step += 1
             if callbacks is not None:
                 for callback in callbacks:
-                    callback.on_batch_end(batch_idx)
+                    callback.on_batch_end(batch_idx, logs=metrics)
 
     def train_batch(self, batch, batch_info):
         """Computes loss and updates the model over one batch.

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
@@ -616,7 +616,7 @@ class TestPyTorchEstimator(TestCase):
                           feature_cols=["feature"],
                           label_cols=["label"])
 
-            assert len(os.listdir(log_dir))) > 0
+            assert len(os.listdir(log_dir)) > 0
         finally:
             shutil.rmtree(temp_dir)
 

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
@@ -604,7 +604,7 @@ class TestPyTorchEstimator(TestCase):
                           feature_cols=["feature"],
                           label_cols=["label"])
 
-            assert len(os.listdir(log_dir))) > 0
+            assert len(os.listdir(log_dir)) > 0
 
             log_dir = os.path.join(temp_dir, "runs_batch")
 

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
@@ -574,6 +574,53 @@ class TestPyTorchEstimator(TestCase):
         estimator.fit(train_data_loader, epochs=4, batch_size=128,
                       validation_data=val_data_loader, callbacks=callbacks)
 
+    def test_tensorboard_callback(self):
+        from bigdl.orca.learn.pytorch.callbacks.tensorboard import TensorBoardCallback
+        sc = OrcaContext.get_spark_context()
+        spark = SparkSession.builder.getOrCreate()
+        rdd = sc.range(0, 100)
+        epochs = 2
+        data = rdd.map(lambda x: (np.random.randn(50).astype(np.float).tolist(),
+                                  [float(np.random.randint(0, 2, size=()))])
+                       )
+        schema = StructType([
+            StructField("feature", ArrayType(FloatType()), True),
+            StructField("label", ArrayType(FloatType()), True)
+        ])
+        df = spark.createDataFrame(data=data, schema=schema)
+        df = df.cache()
+
+        estimator = get_estimator(workers_per_node=2, log_level=logging.DEBUG)
+
+        try:
+            temp_dir = tempfile.mkdtemp()
+            log_dir = os.path.join(temp_dir, "runs_epoch")
+
+            callbacks = [
+                TensorBoardCallback(log_dir=log_dir, freq="epoch")
+            ]
+            estimator.fit(df, batch_size=4, epochs=epochs,
+                          callbacks=callbacks,
+                          feature_cols=["feature"],
+                          label_cols=["label"])
+
+            assert len(os.listdir(log_dir))) > 0
+
+            log_dir = os.path.join(temp_dir, "runs_batch")
+
+            callbacks = [
+                TensorBoardCallback(log_dir=log_dir, freq="batch")
+            ]
+            estimator.fit(df, batch_size=4, epochs=epochs,
+                          callbacks=callbacks,
+                          feature_cols=["feature"],
+                          label_cols=["label"])
+
+            assert len(os.listdir(log_dir))) > 0
+        finally:
+            shutil.rmtree(temp_dir)
+
+        estimator.shutdown()
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_backend.py
@@ -706,7 +706,7 @@ class TestPyTorchEstimator(TestCase):
                           feature_cols=["feature"],
                           label_cols=["label"])
 
-            assert len(os.listdir(log_dir))) > 0
+            assert len(os.listdir(log_dir)) > 0
 
             log_dir = os.path.join(temp_dir, "runs_batch")
 

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_backend.py
@@ -676,6 +676,53 @@ class TestPyTorchEstimator(TestCase):
         estimator.fit(train_data_loader, epochs=4, batch_size=128,
                       validation_data=val_data_loader)
 
+    def test_tensorboard_callback(self):
+        from bigdl.orca.learn.pytorch.callbacks.tensorboard import TensorBoardCallback
+        sc = OrcaContext.get_spark_context()
+        spark = SparkSession.builder.getOrCreate()
+        rdd = sc.range(0, 100)
+        epochs = 2
+        data = rdd.map(lambda x: (np.random.randn(50).astype(np.float).tolist(),
+                                  [float(np.random.randint(0, 2, size=()))])
+                       )
+        schema = StructType([
+            StructField("feature", ArrayType(FloatType()), True),
+            StructField("label", ArrayType(FloatType()), True)
+        ])
+        df = spark.createDataFrame(data=data, schema=schema)
+        df = df.cache()
+
+        estimator = get_estimator(workers_per_node=2, log_level=logging.DEBUG)
+
+        try:
+            temp_dir = tempfile.mkdtemp()
+            log_dir = os.path.join(temp_dir, "runs_epoch")
+
+            callbacks = [
+                TensorBoardCallback(log_dir=log_dir, freq="epoch")
+            ]
+            estimator.fit(df, batch_size=4, epochs=epochs,
+                          callbacks=callbacks,
+                          feature_cols=["feature"],
+                          label_cols=["label"])
+
+            assert len(os.listdir(log_dir))) > 0
+
+            log_dir = os.path.join(temp_dir, "runs_batch")
+
+            callbacks = [
+                TensorBoardCallback(log_dir=log_dir, freq="batch")
+            ]
+            estimator.fit(df, batch_size=4, epochs=epochs,
+                          callbacks=callbacks,
+                          feature_cols=["feature"],
+                          label_cols=["label"])
+
+            assert len(os.listdir(log_dir))) > 0
+        finally:
+            shutil.rmtree(temp_dir)
+
+        estimator.shutdown()
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_backend.py
@@ -718,7 +718,7 @@ class TestPyTorchEstimator(TestCase):
                           feature_cols=["feature"],
                           label_cols=["label"])
 
-            assert len(os.listdir(log_dir))) > 0
+            assert len(os.listdir(log_dir)) > 0
         finally:
             shutil.rmtree(temp_dir)
 


### PR DESCRIPTION
## Description
Add PyTorch TensorBoard callback for user convenience and API consistency.

### 1. Why the change?
+ User convenience: users have to use `torch.utils.tensorboard.SummaryWriter()` to record the metrics manually, it is not as convenient as TensorFlow callbacks.
+ API consistency: we have callbacks in TensorFlow Estimator, to unify the usage and estimator API, we need to add PyTorch TensorBoard callback as well.

### 2. User API changes
No changes, add an example here:
```python
orca_estimator = Estimator.from_torch(model=model_creator,
                                              optimizer=optimizer_creator,
                                              loss=criterion,
                                              metrics=[Accuracy()],
                                              use_tqdm=True,
                                              backend=args.backend)
tensorboard_callback = TensorBoardCallback(log_dir = "hdfs://hdfs/path/to/logdir")
stats = orca_estimator.fit(train_data_creator, epochs=epochs, batch_size=batch_size, callbacks=[tensorboard_callback])

```


### 3. Summary of the change 
Add new class `TensorBoardCallback`, which Inherit and extend the class `bigdl.orca.learn.pytorch.callbacks` , record the metrics and loss at the end of the batch or epoch according to the frequency, and store them in the target path at the end of the training, including the remote filesystem.


### 4. How to test?
- [x] Unit test
- [x] Application test: Test on yarn cluster/local with ray/spark backend and store the log in HDFS.
