### PR TITLE
Nano: add more installation options for pytorch (include `pytorch_nightly` / `pytorch_110` / `pytorch_111` / `pytorch_112` / `pytorch_113`)

### DIFF
--- a/.github/workflows/nano_unit_tests_pytorch.yml
+++ b/.github/workflows/nano_unit_tests_pytorch.yml
@@ -54,7 +54,7 @@ jobs:
           $CONDA/bin/conda info
           if [ ! -z "${{matrix.pytorch-version}}" ]; then
             requirements=(${{matrix.pytorch-version}})
-            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]}
+            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]} -f https://software.intel.com/ipex-whl-stable
           fi
           source bigdl-nano-init
           if [ 0"$LD_PRELOAD" = "0" ]; then
@@ -90,7 +90,7 @@ jobs:
           pip install pytest
           if [ ! -z "${{matrix.pytorch-version}}" ]; then
             requirements=(${{matrix.pytorch-version}})
-            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]}
+            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]} -f https://software.intel.com/ipex-whl-stable
           fi
           source bigdl-nano-init
           bash python/nano/test/run-nano-pytorch-tests.sh
@@ -112,7 +112,7 @@ jobs:
           pip install ray[default]==1.11.0 prometheus_client==0.13.0
           if [ ! -z "${{matrix.pytorch-version}}" ]; then
             requirements=(${{matrix.pytorch-version}})
-            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]}
+            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]} -f https://software.intel.com/ipex-whl-stable
           fi
           source bigdl-nano-init
           bash python/nano/test/run-nano-pytorch-ray-tests.sh
@@ -131,7 +131,7 @@ jobs:
           pip install pytest
           if [ ! -z "${{matrix.pytorch-version}}" ]; then
             requirements=(${{matrix.pytorch-version}})
-            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]}
+            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]} -f https://software.intel.com/ipex-whl-stable
           fi
           source bigdl-nano-init
           bash python/nano/test/run-nano-pytorch-openvino-tests.sh
@@ -186,7 +186,7 @@ jobs:
           bash python/nano/dev/build_and_install.sh linux default false pytorch,inference
           if [ ! -z "${{matrix.pytorch-version}}" ]; then
             requirements=(${{matrix.pytorch-version}})
-            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]}
+            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]} -f https://software.intel.com/ipex-whl-stable
           fi
           pip install pytest
           source bigdl-nano-init
@@ -236,7 +236,7 @@ jobs:
           pip install pytest
           if [ ! -z "${{matrix.pytorch-version}}" ]; then
             requirements=(${{matrix.pytorch-version}})
-            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]}
+            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]} -f https://software.intel.com/ipex-whl-stable
             pip install ${requirements[1]}
           fi
           source bigdl-nano-init
@@ -286,7 +286,7 @@ jobs:
           pip install pytest
           if [ ! -z "${{matrix.pytorch-version}}" ]; then
             requirements=(${{matrix.pytorch-version}})
-            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]}
+            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]} -f https://software.intel.com/ipex-whl-stable
             pip install ${requirements[1]}
           fi
           source bigdl-nano-init

--- a/.github/workflows/nano_unit_tests_pytorch.yml
+++ b/.github/workflows/nano_unit_tests_pytorch.yml
@@ -29,10 +29,10 @@ jobs:
         os: ["ubuntu-20.04"]
         python-version: ["3.7"]
         pytorch-version: [
-          "pytorch_110 neural-compressor==1.13.1"
-          "pytorch_111 neural-compressor==1.13.1"
-          "pytorch_112 neural-compressor==1.13.1"
-          "pytorch_113 neural-compressor==1.14.2"
+          "pytorch_110 neural-compressor==1.13.1",
+          "pytorch_111 neural-compressor==1.13.1",
+          "pytorch_112 neural-compressor==1.13.1",
+          "pytorch_113 neural-compressor==1.14.2",
           ]
     steps:
       - uses: actions/checkout@v2
