### PR TITLE
Nano: add dataloader transformation for `quantize` method

### DIFF
--- a/.github/workflows/nano_unit_tests_pytorch.yml
+++ b/.github/workflows/nano_unit_tests_pytorch.yml
@@ -240,7 +240,7 @@ jobs:
           $CONDA/bin/conda create -n pytorch-ipex -y python==3.7.10 setuptools=58.0.4
           source $CONDA/bin/activate pytorch-ipex
           $CONDA/bin/conda info
-          bash python/nano/dev/build_and_install.sh linux default false pytorch
+          bash python/nano/dev/build_and_install.sh linux default false pytorch,inference
           pip install pytest
           pip uninstall -y intel_extension_for_pytorch
           if [ ! -z "${{matrix.pytorch-version}}" ]; then

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/utils.py
@@ -22,6 +22,9 @@ def _check_data_type(data):
         return
     else:
         for x in data:
+            if isinstance(x, tuple):
+                _check_data_type(x)
+                continue
             if not isinstance(x, torch.Tensor):
                 invalidInputError(False, "expect torch.Tensor here")
 

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/dataloader.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/dataloader.py
@@ -55,7 +55,7 @@ def _need_dataloader_type_transformation(model, dataloader):
     # a special case is 0, this means *args is used in
     # users' forward method, we will also skip it as well
     if forward_args_len <= 1:
-        return False
+        return False, forward_args_len
 
     # check if a dataloader has met inc format
     input_sample = next(iter(dataloader))

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/dataloader.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/dataloader.py
@@ -1,0 +1,68 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from bigdl.nano.utils.inference.pytorch.model_utils import get_forward_args
+from typing import Sequence
+from copy import deepcopy
+
+
+def transform_multiple_input_dataloader_to_inc_mode(model, dataloader):
+    if _need_dataloader_type_transformation(model, dataloader):
+        # define a decorator to change multiple inputs to 2 items
+        def tuple_collate_fn_wrapper(func, forward_args_len):
+            def collate_fn(batch):
+                res = func(batch)
+                if len(res) - forward_args_len <= 1:
+                    # if only one y is provided
+                    return tuple(res[:forward_args_len]), res[forward_args_len:]
+                else:
+                    # if multiple y are provided
+                    return tuple(res[:forward_args_len]), tuple(res[forward_args_len:])
+            return collate_fn
+
+        # deepcopy the dataloader so that the transformation will not pollute the original one
+        new_dataloader = deepcopy(dataloader)
+
+        # get forward method's parameter number
+        forward_args = get_forward_args(model)
+        forward_args_len = len(forward_args)
+
+        # add collate fn to the dataloader
+        new_dataloader.collate_fn = tuple_collate_fn_wrapper(new_dataloader.collate_fn,
+                                                             forward_args_len)
+
+        return new_dataloader
+    return dataloader
+
+
+def _need_dataloader_type_transformation(model, dataloader):
+    # get forward method's parameter number
+    forward_args = get_forward_args(model)
+    forward_args_len = len(forward_args)
+
+    # if the model is a simple model(x) format
+    # we don't need to transform the dataloader
+    # a special case is 0, this means *args is used in
+    # users' forward method, we will also skip it as well
+    if forward_args_len <= 1:
+        return False
+
+    # check if a dataloader has met inc format
+    input_sample = next(iter(dataloader))
+    if isinstance(input_sample[0], Sequence):
+        if len(input_sample[0]) == forward_args_len:
+            return False
+    return True

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/dataloader.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/dataloader.py
@@ -25,9 +25,9 @@ def transform_multiple_input_dataloader_to_inc_mode(model, dataloader):
         def tuple_collate_fn_wrapper(func, forward_args_len):
             def collate_fn(batch):
                 res = func(batch)
-                if len(res) - forward_args_len <= 1:
+                if len(res) - forward_args_len == 1:
                     # if only one y is provided
