### PR TITLE
Chronos: update pip mirror in chronos workflows

### DIFF
--- a/.github/actions/python-requirements/requirements-chronos-python-ut.txt
+++ b/.github/actions/python-requirements/requirements-chronos-python-ut.txt
@@ -1,0 +1,13 @@
+pytest==5.4.1
+prophet==1.0.1
+pmdarima==1.8.4
+tsfresh==0.17.0
+ray==1.9.2
+ray[tune]==1.9.2
+ray[default]==1.9.2
+pyarrow==6.0.1
+ConfigSpace==0.5.0
+optuna==2.10.1
+scipy==1.5.4
+cloudpickle
+matplotlib

--- a/.github/workflows/chronos-howto-guides-test.yml
+++ b/.github/workflows/chronos-howto-guides-test.yml
@@ -43,16 +43,11 @@ jobs:
           conda create -n chronos-howto-env -y python==3.7.10 setuptools=58.0.4 -c ${CONDA_CHANNEL} --override-channels
           conda info -e
           source activate chronos-howto-env
-          pip install pytest nbmake
-          pip install neural-compressor==1.13.1
-          pip install onnx==1.11.0
-          pip install onnxruntime==1.11.1
-          pip install onnxruntime-extensions==0.4.2
-          pip install openvino-dev==2022.2.0
-          pip install ipykernel==5.5.6
+          pip install nbmake ipykernel==5.5.6
           apt-get update
           apt-get install -y libgl1
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
+          pip install -i ${PIP_MIRROR} --trusted-host ${TRUSTED_HOST} -r .github/actions/python-requirements/requirements-chronos-python-ut.txt
           bash python/dev/release_default_linux_spark246.sh default false false
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
           whl_name=`ls python/nano/dist/`

--- a/.github/workflows/chronos-prvn-python-spark-2.4-py37-onnxrt.yml
+++ b/.github/workflows/chronos-prvn-python-spark-2.4-py37-onnxrt.yml
@@ -43,27 +43,14 @@ jobs:
       - name: Run Chronos python test
         shell: bash
         run: |
-          if conda info --env | grep "chronos-prvn-env-2"; then
-            source deactivate
-            conda remove -n chronos-prvn-env-2 -y --all
-          fi
+          conda remove -n chronos-prvn-env-2 -y --all
           conda create -n chronos-prvn-env-2 -y python==3.7.10 setuptools==58.0.4 -c ${CONDA_CHANNEL} --override-channels
           source activate chronos-prvn-env-2
-          pip install pytest==5.4.1
-          pip install prophet==1.1
-          pip install pmdarima==1.8.4
-          pip install tsfresh==0.17.0
-          pip install ray==1.9.2 ray[tune]==1.9.2 ray[default]==1.9.2
-          pip install pyarrow==6.0.1
-          pip install ConfigSpace==0.5.0
-          pip install optuna==2.10.1
-          pip install scipy==1.5.4
-          pip install cloudpickle
           apt-get update
           apt-get install -y libgl1
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
-          #sed -i "s/'bigdl-core=='+VERSION/'bigdl-core==2.1.0b20220811'/g" python/dllib/src/setup.py
+          pip install -i ${PIP_MIRROR} --trusted-host ${TRUSTED_HOST} -r .github/actions/python-requirements/requirements-chronos-python-ut.txt
           bash python/dev/release_default_linux_spark246.sh default false false
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
           whl_name=`ls python/nano/dist/`

--- a/.github/workflows/chronos-prvn-python-spark-2.4-py37-ray.yml
+++ b/.github/workflows/chronos-prvn-python-spark-2.4-py37-ray.yml
@@ -43,28 +43,14 @@ jobs:
       - name: Run Chronos python test
         shell: bash
         run: |
-          if conda info --env | grep "chronos-prvn-env-1"; then
-            source deactivate
-            conda remove -n chronos-prvn-env-1 -y --all
-          fi
+          conda remove -n chronos-prvn-env-1 -y --all
           conda create -n chronos-prvn-env-1 -y python==3.7.10 setuptools==58.0.4 -c ${CONDA_CHANNEL} --override-channels
           source activate chronos-prvn-env-1
