### PR TITLE
Chronos: fix `ImportError: libGL.so.1` in github actions

### DIFF
--- a/.github/workflows/chronos-install-option-py38-test.yml
+++ b/.github/workflows/chronos-install-option-py38-test.yml
@@ -43,6 +43,7 @@ jobs:
           source activate chronos-py38-env
           pip install pytest==5.4.1
           apt-get update
+          apt-get install -y libgl1
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install --pre --upgrade bigdl-chronos[pytorch]
@@ -79,6 +80,7 @@ jobs:
           source activate chronos-py38-env
           pip install pytest==5.4.1
           apt-get update
+          apt-get install -y libgl1
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install --pre --upgrade bigdl-chronos[tensorflow]
@@ -115,6 +117,7 @@ jobs:
           source activate chronos-py38-env
           pip install pytest==5.4.1
           apt-get update
+          apt-get install -y libgl1
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install --pre --upgrade bigdl-chronos[pytorch,inference]
@@ -151,6 +154,7 @@ jobs:
           source activate chronos-py38-env
           pip install pytest==5.4.1
           apt-get update
+          apt-get install -y libgl1
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install --pre --upgrade bigdl-chronos[pytorch,inference,automl]


### PR DESCRIPTION
## Description

Fix "ImportError: libGL.so.1: cannot open shared object file: No such file or directory" in Chronos installation tests.

### 4. How to test?
- [x] Unit test