-                    return tuple(res[:forward_args_len]), res[forward_args_len:]
+                    return tuple(res[:forward_args_len]), res[-1]
                 else:
                     # if multiple y are provided
                     return tuple(res[:forward_args_len]), tuple(res[forward_args_len:])

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
@@ -20,13 +20,15 @@ from torch.utils.data import DataLoader
 import torch
 from bigdl.nano.utils.log4Error import invalidInputError
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_11, TORCH_VERSION_LESS_1_12
+from bigdl.nano.utils.inference.pytorch.model import AcceleratedLightningModule
 
 
 def get_forward_args(model):
     forward_args = inspect.getfullargspec(model.forward).args[1:]
     if isinstance(model, LightningModule):
-        # forward param list for compiled model
-        forward_args = get_forward_args(model.model)
+        if not isinstance(model, AcceleratedLightningModule):
+            # forward param list for compiled model
+            forward_args = get_forward_args(model.model)
     return forward_args
 
 

--- a/python/nano/test/inc/pytorch/test_dataloader.py
+++ b/python/nano/test/inc/pytorch/test_dataloader.py
@@ -25,8 +25,8 @@ from bigdl.nano.pytorch import Trainer
 
 input1 = TensorDataset(torch.ones(10, 3))
 input2 = TensorDataset(torch.ones(10, 4))
-label1 = TensorDataset(torch.ones(10))
-label2 = TensorDataset(torch.ones(10))
+label1 = TensorDataset(torch.ones(10, dtype=torch.int))
+label2 = TensorDataset(torch.ones(10, dtype=torch.int))
 
 
 def illegal_func(data):
@@ -97,15 +97,14 @@ class TestDataloader(TestCase):
 
         trainer.quantize(model, calib_dataloader=loader)
 
-    def test_illegal_data_format(self):
-        # illegal dataloader: torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
-        dataset = ChainTensorDataset(input1, input2, label1, label2)
+    def test_legal_data_format(self):
+        # we can now easily support this test!
+        dataset = ChainTensorDataset(input1, input2, label1)
         dataloader = DataLoader(dataset, batch_size=5)
         trainer = Trainer()
         model = ModelWithMultipleInputs()
 
-        with pytest.raises(RuntimeError, match="Dataloader for quantization should yield data *"):
-            trainer.quantize(model, calib_dataloader=dataloader, metric=torchmetrics.F1(10))
+        trainer.quantize(model, calib_dataloader=dataloader, metric=torchmetrics.F1())
 
     def test_no_output_check(self):
         # dataloader 1: torch.Tensor, numpy.ndarray

--- a/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
+++ b/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
@@ -27,6 +27,7 @@ import torch
 import torch.nn.functional as F
 from test.pytorch.utils._train_torch_lightning import create_data_loader
 from torch.utils.data import TensorDataset, DataLoader
+from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
 
 
 data_transform = transforms.Compose([
@@ -298,6 +299,10 @@ class TestInferencePipeline(TestCase):
                                latency_sample_num=10)
 
     def test_multiple_input_dataloader(self):
+        # will not run this test if torch < 1.10
+        if TORCH_VERSION_LESS_1_10:
+            return
+
         net = MultipleInputNet()
         x1 = torch.randn(32, 10)
         x2 = torch.randn(32, 10)


### PR DESCRIPTION
## Description

### 1. Why the change?
https://github.com/intel-analytics/BigDL/issues/6389

### 2. User API changes
Nothing is changed

### 3. Summary of the change 
for inc based quantization in `InferenceOptimizer.quantize`, a pre-step is done to detect and transform the dataloader from 
```python
class MultipleTensorDataset(Dataset):
    ...
    def __getitem__(self, idx):
        return self.x1[idx], self.x2[idx], self.y[idx]
```
to
```python
class MultipleTensorDataset(Dataset):
    ...
    def __getitem__(self, idx):
        return (self.x1[idx], self.x2[idx]), self.y[idx]
```
### 4. How to test?
- [x] Unit test

Need a new how-to page to guide users about the supported dataloader.