### PR TITLE
[PPML] Allow users to turn off dcap attestation when building image

### DIFF
--- a/ppml/README.md
+++ b/ppml/README.md
@@ -205,6 +205,7 @@ To build a secure PPML image which can be used in production environment, BigDL 
     ./build-custom-image.sh
     cd ..
     ```
+    **Warning:** If you want to skip DCAP attestation in runtime containers, you can set `Attestation` to *false* in `build-custom-image.sh`, and this will generate a none-attestation image. **But never do this unsafe operation in producation!**
 
     The sensitive encalve key will not be saved in the built image. Two values `mr_enclave` and `mr_signer` are recorded while the Enclave is built, you can find `mr_enclave` and `mr_signer` values in the console log, which are hash values and used to register your MREnclave in the following attestation step.
 

--- a/ppml/README.md
+++ b/ppml/README.md
@@ -205,7 +205,7 @@ To build a secure PPML image which can be used in production environment, BigDL 
     ./build-custom-image.sh
     cd ..
     ```
-    **Warning:** If you want to skip DCAP attestation in runtime containers, you can set `Attestation` to *false* in `build-custom-image.sh`, and this will generate a none-attestation image. **But never do this unsafe operation in producation!**
+    **Warning:** If you want to skip DCAP attestation in runtime containers, you can set `ENABLE_DCAP_ATTESTATION` to *false* in `build-custom-image.sh`, and this will generate a none-attestation image. **But never do this unsafe operation in producation!**
 
     The sensitive encalve key will not be saved in the built image. Two values `mr_enclave` and `mr_signer` are recorded while the Enclave is built, you can find `mr_enclave` and `mr_signer` values in the console log, which are hash values and used to register your MREnclave in the following attestation step.
 

--- a/ppml/trusted-big-data-ml/python/docker-gramine/README.md
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/README.md
@@ -38,7 +38,7 @@ Then, use the `enclave-key.pem` and the bigdl base image to build your own custo
 ./build-custom-image.sh
 cd ..
 ```
-**Warning:** If you want to skip DCAP attestation when starting containers, you can set `Attestation` to *false* in `build-custom-image.sh`, and this will generate a none-attestation image. **But never do this unsafe operation in producation!**
+**Warning:** If you want to skip DCAP attestation in runtime containers, you can set `Attestation` to *false* in `build-custom-image.sh`, and this will generate a none-attestation image. **But never do this unsafe operation in producation!**
 
 The docker build console will also output `mr_enclave` and `mr_signer` like below, which are hash values and used to  register your MREnclave in the following.
 

--- a/ppml/trusted-big-data-ml/python/docker-gramine/README.md
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/README.md
@@ -38,6 +38,7 @@ Then, use the `enclave-key.pem` and the bigdl base image to build your own custo
 ./build-custom-image.sh
 cd ..
 ```
+**Warning:** If you want to skip DCAP attestation when starting containers, you can set `Attestation` to *false* in `build-custom-image.sh`, and this will generate a none-attestation image. **But never do this unsafe operation in producation!**
 
 The docker build console will also output `mr_enclave` and `mr_signer` like below, which are hash values and used to  register your MREnclave in the following.
 

