### PR TITLE
Update MMCVRayEstimator and MMCVRayEpochRunner code style

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/experimential/core/base_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/experimential/core/base_ray_estimator.py
@@ -30,7 +30,7 @@ from ray.exceptions import RayActorError
 from abc import abstractmethod, ABCMeta
 
 from bigdl.orca.learn.pytorch.utils import find_free_port
-from bigdl.dllib.utils.log4Error import *
+from bigdl.dllib.utils.log4Error import invalidInputError
 
 # TODO: full path when merge
 from ..utils import check_for_failure, get_driver_node_ip

--- a/python/orca/src/bigdl/orca/learn/pytorch/experimential/core/lifecycle.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/experimential/core/lifecycle.py
@@ -14,13 +14,9 @@
 # limitations under the License.
 #
 
-
 from abc import abstractmethod, ABCMeta
 import ray
-
 from bigdl.orca.learn.pytorch.utils import find_free_port
-from bigdl.dllib.utils.log4Error import *
-
 from torch.utils.data import DataLoader, IterableDataset
 from torch.utils.data.distributed import DistributedSampler
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/experimential/core/model_io.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/experimential/core/model_io.py
@@ -18,7 +18,6 @@ from abc import ABCMeta, abstractmethod
 import io
 import torch
 from bigdl.orca.learn.pytorch.utils import get_filesystem
-from bigdl.dllib.utils.log4Error import *
 
 
 class ModelIO(metaclass=ABCMeta):

--- a/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_estimator.py
@@ -16,7 +16,7 @@
 
 import types
 import copy
-from bigdl.dllib.utils.log4Error import *
+from bigdl.dllib.utils.log4Error import invalidInputError
 
 from typing import (Any, Dict, List, Optional, Tuple, Callable, overload)
 
@@ -44,7 +44,6 @@ class MMCVRayEstimator(BaseRayEstimator):
             config=worker_config
         )
         self.setup(params, self.backend, self.runner_cls, workers_per_node)
-        self.num_workers = len(self.remote_workers)
 
     def fit(self,
             data_loaders_creators: List[Callable],
@@ -86,7 +85,7 @@ class MMCVRayEstimator(BaseRayEstimator):
             reduce_results=True,
             **kwargs):
         """
-        Same as fit method, keep consistent with mmcv runner.run()
+        Same as fit method, the parameters are consistent with MMCV runner.run()
         """
         return self.fit(data_loaders_creators, workflow, max_epochs, reduce_results, **kwargs)
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_runner.py
@@ -21,7 +21,7 @@ from mmcv.runner import EpochBasedRunner
 from mmcv.runner.utils import get_host_info
 from mmcv.parallel.distributed import MMDistributedDataParallel
 from bigdl.orca.learn.pytorch.utils import AverageMeterCollection
-from bigdl.dllib.utils.log4Error import *
+from bigdl.dllib.utils.log4Error import invalidInputError
 from bigdl.orca.learn.pytorch.experimential.core.base_ray_runner import BaseRayRunner
 
 from typing import (Any, Dict, List, Optional, Tuple, Callable, overload)
@@ -57,6 +57,10 @@ class MMCVRayEpochRunner(BaseRayRunner, EpochBasedRunner):
     def setup_components(self):
         runner = self.mmcv_runner_creator(self.config)
         self._wrap_from_ebr(runner)
+        # MMDDP is implemented by MMCV, it has two main differences with PyTorch DDP:
+        # 1. It supports a custom type :class:`DataContainer` which allows more
+        #    flexible control of input data.
+        # 2. It implement two APIs ``train_step()`` and ``val_step()``.
         self.model = MMDistributedDataParallel(self.model)
 
     def train_epochs(self,

--- a/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_runner.py
@@ -17,6 +17,7 @@
 import time
 import mmcv
 import torch
+import warnings
 from mmcv.runner import EpochBasedRunner
 from mmcv.runner.utils import get_host_info
 from mmcv.parallel.distributed import MMDistributedDataParallel


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->
According to the suggestion 1 to 4 in https://github.com/intel-analytics/BigDL/pull/6600, optimize the code in MMCVRayEstimator and MMCVRayEpochRunner.
- add more comment
- optimize the import statements, stop using `import *` 
- remove useless code