@@ -207,9 +207,9 @@ jobs:
         pytorch-version: [
           # The reason why ipex1.10 is not currently supported is that the optimization of ipex1.10
           # will change the require_grad attribute of layers, which will make some tests of nano fail.
-          "pytorch_111 neural-compressor==1.13.1"
-          "pytorch_112 neural-compressor==1.13.1"
-          "pytorch_113 neural-compressor==1.14.2"
+          "pytorch_111 neural-compressor==1.13.1",
+          "pytorch_112 neural-compressor==1.13.1",
+          "pytorch_113 neural-compressor==1.14.2",
           ]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -257,9 +257,9 @@ jobs:
         pytorch-version: [
           # The reason why ipex1.10 is not currently supported is that the optimization of ipex1.10
           # will change the require_grad attribute of layers, which will make some tests of nano fail.
-          "pytorch_111 neural-compressor==1.13.1"
-          "pytorch_112 neural-compressor==1.13.1"
-          "pytorch_113 neural-compressor==1.14.2"
+          "pytorch_111 neural-compressor==1.13.1",
+          "pytorch_112 neural-compressor==1.13.1",
+          "pytorch_113 neural-compressor==1.14.2",
           ]
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/nano_unit_tests_pytorch.yml
+++ b/.github/workflows/nano_unit_tests_pytorch.yml
@@ -167,7 +167,7 @@ jobs:
           pip install pytest
           if [ ! -z "${{matrix.pytorch-version}}" ]; then
             requirements=(${{matrix.pytorch-version}})
-            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]}
+            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]} -f https://software.intel.com/ipex-whl-stable
             pip install ${requirements[1]}
           fi
           source bigdl-nano-init

--- a/.github/workflows/nano_unit_tests_pytorch.yml
+++ b/.github/workflows/nano_unit_tests_pytorch.yml
@@ -29,10 +29,10 @@ jobs:
         os: ["ubuntu-20.04"]
         python-version: ["3.7"]
         pytorch-version: [
-          "torch==1.10.1+cpu torchvision==0.11.2+cpu intel_extension_for_pytorch==1.11.0 neural-compressor==1.13.1",
-          "torch==1.11.0+cpu torchvision==0.12.0+cpu intel_extension_for_pytorch==1.11.0 neural-compressor==1.13.1", 
-          "torch==1.12.1+cpu torchvision==0.13.1+cpu intel_extension_for_pytorch==1.12.100 neural-compressor==1.13.1",
-          "torch==1.13.0+cpu torchvision==0.14.0+cpu intel_extension_for_pytorch==1.13.0 neural-compressor==1.14.2"
+          "pytorch_110 neural-compressor==1.13.1"
+          "pytorch_111 neural-compressor==1.13.1"
+          "pytorch_112 neural-compressor==1.13.1"
+          "pytorch_113 neural-compressor==1.14.2"
           ]
     steps:
       - uses: actions/checkout@v2
@@ -52,11 +52,9 @@ jobs:
           $CONDA/bin/conda create -n bigdl-init -y python==3.7.10 setuptools==58.0.4
           source $CONDA/bin/activate bigdl-init
           $CONDA/bin/conda info
-          bash python/nano/dev/build_and_install.sh linux default false pytorch
           if [ ! -z "${{matrix.pytorch-version}}" ]; then
             requirements=(${{matrix.pytorch-version}})
-            pip install ${requirements[0]} ${requirements[1]} -f https://download.pytorch.org/whl/torch_stable.html
-            pip install ${requirements[2]} -f https://software.intel.com/ipex-whl-stable
+            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]}
           fi
           source bigdl-nano-init
           if [ 0"$LD_PRELOAD" = "0" ]; then
@@ -92,8 +90,7 @@ jobs:
           pip install pytest
           if [ ! -z "${{matrix.pytorch-version}}" ]; then
             requirements=(${{matrix.pytorch-version}})
-            pip install ${requirements[0]} ${requirements[1]} -f https://download.pytorch.org/whl/torch_stable.html
-            pip install ${requirements[2]} -f https://software.intel.com/ipex-whl-stable
+            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]}
           fi
           source bigdl-nano-init
           bash python/nano/test/run-nano-pytorch-tests.sh
