### PR TITLE
Nano: add multi-instance inference

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/inference/multi_instance.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/multi_instance.py
@@ -1,0 +1,71 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from typing import Union, List
+
+import torch
+from torch.utils.data.dataloader import DataLoader
+
+from bigdl.nano.utils.log4Error import invalidInputError, invalidOperationError
+
+
+class _MultiInstanceModel(torch.nn.Module):
+    def __init__(self, model, ps, mgr, send_queues, recv_queues):
+        super().__init__()
+        self.model = model
+        self.ps = ps
+        self.p_num = len(ps)
+        self.mgr = mgr
+        self.send_queues = send_queues
+        self.recv_queues = recv_queues
+
+    def forward(self, input_data: Union[DataLoader, List]) -> List:
+        if isinstance(input_data, (DataLoader, list)):
+            length = len(input_data)
+        else:
+            invalidInputError(False, "The input should be a DataLoader or a list of input batchs")
+
+        for idx, batch in enumerate(input_data):
+            self.send_queues[idx % self.p_num].put(batch)
+
+        outputs = []
+        for idx in range(length):
+            output = self.recv_queues[idx % self.p_num].get()
+            invalidOperationError(not isinstance(output, Exception), f"{output}")
+            outputs.append(output)
+        return outputs
+
+    def __del__(self):
+        for i in range(self.p_num):
+            self.send_queues[i].put('exit')
+        _ = [p.join() for p in self.ps]
+
+
+def _multi_instance_helper(model, recv_queue, send_queue):
+    with torch.no_grad():
+        while True:
+            try:
+                args = recv_queue.get()
+                if isinstance(args, str) and args == 'exit':
+                    return
+                if isinstance(args, tuple):
+                    output = model(*args)
+                else:
+                    output = model(args)
+                send_queue.put(output)
+            except Exception as e:
+                send_queue.put(e)

--- a/python/nano/src/bigdl/nano/pytorch/inference/multi_instance.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/multi_instance.py
@@ -40,13 +40,23 @@ class _MultiInstanceModel(torch.nn.Module):
             invalidInputError(False, "The input should be a DataLoader or a list of input batchs")
 
         for idx, batch in enumerate(input_data):
-            self.send_queues[idx % self.p_num].put(batch)
+            try:
+                self.send_queues[idx % self.p_num].put(batch)
+            except Exception as e:
+                print(idx)
+                print(e)
+                exit(-1)
 
         outputs = []
         for idx in range(length):
-            output = self.recv_queues[idx % self.p_num].get()
-            invalidOperationError(not isinstance(output, Exception), f"{output}")
-            outputs.append(output)
+            try:
+                output = self.recv_queues[idx % self.p_num].get()
+                invalidOperationError(not isinstance(output, Exception), f"{output}")
+                outputs.append(output)
+            except Exception as e:
+                print(idx)
+                print(e)
+                exit(-1)
         return outputs
 
     def __del__(self):

--- a/python/nano/src/bigdl/nano/pytorch/inference/multi_instance.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/multi_instance.py
@@ -40,23 +40,13 @@ class _MultiInstanceModel(torch.nn.Module):
             invalidInputError(False, "The input should be a DataLoader or a list of input batchs")
 
         for idx, batch in enumerate(input_data):
-            try:
-                self.send_queues[idx % self.p_num].put(batch)
-            except Exception as e:
-                print(idx)
-                print(e)
-                exit(-1)
+            self.send_queues[idx % self.p_num].put(batch)
 
         outputs = []
         for idx in range(length):
-            try:
-                output = self.recv_queues[idx % self.p_num].get()
-                invalidOperationError(not isinstance(output, Exception), f"{output}")
-                outputs.append(output)
-            except Exception as e:
-                print(idx)
-                print(e)
-                exit(-1)
+            output = self.recv_queues[idx % self.p_num].get()
+            invalidOperationError(not isinstance(output, Exception), f"{output}")
+            outputs.append(output)
         return outputs
 
     def __del__(self):

