### PR TITLE
Fix wrong num_steps in PyTorch pyspark estimator evaluate

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -306,8 +306,9 @@ class PyTorchPySparkEstimator(BaseEstimator):
             self.state_dict = PyTorchPySparkEstimator._get_state_dict_from_remote(self.model_dir)
             worker_stats = res
         else:
-            self.state_dict = res[0]
-            worker_stats = res[1]
+            self.state_dict = res[0]  # state dicts of all runners would be the same
+            # Each runner would return a list of worker stats for different epochs
+            worker_stats = [item for item in res if isinstance(item, list)]
 
         epoch_stats = list(map(list, zip(*worker_stats)))
         if reduce_results:

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -477,6 +477,7 @@ class PyTorchPySparkEstimator(BaseEstimator):
                                              mode="evaluate",
                                              num_workers=self.num_workers)
         if isinstance(data, SparkXShards):
+            params["wrap_dataloader"] = False
             if data._get_class_name() == 'pandas.core.frame.DataFrame':
                 data = process_xshards_of_pandas_dataframe(data, feature_cols, label_cols)
             # set train/validation data

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
@@ -147,7 +147,7 @@ class PytorchPysparkWorker(TorchRunner):
         if self.model_dir is not None:
             return [stats_list]
         else:
-            return state_dict, [stats_list]
+            return [state_dict, stats_list]
 
     def validate(self, data_creator, batch_size=32, num_steps=None, profile=False,
                  info=None, wrap_dataloader=None):

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
@@ -330,6 +330,7 @@ class TestPyTorchEstimator(TestCase):
                round(sum(validation_time) / 2, 4)
         assert round(agg_worker_stats["profile"]["mean_eval_fwd_s"], 4) == \
                round(sum(forward_time) / 2, 4)
+        assert agg_worker_stats["num_samples"] == 100
 
     def test_partition_num_less_than_workers(self):
         sc = init_nncontext()


### PR DESCRIPTION
Fix https://github.com/intel-analytics/BigDL/issues/6573

1. Bug for Pyspark estimator evaluate: for SparkXShards input, should explicitly set wrap_dataloader=False.
2. Bug for Pyspark estimator fit:
- When return state_dict and stats, should be one list instead of a tuple of dict and list; otherwise worker_stats will have one extra list dimension
- Stats for all workers are not correctly get, res[1] is only the stats for the first worker.

Checked for both spark and ray backends, fit and evaluate all wrap_dataloader=False for SparkXShards.
predict doesn't involve wrap_dataloader.

Tested the stats for both fit and evaluate