### PR TITLE
Nano : add workflow for torch1.13

### DIFF
--- a/.github/workflows/nano_unit_tests_pytorch.yml
+++ b/.github/workflows/nano_unit_tests_pytorch.yml
@@ -33,7 +33,7 @@ jobs:
           "torch==1.10.1+cpu torchvision==0.11.2+cpu intel_extension_for_pytorch==1.11.0",
           "torch==1.11.0+cpu torchvision==0.12.0+cpu intel_extension_for_pytorch==1.11.0", 
           "torch==1.12.1+cpu torchvision==0.13.1+cpu intel_extension_for_pytorch==1.12.100",
-          "torch==1.13.0+cpu torchvision==0.14.0+cpu intel_extension_for_pytorch==1.12.300"
+          "torch==1.13.0+cpu torchvision==0.14.0+cpu intel_extension_for_pytorch==1.13.0"
           ]
     steps:
       - uses: actions/checkout@v2
@@ -218,7 +218,7 @@ jobs:
           "torch==1.9.0+cpu torchvision==0.10.0+cpu torch_ipex==1.9.0",
           "torch==1.11.0+cpu torchvision==0.12.0+cpu intel_extension_for_pytorch==1.11.0", 
           "torch==1.12.1+cpu torchvision==0.13.1+cpu intel_extension_for_pytorch==1.12.100",
-          "torch==1.13.0+cpu torchvision==0.14.0+cpu intel_extension_for_pytorch==1.12.300"
+          "torch==1.13.0+cpu torchvision==0.14.0+cpu intel_extension_for_pytorch==1.13.0"
           # "torch==1.10.1+cpu torchvision==0.11.2+cpu intel_extension_for_pytorch==1.10.0 psutil"
           ]
 

--- a/.github/workflows/nano_unit_tests_pytorch.yml
+++ b/.github/workflows/nano_unit_tests_pytorch.yml
@@ -32,7 +32,8 @@ jobs:
           "torch==1.9.0+cpu torchvision==0.10.0+cpu intel_extension_for_pytorch==1.11.0",
           "torch==1.10.1+cpu torchvision==0.11.2+cpu intel_extension_for_pytorch==1.11.0",
           "torch==1.11.0+cpu torchvision==0.12.0+cpu intel_extension_for_pytorch==1.11.0", 
-          "torch==1.12.1+cpu torchvision==0.13.1+cpu intel_extension_for_pytorch==1.12.100"
+          "torch==1.12.1+cpu torchvision==0.13.1+cpu intel_extension_for_pytorch==1.12.100",
+          "torch==1.13.0+cpu torchvision==0.14.0+cpu intel_extension_for_pytorch==1.12.300"
           ]
     steps:
       - uses: actions/checkout@v2
@@ -216,7 +217,8 @@ jobs:
           # will change the require_grad attribute of layers, which will make some tests of nano fail.
           "torch==1.9.0+cpu torchvision==0.10.0+cpu torch_ipex==1.9.0",
           "torch==1.11.0+cpu torchvision==0.12.0+cpu intel_extension_for_pytorch==1.11.0", 
-          "torch==1.12.1+cpu torchvision==0.13.1+cpu intel_extension_for_pytorch==1.12.100"
+          "torch==1.12.1+cpu torchvision==0.13.1+cpu intel_extension_for_pytorch==1.12.100",
+          "torch==1.13.0+cpu torchvision==0.14.0+cpu intel_extension_for_pytorch==1.12.300"
           # "torch==1.10.1+cpu torchvision==0.11.2+cpu intel_extension_for_pytorch==1.10.0 psutil"
           ]
 

