### PR TITLE
Orca: Add data loader examples to NCF with merged features

### DIFF
--- a/python/orca/tutorial/NCF/pytorch_dataset.py
+++ b/python/orca/tutorial/NCF/pytorch_dataset.py
@@ -23,69 +23,98 @@ import pandas as pd
 import scipy.sparse as sp
 
 import torch.utils.data as data
+from sklearn.preprocessing import MinMaxScaler
 
 
 class NCFData(data.Dataset):
-    def __init__(self, features,
-                 num_item=0, train_mat=None, num_ng=0):
-        super(NCFData, self).__init__()
-        """ Note that the labels are only useful when training, we thus
-            add them in the ng_sample() function.
-        """
-        self.features_ps = features
-        self.num_item = num_item
-        self.train_mat = train_mat
-        self.num_ng = num_ng
-        self.is_sampling = False
-        self.labels = [1 for _ in range(len(features))]
-
-    def ng_sample(self):
-        self.is_sampling = True
-        self.features_ng = []
-        for x in self.features_ps:
-            u = x[0]
-            for t in range(self.num_ng):
-                j = np.random.randint(self.num_item)
-                while (u, j) in self.train_mat:
-                    j = np.random.randint(self.num_item)
-                self.features_ng.append([u, j])
-
-        labels_ps = [1 for _ in range(len(self.features_ps))]
-        labels_ng = [0 for _ in range(len(self.features_ng))]
-
-        self.features_fill = self.features_ps + self.features_ng
-        self.labels_fill = labels_ps + labels_ng
+    def __init__(self, data):
+        self.data = data
 
     def __len__(self):
-        return (self.num_ng + 1) * len(self.labels)
+        return len(self.data)
 
     def __getitem__(self, idx):
