### PR TITLE
[PPML] k8s RBAC support

### DIFF
--- a/ppml/trusted-big-data-ml/python/docker-gramine/README.md
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/README.md
@@ -263,9 +263,7 @@ kubectl apply -f password/password.yaml
 ```bash
 kubectl create serviceaccount spark
 kubectl create clusterrolebinding spark-role --clusterrole=edit --serviceaccount=default:spark --namespace=default
-
 kubectl get secret|grep service-account-token # you will find a spark service account secret, format like spark-token-12345
-kubectl get secret <spark_service_account_secret> -o yaml
 
 # bind service account and user
 kubectl config set-credentials spark-user \

--- a/ppml/trusted-big-data-ml/python/docker-gramine/README.md
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/README.md
@@ -263,16 +263,34 @@ kubectl apply -f password/password.yaml
 ```bash
 kubectl create serviceaccount spark
 kubectl create clusterrolebinding spark-role --clusterrole=edit --serviceaccount=default:spark --namespace=default
+
+kubectl get secret|grep service-account-token # you will find a spark service account secret, format like spark-token-12345
+kubectl get secret <spark_service_account_secret> -o yaml
+
+# bind service account and user
+kubectl config set-credentials spark-user \
+--token=$(kubectl get secret <spark_service_account_secret> -o jsonpath={.data.token} | base64 -d)
+
+# bind user and context
+kubectl config set-context spark-context --user=spark-user
+
+# bind context and cluster
+kubectl config get-clusters
+kubectl config set-context spark-context --cluster=<cluster_name> --user=spark-user
 ```
 #### 1.2.2 Generate k8s config file
 ```bash
+kubectl config use-context spark-context
 kubectl config view --flatten --minify > /YOUR_DIR/kubeconfig
 ```
 #### 1.2.3 Create k8s secret
 ```bash
 kubectl create secret generic spark-secret --from-literal secret=YOUR_SECRET
-kubectl create secret generic kms-secret --from-literal=app_id=YOUR_KMS_APP_ID --from-literal=api_key=YOUR_KMS_API_KEY
-kubectl create secret generic policy-id-secret --from-literal=policy_id=YOUR_POLICY_ID
+kubectl create secret generic kms-secret \
+                      --from-literal=app_id=YOUR_KMS_APP_ID \
+                      --from-literal=api_key=YOUR_KMS_API_KEY \
+                      --from-literal=policy_id=YOUR_POLICY_ID
+kubectl create secret generic kubeconfig-secret --from-file=/YOUR_DIR/kubeconfig
 ```
 **The secret created (`YOUR_SECRET`) should be the same as the password you specified in section 1.1**
 
@@ -354,7 +372,6 @@ export sgx_command="/opt/jdk8/bin/java \
         --conf spark.executor.cores=$RUNTIME_EXECUTOR_CORES \
         --conf spark.executor.memory=$RUNTIME_EXECUTOR_MEMORY \
         --conf spark.executor.instances=$RUNTIME_EXECUTOR_INSTANCES \
-        --conf spark.kubernetes.authenticate.driver.serviceAccountName=spark \
         --conf spark.kubernetes.container.image=$RUNTIME_K8S_SPARK_IMAGE \
         --conf spark.kubernetes.driver.podTemplateFile=/ppml/trusted-big-data-ml/spark-driver-template.yaml \
         --conf spark.kubernetes.executor.podTemplateFile=/ppml/trusted-big-data-ml/spark-executor-template.yaml \
@@ -547,7 +564,6 @@ export secure_password=`openssl rsautl -inkey /ppml/trusted-big-data-ml/work/pas
 --conf spark.executor.heartbeatInterval=10000000 \
 --conf spark.python.use.daemon=false \
 --conf spark.python.worker.reuse=false \
---conf spark.kubernetes.authenticate.driver.serviceAccountName=spark \
 --conf spark.kubernetes.driver.podTemplateFile=/ppml/trusted-big-data-ml/spark-driver-template.yaml \
 --conf spark.kubernetes.executor.podTemplateFile=/ppml/trusted-big-data-ml/spark-executor-template.yaml \
 --conf spark.kubernetes.executor.deleteOnTermination=false \

--- a/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-driver-template.yaml
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-driver-template.yaml
@@ -25,7 +25,7 @@ spec:
       #- name: ATTESTATION_POLICYID
       #  valueFrom:
       #    secretKeyRef:
-      #      name: policy-id-secret
+      #      name: kms-secret
       #      key: policy_id
     volumeMounts:
       - name: device-plugin

--- a/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-driver-template.yaml
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-driver-template.yaml
@@ -36,9 +36,8 @@ spec:
         mountPath: /ppml/trusted-big-data-ml/work/data
       - name: secure-keys
         mountPath: /ppml/trusted-big-data-ml/work/keys
-      - name: nfs-storage
+      - name: kubeconfig
         mountPath: /root/.kube/config
-        subPath: kubeconfig
      #resources:
       #requests:
         #cpu: 16
@@ -65,3 +64,6 @@ spec:
     - name: nfs-storage
       persistentVolumeClaim:
         claimName: nfsvolumeclaim
+    - name: kubeconfig
+      secret:
+        secretName: kubeconfig-secret

--- a/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-executor-template.yaml
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-executor-template.yaml
@@ -25,7 +25,7 @@ spec:
       #- name: ATTESTATION_POLICYID
       #  valueFrom:
       #    secretKeyRef:
-      #      name: policy-id-secret
+      #      name: kms-secret
       #      key: policy_id
     volumeMounts:
       - name: device-plugin

--- a/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-executor-template.yaml
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-executor-template.yaml
@@ -34,9 +34,6 @@ spec:
         mountPath: /var/run/aesmd/aesm.socket
       - name: nfs-storage
         mountPath: /ppml/trusted-big-data-ml/work/data
-      - name: nfs-storage
-        mountPath: /root/.kube/config
-        subPath: kubeconfig
     #resources:
       #requests:
         #cpu: 16

--- a/ppml/trusted-big-data-ml/python/docker-gramine/kubernetes/kms-secret.yaml
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/kubernetes/kms-secret.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 data:
   app_id: YOUR_APP_ID
   app_key: YOUR_APP_KEY
+  policy_id: YOUR_POLICY_ID
 kind: Secret
 metadata:
  name: kms-secret

--- a/ppml/trusted-big-data-ml/python/docker-gramine/kubernetes/policy-id-secret.yaml
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/kubernetes/policy-id-secret.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-data:
-  policy_id: YOUR_POLICY_ID
-kind: Secret
-metadata:
- name: policy-id-secret
-type: Opaque


### PR DESCRIPTION
## Description

Enhance security by mounting service account kubeconfig file rather than the admin one as a k8s secret into driver.

### 1. Why the change?

kubeconfig is not needed by executor and used to mount the admin file through NFS.

### 2. User API changes

More RBAC steps.

### 3. Summary of the change 

k8s RBAC support

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [x] Document test
- [ ] ...

### 5. New dependencies

None.