### PR TITLE
fix extrapath in init_k8s_cluster

### DIFF
--- a/python/dllib/src/bigdl/dllib/utils/spark.py
+++ b/python/dllib/src/bigdl/dllib/utils/spark.py
@@ -436,7 +436,7 @@ class SparkRunner:
         if "spark.executor.extraClassPath" not in conf:
             # BigDL Class path in k8s image
             bigdl_class_version = get_bigdl_class_version()
-            conf["spark.executor.extraClassPath"] = "/opt/" + "bigdl-" +  bigdl_class_version \
+            conf["spark.executor.extraClassPath"] = "/opt/" + "bigdl-" + bigdl_class_version \
                 + "/jars/*"
         conf["spark.driver.extraClassPath"] = conf["spark.executor.extraClassPath"]
         sys_args = "local://" + " ".join(sys.argv)

--- a/python/dllib/src/bigdl/dllib/utils/spark.py
+++ b/python/dllib/src/bigdl/dllib/utils/spark.py
@@ -433,10 +433,7 @@ class SparkRunner:
                      "spark.executor.extraLibraryPath": ld_path,
                      "spark.executorEnv.LD_PRELOAD": preload_so,
                      "spark.kubernetes.container.image": container_image})
-        if "spark.executor.extraClassPath" in conf:
-            conf["spark.executor.extraClassPath"] = "{}:{}".format(
-                zoo_bigdl_path_on_executor, conf["spark.executor.extraClassPath"])
-        else:
+        if "spark.executor.extraClassPath" not in conf:
             # BigDL Class path in k8s image
             bigdl_class_version = get_bigdl_class_version()
             conf["spark.executor.extraClassPath"] = "/opt/" + bigdl_class_version + "bigdl-" \

--- a/python/dllib/src/bigdl/dllib/utils/spark.py
+++ b/python/dllib/src/bigdl/dllib/utils/spark.py
@@ -436,7 +436,7 @@ class SparkRunner:
         if "spark.executor.extraClassPath" not in conf:
             # BigDL Class path in k8s image
             bigdl_class_version = get_bigdl_class_version()
-            conf["spark.executor.extraClassPath"] = "/opt/" + bigdl_class_version + "bigdl-" \
+            conf["spark.executor.extraClassPath"] = "/opt/" + "bigdl-" +  bigdl_class_version \
                 + "/jars/*"
         conf["spark.driver.extraClassPath"] = conf["spark.executor.extraClassPath"]
         sys_args = "local://" + " ".join(sys.argv)


### PR DESCRIPTION
## Description

Default path of "spark.executor.extraClassPath" is the BigDL Class path in k8s image.
If user defines another path, it will use that in conf.