### PR TITLE
[PPML]fix: use BIGDL_VERSION to name jars

### DIFF
--- a/ppml/base/download_jars.sh
+++ b/ppml/base/download_jars.sh
@@ -13,12 +13,15 @@ cd jars
 if [[ $BIGDL_VERSION == *"SNAPSHOT"* ]]; then
   NIGHTLY_VERSION=$(echo $(echo `wget -qO - https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/bigdl/bigdl-ppml-spark_$SPARK_VERSION/$BIGDL_VERSION/maven-metadata.xml | sed -n '/<value>[0-9]*\.[0-9]*\.[0-9]*-[0-9][0-9]*\.[0-9][0-9]*-[0-9][0-9]*.*value>/p' | head -n1 | awk -F'>' '{print $2}' | tr '</value' ' '`))
   wget https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/bigdl/bigdl-ppml-spark_$SPARK_VERSION/$BIGDL_VERSION/bigdl-ppml-spark_$SPARK_VERSION-$NIGHTLY_VERSION.jar
+  mv bigdl-ppml-spark_$SPARK_VERSION-$NIGHTLY_VERSION.jar bigdl-ppml-spark_$SPARK_VERSION-$BIGDL_VERSION.jar
 
   NIGHTLY_VERSION=$(echo $(echo `wget -qO - https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/bigdl/bigdl-dllib-spark_$SPARK_VERSION/$BIGDL_VERSION/maven-metadata.xml | sed -n '/<value>[0-9]*\.[0-9]*\.[0-9]*-[0-9][0-9]*\.[0-9][0-9]*-[0-9][0-9]*.*value>/p' | head -n1 | awk -F'>' '{print $2}' | tr '</value' ' '`))
   wget https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/bigdl/bigdl-dllib-spark_$SPARK_VERSION/$BIGDL_VERSION/bigdl-dllib-spark_$SPARK_VERSION-$NIGHTLY_VERSION.jar
+  mv bigdl-dllib-spark_$SPARK_VERSION-$NIGHTLY_VERSION.jar bigdl-dllib-spark_$SPARK_VERSION-$BIGDL_VERSION.jar
 
   NIGHTLY_VERSION=$(echo $(echo `wget -qO - https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/bigdl/core/dist/all/$BIGDL_VERSION/maven-metadata.xml | sed -n '/<value>[0-9]*\.[0-9]*\.[0-9]*-[0-9][0-9]*\.[0-9][0-9]*-[0-9][0-9]*.*value>/p' | head -n1 | awk -F'>' '{print $2}' | tr '</value' ' '`))
   wget https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/bigdl/core/dist/all/$BIGDL_VERSION/all-$NIGHTLY_VERSION.jar
+  mv all-$NIGHTLY_VERSION.jar all-$BIGDL_VERSION.jar
 else
   wget https://repo1.maven.org/maven2/com/intel/analytics/bigdl/bigdl-ppml-spark_$SPARK_VERSION/$BIGDL_VERSION/bigdl-ppml-spark_$SPARK_VERSION-$BIGDL_VERSION.jar
   wget https://repo1.maven.org/maven2/com/intel/analytics/bigdl/bigdl-dllib-spark_$SPARK_VERSION/$BIGDL_VERSION/bigdl-dllib-spark_$SPARK_VERSION-$BIGDL_VERSION.jar


### PR DESCRIPTION
## Description

name of jars shouldn't include date information NIGHTLY_VERSION which is hard to use. I use BIGDL_VERSION instead
