### PR TITLE
Chronos: optimize forecaster to reduce memory consumption

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -608,7 +608,7 @@ class BasePytorchForecaster(Forecaster):
                 precision=precision,
                 accuracy_criterion=accuracy_criterion)
             self.optim_model = optim_model
-            self.metadata = option  # represent model type of the best model
+            self.metadata = option  # represent which model is stored in self.optim_model
         except Exception:
             invalidInputError(False, "Unable to find an optimized model that meets your conditions."
                               "Maybe you can relax your search limit.")

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -714,8 +714,8 @@ class BasePytorchForecaster(Forecaster):
                                                       input_data=data,
                                                       batch_size=batch_size)
                 else:
-                    self.accelerated_model.eval()
-                    yhat = _pytorch_fashion_inference(model=self.accelerated_model,
+                    self.optim_model.eval()
+                    yhat = _pytorch_fashion_inference(model=self.optim_model,
                                                       input_data=data,
                                                       batch_size=batch_size)
             if not is_local_data:
@@ -1057,8 +1057,8 @@ class BasePytorchForecaster(Forecaster):
                                                       input_data=input_data,
                                                       batch_size=batch_size)
                 else:
-                    self.accelerated_model.eval()
-                    yhat = _pytorch_fashion_inference(model=self.accelerated_model,
+                    self.optim_model.eval()
+                    yhat = _pytorch_fashion_inference(model=self.optim_model,
                                                       input_data=input_data,
                                                       batch_size=batch_size)
 

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -699,7 +699,7 @@ class TestChronosModelLSTMForecaster(TestCase):
         forecaster.fit(train_loader, epochs=2)
         forecaster.evaluate(val_loader)
         forecaster.predict(test_loader)
-        assert forecaster.optim_model is None
+        assert forecaster.accelerated_model is None
 
     def test_lstm_forecaster_eval_shuffle_loader(self):
         from torch.utils.data import DataLoader, TensorDataset

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -630,7 +630,7 @@ class TestChronosNBeatsForecaster(TestCase):
         forecaster.fit(train_loader, epochs=2)
         forecaster.evaluate(val_loader)
         forecaster.predict(test_loader)
-        assert forecaster.optim_model is None
+        assert forecaster.accelerated_model is None
 
     def test_nbeats_forecaster_eval_shuffle_loader(self):
         from torch.utils.data import DataLoader, TensorDataset

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -586,7 +586,7 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
         forecaster.fit(train_loader, epochs=2)
         forecaster.evaluate(val_loader)
         forecaster.predict(test_loader)
-        assert forecaster.optim_model is None
+        assert forecaster.accelerated_model is None
 
     def test_s2s_forecaster_eval_shuffle_loader(self):
         from torch.utils.data import DataLoader, TensorDataset

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -1283,7 +1283,7 @@ class TestChronosModelTCNForecaster(TestCase):
         forecaster.fit(train_loader, epochs=2)
         forecaster.evaluate(val_loader)
         forecaster.predict(test_loader)
-        assert forecaster.optim_model is None
+        assert forecaster.accelerated_model is None
 
     @op_diff_set_all
     @op_onnxrt16


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

<!-- Provide the related github issue link if available -->
When forecasters are accelerated by various accelerators (onnxruntime, openvino, ...), all the accelerated models will be saved inside forecaster, which causes more memory consumption.
### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->
N/A
### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
- The forecaster only saves the latest accelerated model. The accelerated model will be saved at `self.accelerated_model`, and the model type will be saved at `self.accelerated_method`. 
- The quantized model will be saved in a dictionary because multiple frameworks can be specified when calling `.quantize()`. 
### 4. How to test?
- [ ] Unit test