### PR TITLE
Chronos: support installation on Mac with intel chip

### DIFF
--- a/python/chronos/src/setup.py
+++ b/python/chronos/src/setup.py
@@ -76,6 +76,7 @@ def setup_package():
                                 'prophet==1.1.0',
                                 'tsfresh==0.17.0',
                                 'pyarrow==6.0.1',
+                                'matplotlib',
                                 'bigdl-nano[inference]==' + VERSION]},
         dependency_links=['https://d3kbcqa49mib13.cloudfront.net/spark-2.0.0-bin-hadoop2.7.tgz'],
         include_package_data=True,

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -148,14 +148,12 @@ def setup_package():
 
     inference_requires = ["onnx==1.12.0",
                           "onnxruntime==1.12.1",
-                          "onnxruntime-extensions==0.4.2; platform_machine=='x86_64' and \
-                          platform_system!='Darwin'",
+                          "onnxruntime-extensions==0.4.2; platform_system!='Darwin'",
                           "onnxruntime-extensions==0.3.1; platform_machine=='x86_64' and \
                           platform_system=='Darwin'",
                           "openvino-dev==2022.2.0",
                           "neural-compressor==1.13.1",
-                          "onnxsim==0.4.8; platform_machine=='x86_64' and \
-                          platform_system!='Darwin'",
+                          "onnxsim==0.4.8; platform_system!='Darwin'",
                           "onnxsim==0.4.1; platform_machine=='x86_64' and \
                           platform_system=='Darwin'"]
 

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -73,6 +73,7 @@ def download_libs(url: str):
 
 def setup_package():
 