@@ -115,8 +112,7 @@ jobs:
           pip install ray[default]==1.11.0 prometheus_client==0.13.0
           if [ ! -z "${{matrix.pytorch-version}}" ]; then
             requirements=(${{matrix.pytorch-version}})
-            pip install ${requirements[0]} ${requirements[1]} -f https://download.pytorch.org/whl/torch_stable.html
-            pip install ${requirements[2]} -f https://software.intel.com/ipex-whl-stable
+            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]}
           fi
           source bigdl-nano-init
           bash python/nano/test/run-nano-pytorch-ray-tests.sh
@@ -135,8 +131,7 @@ jobs:
           pip install pytest
           if [ ! -z "${{matrix.pytorch-version}}" ]; then
             requirements=(${{matrix.pytorch-version}})
-            pip install ${requirements[0]} ${requirements[1]} -f https://download.pytorch.org/whl/torch_stable.html
-            pip install ${requirements[2]} -f https://software.intel.com/ipex-whl-stable
+            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]}
           fi
           source bigdl-nano-init
           bash python/nano/test/run-nano-pytorch-openvino-tests.sh
@@ -172,9 +167,8 @@ jobs:
           pip install pytest
           if [ ! -z "${{matrix.pytorch-version}}" ]; then
             requirements=(${{matrix.pytorch-version}})
-            pip install ${requirements[0]} ${requirements[1]} -f https://download.pytorch.org/whl/torch_stable.html
-            pip install ${requirements[2]} -f https://software.intel.com/ipex-whl-stable
-            pip install ${requirements[3]}
+            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]}
+            pip install ${requirements[1]}
           fi
           source bigdl-nano-init
           bash python/nano/test/run-nano-pytorch-inc-tests.sh
@@ -192,8 +186,7 @@ jobs:
           bash python/nano/dev/build_and_install.sh linux default false pytorch,inference
           if [ ! -z "${{matrix.pytorch-version}}" ]; then
             requirements=(${{matrix.pytorch-version}})
-            pip install ${requirements[0]} ${requirements[1]} -f https://download.pytorch.org/whl/torch_stable.html
-            pip install ${requirements[2]} -f https://software.intel.com/ipex-whl-stable
+            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]}
           fi
           pip install pytest
           source bigdl-nano-init
@@ -214,10 +207,9 @@ jobs:
         pytorch-version: [
           # The reason why ipex1.10 is not currently supported is that the optimization of ipex1.10
           # will change the require_grad attribute of layers, which will make some tests of nano fail.
-          "torch==1.11.0+cpu torchvision==0.12.0+cpu intel_extension_for_pytorch==1.11.0 neural-compressor==1.13.1", 
-          "torch==1.12.1+cpu torchvision==0.13.1+cpu intel_extension_for_pytorch==1.12.100 neural-compressor==1.13.1",
-          "torch==1.13.0+cpu torchvision==0.14.0+cpu intel_extension_for_pytorch==1.13.0 neural-compressor==1.14.2"
-          # "torch==1.10.1+cpu torchvision==0.11.2+cpu intel_extension_for_pytorch==1.10.0 psutil"
+          "pytorch_111 neural-compressor==1.13.1"
+          "pytorch_112 neural-compressor==1.13.1"
+          "pytorch_113 neural-compressor==1.14.2"
           ]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -244,9 +236,8 @@ jobs:
           pip install pytest
           if [ ! -z "${{matrix.pytorch-version}}" ]; then
             requirements=(${{matrix.pytorch-version}})
-            pip install ${requirements[0]} ${requirements[1]} -f https://download.pytorch.org/whl/torch_stable.html
-            pip install ${requirements[2]} -f https://software.intel.com/ipex-whl-stable
-            pip install ${requirements[3]}
+            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]}
+            pip install ${requirements[1]}
           fi
           source bigdl-nano-init
           bash python/nano/test/run-nano-pytorch-tests-ipex.sh
