### PR TITLE
Nano: Fix: env variables are different when keep sourcing `bigdl-nano-init` twice

### DIFF
--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -44,8 +44,8 @@ function display-help {
         echo "    -h, --help                Display this help message and exit."
         echo "    -o, --disable-openmp      Disable openMP and unset related variables"
         echo "    -j, --enable-jemalloc     Enable jemalloc and unset related variables"
-		echo "    -c, --disable-tcmalloc    Disable tcmalloc and unset related variables"
-		echo "    -f, --enable-tensorflow   Enable tensorflow specific OMP_NUM_THREADS setting"
+        echo "    -c, --disable-tcmalloc    Disable tcmalloc and unset related variables"
+        echo "    -f, --enable-tensorflow   Enable tensorflow specific OMP_NUM_THREADS setting"
 }
 
 # Init

--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -44,8 +44,16 @@ function display-help {
         echo "    -h, --help                Display this help message and exit."
         echo "    -o, --disable-openmp      Disable openMP and unset related variables"
         echo "    -j, --enable-jemalloc     Enable jemalloc and unset related variables"
-		echo "    -c, --disable-tcmalloc   Disable tcmalloc and unset related variables"
+		echo "    -c, --disable-tcmalloc    Disable tcmalloc and unset related variables"
+		echo "    -f, --enable-tensorflow   Enable tensorflow specific OMP_NUM_THREADS setting"
 }
+
+# Init
+OPENMP=0
+JEMALLOC=1
+TCMALLOC=1
+# Set TF_ENABLE_ONEDNN_OPTS
+export TF_ENABLE_ONEDNN_OPTS=1
 
 while getopts ":ojhc-:" opt; do
 	case ${opt} in
@@ -82,6 +90,9 @@ while getopts ":ojhc-:" opt; do
 		c )
 			disable-tcmalloc-var
 			;;
+		f )
+			enable-tensorflow-var
+			;;
 		h )
 			display-help
 			exit 0
@@ -93,11 +104,6 @@ while getopts ":ojhc-:" opt; do
 done
 
 shift $((OPTIND -1))
-
-# Init
-OPENMP=0
-JEMALLOC=0
-TCMALLOC=0
 
 # Find conda dir
 if [ ! -z $BASH_SOURCE ]; then
@@ -140,6 +146,7 @@ if [ -f "${LIB_DIR}/libiomp5.so" ]; then
 		export OMP_NUM_THREADS=$((cores_per_socket*sockets_))
 		export NANO_TF_INTER_OP=1
 	else
+		echo "Setting OMP_NUM_THREADS specified for tensorflow..."
 		export OMP_NUM_THREADS=${cores_per_socket}
 		export NANO_TF_INTER_OP=$sockets_
 	fi
@@ -153,12 +160,6 @@ if [ -f "${LIB_DIR}/libiomp5.so" ]; then
 else
 	echo "No openMP library found in ${LIB_DIR}."
 fi
-
-# Detect jemalloc library
-JEMALLOC=1
-
-# Detect tcmalloc library
-TCMALLOC=1
 
 # set env variables
 echo "Setting MALLOC_CONF..."
@@ -193,10 +194,6 @@ if [ -z "${LD_PRELOAD:-}" ]; then
 		export LD_PRELOAD=$(echo ${LD_PRELOAD} ${TCMALLOC_PATH})
 	fi
 fi
-
-# Set TF_ENABLE_ONEDNN_OPTS
-export TF_ENABLE_ONEDNN_OPTS=1
-export ENABLE_TF_OPTS=1
 
 # Disable openmp or jemalloc according to options
 if [ ! -z "${DISABLE_OPENMP_VAR:-}" ]; then


### PR DESCRIPTION
## Description

Fix: env variables are different when keep sourcing `bigdl-nano-init` twice, see #6634