### PR TITLE
Nano: add partial m-series chip support for tensorflow (training and installation)

### DIFF
--- a/docs/readthedocs/source/doc/Nano/Overview/install.md
+++ b/docs/readthedocs/source/doc/Nano/Overview/install.md
@@ -21,6 +21,15 @@ conda activate env
 pip install --pre --upgrade bigdl-nano[tensorflow]
 ```
 
+We also partially support M-series chip users with no guarantee of acceleration with same API. Currently only tensorflow is experimentally supported.
+
+```bash
+conda create -n env python=3.8
+conda activate env
+conda install -c apple tensorflow-deps
+pip install --pre --upgrade bigdl-nano[tensorflow]
+```
+
 ```eval_rst
 .. note::
     Since bigdl-nano is still in the process of rapid iteration, we highly recommend that you install nightly build version through the above command to facilitate your use of the latest features.

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -73,10 +73,12 @@ def download_libs(url: str):
 
 def setup_package():
 
-    tensorflow_requires = ["intel-tensorflow==2.7.0",
-                           "keras==2.7.0",
-                           "tensorflow-estimator==2.7.0",
-                           "tf2onnx==1.12.1"]
+    tensorflow_requires = ["intel-tensorflow==2.7.0; platform_machine=='x86_64'",
+                           "keras==2.7.0; platform_machine=='x86_64'",
+                           "tensorflow-estimator==2.7.0; platform_machine=='x86_64'",
+                           "tf2onnx==1.12.1; platform_machine=='x86_64'",
+                           "tensorflow-macos==2.7.0; platform_machine=='arm64' and sys_platform=='darwin'",
+                           "tensorflow-metal==0.3.0; platform_machine=='arm64' and sys_platform=='darwin'"]
 
     # ipex is only avaliable for linux now
     pytorch_113_requires = ["torch==1.13.0",
@@ -120,7 +122,10 @@ def setup_package():
                           "neural-compressor==1.13.1",
                           "onnxsim==0.4.8"]
 
-    install_requires = ["intel-openmp", "cloudpickle", "protobuf==3.19.5", "py-cpuinfo"]
+    install_requires = ["intel-openmp; platform_machine=='x86_64'",
+                        "cloudpickle",
+                        "protobuf==3.19.4",
+                        "py-cpuinfo"]
 
     package_data = [
         "libs/libjemalloc.so",

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -124,7 +124,7 @@ def setup_package():
 
     install_requires = ["intel-openmp; platform_machine=='x86_64'",
                         "cloudpickle",
-                        "protobuf==3.19.4",
+                        "protobuf==3.19.5",
                         "py-cpuinfo"]
 
     package_data = [


### PR DESCRIPTION
## Description
We also partially support M-series chip users with no guarantee of acceleration with same API. Currently only tensorflow is experimentally supported.

Install by this
```bash
conda create -n env python=3.8
conda activate env
conda install -c apple tensorflow-deps
pip install --pre --upgrade bigdl-nano[tensorflow]
```

The installation is validated on a M1 chip Macbook with following easy example
```python
import numpy as np
from tensorflow import keras
from bigdl.nano.tf.keras import Sequential
from tensorflow.keras import layers

# Model / data parameters
num_classes = 10
input_shape = (28, 28, 1)

# Load the data and split it between train and test sets
(x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()

# Scale images to the [0, 1] range
x_train = x_train.astype("float32") / 255
x_test = x_test.astype("float32") / 255
# Make sure images have shape (28, 28, 1)
x_train = np.expand_dims(x_train, -1)
x_test = np.expand_dims(x_test, -1)
print("x_train shape:", x_train.shape)
print(x_train.shape[0], "train samples")
print(x_test.shape[0], "test samples")


# convert class vectors to binary class matrices
y_train = keras.utils.to_categorical(y_train, num_classes)
y_test = keras.utils.to_categorical(y_test, num_classes)

model = Sequential(
    [
        keras.Input(shape=input_shape),
        layers.Conv2D(32, kernel_size=(3, 3), activation="relu"),
        layers.MaxPooling2D(pool_size=(2, 2)),
        layers.Conv2D(64, kernel_size=(3, 3), activation="relu"),
        layers.MaxPooling2D(pool_size=(2, 2)),
        layers.Flatten(),
        layers.Dropout(0.5),
        layers.Dense(num_classes, activation="softmax"),
    ]
)

model.summary()

batch_size = 128
epochs = 15

model.compile(loss="categorical_crossentropy", optimizer="adam", metrics=["accuracy"])

model.fit(x_train, y_train, batch_size=batch_size, epochs=epochs, validation_split=0.1)

score = model.evaluate(x_test, y_test, verbose=0)
print("Test loss:", score[0])
print("Test accuracy:", score[1])
```


### 4. How to test?
- [x] N/A

### 5. New dependencies

- [x] New Python dependencies
       - tensorflow-macos==2.7.0
       - tensorflow-metal==0.3.0