--- a/.github/workflows/nano_unit_tests_pytorch.yml
+++ b/.github/workflows/nano_unit_tests_pytorch.yml
@@ -29,11 +29,11 @@ jobs:
         os: ["ubuntu-20.04"]
         python-version: ["3.7"]
         pytorch-version: [
-          "torch==1.9.0+cpu torchvision==0.10.0+cpu intel_extension_for_pytorch==1.11.0",
-          "torch==1.10.1+cpu torchvision==0.11.2+cpu intel_extension_for_pytorch==1.11.0",
-          "torch==1.11.0+cpu torchvision==0.12.0+cpu intel_extension_for_pytorch==1.11.0", 
-          "torch==1.12.1+cpu torchvision==0.13.1+cpu intel_extension_for_pytorch==1.12.100",
-          "torch==1.13.0+cpu torchvision==0.14.0+cpu intel_extension_for_pytorch==1.13.0"
+          "torch==1.9.0+cpu torchvision==0.10.0+cpu intel_extension_for_pytorch==1.11.0 neural-compressor==1.13.1",
+          "torch==1.10.1+cpu torchvision==0.11.2+cpu intel_extension_for_pytorch==1.11.0 neural-compressor==1.13.1",
+          "torch==1.11.0+cpu torchvision==0.12.0+cpu intel_extension_for_pytorch==1.11.0 neural-compressor==1.13.1", 
+          "torch==1.12.1+cpu torchvision==0.13.1+cpu intel_extension_for_pytorch==1.12.100 neural-compressor==1.13.1",
+          "torch==1.13.0+cpu torchvision==0.14.0+cpu intel_extension_for_pytorch==1.13.0 neural-compressor==1.14.2"
           ]
     steps:
       - uses: actions/checkout@v2
@@ -175,8 +175,8 @@ jobs:
             requirements=(${{matrix.pytorch-version}})
             pip install ${requirements[0]} ${requirements[1]} -f https://download.pytorch.org/whl/torch_stable.html
             pip install ${requirements[2]} -f https://software.intel.com/ipex-whl-stable
+            pip install ${requirements[3]}
           fi
-          pip install neural-compressor==1.13.1
           source bigdl-nano-init
           bash python/nano/test/run-nano-pytorch-inc-tests.sh
           source $CONDA/bin/deactivate

--- a/.github/workflows/nano_unit_tests_pytorch.yml
+++ b/.github/workflows/nano_unit_tests_pytorch.yml
@@ -215,10 +215,10 @@ jobs:
         pytorch-version: [
           # The reason why ipex1.10 is not currently supported is that the optimization of ipex1.10
           # will change the require_grad attribute of layers, which will make some tests of nano fail.
-          "torch==1.9.0+cpu torchvision==0.10.0+cpu torch_ipex==1.9.0",
-          "torch==1.11.0+cpu torchvision==0.12.0+cpu intel_extension_for_pytorch==1.11.0", 
-          "torch==1.12.1+cpu torchvision==0.13.1+cpu intel_extension_for_pytorch==1.12.100",
-          "torch==1.13.0+cpu torchvision==0.14.0+cpu intel_extension_for_pytorch==1.13.0"
+          "torch==1.9.0+cpu torchvision==0.10.0+cpu torch_ipex==1.9.0 neural-compressor==1.13.1",
+          "torch==1.11.0+cpu torchvision==0.12.0+cpu intel_extension_for_pytorch==1.11.0 neural-compressor==1.13.1", 
+          "torch==1.12.1+cpu torchvision==0.13.1+cpu intel_extension_for_pytorch==1.12.100 neural-compressor==1.13.1",
+          "torch==1.13.0+cpu torchvision==0.14.0+cpu intel_extension_for_pytorch==1.13.0 neural-compressor==1.14.2"
           # "torch==1.10.1+cpu torchvision==0.11.2+cpu intel_extension_for_pytorch==1.10.0 psutil"
           ]
 
@@ -249,6 +249,7 @@ jobs:
             requirements=(${{matrix.pytorch-version}})
             pip install ${requirements[0]} ${requirements[1]} -f https://download.pytorch.org/whl/torch_stable.html
             pip install ${requirements[2]} -f https://software.intel.com/ipex-whl-stable
