### PR TITLE
Nano: Add ONNX quantize support for tensorflow

### DIFF
--- a/.github/workflows/nano_unit_tests_tensorflow.yml
+++ b/.github/workflows/nano_unit_tests_tensorflow.yml
@@ -159,7 +159,7 @@ jobs:
           $CONDA/bin/conda create -n onnx-tensorflow -y python==3.7.10 setuptools=58.0.4
           source $CONDA/bin/activate onnx-tensorflow
           $CONDA/bin/conda info
-          bash python/nano/dev/build_and_install.sh linux default false tensorflow
+          bash python/nano/dev/build_and_install.sh linux default false tensorflow,inference
           if [ ! -z "${{matrix.tf-version}}" ]; then
             pip install ${{matrix.tf-version}}
           fi

--- a/.github/workflows/nano_unit_tests_tensorflow.yml
+++ b/.github/workflows/nano_unit_tests_tensorflow.yml
@@ -164,7 +164,6 @@ jobs:
             pip install ${{matrix.tf-version}}
           fi
           pip install pytest
-          pip install onnx onnxruntime tf2onnx pyyaml
           source bigdl-nano-init
           bash python/nano/test/run-nano-tf-onnx-tests.sh
           source $CONDA/bin/deactivate

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
@@ -49,12 +49,14 @@ def quantize(model, dataloader=None, metric=None, **kwargs):
         from .pytorch.quantization import PytorchQuantization
         quantizer = PytorchQuantization(**not_none_kwargs)
     if 'onnx' in not_none_kwargs['framework']:
-        invalidInputError('torch' in str(type(dataloader)),
-                          errMsg="ONNXRuntime quantization only support in Pytorch.")
-        from .onnx.pytorch.quantization import PytorchONNXRuntimeQuantization
-        quantizer =\
-            PytorchONNXRuntimeQuantization(onnxruntime_session_options=onnxruntime_session_options,
-                                           **not_none_kwargs)
+        if 'torch' in str(type(dataloader)):
+            from .onnx.pytorch.quantization import PytorchONNXRuntimeQuantization
+            quantizer = PytorchONNXRuntimeQuantization(
+                onnxruntime_session_options=onnxruntime_session_options, **not_none_kwargs)
+        else:
+            from .onnx.tensorflow.quantization import KerasONNXRuntimeQuantization
+            quantizer = KerasONNXRuntimeQuantization(
+                onnxruntime_session_options=onnxruntime_session_options, **not_none_kwargs)
     if 'tensorflow' in not_none_kwargs['framework']:
         from .tensorflow.quantization import TensorflowQuantization
         quantizer = TensorflowQuantization(**not_none_kwargs)

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
@@ -49,13 +49,14 @@ def quantize(model, dataloader=None, metric=None, **kwargs):
         from .pytorch.quantization import PytorchQuantization
         quantizer = PytorchQuantization(**not_none_kwargs)
     if 'onnx' in not_none_kwargs['framework']:
