### PR TITLE
Build python toolkit image in manually build for test.

### DIFF
--- a/.github/workflows/manually_build_for_testing.yml
+++ b/.github/workflows/manually_build_for_testing.yml
@@ -26,6 +26,8 @@ on:
         - bigdl-ppml-trusted-realtime-ml-scala-occlum
         - bigdl-ppml-kmsutil
         - bigdl-ppml-pccs
+        - bigdl-ppml-trusted-deep-learning-gramine-base
+        - bigdl-ppml-trusted-deep-learning-gramine-ref
       tag:
         description: 'docker image tag (e.g. test)'
         required: true
@@ -572,3 +574,64 @@ jobs:
         docker tag ${IMAGE}:${TAG} 10.239.45.10/arda/${IMAGE}:${TAG}
         docker push 10.239.45.10/arda/${IMAGE}:${TAG}
         docker rmi -f ${IMAGE}:${TAG} 10.239.45.10/arda/${IMAGE}:${TAG}
+
+bigdl-ppml-trusted-python-toolkit-base:
+    if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-python-toolkit-base' || github.event.inputs.artifact == 'all' }}
+    runs-on: [self-hosted, Shire]
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.inputs.sha }}
+    - name: docker login
+      run: |
+        docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
+    - name: bigdl-ppml-trusted-python-toolkit-base
+      run: |
+        echo "##############################################################"
+        echo "########## bigdl-ppml-trusted-python-toolkit-base ############"
+        echo "##############################################################"
+        export base_image=intelanalytics/bigdl-ppml-gramine-base
+        export image=intelanalytics/bigdl-ppml-trusted-python-toolkit-base
+        cd ppml/trusted-python-toolkit
+        sudo docker build \
+          --no-cache=true \
+          --build-arg http_proxy=${HTTP_PROXY} \
+          --build-arg https_proxy=${HTTPS_PROXY} \
+          --build-arg BASE_IMAGE_NAME=${base_image} \
+          --build-arg BASE_IMAGE_TAG=${TAG} \
+          -t ${image}:${TAG} -f ./Dockerfile .
+        sudo docker push ${image}:${TAG}
+        sudo docker tag ${image}:${TAG} 10.239.45.10/arda/${image}:${TAG}
+        sudo docker push 10.239.45.10/arda/${image}:${TAG}
+        sudo docker rmi -f ${image}:${TAG}
+ bigdl-ppml-trusted-python-toolkit-ref:
+    if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-python-toolkit-ref' || github.event.inputs.artifact == 'all' }}
+    runs-on: [self-hosted, Shire]
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.inputs.sha }}
+    - name: docker login
+      run: |
+        docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
+    - name: bigdl-ppml-trusted-deep-learning-gramine-ref
+      run: |
+        echo "##############################################################"
+        echo "########## bigdl-ppml-trusted-python-toolkit-ref #############"
+        echo "##############################################################"
+        export base_image=intelanalytics/bigdl-ppml-trusted-python-toolkit-base
+        export image=intelanalytics/bigdl-ppml-trusted-python-toolkit-ref
+        cd ppml/trusted-python-toolkit
+        openssl genrsa -3 -out enclave-key.pem 3072
+        sudo docker build \
+          --no-cache=true \
+          --build-arg http_proxy=${HTTP_PROXY} \
+          --build-arg https_proxy=${HTTPS_PROXY} \
+          --build-arg BASE_IMAGE_NAME=${base_image} \
+          --build-arg SGX_MEM_SIZE=64G \
+          --build-arg BASE_IMAGE_TAG=${TAG} \
+          -t ${image}:${TAG} -f ./Dockerfile .
+        sudo docker push ${image}:${TAG}
+        sudo docker tag ${image}:${TAG} 10.239.45.10/arda/${image}:${TAG}
+        sudo docker push 10.239.45.10/arda/${image}:${TAG}
+        sudo docker rmi -f ${image}:${TAG}

--- a/.github/workflows/manually_build_for_testing.yml
+++ b/.github/workflows/manually_build_for_testing.yml
@@ -26,8 +26,8 @@ on:
         - bigdl-ppml-trusted-realtime-ml-scala-occlum
         - bigdl-ppml-kmsutil
         - bigdl-ppml-pccs
-        - bigdl-ppml-trusted-deep-learning-gramine-base
-        - bigdl-ppml-trusted-deep-learning-gramine-ref
+        - bigdl-ppml-trusted-python-toolkit-base
+        - bigdl-ppml-trusted-python-toolkit-ref
       tag:
         description: 'docker image tag (e.g. test)'
         required: true
@@ -604,6 +604,7 @@ bigdl-ppml-trusted-python-toolkit-base:
         sudo docker tag ${image}:${TAG} 10.239.45.10/arda/${image}:${TAG}
         sudo docker push 10.239.45.10/arda/${image}:${TAG}
         sudo docker rmi -f ${image}:${TAG}
+
  bigdl-ppml-trusted-python-toolkit-ref:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-python-toolkit-ref' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
@@ -614,7 +615,7 @@ bigdl-ppml-trusted-python-toolkit-base:
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
-    - name: bigdl-ppml-trusted-deep-learning-gramine-ref
+    - name: bigdl-ppml-trusted-python-toolkit-ref
       run: |
         echo "##############################################################"
         echo "########## bigdl-ppml-trusted-python-toolkit-ref #############"


### PR DESCRIPTION
## Description

Build python toolkit base and ref images.

### 1. Why the change?

Build python toolkit ref image for customer.

### 2. User API changes

Use image bigdl-ppml-trusted-python-toolkit-ref to build container.

### 3. Summary of the change 

Add two jobs to manually build for testing
