### PR TITLE
[PPML]fix: put resources into /ppml in bigdata

### DIFF
--- a/ppml/trusted-bigdata/Dockerfile
+++ b/ppml/trusted-bigdata/Dockerfile
@@ -138,6 +138,7 @@ RUN mkdir -p /ppml/lib && \
     mkdir -p /ppml/apps
 
 COPY --from=bigdata /opt/spark-${SPARK_VERSION} /ppml/spark-${SPARK_VERSION}
+COPY --from=bigdata /opt/spark-${SPARK_VERSION}/examples/src/main/resources /ppml/examples/src/main/resources
 
 ADD ./bigdl-ppml-submit.sh /ppml/bigdl-ppml-submit.sh
 ADD ./spark-executor-template.yaml /ppml/spark-executor-template.yaml


### PR DESCRIPTION
## Description

put /opt/spark-${SPARK_VERSION}/examples/src/main/resources into /ppml/examples/src/main/resources in bigdata as gramine did 