--- a/ppml/trusted-big-data-ml/python/docker-gramine/README.md
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/README.md
@@ -38,7 +38,7 @@ Then, use the `enclave-key.pem` and the bigdl base image to build your own custo
 ./build-custom-image.sh
 cd ..
 ```
-**Warning:** If you want to skip DCAP attestation in runtime containers, you can set `Attestation` to *false* in `build-custom-image.sh`, and this will generate a none-attestation image. **But never do this unsafe operation in producation!**
+**Warning:** If you want to skip DCAP attestation in runtime containers, you can set `ENABLE_DCAP_ATTESTATION` to *false* in `build-custom-image.sh`, and this will generate a none-attestation image. **But never do this unsafe operation in producation!**
 
 The docker build console will also output `mr_enclave` and `mr_signer` like below, which are hash values and used to  register your MREnclave in the following.
 

--- a/ppml/trusted-big-data-ml/python/docker-gramine/base/bash.manifest.template
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/base/bash.manifest.template
@@ -10,7 +10,7 @@ loader.env.LD_PRELOAD  = ""
 loader.insecure_disable_aslr = true
 loader.argv_src_file = "file:/ppml/trusted-big-data-ml/secured_argvs"
 
-sgx.remote_attestation = "none"
+sgx.remote_attestation = "dcap"
 sgx.ra_client_spid = ""
 
 sys.enable_extra_runtime_domain_names_conf = true

--- a/ppml/trusted-big-data-ml/python/docker-gramine/base/bash.manifest.template
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/base/bash.manifest.template
@@ -10,7 +10,7 @@ loader.env.LD_PRELOAD  = ""
 loader.insecure_disable_aslr = true
 loader.argv_src_file = "file:/ppml/trusted-big-data-ml/secured_argvs"
 
-sgx.remote_attestation = "dcap"
+sgx.remote_attestation = "none"
 sgx.ra_client_spid = ""
 
 sys.enable_extra_runtime_domain_names_conf = true

--- a/ppml/trusted-big-data-ml/python/docker-gramine/bigdl-gramine/Dockerfile
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/bigdl-gramine/Dockerfile
@@ -6,7 +6,7 @@ FROM $BASE_IMAGE_NAME:$BASE_IMAGE_TAG as temp
 
 ARG SGX_MEM_SIZE
 ARG SGX_LOG_LEVEL
-ARG ATTESTATION
+ARG ENABLE_DCAP_ATTESTATION
 
 ADD ./enclave-key.pem /root/.config/gramine/enclave-key.pem
 ADD ./make-sgx.sh /ppml/trusted-big-data-ml/make-sgx.sh

--- a/ppml/trusted-big-data-ml/python/docker-gramine/bigdl-gramine/Dockerfile
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/bigdl-gramine/Dockerfile
@@ -6,6 +6,7 @@ FROM $BASE_IMAGE_NAME:$BASE_IMAGE_TAG as temp
 
 ARG SGX_MEM_SIZE
 ARG SGX_LOG_LEVEL
+ARG ATTESTATION
 
 ADD ./enclave-key.pem /root/.config/gramine/enclave-key.pem
 
@@ -13,6 +14,8 @@ ADD ./enclave-key.pem /root/.config/gramine/enclave-key.pem
 RUN cd /ppml/trusted-big-data-ml && \
     echo SGX_MEM_SIZE:$SGX_MEM_SIZE && \
     echo SGX_LOG_LEVEL:$SGX_LOG_LEVEL && \
+    echo ATTESTATION:$ATTESTATION && \
+    if [ $ATTESTATION == "false" ]; then sed -i 's/"dcap"/"none"/g' bash.manifest.template; fi; && \
     make SGX=1 DEBUG=1 THIS_DIR=/ppml/trusted-big-data-ml  SPARK_USER=root G_SGX_SIZE=$SGX_MEM_SIZE G_LOG_LEVEL=$SGX_LOG_LEVEL
 
 # stage 2. copy sign etc. secrets from temp into target image and generate AS secrets

--- a/ppml/trusted-big-data-ml/python/docker-gramine/bigdl-gramine/Dockerfile
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/bigdl-gramine/Dockerfile
@@ -9,14 +9,12 @@ ARG SGX_LOG_LEVEL
 ARG ATTESTATION
 
 ADD ./enclave-key.pem /root/.config/gramine/enclave-key.pem
+ADD ./make-sgx.sh /ppml/trusted-big-data-ml/make-sgx.sh
 
 # 1.1 make SGX and sign in a temp image
 RUN cd /ppml/trusted-big-data-ml && \
-    echo SGX_MEM_SIZE:$SGX_MEM_SIZE && \
-    echo SGX_LOG_LEVEL:$SGX_LOG_LEVEL && \
-    echo ATTESTATION:$ATTESTATION && \
-    if [ $ATTESTATION == "false" ]; then sed -i 's/"dcap"/"none"/g' bash.manifest.template; fi; && \
-    make SGX=1 DEBUG=1 THIS_DIR=/ppml/trusted-big-data-ml  SPARK_USER=root G_SGX_SIZE=$SGX_MEM_SIZE G_LOG_LEVEL=$SGX_LOG_LEVEL
+    chmod a+x make-sgx.sh && \
+    ./make-sgx.sh
 
 # stage 2. copy sign etc. secrets from temp into target image and generate AS secrets
 FROM $BASE_IMAGE_NAME:$BASE_IMAGE_TAG

--- a/ppml/trusted-big-data-ml/python/docker-gramine/bigdl-gramine/build-custom-image.sh
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/bigdl-gramine/build-custom-image.sh
@@ -4,7 +4,7 @@ export BASE_IMAGE_NAME=bigdl-ppml-trusted-big-data-ml-python-gramine-base
 export BASE_IMAGE_TAG=2.1.0-SNAPSHOT
 export SGX_MEM_SIZE=memory_size_of_sgx_in_custom_image
 export SGX_LOG_LEVEL=log_level_of_sgx_in_custom_image
-export ATTESTATION=true
+export ENABLE_DCAP_ATTESTATION=true
 
 if [[ "$SGX_MEM_SIZE" == "memory_size_of_sgx_in_custom_image" ]] || [[ "$SGX_LOG_LEVEL" == "log_level_of_sgx_in_custom_image" ]]
 then
@@ -15,7 +15,7 @@ else
          --build-arg BASE_IMAGE_TAG=${BASE_IMAGE_TAG} \
 	 --build-arg SGX_MEM_SIZE=${SGX_MEM_SIZE} \
 	 --build-arg SGX_LOG_LEVEL=${SGX_LOG_LEVEL} \
-	 --build-arg ATTESTATION=${ATTESTATION} \
+	 --build-arg ENABLE_DCAP_ATTESTATION=${ENABLE_DCAP_ATTESTATION} \
          -t ${CUSTOM_IMAGE_NAME}:${CUSTOM_IMAGE_TAG} -f ./Dockerfile .
 fi
 

--- a/ppml/trusted-big-data-ml/python/docker-gramine/bigdl-gramine/build-custom-image.sh
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/bigdl-gramine/build-custom-image.sh
@@ -4,6 +4,7 @@ export BASE_IMAGE_NAME=bigdl-ppml-trusted-big-data-ml-python-gramine-base
 export BASE_IMAGE_TAG=2.1.0-SNAPSHOT
 export SGX_MEM_SIZE=memory_size_of_sgx_in_custom_image
 export SGX_LOG_LEVEL=log_level_of_sgx_in_custom_image
+export ATTESTATION=true
 
 if [[ "$SGX_MEM_SIZE" == "memory_size_of_sgx_in_custom_image" ]] || [[ "$SGX_LOG_LEVEL" == "log_level_of_sgx_in_custom_image" ]]
 then
@@ -14,6 +15,7 @@ else
          --build-arg BASE_IMAGE_TAG=${BASE_IMAGE_TAG} \
 	 --build-arg SGX_MEM_SIZE=${SGX_MEM_SIZE} \
 	 --build-arg SGX_LOG_LEVEL=${SGX_LOG_LEVEL} \
+	 --build-arg ATTESTATION=${ATTESTATION} \
          -t ${CUSTOM_IMAGE_NAME}:${CUSTOM_IMAGE_TAG} -f ./Dockerfile .
 fi
 

--- a/ppml/trusted-big-data-ml/python/docker-gramine/bigdl-gramine/make-sgx.sh
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/bigdl-gramine/make-sgx.sh
@@ -1,20 +1,4 @@
 #!/bin/bash
-#
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 
 echo SGX_MEM_SIZE:$SGX_MEM_SIZE
 echo SGX_LOG_LEVEL:$SGX_LOG_LEVEL

--- a/ppml/trusted-big-data-ml/python/docker-gramine/bigdl-gramine/make-sgx.sh
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/bigdl-gramine/make-sgx.sh
@@ -3,7 +3,7 @@
 echo SGX_MEM_SIZE:$SGX_MEM_SIZE
 echo SGX_LOG_LEVEL:$SGX_LOG_LEVEL
 echo ATTESTATION:$ATTESTATION
-if [[ "$ATTESTATION" == "false" ]]; then
+if [[ "ENABLE_DCAP_ATTESTATION" == "false" ]]; then
    sed -i 's/"dcap"/"none"/g' bash.manifest.template
 fi
 make SGX=1 DEBUG=1 THIS_DIR=/ppml/trusted-big-data-ml  SPARK_USER=root G_SGX_SIZE=$SGX_MEM_SIZE G_LOG_LEVEL=$SGX_LOG_LEVEL

--- a/ppml/trusted-big-data-ml/python/docker-gramine/bigdl-gramine/make-sgx.sh
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/bigdl-gramine/make-sgx.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+echo SGX_MEM_SIZE:$SGX_MEM_SIZE
+echo SGX_LOG_LEVEL:$SGX_LOG_LEVEL
+echo ATTESTATION:$ATTESTATION
+if [[ "$ATTESTATION" == "false" ]]; then
+   sed -i 's/"dcap"/"none"/g' bash.manifest.template
+fi
+make SGX=1 DEBUG=1 THIS_DIR=/ppml/trusted-big-data-ml  SPARK_USER=root G_SGX_SIZE=$SGX_MEM_SIZE G_LOG_LEVEL=$SGX_LOG_LEVEL


### PR DESCRIPTION
## Description

Add a flag in build console, which allow users to turn off dcap.

### 1. Why the change?

Many customers want a non-attestation for demo.

### 2. User API changes

None.

### 3. Summary of the change 

Allow users to turn off dcap attestation when building image.

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [x] Document test
- [ ] ...