### PR TITLE
[PPML][EHSM] Dkeyserver Fault Tolerance

### DIFF
--- a/ppml/services/ehsm/kubernetes/README.md
+++ b/ppml/services/ehsm/kubernetes/README.md
@@ -64,6 +64,7 @@ nfsPath: a_nfs_shared_folder_path_on_the_server   --->   <an_existing_shared_fol
 ......
 pccsIP: your_pccs_ip                              --->   <the_ip_address_in_your_subnetwork_you_have_assigned_to_pccs_in_step1>
 kmsIP: your_kms_ip_to_use_as                      --->   <an_unused_ip_address_in_your_subnetwork_to_assign_to_kms>
+dkeyserverNodeName: the_fixed_node_you_want_to_assign_dkeyserver_to --->   <a_node_name_in_k8s_cluster_to_run_dkerysever_on>
 ```
 
 Then, deploy BigDL-eHSM-KMS on kubernetes:

--- a/ppml/services/ehsm/kubernetes/bigdl-ehsm-kms.yaml
+++ b/ppml/services/ehsm/kubernetes/bigdl-ehsm-kms.yaml
@@ -9,6 +9,22 @@ data:
     couch_root_username: $couchdbRootUsername
     couch_root_password: $couchdbRootPassword
 ---
+# bigdl-ehsm-kms PersistentVolume used by dkeyserver and couchdb
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ehsm-pv-nfs
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: nfs
+  nfs:
+    path: $nfsPath
+    server: $nfsServerIp
+---
 # bigdl-ehsm-kms dkeyserver
 apiVersion: v1
 kind: Service
@@ -66,12 +82,26 @@ spec:
           name: dev-provision
         - mountPath: /var/run/aesmd
           name: dev-aesmd
+        - mountPath: /etc/dkey.bin
+          name: domain-key-persistent-storage
         env:
         - name: PCCS_URL
           value: "https://$pccsIP:18081"
         ports:
         - containerPort: 8888
           name: dkeyserver-port
+      nodeSelector:
+        dkeyservernode: true
+    # Annotate below if restart
+    volumeClaimTemplates:
+        - metadata:
+            name: domain-key-persistent-storage
+          spec:
+            accessModes: [ "ReadWriteOnce" ]
+            storageClassName: "nfs"
+            resources:
+              requests:
+              storage: 500Mi
 ---
 # bigdl-ehsm-kms ConfigMap
 apiVersion: v1
@@ -86,23 +116,6 @@ data:
   dkeyserver_ip: "dkeyserver-0.dkeyserver"
   dkeyserver_port: "8888"
   pccs_url: "https://$pccsIP:18081"
----
-# bigdl-ehsm-kms PersistentVolume for CouchDB
-apiVersion: v1
-kind: PersistentVolume 
-metadata:
-  name: ehsm-pv-nfs
-spec:
-  capacity:
-    storage: 10Gi 
-  accessModes:
-    - ReadWriteOnce 
-  persistentVolumeReclaimPolicy: Retain 
-  storageClassName: nfs
-  nfs:
-    path: $nfsPath
-    server: $nfsServerIp
-
 ---
 # bigdl-ehsm-kms CouchDB
 apiVersion: v1
@@ -179,7 +192,7 @@ spec:
       storageClassName: "nfs"
       resources:
         requests:
-          storage: 10Gi
+          storage: 9Gi
 
 ---
 # dkey cache          

--- a/ppml/services/ehsm/kubernetes/bigdl-ehsm-kms.yaml
+++ b/ppml/services/ehsm/kubernetes/bigdl-ehsm-kms.yaml
@@ -9,14 +9,14 @@ data:
     couch_root_username: $couchdbRootUsername
     couch_root_password: $couchdbRootPassword
 ---
-# bigdl-ehsm-kms PersistentVolume used by dkeyserver and couchdb
+# bigdl-ehsm-kms PersistentVolume used by dkeyserver
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: ehsm-pv-nfs
+  name: domain-key-nfs-pv
 spec:
   capacity:
-    storage: 10Gi
+    storage: 100Mi
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
@@ -91,17 +91,17 @@ spec:
         - containerPort: 8888
           name: dkeyserver-port
       nodeSelector:
-        dkeyservernode: true
-    # Annotate below if restart
-    volumeClaimTemplates:
-        - metadata:
-            name: domain-key-persistent-storage
-          spec:
-            accessModes: [ "ReadWriteOnce" ]
-            storageClassName: "nfs"
-            resources:
-              requests:
-              storage: 500Mi
+        dkeyservernode: "true"
+  # Annotate below if restart
+  volumeClaimTemplates:
+      - metadata:
+          name: domain-key-persistent-storage
+        spec:
+          accessModes: [ "ReadWriteOnce" ]
+          storageClassName: "nfs"
+          resources:
+            requests:
+              storage: 100Mi
 ---
 # bigdl-ehsm-kms ConfigMap
 apiVersion: v1
@@ -116,6 +116,22 @@ data:
   dkeyserver_ip: "dkeyserver-0.dkeyserver"
   dkeyserver_port: "8888"
   pccs_url: "https://$pccsIP:18081"
+---
+# bigdl-ehsm-kms PersistentVolume used by couchdb
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: couchdb-nfs-pv
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: nfs
+  nfs:
+    path: $nfsPath
+    server: $nfsServerIp
 ---
 # bigdl-ehsm-kms CouchDB
 apiVersion: v1
@@ -192,7 +208,7 @@ spec:
       storageClassName: "nfs"
       resources:
         requests:
-          storage: 9Gi
+          storage: 10Gi
 
 ---
 # dkey cache          

--- a/ppml/services/ehsm/kubernetes/install-bigdl-ehsm-kms.sh
+++ b/ppml/services/ehsm/kubernetes/install-bigdl-ehsm-kms.sh
@@ -10,7 +10,9 @@ export dkeycacheImageName=intelccc/ehsm_dkeycache:0.3.0
 export ehsmKmsImageName=intelccc/ehsm_kms:0.3.0
 export pccsIP=your_pccs_IP
 export kmsIP=your_kms_ip_to_use_as
+export dkeyserverNodeName=the_fixed_node_you_want_to_assign_dkeyserver_to #kubectl get nodes, and choose one
 
 # Create k8s namespace and apply BigDL-eHSM-KMS
 kubectl create namespace bigdl-ehsm-kms
+kubectl label nodes $dkeyserverNodeName dkeyservernode=true
 envsubst < bigdl-ehsm-kms.yaml | kubectl apply -f -

--- a/ppml/services/ehsm/kubernetes/uninstall-bigdl-ehsm-kms.sh
+++ b/ppml/services/ehsm/kubernetes/uninstall-bigdl-ehsm-kms.sh
@@ -6,5 +6,5 @@ kubectl delete deployment dkeycache -n bigdl-ehsm-kms
 kubectl delete statefulsets.apps couchdb -n bigdl-ehsm-kms
 kubectl delete statefulsets.apps dkeyserver -n bigdl-ehsm-kms
 kubectl delete pvc couch-persistent-storage-couchdb-0 -n bigdl-ehsm-kms
-kubectl delete pv ehsm-pv-nfs
+kubectl delete pvc domain-key-persistent-storage-dkeyserver-0
 kubectl delete namespace bigdl-ehsm-kms


### PR DESCRIPTION
## Description

1. Store domainkey persistently by stateful PVC.
2. Label dkeyserver to a fixed node as ckey is generated from CPU which results in that dkeyserver cannot be moved among nodes. The better patch will be released by ehsm, and we temporarily patch in this way to avoid dkeyserver failure.

### 1. Why the change?

Patch for two vulnerabilities (domainkey and ckey) of dkeyserver.

### 2. User API changes

Need to manually select a fixed node for dkeyserver in k8s cluster.

### 3. Summary of the change 

Dkeyserver fault tolerance.

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...