@@ -266,10 +257,9 @@ jobs:
         pytorch-version: [
           # The reason why ipex1.10 is not currently supported is that the optimization of ipex1.10
           # will change the require_grad attribute of layers, which will make some tests of nano fail.
-          "torch==1.11.0+cpu torchvision==0.12.0+cpu intel_extension_for_pytorch==1.11.0 neural-compressor==1.13.1", 
-          "torch==1.12.1+cpu torchvision==0.13.1+cpu intel_extension_for_pytorch==1.12.100 neural-compressor==1.13.1",
-          "torch==1.13.0+cpu torchvision==0.14.0+cpu intel_extension_for_pytorch==1.13.0 neural-compressor==1.14.2"
-          # "torch==1.10.1+cpu torchvision==0.11.2+cpu intel_extension_for_pytorch==1.10.0 psutil"
+          "pytorch_111 neural-compressor==1.13.1"
+          "pytorch_112 neural-compressor==1.13.1"
+          "pytorch_113 neural-compressor==1.14.2"
           ]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -296,9 +286,8 @@ jobs:
           pip install pytest
           if [ ! -z "${{matrix.pytorch-version}}" ]; then
             requirements=(${{matrix.pytorch-version}})
-            pip install ${requirements[0]} ${requirements[1]} -f https://download.pytorch.org/whl/torch_stable.html
-            pip install ${requirements[2]} -f https://software.intel.com/ipex-whl-stable
-            pip install ${requirements[3]}
+            bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]}
+            pip install ${requirements[1]}
           fi
           source bigdl-nano-init
           bash python/nano/test/run-nano-pytorch-tests-optimizer.sh

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -79,6 +79,10 @@ def setup_package():
                            "tf2onnx==1.12.1"]
 
     # ipex is only avaliable for linux now
+    pytorch_113_requires = ["torch==1.13.0",
+                            "torchvision==0.14.0",
+                            "intel_extension_for_pytorch==1.13.0;platform_system!='Windows'"]
+
     pytorch_112_requires = ["torch==1.12.1",
                             "torchvision==0.13.1",
                             "intel_extension_for_pytorch==1.12.100;platform_system!='Windows'"]
@@ -103,6 +107,7 @@ def setup_package():
 
     # default pytorch_dep
     pytorch_requires = pytorch_112_requires + pytorch_common_requires
+    pytorch_113_requires += pytorch_common_requires
     pytorch_112_requires += pytorch_common_requires
     pytorch_111_requires += pytorch_common_requires
     pytorch_110_requires += pytorch_common_requires
@@ -143,6 +148,7 @@ def setup_package():
         install_requires=install_requires,
         extras_require={"tensorflow": tensorflow_requires,
                         "pytorch": pytorch_requires,
+                        "pytorch_113": pytorch_113_requires,
                         "pytorch_112": pytorch_112_requires,
                         "pytorch_111": pytorch_111_requires,
                         "pytorch_110": pytorch_110_requires,

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -149,9 +149,6 @@ def setup_package():
                         "pytorch_nightly": pytorch_nightly_requires,
                         "inference": inference_requires},
         package_data={"bigdl.nano": package_data},
-        dependency_links=[
-            'https://download.pytorch.org/whl/nightly/'
-        ],
         scripts=scripts,
         package_dir={"": "src"},
         entry_points = {

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -91,6 +91,10 @@ def setup_package():
                             "torchvision==0.11.2",
                             "intel_extension_for_pytorch==1.10.100;platform_system!='Windows'"]
 
