### PR TITLE
Nano: update the metadata saved and loaded for openvino

### DIFF
--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -76,6 +76,7 @@ class OpenVINOModel:
         self._compiled_model = self._ie.compile_model(model=self.ie_network,
                                                       device_name=self._device,
                                                       config=config)
+        self.final_config = config
         self._infer_request = self._compiled_model.create_infer_request()
         input_names = [t.any_name for t in self._ie_network.inputs]
         self._forward_args = input_names

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -69,7 +69,9 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
     @property
     def status(self):
         status = super().status
-        status.update({"xml_path": 'ov_saved_model.xml', "weight_path": 'ov_saved_model.bin'})
+        status.update({"xml_path": 'ov_saved_model.xml',
+                       "weight_path": 'ov_saved_model.bin',
+                       "config": self.ov_model.final_config})
         return status
 
     @property  # type: ignore
@@ -92,7 +94,7 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         else:
             invalidInputError(False, "nano_model_meta.yml must specify 'xml_path' for loading.")
         xml_path = Path(path) / status['xml_path']
-        return PytorchOpenVINOModel(xml_path)
+        return PytorchOpenVINOModel(xml_path, config=status['config'])
 
     def pot(self,
             dataloader,

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -64,7 +64,9 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
     @property
     def status(self):
         status = super().status
-        status.update({"xml_path": 'ov_saved_model.xml', "weight_path": 'ov_saved_model.bin'})
+        status.update({"xml_path": 'ov_saved_model.xml',
+                       "weight_path": 'ov_saved_model.bin',
+                       "config": self.ov_model.final_config})
         return status
 
     def pot(self,
@@ -101,7 +103,7 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
         else:
             invalidInputError(False, "nano_model_meta.yml must specify 'xml_path' for loading.")
         xml_path = Path(path) / status['xml_path']
-        return KerasOpenVINOModel(xml_path)
+        return KerasOpenVINOModel(xml_path, config=status['config'])
 
     def _save_model(self, path):
         """


### PR DESCRIPTION
## Description

### 1. Why the change?

Nano serve users as a runtime API rather than a development tool, so we need to preserve the runtime config to disk and make sure they are properly loaded back. Currently we don't load back the config and some of the configurations such as num_thread and precision hint lost when the model is loaded back

With this PR, a typical metadata yml could be
```yaml
ModelType: PytorchOpenVINOModel
config:
  CPU_THREADS_NUM: '4'
  INFERENCE_PRECISION_HINT: f32
weight_path: ov_saved_model.bin
xml_path: ov_saved_model.xml
```



### 2. User API changes
Nothing

### 3. Summary of the change 
add a "config" key when saving and loading.

### 4. How to test?
- [ ] Unit test
