### PR TITLE
Nano : automatic add label for quantization

### DIFF
--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/dataloader.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/dataloader.py
@@ -20,14 +20,17 @@ from bigdl.nano.utils.log4Error import invalidInputError
 
 
 class PytorchOpenVINODataLoader(DataLoader):
-    def __init__(self, dataloader, collate_fn=None):
+    def __init__(self, dataloader, collate_fn=None, original_collate_fn=None):
         invalidInputError(isinstance(dataloader, TorchLoader),
                           "Please provide an instance of torch.utils.data.dataloader.Dataloader.")
         self.dataset = dataloader.dataset
         self.collate_fn = collate_fn
+        self.original_fn = original_collate_fn
 
     def __getitem__(self, index):
         data = self.dataset[index]
+        if self.original_fn:
+            data = self.original_fn(data)
         if self.collate_fn:
             data = self.collate_fn(data)
         return data

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/dataloader.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/dataloader.py
@@ -30,7 +30,8 @@ class PytorchOpenVINODataLoader(DataLoader):
     def __getitem__(self, index):
         data = self.dataset[index]
         if self.original_fn:
-            data = self.original_fn(data)
+            # turn single element into list for default colleta_fn
+            data = self.original_fn([data])
         if self.collate_fn:
             data = self.collate_fn(data)
         return data

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -110,7 +110,8 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         # convert torch metric/dataloader to openvino format
         if metric:
             metric = PytorchOpenVINOMetric(metric=metric, higher_better=higher_better)
-        dataloader = PytorchOpenVINODataLoader(dataloader, collate_fn=self.tensors_to_numpy)
+        dataloader = PytorchOpenVINODataLoader(dataloader, collate_fn=self.tensors_to_numpy,
+                                               original_collate_fn=dataloader.collate_fn)
         model = self.ov_model.pot(dataloader, metric=metric, drop_type=drop_type,
                                   maximal_drop=maximal_drop, max_iter_num=max_iter_num,
                                   n_requests=n_requests, sample_size=sample_size)

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -198,7 +198,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
 
         :param input_sample: (optional) A set of inputs for trace, defaults to None.
                In most cases, you don't need specify this parameter, it will be obtained from
-               training_data.
+               training_data. You have to specidy this parameter only if the forward function
+               of your model contains some kwargs like `def forward(self, x1, x2, x3=1)`.
         :param metric: (optional) A callable object which is used for calculating accuracy.
                It supports two kinds of callable object:
 
@@ -574,7 +575,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             # if not, will append label at last
             if accelerator is not None:
                 calib_dataloader = automatic_add_label_in_dataloader(model,
-                                                                     calib_dataloader)
+                                                                     calib_dataloader,
+                                                                     input_sample)
 
             # transform the dataloader to inc mode
             inc_calib_dataloader =\

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -37,7 +37,7 @@ from bigdl.nano.utils.inference.pytorch.model_utils import get_forward_args, get
 from bigdl.nano.utils.inference.pytorch.metrics import NanoMetric
 from bigdl.nano.utils.inference.pytorch.dataset import RepeatDataset, remove_batch_dim_fn
 from bigdl.nano.utils.inference.pytorch.dataloader import\
-    transform_multiple_input_dataloader_to_inc_mode
+    transform_multiple_input_dataloader_to_inc_mode, automatic_add_label_in_dataloader
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10, save_model, load_model
 from bigdl.nano.common.cpu_schedule import schedule_processors
 from .multi_instance import _MultiInstanceModel, _multi_instance_helper
@@ -570,11 +570,17 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                     calib_dataloader = calib_dataloader
                 else:
                     calib_dataloader = calib_data
+            # judge whether contains label in calib_datalaoder
+            # if not, will append label at last
+            if accelerator is not None:
+                calib_dataloader = automatic_add_label_in_dataloader(model,
+                                                                     calib_dataloader)
 
             # transform the dataloader to inc mode
             inc_calib_dataloader =\
                 transform_multiple_input_dataloader_to_inc_mode(model,
                                                                 calib_dataloader)
