### PR TITLE
Use copy_bom to generate occlum spark content

### DIFF
--- a/ppml/trusted-big-data-ml/scala/docker-occlum/run_spark_on_occlum_glibc.sh
+++ b/ppml/trusted-big-data-ml/scala/docker-occlum/run_spark_on_occlum_glibc.sh
@@ -138,50 +138,11 @@ init_instance() {
 }
 
 build_spark() {
-    # Copy python examples and unzip python lib
-    mkdir -p image/py-examples
-    cp -rf /opt/py-examples/* image/py-examples
-    # Copy scala files for absolute path examples
-    mkdir -p image/examples/
-    cp -rf /opt/spark/examples/* image/examples/
-    # Copy JVM and class file into Occlum instance and build
-    cd /opt/occlum_spark
-    mkdir -p image/usr/lib/jvm
-    cp -r /usr/lib/jvm/java-8-openjdk-amd64 image/usr/lib/jvm
-    cp -rf /etc/java-8-openjdk image/etc/
     # Copy K8s secret
     mkdir -p image/var/run/secrets/
     cp -r /var/run/secrets/* image/var/run/secrets/
-    ls image/var/run/secrets/kubernetes.io/serviceaccount/
-    # Copy libs
-    cp /lib/x86_64-linux-gnu/libz.so.1 image/lib
-    cp /lib/x86_64-linux-gnu/libz.so.1 image/$occlum_glibc
-    cp /lib/x86_64-linux-gnu/libtinfo.so.5 image/$occlum_glibc
-    cp /lib/x86_64-linux-gnu/libnss*.so.2 image/$occlum_glibc
-    cp /lib/x86_64-linux-gnu/libresolv.so.2 image/$occlum_glibc
-    cp $occlum_glibc/libdl.so.2 image/$occlum_glibc
-    cp $occlum_glibc/librt.so.1 image/$occlum_glibc
-    cp $occlum_glibc/libm.so.6 image/$occlum_glibc
-    # Copy libhadoop
-    cp /opt/libhadoop.so image/lib
-    # Prepare Spark
-    mkdir -p image/opt/spark
-    cp -rf $SPARK_HOME/* image/opt/spark/
-    # Copy etc files
-    cp -rf /etc/hosts image/etc/
-    echo "$HOST_IP occlum-node" >> image/etc/hosts
-    # cat image/etc/hosts
 
-    cp -rf /etc/hostname image/etc/
-    cp -rf /etc/ssl image/etc/
-    cp -rf /etc/passwd image/etc/
-    cp -rf /etc/group image/etc/
-    cp -rf /etc/nsswitch.conf image/etc/
-
-    # Prepare BigDL
-    mkdir -p image/bin/jars
-    cp -f $BIGDL_HOME/jars/* image/bin/jars
-    cp -rf /opt/spark-source image/opt/
+    copy_bom -f /opt/spark.yaml --root image --include-dir /opt/occlum/etc/template
 
     # Build
     occlum build

--- a/ppml/trusted-big-data-ml/scala/docker-occlum/spark.yaml
+++ b/ppml/trusted-big-data-ml/scala/docker-occlum/spark.yaml
@@ -1,0 +1,49 @@
+includes:
+  - base.yaml
+  - python-glibc.yaml
+targets:
+  - target: /
+    copy:
+      - dirs:
+        # python examples
+        - /opt/py-examples
+        # scala files
+        - /opt/spark/examples
+  # JVM and class file
+  - target: /usr/lib/jvm
+    copy:
+      - dirs:
+        - /usr/lib/jvm/java-8-openjdk-amd64
+  # K8s secret
+  # - target: /var/run
+  #   copy:
+  #     - dirs:
+  #       - /var/run/secrets
+  # extra libs
+  - target: /opt/occlum/glibc/lib
+    copy:
+      - files:
+        - /opt/libhadoop.so
+        - /lib/x86_64-linux-gnu/libnss_dns.so.2
+        - /lib/x86_64-linux-gnu/libnss_files.so.2
+  # Prepare BigDL
+  - target: /bin
+    copy:
+      - dirs:
+        - $BIGDL_HOME/jars
+  # prepare spark
+  - target: /opt
+    copy:
+      - dirs:
+        - $SPARK_HOME
+        - /opt/spark-source
+  # etc files
+  - target: /etc
+    copy:
+      - dirs:
+        - /etc/java-8-openjdk
+        - /etc/ssl
+      - files:
+        - /etc/nsswitch.conf
+        - /etc/passwd
+        - /etc/group


### PR DESCRIPTION
Signed-off-by: Zheng, Qi <huaiqing.zq@antgroup.com>

## Description

Use `copy_bom` to generate occlum spark content instead of `copy`.
