### PR TITLE
Orca: add batch_size arguments to model.fit()

### DIFF
--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -305,7 +305,8 @@ class SparkRunner:
                             initial_epoch=initial_epoch,
                             steps_per_epoch=steps_per_epoch,
                             validation_steps=validation_steps,
-                            validation_freq=validation_freq)
+                            validation_freq=validation_freq,
+                            batch_size=config["batch_size"])
 
         if callbacks:
             if replaced_log_dir and os.path.exists(replaced_log_dir):

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -390,7 +390,8 @@ class TFRunner:
                                  initial_epoch=self.epoch,
                                  steps_per_epoch=steps_per_epoch,
                                  validation_steps=validation_steps,
-                                 validation_freq=validation_freq)
+                                 validation_freq=validation_freq,
+                                 batch_size=batch_size)
         if callbacks:
             if replaced_log_dir and os.path.exists(replaced_log_dir):
                 shutil.rmtree(replaced_log_dir)


### PR DESCRIPTION
## Description
This PR is to add `batch_size` arguments while calling function `model.fit()` in tensorflow 2.x estimator, which is to support the mlflow tracking.