### PR TITLE
Chronos: Speed ​​up initialization weight matrix of tf2 model

### DIFF
--- a/python/chronos/src/bigdl/chronos/model/tf2/Seq2Seq_keras.py
+++ b/python/chronos/src/bigdl/chronos/model/tf2/Seq2Seq_keras.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import numpy as np
 import tensorflow as tf
 from tensorflow.keras import backend as K
 from bigdl.nano.tf.keras import Model
@@ -169,7 +170,7 @@ def model_creator_auto(config):
                         lstm_layer_num=config.get("lstm_layer_num", 2),
                         dropout=config.get("dropout", 0.25),
                         teacher_forcing=config.get("teacher_forcing", False))
-    inputs = Input(shape=(None, config['input_feature_num']))
+    inputs = np.zeros(shape=(1, 1, 1))
     model(inputs)
     learning_rate = config.get('lr', 1e-3)
     model.compile(optimizer=getattr(tf.keras.optimizers,

--- a/python/chronos/src/bigdl/chronos/model/tf2/Seq2Seq_keras.py
+++ b/python/chronos/src/bigdl/chronos/model/tf2/Seq2Seq_keras.py
@@ -170,7 +170,7 @@ def model_creator_auto(config):
                         lstm_layer_num=config.get("lstm_layer_num", 2),
                         dropout=config.get("dropout", 0.25),
                         teacher_forcing=config.get("teacher_forcing", False))
-    inputs = np.zeros(shape=(1, 1, 1))
+    inputs = np.zeros(shape=(1, 1, config["input_feature_num"]))
     model(inputs)
     learning_rate = config.get('lr', 1e-3)
     model.compile(optimizer=getattr(tf.keras.optimizers,

--- a/python/chronos/src/bigdl/chronos/model/tf2/TCN_keras.py
+++ b/python/chronos/src/bigdl/chronos/model/tf2/TCN_keras.py
@@ -197,7 +197,7 @@ def model_creator(config):
                             kernel_size=config.get("kernel_size", 7),
                             dropout=config.get("dropout", 0.2),
                             repo_initialization=config.get("repo_initialization", True))
-    inputs = Input(shape=(config["past_seq_len"], config["input_feature_num"]))
+    inputs = np.zeros(shape(1, 1, 1))
     # init weights matrix
     model(inputs)
     learning_rate = config.get('lr', 1e-3)

--- a/python/chronos/src/bigdl/chronos/model/tf2/TCN_keras.py
+++ b/python/chronos/src/bigdl/chronos/model/tf2/TCN_keras.py
@@ -197,7 +197,7 @@ def model_creator(config):
                             kernel_size=config.get("kernel_size", 7),
                             dropout=config.get("dropout", 0.2),
                             repo_initialization=config.get("repo_initialization", True))
-    inputs = np.zeros(shape=(1, 1, 1))
+    inputs = np.zeros(shape=(1, config["past_seq_len"], config["input_feature_num"]))
     # init weights matrix
     model(inputs)
     learning_rate = config.get('lr', 1e-3)

--- a/python/chronos/src/bigdl/chronos/model/tf2/TCN_keras.py
+++ b/python/chronos/src/bigdl/chronos/model/tf2/TCN_keras.py
@@ -197,7 +197,7 @@ def model_creator(config):
                             kernel_size=config.get("kernel_size", 7),
                             dropout=config.get("dropout", 0.2),
                             repo_initialization=config.get("repo_initialization", True))
-    inputs = np.zeros(shape(1, 1, 1))
+    inputs = np.zeros(shape=(1, 1, 1))
     # init weights matrix
     model(inputs)
     learning_rate = config.get('lr', 1e-3)


### PR DESCRIPTION
## Description

Using a smaller `numpy.ndarray` can speed up initializing the weights.

### 1. Why the change?

Initializing the weight matrix is ​​too slow.

### 2. Summary of the change 

```python
# server: 7900
# seq2seq_model_creator

no inputs:  Wall time: 25.8 ms

np.zeros(shape=(1, 1, 1)):  Wall time: 128 ms

Input(shape=(None, config['inputs_feature_num']))  Wall time: 728 ms
```
### 4. How to test?
- [ ] Unit test
- [ ] Application test
- [ ] Document test
