### PR TITLE
Orca: Consistency on `forward_batch` Criterion

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/training_operator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/training_operator.py
@@ -411,7 +411,11 @@ class TrainingOperator:
                                   "Features should be tensor, list/tuple or dict, "
                                   "but got {}".format(type(features)))
 
-            loss = self.criterion(output, target)
+            if isinstance(output, tuple) or isinstance(output, list):
+                # Then target is also assumed to be a tuple or list.
+                loss = self.criterion(*output, *target)
+            else:
+                loss = self.criterion(output, target)
 
         return output, target, loss
 


### PR DESCRIPTION
## Description
Inconsistent behaviors between `train_batch `and `forward_batch `

https://github.com/intel-analytics/BigDL/blob/main/python/orca/src/bigdl/orca/learn/pytorch/training_operator.py#L284-L288
https://github.com/intel-analytics/BigDL/blob/main/python/orca/src/bigdl/orca/learn/pytorch/training_operator.py#L414

related issue:
https://github.com/analytics-zoo/Telecom-CTC-E2E/pull/16#issuecomment-1313385923
