### PR TITLE
Nano: Add CUDA unpatch

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
+++ b/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
@@ -61,6 +61,7 @@ from bigdl.nano.utils.log4Error import invalidInputError
 from bigdl.nano.pytorch.strategies.ipex.ipex_api import ipex_device, ipex_optimize, \
     create_IPEXAccelerator, to_cpu
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
+from bigdl.nano.pytorch.dispatcher import get_patch_status
 
 _STEP_OUTPUT_TYPE = Union[torch.Tensor, Dict[str, Any]]
 
@@ -126,10 +127,12 @@ class _RayLauncher(_SpawnLauncher):
             torch_backend = "nccl" if strategy.use_gpu else "gloo"
         strategy._process_group_backend = torch_backend
 
+        patch_status = get_patch_status()
+
         futures = [
             strategy.workers[i].execute.remote(
                 self._wrapping_function,
-                (i, trainer, strategy, function, args, kwargs)
+                (i, trainer, strategy, function, args, kwargs, patch_status)
             )
             for i in range(strategy.num_workers)
         ]
@@ -148,18 +151,15 @@ class _RayLauncher(_SpawnLauncher):
 
     @staticmethod
     def _wrapping_function(args_pack: tuple) -> Any:   # type: ignore[override]
-        global_rank, trainer, strategy, function, args, kwargs = args_pack
+        global_rank, trainer, strategy, function, args, kwargs, patch_status = args_pack
         invalidInputError(isinstance(strategy, RayStrategy), "expect ray strategy here")
         invalidInputError(isinstance(strategy.cluster_environment, RayEnvironment),
                           "expect ray environment here")
 
         # patch Pytorch and CUDA in subprocess
-        if os.environ.get('BIGDL_NANO_PATCH_TORCH') == '1':
-            patch_cuda = True if os.environ.get('BIGDL_NANO_PATCH_CUDA') == '1' else False
-            os.environ['BIGDL_NANO_PATCH_TORCH'] = '0'
-            os.environ['BIGDL_NANO_PATCH_CUDA'] = '0'
+        if patch_status['patch_torch']:
             from bigdl.nano.pytorch import patch_torch
-            patch_torch(cuda_to_cpu=patch_cuda)
+            patch_torch(cuda_to_cpu=patch_status['patch_cuda'])
 
         strategy.cluster_environment.set_global_rank(global_rank)
         strategy.cluster_environment.set_remote_execution(True)
@@ -253,10 +253,6 @@ class RayStrategy(DDPSpawnStrategy):
             # and subprocess will use it to initialize its `sys.path`,
             # so we can import `test` module in subprocess
             ray.get(worker.set_env_var.remote("PYTHONPATH", envs[i].get("PYTHONPATH", "")))
-            ray.get(worker.set_env_var.remote("BIGDL_NANO_PATCH_TORCH",
-                                              envs[i].get("BIGDL_NANO_PATCH_TORCH", "0")))
-            ray.get(worker.set_env_var.remote("BIGDL_NANO_PATCH_CUDA",
-                                              envs[i].get("BIGDL_NANO_PATCH_CUDA", "0")))
 
             workers.append(worker)
 

--- a/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
+++ b/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
@@ -156,6 +156,8 @@ class _RayLauncher(_SpawnLauncher):
         # patch Pytorch and CUDA in subprocess
         if os.environ.get('BIGDL_NANO_PATCH_TORCH') == '1':
             patch_cuda = True if os.environ.get('BIGDL_NANO_PATCH_CUDA') == '1' else False
+            os.environ['BIGDL_NANO_PATCH_TORCH'] = '0'
+            os.environ['BIGDL_NANO_PATCH_CUDA'] = '0'
             from bigdl.nano.pytorch import patch_torch
             patch_torch(cuda_to_cpu=patch_cuda)
 

