### PR TITLE
Nano: support data sample directly in `inference_opt.optimize()`

### DIFF
--- a/python/nano/src/bigdl/nano/deps/neural_compressor/core/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/core/quantization.py
@@ -128,14 +128,13 @@ class BaseQuantization(Quantization):
         for quantization.
         """
         if self.cfg.quantization.approach == 'post_training_static_quant':
-            invalidInputError(calib_dataloader,
-                              "calib_calib_dataloader must not be None"
+            invalidInputError(calib_dataloader is not None,
+                              "calib_dataloader must not be None"
                               " when approach is post-training static quantization.")
-
         if self.cfg.quantization.approach == 'post_training_dynamic_quant':
             if not metric:
                 invalidInputError(calib_dataloader is None,
-                                  "calib_calib_dataloader should be None when approach is"
+                                  "calib_dataloader should be None when approach is"
                                   " post-training dynamic quantization and metric is None.")
 
         if metric and not calib_dataloader:

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -242,19 +242,19 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                             if accelerator in ("jit", None):
                                 acce_model = \
                                     InferenceOptimizer.trace(model=model,
-                                                                accelerator=accelerator,
-                                                                use_ipex=use_ipex,
-                                                                # channels_last is only for jit
-                                                                channels_last=use_channels_last,
-                                                                input_sample=input_sample)
+                                                             accelerator=accelerator,
+                                                             use_ipex=use_ipex,
+                                                             # channels_last is only for jit
+                                                             channels_last=use_channels_last,
+                                                             input_sample=input_sample)
                             else:
                                 acce_model = \
                                     InferenceOptimizer.trace(model=model,
-                                                                accelerator=accelerator,
-                                                                input_sample=input_sample,
-                                                                thread_num=thread_num,
-                                                                # remove output of openvino
-                                                                logging=logging)
+                                                             accelerator=accelerator,
+                                                             input_sample=input_sample,
+                                                             thread_num=thread_num,
+                                                             # remove output of openvino
+                                                             logging=logging)
                     except Exception as e:
                         print(e)
                         result_map[method]["status"] = "fail to convert"

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -23,7 +23,7 @@ from importlib.util import find_spec
 import time
 import numpy as np
 from copy import deepcopy
-from typing import Dict, Callable, Tuple, Optional, List, Set, Union
+from typing import Dict, Callable, Tuple, Optional, List, Set, Union, Sequence
 from torch.utils.data import DataLoader
 from torchmetrics.metric import Metric
 from bigdl.nano.utils.inference.common.checker import available_acceleration_combination
@@ -39,6 +39,7 @@ from bigdl.nano.deps.neural_compressor.inc_api import quantize as inc_quantize
 from bigdl.nano.utils.inference.pytorch.model import AcceleratedLightningModule
 from bigdl.nano.utils.inference.pytorch.model_utils import get_forward_args, get_input_example
 from bigdl.nano.utils.inference.pytorch.metrics import NanoMetric
+from bigdl.nano.utils.inference.pytorch.dataset import RepeatDataset, remove_batch_dim_fn
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10, save_model, load_model
 from torchmetrics import Metric
 import warnings
@@ -77,8 +78,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         }
 
     def optimize(self, model: nn.Module,
-                 training_data: DataLoader,
-                 validation_data: Optional[DataLoader] = None,
+                 training_data: Union[DataLoader, torch.Tensor, Tuple[torch.Tensor]],
+                 validation_data:
+                     Optional[Union[DataLoader, torch.Tensor, Tuple[torch.Tensor]]] = None,
                  input_sample: Union[torch.Tensor, Dict, Tuple[torch.Tensor], None] = None,
                  metric: Optional[Callable] = None,
                  direction: str = "max",
@@ -98,16 +100,33 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         and "onnxruntime_int8_integer".
 
         :param model: A torch.nn.Module to be optimized
-        :param training_data: A torch.utils.data.dataloader.DataLoader object for training
-               dataset. Users should be careful with this parameter since this dataloader
-               might be exposed to the model, which causing data leak. The
-               batch_size of this dataloader is important as well, users may
-               want to set it to the same batch size you may want to use the model
-               in real deploy environment. E.g. batch size should be set to 1
-               if you would like to use the accelerated model in an online service.
-        :param validation_data: (optional) A torch.utils.data.dataloader.DataLoader object
-               for accuracy evaluation. This is only needed when users care about the possible
-               accuracy drop.
+        :param training_data: training_data support following formats:
+
+                | 1. a torch.utils.data.dataloader.DataLoader object for training dataset.
+                | Users should be careful with this parameter since this dataloader
+                | might be exposed to the model, which causing data leak. The
+                | batch_size of this dataloader is important as well, users may
+                | want to set it to the same batch size you may want to use the model
+                | in real deploy environment. E.g. batch size should be set to 1
+                | if you would like to use the accelerated model in an online service.
+                |
+                | 2. a single torch.Tensor which used for training, this case is used to
+                | accept single sample input x.
+                |
+                | 3. a tuple of torch.Tensor which used for training, this case is used to
+                | accept single sample input (x, y) or (x1, x2) et al.
+
+        :param validation_data: (optional) validation_data is only needed when users care
+                                about the possible accuracy drop. It support following formats:
+
+                | 1. a torch.utils.data.dataloader.DataLoader object for accuracy evaluation.
+                |
+                | 2. a single torch.Tensor which used for training, this case is used to
+                | accept single sample input x.
+                |
+                | 3. a tuple of torch.Tensor which used for training, this case is used to
+                | accept single sample input (x, y) or (x1, x2) et al.
+
         :param input_sample: (optional) A set of inputs for trace, defaults to None.
                In most cases, you don't need specify this parameter, it will be obtained from
                training_data.
@@ -167,7 +186,23 @@ class InferenceOptimizer(BaseInferenceOptimizer):
 
         if input_sample is None:
             forward_args = get_forward_args(model)
-            input_sample = get_input_example(model, training_data, forward_args)
+            if isinstance(training_data, DataLoader):
+                input_sample = get_input_example(model, training_data, forward_args)
+            else:
+                if isinstance(training_data, Sequence):
+                    input_sample = tuple(list(training_data)[:len(forward_args)])
+                else:
+                    input_sample = training_data
+                # turn training_data into dataset
+                dataset = RepeatDataset(sample=training_data, num=1)
+                training_data = DataLoader(dataset, batch_size=1)
+                training_data = remove_batch_dim_fn(training_data)
+                if validation_data is not None and not isinstance(validation_data, DataLoader):
+                    # turn validation_data into dataset
+                    val_dataset = RepeatDataset(sample=validation_data, num=1)
+                    validation_data = DataLoader(val_dataset, batch_size=1)
+                    validation_data = remove_batch_dim_fn(validation_data)
+
         st = time.perf_counter()
         try:
             with torch.no_grad():
@@ -207,19 +242,19 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                             if accelerator in ("jit", None):
                                 acce_model = \
                                     InferenceOptimizer.trace(model=model,
-                                                             accelerator=accelerator,
-                                                             use_ipex=use_ipex,
-                                                             # channels_last is only for jit
-                                                             channels_last=use_channels_last,
-                                                             input_sample=input_sample)
+                                                                accelerator=accelerator,
+                                                                use_ipex=use_ipex,
+                                                                # channels_last is only for jit
+                                                                channels_last=use_channels_last,
+                                                                input_sample=input_sample)
                             else:
                                 acce_model = \
                                     InferenceOptimizer.trace(model=model,
-                                                             accelerator=accelerator,
-                                                             input_sample=input_sample,
-                                                             thread_num=thread_num,
-                                                             # remove output of openvino
-                                                             logging=logging)
+                                                                accelerator=accelerator,
+                                                                input_sample=input_sample,
+                                                                thread_num=thread_num,
+                                                                # remove output of openvino
+                                                                logging=logging)
                     except Exception as e:
                         print(e)
                         result_map[method]["status"] = "fail to convert"

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/dataset.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/dataset.py
@@ -1,0 +1,41 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import torch
+from torch.utils.data import Dataset
+from torch.utils.data.dataloader import default_collate
+
+
+class RepeatDataset(Dataset):
+    def __init__(self, sample, num=1):
+        self.data = sample
+        self.length = num
+    
+    def __len__(self):
+        return self.length
+
+    def __getitem__(self, idx):
+        return self.data
+
+
+def remove_batch_dim_fn(loader):
+    def warpper_fn(batch):
+        data = default_collate(batch)
+        if isinstance(data, torch.Tensor):
+            return data.squeeze(0)
+        return [x.squeeze(0) for x in data]
+    loader.collate_fn = warpper_fn
+    return loader

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/dataset.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/dataset.py
@@ -23,7 +23,7 @@ class RepeatDataset(Dataset):
     def __init__(self, sample, num=1):
         self.data = sample
         self.length = num
-    
+
     def __len__(self):
         return self.length
 

--- a/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
+++ b/python/nano/test/pytorch/tests/test_inference_pipeline_ipex.py
@@ -259,3 +259,29 @@ class TestInferencePipeline(TestCase):
             assert isinstance(model, PytorchIPEXJITModel)
         except:
             pass
+
+    def test_pipeline_with_single_tensor(self):
+        input_sample = torch.rand(1, 3, 32, 32)
+        inference_opt = InferenceOptimizer()
+        inference_opt.optimize(model=self.model,
+                               training_data=input_sample,
+                               thread_num=1,
+                               latency_sample_num=10)
+
+    def test_pipeline_with_single_tuple_of_tensor(self):
+        input_sample = (torch.rand(1, 3, 32, 32), torch.Tensor([1]).int())
+        inference_opt = InferenceOptimizer()
+        inference_opt.optimize(model=self.model,
+                               training_data=input_sample,
+                               thread_num=1,
+                               latency_sample_num=10)
+
+    def test_pipeline_accuracy_with_single_tuple_of_tensor(self):
+        input_sample = (torch.rand(1, 3, 32, 32), torch.Tensor([1]).int())
+        inference_opt = InferenceOptimizer()
+        inference_opt.optimize(model=self.model,
+                               training_data=input_sample,
+                               validation_data=input_sample,
+                               metric=self.metric,
+                               thread_num=1,
+                               latency_sample_num=10)

--- a/python/nano/test/pytorch/utils/_train_torch_lightning.py
+++ b/python/nano/test/pytorch/utils/_train_torch_lightning.py
@@ -64,10 +64,10 @@ def create_data_loader(dir, batch_size, num_workers, transform, subset=50, shuff
     if sampler:
         sampler_set = SequentialSampler(train_subset)
         data_loader = DataLoader(train_subset, batch_size=batch_size, shuffle=shuffle,
-                             num_workers=num_workers, sampler=sampler_set)
+                                 num_workers=num_workers, sampler=sampler_set)
     else:
         data_loader = DataLoader(train_subset, batch_size=batch_size, shuffle=shuffle,
-                             num_workers=num_workers)
+                                 num_workers=num_workers)
     return data_loader
 
 


### PR DESCRIPTION
## Description

support data sample directly in `inference_opt.optimize()` to support GNN and other cv models.

### 1. Why the change?

https://github.com/intel-analytics/BigDL/issues/6391

### 2. User API changes

Now inference_opt.optimize can accept Tensor and tuple of Tensor as training_data and validation_data.
```
input_sample = torch.rand(1, 3, 32, 32)
inference_opt = InferenceOptimizer()
inference_opt.optimize(model=self.model,
                       training_data=input_sample)
```
```
input_sample = (torch.rand(1, 3, 32, 32), torch.Tensor([1]))
inference_opt = InferenceOptimizer()
inference_opt.optimize(model=self.model,
                       training_data=input_sample,
                       validation_data=input_sample,
                       metric=metric)
```


### 3. Summary of the change 

support data sample directly in `inference_opt.optimize()`

### 4. How to test?
- [ ] Unit test
