### PR TITLE
Chronos: add dummy encoder choice to lighten the TCN model

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
@@ -44,6 +44,7 @@ class TCNForecaster(BasePytorchForecaster):
                  future_seq_len,
                  input_feature_num,
                  output_feature_num,
+                 dummy_encoder=False,
                  num_channels=[16]*3,
                  kernel_size=3,
                  normalization=True,
@@ -69,6 +70,9 @@ class TCNForecaster(BasePytorchForecaster):
         :param future_seq_len: Specify the output time steps (i.e. horizon).
         :param input_feature_num: Specify the feature dimension.
         :param output_feature_num: Specify the output dimension.
+        :param dummy_encoder: bool, no encoder is applied if True, which will
+               turn TCNForecaster to a Linear Model. If True, input_feature_num
+               should equals to output_feature_num.
         :param num_channels: Specify the convolutional layer filter number in
                TCN's encoder. This value defaults to [16]*3.
         :param kernel_size: Specify convolutional layer filter height in TCN's
@@ -127,7 +131,8 @@ class TCNForecaster(BasePytorchForecaster):
             "dropout": dropout,
             "seed": seed,
             "normalization": normalization,
-            "decomposition_kernel_size": decomposition_kernel_size
+            "decomposition_kernel_size": decomposition_kernel_size,
+            "dummy_encoder": dummy_encoder
         }
         self.loss_config = {
             "loss": loss

--- a/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
@@ -17,6 +17,7 @@
 import torch
 from bigdl.chronos.forecaster.base_forecaster import BasePytorchForecaster
 from bigdl.chronos.model.tcn import model_creator, optimizer_creator, loss_creator
+from bigdl.nano.utils.log4Error import invalidInputError
 
 
 class TCNForecaster(BasePytorchForecaster):
@@ -117,6 +118,13 @@ class TCNForecaster(BasePytorchForecaster):
         :param distributed_backend: str, select from "ray" or
                "horovod". The value defaults to "ray".
         """
+        # config check
+        if dummy_encoder:
+            invalidInputError(input_feature_num == output_feature_num,
+                              "if dummy_encoder is set to True, then the "
+                              "model should have equal input_feature_num "
+                              "and output_feature_num.")
+
         # config setting
         self.data_config = {
             "past_seq_len": past_seq_len,

--- a/python/chronos/src/bigdl/chronos/model/tcn.py
+++ b/python/chronos/src/bigdl/chronos/model/tcn.py
@@ -60,7 +60,7 @@ class Chomp1d(nn.Module):
 class DummyEncoder(nn.Module):
     def __init__(self):
         super().__init__()
-    
+
     def forward(self, x):
         return x
 

--- a/python/chronos/src/bigdl/chronos/model/tcn.py
+++ b/python/chronos/src/bigdl/chronos/model/tcn.py
@@ -57,6 +57,14 @@ class Chomp1d(nn.Module):
         return x[:, :, :-self.chomp_size].contiguous()
 
 
+class DummyEncoder(nn.Module):
+    def __init__(self):
+        super().__init__()
+    
+    def forward(self, x):
+        return x
+
+
 class TemporalBlock(nn.Module):
     def __init__(self, n_inputs, n_outputs, kernel_size, stride, dilation, padding, dropout=0.2,
                  repo_initialization=True):
@@ -101,6 +109,7 @@ class TemporalConvNet(nn.Module):
                  future_seq_len,
                  output_feature_num,
                  num_channels,
+                 dummy_encoder=False,
                  kernel_size=3,
                  dropout=0.1,
                  repo_initialization=True,
@@ -110,7 +119,7 @@ class TemporalConvNet(nn.Module):
         num_channels.append(output_feature_num)
 
         layers = []
-        num_levels = len(num_channels)
+        num_levels = 0 if dummy_encoder else len(num_channels)
         for i in range(num_levels):
             dilation_size = 2 ** i
             in_channels = input_feature_num if i == 0 else num_channels[i - 1]
@@ -120,7 +129,7 @@ class TemporalConvNet(nn.Module):
                                      padding=(kernel_size-1) * dilation_size,
                                      dropout=dropout, repo_initialization=repo_initialization)]
 
-        self.tcn = nn.Sequential(*layers)
+        self.tcn = DummyEncoder() if dummy_encoder else nn.Sequential(*layers)
         self.linear = nn.Linear(past_seq_len, future_seq_len)
         if repo_initialization:
             self.init_weights()
@@ -152,6 +161,7 @@ def model_creator(config):
                             future_seq_len=config["future_seq_len"],
                             output_feature_num=config["output_feature_num"],
                             num_channels=num_channels.copy(),
+                            dummy_encoder=config.get("dummy_encoder", False),
                             kernel_size=config.get("kernel_size", 7),
                             dropout=config.get("dropout", 0.2),
                             repo_initialization=config.get("repo_initialization", True),
@@ -166,6 +176,7 @@ def model_creator(config):
                                      future_seq_len=config["future_seq_len"],
                                      output_feature_num=config["output_feature_num"],
                                      num_channels=num_channels.copy(),
+                                     dummy_encoder=config.get("dummy_encoder", False),
                                      kernel_size=config.get("kernel_size", 7),
                                      dropout=config.get("dropout", 0.2),
                                      repo_initialization=config.get("repo_initialization", True),

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -1329,6 +1329,30 @@ class TestChronosModelTCNForecaster(TestCase):
         eval_t = forecaster.evaluate(test_loader_shuffle_t)
         assert_almost_equal(eval_f, eval_t)
 
+    def test_tcn_forecaster_dummy_encoder(self):
+        from torch.utils.data import DataLoader, TensorDataset
+        from numpy.testing import assert_almost_equal
+        train_data, val_data, test_data = create_data()
+        forecaster = TCNForecaster(past_seq_len=24,
+                                   future_seq_len=5,
+                                   input_feature_num=1,
+                                   output_feature_num=1,
+                                   dummy_encoder=True,
+                                   loss="mse",
+                                   lr=0.01)
+        forecaster.fit(train_data, epochs=2)
+        test_loader_shuffle_f = DataLoader(TensorDataset(torch.from_numpy(test_data[0]),
+                                                         torch.from_numpy(test_data[1])),
+                                           batch_size=32,
+                                           shuffle=False)
+        test_loader_shuffle_t = DataLoader(TensorDataset(torch.from_numpy(test_data[0]),
+                                                         torch.from_numpy(test_data[1])),
+                                           batch_size=32,
+                                           shuffle=True)
+        eval_f = forecaster.evaluate(test_loader_shuffle_f)
+        eval_t = forecaster.evaluate(test_loader_shuffle_t)
+        assert_almost_equal(eval_f, eval_t)
+
     @op_inference
     def test_tcn_forecaster_eval_with_onnx_shuffle_loader(self):
         from torch.utils.data import DataLoader, TensorDataset


### PR DESCRIPTION
## Description

### 1. Why the change?

greatly inspired by https://arxiv.org/abs/2205.13504, we choose to adopt the model in a special way - as a special case of TCN.

### 2. User API changes

add a new `dummy_encoder` parameter to `TCNForecaster`

### 3. Summary of the change 
if `dummy_encoder` is set to True, then tcn encoder is removed and TCN becomes a Linear model.

### 4. How to test?
- [ ] Unit test