+    # this require install option --extra-index-url https://download.pytorch.org/whl/nightly/
+    pytorch_nightly_requires = ["torch~=1.14.0.dev",
+                                "torchvision~=0.15.0.dev"]
+
     pytorch_common_requires = ["pytorch_lightning==1.6.4",
                                "torchmetrics==0.7.2",
                                "opencv-python-headless",
@@ -102,6 +106,7 @@ def setup_package():
     pytorch_112_requires += pytorch_common_requires
     pytorch_111_requires += pytorch_common_requires
     pytorch_110_requires += pytorch_common_requires
+    pytorch_nightly_requires += pytorch_common_requires
 
     inference_requires = ["onnx==1.12.0",
                           "onnxruntime==1.12.1",
@@ -141,8 +146,12 @@ def setup_package():
                         "pytorch_112": pytorch_112_requires,
                         "pytorch_111": pytorch_111_requires,
                         "pytorch_110": pytorch_110_requires,
+                        "pytorch_nightly": pytorch_nightly_requires,
                         "inference": inference_requires},
         package_data={"bigdl.nano": package_data},
+        dependency_links=[
+            'https://download.pytorch.org/whl/nightly/'
+        ],
         scripts=scripts,
         package_dir={"": "src"},
         entry_points = {

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -79,15 +79,30 @@ def setup_package():
                            "tf2onnx==1.12.1"]
 
     # ipex is only avaliable for linux now
-    pytorch_requires = ["torch==1.12.1",
-                        "torchvision==0.13.1",
-                        "pytorch_lightning==1.6.4",
-                        "torchmetrics==0.7.2",
-                        "opencv-python-headless",
-                        "PyTurboJPEG",
-                        "opencv-transforms",
-                        "intel_extension_for_pytorch==1.12.100;platform_system!='Windows'"]
-    
+    pytorch_112_requires = ["torch==1.12.1",
+                            "torchvision==0.13.1",
+                            "intel_extension_for_pytorch==1.12.100;platform_system!='Windows'"]
+
+    pytorch_111_requires = ["torch==1.11.0",
+                            "torchvision==0.12.0",
+                            "intel_extension_for_pytorch==1.11.0;platform_system!='Windows'"]
+
+    pytorch_110_requires = ["torch==1.10.1",
+                            "torchvision==0.11.2",
+                            "intel_extension_for_pytorch==1.10.100;platform_system!='Windows'"]
+
+    pytorch_common_requires = ["pytorch_lightning==1.6.4",
+                               "torchmetrics==0.7.2",
+                               "opencv-python-headless",
+                               "PyTurboJPEG",
+                               "opencv-transforms"]
+
+    # default pytorch_dep
+    pytorch_requires = pytorch_112_requires + pytorch_common_requires
+    pytorch_112_requires += pytorch_common_requires
+    pytorch_111_requires += pytorch_common_requires
+    pytorch_110_requires += pytorch_common_requires
+
     inference_requires = ["onnx==1.12.0",
                           "onnxruntime==1.12.1",
                           "onnxruntime-extensions==0.4.2",
@@ -123,6 +138,9 @@ def setup_package():
         install_requires=install_requires,
         extras_require={"tensorflow": tensorflow_requires,
                         "pytorch": pytorch_requires,
+                        "pytorch_112": pytorch_112_requires,
+                        "pytorch_111": pytorch_111_requires,
+                        "pytorch_110": pytorch_110_requires,
                         "inference": inference_requires},
         package_data={"bigdl.nano": package_data},
         scripts=scripts,


### PR DESCRIPTION
## Description

This PR implements more options for nano's pytorch installation, this include
```bash
# torch 1.10 and its dependencies
pip install --pre --upgrade bigdl-nano[pytorch_110]

# torch 1.11 and its dependencies
pip install --pre --upgrade bigdl-nano[pytorch_111]

# torch 1.12 and its dependencies
pip install --pre --upgrade bigdl-nano[pytorch_112]  # default "pytorch" option is assigned to 1.12

# torch 1.13 and its dependencies
pip install --pre --upgrade bigdl-nano[pytorch_113]

# torch nightly and its dependencies
pip install --pre --upgrade bigdl-nano[pytorch_nightly] --extra-index-url https://download.pytorch.org/whl/nightly/
```

Due to many reasons, we decided to not support 1.9 in this friendly installation options
- ipex 1.9 does not have the same name as >=1.10
- some of our required inference optimization depdencies does not support 1.9 anymore
- some of our features does not work for 1.9 very well
