### PR TITLE
Update PyTorch Estimator doc

### DIFF
--- a/docs/readthedocs/source/doc/Orca/QuickStart/ray-quickstart.md
+++ b/docs/readthedocs/source/doc/Orca/QuickStart/ray-quickstart.md
@@ -18,7 +18,7 @@ conda activate bigdl
 pip install bigdl-orca[ray]
 ```
 
-### Step 1: Initialize
+### Step 1: Init Orca Context
 
 We recommend using `init_orca_context` to initiate and run BigDL on the underlying cluster. The Ray cluster would be launched automatically by specifying `init_ray_on_spark=True`.
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
@@ -25,57 +25,59 @@ class Estimator(object):
                    optimizer,
                    loss=None,
                    metrics=None,
-                   scheduler_creator=None,
                    backend="spark",
                    config=None,
-                   training_operator_cls=TrainingOperator,
-                   initialization_hook=None,
+                   workers_per_node=1,
+                   scheduler_creator=None,
                    scheduler_step_freq="batch",
                    use_tqdm=False,
-                   workers_per_node=1,
                    model_dir=None,
                    sync_stats=False,
                    log_level=logging.INFO,
                    log_to_driver=True,
+                   training_operator_cls=TrainingOperator,
                    ):
         """
         Create an Estimator for PyTorch.
 
-        :param model: A model creator function that returns a PyTorch model.
-               You can directly input a PyTorch model instance for bigdl backend.
-        :param optimizer: Orca/PyTorch optimizer or optimizer creator function if backend="bigdl"
-               , PyTorch optimizer creator function if backend="horovod" or "ray"
-        :param loss: PyTorch loss or loss creator function if backend="bigdl", PyTorch loss creator
-               function if backend="horovod" or "ray"
-        :param metrics: Orca validation methods for evaluate.
-        :param scheduler_creator: parameter for `horovod` and `ray` backends. a
-               learning rate scheduler wrapping the optimizer. You will need to set
-               ``scheduler_step_freq="epoch"`` for the scheduler to be incremented correctly.
-        :param backend: The distributed backend for the Estimator.
-               One of "spark",  "ray", "bigdl" or "horovod". Default: `spark`.
-        :param config: Parameter config dict, CfgNode or any class that plays a role of
-               configuration to create model, optimizer loss and data.
-        :param scheduler_step_freq: parameter for `horovod` and `ray` backends.
-               "batch", "epoch" or None. This will determine when ``scheduler.step`` is called. If
-               "batch", ``step`` will be called after every optimizer step. If "epoch", ``step``
-               will be called after one pass of the DataLoader. If a scheduler is passed in, this
-               value is expected to not be None.
-        :param use_tqdm: parameter for `horovod` and `ray` backends. You can monitor
-               training progress if use_tqdm=True.
-        :param workers_per_node: parameter for `horovod` and `ray` backends. worker
-               number on each node. default: 1.
-        :param model_dir: parameter for `bigdl` and `spark` backend. The path to save model. During
-               the training, if checkpoint_trigger is defined and triggered, the model will be
-               saved to model_dir.
+        :param model: A model creator function that takes the parameter "config" and returns a
+               PyTorch model.
+        :param optimizer: An optimizer creator function that has two parameters "model" and
+               "config" and returns a PyTorch optimizer.
+               Default: None if training is not performed.
+        :param loss: An instance of PyTorch loss.
+               Default: None if loss computation is not needed.
+        :param metrics: One or a list of Orca validation metrics. Function(s) that computes the
+               metrics between the output and target tensors are also supported.
+               Default: None if no validation is involved.
+        :param backend: The distributed backend for the Estimator. One of "spark",  "ray",
+               "bigdl" or "horovod".
+               Default: `spark`.
+        :param config: A parameter config dict, CfgNode or any class instance that plays a role of
+               configuration to create model, loss, optimizer, scheduler and data.
+               Default: None if no config is needed.
+        :param workers_per_node: The number of PyTorch workers on each node.
+               Default: 1.
+        :param scheduler_creator: An scheduler creator function that has two parameters "optimizer"
+               and "config" and returns a PyTorch learning rate scheduler wrapping the optimizer.
+               Note that if you specify this parameter, you need to take care of the argument
+               scheduler_step_freq accordingly as well.
+               Default: None if no scheduler is needed.
+        :param scheduler_step_freq: The frequency when `scheduler.step` is called.
+               "batch" or "epoch" if there is a scheduler.
+               Default: "batch".
+        :param use_tqdm: Whether to use tqdm to monitor the training progress.
+               Default: False.
+        :param model_dir: The path to save the PyTorch model during the training if
+               checkpoint_trigger is defined and triggered.
+               Default: None.
         :param sync_stats: Whether to sync metrics across all distributed workers after each epoch.
-               If set to False, only rank 0's metrics are printed. This param only works horovod,
-               ray and pyspark backend. For spark backend, the metrics printed are
-               are always synced. This param only affects the printed metrics, the returned metrics
-               are always averaged across workers. Default: True
-        :param log_level: Setting the log_level of each distributed worker. This param only works
-               horovod, ray and pyspark backend.
-        :param log_to_driver: (bool) Whether display executor log on driver in cluster mode.
-               Default: True. This option is only for "spark" backend.
+               If set to False, only the metrics of the worker with rank 0 are printed.
+               Default: True
+        :param log_level: The log_level of each distributed worker.
+               Default: logging.INFO.
+        :param log_to_driver: Whether to display executor log on driver in cluster mode for spark
+               backend. Default: True.
 
         :return: A Estimator object for PyTorch.
         """
@@ -87,7 +89,6 @@ class Estimator(object):
                                        metrics=metrics,
                                        scheduler_creator=scheduler_creator,
                                        training_operator_cls=training_operator_cls,
-                                       initialization_hook=initialization_hook,
                                        config=config,
                                        scheduler_step_freq=scheduler_step_freq,
                                        use_tqdm=use_tqdm,
@@ -112,7 +113,6 @@ class Estimator(object):
                                            metrics=metrics,
                                            scheduler_creator=scheduler_creator,
                                            training_operator_cls=training_operator_cls,
-                                           initialization_hook=initialization_hook,
                                            config=config,
                                            scheduler_step_freq=scheduler_step_freq,
                                            use_tqdm=use_tqdm,

--- a/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
@@ -52,7 +52,7 @@ class Estimator(object):
                Default: None if no validation is involved.
         :param backend: The distributed backend for the Estimator. One of "spark",  "ray",
                "bigdl" or "horovod".
-               Default: `spark`.
+               Default: "spark".
         :param config: A parameter config dict, CfgNode or any class instance that plays a role of
                configuration to create model, loss, optimizer, scheduler and data.
                Default: None if no config is needed.

--- a/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
@@ -58,7 +58,7 @@ class Estimator(object):
                Default: None if no config is needed.
         :param workers_per_node: The number of PyTorch workers on each node.
                Default: 1.
-        :param scheduler_creator: An scheduler creator function that has two parameters "optimizer"
+        :param scheduler_creator: A scheduler creator function that has two parameters "optimizer"
                and "config" and returns a PyTorch learning rate scheduler wrapping the optimizer.
                Note that if you specify this parameter, you need to take care of the argument
                scheduler_step_freq accordingly as well.

--- a/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
@@ -26,23 +26,23 @@ class Estimator(object):
                    loss=None,
                    metrics=None,
                    scheduler_creator=None,
+                   backend="spark",
+                   config=None,
                    training_operator_cls=TrainingOperator,
                    initialization_hook=None,
-                   config=None,
                    scheduler_step_freq="batch",
                    use_tqdm=False,
                    workers_per_node=1,
                    model_dir=None,
-                   backend="spark",
                    sync_stats=False,
                    log_level=logging.INFO,
                    log_to_driver=True,
                    ):
         """
-        Create an Estimator for torch.
+        Create an Estimator for PyTorch.
 
-        :param model: PyTorch model or model creator function if backend="bigdl", PyTorch
-               model creator function if backend="horovod" or "ray"
+        :param model: A model creator function that returns a PyTorch model.
+               You can directly input a PyTorch model instance for bigdl backend.
         :param optimizer: Orca/PyTorch optimizer or optimizer creator function if backend="bigdl"
                , PyTorch optimizer creator function if backend="horovod" or "ray"
         :param loss: PyTorch loss or loss creator function if backend="bigdl", PyTorch loss creator
@@ -51,7 +51,9 @@ class Estimator(object):
         :param scheduler_creator: parameter for `horovod` and `ray` backends. a
                learning rate scheduler wrapping the optimizer. You will need to set
                ``scheduler_step_freq="epoch"`` for the scheduler to be incremented correctly.
-        :param config: parameter config dict, CfgNode or any class that plays a role of
+        :param backend: The distributed backend for the Estimator.
+               One of "spark",  "ray", "bigdl" or "horovod". Default: `spark`.
+        :param config: Parameter config dict, CfgNode or any class that plays a role of
                configuration to create model, optimizer loss and data.
         :param scheduler_step_freq: parameter for `horovod` and `ray` backends.
                "batch", "epoch" or None. This will determine when ``scheduler.step`` is called. If
@@ -65,8 +67,6 @@ class Estimator(object):
         :param model_dir: parameter for `bigdl` and `spark` backend. The path to save model. During
                the training, if checkpoint_trigger is defined and triggered, the model will be
                saved to model_dir.
-        :param backend: You can choose "horovod",  "ray", "bigdl" or "spark" as
-               backend. Default: `spark`.
         :param sync_stats: Whether to sync metrics across all distributed workers after each epoch.
                If set to False, only rank 0's metrics are printed. This param only works horovod,
                ray and pyspark backend. For spark backend, the metrics printed are
@@ -76,7 +76,8 @@ class Estimator(object):
                horovod, ray and pyspark backend.
         :param log_to_driver: (bool) Whether display executor log on driver in cluster mode.
                Default: True. This option is only for "spark" backend.
-        :return: an Estimator object.
+
+        :return: A Estimator object for PyTorch.
         """
         if backend in {"horovod", "ray"}:
             from bigdl.orca.learn.pytorch.pytorch_ray_estimator import PyTorchRayEstimator

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -86,7 +86,6 @@ class PyTorchPySparkEstimator(BaseEstimator):
             metrics=None,
             scheduler_creator=None,
             training_operator_cls=TrainingOperator,
-            initialization_hook=None,
             config=None,
             scheduler_step_freq="batch",
             use_tqdm=False,
@@ -121,7 +120,6 @@ class PyTorchPySparkEstimator(BaseEstimator):
         self.model_dir = parse_model_dir(model_dir)
 
         self.model_creator = model_creator
-        self.initialization_hook = initialization_hook
 
         num_nodes, cores_per_node = get_node_and_core_number()
         self.num_workers = num_nodes * workers_per_node

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -108,7 +108,6 @@ class PyTorchRayEstimator(OrcaRayEstimator):
             metrics=None,
             scheduler_creator=None,
             training_operator_cls=TrainingOperator,
-            initialization_hook=None,
             config=None,
             scheduler_step_freq="batch",
             use_tqdm=False,
@@ -144,7 +143,6 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                               "If a loss_creator is not provided, you must "
                               "provide a custom training operator.")
 
-        self.initialization_hook = initialization_hook
         self.config = {} if config is None else config
         worker_config = copy.copy(self.config)
         params = dict(


### PR DESCRIPTION
Correct the inline doc for PyTorch estimator.
Change the order based on importance.
Remove initialization_hook as it is not used anywhere.

The doc for bigdl backend is not included as it will be deprecated in the future.