### PR TITLE
[Nano] Add missing error messages for `InferenceOptimizer.optimize`

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -301,6 +301,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                         torch.set_num_threads(default_threads)
                         continue
                 except Exception as e:
+                    print(e)
                     result_map[method]["status"] = "fail to forward"
                     print(f"----------{method} failed to forward----------")
                     torch.set_num_threads(default_threads)


### PR DESCRIPTION
Add missing error messages for `InferenceOptimizer.optimize`for the case "failed to forward"
