### PR TITLE
[Doc] Mock module `cpuinfo` for fixing missing Nano/Chronos api doc

### DIFF
--- a/docs/readthedocs/source/conf.py
+++ b/docs/readthedocs/source/conf.py
@@ -18,7 +18,7 @@ import glob
 import shutil
 import urllib
 
-autodoc_mock_imports = ["openvino", "pytorch_lightning", "keras"]
+autodoc_mock_imports = ["openvino", "pytorch_lightning", "keras", "cpuinfo"]
 
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, '.')


### PR DESCRIPTION
Mock module `cpuinfo` for fixing missing Nano/Chronos api doc

Document test: https://yuwentestdocs.readthedocs.io/en/fix-api-doc/doc/PythonAPI/Nano/pytorch.html