### PR TITLE
[ORCA] RayContext supports setting cpu nums through init_orca_context

### DIFF
--- a/python/orca/src/bigdl/orca/common.py
+++ b/python/orca/src/bigdl/orca/common.py
@@ -231,8 +231,6 @@ def init_orca_context(cluster_mode=None, runtime="spark", cores=None, memory="2g
         from bigdl.orca.ray import OrcaRayContext
         ray_ctx = OrcaRayContext(runtime="ray", cores=cores, num_nodes=num_nodes,
                                  **kwargs)
-        invalidInputError("address" in kwargs,
-                          "ray_address must be specified if the runtime is ray.")
         ray_ctx.init()
         return ray_ctx
     elif runtime == "spark":

--- a/python/orca/src/bigdl/orca/ray/raycontext.py
+++ b/python/orca/src/bigdl/orca/ray/raycontext.py
@@ -48,8 +48,7 @@ class OrcaRayContext(object):
 
         elif runtime == "ray":
             self.is_local = False
-            ray_args = kwargs.copy()
-            self.ray_args = ray_args
+            self.ray_args = kwargs.copy()
             self.num_ray_nodes = num_nodes
             self.ray_node_cpu_cores = cores
         else:
@@ -62,7 +61,10 @@ class OrcaRayContext(object):
     def init(self, driver_cores=0):
         if self.runtime == "ray":
             import ray
-            results = ray.init(num_cpus=self.ray_node_cpu_cores, **self.ray_args)
+            if "address" not in self.ray_args:
+                results = ray.init(num_cpus=self.ray_node_cpu_cores, **self.ray_args)
+            else:
+                results = ray.init(**self.ray_args)
         else:
             results = self._ray_on_spark_context.init(driver_cores=driver_cores)
             self.num_ray_nodes = self._ray_on_spark_context.num_ray_nodes

--- a/python/orca/src/bigdl/orca/ray/raycontext.py
+++ b/python/orca/src/bigdl/orca/ray/raycontext.py
@@ -62,7 +62,7 @@ class OrcaRayContext(object):
     def init(self, driver_cores=0):
         if self.runtime == "ray":
             import ray
-            results = ray.init(**self.ray_args)
+            results = ray.init(num_cpus=self.ray_node_cpu_cores, **self.ray_args)
         else:
             results = self._ray_on_spark_context.init(driver_cores=driver_cores)
             self.num_ray_nodes = self._ray_on_spark_context.num_ray_nodes

--- a/python/orca/src/bigdl/orca/ray/raycontext.py
+++ b/python/orca/src/bigdl/orca/ray/raycontext.py
@@ -65,14 +65,9 @@ class OrcaRayContext(object):
     def init(self, driver_cores=0):
         if self.runtime == "ray":
             address_env_var = os.environ.get(ray_constants.RAY_ADDRESS_ENVIRONMENT_VARIABLE)
-            if "address" not in self.ray_args:
-                if address_env_var is None:
+            if "address" not in self.ray_args and address_env_var is None:
                     print("Creating a local Ray instance.")
                     results = ray.init(num_cpus=self.ray_node_cpu_cores, **self.ray_args)
-                else:
-                    print("Connecting to an existing ray cluster, num_cpus "
-                          "must not be provided.")
-                    results = ray.init(**self.ray_args)
             else:
                 print("Connecting to an existing ray cluster, num_cpus "
                       "must not be provided.")

--- a/python/orca/src/bigdl/orca/ray/raycontext.py
+++ b/python/orca/src/bigdl/orca/ray/raycontext.py
@@ -70,11 +70,11 @@ class OrcaRayContext(object):
                     print("Creating a local Ray instance.")
                     results = ray.init(num_cpus=self.ray_node_cpu_cores, **self.ray_args)
                 else:
-                    print("Connecting to an existing ray cluster, num_cpus " 
+                    print("Connecting to an existing ray cluster, num_cpus "
                           "must not be provided.")
                     results = ray.init(**self.ray_args)
             else:
-                print("Connecting to an existing ray cluster, num_cpus " 
+                print("Connecting to an existing ray cluster, num_cpus "
                       "must not be provided.")
                 results = ray.init(**self.ray_args)
         else:


### PR DESCRIPTION
## Description
OrcaRayContext supports to create a new Ray instance instead of only connecting to an existing Ray cluster, and also supports users to specify `cores` to specify `num_cpus` resources.

### 1. Why the change?
For https://github.com/intel-analytics/BigDL/issues/6500

### 2. User API changes

In the previous version, we required users to provide `address` for `OrcaRayContext` to connect to an existing Ray cluster, and due to Ray's limitation, users could not specify `num_cpus` to control cluster resources.
```python
from bigdl.orca import init_orca_context

init_orca_context(runtime="ray",  address="localhost:6379")
```

Currently, we provide an option for users, which could support users to create a new local Ray instance and set `num_cpus` as below:
```python
from bigdl.orca import init_orca_context

# set `num_cpus` through `cores`
init_orca_context(runtime="ray",  cores=2)
```

### 3. Summary of the change 
1. Support creating a new Ray instance.
2. Support set `num_cpus`.

### 4. How to test?
- [x] Unit test

