### PR TITLE
Nano: Add openvino quantize support for Tensorflow

### DIFF
--- a/python/nano/src/bigdl/nano/deps/openvino/tf/dataloader.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/dataloader.py
@@ -21,6 +21,7 @@ from tensorflow.python.data.ops.dataset_ops import BatchDataset
 
 from bigdl.nano.utils.log4Error import invalidInputError
 
+
 class KerasOpenVINODataLoader(DataLoader):
     def __init__(self, dataset, collate_fn=None):
         invalidInputError(isinstance(dataset, tf.data.Dataset),

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/dataloader.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/dataloader.py
@@ -1,0 +1,52 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from openvino.tools.pot import DataLoader
+import tensorflow as tf
+from tensorflow.python.data.ops.dataset_ops import BatchDataset
+
+from bigdl.nano.utils.log4Error import invalidInputError
+
+class KerasOpenVINODataLoader(DataLoader):
+    def __init__(self, dataset, collate_fn=None):
+        invalidInputError(isinstance(dataset, tf.data.Dataset),
+                          "Please provide an instance of tf.data.Dataset")
+        self.dataset = dataset
+        self.collate_fn = collate_fn
+        self.next_index = 0
+        self.iter = iter(self.dataset)
+
+    def __getitem__(self, index):
+        if index > len(self):
+            invalidInputError(False, f"index out of bounds, index:{index}, length:{len(self)}")
+
+        if index < self.next_index:
+            self.next_index = 0
+            self.iter = iter(self.dataset)
+        if index > self.next_index:
+            for _ in range(index - self.next_index):
+                _ = next(self.iter)
+            self.next_index = index
+
+        data = next(self.iter)
+        if self.collate_fn:
+            data = self.collate_fn(data)
+        self.next_index += 1
+        return data
+
+    def __len__(self):
+        return len(self.dataset)

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/metric.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/metric.py
@@ -1,0 +1,44 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import tensorflow as tf
+from tensorflow.keras.metrics import Metric
+from bigdl.nano.utils.log4Error import invalidInputError
+
+from ..core.metric import BaseOpenVINOMetric
+
+class KerasOpenVINOMetric(BaseOpenVINOMetric):
+    def __init__(self, metric, higher_better=True):
+        invalidInputError(isinstance(metric, Metric),
+                          "Please provide an instance of tf.keras.metrics.Metric")
+        super().__init__(metric, higher_better)
+
+    def stack(self, output):
+        return tf.stack(output)
+
+    def update(self, output, target):
+        def numpy_to_tensors(np_arrays):
+            return tuple(map(lambda x: tf.convert_to_tensor(x), np_arrays))
+        output = numpy_to_tensors(output)
+        target = numpy_to_tensors(target)
+        return super().update(output, target)
+
+    def reset(self):
+        self._scores = []
+
+    def to_scalar(self, score):
+        return float(score)

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/metric.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/metric.py
@@ -21,6 +21,7 @@ from bigdl.nano.utils.log4Error import invalidInputError
 
 from ..core.metric import BaseOpenVINOMetric
 
+
 class KerasOpenVINOMetric(BaseOpenVINOMetric):
     def __init__(self, metric, higher_better=True):
         invalidInputError(isinstance(metric, Metric),

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -66,7 +66,7 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
         return status
 
     def pot(self,
-            dataloader,
+            dataset,
             metric=None,
             higher_better=True,
             drop_type="relative",
@@ -74,10 +74,9 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
             max_iter_num=1,
             n_requests=None,
             sample_size=300):
-        # convert torch metric/dataloader to openvino format
         if metric:
             metric = KerasOpenVINOMetric(metric=metric, higher_better=higher_better)
-        dataloader = KerasOpenVINODataLoader(dataloader, collate_fn=self.tensors_to_numpy)
+        dataloader = KerasOpenVINODataLoader(dataset, collate_fn=self.tensors_to_numpy)
         model = self.ov_model.pot(dataloader, metric=metric, drop_type=drop_type,
                                   maximal_drop=maximal_drop, max_iter_num=max_iter_num,
                                   n_requests=n_requests, sample_size=sample_size)

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -18,6 +18,8 @@ from tempfile import TemporaryDirectory
 from ..core.model import OpenVINOModel
 from bigdl.nano.utils.inference.tf.model import AcceleratedKerasModel
 from .utils import export
+from .dataloader import KerasOpenVINODataLoader
+from .metric import KerasOpenVINOMetric
 import tensorflow as tf
 from bigdl.nano.utils.log4Error import invalidInputError
 from ..core.utils import save
@@ -62,6 +64,24 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
         status = super().status
         status.update({"xml_path": 'ov_saved_model.xml', "weight_path": 'ov_saved_model.bin'})
         return status
+
+    def pot(self,
+            dataloader,
+            metric=None,
+            higher_better=True,
+            drop_type="relative",
+            maximal_drop=0.999,
+            max_iter_num=1,
+            n_requests=None,
+            sample_size=300):
+        # convert torch metric/dataloader to openvino format
+        if metric:
+            metric = KerasOpenVINOMetric(metric=metric, higher_better=higher_better)
+        dataloader = KerasOpenVINODataLoader(dataloader, collate_fn=self.tensors_to_numpy)
+        model = self.ov_model.pot(dataloader, metric=metric, drop_type=drop_type,
+                                  maximal_drop=maximal_drop, max_iter_num=max_iter_num,
+                                  n_requests=n_requests, sample_size=sample_size)
+        return KerasOpenVINOModel(model)
 
     @staticmethod
     def _load(path):

--- a/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
@@ -39,12 +39,14 @@ class InferenceUtils:
                  max_trials: int = None,
                  batch=None,
                  inputs: List[str] = None,
-                 outputs: List[str] = None):
+                 outputs: List[str] = None,
+                 sample_size: int = 100):
         """
         Post-training quantization on a keras model.
 
-        :param calib_dataset:   A tf.data.Dataset object for calibration. Required for
-                                static quantization. It's also used as validation dataloader.
+        :param calib_dataset:   A tf.data.Dataset object for calibration without setting
+                                batch_size or batch_size=1. Required for static quantization.
+                                It's also used as validation dataloader.
         :param precision:       Global precision of quantized model,
                                 supported type: 'int8', 'bf16', 'fp16', defaults to 'int8'.
         :param accelerator:     Use accelerator 'None', 'onnxruntime', 'openvino', defaults to None.
@@ -81,6 +83,11 @@ class InferenceUtils:
                             Default: None, automatically get names from graph.
         :param outputs:     A list of output names.
                             Default: None, automatically get names from graph.
+        :param sample_size: (optional) a int represents how many samples will be used for
+                            Post-training Optimization Tools (POT) from OpenVINO toolkit,
+                            only valid for accelerator='openvino'. Default to 100.
+                            The larger the value, the more accurate the conversion,
+                            the lower the performance degradation, but the longer the time.
         :return:            A TensorflowBaseModel for INC. If there is no model found, return None.
         """
         if accelerator is None:
