### PR TITLE
Nano: add openvino_config and default fp32 config to quantize/trace

### DIFF
--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -25,10 +25,11 @@ import numpy as np
 
 
 class OpenVINOModel:
-    def __init__(self, ie_network: str, device='CPU', thread_num=None):
+    def __init__(self, ie_network: str, device='CPU', thread_num=None, config=None):
         self._ie = Core()
         self._device = device
         self.thread_num = thread_num
+        self.additional_config = config
         self.ie_network = ie_network
 
     def on_forward_start(self, inputs):
@@ -70,6 +71,8 @@ class OpenVINOModel:
             config = {"CPU_THREADS_NUM": str(self.thread_num)}
         else:
             config = {}
+        if self.additional_config is not None:
+            config.update(self.additional_config)
         self._compiled_model = self._ie.compile_model(model=self.ie_network,
                                                       device_name=self._device,
                                                       config=config)

--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -17,7 +17,7 @@ from functools import partial
 
 
 def PytorchOpenVINOModel(model, input_sample=None, thread_num=None,
-                         logging=True, **export_kwargs):
+                         logging=True, config=None, **export_kwargs):
     """
     Create a OpenVINO model from pytorch.
 
@@ -28,11 +28,17 @@ def PytorchOpenVINOModel(model, input_sample=None, thread_num=None,
     :param thread_num: a int represents how many threads(cores) is needed for
                        inference. default: None.
     :param logging: whether to log detailed information of model conversion. default: True.
+    :param config: The config to be inputted in core.compile_model.
     :param **export_kwargs: will be passed to torch.onnx.export function.
     :return: PytorchOpenVINOModel model for OpenVINO inference.
     """
     from .pytorch.model import PytorchOpenVINOModel
-    return PytorchOpenVINOModel(model, input_sample, thread_num, logging, **export_kwargs)
+    return PytorchOpenVINOModel(model=model,
+                                input_sample=input_sample,
+                                thread_num=thread_num,
+                                logging=logging,
+                                config=config,
+                                **export_kwargs)
 
 
 def load_openvino_model(path):
@@ -40,7 +46,7 @@ def load_openvino_model(path):
     return PytorchOpenVINOModel._load(path)
 
 
-def KerasOpenVINOModel(model, input_sample=None, thread_num=None):
+def KerasOpenVINOModel(model, input_sample=None, thread_num=None, config=None):
     """
     Create a OpenVINO model from Keras.
 
@@ -50,10 +56,11 @@ def KerasOpenVINOModel(model, input_sample=None, thread_num=None):
                          model is a LightningModule with any dataloader attached, defaults to None
     :param thread_num: a int represents how many threads(cores) is needed for
                        inference. default: None.
+    :param config: The config to be inputted in core.compile_model.
     :return: KerasOpenVINOModel model for OpenVINO inference.
     """
     from .tf.model import KerasOpenVINOModel
-    return KerasOpenVINOModel(model, thread_num=thread_num)
+    return KerasOpenVINOModel(model, thread_num=thread_num, config=config)
 
 
 def OpenVINOModel(model, device='CPU'):

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -26,7 +26,7 @@ from ..core.utils import save
 
 
 class KerasOpenVINOModel(AcceleratedKerasModel):
-    def __init__(self, model, thread_num=None):
+    def __init__(self, model, thread_num=None, config=None):
         """
         Create a OpenVINO model from Keras.
 
@@ -34,6 +34,7 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
                       path to Openvino saved model.
         :param thread_num: a int represents how many threads(cores) is needed for
                     inference. default: None.
+        :param config: The config to be inputted in core.compile_model.
         """
         ov_model_path = model
         with TemporaryDirectory() as dir:
@@ -41,7 +42,9 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
             if isinstance(model, tf.keras.Model):
                 export(model, str(dir / 'tmp.xml'))
                 ov_model_path = dir / 'tmp.xml'
-            self.ov_model = OpenVINOModel(ov_model_path, thread_num=thread_num)
+            self.ov_model = OpenVINOModel(ov_model_path,
+                                          thread_num=thread_num,
+                                          config=config)
             super().__init__(None)
 
     def forward_step(self, *inputs):
@@ -72,6 +75,7 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
             maximal_drop=0.999,
             max_iter_num=1,
             n_requests=None,
+            config=None,
             sample_size=300):
         if metric:
             metric = KerasOpenVINOMetric(metric=metric, higher_better=higher_better)
