### PR TITLE
Nano : support thread_num control in keras Model.trace

### DIFF
--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -40,7 +40,7 @@ def load_openvino_model(path):
     return PytorchOpenVINOModel._load(path)
 
 
-def KerasOpenVINOModel(model, input_sample=None):
+def KerasOpenVINOModel(model, input_sample=None, thread_num=None):
     """
     Create a OpenVINO model from Keras.
 
@@ -48,10 +48,12 @@ def KerasOpenVINOModel(model, input_sample=None):
                   path to Openvino saved model.
     :param input_sample: A set of inputs for trace, defaults to None if you have trace before or
                          model is a LightningModule with any dataloader attached, defaults to None
+    :param thread_num: a int represents how many threads(cores) is needed for
+                       inference. default: None.
     :return: KerasOpenVINOModel model for OpenVINO inference.
     """
     from .tf.model import KerasOpenVINOModel
-    return KerasOpenVINOModel(model)
+    return KerasOpenVINOModel(model, thread_num=thread_num)
 
 
 def OpenVINOModel(model, device='CPU'):

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -24,15 +24,14 @@ from ..core.utils import save
 
 
 class KerasOpenVINOModel(AcceleratedKerasModel):
-    def __init__(self, model):
+    def __init__(self, model, thread_num=None):
         """
         Create a OpenVINO model from Keras.
 
         :param model: Keras model to be converted to OpenVINO for inference or
                       path to Openvino saved model.
-        :param input_sample: A set of inputs for trace, defaults to None if you have trace before or
-                             model is a LightningModule with any dataloader attached,
-                             defaults to None.
+        :param thread_num: a int represents how many threads(cores) is needed for
+                    inference. default: None.
         """
         ov_model_path = model
         with TemporaryDirectory() as dir:
@@ -40,7 +39,7 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
             if isinstance(model, tf.keras.Model):
                 export(model, str(dir / 'tmp.xml'))
                 ov_model_path = dir / 'tmp.xml'
-            self.ov_model = OpenVINOModel(ov_model_path)
+            self.ov_model = OpenVINOModel(ov_model_path, thread_num)
             super().__init__(None)
 
     def forward_step(self, *inputs):

--- a/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
@@ -20,6 +20,7 @@ from tensorflow.keras.metrics import Metric
 from bigdl.nano.utils.log4Error import invalidInputError
 from bigdl.nano.deps.openvino.openvino_api import KerasOpenVINOModel
 from bigdl.nano.deps.onnxruntime.onnxruntime_api import KerasONNXRuntimeModel
+from typing import Optional, List
 
 
 class InferenceUtils:
@@ -27,7 +28,7 @@ class InferenceUtils:
 
     def quantize(self,
                  precision: str = 'int8',
-                 accelerator: str = None,
+                 accelerator: Optional[str] = None,
                  calib_dataset: tf.data.Dataset = None,
                  metric: Metric = None,
                  accuracy_criterion: dict = None,
@@ -99,7 +100,11 @@ class InferenceUtils:
         else:
             invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))
 
-    def trace(self, accelerator=None, input_sample=None, onnxruntime_session_options=None):
+    def trace(self,
+              accelerator: Optional[str] = None,
+              input_sample=None,
+              thread_num: Optional[int] = None,
+              onnxruntime_session_options=None):
         """
         Trace a Keras model and convert it into an accelerated module for inference.
 
@@ -109,12 +114,21 @@ class InferenceUtils:
             is 'openvino'.
         :param accelerator: The accelerator to use, defaults to None meaning staying in Keras
                             backend. 'openvino' and 'onnxruntime' are supported for now.
+        :param thread_num: (optional) a int represents how many threads(cores) is needed for
+                           inference, only valid for accelerator='onnxruntime'
+                           or accelerator='openvino'.
         :param onnxruntime_session_options: The session option for onnxruntime, only valid when
                                             accelerator='onnxruntime', otherwise will be ignored.
         :return: Model with different acceleration(OpenVINO/ONNX Runtime).
         """
         if accelerator == 'openvino':
-            return KerasOpenVINOModel(self, input_sample)
+            return KerasOpenVINOModel(self, input_sample, thread_num)
         elif accelerator == 'onnxruntime':
+            if onnxruntime_session_options is None:
+                import onnxruntime
+                onnxruntime_session_options = onnxruntime.SessionOptions()
+                if thread_num is not None:
+                    onnxruntime_session_options.intra_op_num_threads = thread_num
+                    onnxruntime_session_options.inter_op_num_threads = thread_num
             return KerasONNXRuntimeModel(self, input_sample, onnxruntime_session_options)
         return self


### PR DESCRIPTION
## Description

Before starting keras InferenceOptimizer, we should support thread num control in trace and quantize(maybe later).

### 1. Why the change?

support thread_num control in keras Model.trace.

### 2. User API changes
new parameter `thread_num` for Keras model.trace
```
onnx_model = model.trace(accelerator='onnxruntime', input_sample=spec, thread_num=1)

openvino_model = model.trace(accelerator="openvino", thread_num=1)
```

### 3. Summary of the change 

support thread_num control in keras Model.trace

### 4. How to test?
- [x] Application test