--- a/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
+++ b/python/nano/src/bigdl/nano/deps/ray/ray_distributed.py
@@ -61,7 +61,7 @@ from bigdl.nano.utils.log4Error import invalidInputError
 from bigdl.nano.pytorch.strategies.ipex.ipex_api import ipex_device, ipex_optimize, \
     create_IPEXAccelerator, to_cpu
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
-from bigdl.nano.pytorch.dispatcher import get_patch_status
+from bigdl.nano.pytorch.dispatcher import _get_patch_status
 
 _STEP_OUTPUT_TYPE = Union[torch.Tensor, Dict[str, Any]]
 
@@ -127,7 +127,7 @@ class _RayLauncher(_SpawnLauncher):
             torch_backend = "nccl" if strategy.use_gpu else "gloo"
         strategy._process_group_backend = torch_backend
 
-        patch_status = get_patch_status()
+        patch_status = _get_patch_status()
 
         futures = [
             strategy.workers[i].execute.remote(

--- a/python/nano/src/bigdl/nano/pytorch/dispatcher.py
+++ b/python/nano/src/bigdl/nano/pytorch/dispatcher.py
@@ -16,7 +16,7 @@
 
 import os
 from importlib.util import find_spec
-from bigdl.nano.pytorch.gpu_cpu import patch_cuda
+from bigdl.nano.pytorch.gpu_cpu import patch_cuda, unpatch_cuda
 
 
 _mapping_torch = None
@@ -90,6 +90,8 @@ def unpatch_torch():
 
     for mapping_iter in mapping_torch:
         setattr(mapping_iter[0], mapping_iter[1], mapping_iter[3])
+
+    unpatch_cuda()
 
     os.environ['BIGDL_NANO_PATCH_TORCH'] = '0'
     os.environ['BIGDL_NANO_PATCH_CUDA'] = '0'

--- a/python/nano/src/bigdl/nano/pytorch/dispatcher.py
+++ b/python/nano/src/bigdl/nano/pytorch/dispatcher.py
@@ -100,7 +100,7 @@ def unpatch_torch():
     is_torch_patched = False
 
 
-def get_patch_status():
+def _get_patch_status():
     return {
         "patch_torch": is_torch_patched,
         "patch_cuda": get_cuda_status(),

--- a/python/nano/src/bigdl/nano/pytorch/dispatcher.py
+++ b/python/nano/src/bigdl/nano/pytorch/dispatcher.py
@@ -67,6 +67,9 @@ def patch_torch(cuda_to_cpu: bool = True):
            This feature is still experimental and only valid in python layer codes.
            Default to True.
     """
+    if os.environ.get('BIGDL_NANO_PATCH_TORCH', '0') == '1':
+        return
+
     if cuda_to_cpu:
         patch_cuda()
     mapping_torch = _get_patch_map()
@@ -79,12 +82,12 @@ def patch_torch(cuda_to_cpu: bool = True):
     # we need these environment variables to know whether we should
     # call this patch in subprocess when multi-instance training
     os.environ['BIGDL_NANO_PATCH_TORCH'] = '1'
-    os.environ['BIGDL_NANO_PATCH_CUDA'] = '1' if cuda_to_cpu else '0'
 
 
 def unpatch_torch():
     """unpatch_torch is used to unpatch optimized torch classes to original ones."""
-    # TODO: unpatch_torch to support gpu-to-cpu unpatching
+    if os.environ.get('BIGDL_NANO_PATCH_TORCH', '0') == '0':
+        return
 
     mapping_torch = _get_patch_map()
 
@@ -94,4 +97,3 @@ def unpatch_torch():
     unpatch_cuda()
 
     os.environ['BIGDL_NANO_PATCH_TORCH'] = '0'
-    os.environ['BIGDL_NANO_PATCH_CUDA'] = '0'

--- a/python/nano/src/bigdl/nano/pytorch/gpu_cpu/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/gpu_cpu/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-from .gpu_cpu import patch_cuda, unpatch_cuda
+from .gpu_cpu import patch_cuda, unpatch_cuda, get_cuda_status

--- a/python/nano/src/bigdl/nano/pytorch/gpu_cpu/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/gpu_cpu/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-from .gpu_cpu import patch_cuda
+from .gpu_cpu import patch_cuda, unpatch_cuda

--- a/python/nano/src/bigdl/nano/pytorch/gpu_cpu/gpu_cpu.py
+++ b/python/nano/src/bigdl/nano/pytorch/gpu_cpu/gpu_cpu.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import os
 import torch
 from logging import warning
 
@@ -145,6 +146,9 @@ def create_tensor_func(torch_create_tensor_func):
 
 
 def patch_cuda(disable_jit=True):
+    if os.environ.get('BIGDL_NANO_PATCH_CUDA', '0') == '1':
+        return
+
     # add this parameter since it's a known issue
     if disable_jit:
         warning("This CUDA patch is incompatible with JIT, JIT will be disabled!")
@@ -175,8 +179,15 @@ def patch_cuda(disable_jit=True):
         except AttributeError:
             pass
 
+    os.environ['BIGDL_NANO_PATCH_CUDA'] = '1'
+
 
 def unpatch_cuda():
+    if os.environ.get('BIGDL_NANO_PATCH_CUDA', '0') == '0':
+        return
+
     torch.jit._state.enable()
     for obj, name, torch_attr in attrs:
         setattr(obj, name, torch_attr)
+
+    os.environ['BIGDL_NANO_PATCH_CUDA'] = '0'

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -161,6 +161,8 @@ class _DDPSpawnLauncher(_SpawnLauncher):
         # patch Pytorch and CUDA in subprocess
         if os.environ.get('BIGDL_NANO_PATCH_TORCH') == '1':
             patch_cuda = True if os.environ.get('BIGDL_NANO_PATCH_CUDA') == '1' else False
+            os.environ['BIGDL_NANO_PATCH_TORCH'] = '0'
+            os.environ['BIGDL_NANO_PATCH_CUDA'] = '0'
             from bigdl.nano.pytorch import patch_torch
             patch_torch(cuda_to_cpu=patch_cuda)
         super()._wrapping_function(*args, **kwargs)

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -40,7 +40,7 @@ from typing import Any, List, Optional, Callable, Union, Dict
 import torch
 from torch import nn
 from torch import Tensor
-from torch.multiprocessing.spawn import _wrap, ProcessContext
+from torch.multiprocessing.spawn import ProcessContext
 from torch.nn.parallel.distributed import DistributedDataParallel
 from torch.optim.lr_scheduler import _LRScheduler
 
@@ -57,6 +57,7 @@ from pytorch_lightning.plugins.environments import LightningEnvironment
 from pytorch_lightning.utilities.distributed import ReduceOp
 
 from bigdl.nano.common.cpu_schedule import schedule_processors
+from bigdl.nano.pytorch.dispatcher import get_patch_status
 from bigdl.nano.pytorch.strategies.ipex.ipex_api import ipex_device, \
     ipex_optimize, create_IPEXAccelerator, to_cpu
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
@@ -122,6 +123,7 @@ class _DDPSpawnLauncher(_SpawnLauncher):
         error_queues = []
         processes = []
         args = (trainer, function, args, kwargs, return_queue)
+        patch_status = get_patch_status()
 
         for i in range(self._strategy.num_processes):
             os.environ["KMP_AFFINITY"] = envs[i]['KMP_AFFINITY']
@@ -130,8 +132,8 @@ class _DDPSpawnLauncher(_SpawnLauncher):
             log.debug(f"[Process {i}]: using OMP_NUM_THREADS: {os.environ['OMP_NUM_THREADS']}")
             error_queue = mp.SimpleQueue()
             process = mp.Process(   # type: ignore
-                target=_wrap,
-                args=(self._wrapping_function, i, args, error_queue),
+                target=self._wrap,
+                args=(self._wrapping_function, i, args, error_queue, patch_status),
                 daemon=False,
             )
             process.start()
@@ -157,15 +159,14 @@ class _DDPSpawnLauncher(_SpawnLauncher):
         self._recover_results_in_main_process(spawn_output, trainer)
         return spawn_output.trainer_results
 
-    def _wrapping_function(self, *args, **kwargs):    # type: ignore
-        # patch Pytorch and CUDA in subprocess
-        if os.environ.get('BIGDL_NANO_PATCH_TORCH') == '1':
-            patch_cuda = True if os.environ.get('BIGDL_NANO_PATCH_CUDA') == '1' else False
-            os.environ['BIGDL_NANO_PATCH_TORCH'] = '0'
-            os.environ['BIGDL_NANO_PATCH_CUDA'] = '0'
-            from bigdl.nano.pytorch import patch_torch
-            patch_torch(cuda_to_cpu=patch_cuda)
-        super()._wrapping_function(*args, **kwargs)
+    @staticmethod
+    def _wrap(fn, i, args, error_queue, patch_status):
+        if patch_status['patch_torch']:
+            from bigdl.nano.pytorch.dispatcher import patch_torch
+            patch_torch(cuda_to_cpu=patch_status['patch_cuda'])
+
+        from torch.multiprocessing.spawn import _wrap
+        _wrap(fn, i, args, error_queue)
 
 
 class DDPSpawnStrategy(_DDPSpawnStrategy):

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_spawn.py
@@ -57,7 +57,7 @@ from pytorch_lightning.plugins.environments import LightningEnvironment
 from pytorch_lightning.utilities.distributed import ReduceOp
 
 from bigdl.nano.common.cpu_schedule import schedule_processors
-from bigdl.nano.pytorch.dispatcher import get_patch_status
+from bigdl.nano.pytorch.dispatcher import _get_patch_status
 from bigdl.nano.pytorch.strategies.ipex.ipex_api import ipex_device, \
     ipex_optimize, create_IPEXAccelerator, to_cpu
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
@@ -123,7 +123,7 @@ class _DDPSpawnLauncher(_SpawnLauncher):
         error_queues = []
         processes = []
         args = (trainer, function, args, kwargs, return_queue)
-        patch_status = get_patch_status()
+        patch_status = _get_patch_status()
 
         for i in range(self._strategy.num_processes):
             os.environ["KMP_AFFINITY"] = envs[i]['KMP_AFFINITY']

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_subprocess.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_subprocess.py
@@ -47,7 +47,7 @@ from bigdl.nano.pytorch.strategies.ddp_spawn import DDPSpawnStrategy, _DDPSpawnL
 from bigdl.nano.common.cpu_schedule import schedule_processors
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
 from bigdl.nano.utils.log4Error import invalidInputError
-from bigdl.nano.pytorch.dispatcher import get_patch_status
+from bigdl.nano.pytorch.dispatcher import _get_patch_status
 
 import logging
 
@@ -122,7 +122,7 @@ class _DDPSubprocessLauncher(_DDPSpawnLauncher):
                 cloudpickle.dump(sys.path, f)
 
             with open(os.path.join(temp_dir, "patch_status.pkl"), "wb") as f:
-                cloudpickle.dump(get_patch_status(), f)
+                cloudpickle.dump(_get_patch_status(), f)
 
             processes = []
             cwd_path = os.path.split(os.path.realpath(__file__))[0]

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ddp_subprocess.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ddp_subprocess.py
@@ -47,6 +47,7 @@ from bigdl.nano.pytorch.strategies.ddp_spawn import DDPSpawnStrategy, _DDPSpawnL
 from bigdl.nano.common.cpu_schedule import schedule_processors
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
 from bigdl.nano.utils.log4Error import invalidInputError
+from bigdl.nano.pytorch.dispatcher import get_patch_status
 
 import logging
 
@@ -119,6 +120,9 @@ class _DDPSubprocessLauncher(_DDPSpawnLauncher):
             # we also need to pass sys.path to subprocess
             with open(os.path.join(temp_dir, "sys_path.pkl"), "wb") as f:
                 cloudpickle.dump(sys.path, f)
+
+            with open(os.path.join(temp_dir, "patch_status.pkl"), "wb") as f:
+                cloudpickle.dump(get_patch_status(), f)
 
             processes = []
             cwd_path = os.path.split(os.path.realpath(__file__))[0]

--- a/python/nano/src/bigdl/nano/pytorch/strategies/worker.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/worker.py
@@ -20,6 +20,7 @@ import sys
 import cloudpickle
 import multiprocessing
 from torch.multiprocessing.spawn import _wrap
+from bigdl.nano.pytorch.dispatcher import patch_torch
 
 
 if __name__ == '__main__':
@@ -35,6 +36,11 @@ if __name__ == '__main__':
     # i.e. cannot find some modules located in main process's sys.path
     with open(os.path.join(temp_dir, "sys_path.pkl"), "rb") as f:
         sys.path = cloudpickle.load(f)
+
+    with open(os.path.join(temp_dir, "patch_status.pkl"), "rb") as f:
+        patch_status = cloudpickle.load(f)
+        if patch_status['patch_torch']:
+            patch_torch(cuda_to_cpu=patch_status['patch_cuda'])
 
     with open(os.path.join(temp_dir, "args.pkl"), "rb") as f:
         (fn, args, error_queue) = cloudpickle.load(f)

--- a/python/nano/test/pytorch/tests/test_dispatcher.py
+++ b/python/nano/test/pytorch/tests/test_dispatcher.py
@@ -99,6 +99,7 @@ class TestDispatcherPytorch(TestCase):
     def test_unpatch_cuda(self):
         from bigdl.nano.pytorch import patch_torch, unpatch_torch
         patch_torch(cuda_to_cpu=True)
+        patch_torch(cuda_to_cpu=True) # call patch twice
         import torch
         unpatch_torch()
 

--- a/python/nano/test/pytorch/tests/test_dispatcher.py
+++ b/python/nano/test/pytorch/tests/test_dispatcher.py
@@ -17,7 +17,9 @@
 from unittest import TestCase
 import tempfile
 import os
+import pytest
 
+from bigdl.nano.utils.log4Error import invalidOperationError
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
 
 
@@ -91,3 +93,18 @@ class TestDispatcherPytorch(TestCase):
         # other utils
         torch.cuda.reset_peak_memory_stats()
         torch.cuda.reset_accumulated_memory_stats()
+
+        unpatch_torch()
+
+    def test_unpatch_cuda(self):
+        from bigdl.nano.pytorch import patch_torch, unpatch_torch
+        patch_torch(cuda_to_cpu=True)
+        import torch
+        unpatch_torch()
+
+        with pytest.raises(RuntimeError, match="Found no NVIDIA driver on your system."):
+            _t = torch.tensor([0], device='cuda:0')
+            invalidOperationError(False, "cuda unpatch is incorrect")
+
+        cuda_device = torch.device('cuda:0')
+        assert cuda_device.type == 'cuda'

--- a/python/nano/test/pytorch/tests/test_dispatcher.py
+++ b/python/nano/test/pytorch/tests/test_dispatcher.py
@@ -102,7 +102,7 @@ class TestDispatcherPytorch(TestCase):
         import torch
         unpatch_torch()
 
-        with pytest.raises(RuntimeError, match="Found no NVIDIA driver on your system."):
+        with pytest.raises(RuntimeError):
             _t = torch.tensor([0], device='cuda:0')
             invalidOperationError(False, "cuda unpatch is incorrect")
 

--- a/python/nano/test/pytorch/tests/test_dispatcher.py
+++ b/python/nano/test/pytorch/tests/test_dispatcher.py
@@ -102,7 +102,7 @@ class TestDispatcherPytorch(TestCase):
         import torch
         unpatch_torch()
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises((RuntimeError, AssertionError), match="CUDA|NVIDIA"):
             _t = torch.tensor([0], device='cuda:0')
             invalidOperationError(False, "cuda unpatch is incorrect")
 


### PR DESCRIPTION
## Description

- Add `unpatch_cuda()`, which will be called automatically in `unpatch_torch()`.
- Protect the patch and unpatch from being called more than once.
- Eliminate the usage of `BIGDL_NANO_PATCH_TORCH` and `BIGDL_NANO_PATCH_CUDA` environment variable.

### 1. Why the change?

The `unpatch_torch()` function will not unpatch CUDA's patch for now, so we fix it in this PR.

### 2. User API changes

N/A

### 3. Summary of the change 

- Replace `setattr` with `replace_attr` helper function, which will not only set new attribute, but also store the original attributes, then use them to do unpatch.
- Use global variables instead of environment variables to indicate the status of patch

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

N/A