-        if 'torch' in str(type(dataloader)):
-            from .onnx.pytorch.quantization import PytorchONNXRuntimeQuantization
-            quantizer = PytorchONNXRuntimeQuantization(
-                onnxruntime_session_options=onnxruntime_session_options, **not_none_kwargs)
-        else:
+        onnx_option = not_none_kwargs.pop('onnx_option', None)
+        if onnx_option == 'tensorflow':
             from .onnx.tensorflow.quantization import KerasONNXRuntimeQuantization
             quantizer = KerasONNXRuntimeQuantization(
+                onnxruntime_session_options=onnxruntime_session_options, **not_none_kwargs)
+        else:
+            from .onnx.pytorch.quantization import PytorchONNXRuntimeQuantization
+            quantizer = PytorchONNXRuntimeQuantization(
                 onnxruntime_session_options=onnxruntime_session_options, **not_none_kwargs)
     if 'tensorflow' in not_none_kwargs['framework']:
         from .tensorflow.quantization import TensorflowQuantization

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/tensorflow/__init__.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/tensorflow/__init__.py
@@ -13,17 +13,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from ..core import version
-from packaging import version as v
-from bigdl.nano.utils.log4Error import invalidInputError
-
-
-if v.parse(version) >= v.parse("1.11"):
-    try:
-        import onnxruntime_extensions
-    except ImportError:
-        invalidInputError(
-            False,
-            errMsg="Neural Compressor >=1.11 requires onnxruntime_extensions.",
-            fixMsg="Please run installation:\n\t pip install onnxruntime-extensions"
-        )

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/tensorflow/metric.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/tensorflow/metric.py
@@ -13,17 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from ..core import version
-from packaging import version as v
-from bigdl.nano.utils.log4Error import invalidInputError
 
 
-if v.parse(version) >= v.parse("1.11"):
-    try:
-        import onnxruntime_extensions
-    except ImportError:
-        invalidInputError(
-            False,
-            errMsg="Neural Compressor >=1.11 requires onnxruntime_extensions.",
-            fixMsg="Please run installation:\n\t pip install onnxruntime-extensions"
-        )
+from ..metric import ONNXRuntimeINCMetic
+import tensorflow as tf
+
+
+class KerasONNXRuntimeINCMetic(ONNXRuntimeINCMetic):
+    '''
+    ONNXRuntime will use numpy as data type.
+    ONNXRuntime quantization in tensorflow will use tf.keras.metrics.Metric
+    '''
+
+    def stack(self, preds, labels):
+        # calculate accuracy
+        preds, labels = super().stack(preds, labels)
+        preds = tf.convert_to_tensor(preds)
+        labels = tf.convert_to_tensor(labels)
+        return preds, labels
+
+    def to_scalar(self, tensor):
+        return float(tensor)

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/tensorflow/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/tensorflow/quantization.py
@@ -1,0 +1,65 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import tensorflow as tf
+
+from bigdl.nano.deps.onnxruntime.tensorflow.tensorflow_onnxruntime_model \
+    import KerasONNXRuntimeModel
+
+from ..quantization import BaseONNXRuntimeQuantization
+from ...tensorflow import TensorflowQuantization
+from .metric import KerasONNXRuntimeINCMetic
+
+
+class KerasONNXRuntimeQuantization(BaseONNXRuntimeQuantization):
+    def __init__(self, framework='onnxrt_qlinear', **kwargs):
+        """
+        Create a Intel Neural Compressor Quantization object for ONNXRuntime in Tensorflow.
+        """
+        kwargs['framework'] = framework
+        self.session_options = kwargs.pop('onnxruntime_session_options', None)
+        super().__init__(**kwargs)
+        self._inc_metric_cls = KerasONNXRuntimeINCMetic
+
+    def _pre_execution(self, model, calib_dataset=None, metric=None):
+        if calib_dataset:
+            calib_dataset = KerasNumpyDataset(calib_dataset, model.dtype)
+
+        if isinstance(model, KerasONNXRuntimeModel):
+            model = model.onnx_model
+
+        return model, calib_dataset, metric
+
+    def _post_execution(self, q_model):
+        return KerasONNXRuntimeModel(q_model.model, input_sample=None,
+                                     onnxruntime_session_options=self.session_options)
+
+
+# we cannot call `.numpy()` in `Dataset.map()`,
+# so we use this wrapper to transform the output of dataset to numpy array
+class KerasNumpyDataset():
+    def __init__(self, dataset, dtype):
+        self.dataset = dataset
+        self.batch_size = 1     # it's necessary
+        self.dtype = dtype      # the dtype of dataset and model must be exactly the same
+
+    def __len__(self):
+        return len(self.dataset)
+
+    def __iter__(self):
+        for batch in self.dataset:
+            yield tuple(map(lambda x: x.numpy().astype(self.dtype), batch))

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/tensorflow/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/tensorflow/quantization.py
@@ -62,4 +62,7 @@ class KerasNumpyDataset():
 
     def __iter__(self):
         for batch in self.dataset:
-            yield tuple(map(lambda x: x.numpy().astype(self.dtype), batch))
+            yield tuple(
+                map(lambda x: x.numpy().astype(self.dtype) if isinstance(x, tf.Tensor) else x,
+                    batch)
+            )

--- a/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
@@ -62,7 +62,7 @@ class InferenceUtils:
         :param approach:        'static' or 'dynamic'.
                                 'static': post_training_static_quant,
                                 'dynamic': post_training_dynamic_quant.
-                                Default: 'static'. Now only static mode is supported.
+                                Default: 'static'. Only 'static' approach is supported now.
         :param method:      Method to do quantization. When accelerator=None, supported methods:
                 None. When accelerator='onnxruntime', supported methods: 'qlinear', 'integer',
                 defaults to 'qlinear'. Suggest 'qlinear' for lower accuracy drop if using
@@ -94,6 +94,7 @@ class InferenceUtils:
                                             accelerator='onnxruntime', otherwise will be ignored.
         :return:            A TensorflowBaseModel for INC. If there is no model found, return None.
         """
+        invalidInputError(approach == 'static', "Only 'static' approach is supported now.")
         if accelerator is None:
             if batch:
                 calib_dataset = calib_dataset.batch(batch)

--- a/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
@@ -46,8 +46,8 @@ class InferenceUtils:
         """
         Post-training quantization on a keras model.
 
