### PR TITLE
[WIP] Orca: extend bigdl-submit CLI.

### DIFF
--- a/scripts/bigdl-submit
+++ b/scripts/bigdl-submit
@@ -3,20 +3,19 @@
 set -e
 
 # usage
-usage() { echo "Usage: $0 [-a|--archives <string#string> -h|--help]" 1>&2; exit 1; }
+usage() { echo "Usage: $0 [-a|--archives <string#string,...> -d|--deploy-mode <string> -c|--conf <string=string> -h|--help]" 1>&2; exit 1; }
 
 cmd=$@
 # get options
 set +e
-ARGS=`getopt -q -o a:h --long archives:,help -- "$@"`
+ARGS=`getopt -o a:d:c:h: --long archives:,deploy-mode:,conf:,help -- "$@"`
 set -e
 eval set -- "$ARGS"
 
 # extract options and their arguments into variables.
-archive-array=()
-dir-array=()
-dir=$PYSPARK_PYTHON
-deploy-mode=""
+declare -A archives_map
+declare -A conf_map
+dir="environment"
 while true ; do
     case "$1" in
         -a|--archives)
@@ -24,22 +23,18 @@ while true ; do
             for archive in $archives
             do
                 array=(${archive//#/ })
-                archive-array[${#archive-array[@]}]=${array[0]}
-                dir-array[${dir-array[@]}]=${array[1]}
+                archives_map[${array[1]}]=${array[0]}
             done
             shift 2
             ;;
         -d|--deploy-mode)
-            deploy-mode=$2
+            deploy_mode=$2
             shift 2
             ;;
         -c|--conf)
-            echo $deploy-mode
-            if [ $2 =~ "spark.pyspark.driver.python" -o $2 =~ "spark.yarn.appMasterEnv.PYSPARK_PYTHON" -o $2 =~ "spark.executorEnv.PYSPARK_PYTHON"  ]
-            then
-                array=(${2//=/ })
-                dir=${array[1]}
-            fi
+            array=(${2//=/ })
+            array2=(${array[1]///bin/ })
+            conf_map[${array[0]}]=${array2[0]}
             shift 2
             ;;
         -h|--help)
@@ -51,33 +46,38 @@ while true ; do
     esac
 done
 
-echo $archive-array
-echo $dir-array
-echo $dir
-echo $deploy-mode
-exit 1
-# check if environment exists
-if [ ! -d "${dir}" ]
+if [ $deploy_mode == "client" ]
 then
-    # extract environment
-    echo "extracting ${archives} to ${dir} ..."
-    mkdir -p ${dir}
-    set +e
-    which "pv" >/dev/null 2>&1
-    if [ $? -eq 0 ]
-    then
-        echo "extracting with progress bar..."
-        pv ${archives}|tar -xz -C ${dir}
-    else
-        echo "extracting without progress bar...please install pv if you need progress bar."
-        tar -xzf ${archives} -C ${dir}
-    fi
-    set -e
+    dir=${conf_map["spark.pyspark.driver.python"]} # todo: deal with corner case.
+else
+    dir=${conf_map["spark.yarn.appMasterEnv.PYSPARK_PYTHON"]}
 fi
 
+archive=${archives_map[$dir]}
 
-# activate environment
-source ${dir}/bin/activate
+set +e
+which "conda" >/dev/null 2>&1
+if [ $? -eq 0 ]
+    # check if environment exists
+    if [ ! -d "${dir}" ]
+    then
+        # extract environment
+        echo "extracting ${archive} to ${dir} ..."
+        mkdir -p ${dir}
+        which "pv" >/dev/null 2>&1
+        if [ $? -eq 0 ]
+        then
+            echo "extracting with progress bar..."
+            pv ${archive}|tar -xz -C ${dir}
+        else
+            echo "extracting without progress bar...please install pv if you need progress bar."
+            tar -xzf ${archive} -C ${dir}
+        fi
+    fi
+    # activate environment
+    source ${dir}/bin/activate
+fi
+set -e
 
 # detect paths
 export BIGDL_ENV=`python -c """from bigdl.dllib.utils.engine import *

--- a/scripts/bigdl-submit
+++ b/scripts/bigdl-submit
@@ -13,9 +13,13 @@ set -e
 eval set -- "$ARGS"
 
 # extract options and their arguments into variables.
+# declare dir -> archive map
 declare -A archives_map
+# declare spark conf map
 declare -A conf_map
-dir="environment"
+# parse PYSPARK_PYTHON for default value of environment directory.
+array=(${PYSPARK_PYTHON///bin/ })
+dir=${array[0]}
 while true ; do
     case "$1" in
         -a|--archives)
@@ -46,31 +50,55 @@ while true ; do
     esac
 done
 
-if [ $deploy_mode == "client" ]
-then
-    dir=${conf_map["spark.pyspark.driver.python"]} # todo: deal with corner case.
-else
-    dir=${conf_map["spark.yarn.appMasterEnv.PYSPARK_PYTHON"]}
-fi
-
-archive=${archives_map[$dir]}
-
-set +e
-which "conda" >/dev/null 2>&1
+# check if there is conda command
 if [ $? -eq 0 ]
+    if [ $deploy_mode == "client" ]
+    then
+        if [ conf_map["spark.pyspark.driver.python"] ]
+        then
+            dir=${conf_map["spark.pyspark.driver.python"]}
+        else
+            if [ conf_map["spark.pyspark.python"] ]
+            then
+                dir=${conf_map["spark.pyspark.python"]}
+            fi
+        fi
+    else
+        if [ $deploy_mode == "cluster" ]
+        then
+            if [ conf_map["spark.yarn.appMasterEnv.PYSPARK_PYTHON"]]
+                dir=${conf_map["spark.yarn.appMasterEnv.PYSPARK_PYTHON"]}
+            fi
+        fi
+    fi
+    # check environment directory.
+    if [ ! $dir ]
+    then
+        echo "Please specify python environment directory." 
+        echo "You can specify environment variable 'PYSPARK_PYTHON' or specify it in SparkConf."
+        exit 1
+    fi
+    # obtain archive file.
+    archive=${archives_map[$dir]}
+    # check archive file.
+    if [ ! archive ]
+    then
+        echo "Please specify the archive file for environment."
+        exit 1
+    fi
     # check if environment exists
     if [ ! -d "${dir}" ]
     then
         # extract environment
-        echo "extracting ${archive} to ${dir} ..."
+        echo "Extracting ${archive} to ${dir} ..."
         mkdir -p ${dir}
         which "pv" >/dev/null 2>&1
         if [ $? -eq 0 ]
         then
-            echo "extracting with progress bar..."
+            echo "Extracting with progress bar..."
             pv ${archive}|tar -xz -C ${dir}
         else
-            echo "extracting without progress bar...please install pv if you need progress bar."
+            echo "Extracting without progress bar...please install pv if you need progress bar."
             tar -xzf ${archive} -C ${dir}
         fi
     fi

--- a/scripts/bigdl-submit
+++ b/scripts/bigdl-submit
@@ -51,7 +51,7 @@ while true ; do
 done
 
 # check if there is conda command
-if [ $? -eq 0 ]
+if [ $? -eq 0 ]# check dllib & spark-submit & master == yarn?
     if [ $deploy_mode == "client" ]
     then
         if [ conf_map["spark.pyspark.driver.python"] ]

--- a/scripts/bigdl-submit
+++ b/scripts/bigdl-submit
@@ -50,8 +50,26 @@ while true ; do
     esac
 done
 
-# check if there is conda command
-if [ $? -eq 0 ]# check dllib & spark-submit & master == yarn?
+flag=0
+set +e
+# check bigdl.dllib
+python -c "from bigdl import dllib" >/dev/null 2>&1
+if [ $? -ne 0 ]
+then
+    echo "no bigdl.dllib in local environment."
+    flag=1
+fi
+
+# check spark-submit
+which "spark-submit" >/dev/null 2>&1
+if [ $? -ne 0 ]
+then
+    echo "no spark-submit in local environment."
+    flag=1
+fi
+
+set -e
+if [ $flag -eq 1 ]
     if [ $deploy_mode == "client" ]
     then
         if [ conf_map["spark.pyspark.driver.python"] ]
@@ -92,6 +110,7 @@ if [ $? -eq 0 ]# check dllib & spark-submit & master == yarn?
         # extract environment
         echo "Extracting ${archive} to ${dir} ..."
         mkdir -p ${dir}
+        set +e
         which "pv" >/dev/null 2>&1
         if [ $? -eq 0 ]
         then
@@ -102,10 +121,10 @@ if [ $? -eq 0 ]# check dllib & spark-submit & master == yarn?
             tar -xzf ${archive} -C ${dir}
         fi
     fi
+    set -e
     # activate environment
     source ${dir}/bin/activate
 fi
-set -e
 
 # detect paths
 export BIGDL_ENV=`python -c """from bigdl.dllib.utils.engine import *

--- a/scripts/bigdl-submit
+++ b/scripts/bigdl-submit
@@ -3,38 +3,44 @@
 set -e
 
 # usage
-usage() { echo "Usage: $0 [-a|--archive <string#string>]" 1>&2; exit 1; }
+usage() { echo "Usage: $0 [-a|--archives <string#string> -h|--help]" 1>&2; exit 1; }
 
+cmd=$@
 # get options
-TEMP=`getopt -o a:h:: --long archive:,help:: -- "$@"`
-eval set -- "$TEMP"
+set +e
+ARGS=`getopt -q -o a:h --long archives:,help -- "$@"`
+set -e
+eval set -- "$ARGS"
 
 # extract options and their arguments into variables.
-archive="./environment.tar.gz"
+archives="./environment.tar.gz"
 dir="./environment"
 while true ; do
     case "$1" in
-        -a|--archive)
-            array=(${2//#/ }) archive=${array[0]} dir=${array[1]} ; shift 2 ;;
+        -a|--archives)
+            array=(${2//#/ }) archives=${array[0]} dir=${array[1]} ; break ;;
         -h|--help)
-            usage ;;
-        --) shift ; break ;;
-        *) echo "Internal Error" ; exit 1 ;;
+            usage ; break ;;
+        *) break ;;
     esac
 done
-
-# extract environment
-echo "extracting ${archive} to ${dir} ..."
-mkdir -p ${dir}
-which "pv" >/dev/null 2>&1
-
-if [ $? -eq 0 ]; then
-    echo "extracting with progress bar..."
-    pv ${archive}|tar -xz -C ${dir}
-else
-    echo "extracting without progress bar..."
-    tar -xzf ${archive} -C ${dir}
+# check if environment exists
+if [ ! -d "${dir}" ]; then
+    # extract environment
+    echo "extracting ${archives} to ${dir} ..."
+    mkdir -p ${dir}
+    set +e
+    which "pv" >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        echo "extracting with progress bar..."
+        pv ${archives}|tar -xz -C ${dir}
+    else
+        echo "extracting without progress bar...please install pv if you need progress bar."
+        tar -xzf ${archives} -C ${dir}
+    fi
+    set -e
 fi
+
 
 # activate environment
 source ${dir}/bin/activate
@@ -69,4 +75,4 @@ spark-submit \
   --jars ${BIGDL_JARS} \
   --conf spark.driver.extraClassPath=${BIGDL_JARS} \
   --conf spark.executor.extraClassPath=${BIGDL_JARS} \
-  $*
+  ${cmd}

--- a/scripts/bigdl-submit
+++ b/scripts/bigdl-submit
@@ -2,7 +2,44 @@
 
 set -e
 
-#detect paths
+# usage
+usage() { echo "Usage: $0 [-a|--archive <string#string>]" 1>&2; exit 1; }
+
+# get options
+TEMP=`getopt -o a:h:: --long archive:,help:: -- "$@"`
+eval set -- "$TEMP"
+
+# extract options and their arguments into variables.
+archive="./environment.tar.gz"
+dir="./environment"
+while true ; do
+    case "$1" in
+        -a|--archive)
+            array=(${2//#/ }) archive=${array[0]} dir=${array[1]} ; shift 2 ;;
+        -h|--help)
+            usage ;;
+        --) shift ; break ;;
+        *) echo "Internal Error" ; exit 1 ;;
+    esac
+done
+
+# extract environment
+echo "extracting ${archive} to ${dir} ..."
+mkdir -p ${dir}
+which "pv" >/dev/null 2>&1
+
+if [ $? -eq 0 ]; then
+    echo "extracting with progress bar..."
+    pv ${archive}|tar -xz -C ${dir}
+else
+    echo "extracting without progress bar..."
+    tar -xzf ${archive} -C ${dir}
+fi
+
+# activate environment
+source ${dir}/bin/activate
+
+# detect paths
 export BIGDL_ENV=`python -c """from bigdl.dllib.utils.engine import *
 print(' ' + get_bigdl_conf(), end=' ')
 bigdl_jars = get_bigdl_jars()
@@ -10,13 +47,13 @@ print(','.join(bigdl_jars), end=' ')
 """
 `
 
-#setup env
+# setup env
 IFS=$' ' array=($(echo $BIGDL_ENV))
 len=${#array[@]}
 export BIGDL_CONF="${array[$len-2]}"
 export BIGDL_JARS="${array[$len-1]}"
 
-# Check env
+# check env
 if [ -z ${BIGDL_CONF} ]; then
     echo "Cannot find BigDL configuration file, please check your BigDL installation"
     exit 1

--- a/scripts/bigdl-submit
+++ b/scripts/bigdl-submit
@@ -13,25 +13,59 @@ set -e
 eval set -- "$ARGS"
 
 # extract options and their arguments into variables.
-archives="./environment.tar.gz"
-dir="./environment"
+archive-array=()
+dir-array=()
+dir=$PYSPARK_PYTHON
+deploy-mode=""
 while true ; do
     case "$1" in
         -a|--archives)
-            array=(${2//#/ }) archives=${array[0]} dir=${array[1]} ; break ;;
+            archives=(${2//,/ })
+            for archive in $archives
+            do
+                array=(${archive//#/ })
+                archive-array[${#archive-array[@]}]=${array[0]}
+                dir-array[${dir-array[@]}]=${array[1]}
+            done
+            shift 2
+            ;;
+        -d|--deploy-mode)
+            deploy-mode=$2
+            shift 2
+            ;;
+        -c|--conf)
+            echo $deploy-mode
+            if [ $2 =~ "spark.pyspark.driver.python" -o $2 =~ "spark.yarn.appMasterEnv.PYSPARK_PYTHON" -o $2 =~ "spark.executorEnv.PYSPARK_PYTHON"  ]
+            then
+                array=(${2//=/ })
+                dir=${array[1]}
+            fi
+            shift 2
+            ;;
         -h|--help)
             usage ; break ;;
-        *) break ;;
+        --)
+              shift
+              break
+              ;;
     esac
 done
+
+echo $archive-array
+echo $dir-array
+echo $dir
+echo $deploy-mode
+exit 1
 # check if environment exists
-if [ ! -d "${dir}" ]; then
+if [ ! -d "${dir}" ]
+then
     # extract environment
     echo "extracting ${archives} to ${dir} ..."
     mkdir -p ${dir}
     set +e
     which "pv" >/dev/null 2>&1
-    if [ $? -eq 0 ]; then
+    if [ $? -eq 0 ]
+    then
         echo "extracting with progress bar..."
         pv ${archives}|tar -xz -C ${dir}
     else


### PR DESCRIPTION
## Description

This PR is to extend bigdl-submit CLI.


## User Usage

For the previous version, we only support users (which cannot install conda) to run programs as below:
```python
1. Download BigDL assembly package.
2. Run spark-submit command:
    spark-submit \
        --master yarn \
        --deploy-mode client \
        --archives /path/to/environment.tar.gz#environment \
        --py-files /path/to/python.zip \
        --jars /path/to/jars \
        train.py
```

For currently, we could do this work like:
```python
bigdl-submit
    --master yarn \
    --deploy-mode client \
    --archives /path/to/environment.tar.gz#environment \
    train.py
```

This new extending `bigdl-submit` CLI could provide users an automatically way to run their programs with none-conda directly, what they need to do is just prepare the conda archive.