--- a/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
+++ b/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
@@ -356,3 +356,18 @@ class TestInferencePipeline(TestCase):
                                metric=metric,
                                direction="max",
                                thread_num=4)
+
+    def test_multi_instance(self):
+        self.model.eval()
+        inference_opt = InferenceOptimizer()
+        multi_instance_model = inference_opt.to_multi_instance(self.model, num_processes=2)
+
+        input_data = list(map(lambda b: b[0], self.test_loader))
+
+        with torch.no_grad():
+            preds1 = multi_instance_model(input_data)
+            preds2 = [self.model(b) for b in input_data]
+
+            for (pred1, pred2) in zip(preds1, preds2):
+                np.testing.assert_allclose(pred1, pred2, atol=1e-4,
+                                           err_msg=f"\npred1: {pred1}\npred2: {pred2}\n")

--- a/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
+++ b/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
@@ -358,16 +358,21 @@ class TestInferencePipeline(TestCase):
                                thread_num=4)
 
     def test_multi_instance(self):
-        self.model.eval()
+        model = Net()
+        model.eval()
         inference_opt = InferenceOptimizer()
-        multi_instance_model = inference_opt.to_multi_instance(self.model, num_processes=2)
+        multi_instance_model = inference_opt.to_multi_instance(model, num_processes=2)
 
-        input_data = list(map(lambda b: b[0], self.test_loader))
+        test_loader = create_data_loader(self.data_dir, 1, self.num_workers, data_transform, subset=50, shuffle=False)
+        input_data = list(map(lambda b: b[0], test_loader))
 
         with torch.no_grad():
             preds1 = multi_instance_model(input_data)
-            preds2 = [self.model(b) for b in input_data]
+            print('one:', len(preds1))
+            preds2 = [model(b) for b in input_data]
+            print('two:', len(preds2))
 
-            for (pred1, pred2) in zip(preds1, preds2):
-                np.testing.assert_allclose(pred1, pred2, atol=1e-4,
-                                           err_msg=f"\npred1: {pred1}\npred2: {pred2}\n")
+        for (pred1, pred2) in zip(preds1, preds2):
+            np.testing.assert_allclose(pred1, pred2, atol=1e-4,
+                                        err_msg=f"\npred1: {pred1}\npred2: {pred2}\n")
+        print('three:', len(preds1), len(preds2))

--- a/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
+++ b/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
@@ -368,11 +368,8 @@ class TestInferencePipeline(TestCase):
 
         with torch.no_grad():
             preds1 = multi_instance_model(input_data)
-            print('one:', len(preds1))
             preds2 = [model(b) for b in input_data]
-            print('two:', len(preds2))
 
         for (pred1, pred2) in zip(preds1, preds2):
             np.testing.assert_allclose(pred1, pred2, atol=1e-4,
                                         err_msg=f"\npred1: {pred1}\npred2: {pred2}\n")
-        print('three:', len(preds1), len(preds2))


### PR DESCRIPTION
## Description

Add multi-instance inference for Nano

### 1. Why the change?

Improve inference performance.


### 2. User API changes

The API should be:

```python

model = Model()

# use InferenceOptimizer.to_multi_instance to transform it
from bigdl.nano.pytorch import InferenceOptimizer
inference_opt = InferenceOptimizer()
model = inference_opt.to_multi_instance(model, num_processes=4)

# predict DataLoader:
preds = model(loader)

# predict a list of inputs:
input_list = []
it = iter(loader)
for i in range(100):
    input_list.append(next(it))
preds = model(input_list)
```

it return a list of inference results, e.g.
```python
for pred in preds:
    do_something()
```

It will split the input dataloader or list and send them to multiple backend processes to run inference, then collect results from backend processes and return a list of inference results.

### 3. Summary of the change 

Add a `to_multi_instance` method for `InferenceOptimizer`, which can be used to transform a normal model to a multi-instance model.

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

