### PR TITLE
[PPML] Fix attestation.sh in gramine base image to exit when attestation failed

### DIFF
--- a/ppml/base/attestation.sh
+++ b/ppml/base/attestation.sh
@@ -31,4 +31,7 @@ elif [ "$ATTESTATION" = "true" ]; then
     ATTESTATION_COMMAND="${ATTESTATION_COMMAND} -o ${ATTESTATION_POLICYID}"
   fi
   echo $ATTESTATION_COMMAND > temp_command_file
+  echo 'if [ $? -gt 0 ]; then ' >> temp_command_file
+  echo '  exit 1' >> temp_command_file
+  echo 'fi' >> temp_command_file
 fi


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

Add check in temp_command_file generated by `attestation.sh` to exit sgx_command when attestation failed.
