### PR TITLE
[PPML] Add warning in make-sgx script

### DIFF
--- a/ppml/trusted-big-data-ml/python/docker-gramine/bigdl-gramine/make-sgx.sh
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/bigdl-gramine/make-sgx.sh
@@ -4,6 +4,8 @@ echo SGX_MEM_SIZE:$SGX_MEM_SIZE
 echo SGX_LOG_LEVEL:$SGX_LOG_LEVEL
 echo ENABLE_DCAP_ATTESTATION:$ENABLE_DCAP_ATTESTATION
 if [[ "ENABLE_DCAP_ATTESTATION" == "false" ]]; then
+   echo "Warning: Disable dcap! Do not use this in production!"
    sed -i 's/"dcap"/"none"/g' bash.manifest.template
 fi
+cat bash.manifest.template|grep sgx.remote_attestation
 make SGX=1 DEBUG=1 THIS_DIR=/ppml/trusted-big-data-ml  SPARK_USER=root G_SGX_SIZE=$SGX_MEM_SIZE G_LOG_LEVEL=$SGX_LOG_LEVEL


### PR DESCRIPTION
## Description

Warn the dcap disabling in image build console.

### 1. Why the change?

For warning and testing.

### 2. User API changes

None.

### 3. Summary of the change 

Add warning in make-sgx script.

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...