### PR TITLE
Nano: update quantize with BF16

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -46,15 +46,11 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         :param from_load: this will only be set by _load method.
         '''
         if use_ipex:
-            # invalidInputError(
-            #     self._check_cpu_isa,
-            #     errMsg="Applying IPEX BF16 optimization needs the cpu support avx512.",
-            #     fixMsg="Please set use_ipex to False or not set precision to bf16."
-            # )
-            if self._check_cpu_isa is False:
-                warning("Your machine or OS doesn't support BF16 instructions. "
-                        "You are running BF16 model without ISA support, and the "
-                        "performance might be quite low.")
+            invalidInputError(
+                self._check_cpu_isa,
+                errMsg="Applying IPEX BF16 optimization needs the cpu support avx512.",
+                fixMsg="Please set use_ipex to False or not set precision to bf16."
+            )
 
         PytorchIPEXJITModel.__init__(self, model, input_sample=input_sample, use_ipex=use_ipex,
                                      dtype=torch.bfloat16, use_jit=use_jit,

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -46,11 +46,16 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         :param from_load: this will only be set by _load method.
         '''
         if use_ipex:
-            invalidInputError(
-                self._check_cpu_isa,
-                errMsg="Applying IPEX BF16 optimization needs the cpu support avx512.",
-                fixMsg="Please set use_ipex to False or not set precision to bf16."
-            )
+            # invalidInputError(
+            #     self._check_cpu_isa,
+            #     errMsg="Applying IPEX BF16 optimization needs the cpu support avx512.",
+            #     fixMsg="Please set use_ipex to False or not set precision to bf16."
+            # )
+            if self._check_cpu_isa is False:
+                warning("Your machine or OS doesn't support BF16 instructions. "
+                        "You are running BF16 model without ISA support, and the "
+                        "performance might be quite low.")
+    
         PytorchIPEXJITModel.__init__(self, model, input_sample=input_sample, use_ipex=use_ipex,
                                      dtype=torch.bfloat16, use_jit=use_jit,
                                      channels_last=channels_last, from_load=from_load)
@@ -63,7 +68,7 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
 
     def autocast_context_manager(self):
         """Create autocast context"""
-        return autocast(enabled=self._check_cpu_isa)
+        return autocast(enabled=True, dtype=torch.bfloat16)
 
     @contextlib.contextmanager
     def forward_context(self):

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -55,7 +55,7 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
                 warning("Your machine or OS doesn't support BF16 instructions. "
                         "You are running BF16 model without ISA support, and the "
                         "performance might be quite low.")
-    
+
         PytorchIPEXJITModel.__init__(self, model, input_sample=input_sample, use_ipex=use_ipex,
                                      dtype=torch.bfloat16, use_jit=use_jit,
                                      channels_last=channels_last, from_load=from_load)

--- a/python/nano/src/bigdl/nano/pytorch/amp/amp_api.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/amp_api.py
@@ -17,3 +17,8 @@
 def BF16Model(*args, **kwargs):
     from .bfloat16 import BF16Model
     return BF16Model(*args, **kwargs)
+
+
+def load_bf16_model(path, model):
+    from .bfloat16 import BF16Model
+    return BF16Model._load(path, model)

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -159,7 +159,7 @@ class BF16Model(LightningModule):
             max_bf16_isa = "AVX512"
         return max_bf16_isa
 
-    @autocast()
+    @autocast(enabled=True, dtype=torch.bfloat16)
     def forward(self, *args, **kwargs):  # noqa
         # self._bf16_check(*args, **kwargs)
         return self.bf16_model(*args, **kwargs)

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -119,7 +119,7 @@ class BF16Model(LightningModule):
 
     def __init__(self, model):  # noqa
         super().__init__()
-        self.bf16_model = model.bfloat16()
+        self.bf16_model = model
 
     @property
     def _has_bf16_isa(self):
@@ -161,7 +161,7 @@ class BF16Model(LightningModule):
 
     @autocast()
     def forward(self, *args, **kwargs):  # noqa