-          pip install pytest==5.4.1
-          pip install prophet==1.0.1
-          pip install pmdarima==1.8.4
-          pip install tsfresh==0.17.0
-          pip install ray==1.9.2 ray[tune]==1.9.2 ray[default]==1.9.2
-          pip install pyarrow==6.0.1
-          pip install ConfigSpace==0.5.0
-          pip install optuna==2.10.1
-          pip install scipy==1.5.4
-          pip install cloudpickle
-          pip install matplotlib
           apt-get update
           apt-get install -y libgl1
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
-          #sed -i "s/'bigdl-core=='+VERSION/'bigdl-core==2.1.0b20220811'/g" python/dllib/src/setup.py
+          pip install -i ${PIP_MIRROR} --trusted-host ${TRUSTED_HOST} -r .github/actions/python-requirements/requirements-chronos-python-ut.txt
           bash python/dev/release_default_linux_spark246.sh default false false
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
           whl_name=`ls python/nano/dist/`

--- a/.github/workflows/chronos-prvn-python-spark-3.1-py37-onnxrt.yml
+++ b/.github/workflows/chronos-prvn-python-spark-3.1-py37-onnxrt.yml
@@ -43,28 +43,15 @@ jobs:
       - name: Run Chronos python test
         shell: bash
         run: |
-          if conda info --env | grep "chronos-prvn-env-4"; then
-            source deactivate
-            conda remove -n chronos-prvn-env-4 -y --all
-          fi
+          conda remove -n chronos-prvn-env-4 -y --all
           conda create -n chronos-prvn-env-4 -y python==3.7.10 setuptools==58.0.4 -c ${CONDA_CHANNEL} --override-channels
           source activate chronos-prvn-env-4
-          pip install pytest==5.4.1
-          pip install prophet==1.1
-          pip install pmdarima==1.8.4
-          pip install tsfresh==0.17.0
-          pip install ray==1.9.2 ray[tune]==1.9.2 ray[default]==1.9.2
-          pip install pyarrow==6.0.1
-          pip install ConfigSpace==0.5.0
-          pip install optuna==2.10.1
-          pip install scipy==1.5.4
-          pip install cloudpickle
           apt-get update
           apt-get install -y libgl1
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           sed -i "s/pyspark==2.4.6/pyspark==3.1.3/g" python/dllib/src/setup.py
-          #sed -i "s/'bigdl-core=='+VERSION/'bigdl-core==2.1.0b20220811'/g" python/dllib/src/setup.py
+          pip install -i ${PIP_MIRROR} --trusted-host ${TRUSTED_HOST} -r .github/actions/python-requirements/requirements-chronos-python-ut.txt
           bash python/dev/release_default_linux_spark313.sh default false false
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
           whl_name=`ls python/nano/dist/`

--- a/.github/workflows/chronos-prvn-python-spark-3.1-py37-ray.yml
+++ b/.github/workflows/chronos-prvn-python-spark-3.1-py37-ray.yml
@@ -43,29 +43,15 @@ jobs:
       - name: Run Chronos python test
         shell: bash
         run: |
-          if conda info --env | grep "chronos-prvn-env-3"; then
-            source deactivate
-            conda remove -n chronos-prvn-env-3 -y --all
-          fi
+          conda remove -n chronos-prvn-env-3 -y --all
           conda create -n chronos-prvn-env-3 -y python==3.7.10 setuptools==58.0.4 -c ${CONDA_CHANNEL} --override-channels
           source activate chronos-prvn-env-3
-          pip install pytest==5.4.1
-          pip install prophet==1.0.1
-          pip install pmdarima==1.8.4
-          pip install tsfresh==0.17.0
-          pip install ray==1.9.2 ray[tune]==1.9.2 ray[default]==1.9.2
-          pip install pyarrow==6.0.1
-          pip install ConfigSpace==0.5.0
-          pip install optuna==2.10.1
-          pip install scipy==1.5.4
-          pip install cloudpickle
-          pip install matplotlib
           apt-get update
           apt-get install -y libgl1
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           sed -i "s/pyspark==2.4.6/pyspark==3.1.3/g" python/dllib/src/setup.py
-          #sed -i "s/'bigdl-core=='+VERSION/'bigdl-core==2.1.0b20220811'/g" python/dllib/src/setup.py
+          pip install -i ${PIP_MIRROR} --trusted-host ${TRUSTED_HOST} -r .github/actions/python-requirements/requirements-chronos-python-ut.txt
           bash python/dev/release_default_linux_spark313.sh default false false
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
           whl_name=`ls python/nano/dist/`


### PR DESCRIPTION
## Description

Dependencies need to be installed in Chronos workflow are concluded in requirements-chronos-python-ut.txt and install directly through pip mirror. In this way, installation will be faster.


### 4. How to test?
- [x] Unit test
