### PR TITLE
Chronos: a better implementation for cycle length detection

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/utils/cycle_detection.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/cycle_detection.py
@@ -18,7 +18,7 @@ from scipy.fftpack import fft, fftfreq
 import numpy as np
 
 
-def cycle_length_est(data, top_k=3, return_acf_score=False, adjust=False):
+def cycle_length_est(data, top_k=3, adjust=False):
     '''
     Detect the cycle of a time series.
     code adaptted from https://zhuanlan.zhihu.com/p/394327245
@@ -27,6 +27,7 @@ def cycle_length_est(data, top_k=3, return_acf_score=False, adjust=False):
     :param top_k: The freq with top top_k power after fft will be
            used to check the autocorrelation. Higher top_k might be time-consuming.
            The value is default to 3.
+    :param adjust: if normalization is applied to the final result.
     '''
     from bigdl.nano.utils.log4Error import invalidInputError
     invalidInputError((data.size//2) > abs(top_k)+1,
@@ -56,10 +57,7 @@ def cycle_length_est(data, top_k=3, return_acf_score=False, adjust=False):
             cycle_length_est = lag
             largest_acf_score = acf_score
 
-    if return_acf_score:
-        return cycle_length_est, largest_acf_score
-    else:
-        return cycle_length_est
+    return cycle_length_est
 
 
 def acf(x, lag, adjust):

--- a/python/chronos/src/bigdl/chronos/data/utils/cycle_detection.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/cycle_detection.py
@@ -18,7 +18,7 @@ from scipy.fftpack import fft, fftfreq
 import numpy as np
 
 
-def cycle_length_est(data, top_k=3):
+def cycle_length_est(data, top_k=3, return_acf_score=False, adjust=False):
     '''
     Detect the cycle of a time series.
     code adaptted from https://zhuanlan.zhihu.com/p/394327245
@@ -32,7 +32,6 @@ def cycle_length_est(data, top_k=3):
     invalidInputError((data.size//2) > abs(top_k)+1,
                       "top_k must be less than half the length of the time series,"
                       " but top_k and data length are {top_k} and {data.size} respectively.")
-    invalidInputError(np.any(np.diff(data) != 0), "Data elements cannot all be the same.")
 
     fft_series = fft(data)
     power = np.abs(fft_series)
@@ -50,11 +49,31 @@ def cycle_length_est(data, top_k=3):
     # Expected time period
     largest_acf_score = -float("inf")
     cycle_length_est = None
-    from statsmodels.tsa.stattools import acf
+
     for lag in fft_periods:
-        acf_score = acf(data, nlags=lag)[-1]
+        acf_score = acf(data, lag, adjust)
         if acf_score > largest_acf_score:
             cycle_length_est = lag
             largest_acf_score = acf_score
 
-    return cycle_length_est
+    if return_acf_score:
+        return cycle_length_est, largest_acf_score
+    else:
+        return cycle_length_est
+
+
+def acf(x, lag, adjust):
+    '''
+    generate acf score as in statsmodels.tsa.stattools.acf
+    code adapted from https://stackoverflow.com/questions/36038927/
+    '''
+    length = x.size
+    y1, y2 = x[:(length-lag)], x[lag:]
+    sum_product = np.sum((y1-np.mean(x))*(y2-np.mean(x)))
+    if adjust:
+        var = np.var(x)
+        if var == 0:
+            return 0
+        return sum_product / ((length - lag) * var)
+    else:
+        return sum_product

--- a/python/chronos/test/bigdl/chronos/data/test_tsdataset.py
+++ b/python/chronos/test/bigdl/chronos/data/test_tsdataset.py
@@ -1200,8 +1200,8 @@ class TestTSDataset(TestCase):
         tsdata = TSDataset.from_pandas(df,
                                        target_col='value',
                                        dt_col='datetime')
-        with pytest.raises(RuntimeError):
-            tsdata.get_cycle_length(aggregate='min', top_k=3)
+        # not meaningful, but no error should be raised.
+        tsdata.get_cycle_length(aggregate='min', top_k=3)
 
     @op_torch
     def test_lookback_equal_to_one(self):


### PR DESCRIPTION
## Description

### 1. Why the change?
`statsmodel` is needed for cycle length detection, we remove our requirement for this dependency.
More robust than `statsmodel`'s implementation

### 2. User API changes
Nothing

### 3. Summary of the change 
Change to a `numpy` implementation

### 4. How to test?
- [ ] Unit test

### 5. New dependencies
remove `statsmodel`
