### PR TITLE
Chronos: fix tests for how-to guides

### DIFF
--- a/.github/workflows/chronos-howto-guides-test.yml
+++ b/.github/workflows/chronos-howto-guides-test.yml
@@ -48,6 +48,7 @@ jobs:
           pip install neural-compressor==1.11
           pip install onnx==1.11.0
           pip install onnxruntime==1.11.1
+          pip install onnxruntime-extensions==0.4.2
           pip install openvino-dev==2022.2.0
           pip install ipykernel==5.5.6
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3

--- a/python/chronos/colab-notebook/howto/how-to-create-forecaster.ipynb
+++ b/python/chronos/colab-notebook/howto/how-to-create-forecaster.ipynb
@@ -99,7 +99,7 @@
    "outputs": [],
    "source": [
     "# create a TSDataset\n",
-    "#from bigdl.chronos.data import get_public_dataset\n",
+    "from bigdl.chronos.data import get_public_dataset\n",
     "\n",
     "tsdataset = get_public_dataset('nyc_taxi', with_split=False)"
    ]

--- a/python/chronos/colab-notebook/howto/how-to-create-forecaster.ipynb
+++ b/python/chronos/colab-notebook/howto/how-to-create-forecaster.ipynb
@@ -99,7 +99,7 @@
    "outputs": [],
    "source": [
     "# create a TSDataset\n",
-    "from bigdl.chronos.data import get_public_dataset\n",
+    "#from bigdl.chronos.data import get_public_dataset\n",
     "\n",
     "tsdataset = get_public_dataset('nyc_taxi', with_split=False)"
    ]

--- a/python/chronos/dev/test/run-pytests-howto-guides.sh
+++ b/python/chronos/dev/test/run-pytests-howto-guides.sh
@@ -26,4 +26,10 @@ sed -i 's/!pip install/#!pip install/' $Chronos_Howto_Guides_dir/*.ipynb
 echo "Running tests for Chronos How-to Guides"
 python -m pytest -v  --nbmake --nbmake-timeout=6000 --nbmake-kernel=python3 ${Chronos_Howto_Guides_dir}
 
+exit_status_0=$?
+if [ $exit_status_0 -ne 0 ];
+then
+    exit $exit_status_0
+fi
+
 echo "Tests for Chronos How-to Guides finished."


### PR DESCRIPTION
## Description

Although test fails, the action "Chronos Tests for How-to Guides" can still pass. To solve this problem, add `exit_status_0` in test script.

### 4. How to test?
- [x] Unit test
