### PR TITLE
Add gramine encrypting FS to base image.

### DIFF
--- a/ppml/base/Dockerfile
+++ b/ppml/base/Dockerfile
@@ -99,7 +99,8 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     mkdir -p /root/.keras/datasets && \
     mkdir -p /root/.zinc && \
     mkdir -p /root/.m2 && \
-    mkdir -p /root/.kube/
+    mkdir -p /root/.kube/ && \
+    mkdir -p /ppml/encrypted
 
 
 ADD ./download_jars.sh /ppml

--- a/ppml/base/bash.manifest.template
+++ b/ppml/base/bash.manifest.template
@@ -67,6 +67,7 @@ fs.mounts = [
   { path = "/usr/lib/gcc", uri = "file:/usr/lib/gcc" },
   #{ path = "/ppml/trusted-big-data-ml", uri = "file:/ppml/trusted-big-data-ml" },
   { path = "/ppml", uri = "file:/ppml" },
+  { type = "encrypted", path = "/ppml/encrypted", uri = "file:/ppml/encrypted", key_name = "_sgx_mrsigner" },
 ]
 #  { path = "{{ gramine.runtimedir() }}/etc/localtime", uri = "file:/etc" },
 


### PR DESCRIPTION
## Description

Enable gramine encrypting file system in base image.

### 1. Why the change?

Enable gramine encrypting FS for fast and convenient data storage.

### 2. User API changes

The default encrypted directory is /ppml/encrypted. You can create a file and write by gramine. The file will be encrypted automatically and can only be read by gramine.
You can also edit fs.mount in bash.manifast.template to add or delete the encrypted directories.

You can encrypt a file and decrypt it in one container or in another container on the same server. However, you cannot use this function between different servers.

### 3. Summary of the change 

Add a new directory, /ppml/encrypted, to base image in Dockerfile.
Mount /ppml/encrypted to gramine in bash.manifast.template.