+
             if not accelerator or accelerator == 'onnxruntime':
                 method_map = {
                     None: {

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/dataloader.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/dataloader.py
@@ -52,7 +52,8 @@ def automatic_add_label_in_dataloader(model, dataloader):
         # need to add label automaticly
         # generate a warning for user first
         warnings.warn("After checking, it is found that your data does not contain a label item. "
-                      "In order to make quantification work normally, we will automatically generate a dummy label.")
+                      "In order to make quantification work normally, we will automatically "
+                      "generate a dummy label.")
 
         # define a decorator to add label
         def label_collate_fn_wrapper(func):
@@ -97,7 +98,7 @@ def _check_whether_add_label(model, dataloader):
     forward_args = get_forward_args(model)
     forward_args_len = len(forward_args)
     input_sample = next(iter(dataloader))
-    
+
     if isinstance(input_sample, torch.Tensor):
         if forward_args_len >= 1:
             return True

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/dataloader.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/dataloader.py
@@ -58,10 +58,7 @@ def automatic_add_label_in_dataloader(model, dataloader, input_sample=None):
         # define a decorator to add label
         def label_collate_fn_wrapper(func):
             def collate_fn(batch):
-                if isinstance(batch, torch.Tensor):
-                    res = batch
-                else:
-                    res = func(batch)
+                res = func(batch)
                 # add dummy label
                 return res, torch.ones(1).long()
             return collate_fn

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/dataloader.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/dataloader.py
@@ -17,6 +17,8 @@
 from bigdl.nano.utils.inference.pytorch.model_utils import get_forward_args
 from typing import Sequence
 from copy import deepcopy
+import torch
+import warnings
 
 
 def transform_multiple_input_dataloader_to_inc_mode(model, dataloader):
@@ -45,6 +47,31 @@ def transform_multiple_input_dataloader_to_inc_mode(model, dataloader):
     return dataloader
 
 
+def automatic_add_label_in_dataloader(model, dataloader):
+    if _check_whether_add_label(model, dataloader) is True:
+        # need to add label automaticly
+        # generate a warning for user first
+        warnings.warn("After checking, it is found that your data does not contain a label item. "
+                      "In order to make quantification work normally, we will automatically generate a dummy label.")
+
+        # define a decorator to add label
+        def label_collate_fn_wrapper(func):
+            def collate_fn(batch):
+                if isinstance(batch, torch.Tensor):
+                    res = batch
+                else:
+                    res = func(batch)
+                # add dummy label
+                return res, torch.ones(1).long()
+            return collate_fn
+
+        # construct a new dataloader
+        new_dataloader = deepcopy(dataloader)
+        new_dataloader.collate_fn = label_collate_fn_wrapper(new_dataloader.collate_fn)
+        return new_dataloader
+    return dataloader
+
+
 def _need_dataloader_type_transformation(model, dataloader):
     # get forward method's parameter number
     forward_args = get_forward_args(model)
@@ -63,3 +90,29 @@ def _need_dataloader_type_transformation(model, dataloader):
         if len(input_sample[0]) == forward_args_len:
             return False, forward_args_len
     return True, forward_args_len
+
+
+def _check_whether_add_label(model, dataloader):
+    # get forward method's parameter number and input sample
+    forward_args = get_forward_args(model)
+    forward_args_len = len(forward_args)
+    input_sample = next(iter(dataloader))
+    
+    if isinstance(input_sample, torch.Tensor):
+        if forward_args_len >= 1:
+            return True
+    elif isinstance(input_sample, Sequence):
+        if len(input_sample[0]) == forward_args_len:
+            return False
+        else:
+            if len(input_sample) > forward_args_len:
+                return False
+            else:
+                # test run to check if input_sample meet input requirent
+                try:
+                    model(*input_sample)
+                    return True
+                except RuntimeError:
+                    # input sample may contain label already
+                    pass
+    return False

--- a/python/nano/test/pytorch/tests/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/test_inference_optimizer.py
@@ -292,7 +292,7 @@ class TestInferencePipeline(TestCase):
                                thread_num=1,
                                latency_sample_num=10)
         # test automatic fill label for quantization
-        optim_dict = inference_opt._optimize_result
+        optim_dict = inference_opt.optimized_model_dict
         assert optim_dict["openvino_int8"]["status"] == "successful"
         assert optim_dict["onnxruntime_int8_qlinear"]["status"] == "successful"
         assert optim_dict["onnxruntime_int8_integer"]["status"] == "successful"
@@ -429,7 +429,7 @@ class TestInferencePipeline(TestCase):
                                thread_num=1,
                                latency_sample_num=10)
         # test automatic fill label for quantization
-        optim_dict = inference_opt._optimize_result
+        optim_dict = inference_opt.optimized_model_dict
         assert optim_dict["openvino_int8"]["status"] == "successful"
         assert optim_dict["onnxruntime_int8_qlinear"]["status"] == "successful"
         assert optim_dict["onnxruntime_int8_integer"]["status"] == "successful"

--- a/python/nano/test/pytorch/tests/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/test_inference_optimizer.py
@@ -291,11 +291,10 @@ class TestInferencePipeline(TestCase):
                                training_data=input_sample,
                                thread_num=1,
                                latency_sample_num=10)
-        # test automatic fill label for quantization
+        # test automatic add label for quantization
         optim_dict = inference_opt.optimized_model_dict
