### PR TITLE
[Doc] Sidebar fix

### DIFF
--- a/docs/readthedocs/source/_static/css/custom.css
+++ b/docs/readthedocs/source/_static/css/custom.css
@@ -102,3 +102,8 @@ footer.bd-footer{
 .rendered_html table {
     table-layout: auto !important;
 }
+
+/* for right sidebar word-break */
+/* #bd-toc-nav ul li {
+    word-break: break-word;
+} */

--- a/docs/readthedocs/source/_static/css/custom.css
+++ b/docs/readthedocs/source/_static/css/custom.css
@@ -104,6 +104,6 @@ footer.bd-footer{
 }
 
 /* for right sidebar word-break */
-/* #bd-toc-nav ul li {
+#bd-toc-nav ul li {
     word-break: break-word;
-} */
+}


### PR DESCRIPTION
## Description

### 1. Why the change?
 Fixed an issue where the sidebar‘s content was not fully displayed.

Previous bug: The `bigdl.nano.pytorch.InferenceOptimizer` can't fully display.
![image](https://user-images.githubusercontent.com/71260173/201836583-ecba4701-742e-42c4-842c-3958da6ffbfb.png)

Current effect: Now it will automatically wrap.
![image](https://user-images.githubusercontent.com/71260173/201836467-2551beaf-394c-46b6-80f2-b04aa4124177.png)

### 2. Preview link: [here](https://andytestdoc.readthedocs.io/en/sidebar_fix/doc/PythonAPI/Nano/pytorch.html)