### PR TITLE
[PPML] remove proxy set from ehsm

### DIFF
--- a/ppml/services/ehsm/kubernetes/README.md
+++ b/ppml/services/ehsm/kubernetes/README.md
@@ -49,9 +49,7 @@ dkeyserverIP: your_dkeyserver_ip_to_use_as        --->   <an_used_ip_address_in_
 kmsIP: your_kms_ip_to_use_as                      --->   <an_used_ip_address_in_your_subnetwork_to_assign_to_kms>
 
 # Replace the below parameters according to your environment
-
 apiKey: your_intel_pcs_server_subscription_key_obtained_through_web_registeration
-httpsProxyUrl: your_usable_https_proxy_url
 countryName: your_country_name
 cityName: your_city_name
 organizaitonName: your_organizaition_name

--- a/ppml/services/ehsm/kubernetes/install-bigdl-ehsm-kms.sh
+++ b/ppml/services/ehsm/kubernetes/install-bigdl-ehsm-kms.sh
@@ -16,7 +16,6 @@ export kmsIP=your_kms_ip_to_use_as
 export apiKey=your_intel_pcs_server_subscription_key_obtained_through_web_registeration # Refer to README for obtaining pcs api key
 # The below three service IPs are different IP addresses that unused in your subnetwork
 # Please do not use the same real IPs as nodes
-export httpsProxyUrl=your_usable_https_proxy_url
 export countryName=your_country_name
 export cityName=your_city_name
 export organizaitonName=your_organizaition_name


### PR DESCRIPTION
## Description

removed proxy url in `ppml/services/ehsm/kubernetes/install-bigdl-ehsm-kms.sh` & `ppml/services/ehsm/kubernetes/README.md`

### 1. Why the change?

proxy is not needed in ehsm.