-        self._bf16_check(*args, **kwargs)
+        # self._bf16_check(*args, **kwargs)
         return self.bf16_model(*args, **kwargs)
 
     def _bf16_check(self, *args, **kwargs):

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -165,7 +165,7 @@ class BF16Model(AcceleratedLightningModule):
         elif 'avx512_core_bf16' in dnnl_log:
             max_bf16_isa = "AVX512"
         return max_bf16_isa
-    
+
     def on_forward_start(self, inputs):
         return inputs
 

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -197,9 +197,10 @@ class BF16Model(LightningModule):
             #                    " BF16 acceleration."
             #         )
         else:
-            if self._allow_non_bf16:
-                self._is_bf16 = False
             # close error for no BF16 instructions, just warning.
+            self._is_bf16 = False
+            # if self._allow_non_bf16:
+            #     self._is_bf16 = False
 
             # else:
             #     invalidOperationError(

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -119,6 +119,7 @@ class BF16Model(LightningModule):
 
     def __init__(self, model):  # noqa
         super().__init__()
+        self._bf16_check()
         self.bf16_model = model
 
     @property
@@ -164,9 +165,9 @@ class BF16Model(LightningModule):
         # self._bf16_check(*args, **kwargs)
         return self.bf16_model(*args, **kwargs)
 
-    def _bf16_check(self, *args, **kwargs):
+    def _bf16_check(self):
         if getattr(self, "_is_bf16", None) is not None:
-            return
+            return self._is_bf16
 
         invalidInputError(
             not TORCH_VERSION_LESS_1_12,
@@ -198,14 +199,17 @@ class BF16Model(LightningModule):
         else:
             if self._allow_non_bf16:
                 self._is_bf16 = False
-            else:
-                invalidOperationError(
-                    False,
-                    errMsg="Your machine or OS doesn't support BF16 instructions.",
-                    fixMsg="Please check your machine and OS to make sure"
-                           " BF16 support is available."
-                )
+            # close error for no BF16 instructions, just warning.
+
+            # else:
+            #     invalidOperationError(
+            #         False,
+            #         errMsg="Your machine or OS doesn't support BF16 instructions.",
+            #         fixMsg="Please check your machine and OS to make sure"
+            #                " BF16 support is available."
+            #     )
 
         if not self._is_bf16:
-            warning("You are not running BF16 model with ISA support."
-                    " The performance will be quite low.")
+            warning("Your machine or OS doesn't support BF16 instructions. "
+                    "You are running BF16 model without ISA support, and the "
+                    "performance might be quite low.")

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -455,8 +455,11 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                     return PytorchIPEXJITBF16Model(model, input_sample=input_sample,
                                                    use_ipex=use_ipex, use_jit=use_jit,
                                                    channels_last=channels_last)
-                bf16_model = BF16Model(model)
-                return bf16_model
+                else:
+                    channels_last = export_kwargs["channels_last"] \
+                        if "channels_last" in export_kwargs else None
+                    bf16_model = BF16Model(model, channels_last=channels_last)
+                    return bf16_model
             else:
                 invalidInputError(False,
                                   "Accelerator {} is invalid for BF16.".format(accelerator))

--- a/python/nano/src/bigdl/nano/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/pytorch/utils.py
@@ -28,6 +28,7 @@ from bigdl.nano.deps.openvino.openvino_api import load_openvino_model
 from bigdl.nano.deps.ipex.ipex_api import load_ipexjit_model
 from bigdl.nano.deps.onnxruntime.onnxruntime_api import load_onnxruntime_model
 from bigdl.nano.deps.neural_compressor.inc_api import load_inc_model
+from bigdl.nano.pytorch.amp.amp_api import load_bf16_model
 from bigdl.nano.utils.log4Error import invalidInputError
 from pathlib import Path
 
@@ -147,6 +148,8 @@ def load_model(path, model: pl.LightningModule = None):
         return load_inc_model(path, model, 'pytorch')
     if model_type == 'PytorchIPEXJITModel':
         return load_ipexjit_model(path, model)
+    if model_type == 'BF16Model':
+        return load_bf16_model(path, model)
     if isinstance(model, nn.Module):
         # typically for models of nn.Module, pl.LightningModule type
         model = copy.deepcopy(model)

--- a/python/nano/test/pytorch/tests/test_bf16.py
+++ b/python/nano/test/pytorch/tests/test_bf16.py
@@ -137,25 +137,6 @@ class Pytorch1_12:
             bf16_model._max_bf16_isa = MagicMock(return_value="AVX512")
             y_hat = bf16_model(x)
         assert y_hat.shape == (10, 10) and y_hat.dtype == torch.bfloat16
-        
-    def test_bf16_save_load(self):
-        model = resnet18(num_classes=10)
-
-        x = torch.rand((10, 3, 256, 256))
-        y = torch.ones((10,), dtype=torch.long)
-
-        bf16_model = InferenceOptimizer.quantize(model, precision='bf16')
-        with patch.object(type(bf16_model), "_has_bf16_isa", PropertyMock(return_value=True)):
-            bf16_model._max_bf16_isa = MagicMock(return_value="AVX512")
-            y_hat = bf16_model(x)
-        assert y_hat.shape == (10, 10) and y_hat.dtype == torch.bfloat16
-        InferenceOptimizer.save(bf16_model, "bf16_model")
-        
-        load_model = InferenceOptimizer.load("bf16_model", model)
-        with patch.object(type(bf16_model), "_has_bf16_isa", PropertyMock(return_value=True)):
-            load_model._max_bf16_isa = MagicMock(return_value="AVX512")
-            y_hat = load_model(x)
-        assert y_hat.shape == (10, 10) and y_hat.dtype == torch.bfloat16
 
 
 TORCH_VERSION_CLS = Pytorch1_12

--- a/python/nano/test/pytorch/tests/test_bf16.py
+++ b/python/nano/test/pytorch/tests/test_bf16.py
@@ -69,9 +69,9 @@ class Pytorch1_12:
         x = torch.rand((10, 3, 256, 256))
         y = torch.ones((10,), dtype=torch.long)
         bf16_model = trainer.quantize(model, precision='bf16')
-        with pytest.raises(RuntimeError,
-                           match="Your machine or OS doesn't support BF16 instructions."):
-            y_hat = bf16_model(x)
+        # with pytest.raises(RuntimeError,
+        #                    match="Your machine or OS doesn't support BF16 instructions."):
+        y_hat = bf16_model(x)
 
     @patch("bigdl.nano.pytorch.amp.bfloat16.BF16Model._max_bf16_isa", return_value=None)
     @patch("bigdl.nano.pytorch.amp.bfloat16.BF16Model._has_bf16_isa", new_callable=PropertyMock)
@@ -90,11 +90,11 @@ class Pytorch1_12:
         x = torch.rand((10, 3, 256, 256))
 
         bf16_model = trainer.quantize(model, precision='bf16')
-        with pytest.raises(
-            RuntimeError,
-            match="BF16 ISA support is not enabled under current context."
-        ):
-            bf16_model(x)
+        # with pytest.raises(
+        #     RuntimeError,
+        #     match="BF16 ISA support is not enabled under current context."
+        # ):
+        bf16_model(x)
 
     @patch.dict('os.environ', {"ALLOW_NON_BF16_ISA": "1"})
     def test_bf16_common(self):

--- a/python/nano/test/pytorch/tests/test_bf16.py
+++ b/python/nano/test/pytorch/tests/test_bf16.py
@@ -47,12 +47,11 @@ class Pytorch1_11:
         trainer = Trainer(max_epochs=1)
         model = resnet18(num_classes=10)
         x = torch.rand((10, 3, 256, 256))
-        bf16_model = trainer.quantize(model, precision='bf16')
         with pytest.raises(
             RuntimeError,
             match="Require torch>=1.12 to obtain bfloat16 acceleration."
         ):
-            y_hat = bf16_model(x)
+            bf16_model = trainer.quantize(model, precision='bf16')
 
 
 class Pytorch1_12:

--- a/python/nano/test/pytorch/tests/test_bf16.py
+++ b/python/nano/test/pytorch/tests/test_bf16.py
@@ -152,8 +152,7 @@ class Pytorch1_12:
         bf16_model = InferenceOptimizer.load("bf16_model", model)
         y_hat2 = bf16_model(x)
         assert y_hat2.shape == (10, 10) and y_hat2.dtype == torch.bfloat16
-        np.testing.assert_allclose(y_hat1, y_hat2, atol=1e-4,
-                                   err_msg=f"\npred1: {y_hat1}\npred2: {y_hat2}\n")
+        assert y_hat1.equal(y_hat2)
     
         # test bf16 + channels_last
         bf16_model = trainer.quantize(model, precision='bf16',
@@ -164,8 +163,7 @@ class Pytorch1_12:
         bf16_model = InferenceOptimizer.load("bf16_model", model)
         y_hat2 = bf16_model(x)
         assert y_hat2.shape == (10, 10) and y_hat2.dtype == torch.bfloat16
-        np.testing.assert_allclose(y_hat1, y_hat2, atol=1e-4,
-                                   err_msg=f"\npred1: {y_hat1}\npred2: {y_hat2}\n")
+        assert y_hat1.equal(y_hat2)
     
 
 TORCH_VERSION_CLS = Pytorch1_12

--- a/python/nano/test/pytorch/tests/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/test_bf16_ipex.py
@@ -41,9 +41,9 @@ class CaseWithoutAVX512:
         trainer = Trainer(max_epochs=1)
         model = resnet18(num_classes=10)
 
-        # with pytest.raises(RuntimeError,
-        #                    match="Applying IPEX BF16 optimization needs the cpu support avx512."):
-        bf16_model = trainer.quantize(model, precision='bf16', use_ipex=True)
+        with pytest.raises(RuntimeError,
+                           match="Applying IPEX BF16 optimization needs the cpu support avx512."):
+            bf16_model = trainer.quantize(model, precision='bf16', use_ipex=True)
 
 
 class Pytorch1_11:

--- a/python/nano/test/pytorch/tests/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/test_bf16_ipex.py
@@ -41,9 +41,9 @@ class CaseWithoutAVX512:
         trainer = Trainer(max_epochs=1)
         model = resnet18(num_classes=10)
 
-        with pytest.raises(RuntimeError,
-                           match="Applying IPEX BF16 optimization needs the cpu support avx512."):
-            bf16_model = trainer.quantize(model, precision='bf16', use_ipex=True)
+        # with pytest.raises(RuntimeError,
+        #                    match="Applying IPEX BF16 optimization needs the cpu support avx512."):
+        bf16_model = trainer.quantize(model, precision='bf16', use_ipex=True)
 
 
 class Pytorch1_11:


### PR DESCRIPTION
## Description

According to some experience from OOB, we found BF16 in Nano exists several problems:
- strict check for ISA, however bf16 model sometimes can run on hardware without bf16 related instructions
- now we use complete precision bf16 model(model.bfloat16()), but this will conflict with ipex, and will cause error in `optimize` when model contains layer norm layer ; by the way, mixed precision model seem to be a more general approach
- lack of `bf16 + channels_last` combination
- save & load function fails for bf16 model
- autocast inside forward will bring about additional  30% overhead

This PR will try to solve first four problems, and **leave the last problem in a separate PR**.

### 1. Why the change?

https://github.com/intel-analytics/BigDL/issues/6611

### 2. User API changes
Add new parameter `channels_last` for BF16, and support save & load for BF16 model.
```
from bigdl.nano.pytorch import InferenceOptimizer
bf16_model = InferenceOptimizer.quantize(model,
                                         precision="bf16",
                                         channels_last=True)
output = bf16_model(input)
assert output.dtype == torch.bfloat16  # just for test
InferenceOptimizer.save(bf16_model, "bf16_model")

bf16_model = InferenceOptimizer.load("bf16_model", model)
output = bf16_model(input)
assert output.dtype == torch.bfloat16  # just for test
```
### 3. Summary of the change 

- Update ISA check of bf16 and ipex bf16. Now only check at initialization, and don't throw exception for bf16 model even if there don't exists bf16 related instruction set.
- change from complete precision model to mixed precision
- Add pamater `channels_last` for BF16
- support save & load for BF16 model

### 4. How to test?
- [x] Unit test
- [x] Application test
