### PR TITLE
Fix option not working in source bigdl-nano-init

### DIFF
--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -55,6 +55,8 @@ TCMALLOC=1
 # Set TF_ENABLE_ONEDNN_OPTS
 export TF_ENABLE_ONEDNN_OPTS=1
 
+OPTIND=1
+
 while getopts ":ojhc-:" opt; do
 	case ${opt} in
 		- )


### PR DESCRIPTION
## Description

Fix option not working in `source bigdl-nano-init`.

Setting OPTIND to 1 before calling `getopts`,

