### PR TITLE
Update bigdl-submit script

### DIFF
--- a/python/nano/src/bigdl/nano/k8s/bigdl_submit.py
+++ b/python/nano/src/bigdl/nano/k8s/bigdl_submit.py
@@ -239,7 +239,7 @@ def _create_pod(pod_name: str,
             limits["sgx.intel.com/epc"] = pod_epc_memory
         resource = client.V1ResourceRequirements(limits=limits,
                                                  requests=requests)
-        volumn_mounts = [_deserialize_volume_mounts_object(json_str, api_client)
+        volume_mounts = [_deserialize_volume_mounts_object(json_str, api_client)
                          for json_str in volume_mount_strs]
         if use_command:
             container = client.V1Container(name="pytorch",
@@ -247,14 +247,14 @@ def _create_pod(pod_name: str,
                                           env=envs,
                                           command=command,
                                           resources=resource,
-                                          volume_mounts=volumn_mounts)
+                                          volume_mounts=volume_mounts)
         else:
             container = client.V1Container(name="pytorch",
                                           image=image,
                                           env=envs,
                                           args=command,
                                           resources=resource,
-                                          volume_mounts=volumn_mounts)
+                                          volume_mounts=volume_mounts)
 
         volumes = [_deserialize_volume_object(json_str, api_client) for json_str in volume_strs]
 

--- a/python/nano/src/bigdl/nano/k8s/bigdl_submit.py
+++ b/python/nano/src/bigdl/nano/k8s/bigdl_submit.py
@@ -80,7 +80,8 @@ def _get_args_parser() -> ArgumentParser:
     parser.add_argument(
         '--pod_epc_memory',
         type=str,
-        default="34359738368"
+        default="34359738368",
+        help="The EPC memory allocated to the container (in bytes) if SGX mode is enabled"
     )
 
     parser.add_argument(

--- a/python/nano/src/bigdl/nano/k8s/bigdl_submit.py
+++ b/python/nano/src/bigdl/nano/k8s/bigdl_submit.py
@@ -103,7 +103,7 @@ def _get_args_parser() -> ArgumentParser:
         '--submit_pod_template',
         action='store_true',
         default=False,
-        help='If set, inidicate the main_scipt is a pod template yaml file'
+        help='If set, indicate the main_script is a pod template yaml file'
     )
 
     parser.add_argument(

--- a/python/nano/src/bigdl/nano/k8s/bigdl_submit.py
+++ b/python/nano/src/bigdl/nano/k8s/bigdl_submit.py
@@ -359,7 +359,7 @@ def main():
                                       image=args.image,
                                       command=command,
                                       use_command=args.use_command,
-                                      sgx_command=args.sgx_enabled,
+                                      sgx_enabled=args.sgx_enabled,
                                       volume_strs=args.volume,
                                       volume_mount_strs=args.volume_mount,
                                       pod_file_template_str=template_json_str


### PR DESCRIPTION
## Description
Update Nano bigdl-submit script, so that it will be compatible with pert PyTorch distributed training application.

### 1. Why the change?

Update Nano bigdl-submit script, so that it will be compatible with pert PyTorch distributed training application.

### 2. User API changes
The following arguments are added:
use_command: If set, the script will use the command line arguments as pod's entrypoint.  Otherwise, it will be treated as entrypoint's arguments.

sgx_enabled: If set, the corresponding sgx-related device-plugin arguments will be added into resources/limits

node_label: Choose which node to run with labels

pod_epc_memory: The epc memory allocated to the sgx application. 



### 3. How to test?
- [x] Manually test


Due to an error occurred when installing bigdl, the PR has not been tested yet.
Will do later.

```bash
Collecting pyspark==2.4.6
  Using cached pyspark-2.4.6.tar.gz (218.4 MB)
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-_wqz2mzx/pyspark/setup.py'"'"'; __file__='"'"'/tmp/pip-install-_wqz2mzx/pyspark/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-_wqz2mzx/pyspark/pip-egg-info
         cwd: /tmp/pip-install-_wqz2mzx/pyspark/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-_wqz2mzx/pyspark/setup.py", line 156, in <module>
        long_description = pypandoc.convert('README.md', 'rst')
    AttributeError: module 'pypandoc' has no attribute 'convert'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

