### PR TITLE
[PPML] patch for multi-couchdb in production

### DIFF
--- a/ppml/services/ehsm/kubernetes/bigdl-ehsm-kms.yaml
+++ b/ppml/services/ehsm/kubernetes/bigdl-ehsm-kms.yaml
@@ -158,6 +158,13 @@ spec:
       - name: couchdb
         image: $couchdbImageName
         imagePullPolicy: IfNotPresent
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - sh
+              - -c
+              - "echo [couchdb] single_node=true >> /opt/couchdb/etc/local.d/docker.ini; echo [couchdb] single_node=true >> /opt/couchdb/etc/local.ini"
         readinessProbe:
           httpGet:
             port: couchdb-port


### PR DESCRIPTION
## Description

Fix start-up failure when multi-couchdb in production as customer feedback by using k8s lifecycle hook.

### 1. Why the change?

As the description.

### 2. User API changes

No.

### 3. Summary of the change 

Patch for multi-couchdb in production.

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...
