### PR TITLE
Nano: fix torch version to enable nano API doc

### DIFF
--- a/docs/readthedocs/requirements-doc.txt
+++ b/docs/readthedocs/requirements-doc.txt
@@ -10,7 +10,7 @@ bigdl==0.12.0
 cloudpickle==2.1.0
 ray[tune]==1.9.2
 ray==1.9.2
-torch==1.9.0
+torch==1.11.0
 Pygments==2.7
 setuptools==41.0.1
 docutils==0.17.1


### PR DESCRIPTION
## Description
an error is involved by https://github.com/intel-analytics/BigDL/pull/6318. 

preview:
https://bigdl-junweid.readthedocs.io/en/nano-doc-api-fix/doc/PythonAPI/Nano/pytorch.html