-        features = self.features_fill if self.is_sampling \
-            else self.features_ps
-        labels = self.labels_fill if self.is_sampling \
-            else self.labels
-
-        user = features[idx][0]
-        item = features[idx][1]
-        label = float(labels[idx])
-        return user, item, label
+        return tuple(self.data[idx])
 
 
-def load_dataset(dataset_dir):
-    data_X = pd.read_csv(
+def load_dataset(dataset_dir, num_ng=4, cal_sparse_feats_input_dims=True):
+    """
+    dataset_dir: the path of the datasets;
+    num_ng: number of negative samples to be sampled here;
+    cal_sparse_feats_input_dims: if True, will calculate sparse_feats_input_dims.
+    """
+    feature_cols = ['user', 'item',
+                    'gender', 'occupation', 'zipcode', 'category',  # sparse features
+                    'age']  # dense features
+    label_cols = ["label"]
+
+    users = pd.read_csv(
+        os.path.join(dataset_dir, 'users.dat'),
+        sep="::", header=None, names=['user', 'gender', 'age', 'occupation', 'zipcode'],
+        usecols=[0, 1, 2, 3, 4],
+        dtype={0: np.int64, 1: np.object, 2: np.int64, 3: np.int64, 4: np.object})
+    ratings = pd.read_csv(
         os.path.join(dataset_dir, 'ratings.dat'),
         sep="::", header=None, names=['user', 'item'],
         usecols=[0, 1], dtype={0: np.int64, 1: np.int64})
+    movies = pd.read_csv(
+        os.path.join(dataset_dir, 'movies.dat'),
+        sep="::", header=None, names=['item', 'category'],
+        usecols=[0, 2], dtype={0: np.int64, 1: np.object})
 
-    user_num = data_X['user'].max() + 1
-    item_num = data_X['item'].max() + 1
+    user_num = users['user'].max() + 1
+    item_num = movies['item'].max() + 1
 
-    # load ratings as a dok matrix
-    train_mat = sp.dok_matrix((user_num, item_num), dtype=np.int64)
-    for x in data_X.values.tolist():
-        train_mat[x[0], x[1]] = 1
+    # categorical encoding
+    users.gender, _ = pd.Series(users.gender).factorize()
+    users.zipcode, _ = pd.Series(users.zipcode).factorize()
+    movies.category, _ = pd.Series(movies.category).factorize()
 
-    return data_X, user_num, item_num, train_mat
+    # Calculate input_dims for each sparse features
+    sparse_feats_input_dims = []
+    if cal_sparse_feats_input_dims:
+        sparse_feats_input_dims.append(users['gender'].max()+1)
+        sparse_feats_input_dims.append(users['occupation'].max()+1)
+        sparse_feats_input_dims.append(users['zipcode'].max()+1)
+        sparse_feats_input_dims.append(movies['category'].max()+1)
+
+    # scale dense features
+    scaler = MinMaxScaler()
+    age = users.age.values.reshape(-1, 1) 
+    age = scaler.fit_transform(age)
+    users.age = pd.Series(age[:, 0], dtype=np.float32)
+
+    # sample negative items for training datasets
+    if num_ng > 0:
+        # load ratings as a dok matrix
+        features_ps = ratings.values.tolist()
+        train_mat = sp.dok_matrix((user_num, item_num), dtype=np.int64)
+        for x in features_ps:
+            train_mat[x[0], x[1]] = 1
+
+        features_ng = []
+        for x in features_ps:
+            u = x[0]
+            for t in range(num_ng):
+                j = np.random.randint(item_num)
+                while (u, j) in train_mat:
+                    j = np.random.randint(item_num)
+                features_ng.append([u, j])
+        features = features_ps + features_ng
+        labels_ps = [1.0 for _ in range(len(features_ps))]
+        labels_ng = [0.0 for _ in range(len(features_ng))]
+        labels = labels_ps + labels_ng
+        ratings = pd.DataFrame(features, columns=["user", "item"], dtype=np.int64)
+        ratings["label"] = labels
+    else:
+        ratings["label"] = [1.0 for _ in range(len(ratings))]
+
+    # merge dataframes
+    data_X = users.merge(ratings, on='user')
+    data_X = data_X.merge(movies, on='item')
+    data_X = data_X.loc[:, feature_cols+label_cols]
+
+    return data_X, user_num, item_num, sparse_feats_input_dims, feature_cols, label_cols
 
 
 if __name__ == "__main__":

--- a/python/orca/tutorial/NCF/pytorch_dataset.py
+++ b/python/orca/tutorial/NCF/pytorch_dataset.py
@@ -29,7 +29,6 @@ from sklearn.preprocessing import MinMaxScaler
 class NCFData(data.Dataset):
     def __init__(self, data):
         self.data = data
-        self.data["label"] = [1.0 for _ in range(len(self.data))]
 
     def __len__(self):
         return len(self.data)
@@ -118,6 +117,8 @@ def load_dataset(dataset_dir, cal_sparse_feats_input_dims=True,
     dataset = NCFData(ratings)
     if num_ng > 0:
         dataset.ng_sampling(num_ng, user_num, item_num)
+    else:
+        dataset.data["label"] = [1.0 for _ in range(len(dataset.data))]
     if merge_features:
         dataset.merge_features(users, movies, feature_cols+label_cols)
     dataset.data = list(map(lambda row: list(row[1:]), dataset.data.itertuples()))

--- a/python/orca/tutorial/NCF/pytorch_dataset.py
+++ b/python/orca/tutorial/NCF/pytorch_dataset.py
@@ -119,9 +119,8 @@ def load_dataset(dataset_dir, cal_sparse_feats_input_dims=True,
     users.age = pd.Series(age[:, 0], dtype=np.float32)
 
     # load ratings as a dok matrix
-    features_ps = ratings.values.tolist()
     train_mat = sp.dok_matrix((user_num, item_num), dtype=np.int64)
-    for x in features_ps:
+    for x in ratings.values.tolist():
         train_mat[x[0], x[1]] = 1
 
     dataset = NCFData(ratings, item_num, train_mat, num_ng)

--- a/python/orca/tutorial/NCF/pytorch_dataset.py
+++ b/python/orca/tutorial/NCF/pytorch_dataset.py
@@ -106,7 +106,7 @@ def process_users_items(dataset_dir):
         df = users if i in users.columns else items
         values = df[i].values.reshape(-1, 1)
         values = scaler.fit_transform(values)
-        values = [torch.tensor(v, dtype=torch.float32) for v in values]
+        values = [np.array(v, dtype=np.float32) for v in values]
         df[i] = values
 
     feature_cols = ['user', 'item'] + sparse_features + dense_features
@@ -152,12 +152,11 @@ def load_dataset(dataset_dir, num_ng=4):
     dataset = NCFData(ratings, item_num, train_mat, num_ng)
     dataset.ng_sample()
 
+    # merge features
+    dataset.merge_features(users, items, total_cols)
+
     # train test split
     train_dataset, test_dataset = dataset.train_test_split()
-
-    # merge features
-    train_dataset.merge_features(users, items, total_cols)
-    test_dataset.merge_features(users, items, total_cols)
     return train_dataset, test_dataset
 
 

--- a/python/orca/tutorial/NCF/pytorch_dataset.py
+++ b/python/orca/tutorial/NCF/pytorch_dataset.py
@@ -139,7 +139,7 @@ def process_ratings(dataset_dir, user_num, item_num):
     return ratings, train_mat
 
 
-def load_dataset(dataset_dir, num_ng=4, test_size=0.2):
+def load_dataset(dataset_dir, num_ng=4):
     """
     dataset_dir: the path of the datasets;
     num_ng: number of negative samples to be sampled here.
@@ -156,7 +156,7 @@ def load_dataset(dataset_dir, num_ng=4, test_size=0.2):
     dataset.merge_features(users, items, total_cols)
 
     # train test split
-    train_dataset, test_dataset = dataset.train_test_split(test_size)
+    train_dataset, test_dataset = dataset.train_test_split()
     return train_dataset, test_dataset
 
 

--- a/python/orca/tutorial/NCF/pytorch_dataset.py
+++ b/python/orca/tutorial/NCF/pytorch_dataset.py
@@ -61,8 +61,8 @@ class NCFData(data.Dataset):
                                  columns=["user", "item"], dtype=np.int32)
         self.data['label'] = labels_fill
 
-    def train_test_split(self):
-        train_dataset, test_dataset = train_test_split(self.data, test_size=0.2, random_state=100)
+    def train_test_split(self, test_size=0.2):
+        train_dataset, test_dataset = train_test_split(self.data, test_size=test_size, random_state=100)
         return NCFData(train_dataset), NCFData(test_dataset)
 
     def merge_features(self, users, items, total_cols):
@@ -104,7 +104,7 @@ def process_users_items(dataset_dir):
     for i in dense_features:
         scaler = MinMaxScaler()
         df = users if i in users.columns else items
-        values = df[i].values.reshape(-1, 1)
+        values = df[i].values.reshape(-1, 1)  # MinMaxScaler needs the input to be 2-dim tensor, not 1-dim.
         values = scaler.fit_transform(values)
         values = [np.array(v, dtype=np.float32) for v in values]
         df[i] = values
@@ -139,7 +139,7 @@ def process_ratings(dataset_dir, user_num, item_num):
     return ratings, train_mat
 
 
-def load_dataset(dataset_dir, num_ng=4):
+def load_dataset(dataset_dir, num_ng=4, test_size=0.2):
     """
     dataset_dir: the path of the datasets;
     num_ng: number of negative samples to be sampled here.
@@ -156,7 +156,7 @@ def load_dataset(dataset_dir, num_ng=4):
     dataset.merge_features(users, items, total_cols)
 
     # train test split
-    train_dataset, test_dataset = dataset.train_test_split()
+    train_dataset, test_dataset = dataset.train_test_split(test_size)
     return train_dataset, test_dataset
 
 

--- a/python/orca/tutorial/NCF/pytorch_dataset.py
+++ b/python/orca/tutorial/NCF/pytorch_dataset.py
@@ -78,10 +78,8 @@ class NCFData(data.Dataset):
 
 
 def process_users_items(dataset_dir):
-    sparse_features = ['gender', 'occupation', 'zipcode', 'category']
+    sparse_features = ['gender', 'zipcode', 'category']
     dense_features = ['age']
-    feature_cols = ['user', 'item'] + sparse_features + dense_features
-    label_cols = ["label"]
 
     users = pd.read_csv(
         os.path.join(dataset_dir, 'users.dat'),
@@ -100,6 +98,7 @@ def process_users_items(dataset_dir):
     for i in sparse_features:
         df = users if i in users.columns else items
         df[i], _ = pd.Series(df[i]).factorize()
+    sparse_features.append('occupation')  # occupation is already indexed.
 
     # scale dense features
     for i in dense_features:
@@ -110,6 +109,8 @@ def process_users_items(dataset_dir):
         values = [torch.tensor(v, dtype=torch.float32) for v in values]
         df[i] = values
 
+    feature_cols = ['user', 'item'] + sparse_features + dense_features
+    label_cols = ["label"]
     return users, items, user_num, item_num, \
         sparse_features, dense_features, feature_cols+label_cols
 

--- a/python/orca/tutorial/NCF/pytorch_dataset.py
+++ b/python/orca/tutorial/NCF/pytorch_dataset.py
@@ -22,7 +22,6 @@ import numpy as np
 import pandas as pd
 import scipy.sparse as sp
 
-import torch
 import torch.utils.data as data
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import MinMaxScaler

--- a/python/orca/tutorial/NCF/pytorch_dataset.py
+++ b/python/orca/tutorial/NCF/pytorch_dataset.py
@@ -27,20 +27,9 @@ from sklearn.preprocessing import MinMaxScaler
 
 
 class NCFData(data.Dataset):
-    def __init__(self, data, users=None, movies=None,
-                 num_ng=4, user_num=0, item_num=0,
-                 merge_features=False, total_cols=None):
+    def __init__(self, data):
         self.data = data
-
-        if num_ng > 0:
-            self.ng_sampling(num_ng, user_num, item_num)
-        else:
-            self.data["label"] = [1.0 for _ in range(len(self.data))]
-
-        if merge_features:
-            self.merge_features(users, movies, total_cols)
-
-        self.data = list(map(lambda row: list(row[1:]), self.data.itertuples()))
+        self.data["label"] = [1.0 for _ in range(len(self.data))]
 
     def __len__(self):
         return len(self.data)
@@ -126,9 +115,12 @@ def load_dataset(dataset_dir, cal_sparse_feats_input_dims=True,
     age = scaler.fit_transform(age)
     users.age = pd.Series(age[:, 0], dtype=np.float32)
 
-    dataset = NCFData(ratings, users, movies,
-                      num_ng, user_num, item_num,
-                      merge_features, feature_cols+label_cols)
+    dataset = NCFData(ratings)
+    if num_ng > 0:
+        dataset.ng_sampling(num_ng, user_num, item_num)
+    if merge_features:
+        dataset.merge_features(users, movies, feature_cols+label_cols)
+    dataset.data = list(map(lambda row: list(row[1:]), dataset.data.itertuples()))
     return dataset, user_num, item_num, sparse_feats_input_dims
 
 

--- a/python/orca/tutorial/NCF/pytorch_dataset.py
+++ b/python/orca/tutorial/NCF/pytorch_dataset.py
@@ -23,6 +23,7 @@ import pandas as pd
 import scipy.sparse as sp
 
 import torch.utils.data as data
+from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import MinMaxScaler
 
 
@@ -54,81 +55,110 @@ class NCFData(data.Dataset):
         features_fill = features_ps + features_ng
         labels_fill = labels_ps + labels_ng
         self.data = pd.DataFrame(features_fill,
-                                 columns=["user", "item"], dtype=np.int64)
+                                 columns=["user", "item"], dtype=np.int32)
         self.data['label'] = labels_fill
 
-    def merge_features(self, users, movies, total_cols):
-        self.data = users.merge(self.data, on='user')
-        self.data = self.data.merge(movies, on='item')
-        self.data = self.data.loc[:, total_cols]
+    def train_test_split(self):
+        self.train_dataset, self.test_dataset = train_test_split(self.data,
+                                                                 test_size=0.2, random_state=100)
+
+    def merge_features(self, users, items, total_cols):
+        self.train_dataset = users.merge(self.train_dataset, on='user')
+        self.train_dataset = self.train_dataset.merge(items, on='item')
+        self.train_dataset = self.train_dataset.loc[:, total_cols]
+
+        self.test_dataset = users.merge(self.test_dataset, on='user')
+        self.test_dataset = self.test_dataset.merge(items, on='item')
+        self.test_dataset = self.test_dataset.loc[:, total_cols]
+
+    def datasets_tolist(self):
+        train_dataset = list(map(lambda row: list(row[1:]), self.train_dataset.itertuples()))
+        test_dataset = list(map(lambda row: list(row[1:]), self.test_dataset.itertuples()))
+        return train_dataset, test_dataset
 
     def __len__(self):
         return len(self.data)
 
     def __getitem__(self, idx):
-        return tuple(self.data[idx])
+        return tuple(self.data.iloc[idx, :])
 
 
-def load_dataset(dataset_dir, cal_sparse_feats_input_dims=True,
-                 num_ng=4, merge_features=True):
-    """
-    dataset_dir: the path of the datasets;
-    cal_sparse_feats_input_dims: if True, will calculate sparse_feats_input_dims;
-    num_ng: number of negative samples to be sampled here;
-    merge_features: if True, will merge features in NCF_data.
-    """
-    feature_cols = ['user', 'item',
-                    'gender', 'occupation', 'zipcode', 'category',  # sparse features
-                    'age']  # dense features
-    label_cols = ["label"]
-
+def process_users_items(dataset_dir):
     users = pd.read_csv(
         os.path.join(dataset_dir, 'users.dat'),
         sep="::", header=None, names=['user', 'gender', 'age', 'occupation', 'zipcode'],
         usecols=[0, 1, 2, 3, 4],
-        dtype={0: np.int64, 1: np.object, 2: np.int64, 3: np.int64, 4: np.object})
-    ratings = pd.read_csv(
-        os.path.join(dataset_dir, 'ratings.dat'),
-        sep="::", header=None, names=['user', 'item'],
-        usecols=[0, 1], dtype={0: np.int64, 1: np.int64})
-    movies = pd.read_csv(
+        dtype={0: np.int32, 1: str, 2: np.int32, 3: np.int32, 4: str})
+    items = pd.read_csv(
         os.path.join(dataset_dir, 'movies.dat'),
         sep="::", header=None, names=['item', 'category'],
-        usecols=[0, 2], dtype={0: np.int64, 1: np.object})
+        usecols=[0, 2], dtype={0: np.int32, 1: str})
 
     user_num = users['user'].max() + 1
-    item_num = movies['item'].max() + 1
+    item_num = items['item'].max() + 1
 
     # categorical encoding
     users.gender, _ = pd.Series(users.gender).factorize()
     users.zipcode, _ = pd.Series(users.zipcode).factorize()
-    movies.category, _ = pd.Series(movies.category).factorize()
-
-    # Calculate input_dims for each sparse features
-    sparse_feats_input_dims = []
-    if cal_sparse_feats_input_dims:
-        sparse_feats_input_dims.append(users['gender'].max()+1)
-        sparse_feats_input_dims.append(users['occupation'].max()+1)
-        sparse_feats_input_dims.append(users['zipcode'].max()+1)
-        sparse_feats_input_dims.append(movies['category'].max()+1)
+    items.category, _ = pd.Series(items.category).factorize()
 
     # scale dense features
     scaler = MinMaxScaler()
     age = users.age.values.reshape(-1, 1)
     age = scaler.fit_transform(age)
     users.age = pd.Series(age[:, 0], dtype=np.float32)
+    return users, items, user_num, item_num
+
+
+def get_sparse_feats_input_dims(users, items):
+    # Calculate input_dims for each sparse features
+    sparse_feats_input_dims = []
+    sparse_feats_input_dims.append(users['gender'].max()+1)
+    sparse_feats_input_dims.append(users['occupation'].max()+1)
+    sparse_feats_input_dims.append(users['zipcode'].max()+1)
+    sparse_feats_input_dims.append(items['category'].max()+1)
+    return sparse_feats_input_dims
+
+
+def process_ratings(dataset_dir, user_num, item_num):
+    ratings = pd.read_csv(
+        os.path.join(dataset_dir, 'ratings.dat'),
+        sep="::", header=None, names=['user', 'item'],
+        usecols=[0, 1], dtype={0: np.int32, 1: np.int32})
 
     # load ratings as a dok matrix
-    train_mat = sp.dok_matrix((user_num, item_num), dtype=np.int64)
+    train_mat = sp.dok_matrix((user_num, item_num), dtype=np.int32)
     for x in ratings.values.tolist():
         train_mat[x[0], x[1]] = 1
+    return ratings, train_mat
 
+
+def load_dataset(dataset_dir, num_ng=4):
+    """
+    dataset_dir: the path of the datasets;
+    num_ng: number of negative samples to be sampled here.
+    """
+    feature_cols = ['user', 'item',
+                    'gender', 'occupation', 'zipcode', 'category',  # sparse features
+                    'age']  # dense features
+    label_cols = ["label"]
+
+    users, items, user_num, item_num = process_users_items(dataset_dir)
+    ratings, train_mat = process_ratings(dataset_dir, user_num, item_num)
+
+    # sample negative items
     dataset = NCFData(ratings, item_num, train_mat, num_ng)
-    if num_ng > 0:
-        dataset.ng_sample()
-    if merge_features:
-        dataset.merge_features(users, movies, feature_cols+label_cols)
-    return dataset, user_num, item_num, sparse_feats_input_dims
+    dataset.ng_sample()
+
+    # train test split
+    dataset.train_test_split()
+
+    # merge features
+    dataset.merge_features(users, items, feature_cols+label_cols)
+
+    # convert datasets to list
+    train_dataset, test_dataset = dataset.datasets_tolist()
+    return train_dataset, test_dataset
 
 
 if __name__ == "__main__":

--- a/python/orca/tutorial/NCF/pytorch_model.py
+++ b/python/orca/tutorial/NCF/pytorch_model.py
@@ -142,7 +142,7 @@ class NCF(nn.Module):
                 interaction = torch.cat((interaction, embed_catFeats_MLP), -1)
             if self.num_dense_feats > 0:
                 numeric_feats = torch.stack(args[self.num_sparse_feats:], dim=1)
-                interaction = torch.cat((interaction, numeric_feats), -1)
+                interaction = torch.cat((interaction, numeric_feats.float()), -1)
             output_MLP = self.MLP_layers(interaction)
 
         if self.model == 'GMF':

--- a/python/orca/tutorial/NCF/pytorch_model.py
+++ b/python/orca/tutorial/NCF/pytorch_model.py
@@ -140,9 +140,8 @@ class NCF(nn.Module):
             for i in range(self.num_sparse_feats):
                 embed_catFeats_MLP = self.embed_catFeats_MLP[i](args[i])
                 interaction = torch.cat((interaction, embed_catFeats_MLP), -1)
-            if self.num_dense_feats > 0:
-                numeric_feats = torch.stack(args[self.num_sparse_feats:], dim=1)
-                interaction = torch.cat((interaction, numeric_feats.float()), -1)
+            for i in range(self.num_dense_feats):
+                interaction = torch.cat((interaction, args[i+self.num_sparse_feats]), -1)
             output_MLP = self.MLP_layers(interaction)
 
         if self.model == 'GMF':

--- a/python/orca/tutorial/NCF/pytorch_train_dataloader.py
+++ b/python/orca/tutorial/NCF/pytorch_train_dataloader.py
@@ -37,14 +37,14 @@ sc = init_orca_context()
 
 # Step 2: Define train and test datasets as PyTorch DataLoader
 def train_loader_func(config, batch_size):
-    train_dataset, _ = load_dataset(config['dataset_dir'], config['num_ng'])
+    train_dataset, _ = load_dataset(config['dataset_dir'], config['num_ng'], config['test_size'])
     train_loader = data.DataLoader(train_dataset, batch_size=batch_size,
                                    shuffle=True, num_workers=0)
     return train_loader
 
 
 def test_loader_func(config, batch_size):
-    _, test_dataset = load_dataset(config['dataset_dir'], config['num_ng'])
+    _, test_dataset = load_dataset(config['dataset_dir'], config['num_ng'], config['test_size'])
     test_loader = data.DataLoader(test_dataset, batch_size=batch_size,
                                   shuffle=False, num_workers=0)
     return test_loader
@@ -87,6 +87,7 @@ est = Estimator.from_torch(model=model_creator, optimizer=optimizer_creator,
                            backend=backend,
                            config={'dataset_dir': dataset_dir,
                                    'num_ng': 4,
+                                   'test_size': 0.2,
                                    'factor_num': 16,
                                    'num_layers': 3,
                                    'dropout': 0.5,

--- a/python/orca/tutorial/NCF/pytorch_train_dataloader.py
+++ b/python/orca/tutorial/NCF/pytorch_train_dataloader.py
@@ -40,10 +40,11 @@ def train_loader_func(config, batch_size):
     dataset, user_num, item_num, \
         sparse_feats_input_dims = load_dataset(config['dataset_dir'],
                                                cal_sparse_feats_input_dims=False,
-                                               num_ng=config['num_ng'],       
+                                               num_ng=config['num_ng'],
                                                merge_features=True)
 
     # train test split
+    dataset.data = list(map(lambda row: list(row[1:]), dataset.data.itertuples()))
     train_dataset, _ = train_test_split(dataset, test_size=0.2, random_state=100)
 
     train_loader = data.DataLoader(train_dataset, batch_size=batch_size,
@@ -55,10 +56,11 @@ def test_loader_func(config, batch_size):
     dataset, user_num, item_num, \
         sparse_feats_input_dims = load_dataset(config['dataset_dir'],
                                                cal_sparse_feats_input_dims=False,
-                                               num_ng=config['num_ng'],       
+                                               num_ng=config['num_ng'],
                                                merge_features=True)
 
     # train test split
+    dataset.data = list(map(lambda row: list(row[1:]), dataset.data.itertuples()))
     _, test_dataset = train_test_split(dataset, test_size=0.2, random_state=100)
 
     test_loader = data.DataLoader(test_dataset, batch_size=batch_size,
@@ -71,7 +73,7 @@ def model_creator(config):
     dataset, user_num, item_num, \
         sparse_feats_input_dims = load_dataset(config['dataset_dir'],
                                                cal_sparse_feats_input_dims=True,
-                                               num_ng=0,       
+                                               num_ng=0,
                                                merge_features=False)
 
     model = NCF(user_num=user_num,

--- a/python/orca/tutorial/NCF/pytorch_train_dataloader.py
+++ b/python/orca/tutorial/NCF/pytorch_train_dataloader.py
@@ -15,6 +15,9 @@
 #
 
 # Step 0: Import necessary libraries
+import numpy as np
+import pandas as pd
+
 import torch.nn as nn
 import torch.optim as optim
 import torch.utils.data as data
@@ -34,28 +37,34 @@ sc = init_orca_context()
 
 # Step 2: Define train and test datasets as PyTorch DataLoader
 def train_loader_func(config, batch_size):
-    data_X, user_num, item_num, train_mat = load_dataset(config['dataset_dir'])
-    data_X = data_X.values.tolist()
+    data_X, user_num, item_num, sparse_feats_input_dims, \
+        feature_cols, label_cols = load_dataset(config['dataset_dir'],
+                                                num_ng=config['num_ng'],
+                                                cal_sparse_feats_input_dims=False)
+    total_cols = feature_cols + label_cols
 
     # train test split
-    train_data, _ = train_test_split(data_X, test_size=0.2, random_state=100)
+    data_values = list(map(lambda row: list(row[1:]), data_X.itertuples()))
+    train_data, _ = train_test_split(data_values, test_size=0.2, random_state=100)
 
-    train_dataset = NCFData(train_data, item_num, train_mat, config['num_ng'])
-    train_dataset.ng_sample()
+    train_dataset = NCFData(train_data)
     train_loader = data.DataLoader(train_dataset, batch_size=batch_size,
                                    shuffle=True, num_workers=0)
     return train_loader
 
 
 def test_loader_func(config, batch_size):
-    data_X, user_num, item_num, train_mat = load_dataset(config['dataset_dir'])
-    data_X = data_X.values.tolist()
+    data_X, user_num, item_num, sparse_feats_input_dims, \
+        feature_cols, label_cols = load_dataset(config['dataset_dir'],
+                                                num_ng=config['num_ng'],
+                                                cal_sparse_feats_input_dims=False)
+    total_cols = feature_cols + label_cols
 
     # train test split
-    _, test_data = train_test_split(data_X, test_size=0.2, random_state=100)
+    data_values = list(map(lambda row: list(row[1:]), data_X.itertuples()))
+    _, test_data = train_test_split(data_values, test_size=0.2, random_state=100)
 
-    test_dataset = NCFData(test_data, item_num, train_mat, config['num_ng'])
-    test_dataset.ng_sample()
+    test_dataset = NCFData(test_data)
     test_loader = data.DataLoader(test_dataset, batch_size=batch_size,
                                   shuffle=False, num_workers=0)
     return test_loader
@@ -63,12 +72,20 @@ def test_loader_func(config, batch_size):
 
 # Step 3: Define the model, optimizer and loss
 def model_creator(config):
-    data_X, user_num, item_num, train_mat = load_dataset(config['dataset_dir'])
-    model = NCF(user_num, item_num,
+    data_X, user_num, item_num, sparse_feats_input_dims, \
+        feature_cols, label_cols = load_dataset(config['dataset_dir'],
+                                                num_ng=0,
+                                                cal_sparse_feats_input_dims=True)
+
+    model = NCF(user_num=user_num,
+                item_num=item_num,
                 factor_num=config['factor_num'],
                 num_layers=config['num_layers'],
                 dropout=config['dropout'],
-                model=config['model'])
+                model=config['model'],
+                sparse_feats_input_dims=sparse_feats_input_dims,
+                sparse_feats_embed_dims=config['sparse_feats_embed_dims'],
+                num_dense_feats=config['num_dense_feats'])
     model.train()
     return model
 
@@ -93,7 +110,9 @@ est = Estimator.from_torch(model=model_creator, optimizer=optimizer_creator,
                                    'num_layers': 3,
                                    'dropout': 0.5,
                                    'lr': 0.001,
-                                   'model': "NeuMF-end"})
+                                   'model': "NeuMF-end",
+                                   'sparse_feats_embed_dims': 8,
+                                   'num_dense_feats': 1})
 est.fit(data=train_loader_func, epochs=10, batch_size=256)
 
 

--- a/python/orca/tutorial/NCF/pytorch_train_dataloader.py
+++ b/python/orca/tutorial/NCF/pytorch_train_dataloader.py
@@ -78,8 +78,7 @@ loss = nn.BCEWithLogitsLoss()
 # Step 4: Distributed training with Orca PyTorch Estimator
 dataset_dir = "./ml-1m"
 backend = "ray"  # "ray" or "spark"
-callbacks = [TensorBoardCallback(log_dir="runs",
-                                 freq="epoch")]
+callbacks = [TensorBoardCallback(log_dir="runs", freq="epoch")]
 
 est = Estimator.from_torch(model=model_creator, optimizer=optimizer_creator,
                            loss=loss,

--- a/python/orca/tutorial/NCF/pytorch_train_dataloader.py
+++ b/python/orca/tutorial/NCF/pytorch_train_dataloader.py
@@ -27,6 +27,7 @@ from pytorch_model import NCF
 
 from bigdl.orca import init_orca_context, stop_orca_context
 from bigdl.orca.learn.pytorch import Estimator
+from bigdl.orca.learn.pytorch.callbacks.tensorboard import TensorBoardCallback
 from bigdl.orca.learn.metrics import Accuracy, Precision, Recall
 
 
@@ -77,6 +78,8 @@ loss = nn.BCEWithLogitsLoss()
 # Step 4: Distributed training with Orca PyTorch Estimator
 dataset_dir = "./ml-1m"
 backend = "ray"  # "ray" or "spark"
+callbacks = [TensorBoardCallback(log_dir="runs",
+                                 freq="epoch")]
 
 est = Estimator.from_torch(model=model_creator, optimizer=optimizer_creator,
                            loss=loss,
@@ -90,7 +93,7 @@ est = Estimator.from_torch(model=model_creator, optimizer=optimizer_creator,
                                    'lr': 0.001,
                                    'model': "NeuMF-end",
                                    'sparse_feats_embed_dims': 8})
-est.fit(data=train_loader_func, epochs=10, batch_size=256)
+est.fit(data=train_loader_func, epochs=10, batch_size=256, callbacks=callbacks)
 
 
 # Step 5: Distributed evaluation of the trained model

--- a/python/orca/tutorial/NCF/pytorch_train_dataloader.py
+++ b/python/orca/tutorial/NCF/pytorch_train_dataloader.py
@@ -37,14 +37,14 @@ sc = init_orca_context()
 
 # Step 2: Define train and test datasets as PyTorch DataLoader
 def train_loader_func(config, batch_size):
-    train_dataset, _ = load_dataset(config['dataset_dir'], config['num_ng'], config['test_size'])
+    train_dataset, _ = load_dataset(config['dataset_dir'], config['num_ng'])
     train_loader = data.DataLoader(train_dataset, batch_size=batch_size,
                                    shuffle=True, num_workers=0)
     return train_loader
 
 
 def test_loader_func(config, batch_size):
-    _, test_dataset = load_dataset(config['dataset_dir'], config['num_ng'], config['test_size'])
+    _, test_dataset = load_dataset(config['dataset_dir'], config['num_ng'])
     test_loader = data.DataLoader(test_dataset, batch_size=batch_size,
                                   shuffle=False, num_workers=0)
     return test_loader
@@ -87,7 +87,6 @@ est = Estimator.from_torch(model=model_creator, optimizer=optimizer_creator,
                            backend=backend,
                            config={'dataset_dir': dataset_dir,
                                    'num_ng': 4,
-                                   'test_size': 0.2,
                                    'factor_num': 16,
                                    'num_layers': 3,
                                    'dropout': 0.5,

--- a/python/orca/tutorial/NCF/pytorch_train_dataloader.py
+++ b/python/orca/tutorial/NCF/pytorch_train_dataloader.py
@@ -78,7 +78,7 @@ loss = nn.BCEWithLogitsLoss()
 # Step 4: Distributed training with Orca PyTorch Estimator
 dataset_dir = "./ml-1m"
 backend = "ray"  # "ray" or "spark"
-callbacks = [TensorBoardCallback(log_dir="runs", freq="epoch")]
+callbacks = [TensorBoardCallback(log_dir="runs", freq=1000)]
 
 est = Estimator.from_torch(model=model_creator, optimizer=optimizer_creator,
                            loss=loss,

--- a/python/orca/tutorial/NCF/pytorch_train_dataloader.py
+++ b/python/orca/tutorial/NCF/pytorch_train_dataloader.py
@@ -21,9 +21,8 @@ import pandas as pd
 import torch.nn as nn
 import torch.optim as optim
 import torch.utils.data as data
-from sklearn.model_selection import train_test_split
 
-from pytorch_dataset import load_dataset
+from pytorch_dataset import load_dataset, process_users_items, get_sparse_feats_input_dims
 from pytorch_model import NCF
 
 from bigdl.orca import init_orca_context, stop_orca_context
@@ -37,32 +36,14 @@ sc = init_orca_context()
 
 # Step 2: Define train and test datasets as PyTorch DataLoader
 def train_loader_func(config, batch_size):
-    dataset, user_num, item_num, \
-        sparse_feats_input_dims = load_dataset(config['dataset_dir'],
-                                               cal_sparse_feats_input_dims=False,
-                                               num_ng=config['num_ng'],
-                                               merge_features=True)
-
-    # train test split
-    dataset.data = list(map(lambda row: list(row[1:]), dataset.data.itertuples()))
-    train_dataset, _ = train_test_split(dataset, test_size=0.2, random_state=100)
-
+    train_dataset, _ = load_dataset(config['dataset_dir'], config['num_ng'])
     train_loader = data.DataLoader(train_dataset, batch_size=batch_size,
                                    shuffle=True, num_workers=0)
     return train_loader
 
 
 def test_loader_func(config, batch_size):
-    dataset, user_num, item_num, \
-        sparse_feats_input_dims = load_dataset(config['dataset_dir'],
-                                               cal_sparse_feats_input_dims=False,
-                                               num_ng=config['num_ng'],
-                                               merge_features=True)
-
-    # train test split
-    dataset.data = list(map(lambda row: list(row[1:]), dataset.data.itertuples()))
-    _, test_dataset = train_test_split(dataset, test_size=0.2, random_state=100)
-
+    _, test_dataset = load_dataset(config['dataset_dir'], config['num_ng'])
     test_loader = data.DataLoader(test_dataset, batch_size=batch_size,
                                   shuffle=False, num_workers=0)
     return test_loader
@@ -70,12 +51,8 @@ def test_loader_func(config, batch_size):
 
 # Step 3: Define the model, optimizer and loss
 def model_creator(config):
-    dataset, user_num, item_num, \
-        sparse_feats_input_dims = load_dataset(config['dataset_dir'],
-                                               cal_sparse_feats_input_dims=True,
-                                               num_ng=0,
-                                               merge_features=False)
-
+    users, items, user_num, item_num = process_users_items(config['dataset_dir'])
+    sparse_feats_input_dims = get_sparse_feats_input_dims(users, items)
     model = NCF(user_num=user_num,
                 item_num=item_num,
                 factor_num=config['factor_num'],


### PR DESCRIPTION
## Description

Add data loader examples to NCF. 

### 1. Why the change?

To show how to use `pandas.dataframe.merge` API to add features to datasets.

### 2. User API changes

No change.
