### PR TITLE
[ORCA] Refactor `get_model` to support optional `model_creator` with tf2 ray estimator

### DIFF
--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -695,6 +695,7 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                     os.makedirs(temp_path)
                 get_remote_dir_to_local(self.load_params["filepath"], temp_path)
             try:
+                self.load_params["filepath"] = temp_path
                 model = tf.keras.models.load_model(**self.load_params)
             finally:
                 shutil.rmtree(temp_dir)
@@ -709,6 +710,4 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                                         "Failed to set model weights, please provide real tensor "
                                         "data (of the correct dtype) as sample_input in the "
                                         "get_model method.")
-
         return model
-

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -482,6 +482,14 @@ class TensorFlow2Estimator(OrcaRayEstimator):
 
         return result
 
+    def get_model(self):
+        """
+        Returns the learned model.
+
+        :return: the learned model.
+        """
+        invalidInputError(False, "not implemented")
+
     @enable_multi_fs_save
     def save_checkpoint(self, checkpoint):
         """

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -704,7 +704,6 @@ class TensorFlow2Estimator(OrcaRayEstimator):
             model(sample_input)
         try:
             model.set_weights(state["weights"])
-            model.optimizer.set_weights(state["optimizer_weights"])
         except Exception:
             log4Error.invalidInputError(False,
                                         "Failed to set model weights, please provide real tensor "

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -559,8 +559,7 @@ class TensorFlow2Estimator(OrcaRayEstimator):
             signatures=signatures,
             options=options
         )
-        model_refs = [w.save_model.remote(**params) for w in self.remote_workers]
-        ray.get(model_refs[0])
+        ray.get([w.save_model.remote(**params) for w in self.remote_workers])
 
     def load(self,
              filepath,
@@ -614,8 +613,7 @@ class TensorFlow2Estimator(OrcaRayEstimator):
             save_format=save_format,
             options=options
         )
-        weights_refs = [w.save_weights.remote(**params) for w in self.remote_workers]
-        ray.get(weights_refs[0])
+        ray.get([w.save_weights.remote(**params) for w in self.remote_workers])
 
     def load_weights(self, filepath, by_name=False, skip_mismatch=False, options=None):
         """

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -571,17 +571,17 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                options for loading from SavedModel.
 
         """
-        self.load_params = dict(
+        params = dict(
             filepath=filepath,
             custom_objects=custom_objects,
             compile=compile,
             options=options
         )
         if is_local_path(filepath):
-            ray.get([worker.load_model.remote(**self.load_params)
+            ray.get([worker.load_model.remote(**params)
                      for worker in self.remote_workers])
         else:
-            ray.get([worker.load_remote_model.remote(**self.load_params)
+            ray.get([worker.load_remote_model.remote(**params)
                      for worker in self.remote_workers])
 
     def save_weights(self, filepath, overwrite=True, save_format=None, options=None):

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -603,7 +603,8 @@ class TFRunner:
                 put_local_file_to_remote(temp_path, filepath)
             else:
                 # tf format
-                put_local_files_with_prefix_to_remote(temp_path, filepath)
+                remote_dir = os.path.dirname(filepath)
+                put_local_files_with_prefix_to_remote(temp_path, remote_dir)
         finally:
             shutil.rmtree(temp_dir)
 

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -549,7 +549,8 @@ class TFRunner:
         temp_dir = tempfile.mkdtemp()
         temp_path = os.path.join(temp_dir, file_name)
         try:
-            self.model.save(temp_path, overwrite, include_optimizer, save_format, signatures, options)
+            self.model.save(temp_path, overwrite, include_optimizer, save_format, signatures,
+                            options)
             if save_format == 'h5' or filepath.endswith('.h5') or filepath.endswith('.keras'):
                 # hdf5 format
                 put_local_file_to_remote(temp_path, filepath)

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -44,7 +44,8 @@ from contextlib import closing
 from bigdl.dllib.utils import log4Error
 from bigdl.orca.data.utils import ray_partitions_get_data_label, ray_partitions_get_tf_dataset
 from bigdl.orca.data.file import is_file, get_remote_file_to_local, get_remote_dir_to_local, \
-    get_remote_files_with_prefix_to_local
+    get_remote_files_with_prefix_to_local, put_local_file_to_remote, \
+    put_local_dir_tree_to_remote, put_local_files_with_prefix_to_remote
 from bigdl.orca.learn.utils import process_tensorboard_in_callbacks
 from bigdl.dllib.utils.log4Error import *
 
@@ -543,6 +544,21 @@ class TFRunner:
                                         "data (of the correct dtype) as sample_input in the load "
                                         "method.")
 
+    def save_model(self, filepath, overwrite, include_optimizer, save_format, signatures, options):
+        file_name = os.path.basename(filepath)
+        temp_dir = tempfile.mkdtemp()
+        temp_path = os.path.join(temp_dir, file_name)
+        try:
+            self.model.save(temp_path, overwrite, include_optimizer, save_format, signatures, options)
+            if save_format == 'h5' or filepath.endswith('.h5') or filepath.endswith('.keras'):
+                # hdf5 format
+                put_local_file_to_remote(temp_path, filepath)
+            else:
+                # savemodel format
+                put_local_dir_tree_to_remote(temp_path, filepath)
+        finally:
+            shutil.rmtree(temp_dir)
+
     def load_model(self, filepath, custom_objects, compile, options):
         """Load the model from provided local filepath."""
         import tensorflow as tf
@@ -574,6 +590,21 @@ class TFRunner:
                 shutil.rmtree(temp_path)
             else:
                 os.remove(temp_path)
+
+    def save_weights(self, filepath, overwrite, save_format, options):
+        file_name = os.path.basename(filepath)
+        temp_dir = tempfile.mkdtemp()
+        temp_path = os.path.join(temp_dir, file_name)
+        try:
+            self.model.save_weights(temp_path, overwrite, save_format, options)
+            if save_format == 'h5' or filepath.endswith('.h5') or filepath.endswith('.keras'):
+                # hdf5 format
+                put_local_file_to_remote(temp_path, filepath)
+            else:
+                # tf format
+                put_local_files_with_prefix_to_remote(temp_path, filepath)
+        finally:
+            shutil.rmtree(temp_dir)
 
     def load_weights(self, filepath, by_name, skip_mismatch, options):
         """Loads all layer weights from a TensorFlow or an HDF5 weight file."""

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -551,12 +551,13 @@ class TFRunner:
         try:
             self.model.save(temp_path, overwrite, include_optimizer, save_format, signatures,
                             options)
-            if save_format == 'h5' or filepath.endswith('.h5') or filepath.endswith('.keras'):
-                # hdf5 format
-                put_local_file_to_remote(temp_path, filepath)
-            else:
-                # savemodel format
-                put_local_dir_tree_to_remote(temp_path, filepath)
+            if self.rank == 0:
+                if save_format == 'h5' or filepath.endswith('.h5') or filepath.endswith('.keras'):
+                    # hdf5 format
+                    put_local_file_to_remote(temp_path, filepath)
+                else:
+                    # savemodel format
+                    put_local_dir_tree_to_remote(temp_path, filepath)
         finally:
             shutil.rmtree(temp_dir)
 
@@ -598,13 +599,14 @@ class TFRunner:
         temp_path = os.path.join(temp_dir, file_name)
         try:
             self.model.save_weights(temp_path, overwrite, save_format, options)
-            if save_format == 'h5' or filepath.endswith('.h5') or filepath.endswith('.keras'):
-                # hdf5 format
-                put_local_file_to_remote(temp_path, filepath)
-            else:
-                # tf format
-                remote_dir = os.path.dirname(filepath)
-                put_local_files_with_prefix_to_remote(temp_path, remote_dir)
+            if self.rank == 0:
+                if save_format == 'h5' or filepath.endswith('.h5') or filepath.endswith('.keras'):
+                    # hdf5 format
+                    put_local_file_to_remote(temp_path, filepath)
+                else:
+                    # tf format
+                    remote_dir = os.path.dirname(filepath)
+                    put_local_files_with_prefix_to_remote(temp_path, remote_dir)
         finally:
             shutil.rmtree(temp_dir)
 

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
@@ -994,5 +994,53 @@ class TestTFRayEstimator(TestCase):
         finally:
             shutil.rmtree(temp_dir)
 
+    def test_get_model(self):   
+        sc = OrcaContext.get_spark_context()
+        rdd = sc.range(0, 100)
+        spark = OrcaContext.get_spark_session()
+
+        from pyspark.ml.linalg import DenseVector
+        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float)),
+                                int(np.random.randint(0, 2, size=())))).toDF(["feature", "label"])
+
+        config = {
+            "lr": 0.2
+        }
+
+        try:
+            temp_dir = tempfile.mkdtemp()
+
+            trainer = Estimator.from_keras(
+                model_creator=model_creator,
+                verbose=True,
+                config=config,
+                workers_per_node=3,
+                backend="ray")
+
+            res = trainer.fit(df, epochs=5, batch_size=4, steps_per_epoch=25,
+                              feature_cols=["feature"],
+                              label_cols=["label"],
+                              validation_data=df,
+                              validation_steps=1)
+
+            trainer.save(os.path.join(temp_dir, "cifar10.h5"))
+            pre_model_weights = trainer.get_model().get_weights()
+
+            trainer.shutdown()
+
+            est = Estimator.from_keras(
+                verbose=True,
+                config=config,
+                workers_per_node=3,
+                backend="ray")
+
+            est.load(os.path.join(temp_dir, "cifar10.h5"))
+            after_model_weights = est.get_model().get_weights()
+
+            for pre_tensor, after_tensor in list(zip(pre_model_weights, after_model_weights)):
+                assert np.allclose(pre_tensor, after_tensor)
+        finally:
+            shutil.rmtree(temp_dir)
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
@@ -779,6 +779,7 @@ class TestTFRayEstimator(TestCase):
                 backend="ray")
 
             est.load(os.path.join(temp_dir, "cifar10.h5"))
+            est.save(os.path.join(temp_dir, "cifar10_option.h5"))
 
             after_res = est.predict(df, feature_cols=["feature"]).collect()
             pred_res = np.concatenate([part["prediction"] for part in after_res])


### PR DESCRIPTION
## Description

In #6251, we have supported using `estimator.load` instead of `model_creator`. This PR mainly adds a supporting save model in this case.

### 1. Why the change?
Support saving model when `model_creator` is optional.

### 2. User API changes

```python
trainer = Estimator.from_keras(backend="ray")

trainer.load("/path/to/load_model.h5")

trainer.save("/path/to/save_model.h5")
```

### 3. Summary of the change 
When using `estimator.load` instead of `model_creator`, the `estimator.save` will load the model on driver with updating `model_weights` and `optimizer_weights`.


### 4. How to test?
- [x] Unit test