+
     # all intel-tensorflow is only avaliable for linux now
     tensorflow_27_requires = ["intel-tensorflow==2.7.0; platform_machine=='x86_64' and \
                               platform_system!='Darwin'",
@@ -106,6 +107,7 @@ def setup_package():
     tensorflow_29_requires += tensorflow_common_requires
     tensorflow_28_requires += tensorflow_common_requires
     tensorflow_27_requires += tensorflow_common_requires
+
 
     # ipex is only avaliable for linux now
     pytorch_113_requires = ["torch==1.13.0",
@@ -144,12 +146,16 @@ def setup_package():
 
     inference_requires = ["onnx==1.12.0",
                           "onnxruntime==1.12.1",
-                          "onnxruntime-extensions==0.4.2;platform_system!='Darwin'",
-                          "onnxruntime-extensions==0.3.1;platform_system=='Darwin'",
+                          "onnxruntime-extensions==0.4.2; platform_machine=='x86_64' and \
+                          platform_system!='Darwin'",
+                          "onnxruntime-extensions==0.3.1; platform_machine=='x86_64' and \
+                          platform_system=='Darwin'",
                           "openvino-dev==2022.2.0",
                           "neural-compressor==1.13.1",
-                          "onnxsim==0.4.8;platform_system!='Darwin'",
-                          "onnxsim==0.4.1;platform_system=='Darwin'"]
+                          "onnxsim==0.4.8; platform_machine=='x86_64' and \
+                          platform_system!='Darwin'",
+                          "onnxsim==0.4.1; platform_machine=='x86_64' and \
+                          platform_system=='Darwin'"]
 
     install_requires = ["intel-openmp; platform_machine=='x86_64'",
                         "cloudpickle",

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -73,7 +73,6 @@ def download_libs(url: str):
 
 def setup_package():
 
-
     # all intel-tensorflow is only avaliable for linux now
     tensorflow_27_requires = ["intel-tensorflow==2.7.0; platform_machine=='x86_64' and \
                               platform_system!='Darwin'",
@@ -107,7 +106,6 @@ def setup_package():
     tensorflow_29_requires += tensorflow_common_requires
     tensorflow_28_requires += tensorflow_common_requires
     tensorflow_27_requires += tensorflow_common_requires
-
 
     # ipex is only avaliable for linux now
     pytorch_113_requires = ["torch==1.13.0",

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -74,19 +74,27 @@ def download_libs(url: str):
 def setup_package():
 
     # all intel-tensorflow is only avaliable for linux now
-    tensorflow_27_requires = ["intel-tensorflow==2.7.0; platform_machine=='x86_64'",
+    tensorflow_27_requires = ["intel-tensorflow==2.7.0; platform_machine=='x86_64' and \
+                              platform_system!='Darwin'",
+                              "tensorflow==2.7.0;platform_system=='Darwin'",
                               "keras==2.7.0; platform_machine=='x86_64'",
                               "tensorflow-estimator==2.7.0; platform_machine=='x86_64'"]
     
-    tensorflow_28_requires = ["intel-tensorflow==2.8.0; platform_machine=='x86_64'",
+    tensorflow_28_requires = ["intel-tensorflow==2.8.0; platform_machine=='x86_64' and \
+                              platform_system!='Darwin'",
+                              "tensorflow==2.8.0;platform_system=='Darwin'",
                               "keras==2.8.0; platform_machine=='x86_64'",
                               "tensorflow-estimator==2.8.0; platform_machine=='x86_64'"]
     
-    tensorflow_29_requires = ["intel-tensorflow==2.9.1; platform_machine=='x86_64'",
+    tensorflow_29_requires = ["intel-tensorflow==2.9.0; platform_machine=='x86_64' and \
+                              platform_system!='Darwin'",
+                              "tensorflow==2.9.0;platform_system=='Darwin'",
                               "keras==2.9.0; platform_machine=='x86_64'",
                               "tensorflow-estimator==2.9.0; platform_machine=='x86_64'"]
     
-    tensorflow_210_requires = ["intel-tensorflow==2.10.0; platform_machine=='x86_64'",
+    tensorflow_210_requires = ["intel-tensorflow==2.10.0; platform_machine=='x86_64' and \
+                               platform_system!='Darwin'",
+                               "tensorflow==2.10.0;platform_system=='Darwin'",
                                "keras==2.10.0; platform_machine=='x86_64'",
                                "tensorflow-estimator==2.10.0; platform_machine=='x86_64'"]
     
@@ -102,19 +110,19 @@ def setup_package():
     # ipex is only avaliable for linux now
     pytorch_113_requires = ["torch==1.13.0",
                             "torchvision==0.14.0",
-                            "intel_extension_for_pytorch==1.13.0;platform_system!='Windows'"]
+                            "intel_extension_for_pytorch==1.13.0;platform_system=='Linux'"]
 
     pytorch_112_requires = ["torch==1.12.1",
                             "torchvision==0.13.1",
-                            "intel_extension_for_pytorch==1.12.300;platform_system!='Windows'"]
+                            "intel_extension_for_pytorch==1.12.300;platform_system=='Linux'"]
 
     pytorch_111_requires = ["torch==1.11.0",
                             "torchvision==0.12.0",
-                            "intel_extension_for_pytorch==1.11.0;platform_system!='Windows'"]
+                            "intel_extension_for_pytorch==1.11.0;platform_system=='Linux'"]
 
     pytorch_110_requires = ["torch==1.10.1",
                             "torchvision==0.11.2",
-                            "intel_extension_for_pytorch==1.10.100;platform_system!='Windows'"]
+                            "intel_extension_for_pytorch==1.10.100;platform_system=='Linux'"]
 
     # this require install option --extra-index-url https://download.pytorch.org/whl/nightly/
     pytorch_nightly_requires = ["torch~=1.14.0.dev",
@@ -136,10 +144,12 @@ def setup_package():
 
     inference_requires = ["onnx==1.12.0",
                           "onnxruntime==1.12.1",
-                          "onnxruntime-extensions==0.4.2",
+                          "onnxruntime-extensions==0.4.2;platform_system!='Darwin'",
+                          "onnxruntime-extensions==0.3.1;platform_system=='Darwin'",
                           "openvino-dev==2022.2.0",
                           "neural-compressor==1.13.1",
-                          "onnxsim==0.4.8"]
+                          "onnxsim==0.4.8;platform_system!='Darwin'",
+                          "onnxsim==0.4.1;platform_system=='Darwin'"]
 
     install_requires = ["intel-openmp; platform_machine=='x86_64'",
                         "cloudpickle",

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -86,7 +86,7 @@ def setup_package():
                               "keras==2.8.0; platform_machine=='x86_64'",
                               "tensorflow-estimator==2.8.0; platform_machine=='x86_64'"]
     
-    tensorflow_29_requires = ["intel-tensorflow==2.9.0; platform_machine=='x86_64' and \
+    tensorflow_29_requires = ["intel-tensorflow==2.9.1; platform_machine=='x86_64' and \
                               platform_system!='Darwin'",
                               "tensorflow==2.9.0;platform_system=='Darwin'",
                               "keras==2.9.0; platform_machine=='x86_64'",

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -76,25 +76,29 @@ def setup_package():
     # all intel-tensorflow is only avaliable for linux now
     tensorflow_27_requires = ["intel-tensorflow==2.7.0; platform_machine=='x86_64' and \
                               platform_system!='Darwin'",
-                              "tensorflow==2.7.0;platform_system=='Darwin'",
+                              "tensorflow==2.7.0; platform_machine=='x86_64' and \
+                              platform_system=='Darwin'",
                               "keras==2.7.0; platform_machine=='x86_64'",
                               "tensorflow-estimator==2.7.0; platform_machine=='x86_64'"]
     
     tensorflow_28_requires = ["intel-tensorflow==2.8.0; platform_machine=='x86_64' and \
                               platform_system!='Darwin'",
-                              "tensorflow==2.8.0;platform_system=='Darwin'",
+                              "tensorflow==2.8.0; platform_machine=='x86_64' and \
+                              platform_system=='Darwin'",
                               "keras==2.8.0; platform_machine=='x86_64'",
                               "tensorflow-estimator==2.8.0; platform_machine=='x86_64'"]
     
     tensorflow_29_requires = ["intel-tensorflow==2.9.1; platform_machine=='x86_64' and \
                               platform_system!='Darwin'",
-                              "tensorflow==2.9.0;platform_system=='Darwin'",
+                              "tensorflow==2.9.0; platform_machine=='x86_64' and \
+                              platform_system=='Darwin'",
                               "keras==2.9.0; platform_machine=='x86_64'",
                               "tensorflow-estimator==2.9.0; platform_machine=='x86_64'"]
     
     tensorflow_210_requires = ["intel-tensorflow==2.10.0; platform_machine=='x86_64' and \
                                platform_system!='Darwin'",
-                               "tensorflow==2.10.0;platform_system=='Darwin'",
+                               "tensorflow==2.10.0; platform_machine=='x86_64' and \
+                               platform_system=='Darwin'",
                                "keras==2.10.0; platform_machine=='x86_64'",
                                "tensorflow-estimator==2.10.0; platform_machine=='x86_64'"]
     


### PR DESCRIPTION
## Description

Support installation on Mac.
After testing on mac server, some dependencies have to be removed or installed other version on Mac.

### 2. User API changes

None.
(But because of limitation of INC and ipex, fail to quantize on Mac)

### 3. Summary of the change 

1) ipex will not be installed on Mac
2) install lower version of intel-tensorflow, onnxruntime-extensions and onnxsim
3) add matplotlib in Chronos[all]

