### PR TITLE
Orca: Refactor Runner with ModelIO ABC

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/core/base_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/core/base_runner.py
@@ -17,10 +17,10 @@
 
 # from .lifecycle import LifeCycle
 from .trainable import Trainable
-# from .model_io import ModelIO
+from .modelIO import ModelIO
 
 from abc import ABCMeta
 
 
-class BaseRunner(Trainable, metaclass=ABCMeta):
+class BaseRunner(Trainable, ModelIO, metaclass=ABCMeta):
     pass

--- a/python/orca/src/bigdl/orca/learn/pytorch/core/base_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/core/base_runner.py
@@ -23,5 +23,4 @@ from abc import ABCMeta
 
 
 class BaseRunner(Trainable, ModelIO, metaclass=ABCMeta):
-    def __init__(self, logger) -> None:
-        ModelIO.__init__(self, logger=logger)
+    pass

--- a/python/orca/src/bigdl/orca/learn/pytorch/core/base_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/core/base_runner.py
@@ -23,4 +23,5 @@ from abc import ABCMeta
 
 
 class BaseRunner(Trainable, ModelIO, metaclass=ABCMeta):
-    pass
+    def __init__(self, logger) -> None:
+        ModelIO.__init__(self, logger=logger)

--- a/python/orca/src/bigdl/orca/learn/pytorch/core/modelIO.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/core/modelIO.py
@@ -1,0 +1,94 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from abc import ABCMeta, abstractmethod
+import io
+import torch
+from bigdl.orca.learn.pytorch.utils import get_filesystem
+from bigdl.dllib.utils.log4Error import invalidInputError
+
+
+class ModelIO(metaclass=ABCMeta):
+    def __init__(self, logger):
+        self.logger = logger
+
+    @abstractmethod
+    def get_state_dict(self):
+        """Returns the state of the runner."""
+        pass
+
+    @abstractmethod
+    def load_state_dict(self, state):
+        """Sets the state of the model."""
+        pass
+
+    @abstractmethod
+    def save_checkpoint(self, filepath, save_weights_only=False):
+        """Save checkpoint."""
+        pass
+
+    def get_state_stream(self):
+        """Returns a bytes object for the state dict."""
+        state_dict = self.get_state_dict()
+        state_stream = ModelIO._state_dict2stream(state_dict)
+        return state_stream
+
+    def load_state_stream(self, byte_obj):
+        """Loads a bytes object the training state dict."""
+        state_dict = ModelIO._state_stream2dict(byte_obj)
+        return self.load_state_dict(state_dict)
+
+    def load_checkpoint(self, filepath):
+        fs = get_filesystem(filepath)
+        if not fs.exists(filepath):
+            invalidInputError(False,
+                              f"Checkpoint at {filepath} not found. Aborting training.")
+        with fs.open(filepath, "rb") as f:
+            state_dict = torch.load(f)
+        self.load_state_dict(state_dict)
+
+    def remove_checkpoint(self, filepath):
+        if self.rank == 0:
+            self._remove_checkpoint(filepath)
+
+    def _remove_checkpoint(self, filepath):
+        fs = get_filesystem(filepath)
+        if fs.exists(filepath):
+            fs.rm(filepath, recursive=True)
+            self.logger.debug(f"Removed checkpoint: {filepath}")
+
+    # Internal variables must be accessible
+    @property
+    @abstractmethod
+    def rank(self):
+        pass
+
+    @rank.setter
+    @abstractmethod
+    def rank(self, rank):
+        pass
+
+    @staticmethod
+    def _state_dict2stream(state_dict):
+        _buffer = io.BytesIO()
+        torch.save(state_dict, _buffer)
+        return _buffer.getvalue()
+
+    @staticmethod
+    def _state_stream2dict(byte_obj):
+        _buffer = io.BytesIO(byte_obj)
+        state_dict = torch.load(_buffer)
+        return state_dict

--- a/python/orca/src/bigdl/orca/learn/pytorch/core/modelIO.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/core/modelIO.py
@@ -40,6 +40,11 @@ class ModelIO(metaclass=ABCMeta):
         """Save checkpoint."""
         pass
 
+    @abstractmethod
+    def remove_checkpoint(self, filepath):
+        """Remove checkpoint"""
+        pass
+
     def get_state_stream(self):
         """Returns a bytes object for the state dict."""
         state_dict = self.get_state_dict()
@@ -59,27 +64,6 @@ class ModelIO(metaclass=ABCMeta):
         with fs.open(filepath, "rb") as f:
             state_dict = torch.load(f)
         self.load_state_dict(state_dict)
-
-    def remove_checkpoint(self, filepath):
-        if self.rank == 0:
-            self._remove_checkpoint(filepath)
-
-    def _remove_checkpoint(self, filepath):
-        fs = get_filesystem(filepath)
-        if fs.exists(filepath):
-            fs.rm(filepath, recursive=True)
-            self.logger.debug(f"Removed checkpoint: {filepath}")
-
-    # Internal variables must be accessible
-    @property
-    @abstractmethod
-    def rank(self):
-        pass
-
-    @rank.setter
-    @abstractmethod
-    def rank(self, rank):
-        pass
 
     @staticmethod
     def _state_dict2stream(state_dict):

--- a/python/orca/src/bigdl/orca/learn/pytorch/core/modelIO.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/core/modelIO.py
@@ -22,9 +22,6 @@ from bigdl.dllib.utils.log4Error import invalidInputError
 
 
 class ModelIO(metaclass=ABCMeta):
-    def __init__(self, logger):
-        self.logger = logger
-
     @abstractmethod
     def get_state_dict(self):
         """Returns the state of the runner."""

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -114,7 +114,7 @@ class TorchRunner(BaseRunner):
                             format='[%(asctime)s] %(levelname)-8s %(message)s',
                             datefmt='%Y-%m-%d %H:%M:%S'
                             )
-        self.logger = logging.getLogger(__name__)
+        BaseRunner.__init__(self, logging.getLogger(__name__))
         self.model_creator = model_creator
         self.optimizer_creator = optimizer_creator
         self.loss_creator = loss_creator

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -115,7 +115,7 @@ class TorchRunner(BaseRunner):
                             format='[%(asctime)s] %(levelname)-8s %(message)s',
                             datefmt='%Y-%m-%d %H:%M:%S'
                             )
-        BaseRunner.__init__(self, logging.getLogger(__name__))
+        self.logger = logging.getLogger(__name__)
         self.model_creator = model_creator
         self.optimizer_creator = optimizer_creator
         self.loss_creator = loss_creator


### PR DESCRIPTION
## Description

ModelIO takes charge of load and save stuffs.

All runners should inherit `ModelIO`` as the worker interface and implement the following APIs:
```python
    @abstractmethod
    def get_state_dict(self):
        """Returns the state of the runner."""
        pass

    @abstractmethod
    def load_state_dict(self, state):
        """Sets the state of the model."""
        pass

    @abstractmethod
    def save_checkpoint(self, filepath, save_weights_only=False):
        """Save checkpoint."""
        pass
```

https://github.com/intel-analytics/BigDL/pull/6408#issue-1432988407
