### PR TITLE
[ORCA] Support `model_creator` optional with tf2 pyspark estimator

### DIFF
--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -78,7 +78,7 @@ class SparkTFEstimator():
             self.config["intra_op_parallelism"] = num_core // workers_per_node
 
         self.model_weights = None
-        self.load_path=None
+        self.load_path = None
 
         if "batch_size" in self.config:
             invalidInputError(False,

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -520,11 +520,12 @@ class SparkTFEstimator():
         sc = OrcaContext.get_spark_context()
         model = load_model(filepath, custom_objects=custom_objects, compile=compile)
         self.model_weights = model.get_weights()
-        self.load_path = filepath
-        if self.load_path.endswith('.h5') or self.load_path.endswith('.keras'):
-            sc.addFile(self.load_path, recursive=False)
-        else:
-            sc.addFile(self.load_path, recursive=True)
+        if self.model_creator is None:
+            self.load_path = filepath
+            if self.load_path.endswith('.h5') or self.load_path.endswith('.keras'):
+                sc.addFile(self.load_path, recursive=False)
+            else:
+                sc.addFile(self.load_path, recursive=True)
         # update remote model
         if self.model_dir is not None:
             save_model(model, self._model_saved_path, save_format="h5", filemode=0o666)

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -78,6 +78,7 @@ class SparkTFEstimator():
             self.config["intra_op_parallelism"] = num_core // workers_per_node
 
         self.model_weights = None
+        self.load_path=None
 
         if "batch_size" in self.config:
             invalidInputError(False,
@@ -148,6 +149,7 @@ class SparkTFEstimator():
 
         init_params = dict(
             model_creator=self.model_creator,
+            model_load=self.load_path,
             compile_args_creator=self.compile_args_creator,
             config=self.config,
             verbose=self.verbose,
@@ -272,6 +274,7 @@ class SparkTFEstimator():
 
         init_params = dict(
             model_creator=self.model_creator,
+            model_load=self.load_path,
             compile_args_creator=self.compile_args_creator,
             config=self.config,
             verbose=self.verbose,
@@ -344,6 +347,7 @@ class SparkTFEstimator():
 
         init_params = dict(
             model_creator=self.model_creator,
+            model_load=self.load_path,
             compile_args_creator=self.compile_args_creator,
             config=self.config,
             verbose=self.verbose,
@@ -513,8 +517,14 @@ class SparkTFEstimator():
         options for loading from SavedModel.
 
         """
+        sc = OrcaContext.get_spark_context()
         model = load_model(filepath, custom_objects=custom_objects, compile=compile)
         self.model_weights = model.get_weights()
+        self.load_path = filepath
+        if self.load_path.endswith('.h5') or self.load_path.endswith('.keras'):
+            sc.addFile(self.load_path, recursive=False)
+        else:
+            sc.addFile(self.load_path, recursive=True)
         # update remote model
         if self.model_dir is not None:
             save_model(model, self._model_saved_path, save_format="h5", filemode=0o666)

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -522,7 +522,7 @@ class SparkTFEstimator():
         self.model_weights = model.get_weights()
         if self.model_creator is None:
             self.load_path = filepath
-            if self.load_path.endswith('.h5') or self.load_path.endswith('.keras'):
+            if is_file(self.load_path):
                 sc.addFile(self.load_path, recursive=False)
             else:
                 sc.addFile(self.load_path, recursive=True)

--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -423,10 +423,10 @@ class SparkRunner:
         if results is None:
             if self.model_creator is not None:
                 local_model = self.model_creator(self.config)
-                if self.model_weights:
-                    local_model = local_model.set_weights(self.model_weights.value)
             else:
                 local_model = tf.keras.models.load_model(self.model_load)
+            if self.model_weights:
+                local_model = local_model.set_weights(self.model_weights.value)
             results = local_model.evaluate(dataset, **params)
 
         if isinstance(results, list):

--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -290,7 +290,7 @@ class SparkRunner:
                 else:
                     model = tf.keras.models.load_model(self.model_load)
                 if self.model_weights:
-                        model.set_weights(self.model_weights.value)
+                    model.set_weights(self.model_weights.value)
 
             if not model._is_compiled and self.compile_args_creator:
                 model.compile(**self.compile_args_creator(config))
@@ -470,7 +470,7 @@ class SparkRunner:
         else:
             local_model = tf.keras.models.load_model(self.model_load)
         if self.model_weights:
-                local_model.set_weights(self.model_weights.value)
+            local_model.set_weights(self.model_weights.value)
 
         def predict_fn(shard):
             y = local_model.predict(shard["x"], **params)

--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -287,10 +287,10 @@ class SparkRunner:
             else:
                 if self.model_creator is not None:
                     model = self.model_creator(self.config)
-                    if self.model_weights:
-                        model.set_weights(self.model_weights.value)
                 else:
                     model = tf.keras.models.load_model(self.model_load)
+                if self.model_weights:
+                        model.set_weights(self.model_weights.value)
 
             if not model._is_compiled and self.compile_args_creator:
                 model.compile(**self.compile_args_creator(config))
@@ -396,10 +396,10 @@ class SparkRunner:
         with self.strategy.scope():
             if self.model_creator is not None:
                 model = self.model_creator(self.config)
-                if self.model_weights:
-                    model.set_weights(self.model_weights.value)
             else:
                 model = tf.keras.models.load_model(self.model_load)
+            if self.model_weights:
+                model.set_weights(self.model_weights.value)
 
         with self.strategy.scope():
             dataset_handler = DatasetHandler.get_handler(self.backend,
@@ -467,10 +467,10 @@ class SparkRunner:
 
         if self.model_creator is not None:
             local_model = self.model_creator(self.config)
-            if self.model_weights:
-                local_model.set_weights(self.model_weights.value)
         else:
             local_model = tf.keras.models.load_model(self.model_load)
+        if self.model_weights:
+                local_model.set_weights(self.model_weights.value)
 
         def predict_fn(shard):
             y = local_model.predict(shard["x"], **params)

--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -238,7 +238,6 @@ class SparkRunner:
         self.application_id = application_id
 
         if self.model_creator is None:
-            import tensorflow as tf
             from pyspark import SparkFiles
             if self.model_load.startswith("hdfs") or self.model_load.startswith("s3"):
                 self.model_load = self.model_load.split("/")[-1]

--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -240,7 +240,7 @@ class SparkRunner:
         if self.model_creator is None:
             import tensorflow as tf
             from pyspark import SparkFiles
-            if self.model_load.startswith("hdfs"):
+            if self.model_load.startswith("hdfs") or self.model_load.startswith("s3"):
                 self.model_load = self.model_load.split("/")[-1]
             self.model_load = SparkFiles.get(self.model_load)
 

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
@@ -600,6 +600,66 @@ class TestTFEstimator(TestCase):
             if os.path.exists(model_path):
                 os.remove(model_path)
 
+    def test_optional_model_creator(self):
+        sc = OrcaContext.get_spark_context()
+        rdd = sc.range(0, 100)
+        spark = OrcaContext.get_spark_session()
+
+        from pyspark.ml.linalg import DenseVector
+        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float)),
+                                int(np.random.randint(0, 2, size=())))).toDF(["feature", "label"])
+
+        config = {
+            "lr": 0.2
+        }
+
+        try:
+            temp_dir = tempfile.mkdtemp()
+
+            trainer = Estimator.from_keras(
+                model_creator=model_creator,
+                verbose=True,
+                config=config,
+                workers_per_node=2,
+                backend="spark")
+
+            trainer.fit(df, epochs=5, batch_size=4, steps_per_epoch=25,
+                        feature_cols=["feature"],
+                        label_cols=["label"],
+                        validation_data=df,
+                        validation_steps=1)
+
+            # save model as h5 format
+            trainer.save(os.path.join(temp_dir, "saved_model.h5"))
+            before_res = trainer.predict(df, feature_cols=["feature"]).collect()
+            expect_res = np.concatenate([part["prediction"] for part in before_res])
+            trainer.shutdown()
+
+            est = Estimator.from_keras(
+                verbose=True,
+                config=config,
+                workers_per_node=2,
+                backend="spark")
+
+            est.load(os.path.join(temp_dir, "saved_model.h5"))
+            # test continous predicting
+            after_res = est.predict(df, feature_cols=["feature"]).collect()
+            pred_res = np.concatenate([part["prediction"] for part in after_res])
+            assert np.array_equal(expect_res, pred_res)
+
+            # test continuous training
+            est.fit(df, epochs=5, batch_size=4, steps_per_epoch=25,
+                    feature_cols=["feature"],
+                    label_cols=["label"],
+                    validation_data=df,
+                    validation_steps=1)
+            # test continuous evaluation
+            res = est.evaluate(df, batch_size=4, num_steps=25, feature_cols=["feature"],
+                               label_cols=["label"])
+            print("validation result: ", res)
+        finally:
+            shutil.rmtree(temp_dir)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Support load model instead of `model_creator` when using tf2 pyspark estimator.

### 1. Why the change?
For user cases, that will load a saved tf model directly.

### 2. User API changes
```python
trainer = estimator.from_keras(backend="spark")

# load model for continuous pipeline
trainer.load("model.h5")

trainer.trainer(df, epochs, batch_size...)
```

### 3. Summary of the change 
- [x] continuous evaluation support
- [x] continuous prediction support
- [x] hdfs support
- [x] s3 support

### 4. How to test?
- [x] Unit test

