### PR TITLE
Add workflow to test Chronos [tensorflow] [inference] [automl] installation on python 3.8 

### DIFF
--- a/.github/workflows/chronos-install-option-py38-test.yml
+++ b/.github/workflows/chronos-install-option-py38-test.yml
@@ -125,7 +125,7 @@ jobs:
           BIGDL_ROOT: ${{ github.workspace }}
           ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
 
-chronos-pytorch-inference-automl-test:
+  chronos-pytorch-inference-automl-test:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
     strategy:
       fail-fast: false

--- a/.github/workflows/chronos-install-option-py38-test.yml
+++ b/.github/workflows/chronos-install-option-py38-test.yml
@@ -118,7 +118,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install --pre --upgrade bigdl-chronos[pytorch,inference]
-          bash python/chronos/dev/test/run-installation-options.sh "torch and inference and not automl and not distributed and not diff_set_all"
+          bash python/chronos/dev/test/run-installation-options.sh "torch and not automl and not distributed and not diff_set_all"
           source deactivate
           conda remove -n chronos-py38-env -y --all
         env:
@@ -154,7 +154,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install --pre --upgrade bigdl-chronos[pytorch,inference,automl]
-          bash python/chronos/dev/test/run-installation-options.sh "torch and inference and automl and not distributed and not diff_set_all"
+          bash python/chronos/dev/test/run-installation-options.sh "torch and not distributed and not diff_set_all"
           source deactivate
           conda remove -n chronos-py38-env -y --all
         env:

--- a/.github/workflows/chronos-install-option-py38-test.yml
+++ b/.github/workflows/chronos-install-option-py38-test.yml
@@ -88,3 +88,75 @@ jobs:
         env:
           BIGDL_ROOT: ${{ github.workspace }}
           ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
+
+  chronos-pytorch-inference-test:
+    runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: ./.github/actions/jdk-setup-action
+      - name: Set up Maven
+        uses: ./.github/actions/maven-setup-action
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run Chronos[pytorch,inference] test
+        shell: bash
+        run: |
+          conda remove -n chronos-py38-env -y --all
+          conda create -n chronos-py38-env -y python==3.8 setuptools==58.0.4 -c ${CONDA_CHANNEL} --override-channels
+          source activate chronos-py38-env
+          pip install pytest==5.4.1
+          apt-get update
+          apt-get install patchelf
+          pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
+          pip install --pre --upgrade bigdl-chronos[pytorch,inference]
+          bash python/chronos/dev/test/run-installation-options.sh "torch and inference and not automl and not distributed and not diff_set_all"
+          source deactivate
+          conda remove -n chronos-py38-env -y --all
+        env:
+          BIGDL_ROOT: ${{ github.workspace }}
+          ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
+
+chronos-pytorch-inference-automl-test:
+    runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: ./.github/actions/jdk-setup-action
+      - name: Set up Maven
+        uses: ./.github/actions/maven-setup-action
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run Chronos[pytorch,inference,automl] test
+        shell: bash
+        run: |
+          conda remove -n chronos-py38-env -y --all
+          conda create -n chronos-py38-env -y python==3.8 setuptools==58.0.4 -c ${CONDA_CHANNEL} --override-channels
+          source activate chronos-py38-env
+          pip install pytest==5.4.1
+          apt-get update
+          apt-get install patchelf
+          pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
+          pip install --pre --upgrade bigdl-chronos[pytorch,inference,automl]
+          bash python/chronos/dev/test/run-installation-options.sh "torch and inference and automl and not distributed and not diff_set_all"
+          source deactivate
+          conda remove -n chronos-py38-env -y --all
+        env:
+          BIGDL_ROOT: ${{ github.workspace }}
+          ANALYTICS_ZOO_ROOT: ${{ github.workspace }}

--- a/.github/workflows/chronos-install-option-py38-test.yml
+++ b/.github/workflows/chronos-install-option-py38-test.yml
@@ -46,7 +46,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install --pre --upgrade bigdl-chronos[pytorch]
-          bash python/chronos/dev/test/run-installation-options.sh "not tf2 and not inference and not automl and not distributed and not diff_set_all"
+          bash python/chronos/dev/test/run-installation-options.sh "torch and not inference and not automl and not distributed and not diff_set_all"
           source deactivate
           conda remove -n chronos-py38-env -y --all
         env:

--- a/.github/workflows/chronos-install-option-py38-test.yml
+++ b/.github/workflows/chronos-install-option-py38-test.yml
@@ -52,3 +52,39 @@ jobs:
         env:
           BIGDL_ROOT: ${{ github.workspace }}
           ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
+
+  chronos-tensorflow-test:
+    runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: ./.github/actions/jdk-setup-action
+      - name: Set up Maven
+        uses: ./.github/actions/maven-setup-action
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run Chronos[tensorflow] test
+        shell: bash
+        run: |
+          conda remove -n chronos-py38-env -y --all
+          conda create -n chronos-py38-env -y python==3.8 setuptools==58.0.4 -c ${CONDA_CHANNEL} --override-channels
+          source activate chronos-py38-env
+          pip install pytest==5.4.1
+          apt-get update
+          apt-get install patchelf
+          pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
+          pip install --pre --upgrade bigdl-chronos[tensorflow]
+          bash python/chronos/dev/test/run-installation-options.sh "tf2 and not inference and not automl and not distributed and not diff_set_all"
+          source deactivate
+          conda remove -n chronos-py38-env -y --all
+        env:
+          BIGDL_ROOT: ${{ github.workspace }}
+          ANALYTICS_ZOO_ROOT: ${{ github.workspace }}

--- a/.github/workflows/chronos-install-option-py38-test.yml
+++ b/.github/workflows/chronos-install-option-py38-test.yml
@@ -46,7 +46,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install --pre --upgrade bigdl-chronos[pytorch]
-          bash python/chronos/dev/test/run-installation-options.sh true
+          bash python/chronos/dev/test/run-installation-options.sh "not tf2 and not inference and not automl and not distributed and not diff_set_all"
           source deactivate
           conda remove -n chronos-py38-env -y --all
         env:

--- a/.github/workflows/chronos-install-option-py38-test.yml
+++ b/.github/workflows/chronos-install-option-py38-test.yml
@@ -154,6 +154,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install --pre --upgrade bigdl-chronos[pytorch,inference,automl]
+          pip install SQLAlchemy==1.4.27
           bash python/chronos/dev/test/run-installation-options.sh "torch and not distributed and not diff_set_all"
           source deactivate
           conda remove -n chronos-py38-env -y --all

--- a/python/chronos/dev/test/run-installation-options.sh
+++ b/python/chronos/dev/test/run-installation-options.sh
@@ -27,16 +27,15 @@ fi
 
 # ray stop -f
 
-if [ $1 = true ]; then
-    echo "Running chronos[pytorch] tests"
-    python -m pytest -v -m "not tf2 and not onnxrt16 and not automl and not distributed and not diff_set_all" test/bigdl/chronos/data \
-                                                                                                              test/bigdl/chronos/detector \
-                                                                                                              test/bigdl/chronos/forecaster \
-                                                                                                              test/bigdl/chronos/metric \
-                                                                                                              test/bigdl/chronos/model \
-                                                                                                              test/bigdl/chronos/pytorch \
-                                                                                                              test/bigdl/chronos/simulator
-fi
+OPTIONS=$1
+echo "Running chronos tests"
+python -m pytest -v -m "${OPTIONS}" test/bigdl/chronos/data \
+                                    test/bigdl/chronos/detector \
+                                    test/bigdl/chronos/forecaster \
+                                    test/bigdl/chronos/metric \
+                                    test/bigdl/chronos/model \
+                                    test/bigdl/chronos/pytorch \
+                                    test/bigdl/chronos/simulator
 
 exit_status_0=$?
 if [ $exit_status_0 -ne 0 ];

--- a/python/chronos/dev/test/run-installation-options.sh
+++ b/python/chronos/dev/test/run-installation-options.sh
@@ -29,7 +29,8 @@ fi
 
 OPTIONS=$1
 echo "Running chronos tests"
-python -m pytest -v -m "${OPTIONS}" test/bigdl/chronos/data \
+python -m pytest -v -m "${OPTIONS}" test/bigdl/chronos/autots \
+                                    test/bigdl/chronos/data \
                                     test/bigdl/chronos/detector \
                                     test/bigdl/chronos/forecaster \
                                     test/bigdl/chronos/metric \

--- a/python/chronos/dev/test/run-pytests-onnxrt16.sh
+++ b/python/chronos/dev/test/run-pytests-onnxrt16.sh
@@ -28,8 +28,8 @@ fi
 ray stop -f
 
 echo "Running chronos tests onnxrt16"
-python -m pytest -v -m "onnxrt16" test/bigdl/chronos/forecaster \
-                                  test/bigdl/chronos/autots
+python -m pytest -v -m "inference" test/bigdl/chronos/forecaster \
+                                   test/bigdl/chronos/autots
 
 exit_status_0=$?
 if [ $exit_status_0 -ne 0 ];

--- a/python/chronos/dev/test/run-pytests.sh
+++ b/python/chronos/dev/test/run-pytests.sh
@@ -43,10 +43,10 @@ fi
 
 if [ $RUN_PART1 = 1 ]; then
 echo "Running chronos tests Part 1"
-python -m pytest -v -m "not onnxrt16" test/bigdl/chronos/model \
-                                      test/bigdl/chronos/forecaster \
-                                      test/bigdl/chronos/metric \
-                                      test/bigdl/chronos/pytorch \
+python -m pytest -v -m "not inference" test/bigdl/chronos/model \
+                                       test/bigdl/chronos/forecaster \
+                                       test/bigdl/chronos/metric \
+                                       test/bigdl/chronos/pytorch \
        -k "not test_forecast_tcmf_distributed"
 exit_status_0=$?
 if [ $exit_status_0 -ne 0 ];
@@ -57,10 +57,10 @@ fi
 
 if [ $RUN_PART2 = 1 ]; then
 echo "Running chronos tests Part 2"
-python -m pytest -v -m "not onnxrt16" test/bigdl/chronos/autots\
-                                      test/bigdl/chronos/data \
-                                      test/bigdl/chronos/simulator \
-                                      test/bigdl/chronos/detector \
+python -m pytest -v -m "not inference" test/bigdl/chronos/autots\
+                                       test/bigdl/chronos/data \
+                                       test/bigdl/chronos/simulator \
+                                       test/bigdl/chronos/detector \
        -k "not test_ae_fit_score_unrolled"
 exit_status_0=$?
 if [ $exit_status_0 -ne 0 ];

--- a/python/chronos/src/bigdl/chronos/autots/__init__.py
+++ b/python/chronos/src/bigdl/chronos/autots/__init__.py
@@ -24,8 +24,8 @@ if os.getenv("LD_PRELOAD", "null") != "null":
                   "in your bash terminal")
 
 try:
-    # TODO: make this a LazyImport
-    from .autotsestimator import AutoTSEstimator
-    from .tspipeline import TSPipeline
+    from bigdl.chronos.utils import LazyImport
+    AutoTSEstimator = LazyImport('bigdl.chronos.autots.autotsestimator.AutoTSEstimator')
+    TSPipeline = LazyImport('bigdl.chronos.autots.tspipeline.TSPipeline')
 except ImportError:
     pass

--- a/python/chronos/src/bigdl/chronos/autots/__init__.py
+++ b/python/chronos/src/bigdl/chronos/autots/__init__.py
@@ -24,8 +24,8 @@ if os.getenv("LD_PRELOAD", "null") != "null":
                   "in your bash terminal")
 
 try:
-    from bigdl.chronos.utils import LazyImport
-    AutoTSEstimator = LazyImport('bigdl.chronos.autots.autotsestimator.AutoTSEstimator')
-    TSPipeline = LazyImport('bigdl.chronos.autots.tspipeline.TSPipeline')
+    # TODO: make this a LazyImport
+    from .autotsestimator import AutoTSEstimator
+    from .tspipeline import TSPipeline
 except ImportError:
     pass

--- a/python/chronos/test/bigdl/chronos/__init__.py
+++ b/python/chronos/test/bigdl/chronos/__init__.py
@@ -24,8 +24,7 @@ op_automl = pytest.mark.automl
 op_distributed = pytest.mark.distributed
 
 # other mark
-op_all = pytest.mark.all # Universe set, including all denpendencies.
+op_inference = pytest.mark.inference
 # The difference set in all, excluding dependencies of installation options such as torch and tf2.
 op_diff_set_all = pytest.mark.diff_set_all
-op_onnxrt16 = pytest.mark.onnxrt16
 

--- a/python/chronos/test/bigdl/chronos/autots/model/test_auto_arima.py
+++ b/python/chronos/test/bigdl/chronos/autots/model/test_auto_arima.py
@@ -14,11 +14,12 @@
 # limitations under the License.
 #
 
-from bigdl.chronos.autots.model.auto_arima import AutoARIMA
-
+from bigdl.chronos.utils import LazyImport
+AutoARIMA = LazyImport('bigdl.chronos.autots.model.auto_arima.AutoARIMA')
+hp = LazyImport('bigdl.orca.automl.hp')
 import numpy as np
 from unittest import TestCase
-from bigdl.orca.automl import hp
+from ... import op_distributed, op_diff_set_all
 
 
 def get_data():
@@ -30,6 +31,8 @@ def get_data():
     return data, validation_data
 
 