-        :param calib_dataset:   A tf.data.Dataset object for calibration without setting
-                                batch_size or batch_size=1. Required for static quantization.
+        :param calib_dataset:   An unbatched tf.data.Dataset object for calibration.
+                                Required for static quantization.
                                 It's also used as validation dataloader.
         :param precision:       Global precision of quantized model,
                                 supported type: 'int8', defaults to 'int8'.
@@ -121,7 +121,7 @@ class InferenceUtils:
                 maximal_drop = accuracy_criterion.get(drop_type, None)
             else:
                 drop_type, higher_is_better, maximal_drop = None, None, None
-            return openvino_model.pot(dataset=calib_dataset,    # type: ignore
+            return openvino_model.pot(dataset=calib_dataset.batch(1),    # type: ignore
                                       metric=metric,
                                       higher_better=higher_is_better,
                                       drop_type=drop_type,
@@ -145,7 +145,8 @@ class InferenceUtils:
                 None: 'onnxrt_qlinearops'  # default
             }
             framework = method_map.get(method, None)
-            return inc_quantzie(onnx_model, dataloader=calib_dataset, metric=metric,
+            return inc_quantzie(onnx_model, dataloader=calib_dataset.batch(1),
+                                metric=metric,
                                 framework=framework,
                                 conf=conf,
                                 approach=approach,

--- a/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
@@ -27,9 +27,9 @@ class InferenceUtils:
     """A mixedin class for nano keras Sequential and Model, adding more functions for Inference."""
 
     def quantize(self,
+                 calib_dataset: tf.data.Dataset,
                  precision: str = 'int8',
                  accelerator: Optional[str] = None,
-                 calib_dataset: tf.data.Dataset = None,
                  metric: Metric = None,
                  accuracy_criterion: dict = None,
                  approach: str = 'static',
@@ -62,7 +62,7 @@ class InferenceUtils:
         :param approach:        'static' or 'dynamic'.
                                 'static': post_training_static_quant,
                                 'dynamic': post_training_dynamic_quant.
-                                Default: 'static'. OpenVINO supports static mode only.
+                                Default: 'static'. Now only static mode is supported.
         :param method:      Method to do quantization. When accelerator=None, supported methods:
                 None. When accelerator='onnxruntime', supported methods: 'qlinear', 'integer',
                 defaults to 'qlinear'. Suggest 'qlinear' for lower accuracy drop if using
@@ -95,7 +95,7 @@ class InferenceUtils:
         :return:            A TensorflowBaseModel for INC. If there is no model found, return None.
         """
         if accelerator is None:
-            if batch and calib_dataset:
+            if batch:
                 calib_dataset = calib_dataset.batch(batch)
             return inc_quantzie(self, dataloader=calib_dataset, metric=metric,
                                 framework='tensorflow',
@@ -156,6 +156,7 @@ class InferenceUtils:
                                 max_trials=max_trials,
                                 inputs=inputs,
                                 outputs=outputs,
+                                onnx_option='tensorflow',
                                 onnxruntime_session_options=onnxruntime_session_options)
         else:
             invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))

--- a/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
@@ -41,7 +41,7 @@ class InferenceUtils:
                  batch=None,
                  inputs: List[str] = None,
                  outputs: List[str] = None,
-                 sample_size: int = 100
+                 sample_size: int = 100,
                  onnxruntime_session_options=None):
         """
         Post-training quantization on a keras model.
@@ -50,8 +50,8 @@ class InferenceUtils:
                                 batch_size or batch_size=1. Required for static quantization.
                                 It's also used as validation dataloader.
         :param precision:       Global precision of quantized model,
-                                supported type: 'int8', 'bf16', 'fp16', defaults to 'int8'.
-        :param accelerator:     Use accelerator 'None', defaults to None.
+                                supported type: 'int8', defaults to 'int8'.
+        :param accelerator:     Use accelerator 'None', 'onnxruntime', 'openvino', defaults to None.
                                 None means staying in tensorflow.
         :param metric:          A tensorflow.keras.metrics.Metric object for evaluation.
         :param accuracy_criterion:  Tolerable accuracy drop.

--- a/python/nano/test/inc/tf/test_keras_quantize.py
+++ b/python/nano/test/inc/tf/test_keras_quantize.py
@@ -53,5 +53,5 @@ class TestModelQuantize(TestCase):
 
         # Case 3: Invalid approach, dynamic or qat is not supported
         invalid_approach = 'dynamic'
-        with pytest.raises(RuntimeError, match="post_training_dynamic_quant is invalid."):
-            model.quantize(approach=invalid_approach)
+        with pytest.raises(RuntimeError, match="Only 'static' approach is supported now."):
+            model.quantize(calib_dataset=None, approach=invalid_approach)

--- a/python/nano/test/onnx/tf/test_inc_onnx.py
+++ b/python/nano/test/onnx/tf/test_inc_onnx.py
@@ -29,7 +29,7 @@ class TestONNX(TestCase):
         input_features = np.random.randint(0, 10, size=100)
         
         train_dataset = tf.data.Dataset.from_tensor_slices((input_examples,
-                                                            input_features)).batch(1)
+                                                            input_features))
 
         # quantize a Keras model
         onnx_quantized_model = model.quantize(model,

--- a/python/nano/test/onnx/tf/test_inc_onnx.py
+++ b/python/nano/test/onnx/tf/test_inc_onnx.py
@@ -1,0 +1,47 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from unittest import TestCase
+import tensorflow as tf
+from tensorflow.keras.applications.resnet50 import ResNet50
+import numpy as np
+from bigdl.nano.tf.keras import Model
+
+
+class TestONNX(TestCase):
+    def test_model_trace_onnx(self):
+        model = ResNet50(weights=None, input_shape=[224, 224, 3], classes=10)
+        model = Model(inputs=model.inputs, outputs=model.outputs)
+        input_examples = np.random.random((100, 224, 224, 3))
+        input_features = np.random.randint(0, 10, size=100)
+        
+        train_dataset = tf.data.Dataset.from_tensor_slices((input_examples,
+                                                            input_features)).batch(1)
+
+        # quantize a Keras model
+        onnx_quantized_model = model.quantize(model,
+                                              accelerator='onnxruntime',
+                                              calib_dataset=train_dataset)
+
+        y_hat = onnx_quantized_model(input_examples[:10])
+        assert y_hat.shape == (10, 10)
+
+        y_hat = onnx_quantized_model.predict(input_examples, batch_size=5)
+        assert y_hat.shape == (100, 10)
+
+        preds = model.predict(input_examples)
+        onnx_preds = onnx_quantized_model.predict(input_examples)
+        np.testing.assert_allclose(preds, onnx_preds, rtol=1e-2)

--- a/python/nano/test/onnx/tf/test_inc_onnx.py
+++ b/python/nano/test/onnx/tf/test_inc_onnx.py
@@ -22,7 +22,7 @@ from bigdl.nano.tf.keras import Model
 
 
 class TestONNX(TestCase):
-    def test_model_trace_onnx(self):
+    def test_model_quantize_onnx(self):
         model = ResNet50(weights=None, input_shape=[224, 224, 3], classes=10)
         model = Model(inputs=model.inputs, outputs=model.outputs)
         input_examples = np.random.random((100, 224, 224, 3))
@@ -32,8 +32,7 @@ class TestONNX(TestCase):
                                                             input_features))
 
         # quantize a Keras model
-        onnx_quantized_model = model.quantize(model,
-                                              accelerator='onnxruntime',
+        onnx_quantized_model = model.quantize(accelerator='onnxruntime',
                                               calib_dataset=train_dataset)
 
         y_hat = onnx_quantized_model(input_examples[:10])

--- a/python/nano/test/openvino/tf/test_openvino_quantize.py
+++ b/python/nano/test/openvino/tf/test_openvino_quantize.py
@@ -26,7 +26,7 @@ class TestOpenVINO(TestCase):
         model = Model(inputs=model.inputs, outputs=model.outputs)
         train_examples = np.random.random((100, 40, 40, 3))
         train_labels = np.random.randint(0, 10, size=(100,))
-        train_dataset = tf.data.Dataset.from_tensor_slices((train_examples, train_labels)).batch(1)
+        train_dataset = tf.data.Dataset.from_tensor_slices((train_examples, train_labels))
 
         # Case1: Trace and quantize
         openvino_model = model.trace(accelerator='openvino')

--- a/python/nano/test/openvino/tf/test_openvino_quantize.py
+++ b/python/nano/test/openvino/tf/test_openvino_quantize.py
@@ -49,5 +49,6 @@ class TestOpenVINO(TestCase):
         y_hat = openvino_quantized_model.predict(train_examples, batch_size=5)
         assert y_hat.shape == (100, 10)
 
-        openvino_quantized_model.compile(metrics=[tf.keras.metrics.CategoricalAccuracy()])
-        acc = openvino_quantized_model.evaluate(train_dataset, return_dict=True)['categorical_accuracy']
+        preds = model.predict(train_examples)
+        openvino_preds = openvino_quantized_model.predict(train_examples)
+        np.testing.assert_allclose(preds, openvino_preds, rtol=1e-2)


### PR DESCRIPTION
## Description

Add ONNX quantize support for Tensorflow

### 1. Why the change?

Support more features

### 2. User API changes

```python
from bigdl.nano.tf.keras import Model
model = Model(...)
dataset = Dataset(...)

# quantize directly
onnx_quantized_model = model.quantize(model, accelerator='onnxruntime', calib_dataset=train_dataset)
```

### 3. Summary of the change 

Add ONNX quantize support for Tensorflow and an UT

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...
