### PR TITLE
[PPML]change SPARK_VERION in base from ENV to ARG

### DIFF
--- a/ppml/base/Dockerfile
+++ b/ppml/base/Dockerfile
@@ -8,9 +8,9 @@ ARG no_proxy
 ARG BIGDL_VERSION
 ARG JDK_VERSION=8u192
 ARG JDK_URL
+ARG SPARK_VERSION
 
 ENV BIGDL_VERSION                       ${BIGDL_VERSION}
-ENV SPARK_VERSION                       ${SPARK_VERSION}
 ENV LOCAL_IP                            127.0.0.1
 ENV LC_ALL                              C.UTF-8
 ENV LANG                                C.UTF-8


### PR DESCRIPTION
## Description

why use ARG:
ENV after FROM can't read ARG before FROM.

why remove ENV:
Since gramine base image won't run actually, there is no need to set ENV which will override the actually used one in Bigdata Toolkit. 