@@ -79,7 +83,7 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
         model = self.ov_model.pot(dataloader, metric=metric, drop_type=drop_type,
                                   maximal_drop=maximal_drop, max_iter_num=max_iter_num,
                                   n_requests=n_requests, sample_size=sample_size)
-        return KerasOpenVINOModel(model)
+        return KerasOpenVINOModel(model, config=config)
 
     @staticmethod
     def _load(path):

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -374,6 +374,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                  input_sample=None,
                  thread_num: Optional[int] = None,
                  onnxruntime_session_options=None,
+                 openvino_config=None,
                  simplification: bool = True,
                  sample_size: int = 100,
                  logging: bool = True,
@@ -424,6 +425,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                            or accelerator='openvino'.
         :param onnxruntime_session_options: The session option for onnxruntime, only valid when
                                             accelerator='onnxruntime', otherwise will be ignored.
+        :param openvino_config: The config to be inputted in core.compile_model. Only valid when
+                                accelerator='openvino', otherwise will be ignored.
         :param simplification: whether we use onnxsim to simplify the ONNX model, only valid when
                                accelerator='onnxruntime', otherwise will be ignored. If this option
                                is set to True, new dependency 'onnxsim' need to be installed.
@@ -545,7 +548,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                     # "n_requests": None,
                     "sample_size": sample_size
                 }
-                return model.pot(calib_dataloader, thread_num=thread_num, **kwargs)
+                return model.pot(calib_dataloader, thread_num=thread_num,
+                                 config=openvino_config, **kwargs)
             else:
                 invalidInputError(False,
                                   "Accelerator {} is invalid.".format(accelerator))
@@ -559,6 +563,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
               use_ipex: bool = False,
               thread_num: Optional[int] = None,
               onnxruntime_session_options=None,
+              openvino_config=None,
               simplification: bool = True,
               logging: bool = True,
               **export_kwargs):
@@ -578,6 +583,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                            or accelerator='openvino'.
         :param onnxruntime_session_options: The session option for onnxruntime, only valid when
                                             accelerator='onnxruntime', otherwise will be ignored.
+        :param openvino_config: The config to be inputted in core.compile_model. Only valid when
+                                accelerator='openvino', otherwise will be ignored.
         :param simplification: whether we use onnxsim to simplify the ONNX model, only valid when
                                accelerator='onnxruntime', otherwise will be ignored. If this option
                                is set to True, new dependency 'onnxsim' need to be installed.
@@ -597,7 +604,11 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             "but got type {}".format(type(model))
         )
         if accelerator == 'openvino':  # openvino backend will not care about ipex usage
-            return PytorchOpenVINOModel(model, input_sample, thread_num, logging, **export_kwargs)
+            final_openvino_option = {"INFERENCE_PRECISION_HINT": "f32"}
+            if openvino_config is not None:
+                final_openvino_option.update(openvino_config)
+            return PytorchOpenVINOModel(model, input_sample, thread_num, logging,
+                                        final_openvino_option, **export_kwargs)
         if accelerator == 'onnxruntime':  # onnxruntime backend will not care about ipex usage
             if onnxruntime_session_options is None:
                 import onnxruntime

--- a/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
@@ -191,8 +191,11 @@ class InferenceUtils:
         :return: Model with different acceleration(OpenVINO/ONNX Runtime).
         """
         if accelerator == 'openvino':
+            final_openvino_option = {"INFERENCE_PRECISION_HINT": "f32"}
+            if openvino_config is not None:
+                final_openvino_option.update(openvino_config)
             return KerasOpenVINOModel(self, input_sample=input_sample,
-                                      thread_num=thread_num, config=openvino_config)
+                                      thread_num=thread_num, config=final_openvino_option)
         elif accelerator == 'onnxruntime':
             if onnxruntime_session_options is None:
                 import onnxruntime

--- a/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
@@ -42,7 +42,8 @@ class InferenceUtils:
                  inputs: List[str] = None,
                  outputs: List[str] = None,
                  sample_size: int = 100,
-                 onnxruntime_session_options=None):
+                 onnxruntime_session_options=None,
+                 openvino_config=None):
         """
         Post-training quantization on a keras model.
 
@@ -92,6 +93,8 @@ class InferenceUtils:
                             the lower the performance degradation, but the longer the time.
         :param onnxruntime_session_options: The session option for onnxruntime, only valid when
                                             accelerator='onnxruntime', otherwise will be ignored.