@@ -96,6 +103,27 @@ class InferenceUtils:
                                 max_trials=max_trials,
                                 inputs=inputs,
                                 outputs=outputs)
+        elif accelerator == 'openvino':
+            from bigdl.nano.deps.openvino.tf.model import KerasOpenVINOModel    # type: ignore
+            if isinstance(self, KerasOpenVINOModel):    # type: ignore
+                openvino_model = self
+            else:
+                openvino_model = self.trace(accelerator='openvino')
+            if metric:
+                if not isinstance(accuracy_criterion, dict):
+                    accuracy_criterion = {'relative': 0.99, 'higher_is_better': True}
+                drop_type = 'relative' if 'relative' in accuracy_criterion else 'absolute'
+                higher_is_better = accuracy_criterion.get('higher_is_better', None)
+                maximal_drop = accuracy_criterion.get(drop_type, None)
+            else:
+                drop_type, higher_is_better, maximal_drop = None, None, None
+            return openvino_model.pot(dataset=calib_dataset,    # type: ignore
+                                      metric=metric,
+                                      higher_better=higher_is_better,
+                                      drop_type=drop_type,
+                                      maximal_drop=maximal_drop,
+                                      max_iter_num=max_trials,
+                                      sample_size=sample_size)
         else:
             invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))
 

--- a/python/nano/test/openvino/tf/test_openvino_quantize.py
+++ b/python/nano/test/openvino/tf/test_openvino_quantize.py
@@ -1,0 +1,53 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from unittest import TestCase
+import tensorflow as tf
+from tensorflow.keras.applications.mobilenet_v2 import MobileNetV2
+import numpy as np
+from bigdl.nano.tf.keras import Model
+
+
+class TestOpenVINO(TestCase):
+    def test_model_trace_openvino(self):
+        model = MobileNetV2(weights=None, input_shape=[40, 40, 3], classes=10)
+        model = Model(inputs=model.inputs, outputs=model.outputs)
+        train_examples = np.random.random((100, 40, 40, 3))
+        train_labels = np.random.randint(0, 10, size=(100,))
+        train_dataset = tf.data.Dataset.from_tensor_slices((train_examples, train_labels)).batch(1)
+
+        # Case1: Trace and quantize
+        openvino_model = model.trace(accelerator='openvino')
+        openvino_quantized_model = openvino_model.quantize(accelerator='openvino',
+                                                           calib_dataset=train_dataset)
+        
+        y_hat = openvino_quantized_model(train_examples[:10])
+        assert y_hat.shape == (10, 10)
+
+        y_hat = openvino_quantized_model.predict(train_examples, batch_size=5)
+        assert y_hat.shape == (100, 10)
+
+        # Case2: Quantize directly from tensorflow
+        openvino_quantized_model = model.quantize(accelerator='openvino',
+                                                  calib_dataset=train_dataset)
+        
+        y_hat = openvino_quantized_model(train_examples[:10])
+        assert y_hat.shape == (10, 10)
+
+        y_hat = openvino_quantized_model.predict(train_examples, batch_size=5)
+        assert y_hat.shape == (100, 10)
+
+        openvino_quantized_model.compile(metrics=[tf.keras.metrics.CategoricalAccuracy()])
+        acc = openvino_quantized_model.evaluate(train_dataset, return_dict=True)['categorical_accuracy']


### PR DESCRIPTION
## Description

Add openvino quantize support for Tensorflow

### 1. Why the change?

Support more features

### 2. User API changes

```python
from bigdl.nano.tf.keras import Model
model = Model(...)

# trace and quantize
openvino_model = model.trace(accelerator='openvino')
openvino_quantized_model = openvino_model.quantize(accelerator='openvino', calib_dataset=dataset)

# or quantize directly from tensorflow
openvino_quantized_model = model.quantize(accelerator='openvino', calib_dataset=train_dataset)
```

### 3. Summary of the change 

Add openvino quantize support for Tensorflow and an UT

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...