+            pip install ${requirements[3]}
           fi
           source bigdl-nano-init
           bash python/nano/test/run-nano-pytorch-tests-ipex.sh

--- a/python/nano/src/bigdl/nano/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/pytorch/utils.py
@@ -36,7 +36,7 @@ TORCH_VERSION_LESS_1_11 = _compare_version("torch", operator.lt, "1.11")
 TORCH_VERSION_LESS_1_12 = _compare_version("torch", operator.lt, "1.12")
 TORCH_VERSION_LESS_1_13 = _compare_version("torch", operator.lt, "1.13")
 TORCHVISION_VERSION_LESS_1_12 = _compare_version("torchvision", operator.lt, "0.12.0")
-
+TORCHVISION_VERSION_LESS_1_14 = _compare_version("torchvision", operator.lt, "0.14.0")
 
 def batch_call(func):
     """

--- a/python/nano/src/bigdl/nano/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/pytorch/utils.py
@@ -34,7 +34,9 @@ from pathlib import Path
 TORCH_VERSION_LESS_1_10 = _compare_version("torch", operator.lt, "1.10")
 TORCH_VERSION_LESS_1_11 = _compare_version("torch", operator.lt, "1.11")
 TORCH_VERSION_LESS_1_12 = _compare_version("torch", operator.lt, "1.12")
+TORCH_VERSION_LESS_1_13 = _compare_version("torch", operator.lt, "1.13")
 TORCHVISION_VERSION_LESS_1_12 = _compare_version("torchvision", operator.lt, "0.12.0")
+TORCHVISION_VERSION_LESS_1_14 = _compare_version("torchvision", operator.lt, "0.14.0")
 
 
 def batch_call(func):

--- a/python/nano/src/bigdl/nano/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/pytorch/utils.py
@@ -38,6 +38,7 @@ TORCH_VERSION_LESS_1_13 = _compare_version("torch", operator.lt, "1.13")
 TORCHVISION_VERSION_LESS_1_12 = _compare_version("torchvision", operator.lt, "0.12.0")
 TORCHVISION_VERSION_LESS_1_14 = _compare_version("torchvision", operator.lt, "0.14.0")
 
+
 def batch_call(func):
     """
     Decorator to extending hook of pl_module.

--- a/python/nano/src/bigdl/nano/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/pytorch/utils.py
@@ -36,7 +36,6 @@ TORCH_VERSION_LESS_1_11 = _compare_version("torch", operator.lt, "1.11")
 TORCH_VERSION_LESS_1_12 = _compare_version("torch", operator.lt, "1.12")
 TORCH_VERSION_LESS_1_13 = _compare_version("torch", operator.lt, "1.13")
 TORCHVISION_VERSION_LESS_1_12 = _compare_version("torchvision", operator.lt, "0.12.0")
-TORCHVISION_VERSION_LESS_1_14 = _compare_version("torchvision", operator.lt, "0.14.0")
 
 
 def batch_call(func):

--- a/python/nano/src/bigdl/nano/pytorch/vision/transforms/transforms.py
+++ b/python/nano/src/bigdl/nano/pytorch/vision/transforms/transforms.py
@@ -28,7 +28,6 @@ import torchvision.transforms as tv_t
 from torchvision.transforms.functional import InterpolationMode
 import opencv_transforms.transforms as cv_t
 from bigdl.nano.utils.log4Error import invalidInputError
