### PR TITLE
Chronos: fix example installation links

### DIFF
--- a/docker/chronos-nightly/README.md
+++ b/docker/chronos-nightly/README.md
@@ -12,7 +12,7 @@ cd BigDL
 cp docker/chronos-nightly/Dockerfile ./Dockerfile
 ```
 When building image, you can specify some build args to install chronos with necessary dependencies according to your own needs.
-The build args are similar to the install options in [Chronos documentation](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install).
+The build args are similar to the install options in [Chronos documentation](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/install.html).
 
 ```
 model: which model or framework you want. 

--- a/docs/readthedocs/source/doc/Chronos/Howto/docker_guide_single_node.md
+++ b/docs/readthedocs/source/doc/Chronos/Howto/docker_guide_single_node.md
@@ -12,7 +12,7 @@ cd BigDL
 cp docker/chronos-nightly/Dockerfile ./Dockerfile
 ```
 When building image, you can specify some build args to install chronos with necessary dependencies according to your own needs.
-The build args are similar to the install options in [Chronos documentation](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install).
+The build args are similar to the install options in [Chronos documentation](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/install.html).
 
 ```
 model: which model or framework you want. 

--- a/python/chronos/example/auto_model/README.md
+++ b/python/chronos/example/auto_model/README.md
@@ -2,13 +2,8 @@
 This example collection will demonstrate Chronos auto models (i.e. autolstm & autoprophet) perform automatic time series forecasting on nyc_taxi dataset. The auto model will search the best hyperparameters automatically.
 
 ## Prepare the environment
