### PR TITLE
[BugFix] Fix start-worker-with-numactl.sh error when executor_num > numa socket number

### DIFF
--- a/scripts/standalone/sbin/start-worker-with-numactl.sh
+++ b/scripts/standalone/sbin/start-worker-with-numactl.sh
@@ -103,7 +103,7 @@ for nnode in ${_NUMA_HARDWARE_INFO[@]}; do
     _PER_WORKER_LENGTH=$((_LENGTH / _WORKER_PER_SOCKET))
 
     for ((i = 0; i < $((_WORKER_PER_SOCKET)); i++)); do
-      core_start=$(( i * _LENGTH ))
+      core_start=$(( i * _PER_WORKER_LENGTH ))
       _NUMACTL="numactl -m ${_NUMA_NO} -C $(join_by , ${_NUMA_CPUS[@]:${core_start}:${_PER_WORKER_LENGTH}})"
       if ht_enabled; then _NUMACTL="$_NUMACTL,$(join_by , ${_NUMA_CPUS[@]:$((core_start + _LENGTH)):${_PER_WORKER_LENGTH}})"; fi
       echo ${_NUMACTL}


### PR DESCRIPTION
## Description

Fix start-worker-with-numactl.sh error when executor_num > numa socket number

### 1. Why the change?

Related issue: https://github.com/intel-analytics/BigDL/issues/6285

### 4. How to test?
- [x] Manual test