-        assert optim_dict["openvino_int8"]["status"] == "successful"
-        assert optim_dict["onnxruntime_int8_qlinear"]["status"] == "successful"
-        assert optim_dict["onnxruntime_int8_integer"]["status"] == "successful"
+        assert optim_dict["openvino_int8"]["status"] in ("successful", "early_stopped")
+        assert optim_dict["onnxruntime_int8_qlinear"]["status"] in ("successful", "early_stopped")
 
     def test_pipeline_with_single_tuple_of_tensor(self):
         input_sample = (torch.rand(1, 3, 32, 32), torch.Tensor([1]).int())
@@ -428,8 +427,7 @@ class TestInferencePipeline(TestCase):
                                training_data=dataloader,
                                thread_num=1,
                                latency_sample_num=10)
-        # test automatic fill label for quantization
+        # test automatic add label for quantization
         optim_dict = inference_opt.optimized_model_dict
-        assert optim_dict["openvino_int8"]["status"] == "successful"
-        assert optim_dict["onnxruntime_int8_qlinear"]["status"] == "successful"
-        assert optim_dict["onnxruntime_int8_integer"]["status"] == "successful"
+        assert optim_dict["openvino_int8"]["status"] in ("successful", "early_stopped")
+        assert optim_dict["onnxruntime_int8_qlinear"]["status"] in ("successful", "early_stopped")

--- a/python/nano/test/pytorch/tests/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/test_inference_optimizer.py
@@ -320,7 +320,11 @@ class TestInferencePipeline(TestCase):
             x1 = torch.randn(32, 10)
             x2 = torch.randn(32, 10)
             y = torch.randn(32, 1)
-            dataloader = DataLoader(TensorDataset(x1, x2, y), batch_size=1)
+            if isinstance(net, MultipleInputNet):
+                dataloader = DataLoader(TensorDataset(x1, x2, y), batch_size=1)
+            else:
+                x3 = torch.randn(32, 1)
+                dataloader = DataLoader(TensorDataset(x1, x2, x3, y), batch_size=1)
 
             # int8
             InferenceOptimizer.quantize(net,
@@ -336,7 +340,7 @@ class TestInferencePipeline(TestCase):
                                      accelerator="onnxruntime",
                                      input_sample=dataloader)
 
-            # int8-openvino
+            # openvino
             InferenceOptimizer.trace(net,
                                      accelerator="openvino",
                                      input_sample=dataloader)

--- a/python/nano/test/pytorch/tests/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/test_inference_optimizer.py
@@ -291,6 +291,8 @@ class TestInferencePipeline(TestCase):
                                training_data=input_sample,
                                thread_num=1,
                                latency_sample_num=10)
+        if TORCH_VERSION_LESS_1_10:
+            return
         # test automatic add label for quantization
         optim_dict = inference_opt.optimized_model_dict
         assert optim_dict["openvino_int8"]["status"] in ("successful", "early_stopped")
@@ -431,6 +433,8 @@ class TestInferencePipeline(TestCase):
                                training_data=dataloader,
                                thread_num=1,
                                latency_sample_num=10)
+        if TORCH_VERSION_LESS_1_10:
+            return
         # test automatic add label for quantization
         optim_dict = inference_opt.optimized_model_dict
         assert optim_dict["openvino_int8"]["status"] in ("successful", "early_stopped")

--- a/python/nano/test/pytorch/tests/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/test_inference_optimizer.py
@@ -291,6 +291,11 @@ class TestInferencePipeline(TestCase):
                                training_data=input_sample,
                                thread_num=1,
                                latency_sample_num=10)
+        # test automatic fill label for quantization
+        optim_dict = inference_opt._optimize_result
+        assert optim_dict["openvino_int8"]["status"] == "successful"
+        assert optim_dict["onnxruntime_int8_qlinear"]["status"] == "successful"
+        assert optim_dict["onnxruntime_int8_integer"]["status"] == "successful"
 
     def test_pipeline_with_single_tuple_of_tensor(self):
         input_sample = (torch.rand(1, 3, 32, 32), torch.Tensor([1]).int())


### PR DESCRIPTION
## Description

* During OOB inference, we found a common case, that is, for users, they only know / remember / can provide a single Tensor / Tensor tuple / dataloader as input, usually they don't have true labels and they don't know they should prepare true labels for quantization.
* However, ONNXRuntime quantization and openvino quantization requires data format like following:
`for idx, (input, label) in enumarate(calib_dataloader)`
* So user always fail on these three methods.
* To make users can quantize successfully as much as possible, here I provide an automatic filling of dummy label for above cases. That is, if users don't provide corresponding labels, for ONNXRuntime and openvino quantization, we will generate a dummy label automaticlly for them.

### 1. Why the change?

To make users can quantize successfully as much as possible even if they don't have data labels or they don't know they should prepare labels.

### 2. User API changes

No change. But below cases which before will fail to convert, now can convert successfully.



### 3. Summary of the change 

* Generate a dummy label automatically for quantization if user don't pass this.

### 4. How to test?
- [x] Unit test
- [x] Application test