-We recommend you to use Anaconda to prepare the environment, especially if you want to run on a yarn cluster, 
-```
-conda create -n my_env python=3.7 # "my_env" is conda environment name, you can use any name you like.
-conda activate my_env
-pip install --pre --upgrade bigdl-chronos[all]
-```
-Please refer to [Chronos Install Guide](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install)
+We recommend you to use Anaconda to prepare the environment, especially if you want to run on a yarn cluster.
+Please refer to [Chronos Install Guide](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/install.html)
 
 ## Prepare data
 We are using the nyc taxi provided by NAB, from 2014-07-01 to 2015-01-31 taxi fare information For more details, you can download it [here](https://raw.githubusercontent.com/numenta/NAB/v1.0/data/realKnownCause/nyc_taxi.csv) and view the detailed information [here](https://github.com/numenta/NAB/tree/master/data).

--- a/python/chronos/example/distributed/README.md
+++ b/python/chronos/example/distributed/README.md
@@ -2,13 +2,8 @@
 LSTM, TCN and Seq2seq users can easily train their forecasters in a distributed fashion to handle extra large dataset and speed up the process (training and data processing) by utilizing a cluster or pseudo-distribution on a single node. The functionality is powered by Project Orca.
 
 ## Prepare the environment
-We recommend you to use Anaconda to prepare the environment, especially if you want to run on a yarn cluster:
-```bash
-conda create -n my_env python=3.7 # "my_env" is conda environment name, you can use any name you like.
-conda activate my_env
-pip install --pre --upgrade bigdl-chronos[all]
-```
-Please refer to [Chronos Install Guide](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install)
+We recommend you to use Anaconda to prepare the environment, especially if you want to run on a yarn cluster.
+Please refer to [Chronos Install Guide](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/install.html)
 
 ## Prepare data
 Users may utilize data from different source (local file, file on HDFS, spark dataframe, etc.)

--- a/python/chronos/example/onnx/README.md
+++ b/python/chronos/example/onnx/README.md
@@ -4,7 +4,7 @@ In this example, onnx speed up the inferencing for ~4X.
 
 ## Prepare the environment
 We recommend you to use Anaconda to prepare the environment, especially if you want to run on a yarn cluster.
-You can refer to [Chronos Install Guide](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install)
+You can refer to [Chronos Install Guide](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/install.html)
 
 ## Prepare data
 **autotsest**: We are using the `nyc taxi` provided by NAB, from 2014-07-01 to 2015-01-31 taxi fare information For more details, please refer to [here](https://raw.githubusercontent.com/numenta/NAB/v1.0/data/realKnownCause/nyc_taxi.csv)

--- a/python/chronos/example/quantization/README.md
+++ b/python/chronos/example/quantization/README.md
@@ -2,14 +2,8 @@
 LSTM, TCN and NBeats users can easily quantize their forecasters to low precision and speed up the inference process (both throughput and latency) by on a single node. The functionality is powered by Project Nano.
 
 ## Prepare the environment
-We recommend you to use Anaconda to prepare the environment, especially if you want to run on a yarn cluster:
-```bash
-conda create -n my_env python=3.7 # "my_env" is conda environment name, you can use any name you like.
-conda activate my_env
-pip install --pre --upgrade bigdl-chronos[all]
-pip install neural-compressor==1.8.1
-```
-Please refer to [Chronos Install Guide](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install)
+We recommend you to use Anaconda to prepare the environment, especially if you want to run on a yarn cluster.
+Please refer to [Chronos Install Guide](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/install.html)
 
 ## Prepare data
 We are using the nyc taxi provided by NAB, from 2014-07-01 to 2015-01-31 taxi fare information For more details, you can refer to the detailed information [here](https://github.com/numenta/NAB/tree/master/data). The dataset will be downloaded automatically for you.

--- a/python/chronos/example/tcmf/README.md
+++ b/python/chronos/example/tcmf/README.md
@@ -6,12 +6,7 @@ and inference for high dimension time series forecasting task.
 
 ## Environment
 We recommend you to use Anaconda to prepare the environment.
-```bash
-conda create -n my_env python=3.7 # "my_env" is conda environment name, you can use any name you like.
-conda activate my_env
-pip install --pre --upgrade bigdl-chronos[all]
-```
-Please refer to [Chronos Install Guide](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install)
+Please refer to [Chronos Install Guide](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/install.html)
 
 ## Prepare data
 The example use the public real-world electricity datasets. You can download by running [download datasets script](https://github.com/rajatsen91/deepglo/blob/master/datasets/download-data.sh). Note that we only need electricity.npy.

--- a/python/chronos/use-case/AIOps/README.md
+++ b/python/chronos/use-case/AIOps/README.md
@@ -14,7 +14,7 @@ This use case example contains two notebooks:
 
 ### Install
 
-You can refer to Chronos installation document [here](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install).
+You can refer to Chronos installation document [here](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/install.html).
 
 ### Prepare dataset
 * run `get_data.sh` to download the full dataset. It will download the resource usage of each machine from m_1932 to m_2085. 

--- a/python/chronos/use-case/electricity/README.md
+++ b/python/chronos/use-case/electricity/README.md
@@ -27,7 +27,7 @@ source bigdl-nano-init # accelerate the environment
 
 
 
-For more detailed information, please refer to [Chronos Install Guide](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install)
+For more detailed information, please refer to [Chronos Install Guide](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/install.html)
 
 
 

--- a/python/chronos/use-case/fsi/README.md
+++ b/python/chronos/use-case/fsi/README.md
@@ -12,7 +12,7 @@ This use case example contains 2 notebook:
 
 ### Install
 
-You can refer to Chronos installation document [here](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install).
+You can refer to Chronos installation document [here](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/install.html).
 
 ### Prepare dataset
 - run `get_data.sh` to download the full dataset. It will download daily stock price of S&P500 stocks during 2013-2018 into data folder, preprocess and merge them into a single csv file `all_stocks_5yr.csv`.

--- a/python/chronos/use-case/network_traffic/README.md
+++ b/python/chronos/use-case/network_traffic/README.md
@@ -21,7 +21,7 @@ demonstrated in the example.
 
 ### Install
 
-You can refer to Chronos installation document [here](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install).
+You can refer to Chronos installation document [here](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/install.html).
 
 ### Prepare dataset
 * run `get_data.sh` to download the full dataset. It will download the monthly aggregated traffic data in year 2018 and 2019 (i.e "201801.agr", "201912.agr") into data folder. The raw data contains aggregated network traffic (average MBPs and total bytes) as well as other metrics.

--- a/python/chronos/use-case/pytorch-forecasting/DeepAR/README.md
+++ b/python/chronos/use-case/pytorch-forecasting/DeepAR/README.md
@@ -9,7 +9,7 @@ conda activate my_env
 pip install --pre --upgrade bigdl-chronos[all]
 pip install pytorch_forecasting  # note: you need to install a version >= 0.10.0
 ```
-Please refer to [Chronos Install Guide](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install)
+Please refer to [Chronos Install Guide](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/install.html)
 
 ## Prepare data
 We use ``pytorch_forecasting.data.example.generate_ar_data`` to generate our data automatically.

--- a/python/chronos/use-case/pytorch-forecasting/TFT/README.md
+++ b/python/chronos/use-case/pytorch-forecasting/TFT/README.md
@@ -10,7 +10,7 @@ pip install --pre --upgrade bigdl-chronos[all]
 pip install pytorch_forecasting
 pip install torch==1.11.0  # if your pytorch_forecasting version is 0.10.0 or above, you need to reinstall torch, otherwise you don't need this.
 ```
-Please refer to [Chronos Install Guide](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.html#install)
+Please refer to [Chronos Install Guide](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/install.html)
 
 ## Prepare data
 We are using the [Stallion dataset from Kaggle](https://www.kaggle.com/datasets/utathya/future-volume-prediction). The data will be loaded as pandas dataframe automatically.


### PR DESCRIPTION
## Description
We could make them consistent and linked to some pages like: https://testbigdldocshane.readthedocs.io/en/rddocs-toc/doc/Chronos/Overview/install.html . So that we don't need to update the installation guide every time.
https://github.com/intel-analytics/BigDL/issues/6118