+        :param openvino_config: The config to be inputted in core.compile_model. Only valid when
+                                accelerator='openvino', otherwise will be ignored.
         :return:            A TensorflowBaseModel for INC. If there is no model found, return None.
         """
         invalidInputError(approach == 'static', "Only 'static' approach is supported now.")
@@ -128,7 +131,8 @@ class InferenceUtils:
                                       drop_type=drop_type,
                                       maximal_drop=maximal_drop,
                                       max_iter_num=max_trials,
-                                      sample_size=sample_size)
+                                      sample_size=sample_size,
+                                      config=openvino_config)
         elif accelerator == 'onnxruntime':
             # convert tensorflow model to onnx model
             from bigdl.nano.deps.onnxruntime.tensorflow.tensorflow_onnxruntime_model \
@@ -166,7 +170,8 @@ class InferenceUtils:
               accelerator: Optional[str] = None,
               input_sample=None,
               thread_num: Optional[int] = None,
-              onnxruntime_session_options=None):
+              onnxruntime_session_options=None,
+              openvino_config=None):
         """
         Trace a Keras model and convert it into an accelerated module for inference.
 
@@ -181,10 +186,13 @@ class InferenceUtils:
                            or accelerator='openvino'.
         :param onnxruntime_session_options: The session option for onnxruntime, only valid when
                                             accelerator='onnxruntime', otherwise will be ignored.
+        :param openvino_config: The config to be inputted in core.compile_model. Only valid when
+                                accelerator='openvino', otherwise will be ignored.
         :return: Model with different acceleration(OpenVINO/ONNX Runtime).
         """
         if accelerator == 'openvino':
-            return KerasOpenVINOModel(self, input_sample, thread_num)
+            return KerasOpenVINOModel(self, input_sample=input_sample,
+                                      thread_num=thread_num, config=openvino_config)
         elif accelerator == 'onnxruntime':
             if onnxruntime_session_options is None:
                 import onnxruntime

--- a/python/nano/test/openvino/tf/test_openvino.py
+++ b/python/nano/test/openvino/tf/test_openvino.py
@@ -38,3 +38,9 @@ class TestOpenVINO(TestCase):
 
         openvino_model.compile(metrics=[tf.keras.metrics.CategoricalAccuracy()])
         acc = openvino_model.evaluate(train_dataset, return_dict=True)['categorical_accuracy']
+
+        # trace a Keras model with config
+        openvino_model = model.trace(accelerator='openvino',
+                                     openvino_config={"PERFORMANCE_HINT": "LATENCY"})
+        y_hat = openvino_model(train_examples[:10])
+        assert y_hat.shape == (10, 10)

--- a/python/nano/test/openvino/tf/test_openvino_quantize.py
+++ b/python/nano/test/openvino/tf/test_openvino_quantize.py
@@ -21,7 +21,7 @@ from bigdl.nano.tf.keras import Model
 
 
 class TestOpenVINO(TestCase):
-    def test_model_trace_openvino(self):
+    def test_model_quantize_openvino(self):
         model = MobileNetV2(weights=None, input_shape=[40, 40, 3], classes=10)
         model = Model(inputs=model.inputs, outputs=model.outputs)
         train_examples = np.random.random((100, 40, 40, 3))
@@ -52,3 +52,11 @@ class TestOpenVINO(TestCase):
         preds = model.predict(train_examples)
         openvino_preds = openvino_quantized_model.predict(train_examples)
         np.testing.assert_allclose(preds, openvino_preds, rtol=1e-2)
+
+        # Case 3: with config
+        openvino_quantized_model = model.quantize(accelerator='openvino',
+                                                  calib_dataset=train_dataset,
+                                                  openvino_config={"PERFORMANCE_HINT": "LATENCY"})
+
+        y_hat = openvino_quantized_model(train_examples[:10])
+        assert y_hat.shape == (10, 10)


### PR DESCRIPTION
## Description

### 1. Why the change?
https://github.com/intel-analytics/BigDL/issues/6473

### 2. User API changes
For pytorch
```python
from bigdl.nano.pytorch import InferenceOptimizer
InferenceOptimizer.trace(..., openvino_config=...)   # if None, a default {"INFERENCE_PRECISION_HINT": "f32"} will be assigned
InferenceOptimizer.quantize(..., openvino_config=...)
```

For tensorflow,
```python
model.trace(..., openvino_config=...)  # if None, a default {"INFERENCE_PRECISION_HINT": "f32"} will be assigned
model.quantize(..., openvino_config=...)
```

### 3. Summary of the change 

a parameter is exposed externally and passed down way to the core.compile_model

### 4. How to test?
- [ ] Unit test