+@op_distributed
+@op_diff_set_all
 class TestAutoARIMA(TestCase):
     def setUp(self) -> None:
         from bigdl.orca import init_orca_context

--- a/python/chronos/test/bigdl/chronos/autots/model/test_auto_lstm.py
+++ b/python/chronos/test/bigdl/chronos/autots/model/test_auto_lstm.py
@@ -22,7 +22,7 @@ from unittest import TestCase
 import pytest
 import tempfile
 
-from ... import op_all, op_onnxrt16
+from ... import op_inference
 
 from bigdl.chronos.autots.model.auto_lstm import AutoLSTM
 from bigdl.orca.automl import hp
@@ -153,8 +153,7 @@ class TestAutoLSTM(TestCase):
         auto_lstm.predict(test_data_x)
         auto_lstm.evaluate((test_data_x, test_data_y))
 
-    @op_all
-    @op_onnxrt16
+    @op_inference
     def test_onnx_methods(self):
         auto_lstm = get_auto_estimator()
         auto_lstm.fit(data=train_dataloader_creator(config={"batch_size": 64}),
@@ -174,8 +173,7 @@ class TestAutoLSTM(TestCase):
         except ImportError:
             pass
 
-    @op_all
-    @op_onnxrt16
+    @op_inference
     def test_save_load(self):
         auto_lstm = get_auto_estimator()
         auto_lstm.fit(data=train_dataloader_creator(config={"batch_size": 64}),

--- a/python/chronos/test/bigdl/chronos/autots/model/test_auto_lstm.py
+++ b/python/chronos/test/bigdl/chronos/autots/model/test_auto_lstm.py
@@ -16,16 +16,16 @@
 
 from bigdl.chronos.utils import LazyImport
 torch = LazyImport('torch')
-import tensorflow as tf
+tf = LazyImport('tensorflow')
 import numpy as np
 from unittest import TestCase
 import pytest
 import tempfile
 
-from ... import op_inference
+from ... import op_torch, op_tf2, op_distributed, op_inference
 
-from bigdl.chronos.autots.model.auto_lstm import AutoLSTM
-from bigdl.orca.automl import hp
+AutoLSTM = LazyImport('bigdl.chronos.autots.model.auto_lstm.AutoLSTM')
+hp = LazyImport('bigdl.orca.automl.hp')
 
 input_feature_dim = 10
 output_feature_dim = 2
@@ -93,6 +93,7 @@ def get_auto_estimator(backend='torch'):
     return auto_lstm
 
 
+@op_distributed
 class TestAutoLSTM(TestCase):
     def setUp(self) -> None:
         from bigdl.orca import init_orca_context
@@ -102,6 +103,7 @@ class TestAutoLSTM(TestCase):
         from bigdl.orca import stop_orca_context
         stop_orca_context()
 
+    @op_torch
     def test_fit_np(self):
         # torch
         auto_lstm = get_auto_estimator(backend='torch')
@@ -116,7 +118,7 @@ class TestAutoLSTM(TestCase):
         assert best_config['batch_size'] in (32, 64)
         assert 1 <= best_config['layer_num'] < 3
 
-    @pytest.mark.skipif(tf.__version__ < '2.0.0', reason="Run only when tf > 2.0.0.")
+    @op_tf2
     def test_fit_np_keras(self):
         keras_auto_lstm = get_auto_estimator(backend='keras')
         keras_auto_lstm.fit(data=get_x_y(size=1000),
@@ -130,6 +132,7 @@ class TestAutoLSTM(TestCase):
         assert best_config['batch_size'] in (32, 64)
         assert 1 <= best_config['layer_num'] < 3
 
+    @op_torch
     def test_fit_data_creator(self):
         auto_lstm = get_auto_estimator()
         auto_lstm.fit(data=train_dataloader_creator,
@@ -143,6 +146,7 @@ class TestAutoLSTM(TestCase):
         assert best_config['batch_size'] in (32, 64)
         assert 1 <= best_config['layer_num'] < 3
 
+    @op_torch
     def test_predict_evaluation(self):
         auto_lstm = get_auto_estimator()
         auto_lstm.fit(data=train_dataloader_creator(config={"batch_size": 64}),
@@ -153,6 +157,7 @@ class TestAutoLSTM(TestCase):
         auto_lstm.predict(test_data_x)
         auto_lstm.evaluate((test_data_x, test_data_y))
 
+    @op_torch
     @op_inference
     def test_onnx_methods(self):
         auto_lstm = get_auto_estimator()
@@ -173,6 +178,7 @@ class TestAutoLSTM(TestCase):
         except ImportError:
             pass
 
+    @op_torch
     @op_inference
     def test_save_load(self):
         auto_lstm = get_auto_estimator()
@@ -196,7 +202,7 @@ class TestAutoLSTM(TestCase):
         except ImportError:
             pass
 
-    @pytest.mark.skipif(tf.__version__ < '2.0.0', reason="Run only when tf > 2.0.0.")
+    @op_tf2
     def test_save_load_keras(self):
         auto_keras_lstm = get_auto_estimator(backend='keras')
         auto_keras_lstm.fit(data=get_x_y(size=1000),

--- a/python/chronos/test/bigdl/chronos/autots/model/test_auto_prophet.py
+++ b/python/chronos/test/bigdl/chronos/autots/model/test_auto_prophet.py
@@ -14,14 +14,16 @@
 # limitations under the License.
 #
 
-from bigdl.chronos.autots.model.auto_prophet import AutoProphet
+from bigdl.chronos.utils import LazyImport
+AutoProphet = LazyImport('bigdl.chronos.autots.model.auto_prophet.AutoProphet')
+hp = LazyImport('bigdl.orca.automl.hp')
 
 import os
 import numpy as np
 import pandas as pd
 import tempfile
 from unittest import TestCase
-from bigdl.orca.automl import hp
+from ... import op_distributed, op_diff_set_all
 
 
 def get_data():
@@ -32,6 +34,8 @@ def get_data():
     return data, expect_horizon
 
 
+@op_distributed
+@op_diff_set_all
 class TestAutoProphet(TestCase):
     def setUp(self) -> None:
         from bigdl.orca import init_orca_context

--- a/python/chronos/test/bigdl/chronos/autots/model/test_auto_seq2seq.py
+++ b/python/chronos/test/bigdl/chronos/autots/model/test_auto_seq2seq.py
@@ -16,16 +16,16 @@
 
 from bigdl.chronos.utils import LazyImport
 torch = LazyImport('torch')
-import tensorflow as tf
+tf = LazyImport('tensorflow')
 import numpy as np
 from unittest import TestCase
 import pytest
 import tempfile
 
-from ... import op_inference
+from ... import op_torch, op_tf2, op_distributed, op_inference
 
-from bigdl.chronos.autots.model.auto_seq2seq import AutoSeq2Seq
-from bigdl.orca.automl import hp
+AutoSeq2Seq = LazyImport('bigdl.chronos.autots.model.auto_seq2seq.AutoSeq2Seq')
+hp = LazyImport('bigdl.orca.automl.hp')
 
 input_feature_dim = 10
 output_feature_dim = 2
@@ -95,6 +95,7 @@ def get_auto_estimator(backend='torch'):
     return auto_seq2seq
 
 
+@op_distributed
 class TestAutoSeq2Seq(TestCase):
     def setUp(self) -> None:
         from bigdl.orca import init_orca_context
@@ -104,6 +105,7 @@ class TestAutoSeq2Seq(TestCase):
         from bigdl.orca import stop_orca_context
         stop_orca_context()
 
+    @op_torch
     def test_fit_np(self):
         # torch
         auto_seq2seq = get_auto_estimator(backend='torch')
@@ -120,7 +122,7 @@ class TestAutoSeq2Seq(TestCase):
         assert best_config['lstm_hidden_dim'] in (32, 64, 128)
         assert best_config['lstm_layer_num'] in (1, 2, 3, 4)
 
-    @pytest.mark.skipif(tf.__version__ < '2.0.0', reason="Run only when tf > 2.0.0.")
+    @op_tf2
     def test_fit_np_keras(self):
         # keras
         keras_auto_s2s = get_auto_estimator(backend='keras')
@@ -136,6 +138,7 @@ class TestAutoSeq2Seq(TestCase):
         assert best_config['lstm_hidden_dim'] in (32, 64, 128)
         assert best_config['lstm_layer_num'] in (1, 2, 3, 4)
 
+    @op_torch
     def test_fit_data_creator(self):
         auto_seq2seq = get_auto_estimator()
         auto_seq2seq.fit(data=train_dataloader_creator,
@@ -151,6 +154,7 @@ class TestAutoSeq2Seq(TestCase):
         assert best_config['lstm_hidden_dim'] in (32, 64, 128)
         assert best_config['lstm_layer_num'] in (1, 2, 3, 4)
 
+    @op_torch
     def test_predict_evaluation(self):
         auto_seq2seq = get_auto_estimator()
         auto_seq2seq.fit(data=train_dataloader_creator(config={"batch_size": 64}),
@@ -161,6 +165,7 @@ class TestAutoSeq2Seq(TestCase):
         auto_seq2seq.predict(test_data_x)
         auto_seq2seq.evaluate((test_data_x, test_data_y))
 
+    @op_torch
     @op_inference
     def test_onnx_methods(self):
         auto_seq2seq = get_auto_estimator()
@@ -181,6 +186,7 @@ class TestAutoSeq2Seq(TestCase):
         except ImportError:
             pass
 
+    @op_torch
     @op_inference
     def test_save_load(self):
         auto_seq2seq = get_auto_estimator()
@@ -204,7 +210,7 @@ class TestAutoSeq2Seq(TestCase):
         except ImportError:
             pass
 
-    @pytest.mark.skipif(tf.__version__ < '2.0.0', reason="Run only when tf > 2.0.0.")
+    @op_tf2
     def test_save_load_keras(self):
         auto_keras_s2s = get_auto_estimator(backend='keras')
         auto_keras_s2s.fit(data=get_x_y(size=1000),

--- a/python/chronos/test/bigdl/chronos/autots/model/test_auto_seq2seq.py
+++ b/python/chronos/test/bigdl/chronos/autots/model/test_auto_seq2seq.py
@@ -22,7 +22,7 @@ from unittest import TestCase
 import pytest
 import tempfile
 
-from ... import op_all, op_onnxrt16
+from ... import op_inference
 
 from bigdl.chronos.autots.model.auto_seq2seq import AutoSeq2Seq
 from bigdl.orca.automl import hp
@@ -161,8 +161,7 @@ class TestAutoSeq2Seq(TestCase):
         auto_seq2seq.predict(test_data_x)
         auto_seq2seq.evaluate((test_data_x, test_data_y))
 
-    @op_all
-    @op_onnxrt16
+    @op_inference
     def test_onnx_methods(self):
         auto_seq2seq = get_auto_estimator()
         auto_seq2seq.fit(data=train_dataloader_creator(config={"batch_size": 64}),
@@ -182,8 +181,7 @@ class TestAutoSeq2Seq(TestCase):
         except ImportError:
             pass
 
-    @op_all
-    @op_onnxrt16
+    @op_inference
     def test_save_load(self):
         auto_seq2seq = get_auto_estimator()
         auto_seq2seq.fit(data=train_dataloader_creator(config={"batch_size": 64}),

--- a/python/chronos/test/bigdl/chronos/autots/model/test_auto_tcn.py
+++ b/python/chronos/test/bigdl/chronos/autots/model/test_auto_tcn.py
@@ -22,7 +22,7 @@ from unittest import TestCase
 import pytest
 import tempfile
 
-from ... import op_all, op_onnxrt16
+from ... import op_inference
 
 from bigdl.chronos.autots.model.auto_tcn import AutoTCN
 from bigdl.orca.automl import hp
@@ -196,8 +196,7 @@ class TestAutoTCN(TestCase):
         auto_tcn.predict(test_data_x)
         auto_tcn.evaluate((test_data_x, test_data_y))
 
-    @op_all
-    @op_onnxrt16
+    @op_inference
     def test_onnx_methods(self):
         auto_tcn = get_auto_estimator()
         auto_tcn.fit(data=train_dataloader_creator(config={"batch_size": 64}),
@@ -217,8 +216,7 @@ class TestAutoTCN(TestCase):
         except ImportError:
             pass
 
-    @op_all
-    @op_onnxrt16
+    @op_inference
     def test_save_load(self):
         auto_tcn = get_auto_estimator()
         auto_tcn.fit(data=train_dataloader_creator(config={"batch_size": 64}),

--- a/python/chronos/test/bigdl/chronos/autots/model/test_auto_tcn.py
+++ b/python/chronos/test/bigdl/chronos/autots/model/test_auto_tcn.py
@@ -16,16 +16,16 @@
 
 from bigdl.chronos.utils import LazyImport
 torch = LazyImport('torch')
-import tensorflow as tf
+tf = LazyImport('tensorflow')
 import numpy as np
 from unittest import TestCase
 import pytest
 import tempfile
 
-from ... import op_inference
+from ... import op_torch, op_tf2, op_distributed, op_inference
 
-from bigdl.chronos.autots.model.auto_tcn import AutoTCN
-from bigdl.orca.automl import hp
+AutoTCN = LazyImport('bigdl.chronos.autots.model.auto_tcn.AutoTCN')
+hp = LazyImport('bigdl.orca.automl.hp')
 
 input_feature_dim = 10
 output_feature_dim = 2
@@ -96,6 +96,7 @@ def get_auto_estimator(backend='torch'):
     return auto_tcn
 
 
+@op_distributed
 class TestAutoTCN(TestCase):
     def setUp(self) -> None:
         from bigdl.orca import init_orca_context
@@ -105,6 +106,7 @@ class TestAutoTCN(TestCase):
         from bigdl.orca import stop_orca_context
         stop_orca_context()
 
+    @op_torch
     def test_fit_np(self):
         auto_tcn = get_auto_estimator()
         auto_tcn.fit(data=get_x_y(size=1000),
@@ -119,7 +121,7 @@ class TestAutoTCN(TestCase):
         assert best_config['batch_size'] in (32, 64)
         assert 1 <= best_config['levels'] < 3
 
-    @pytest.mark.skipif(tf.__version__ < '2.0.0', reason="Run only when tf > 2.0.0.")
+    @op_tf2
     def test_fit_np_keras(self):
         keras_auto_tcn = get_auto_estimator("keras")
         keras_auto_tcn.fit(data=get_x_y(size=1000),
@@ -133,6 +135,7 @@ class TestAutoTCN(TestCase):
         assert best_config['batch_size'] in (32, 64)
         assert 1 <= best_config['levels'] < 3
 
+    @op_torch
     def test_fit_loader(self):
         auto_tcn = get_auto_estimator()
         auto_tcn.fit(data=train_dataloader_creator(config={"batch_size": 64}),
@@ -145,6 +148,7 @@ class TestAutoTCN(TestCase):
         assert 0.1 <= best_config['dropout'] <= 0.2
         assert 1 <= best_config['levels'] < 3
 
+    @op_torch
     def test_fit_data_creator(self):
         auto_tcn = get_auto_estimator()
         auto_tcn.fit(data=train_dataloader_creator,
@@ -159,6 +163,7 @@ class TestAutoTCN(TestCase):
         assert best_config['batch_size'] in (32, 64)
         assert 1 <= best_config['levels'] < 3
 
+    @op_torch
     def test_num_channels(self):
         auto_tcn = AutoTCN(input_feature_num=input_feature_dim,
                            output_target_num=output_feature_dim,
@@ -186,6 +191,7 @@ class TestAutoTCN(TestCase):
         best_config = auto_tcn.get_best_config()
         assert best_config['num_channels'] == [8]*2
 
+    @op_torch
     def test_predict_evaluation(self):
         auto_tcn = get_auto_estimator()
         auto_tcn.fit(data=train_dataloader_creator(config={"batch_size": 64}),
@@ -196,6 +202,7 @@ class TestAutoTCN(TestCase):
         auto_tcn.predict(test_data_x)
         auto_tcn.evaluate((test_data_x, test_data_y))
 
+    @op_torch
     @op_inference
     def test_onnx_methods(self):
         auto_tcn = get_auto_estimator()
@@ -216,6 +223,7 @@ class TestAutoTCN(TestCase):
         except ImportError:
             pass
 
+    @op_torch
     @op_inference
     def test_save_load(self):
         auto_tcn = get_auto_estimator()
@@ -239,7 +247,7 @@ class TestAutoTCN(TestCase):
         except ImportError:
             pass
     
-    @pytest.mark.skipif(tf.__version__ < '2.0.0', reason="Run only when tf > 2.0.0.")
+    @op_tf2
     def test_save_load_keras(self):
         auto_keras_tcn = get_auto_estimator(backend='keras')
         auto_keras_tcn.fit(data=get_x_y(size=1000),

--- a/python/chronos/test/bigdl/chronos/autots/test_autotsestimator.py
+++ b/python/chronos/test/bigdl/chronos/autots/test_autotsestimator.py
@@ -174,6 +174,7 @@ class TestAutoTrainer(TestCase):
         best_model = auto_estimator._get_best_automl_model()
         assert 4 <= best_config["past_seq_len"] <= 6
 
+        from bigdl.chronos.autots import TSPipeline
         assert isinstance(ts_pipeline, TSPipeline)
 
         # use raw base model to predic and evaluate
@@ -347,6 +348,7 @@ class TestAutoTrainer(TestCase):
         best_model = auto_estimator._get_best_automl_model()
         assert 4 <= best_config["past_seq_len"] <= 6
 
+        from bigdl.chronos.autots import TSPipeline
         assert isinstance(ts_pipeline, TSPipeline)
 
         # use raw base model to predic and evaluate
@@ -416,6 +418,7 @@ class TestAutoTrainer(TestCase):
         best_model = auto_estimator._get_best_automl_model()
         assert 4 <= best_config["past_seq_len"] <= 6
 
+        from bigdl.chronos.autots import TSPipeline
         assert isinstance(ts_pipeline, TSPipeline)
 
         # use raw base model to predic and evaluate
@@ -485,6 +488,7 @@ class TestAutoTrainer(TestCase):
         best_model = auto_estimator._get_best_automl_model()
         assert 4 <= best_config["past_seq_len"] <= 6
 
+        from bigdl.chronos.autots import TSPipeline
         assert isinstance(ts_pipeline, TSPipeline)
 
         # use raw base model to predic and evaluate

--- a/python/chronos/test/bigdl/chronos/autots/test_autotsestimator.py
+++ b/python/chronos/test/bigdl/chronos/autots/test_autotsestimator.py
@@ -19,14 +19,15 @@ import pytest
 
 from bigdl.chronos.utils import LazyImport
 torch = LazyImport('torch')
+tf = LazyImport('tensorflow')
+AutoTSEstimator = LazyImport('bigdl.chronos.autots.AutoTSEstimator')
+TSPipeline = LazyImport('bigdl.chronos.autots.TSPipeline')
+hp = LazyImport('bigdl.orca.automl.hp')
 import numpy as np
-from bigdl.chronos.autots import AutoTSEstimator, TSPipeline
 from bigdl.chronos.data import TSDataset
-from bigdl.orca.automl import hp
 import pandas as pd
-import tensorflow as tf
 
-from .. import op_inference
+from .. import op_torch, op_tf2, op_distributed, op_inference
 
 def get_ts_df():
     sample_num = np.random.randint(100, 200)
@@ -133,6 +134,7 @@ def model_creator_keras(config):
     return model
 
 
+@op_distributed
 class TestAutoTrainer(TestCase):
     def setUp(self) -> None:
         from bigdl.orca import init_orca_context
@@ -142,6 +144,7 @@ class TestAutoTrainer(TestCase):
         from bigdl.orca import stop_orca_context
         stop_orca_context()
 
+    @op_torch
     def test_fit_third_party_feature(self):
         from sklearn.preprocessing import StandardScaler
         scaler = StandardScaler()
@@ -201,7 +204,7 @@ class TestAutoTrainer(TestCase):
         # use tspipeline to incrementally train
         new_ts_pipeline.fit(tsdata_valid)
 
-    @pytest.mark.skipif(tf.__version__ < '2.0.0', reason="run only when tf>2.0.0")
+    @op_tf2
     def test_fit_third_party_feature_tf2(self):
         search_space = {'hidden_dim': hp.grid_search([32, 64]),
                         'layer_num': hp.randint(1, 3),
@@ -226,6 +229,7 @@ class TestAutoTrainer(TestCase):
         config = auto_estimator.get_best_config()
         assert config["past_seq_len"] == 7
 
+    @op_torch
     def test_fit_third_party_data_creator(self):
         input_feature_dim = 4
         output_feature_dim = 2  # 2 targets are generated in get_tsdataset
@@ -255,7 +259,7 @@ class TestAutoTrainer(TestCase):
         config = auto_estimator.get_best_config()
         assert config["past_seq_len"] == 7
 
-    @pytest.mark.skipif(tf.__version__ < '2.0.0', reason="run only when tf>2.0.0")
+    @op_tf2
     def test_fit_third_party_data_creator_tf2(self):
         search_space = {'hidden_dim': hp.grid_search([32, 64]),
                         'layer_num': hp.randint(1, 3),
@@ -280,6 +284,7 @@ class TestAutoTrainer(TestCase):
         config = auto_estimator.get_best_config()
         assert config["past_seq_len"] == 7
 
+    @op_torch
     def test_fit_customized_metrics(self):
         from sklearn.preprocessing import StandardScaler
         import torch
@@ -315,6 +320,7 @@ class TestAutoTrainer(TestCase):
         best_model = auto_estimator._get_best_automl_model()
         assert 4 <= best_config["past_seq_len"] <= 6
 
+    @op_torch
     @op_inference
     def test_fit_lstm_feature(self):
         from sklearn.preprocessing import StandardScaler
@@ -382,6 +388,7 @@ class TestAutoTrainer(TestCase):
         # use tspipeline to incrementally train
         new_ts_pipeline.fit(tsdata_valid)
 
+    @op_torch
     @op_inference
     def test_fit_tcn_feature(self):
         from sklearn.preprocessing import StandardScaler
@@ -450,6 +457,7 @@ class TestAutoTrainer(TestCase):
         # use tspipeline to incrementally train
         new_ts_pipeline.fit(tsdata_valid)
 
+    @op_torch
     @op_inference
     def test_fit_seq2seq_feature(self):
         from sklearn.preprocessing import StandardScaler
@@ -518,6 +526,7 @@ class TestAutoTrainer(TestCase):
         # use tspipeline to incrementally train
         new_ts_pipeline.fit(tsdata_valid)
 
+    @op_torch
     def test_fit_lstm_data_creator(self):
         input_feature_dim = 4
         output_feature_dim = 2  # 2 targets are generated in get_tsdataset
@@ -548,6 +557,7 @@ class TestAutoTrainer(TestCase):
         config = auto_estimator.get_best_config()
         assert config["past_seq_len"] == 7
 
+    @op_torch
     def test_select_feature(self):
         sample_num = np.random.randint(100, 200)
         df = pd.DataFrame({"datetime": pd.date_range('1/1/2019', periods=sample_num),
@@ -588,6 +598,7 @@ class TestAutoTrainer(TestCase):
         config = auto_estimator.get_best_config()
         assert config['past_seq_len'] == 6
 
+    @op_torch
     def test_future_list_input(self):
         sample_num = np.random.randint(100, 200)
         df = pd.DataFrame({"datetime": pd.date_range('1/1/2019', periods=sample_num),
@@ -622,6 +633,7 @@ class TestAutoTrainer(TestCase):
         assert config['future_seq_len'] == 2
         assert auto_estimator._future_seq_len == [1, 3]
 
+    @op_torch
     def test_autogener_best_cycle_length(self):
         sample_num = 100
         df = pd.DataFrame({"datetime": pd.date_range('1/1/2019', periods=sample_num),

--- a/python/chronos/test/bigdl/chronos/autots/test_autotsestimator.py
+++ b/python/chronos/test/bigdl/chronos/autots/test_autotsestimator.py
@@ -20,8 +20,8 @@ import pytest
 from bigdl.chronos.utils import LazyImport
 torch = LazyImport('torch')
 tf = LazyImport('tensorflow')
-AutoTSEstimator = LazyImport('bigdl.chronos.autots.AutoTSEstimator')
-TSPipeline = LazyImport('bigdl.chronos.autots.TSPipeline')
+AutoTSEstimator = LazyImport('bigdl.chronos.autots.autotsestimator.AutoTSEstimator')
+TSPipeline = LazyImport('bigdl.chronos.autots.tspipeline.TSPipeline')
 hp = LazyImport('bigdl.orca.automl.hp')
 import numpy as np
 from bigdl.chronos.data import TSDataset

--- a/python/chronos/test/bigdl/chronos/autots/test_autotsestimator.py
+++ b/python/chronos/test/bigdl/chronos/autots/test_autotsestimator.py
@@ -26,7 +26,7 @@ from bigdl.orca.automl import hp
 import pandas as pd
 import tensorflow as tf
 
-from .. import op_all, op_onnxrt16
+from .. import op_inference
 
 def get_ts_df():
     sample_num = np.random.randint(100, 200)
@@ -315,8 +315,7 @@ class TestAutoTrainer(TestCase):
         best_model = auto_estimator._get_best_automl_model()
         assert 4 <= best_config["past_seq_len"] <= 6
 
-    @op_all
-    @op_onnxrt16
+    @op_inference
     def test_fit_lstm_feature(self):
         from sklearn.preprocessing import StandardScaler
         scaler = StandardScaler()
@@ -383,8 +382,7 @@ class TestAutoTrainer(TestCase):
         # use tspipeline to incrementally train
         new_ts_pipeline.fit(tsdata_valid)
 
-    @op_all
-    @op_onnxrt16
+    @op_inference
     def test_fit_tcn_feature(self):
         from sklearn.preprocessing import StandardScaler
         scaler = StandardScaler()
@@ -452,8 +450,7 @@ class TestAutoTrainer(TestCase):
         # use tspipeline to incrementally train
         new_ts_pipeline.fit(tsdata_valid)
 
-    @op_all
-    @op_onnxrt16
+    @op_inference
     def test_fit_seq2seq_feature(self):
         from sklearn.preprocessing import StandardScaler
         scaler = StandardScaler()

--- a/python/chronos/test/bigdl/chronos/autots/test_tspipeline.py
+++ b/python/chronos/test/bigdl/chronos/autots/test_tspipeline.py
@@ -21,7 +21,7 @@ from bigdl.chronos.utils import LazyImport
 torch = LazyImport('torch')
 TensorDataset = LazyImport('torch.utils.data.TensorDataset')
 DataLoader = LazyImport('torch.utils.data.DataLoader')
-TSPipeline = LazyImport('bigdl.chronos.autots.TSPipeline')
+TSPipeline = LazyImport('bigdl.chronos.autots.tspipeline.TSPipeline')
 import os
 import pandas as pd
 import numpy as np

--- a/python/chronos/test/bigdl/chronos/autots/test_tspipeline.py
+++ b/python/chronos/test/bigdl/chronos/autots/test_tspipeline.py
@@ -21,11 +21,11 @@ from bigdl.chronos.utils import LazyImport
 torch = LazyImport('torch')
 TensorDataset = LazyImport('torch.utils.data.TensorDataset')
 DataLoader = LazyImport('torch.utils.data.DataLoader')
+TSPipeline = LazyImport('bigdl.chronos.autots.TSPipeline')
 import os
 import pandas as pd
 import numpy as np
 
-from bigdl.chronos.autots import TSPipeline
 from bigdl.chronos.data import TSDataset
 
 from .. import op_torch, op_inference

--- a/python/chronos/test/bigdl/chronos/autots/test_tspipeline.py
+++ b/python/chronos/test/bigdl/chronos/autots/test_tspipeline.py
@@ -26,7 +26,7 @@ from torch.utils.data import TensorDataset, DataLoader
 from bigdl.chronos.autots import TSPipeline
 from bigdl.chronos.data import TSDataset
 
-from .. import op_all, op_onnxrt16
+from .. import op_inference
 
 def train_data_creator(config):
     return DataLoader(TensorDataset(torch.randn(1000,
@@ -72,8 +72,7 @@ class TestTSPipeline(TestCase):
     def tearDown(self) -> None:
         pass
 
-    @op_all
-    @op_onnxrt16
+    @op_inference
     def test_seq2seq_tsppl_support_dataloader(self):
         # load
         tsppl_seq2seq = TSPipeline.load(
@@ -177,8 +176,7 @@ class TestTSPipeline(TestCase):
         with pytest.raises(RuntimeError):
             yhat = tsppl_lstm.predict(data=get_test_tsdataset(), batch_size=16)
 
-    @op_all
-    @op_onnxrt16
+    @op_inference
     def test_tsppl_quantize_data_creator(self):
         # s2s not support quantize
         with pytest.raises(RuntimeError):

--- a/python/chronos/test/bigdl/chronos/autots/test_tspipeline.py
+++ b/python/chronos/test/bigdl/chronos/autots/test_tspipeline.py
@@ -224,6 +224,7 @@ class TestTSPipeline(TestCase):
         assert q_yhat.shape == yhat.shape == q_onnx_yhat.shape
         assert all([np.mean(q_smape)<100., np.mean(q_onnx_smape)<100., np.mean(smape)<100.])
 
+    @op_inference
     def test_tsppl_quantize_input_data(self):
         tsppl_tcn = TSPipeline.load(os.path.join(self.resource_path,
                                                  "tsppl_ckpt/tcn_tsppl_ckpt"))
@@ -244,6 +245,7 @@ class TestTSPipeline(TestCase):
                                metric='smape',
                                approach='static')
 
+    @op_inference
     def test_tsppl_quantize_public_dataset(self):
         tsppl_tcn = TSPipeline.load(os.path.join(self.resource_path,
                                                  "tsppl_ckpt/tcn_tsppl_ckpt"))

--- a/python/chronos/test/bigdl/chronos/autots/test_tspipeline.py
+++ b/python/chronos/test/bigdl/chronos/autots/test_tspipeline.py
@@ -17,16 +17,18 @@
 import numpy as np
 from unittest import TestCase
 import pytest
-import torch
+from bigdl.chronos.utils import LazyImport
+torch = LazyImport('torch')
+TensorDataset = LazyImport('torch.utils.data.TensorDataset')
+DataLoader = LazyImport('torch.utils.data.DataLoader')
 import os
 import pandas as pd
 import numpy as np
 
-from torch.utils.data import TensorDataset, DataLoader
 from bigdl.chronos.autots import TSPipeline
 from bigdl.chronos.data import TSDataset
 
-from .. import op_inference
+from .. import op_torch, op_inference
 
 def train_data_creator(config):
     return DataLoader(TensorDataset(torch.randn(1000,
@@ -64,6 +66,7 @@ def get_test_tsdataset():
                                  extra_feature_col=["extra feature 1", "extra feature 2"],
                                  id_col="id")
 
+@op_torch
 class TestTSPipeline(TestCase):
 
     def setUp(self) -> None:

--- a/python/chronos/test/bigdl/chronos/data/experimental/test_xshardstsdataset.py
+++ b/python/chronos/test/bigdl/chronos/data/experimental/test_xshardstsdataset.py
@@ -28,7 +28,7 @@ read_csv = LazyImport('bigdl.orca.data.pandas.read_csv')
 init_orca_context = LazyImport('bigdl.orca.common.init_orca_context')
 stop_orca_context = LazyImport('bigdl.orca.common.stop_orca_context')
 OrcaContext = LazyImport('bigdl.orca.common.OrcaContext')
-from ... import op_distributed
+from ... import op_torch, op_distributed
 
 from pandas.testing import assert_frame_equal
 from numpy.testing import assert_array_almost_equal
@@ -61,6 +61,7 @@ def get_ugly_ts_df():
     df["id"] = np.array(['00']*50 + ['01']*50)
     return df
 
+@op_torch
 @op_distributed
 class TestXShardsTSDataset(TestCase):
 

--- a/python/chronos/test/bigdl/chronos/data/test_repo_dataset.py
+++ b/python/chronos/test/bigdl/chronos/data/test_repo_dataset.py
@@ -19,8 +19,11 @@ import random
 
 from unittest import TestCase
 from bigdl.chronos.data import get_public_dataset, gen_synthetic_data
+from .. import op_torch, op_tf2
 
 
+@op_torch
+@op_tf2
 class TestRepoDataset(TestCase):
     def setup_method(self, method):
         pass

--- a/python/chronos/test/bigdl/chronos/data/test_tsdataset.py
+++ b/python/chronos/test/bigdl/chronos/data/test_tsdataset.py
@@ -28,7 +28,7 @@ from pandas.testing import assert_frame_equal
 from numpy.testing import assert_array_almost_equal
 from bigdl.chronos.utils import LazyImport
 tf = LazyImport('tensorflow')
-from .. import op_tf2, op_diff_set_all
+from .. import op_torch, op_tf2, op_diff_set_all
 
 def get_ts_df():
     sample_num = np.random.randint(100, 200)
@@ -149,6 +149,7 @@ class TestTSDataset(TestCase):
     def teardown_method(self, method):
         pass
 
+    @op_torch
     def test_tsdataset_initialization(self):
         df = get_ts_df()
 
@@ -194,6 +195,7 @@ class TestTSDataset(TestCase):
             tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col=["value1"],
                                            extra_feature_col="extra feature", id_col="id")
 
+    @op_torch
     @op_diff_set_all
     def test_tsdataset_from_parquet(self):
         df = get_ts_df()
@@ -216,6 +218,7 @@ class TestTSDataset(TestCase):
         finally:
             shutil.rmtree(temp)
 
+    @op_torch
     def test_tsdataset_initialization_multiple(self):
         df = get_multi_id_ts_df()
         # legal input
@@ -268,6 +271,7 @@ class TestTSDataset(TestCase):
                                            extra_feature_col="extra feature",
                                            id_col="id", repair=False)
 
+    @op_torch
     def test_tsdataset_roll_single_id(self):
         df = get_ts_df()
         horizon = random.randint(1, 10)
@@ -328,6 +332,7 @@ class TestTSDataset(TestCase):
         assert x.shape == (len(df)-lookback-horizon+1, lookback, 2)
         tsdata._check_basic_invariants()
 
+    @op_torch
     def test_tsdataset_roll_multi_id(self):
         df = get_multi_id_ts_df()
         horizon = random.randint(1, 10)
@@ -374,6 +379,7 @@ class TestTSDataset(TestCase):
 
         tsdata._check_basic_invariants()
 
+    @op_torch
     def test_tsdataset_roll_order(self):
         df = pd.DataFrame({"datetime": np.array(['1/1/2019', '1/1/2019', '1/2/2019', '1/2/2019']),
                            "value": np.array([1.9, 2.3, 2.4, 2.6]),
@@ -395,6 +401,7 @@ class TestTSDataset(TestCase):
         assert np.array_equal(x, np.array([[[1.9, 2.3, 1, 2, 0, 9]]], dtype=np.float32))
         assert np.array_equal(y, np.array([[[2.4, 2.6]]], dtype=np.float32))
 
+    @op_torch
     def test_tsdata_roll_int_target(self):
         horizon = random.randint(1, 10)
         lookback = random.randint(1, 20)
@@ -406,6 +413,7 @@ class TestTSDataset(TestCase):
         assert y.dtype == np.float32
         tsdata._check_basic_invariants()
 
+    @op_torch
     def test_tsdata_roll_timeenc(self):
         horizon = random.randint(1, 9)
         lookback = random.randint(10, 20)
@@ -435,6 +443,7 @@ class TestTSDataset(TestCase):
         assert y_time.shape[1:] == (lookback, 3)
         assert x.shape[0] == y.shape[0] == x_time.shape[0] == y_time.shape[0]
 
+    @op_torch
     def test_tsdata_roll_timeenc_predict(self):
         horizon = 10
         lookback = random.randint(10, 20)
@@ -450,6 +459,7 @@ class TestTSDataset(TestCase):
         assert y_time.shape[1:] == (15, 3)
         assert x.shape[0] == y.shape[0] == x_time.shape[0] == y_time.shape[0] == len(df) - lookback + 1
 
+    @op_torch
     def test_tsdata_roll_timeenc_to_torch_data_loader(self):
         horizon = random.randint(1, 9)
         lookback = random.randint(10, 20)
@@ -482,6 +492,7 @@ class TestTSDataset(TestCase):
         # white box check
         assert dataloader.dataset.data_stamp_arr.shape[0] == dataloader.dataset.arr.shape[0]
 
+    @op_torch
     def test_tsdata_roll_timeenc_to_torch_data_loader_predict(self):
         horizon = 10
         lookback = random.randint(10, 20)
@@ -497,6 +508,7 @@ class TestTSDataset(TestCase):
         assert y_time.shape[1:] == (15, 3)
         assert x.shape[0] == y.shape[0] == x_time.shape[0] == y_time.shape[0] == len(df) - lookback + 1
 
+    @op_torch
     def test_tsdataset_to_torch_loader_roll(self):
         df_single_id = get_ts_df()
         df_multi_id = get_multi_id_ts_df()
@@ -563,6 +575,7 @@ class TestTSDataset(TestCase):
                 assert tuple(y_batch.size()) == (batch_size, horizon, 2)
                 break
 
+    @op_torch
     def test_tsdataset_to_torch_loader(self):
         df = get_ts_df()
         horizon = random.randint(1, 10)
@@ -585,6 +598,7 @@ class TestTSDataset(TestCase):
             assert tuple(y_batch.size()) == (batch_size, horizon, 1)
             break
 
+    @op_torch
     def test_tsdataset_to_torch_loader_lessthansample(self):
         lookback = 96
         horizon = 48
@@ -594,7 +608,7 @@ class TestTSDataset(TestCase):
         with pytest.raises(RuntimeError):
             tsdata.to_torch_data_loader(lookback=lookback, horizon=horizon)
 
-
+    @op_torch
     def test_tsdata_multi_unscale_numpy_torch_load(self):
         lookback = random.randint(1, 10)
         horizon = random.randint(1, 20)
@@ -653,6 +667,7 @@ class TestTSDataset(TestCase):
         assert val[0].numpy().shape == (batch_size, lookback, 2)
         assert val[1].numpy().shape == (batch_size, horizon, 1)
 
+    @op_torch
     def test_tsdataset_imputation(self):
         for val in ["last", "const", "linear"]:
             df = get_ugly_ts_df()
@@ -664,6 +679,7 @@ class TestTSDataset(TestCase):
             assert len(tsdata.to_pandas()) == 100
             tsdata._check_basic_invariants()
 
+    @op_torch
     def test_tsdataset_deduplicate(self):
         df = get_ugly_ts_df()
         for _ in range(20):
@@ -676,6 +692,7 @@ class TestTSDataset(TestCase):
         assert len(tsdata.to_pandas()) == 100
         tsdata._check_basic_invariants()
 
+    @op_torch
     def test_tsdataset_datetime_feature(self):
         df = get_ts_df()
         # interval = day
@@ -740,6 +757,7 @@ class TestTSDataset(TestCase):
                                            'extra feature'}
         tsdata._check_basic_invariants()
 
+    @op_torch
     def test_tsdataset_datetime_feature_multiple(self):
         df = get_multi_id_ts_df()
         # interval = day
@@ -804,6 +822,7 @@ class TestTSDataset(TestCase):
                                            'extra feature'}
         tsdata._check_basic_invariants()
 
+    @op_torch
     def test_tsdataset_scale_unscale(self):
         df = get_ts_df()
         df_test = get_ts_df()
@@ -832,6 +851,7 @@ class TestTSDataset(TestCase):
 
         tsdata._check_basic_invariants()
 
+    @op_torch
     def test_tsdataset_unscale_numpy(self):
         df = get_multi_id_ts_df()
         df_test = get_multi_id_ts_df()
@@ -876,6 +896,7 @@ class TestTSDataset(TestCase):
 
             tsdata._check_basic_invariants()
 
+    @op_torch
     def test_tsdataset_resample(self):
         df = get_ts_df()
         tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="value",
@@ -907,6 +928,7 @@ class TestTSDataset(TestCase):
         assert set(before_sampling) == set(tsdata.df.columns)
         tsdata._check_basic_invariants()
 
+    @op_torch
     def test_tsdataset_resample_multiple(self):
         df = get_multi_id_ts_df()
         tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="value",
@@ -947,6 +969,7 @@ class TestTSDataset(TestCase):
         assert set(before_sampling) == set(tsdata.df.columns)
         tsdata._check_basic_invariants()
 
+    @op_torch
     def test_tsdataset_split(self):
         df = get_ts_df()
         # only train and test
@@ -977,6 +1000,7 @@ class TestTSDataset(TestCase):
         assert tsdata_valid.target_col[0] != "new value"
         assert tsdata_test.target_col[0] != "new value"
 
+    @op_torch
     def test_tsdataset_split_multiple(self):
         df = get_multi_id_ts_df()
         tsdata_train, tsdata_valid, tsdata_test =\
@@ -1008,6 +1032,7 @@ class TestTSDataset(TestCase):
         assert tsdata_valid.target_col[0] != "new value"
         assert tsdata_test.target_col[0] != "new value"
 
+    @op_torch
     @op_diff_set_all
     def test_tsdataset_global_feature(self):
         for val in ["minimal"]:
@@ -1017,6 +1042,7 @@ class TestTSDataset(TestCase):
             tsdata.gen_global_feature(settings=val)
             tsdata._check_basic_invariants()
 
+    @op_torch
     @op_diff_set_all
     def test_tsdataset_global_feature_multiple(self):
         df = get_multi_id_ts_df()
@@ -1029,6 +1055,7 @@ class TestTSDataset(TestCase):
         tsdata.gen_global_feature(settings="minimal", n_jobs=2)
         tsdata._check_basic_invariants()
 
+    @op_torch
     @op_diff_set_all
     def test_tsdataset_rolling_feature_multiple(self):
         df = get_multi_id_ts_df()
@@ -1059,6 +1086,7 @@ class TestTSDataset(TestCase):
 
         tsdata._check_basic_invariants()
 
+    @op_torch
     def test_check_scale_sequence(self):
         df = get_multi_id_ts_df()
         # with split is True.
@@ -1082,6 +1110,7 @@ class TestTSDataset(TestCase):
         #     tsdata.gen_global_feature(settings="minimal")\
         #           .gen_rolling_feature(settings="minimal", window_size=5)
 
+    @op_torch
     def test_non_pd_datetime(self):
         df = get_non_dt()
         tsdata = TSDataset.from_pandas(df, dt_col="datetime",
@@ -1098,6 +1127,7 @@ class TestTSDataset(TestCase):
 
         tsdata._check_basic_invariants()
 
+    @op_torch
     def test_not_aligned(self):
         df = get_not_aligned_df()
         tsdata = TSDataset.from_pandas(df, target_col="value",
@@ -1109,6 +1139,7 @@ class TestTSDataset(TestCase):
             tsdata.roll(lookback=5, horizon=2, id_sensitive=True)
         tsdata._check_basic_invariants()
 
+    @op_torch
     def test_dt_sorted(self):
         df = pd.DataFrame({"datetime": np.array(['20000101', '20000102', '20000102', '20000101']),
                            "value": np.array([1.9, 2.3, 2.4, 2.6]),
@@ -1119,6 +1150,7 @@ class TestTSDataset(TestCase):
         with pytest.raises(RuntimeError):
             tsdata._check_basic_invariants(strict_check=True)
 
+    @op_torch
     @op_diff_set_all
     def test_cycle_length_est(self):
         df = get_multi_id_ts_df()
@@ -1161,6 +1193,7 @@ class TestTSDataset(TestCase):
         with pytest.raises(RuntimeError):
             tsdata.get_cycle_length(aggregate='min', top_k=3)
 
+    @op_torch
     def test_lookback_equal_to_one(self):
         df = get_ts_df()
         horizon = random.randint(1, 10)
@@ -1182,6 +1215,7 @@ class TestTSDataset(TestCase):
         assert data[1].shape[1] == max(lookback // 2, 1)
         assert data[3].shape[1] == max(lookback // 2, 1) + horizon
 
+    @op_torch
     def test_is_predict_for_roll_and_numpy(self):
         df = get_ts_df()
         horizon = random.randint(1, 10)
@@ -1203,6 +1237,7 @@ class TestTSDataset(TestCase):
         assert data[1].shape[1] == max(lookback // 2, 1)
         assert data[3].shape[1] == max(lookback // 2, 1) + horizon
 
+    @op_torch
     def test_is_predict_for_roll_and_to_loader(self):
         df = get_ts_df()
         horizon = random.randint(1, 10)
@@ -1231,6 +1266,7 @@ class TestTSDataset(TestCase):
         assert data[3].shape[1] == max(lookback // 2, 1) + horizon
 
 
+    @op_torch
     def test_is_predict_for_to_loader(self):
         df = get_ts_df()
         horizon = random.randint(1, 10)
@@ -1261,6 +1297,7 @@ class TestTSDataset(TestCase):
         assert data[1].shape[1] == max(lookback // 2, 1)
         assert data[3].shape[1] == max(lookback // 2, 1) + horizon
 
+    @op_torch
     def test_tsdataset_missing_check_and_repair(self):
         df = get_missing_df()
         tsdata = TSDataset.from_pandas(df, dt_col="datetime",
@@ -1269,7 +1306,8 @@ class TestTSDataset(TestCase):
                                        repair=True)
         missing_value = tsdata.df.isna().sum().sum()
         assert missing_value == 0
-    
+
+    @op_torch
     def test_tsdataset_non_std_dt_check_and_repair(self):
         df = get_non_std_dt_df()
         tsdata = TSDataset.from_pandas(df, dt_col="datetime",
@@ -1279,6 +1317,7 @@ class TestTSDataset(TestCase):
         _is_pd_datetime = pd.api.types.is_datetime64_any_dtype(tsdata.df["datetime"].dtypes)
         assert _is_pd_datetime is True
 
+    @op_torch
     def test_tsdataset_interval_check_and_repair(self):
         df = get_multi_interval_df()
         tsdata = TSDataset.from_pandas(df, dt_col="datetime",
@@ -1290,6 +1329,7 @@ class TestTSDataset(TestCase):
         unique_intervals = interval[:-1].unique()
         assert len(unique_intervals) == 1
 
+    @op_torch
     def test_tsdataset_interval_repair_for_single_and_multi_id(self):
         df = get_multi_id_ts_df_interval()
         tsdata = TSDataset.from_pandas(df, dt_col="datetime",
@@ -1308,6 +1348,7 @@ class TestTSDataset(TestCase):
         dt_col = tsdata.df["datetime"]
         assert len(dt_col) == 366*2
 
+    @op_torch
     def test_tsdataset_interval_check_and_repair_for_multi_id(self):
         df_multi_id = get_multi_id_ts_df()
         horizon = 10

--- a/python/chronos/test/bigdl/chronos/data/utils/test_cycle_detection.py
+++ b/python/chronos/test/bigdl/chronos/data/utils/test_cycle_detection.py
@@ -21,7 +21,7 @@ import numpy as np
 from unittest import TestCase
 from bigdl.chronos.data.utils.cycle_detection import cycle_length_est
 
-from ... import op_diff_set_all
+from ... import op_torch, op_tf2, op_diff_set_all
 
 class TestCycleDetectionTimeSeries(TestCase):
     def setup_method(self, method):
@@ -30,6 +30,8 @@ class TestCycleDetectionTimeSeries(TestCase):
     def teardown_method(self, method):
         pass
 
+    @op_torch
+    @op_tf2
     @op_diff_set_all
     def test_cycle_detection_timeseries_numpy(self):
         data = np.random.randn(100)

--- a/python/chronos/test/bigdl/chronos/data/utils/test_deduplicate.py
+++ b/python/chronos/test/bigdl/chronos/data/utils/test_deduplicate.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from unittest import TestCase
 from bigdl.chronos.data.utils.deduplicate import deduplicate_timeseries_dataframe
+from ... import op_torch, op_tf2
 
 
 def get_duplicated_ugly_ts_df():
@@ -32,6 +33,8 @@ def get_duplicated_ugly_ts_df():
     return df
 
 
+@op_torch
+@op_tf2
 class TestDeduplicateTimeSeries(TestCase):
     def setup_method(self, method):
         self.df = get_duplicated_ugly_ts_df()

--- a/python/chronos/test/bigdl/chronos/data/utils/test_feature.py
+++ b/python/chronos/test/bigdl/chronos/data/utils/test_feature.py
@@ -22,9 +22,11 @@ from unittest import TestCase
 from bigdl.chronos.data.utils.feature import generate_dt_features, generate_global_features
 from bigdl.chronos.utils import LazyImport
 tsfresh = LazyImport('tsfresh')
-from ... import op_diff_set_all
+from ... import op_torch, op_tf2, op_diff_set_all
 
 
+@op_torch
+@op_tf2
 class TestFeature(TestCase):
     def setup_method(self, method):
         pass

--- a/python/chronos/test/bigdl/chronos/data/utils/test_file.py
+++ b/python/chronos/test/bigdl/chronos/data/utils/test_file.py
@@ -19,7 +19,7 @@ import tempfile
 from bigdl.chronos.data.utils.file import parquet2pd
 import pandas as pd
 import numpy as np
-from ... import op_diff_set_all
+from ... import op_torch, op_tf2, op_diff_set_all
 
 
 def get_ts_df():
@@ -31,6 +31,8 @@ def get_ts_df():
     return train_df
 
 
+@op_torch
+@op_tf2
 class TestFile:
 
     @op_diff_set_all

--- a/python/chronos/test/bigdl/chronos/data/utils/test_impute.py
+++ b/python/chronos/test/bigdl/chronos/data/utils/test_impute.py
@@ -22,6 +22,7 @@ from unittest import TestCase
 from bigdl.chronos.data.utils.impute import impute_timeseries_dataframe, \
     _last_impute_timeseries_dataframe, _const_impute_timeseries_dataframe, \
     _linear_impute_timeseries_dataframe
+from ... import op_torch, op_tf2
 
 
 def get_ugly_ts_df():
@@ -38,6 +39,8 @@ def get_ugly_ts_df():
     return df
 
 
+@op_torch
+@op_tf2
 class TestImputeTimeSeries(TestCase):
     def setup_method(self, method):
         self.df = get_ugly_ts_df()

--- a/python/chronos/test/bigdl/chronos/data/utils/test_public_dataset.py
+++ b/python/chronos/test/bigdl/chronos/data/utils/test_public_dataset.py
@@ -19,8 +19,11 @@ import pytest
 
 from unittest import TestCase
 from bigdl.chronos.data.utils.public_dataset import PublicDataset
+from ... import op_torch, op_tf2
 
 
+@op_torch
+@op_tf2
 class TestPublicDataset(TestCase):
     def setup_method(self, method):
         pass

--- a/python/chronos/test/bigdl/chronos/data/utils/test_quality_inspection.py
+++ b/python/chronos/test/bigdl/chronos/data/utils/test_quality_inspection.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from unittest import TestCase
 from bigdl.chronos.data.utils.quality_inspection import quality_check_timeseries_dataframe
+from ... import op_torch, op_tf2
 
 
 def get_missing_df():
@@ -52,6 +53,8 @@ def get_non_dt_df():
     return df
 
 
+@op_torch
+@op_tf2
 class TestCheckAndRepairTimeSeries(TestCase):
     def setup_method(self, method):
         pass

--- a/python/chronos/test/bigdl/chronos/data/utils/test_resample.py
+++ b/python/chronos/test/bigdl/chronos/data/utils/test_resample.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from unittest import TestCase
 from bigdl.chronos.data.utils.resample import resample_timeseries_dataframe
+from ... import op_torch, op_tf2
 
 
 def get_ugly_ts_df():
@@ -36,6 +37,8 @@ def get_ugly_ts_df():
     return df
 
 
+@op_torch
+@op_tf2
 class TestResampleTimeSeries(TestCase):
     def setup_method(self, method):
         self.df = get_ugly_ts_df()

--- a/python/chronos/test/bigdl/chronos/data/utils/test_roll.py
+++ b/python/chronos/test/bigdl/chronos/data/utils/test_roll.py
@@ -21,8 +21,11 @@ import random
 
 from unittest import TestCase
 from bigdl.chronos.data.utils.roll import roll_timeseries_dataframe
+from ... import op_torch, op_tf2
 
 
+@op_torch
+@op_tf2
 class TestRollTimeSeries(TestCase):
     def setup_method(self, method):
         self.easy_data = pd.DataFrame({"A": np.random.randn(10),

--- a/python/chronos/test/bigdl/chronos/data/utils/test_roll_dataset.py
+++ b/python/chronos/test/bigdl/chronos/data/utils/test_roll_dataset.py
@@ -19,7 +19,9 @@ import numpy as np
 import pandas as pd
 import random
 from bigdl.chronos.data import TSDataset
-from bigdl.chronos.data.utils.roll_dataset import RollDataset
+from bigdl.chronos.utils import LazyImport
+RollDataset = LazyImport('bigdl.chronos.data.utils.roll_dataset.RollDataset')
+from ... import op_torch
 
 
 def get_ts_df():
@@ -41,6 +43,7 @@ def get_multi_id_ts_df():
     return train_df
 
 
+@op_torch
 class TestRollDataset:
 
     @staticmethod

--- a/python/chronos/test/bigdl/chronos/detector/anomaly/test_ae_detector.py
+++ b/python/chronos/test/bigdl/chronos/detector/anomaly/test_ae_detector.py
@@ -19,7 +19,7 @@ import numpy as np
 from unittest import TestCase
 
 from bigdl.chronos.detector.anomaly.ae_detector import AEDetector
-from ... import op_tf2
+from ... import op_torch, op_tf2
 
 
 class TestAEDetector(TestCase):
@@ -47,6 +47,7 @@ class TestAEDetector(TestCase):
         anomaly_indexes = ad.anomaly_indexes()
         assert len(anomaly_indexes) == int(ad.ratio * len(y))
 
+    @op_torch
     def test_ae_fit_score_rolled_pytorch(self):
         y = self.create_data()
         ad = AEDetector(roll_len=314, backend="torch")
@@ -66,6 +67,8 @@ class TestAEDetector(TestCase):
         anomaly_indexes = ad.anomaly_indexes()
         assert len(anomaly_indexes) == int(ad.ratio * len(y))
 
+    @op_torch
+    @op_tf2
     def test_corner_cases(self):
         y = self.create_data()
         ad = AEDetector(roll_len=314, backend="dummy")

--- a/python/chronos/test/bigdl/chronos/detector/anomaly/test_dbscan_detector.py
+++ b/python/chronos/test/bigdl/chronos/detector/anomaly/test_dbscan_detector.py
@@ -19,8 +19,11 @@ import numpy as np
 from unittest import TestCase
 
 from bigdl.chronos.detector.anomaly.dbscan_detector import DBScanDetector
+from ... import op_torch, op_tf2
 
 
+@op_torch
+@op_tf2
 class TestDBScanDetector(TestCase):
 
     def setUp(self):

--- a/python/chronos/test/bigdl/chronos/detector/anomaly/test_th_detector.py
+++ b/python/chronos/test/bigdl/chronos/detector/anomaly/test_th_detector.py
@@ -19,10 +19,13 @@ import numpy as np
 import pandas as pd
 from unittest import TestCase
 
-from bigdl.chronos.forecaster.lstm_forecaster import LSTMForecaster
+from bigdl.chronos.utils import LazyImport
+LSTMForecaster = LazyImport('bigdl.chronos.forecaster.lstm_forecaster.LSTMForecaster')
 from bigdl.chronos.detector.anomaly import ThresholdDetector
+from ... import op_torch
 
 
+@op_torch
 class TestThresholdDetector(TestCase):
 
     def setUp(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_arima_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_arima_forecaster.py
@@ -22,7 +22,7 @@ from bigdl.chronos.utils import LazyImport
 ARIMAForecaster = LazyImport('bigdl.chronos.forecaster.arima_forecaster.ARIMAForecaster')
 from unittest import TestCase
 import pytest
-from .. import op_all, op_diff_set_all
+from .. import op_diff_set_all
 
 
 def create_data():
@@ -33,7 +33,6 @@ def create_data():
     return data, validation_data
 
 
-@op_all
 @op_diff_set_all
 class TestChronosModelARIMAForecaster(TestCase):
 

--- a/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
@@ -24,7 +24,7 @@ AutoformerForecaster = LazyImport('bigdl.chronos.forecaster.autoformer_forecaste
 from bigdl.chronos.data import TSDataset
 from unittest import TestCase
 import pytest
-from .. import op_torch, op_automl, op_all
+from .. import op_torch, op_automl
 
 
 def get_ts_df():
@@ -97,7 +97,6 @@ def create_tsdataset(val_ratio=0):
                         label_len=12)
         return train, val, test
 
-@op_all
 @op_torch
 class TestChronosModelAutoformerForecaster(TestCase):
 

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -23,7 +23,7 @@ torch = LazyImport('torch')
 LSTMForecaster = LazyImport('bigdl.chronos.forecaster.lstm_forecaster.LSTMForecaster')
 from unittest import TestCase
 import pytest
-from .. import op_torch, op_distributed, op_all, op_onnxrt16, op_automl, op_diff_set_all
+from .. import op_torch, op_distributed, op_inference, op_automl, op_diff_set_all
 
 
 def create_data(loader=False):
@@ -97,7 +97,6 @@ def create_tsdataset_val(roll=True, horizon=1):
     return train, val, test
 
 
-@op_all
 @op_torch
 class TestChronosModelLSTMForecaster(TestCase):
 
@@ -124,7 +123,7 @@ class TestChronosModelLSTMForecaster(TestCase):
         assert test_mse[0].shape == test_data[1].shape[1:]
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_lstm_forecaster_fit_loader(self):
         train_loader, val_loader, test_loader = create_data(loader=True)
         forecaster = LSTMForecaster(past_seq_len=24,
@@ -149,7 +148,7 @@ class TestChronosModelLSTMForecaster(TestCase):
         forecaster.evaluate_with_onnx(test_loader, batch_size=32, quantize=True)
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_lstm_forecaster_onnx_methods(self):
         train_data, val_data, test_data = create_data()
         forecaster = LSTMForecaster(past_seq_len=24,
@@ -288,7 +287,7 @@ class TestChronosModelLSTMForecaster(TestCase):
         np.testing.assert_almost_equal(test_pred_save_q, test_pred_load_q)
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_lstm_forecaster_quantization_onnx(self):
         train_data, val_data, test_data = create_data()
         forecaster = LSTMForecaster(past_seq_len=24,
@@ -303,7 +302,7 @@ class TestChronosModelLSTMForecaster(TestCase):
         eval_q = forecaster.evaluate_with_onnx(test_data, quantize=True)
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_lstm_forecaster_quantization_onnx_tuning(self):
         train_data, val_data, test_data = create_data()
         forecaster = LSTMForecaster(past_seq_len=24,
@@ -395,7 +394,7 @@ class TestChronosModelLSTMForecaster(TestCase):
 
     @op_distributed
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_lstm_forecaster_distributed(self):
         from bigdl.orca import init_orca_context, stop_orca_context
         train_data, val_data, test_data = create_data()
@@ -537,7 +536,7 @@ class TestChronosModelLSTMForecaster(TestCase):
         assert yhat.shape == y_test.shape
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_forecaster_from_tsdataset_data_loader_onnx(self):
         train, test = create_tsdataset(roll=False)
         train.gen_dt_feature(one_hot_features=['WEEK'])
@@ -666,7 +665,7 @@ class TestChronosModelLSTMForecaster(TestCase):
         assert yhat.shape == y_test.shape
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_forecaster_optimize_loader(self):
         train_loader, val_loader, test_loader = create_data(loader=True)
         forecaster = LSTMForecaster(past_seq_len=24,
@@ -723,7 +722,7 @@ class TestChronosModelLSTMForecaster(TestCase):
         eval_t = forecaster.evaluate(test_loader_shuffle_t)
         assert_almost_equal(eval_f, eval_t)
 
-    @op_onnxrt16
+    @op_inference
     def test_lstm_forecaster_eval_with_onnx_shuffle_loader(self):
         from torch.utils.data import DataLoader, TensorDataset
         from numpy.testing import assert_almost_equal

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -23,7 +23,7 @@ import pytest
 from bigdl.chronos.utils import LazyImport
 torch = LazyImport('torch')
 NBeatsForecaster = LazyImport('bigdl.chronos.forecaster.nbeats_forecaster.NBeatsForecaster')
-from .. import op_all, op_torch, op_distributed, op_onnxrt16, op_diff_set_all
+from .. import op_torch, op_distributed, op_inference, op_diff_set_all
 
 
 def create_data(loader=False):
@@ -97,7 +97,6 @@ def create_tsdataset_val(roll=True, horizon=5):
     return train, val, test
 
 
-@op_all
 @op_torch
 class TestChronosNBeatsForecaster(TestCase):
     def setUp(self):
@@ -123,7 +122,7 @@ class TestChronosNBeatsForecaster(TestCase):
         assert eva[0].shape == test_data[1].shape[1:]
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_nbeats_forecaster_fit_loader(self):
         train_loader, val_loader, test_loader = create_data(loader=True)
         forecaster = NBeatsForecaster(past_seq_len=24,
@@ -145,7 +144,7 @@ class TestChronosNBeatsForecaster(TestCase):
         forecaster.evaluate_with_onnx(test_loader, batch_size=32, quantize=True)
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_nbeats_forecaster_onnx_methods(self):
         train_data, val_data, test_data = create_data()
         forecaster = NBeatsForecaster(past_seq_len=24,
@@ -251,7 +250,7 @@ class TestChronosNBeatsForecaster(TestCase):
         np.testing.assert_almost_equal(test_pred_save_q, test_pred_load_q)
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_nbeats_forecaster_quantization_onnx(self):
         train_data, val_data, test_data = create_data()
         forecaster = NBeatsForecaster(past_seq_len=24,
@@ -265,7 +264,7 @@ class TestChronosNBeatsForecaster(TestCase):
         eval_q = forecaster.evaluate_with_onnx(test_data, quantize=True)
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_nbeats_forecaster_quantization_onnx_tuning(self):
         train_data, val_data, test_data = create_data()
         forecaster = NBeatsForecaster(past_seq_len=24,
@@ -345,7 +344,7 @@ class TestChronosNBeatsForecaster(TestCase):
 
     @op_distributed
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_nbeats_forecaster_distributed(self):
         train_data, val_data, test_data = create_data()
         _train_loader, _, _test_loader = create_data(loader=True)
@@ -492,7 +491,7 @@ class TestChronosNBeatsForecaster(TestCase):
         assert yhat.shape == y_test.shape
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_forecaster_from_tsdataset_data_loader_onnx(self):
         train, test = create_tsdataset(roll=False)
         loader = train.to_torch_data_loader(lookback=24,
@@ -601,7 +600,7 @@ class TestChronosNBeatsForecaster(TestCase):
         assert yhat.shape == y_test.shape
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_forecaster_optimize_loader(self):
         train_loader, val_loader, test_loader = create_data(loader=True)
         forecaster = NBeatsForecaster(past_seq_len=24,
@@ -653,7 +652,7 @@ class TestChronosNBeatsForecaster(TestCase):
         eval_t = forecaster.evaluate(test_loader_shuffle_t)
         assert_almost_equal(eval_f, eval_t)
 
-    @op_onnxrt16
+    @op_inference
     def test_nbeats_forecaster_eval_with_onnx_shuffle_loader(self):
         from torch.utils.data import DataLoader, TensorDataset
         from numpy.testing import assert_almost_equal

--- a/python/chronos/test/bigdl/chronos/forecaster/test_prophet_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_prophet_forecaster.py
@@ -23,7 +23,7 @@ from bigdl.chronos.utils import LazyImport
 ProphetForecaster = LazyImport('bigdl.chronos.forecaster.prophet_forecaster.ProphetForecaster')
 from unittest import TestCase
 import pytest
-from .. import op_all, op_diff_set_all
+from .. import op_diff_set_all
 
 
 def create_data():
@@ -36,7 +36,6 @@ def create_data():
     return data, validation_data
 
 
-@op_all
 @op_diff_set_all
 class TestChronosModelProphetForecaster(TestCase):
 

--- a/python/chronos/test/bigdl/chronos/forecaster/test_pytorch.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_pytorch.py
@@ -16,10 +16,9 @@
 
 from unittest import TestCase
 from bigdl.chronos.utils import LazyImport
-from .. import op_torch, op_all
+from .. import op_torch
 
 
-@op_all
 @op_torch
 class TestChronosModelPytorch(TestCase):
 

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -23,7 +23,7 @@ torch = LazyImport('torch')
 Seq2SeqForecaster = LazyImport('bigdl.chronos.forecaster.seq2seq_forecaster.Seq2SeqForecaster')
 from unittest import TestCase
 import pytest
-from .. import op_torch, op_distributed, op_all, op_onnxrt16, op_automl, op_diff_set_all
+from .. import op_torch, op_distributed, op_inference, op_automl, op_diff_set_all
 
 
 def create_data(loader=False):
@@ -97,7 +97,6 @@ def create_tsdataset_val(roll=True, horizon=5):
     return train, val, test
 
 
-@op_all
 @op_torch
 class TestChronosModelSeq2SeqForecaster(TestCase):
 
@@ -122,7 +121,7 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
         assert test_mse[0].shape == test_data[1].shape[1:]
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_s2s_forecaster_fit_loader(self):
         train_loader, val_loader, test_loader = create_data(loader=True)
         forecaster = Seq2SeqForecaster(past_seq_len=24,
@@ -139,7 +138,7 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
         forecaster.evaluate_with_onnx(test_loader)
         forecaster.evaluate_with_onnx(test_loader, batch_size=32)
 
-    @op_onnxrt16
+    @op_inference
     def test_s2s_forecaster_onnx_methods(self):
         train_data, val_data, test_data = create_data()
         forecaster = Seq2SeqForecaster(past_seq_len=24,
@@ -302,7 +301,7 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
 
     @op_distributed
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_s2s_forecaster_distributed(self):
         from bigdl.orca import init_orca_context, stop_orca_context
         train_data, val_data, test_data = create_data()
@@ -445,7 +444,7 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
         assert yhat.shape == y_test.shape
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_forecaster_from_tsdataset_data_loader_onnx(self):
         train, test = create_tsdataset(roll=False)
         train.gen_dt_feature(one_hot_features=['WEEK'])
@@ -559,7 +558,7 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
         assert yhat.shape == y_test.shape
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_s2s_optimize_loader(self):
         train_loader, val_loader, test_loader = create_data(loader=True)
         forecaster = Seq2SeqForecaster(past_seq_len=24,
@@ -611,7 +610,7 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
         eval_t = forecaster.evaluate(test_loader_shuffle_t)
         assert_almost_equal(eval_f, eval_t)
 
-    @op_onnxrt16
+    @op_inference
     def test_s2s_forecaster_eval_with_onnx_shuffle_loader(self):
         from torch.utils.data import DataLoader, TensorDataset
         from numpy.testing import assert_almost_equal

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcmf_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcmf_forecaster.py
@@ -23,10 +23,9 @@ from unittest import TestCase
 import tempfile
 import pandas as pd
 
-from .. import op_all, op_distributed, op_torch, op_diff_set_all
+from .. import op_distributed, op_torch, op_diff_set_all
 
 
-@op_all
 @op_torch
 @op_distributed
 class TestChronosModelTCMFForecaster(TestCase):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -23,7 +23,7 @@ torch = LazyImport('torch')
 TCNForecaster = LazyImport('bigdl.chronos.forecaster.tcn_forecaster.TCNForecaster')
 from unittest import TestCase
 import pytest
-from .. import op_torch, op_all, op_distributed, op_automl, op_onnxrt16, op_diff_set_all
+from .. import op_torch, op_distributed, op_automl, op_inference, op_diff_set_all
 
 
 def create_data(loader=False):
@@ -110,7 +110,6 @@ def create_tsdataset_val(roll=True, horizon=5):
     return train, val, test
 
 
-@op_all
 @op_torch
 class TestChronosModelTCNForecaster(TestCase):
 
@@ -137,7 +136,7 @@ class TestChronosModelTCNForecaster(TestCase):
         assert test_mse[0].shape == test_data[1].shape[1:]
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_tcn_forecaster_fit_loader(self):
         train_loader, val_loader, test_loader = create_data(loader=True)
         forecaster = TCNForecaster(past_seq_len=24,
@@ -162,7 +161,7 @@ class TestChronosModelTCNForecaster(TestCase):
         forecaster.evaluate_with_onnx(test_loader, batch_size=32, quantize=True)
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_tcn_forecaster_fit_loader_normalization_decomposation(self):
         train_loader, val_loader, test_loader = create_data(loader=True)
         forecaster = TCNForecaster(past_seq_len=24,
@@ -279,7 +278,7 @@ class TestChronosModelTCNForecaster(TestCase):
 
     @op_automl
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_tcn_forecaster_multi_objective_tune_acceleration(self):
         import bigdl.nano.automl.hpo.space as space
         train_data, val_data, _ = create_data(loader=False)
@@ -299,7 +298,7 @@ class TestChronosModelTCNForecaster(TestCase):
                         acceleration=True, direction=None)
 
     @op_automl
-    @op_onnxrt16
+    @op_inference
     def test_tcn_forecaster_mo_tune_acceleration_fit_input(self):
         import bigdl.nano.automl.hpo.space as space
         train_data, val_data, _ = create_data(loader=False)
@@ -321,7 +320,7 @@ class TestChronosModelTCNForecaster(TestCase):
             forecaster.fit(train_data, epochs=2)
 
     @op_automl
-    @op_onnxrt16
+    @op_inference
     def test_tcn_forecaster_mo_tune_acceleration_fit(self):
         import bigdl.nano.automl.hpo.space as space
         train_data, val_data, _ = create_data(loader=False)
@@ -342,7 +341,7 @@ class TestChronosModelTCNForecaster(TestCase):
         forecaster.fit(train_data, epochs=2, use_trial_id=0)
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_tcn_forecaster_onnx_methods(self):
         train_data, val_data, test_data = create_data()
         forecaster = TCNForecaster(past_seq_len=24,
@@ -373,7 +372,7 @@ class TestChronosModelTCNForecaster(TestCase):
             pass
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_tcn_forecaster_onnx_methods_normalization_decomposation(self):
         train_data, val_data, test_data = create_data()
         forecaster = TCNForecaster(past_seq_len=24,
@@ -467,7 +466,7 @@ class TestChronosModelTCNForecaster(TestCase):
             ckpt_name_q = os.path.join(tmp_dir_name, "int_openvino")
             forecaster.export_openvino_file(dirname=ckpt_name, quantized_dirname=ckpt_name_q)
 
-    @op_onnxrt16
+    @op_inference
     def test_tcn_forecaster_openvino_methods_loader(self):
         train_loader, val_loader, test_loader = create_data(loader=True)
         forecaster = TCNForecaster(past_seq_len=24,
@@ -491,7 +490,7 @@ class TestChronosModelTCNForecaster(TestCase):
         q_openvino_yhat = forecaster.predict_with_openvino(test_loader, quantize=True)
         assert openvino_yhat.shape == q_openvino_yhat.shape
 
-    @op_onnxrt16
+    @op_inference
     def test_tcn_forecaster_openvino_methods_tsdataset(self):
         train, test = create_tsdataset(roll=True, horizon=5)
         forecaster = TCNForecaster(past_seq_len=24,
@@ -693,7 +692,7 @@ class TestChronosModelTCNForecaster(TestCase):
         np.testing.assert_almost_equal(test_pred_save_q, test_pred_load_q)
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_tcn_forecaster_quantization_onnx(self):
         train_data, val_data, test_data = create_data()
         forecaster = TCNForecaster(past_seq_len=24,
@@ -710,7 +709,7 @@ class TestChronosModelTCNForecaster(TestCase):
         eval_q = forecaster.evaluate_with_onnx(test_data, quantize=True)
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_tcn_forecaster_quantization_onnx_tuning(self):
         train_data, val_data, test_data = create_data()
         forecaster = TCNForecaster(past_seq_len=24,
@@ -834,7 +833,7 @@ class TestChronosModelTCNForecaster(TestCase):
 
     @op_distributed
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_tcn_forecaster_distributed(self):
         from bigdl.orca import init_orca_context, stop_orca_context
         train_data, val_data, test_data = create_data()
@@ -889,7 +888,7 @@ class TestChronosModelTCNForecaster(TestCase):
 
     @op_distributed
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_tcn_forecaster_distributed_normalization_decomposation(self):
         from bigdl.orca import init_orca_context, stop_orca_context
         train_data, val_data, test_data = create_data()
@@ -1038,7 +1037,7 @@ class TestChronosModelTCNForecaster(TestCase):
         assert yhat.shape == y_test.shape
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_forecaster_from_tsdataset_data_loader_onnx(self):
         train, test = create_tsdataset(roll=False)
         train.gen_dt_feature(one_hot_features=['WEEK'])
@@ -1220,7 +1219,7 @@ class TestChronosModelTCNForecaster(TestCase):
         assert yhat.shape == y_test.shape
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_forecaster_optimize_loader(self):
         train_loader, val_loader, test_loader = create_data(loader=True)
         forecaster = TCNForecaster(past_seq_len=24,
@@ -1240,7 +1239,7 @@ class TestChronosModelTCNForecaster(TestCase):
         forecaster.predict(test_loader)
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_forecaster_optimize_numpy(self):
         train_data, val_data, test_data = create_data(loader=False)
         forecaster = TCNForecaster(past_seq_len=24,
@@ -1260,7 +1259,7 @@ class TestChronosModelTCNForecaster(TestCase):
         forecaster.predict(test_data[0])
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_forecaster_optimize_tsdataset(self):
         train, val, test = create_tsdataset(roll=True, horizon=5, val_ratio=0.1)
         forecaster = TCNForecaster.from_tsdataset(train,
@@ -1289,7 +1288,7 @@ class TestChronosModelTCNForecaster(TestCase):
         assert forecaster.accelerated_model is None
 
     @op_diff_set_all
-    @op_onnxrt16
+    @op_inference
     def test_forecaster_optimize_loader_without_validation_data(self):
         train_loader, val_loader, test_loader = create_data(loader=True)
         forecaster = TCNForecaster(past_seq_len=24,
@@ -1330,7 +1329,7 @@ class TestChronosModelTCNForecaster(TestCase):
         eval_t = forecaster.evaluate(test_loader_shuffle_t)
         assert_almost_equal(eval_f, eval_t)
 
-    @op_onnxrt16
+    @op_inference
     def test_tcn_forecaster_eval_with_onnx_shuffle_loader(self):
         from torch.utils.data import DataLoader, TensorDataset
         from numpy.testing import assert_almost_equal

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_lstm_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_lstm_keras_forecaster.py
@@ -23,7 +23,7 @@ import numpy as np
 from bigdl.chronos.utils import LazyImport
 LSTMForecaster = LazyImport('bigdl.chronos.forecaster.tf.lstm_forecaster.LSTMForecaster')
 tf = LazyImport('tensorflow')
-from test.bigdl.chronos import op_tf2, op_all
+from test.bigdl.chronos import op_tf2
 
 
 def create_data(tf_data=False, batch_size=32):
@@ -78,7 +78,6 @@ def create_tsdataset(roll=True):
     return train, valid, test
 
 
-@op_all
 @op_tf2
 class TestLSTMForecaster(TestCase):
     def setUp(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_lstm_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_lstm_keras_forecaster.py
@@ -23,7 +23,7 @@ import numpy as np
 from bigdl.chronos.utils import LazyImport
 LSTMForecaster = LazyImport('bigdl.chronos.forecaster.tf.lstm_forecaster.LSTMForecaster')
 tf = LazyImport('tensorflow')
-from test.bigdl.chronos import op_tf2
+from test.bigdl.chronos import op_tf2, op_distributed
 
 
 def create_data(tf_data=False, batch_size=32):
@@ -87,8 +87,6 @@ class TestLSTMForecaster(TestCase):
                                          output_feature_num=2)
 
     def tearDown(self):
-        from bigdl.orca import stop_orca_context
-        stop_orca_context()
         del self.forecaster
 
     def test_lstm_forecaster_fit_predict_evaluate(self):
@@ -181,6 +179,7 @@ class TestLSTMForecaster(TestCase):
         _, y_test = test.to_numpy()
         assert yhat.shape == y_test.shape
 
+    @op_distributed
     def test_lstm_forecaster_distributed(self):
         from bigdl.orca import init_orca_context, stop_orca_context
         init_orca_context(cores=2, memory="2g")
@@ -215,6 +214,7 @@ class TestLSTMForecaster(TestCase):
         np.testing.assert_array_almost_equal(distributed_pred, local_pred, decimal=5)
         stop_orca_context()
 
+    @op_distributed
     def test_lstm_forecaster_distributed_illegal_input(self):
         from bigdl.orca import init_orca_context, stop_orca_context
         init_orca_context(cores=2, memory="2g")

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_mtnet_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_mtnet_forecaster.py
@@ -22,7 +22,7 @@ from bigdl.chronos.data import TSDataset
 from bigdl.chronos.utils import LazyImport
 tf = LazyImport('tensorflow')
 from unittest import TestCase
-from test.bigdl.chronos import op_tf2, op_all
+from test.bigdl.chronos import op_tf2
 
 
 def create_data():
@@ -51,7 +51,6 @@ def create_data():
     return tsdata_train, tsdata_test
 
 
-@op_all
 @op_tf2
 class TestChronosModelMTNetForecaster(TestCase):
 

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_seq2seq_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_seq2seq_keras_forecaster.py
@@ -23,7 +23,7 @@ import numpy as np
 from bigdl.chronos.utils import LazyImport
 tf = LazyImport('tensorflow')
 Seq2SeqForecaster = LazyImport('bigdl.chronos.forecaster.tf.seq2seq_forecaster.Seq2SeqForecaster')
-from test.bigdl.chronos import op_tf2
+from test.bigdl.chronos import op_tf2, op_distributed
 
 
 def create_data(tf_data=False, batch_size=32):
@@ -89,8 +89,6 @@ class TestSeq2SeqForecaster(TestCase):
                                             output_feature_num=2)
 
     def tearDown(self):
-        from bigdl.orca import stop_orca_context
-        stop_orca_context()
         del self.forecaster
 
     def test_seq2seq_fit_predict_evaluate(self):
@@ -183,6 +181,7 @@ class TestSeq2SeqForecaster(TestCase):
         _, y_test = test.to_numpy()
         assert yhat.shape == y_test.shape
 
+    @op_distributed
     def test_s2s_forecaster_distributed(self):
         from bigdl.orca import init_orca_context, stop_orca_context
         train_data, val_data, test_data = create_data()
@@ -218,6 +217,7 @@ class TestSeq2SeqForecaster(TestCase):
         np.testing.assert_almost_equal(distributed_pred, local_pred, decimal=5)
         stop_orca_context()
 
+    @op_distributed
     def test_s2s_forecaster_distributed_illegal_input(self):
         from bigdl.orca import init_orca_context, stop_orca_context
 

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_seq2seq_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_seq2seq_keras_forecaster.py
@@ -23,7 +23,7 @@ import numpy as np
 from bigdl.chronos.utils import LazyImport
 tf = LazyImport('tensorflow')
 Seq2SeqForecaster = LazyImport('bigdl.chronos.forecaster.tf.seq2seq_forecaster.Seq2SeqForecaster')
-from test.bigdl.chronos import op_tf2, op_all
+from test.bigdl.chronos import op_tf2
 
 
 def create_data(tf_data=False, batch_size=32):
@@ -78,7 +78,6 @@ def create_tsdataset(roll=True):
     return train, valid, test
 
 
-@op_all
 @op_tf2
 class TestSeq2SeqForecaster(TestCase):
     

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
@@ -24,7 +24,7 @@ import numpy as np
 from bigdl.chronos.utils import LazyImport
 tf = LazyImport('tensorflow')
 TCNForecaster = LazyImport('bigdl.chronos.forecaster.tf.tcn_forecaster.TCNForecaster')
-from test.bigdl.chronos import op_tf2, op_all
+from test.bigdl.chronos import op_tf2
 
 
 def create_data(tf_data=False, batch_size=32):
@@ -80,7 +80,6 @@ def create_tsdataset(roll=True):
     return train, valid, test
 
 
-@op_all
 @op_tf2
 class TestTCNForecaster(TestCase):
     def setUp(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
@@ -24,7 +24,7 @@ import numpy as np
 from bigdl.chronos.utils import LazyImport
 tf = LazyImport('tensorflow')
 TCNForecaster = LazyImport('bigdl.chronos.forecaster.tf.tcn_forecaster.TCNForecaster')
-from test.bigdl.chronos import op_tf2
+from test.bigdl.chronos import op_tf2, op_distributed
 
 
 def create_data(tf_data=False, batch_size=32):
@@ -91,8 +91,6 @@ class TestTCNForecaster(TestCase):
                                         num_channels=[15]*7)
 
     def tearDown(self):
-        from bigdl.orca import stop_orca_context
-        stop_orca_context()
         del self.forecaster
 
     def test_tcn_forecaster_fit_predict_evaluate(self):
@@ -187,6 +185,7 @@ class TestTCNForecaster(TestCase):
         _, y_test = test.to_numpy()
         assert yhat.shape == y_test.shape
 
+    @op_distributed
     def test_tcn_forecaster_distributed(self):
         from bigdl.orca import init_orca_context, stop_orca_context
         train_data, val_data, test_data = create_data()
@@ -223,6 +222,7 @@ class TestTCNForecaster(TestCase):
         np.testing.assert_almost_equal(distributed_pred, local_pred, decimal=5)
         stop_orca_context()
 
+    @op_distributed
     def test_tcn_forecaster_distributed_illegal_input(self):
         from bigdl.orca import init_orca_context, stop_orca_context
 

--- a/python/chronos/test/bigdl/chronos/metric/test_forecast_metrics.py
+++ b/python/chronos/test/bigdl/chronos/metric/test_forecast_metrics.py
@@ -22,8 +22,10 @@ from numpy.testing import assert_almost_equal
 from numpy.testing import assert_array_almost_equal
 
 from bigdl.chronos.metric.forecast_metrics import Evaluator
-from .. import op_distributed, op_diff_set_all
+from .. import op_torch, op_tf2, op_distributed, op_diff_set_all
 
+@op_torch
+@op_tf2
 class TestChronosForecastMetrics(TestCase):
 
     def setUp(self):

--- a/python/chronos/test/bigdl/chronos/model/test_Seq2Seq_pytorch.py
+++ b/python/chronos/test/bigdl/chronos/model/test_Seq2Seq_pytorch.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 from unittest import TestCase
-from .. import op_distributed
+from .. import op_torch, op_distributed
 import numpy as np
 import tempfile
 import os
@@ -43,6 +43,7 @@ def create_data():
     return train_data, val_data, test_data
 
 
+@op_torch
 @op_distributed
 class TestSeq2SeqPytorch(TestCase):
     train_data, val_data, test_data = create_data()

--- a/python/chronos/test/bigdl/chronos/model/test_TCMF.py
+++ b/python/chronos/test/bigdl/chronos/model/test_TCMF.py
@@ -17,7 +17,7 @@
 import pytest
 
 from unittest import TestCase
-from .. import op_distributed
+from .. import op_torch, op_distributed
 import numpy as np
 import os
 from numpy.testing import assert_array_almost_equal
@@ -26,6 +26,7 @@ from bigdl.chronos.utils import LazyImport
 TCMF = LazyImport('bigdl.chronos.model.tcmf_model.TCMF')
 
 
+@op_torch
 @op_distributed
 class TestTCMF(TestCase):
     def setup_method(self, method):

--- a/python/chronos/test/bigdl/chronos/model/test_VanillaLSTM_pytorch.py
+++ b/python/chronos/test/bigdl/chronos/model/test_VanillaLSTM_pytorch.py
@@ -16,7 +16,7 @@
 
 import pytest
 from unittest import TestCase
-from .. import op_distributed
+from .. import op_torch, op_distributed
 import numpy as np
 import tempfile
 import os
@@ -45,6 +45,7 @@ def create_data(loader=False):
     return train_data, val_data, test_data
 
 
+@op_torch
 @op_distributed
 class TestVanillaLSTMPytorch(TestCase):
     train_data, val_data, test_data = create_data()

--- a/python/chronos/test/bigdl/chronos/model/test_autoformer.py
+++ b/python/chronos/test/bigdl/chronos/model/test_autoformer.py
@@ -15,16 +15,19 @@
 #
 
 from unittest import TestCase
-from bigdl.chronos.model.autoformer import model_creator
-from bigdl.chronos.pytorch import TSTrainer
+from bigdl.chronos.utils import LazyImport
+model_creator = LazyImport('bigdl.chronos.model.autoformer.model_creator')
+TSTrainer = LazyImport('bigdl.chronos.pytorch.TSTrainer')
+torch = LazyImport('torch')
+TensorDataset = LazyImport('torch.utils.data.TensorDataset')
+DataLoader = LazyImport('torch.utils.data.DataLoader')
 from bigdl.chronos.data import TSDataset
 import pandas as pd
 import numpy as np
 from sklearn.preprocessing import StandardScaler
 import tempfile
 import os
-import torch
-from torch.utils.data import TensorDataset, DataLoader
+from .. import op_torch
 
 def get_ts_df():
     sample_num = np.random.randint(400, 500)
@@ -41,6 +44,7 @@ def get_tsdata(mode="train"):
           .roll(lookback=48, horizon=12, time_enc=True, label_len=12)
     return tsdata
 
+@op_torch
 class TestAutoformerPytorch(TestCase):
     def test_fit(self):
         tsdata = get_tsdata()

--- a/python/chronos/test/bigdl/chronos/model/test_nbeats_pytorch.py
+++ b/python/chronos/test/bigdl/chronos/model/test_nbeats_pytorch.py
@@ -15,12 +15,14 @@
 #
 
 from unittest import TestCase
-from bigdl.chronos.model.nbeats_pytorch import model_creator
-from bigdl.nano.pytorch.trainer import Trainer
+from bigdl.chronos.utils import LazyImport
+model_creator = LazyImport('bigdl.chronos.model.nbeats_pytorch.model_creator')
+Trainer = LazyImport('bigdl.nano.pytorch.trainer.Trainer')
+torch = LazyImport('torch')
 import numpy as np
 import tempfile
 import os
-import torch
+from .. import op_torch
 
 
 def create_data(loader=False):
@@ -55,6 +57,7 @@ def create_data(loader=False):
         return train_data, val_data, test_data
 
 
+@op_torch
 class TestNbeatsPytorch(TestCase):
     train_data, val_data, test_data = create_data(loader=True)
 

--- a/python/chronos/test/bigdl/chronos/model/test_nbeats_pytorch.py
+++ b/python/chronos/test/bigdl/chronos/model/test_nbeats_pytorch.py
@@ -45,8 +45,7 @@ def create_data(loader=False):
     test_data = get_x_y(num_test_samples)
 
     if loader:
-        DataLoader = LazyImport('torch.utils.data.DataLoader')
-        TensorDataset = LazyImport('torch.utils.data.TensorDataset')
+        from torch.utils.data import DataLoader, TensorDataset
         train_loader = DataLoader(TensorDataset(torch.from_numpy(train_data[0]),
                                                 torch.from_numpy(train_data[1])), batch_size=32)
         val_loader = DataLoader(TensorDataset(torch.from_numpy(val_data[0]),
@@ -60,13 +59,13 @@ def create_data(loader=False):
 
 @op_torch
 class TestNbeatsPytorch(TestCase):
-    train_data, val_data, test_data = create_data(loader=True)
 
     def test_fit(self):
+        train_data, val_data, test_data = create_data(loader=True)
         model = model_creator({"past_seq_len": 24,
                                "future_seq_len": 5})
         trainer = Trainer(max_epochs=1)
         pl_model = Trainer.compile(model,
                                    loss=torch.nn.MSELoss(),
                                    optimizer=torch.optim.Adam(model.parameters(), lr=0.005))
-        trainer.fit(pl_model, self.train_data)
+        trainer.fit(pl_model, train_data)

--- a/python/chronos/test/bigdl/chronos/model/test_nbeats_pytorch.py
+++ b/python/chronos/test/bigdl/chronos/model/test_nbeats_pytorch.py
@@ -45,7 +45,8 @@ def create_data(loader=False):
     test_data = get_x_y(num_test_samples)
 
     if loader:
-        from torch.utils.data import DataLoader, TensorDataset
+        DataLoader = LazyImport('torch.utils.data.DataLoader')
+        TensorDataset = LazyImport('torch.utils.data.TensorDataset')
         train_loader = DataLoader(TensorDataset(torch.from_numpy(train_data[0]),
                                                 torch.from_numpy(train_data[1])), batch_size=32)
         val_loader = DataLoader(TensorDataset(torch.from_numpy(val_data[0]),

--- a/python/chronos/test/bigdl/chronos/model/test_tcn.py
+++ b/python/chronos/test/bigdl/chronos/model/test_tcn.py
@@ -20,7 +20,7 @@ TCNPytorch = LazyImport('bigdl.chronos.model.tcn.TCNPytorch')
 import numpy as np
 import tempfile
 import os
-from .. import op_distributed
+from .. import op_torch, op_distributed
 
 
 def create_data():
@@ -43,6 +43,7 @@ def create_data():
     return train_data, val_data, test_data
 
 
+@op_torch
 @op_distributed
 class TestTcn(TestCase):
     train_data, val_data, test_data = create_data()

--- a/python/chronos/test/bigdl/chronos/pytorch/loss/test_linex.py
+++ b/python/chronos/test/bigdl/chronos/pytorch/loss/test_linex.py
@@ -14,12 +14,17 @@
 # limitations under the License.
 #
 
-import torch
+from bigdl.chronos.utils import LazyImport
+torch = LazyImport('torch')
+LinexLoss = LazyImport('bigdl.chronos.pytorch.loss.LinexLoss')
 
-from bigdl.chronos.pytorch.loss import LinexLoss
 from unittest import TestCase
 import pytest
 
+from ... import op_torch
+
+
+@op_torch
 class TestChronosPytorchLoss(TestCase):
 
     def setUp(self):

--- a/python/chronos/test/bigdl/chronos/simulator/test_doppelganger_simulator.py
+++ b/python/chronos/test/bigdl/chronos/simulator/test_doppelganger_simulator.py
@@ -45,9 +45,11 @@ import tempfile
 import numpy as np
 import pytest
 
-from bigdl.chronos.simulator import DPGANSimulator
+from bigdl.chronos.utils import LazyImport
+DPGANSimulator = LazyImport('bigdl.chronos.simulator.DPGANSimulator')
 from bigdl.chronos.simulator.doppelganger.output import Output, OutputType, Normalization
 from unittest import TestCase
+from .. import op_torch
 
 
 def get_train_data():
@@ -64,6 +66,7 @@ def get_train_data():
     return df
 
 
+@op_torch
 class TestDoppelganer(TestCase):
     def setup_method(self, method):
         pass

--- a/python/chronos/test/bigdl/chronos/simulator/test_doppelganger_simulator.py
+++ b/python/chronos/test/bigdl/chronos/simulator/test_doppelganger_simulator.py
@@ -47,7 +47,9 @@ import pytest
 
 from bigdl.chronos.utils import LazyImport
 DPGANSimulator = LazyImport('bigdl.chronos.simulator.DPGANSimulator')
-from bigdl.chronos.simulator.doppelganger.output import Output, OutputType, Normalization
+Output = LazyImport('bigdl.chronos.simulator.doppelganger.output.Output')
+OutputType = LazyImport('bigdl.chronos.simulator.doppelganger.output.OutputType')
+Normalization = LazyImport('bigdl.chronos.simulator.doppelganger.output.Normalization')
 from unittest import TestCase
 from .. import op_torch
 


### PR DESCRIPTION
## Description



### 1. Why the change?

Currently Chronos only supports python 3.7.x. We need to support higher version of python and this pr is used to test [tensorflow] [inference] [automl] installation options on python3.8.

### 2. User API changes

nothing

### 3. Summary of the change 

3.1 add several jobs to test other installation options on python3.8
3.2 split uts according to op_torch / op_tf2 / op_automl / op_distributed / op_inference / op_diff_set_all

### 4. How to test?
- [x] Unit test
