### PR TITLE
Nano: remove check for bf16 in optimize

### DIFF
--- a/python/nano/src/bigdl/nano/utils/inference/common/checker.py
+++ b/python/nano/src/bigdl/nano/utils/inference/common/checker.py
@@ -69,8 +69,8 @@ def available_acceleration_combination(excludes: Optional[List[str]],
                           "ipex": _ipex_checker,
                           "onnxruntime": _onnxruntime_checker,
                           "openvino": _openvino_checker,
-                          "pot": _openvino_checker,
-                          "bf16": _bf16_checker}
+                          "pot": _openvino_checker}
+                          # "bf16": _bf16_checker}
     if excludes is None:
         exclude_set: Set[str] = set()
     else:

--- a/python/nano/src/bigdl/nano/utils/inference/common/checker.py
+++ b/python/nano/src/bigdl/nano/utils/inference/common/checker.py
@@ -70,7 +70,6 @@ def available_acceleration_combination(excludes: Optional[List[str]],
                           "onnxruntime": _onnxruntime_checker,
                           "openvino": _openvino_checker,
                           "pot": _openvino_checker}
-                          # "bf16": _bf16_checker}
     if excludes is None:
         exclude_set: Set[str] = set()
     else:


### PR DESCRIPTION
## Description

remove check for bf16 in InferenceOptimizer.optimize()

### How to test?
- [x] Unit test
- [x] Application test