-from bigdl.nano.pytorch.utils import TORCHVISION_VERSION_LESS_1_14
 
 
 __all__ = [
@@ -68,18 +67,9 @@ __all__ = [
     'RandomAdjustSharpness',
     'RandomAutocontrast',
     'RandomEqualize',
-    'InterpolationMode'
+    'InterpolationMode',
+    'ElasticTransform'
 ]
-
-if not TORCHVISION_VERSION_LESS_1_14:
-    __all__.extend(['ElasticTransform'])
-
-    class ElasticTransform(tv_t.RandomEqualize):
-        def __call__(self, img):
-            if type(img) == np.ndarray:
-                img = tv_t.ToTensor()(img)
-
-            return super(ElasticTransform, self).__call__(img)
 
 _cv_strToModes_mapping = {
     'nearest': cv2.INTER_NEAREST,
@@ -929,3 +919,11 @@ class RandomEqualize(tv_t.RandomEqualize):
             img = tv_t.ToTensor()(img)
 
         return super(RandomEqualize, self).__call__(img)
+
+
+class ElasticTransform(tv_t.RandomEqualize):
+        def __call__(self, img):
+            if type(img) == np.ndarray:
+                img = tv_t.ToTensor()(img)
+
+            return super(ElasticTransform, self).__call__(img)

--- a/python/nano/src/bigdl/nano/pytorch/vision/transforms/transforms.py
+++ b/python/nano/src/bigdl/nano/pytorch/vision/transforms/transforms.py
@@ -28,6 +28,7 @@ import torchvision.transforms as tv_t
 from torchvision.transforms.functional import InterpolationMode
 import opencv_transforms.transforms as cv_t
 from bigdl.nano.utils.log4Error import invalidInputError
+from bigdl.nano.pytorch.utils import TORCHVISION_VERSION_LESS_1_14
 
 
 __all__ = [
@@ -67,9 +68,19 @@ __all__ = [
     'RandomAdjustSharpness',
     'RandomAutocontrast',
     'RandomEqualize',
-    'InterpolationMode',
-    'ElasticTransform'
+    'InterpolationMode'
 ]
+
+if not TORCHVISION_VERSION_LESS_1_14:
+    __all__.extend(['ElasticTransform'])
+
+    class ElasticTransform(tv_t.ElasticTransform):
+
+        def __call__(self, img):
+            if type(img) == np.ndarray:
+                img = tv_t.ToTensor()(img)
+
+            return super(ElasticTransform, self).__call__(img)
 
 _cv_strToModes_mapping = {
     'nearest': cv2.INTER_NEAREST,
@@ -919,11 +930,3 @@ class RandomEqualize(tv_t.RandomEqualize):
             img = tv_t.ToTensor()(img)
 
         return super(RandomEqualize, self).__call__(img)
-
-
-class ElasticTransform(tv_t.RandomEqualize):
-        def __call__(self, img):
-            if type(img) == np.ndarray:
-                img = tv_t.ToTensor()(img)
-
-            return super(ElasticTransform, self).__call__(img)

--- a/python/nano/src/bigdl/nano/pytorch/vision/transforms/transforms.py
+++ b/python/nano/src/bigdl/nano/pytorch/vision/transforms/transforms.py
@@ -28,6 +28,7 @@ import torchvision.transforms as tv_t
 from torchvision.transforms.functional import InterpolationMode
 import opencv_transforms.transforms as cv_t
 from bigdl.nano.utils.log4Error import invalidInputError
+from bigdl.nano.pytorch.utils import TORCHVISION_VERSION_LESS_1_14
 
 
 __all__ = [
@@ -69,6 +70,16 @@ __all__ = [
     'RandomEqualize',
     'InterpolationMode'
 ]
+
+if not TORCHVISION_VERSION_LESS_1_14:
+    __all__.extend(['ElasticTransform'])
+
+    class ElasticTransform(tv_t.RandomEqualize):
+        def __call__(self, img):
+            if type(img) == np.ndarray:
+                img = tv_t.ToTensor()(img)
+
+            return super(ElasticTransform, self).__call__(img)
 
 _cv_strToModes_mapping = {
     'nearest': cv2.INTER_NEAREST,


### PR DESCRIPTION
## Description

As PyTorch has released torch==1.13.0 as stable version and ipex has released intel_extension_for_pytorch==1.13.0, we can have corresponding check for this new version.

### How to test?
- [x] Unit test
- [x] Application test
