### PR TITLE
Chronos: fix validation process when previous workflow was stopped

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -33,6 +33,8 @@ from bigdl.chronos.forecaster.utils_hpo import GenericTSTransformerLightningModu
 
 from .utils_hpo import _format_metric_str
 import warnings
+from tempfile import TemporaryDirectory
+import os
 
 
 class AutoformerForecaster(Forecaster):
@@ -397,72 +399,74 @@ class AutoformerForecaster(Forecaster):
                 trial = self.trainer.hposearcher.study.trials[use_trial_id]
                 self.internal = self.tune_internal._model_build(trial)
 
-        from pytorch_lightning.loggers import CSVLogger
-        logger = False if validation_data is None else CSVLogger(".",
-                                                                 flush_logs_every_n_steps=10,
-                                                                 name="forecaster_tmp_log")
-        from pytorch_lightning.callbacks import EarlyStopping
-        early_stopping = EarlyStopping('val_loss', patience=earlystop_patience)
-        from pytorch_lightning.callbacks import ModelCheckpoint
-        checkpoint_callback = ModelCheckpoint(monitor="val_loss", dirpath='validation',
-                                              filename='best', save_on_train_epoch_end=True)
-        if validation_mode == 'earlystop':
-            callbacks = [early_stopping]
-        elif validation_mode == 'best_epoch':
-            callbacks = [checkpoint_callback]
-        else:
-            callbacks = None
+        with TemporaryDirectory() as forecaster_log_dir:
+            with TemporaryDirectory() as validation_ckpt_dir:
+                from pytorch_lightning.loggers import CSVLogger
+                logger = False if validation_data is None else CSVLogger(
+                    save_dir=forecaster_log_dir,
+                    flush_logs_every_n_steps=10,
+                    name="forecaster_tmp_log")
+                from pytorch_lightning.callbacks import EarlyStopping
+                early_stopping = EarlyStopping('val_loss', patience=earlystop_patience)
+                from pytorch_lightning.callbacks import ModelCheckpoint
+                checkpoint_callback = ModelCheckpoint(monitor="val_loss",
+                                                      dirpath=validation_ckpt_dir,
+                                                      filename='best',
+                                                      save_on_train_epoch_end=True)
+                if validation_mode == 'earlystop':
+                    callbacks = [early_stopping]
+                elif validation_mode == 'best_epoch':
+                    callbacks = [checkpoint_callback]
+                else:
+                    callbacks = None
 
-        # Trainer init
-        self.trainer = Trainer(logger=logger, max_epochs=epochs, callbacks=callbacks,
-                               enable_checkpointing=self.checkpoint_callback,
-                               num_processes=self.num_processes, use_ipex=self.use_ipex,
-                               log_every_n_steps=10)
+                # Trainer init
+                self.trainer = Trainer(logger=logger, max_epochs=epochs, callbacks=callbacks,
+                                       enable_checkpointing=self.checkpoint_callback,
+                                       num_processes=self.num_processes, use_ipex=self.use_ipex,
+                                       log_every_n_steps=10)
 
-        # fitting
-        if validation_data is None:
-            self.trainer.fit(self.internal, data)
-            self.fitted = True
-        else:
-            if isinstance(validation_data, tuple):
-                validation_data = DataLoader(
-                    TensorDataset(torch.from_numpy(validation_data[0]),
-                                  torch.from_numpy(validation_data[1]),
-                                  torch.from_numpy(validation_data[2]),
-                                  torch.from_numpy(validation_data[3])),
-                    batch_size=batch_size,
-                    shuffle=False)
-            # transform a TSDataset instance to dataloader
-            if isinstance(validation_data, TSDataset):
-                _rolled = validation_data.numpy_x is None
-                validation_data = validation_data.to_torch_data_loader(
-                    batch_size=batch_size,
-                    roll=_rolled,
-                    lookback=self.data_config['past_seq_len'],
-                    horizon=self.data_config['future_seq_len'],
-                    label_len=self.data_config['label_len'],
-                    time_enc=True,
-                    feature_col=validation_data.roll_feature,
-                    target_col=validation_data.roll_target,
-                    shuffle=False)
-
-            if os.path.exists("./forecaster_tmp_log"):
-                delete_folder("./forecaster_tmp_log")  # clean the log before fitting
-            if os.path.exists("./validation_tmp_ckpt"):
-                delete_folder("./validation_tmp_ckpt")  # clean the ckpt before fitting
-            self.trainer.fit(self.internal, data, validation_data)
-            self.fitted = True
-            fit_out = read_csv('./forecaster_tmp_log/version_0/metrics.csv', loss_name='val_loss')
-            delete_folder("./forecaster_tmp_log")
-            if validation_mode == 'best_epoch':
-                self.load('validation_tmp_ckpt/best.ckpt')
-                delete_folder("./validation_tmp_ckpt")
-            # modify logger attr in trainer, otherwise predict will report error
-            self.trainer._logger_connector.on_trainer_init(False,
-                                                           self.trainer.flush_logs_every_n_steps,
-                                                           self.trainer.log_every_n_steps,
-                                                           self.trainer.move_metrics_to_cpu)
-            return fit_out
+                # fitting
+                if validation_data is None:
+                    self.trainer.fit(self.internal, data)
+                    self.fitted = True
+                else:
+                    if isinstance(validation_data, tuple):
+                        validation_data = DataLoader(
+                            TensorDataset(torch.from_numpy(validation_data[0]),
+                                          torch.from_numpy(validation_data[1]),
+                                          torch.from_numpy(validation_data[2]),
+                                          torch.from_numpy(validation_data[3])),
+                            batch_size=batch_size,
+                            shuffle=False)
+                    # transform a TSDataset instance to dataloader
+                    if isinstance(validation_data, TSDataset):
+                        _rolled = validation_data.numpy_x is None
+                        validation_data = validation_data.to_torch_data_loader(
+                            batch_size=batch_size,
+                            roll=_rolled,
+                            lookback=self.data_config['past_seq_len'],
+                            horizon=self.data_config['future_seq_len'],
+                            label_len=self.data_config['label_len'],
+                            time_enc=True,
+                            feature_col=validation_data.roll_feature,
+                            target_col=validation_data.roll_target,
+                            shuffle=False)
+                    self.trainer.fit(self.internal, data, validation_data)
+                    self.fitted = True
+                    fit_csv = os.path.join(forecaster_log_dir,
+                                           "forecaster_tmp_log/version_0/metrics.csv")
+                    best_path = os.path.join(validation_ckpt_dir, "best.ckpt")
+                    fit_out = read_csv(fit_csv, loss_name='val_loss')
+                    if validation_mode == 'best_epoch':
+                        self.load(best_path)
+                    # modify logger attr in trainer, otherwise predict will report error
+                    self.trainer._logger_connector.on_trainer_init(
+                        False,
+                        self.trainer.flush_logs_every_n_steps,
+                        self.trainer.log_every_n_steps,
+                        self.trainer.move_metrics_to_cpu)
+                    return fit_out
 
     def predict(self, data, batch_size=32):
         """

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -446,13 +446,17 @@ class AutoformerForecaster(Forecaster):
                     target_col=validation_data.roll_target,
                     shuffle=False)
 
+            if os.path.exists("./forecaster_tmp_log"):
+                delete_folder("./forecaster_tmp_log")  # clean the log before fitting
+            if os.path.exists("./validation_tmp_ckpt"):
+                delete_folder("./validation_tmp_ckpt")  # clean the ckpt before fitting
             self.trainer.fit(self.internal, data, validation_data)
             self.fitted = True
             fit_out = read_csv('./forecaster_tmp_log/version_0/metrics.csv', loss_name='val_loss')
             delete_folder("./forecaster_tmp_log")
             if validation_mode == 'best_epoch':
-                self.load('validation/best.ckpt')
-                delete_folder("./validation")
+                self.load('validation_tmp_ckpt/best.ckpt')
+                delete_folder("./validation_tmp_ckpt")
             # modify logger attr in trainer, otherwise predict will report error
             self.trainer._logger_connector.on_trainer_init(False,
                                                            self.trainer.flush_logs_every_n_steps,

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -25,6 +25,7 @@ import warnings
 warnings.filterwarnings('ignore', category=UserWarning, module='pytorch_lightning')
 warnings.filterwarnings('ignore', category=UserWarning, module='torch')
 import os
+from tempfile import TemporaryDirectory
 import torch
 
 from torch.utils.data import TensorDataset, DataLoader
@@ -363,83 +364,89 @@ class BasePytorchForecaster(Forecaster):
             # data transformation
             if isinstance(data, tuple):
                 data = np_to_dataloader(data, batch_size, self.num_processes)
-            from pytorch_lightning.loggers import CSVLogger
-            logger = False if validation_data is None else CSVLogger(".",
-                                                                     flush_logs_every_n_steps=10,
-                                                                     name="forecaster_tmp_log")
-            from pytorch_lightning.callbacks import EarlyStopping
-            early_stopping = EarlyStopping('val/loss', patience=earlystop_patience)
-            from pytorch_lightning.callbacks import ModelCheckpoint
-            checkpoint_callback = ModelCheckpoint(monitor="val/loss", dirpath='validation',
-                                                  filename='best', save_on_train_epoch_end=True)
-            if validation_mode == 'earlystop':
-                callbacks = [early_stopping]
-            elif validation_mode == 'best_epoch':
-                callbacks = [checkpoint_callback]
-            else:
-                callbacks = None
-            # Trainer init
-            self.trainer = Trainer(logger=logger, max_epochs=epochs, callbacks=callbacks,
-                                   enable_checkpointing=self.checkpoint_callback,
-                                   num_processes=self.num_processes, use_ipex=self.use_ipex,
-                                   log_every_n_steps=10,
-                                   distributed_backend=self.local_distributed_backend)
 
-            # This error is only triggered when the python interpreter starts additional processes.
-            # num_process=1 and subprocess will be safely started in the main process,
-            # so this error will not be triggered.
-            invalidInputError(is_main_process(),
-                              "Make sure new Python interpreters can "
-                              "safely import the main module. ",
-                              fixMsg="you should use if __name__ == '__main__':, "
-                              "otherwise performance will be degraded.")
+            with TemporaryDirectory() as forecaster_log_dir:
+                with TemporaryDirectory() as validation_ckpt_dir:
+                    from pytorch_lightning.loggers import CSVLogger
+                    logger = False if validation_data is None else CSVLogger(
+                        save_dir=forecaster_log_dir,
+                        flush_logs_every_n_steps=10,
+                        name="forecaster_tmp_log")
+                    from pytorch_lightning.callbacks import EarlyStopping
+                    early_stopping = EarlyStopping('val/loss', patience=earlystop_patience)
+                    from pytorch_lightning.callbacks import ModelCheckpoint
+                    checkpoint_callback = ModelCheckpoint(monitor="val/loss",
+                                                          dirpath=validation_ckpt_dir,
+                                                          filename='best',
+                                                          save_on_train_epoch_end=True)
+                    if validation_mode == 'earlystop':
+                        callbacks = [early_stopping]
+                    elif validation_mode == 'best_epoch':
+                        callbacks = [checkpoint_callback]
+                    else:
+                        callbacks = None
+                    # Trainer init
+                    self.trainer = Trainer(logger=logger, max_epochs=epochs, callbacks=callbacks,
+                                           enable_checkpointing=self.checkpoint_callback,
+                                           num_processes=self.num_processes, use_ipex=self.use_ipex,
+                                           log_every_n_steps=10,
+                                           distributed_backend=self.local_distributed_backend)
 
-            # build internal according to use_trail_id for multi-objective HPO
-            if hasattr(self, "tune_trainer") and self.tune_trainer.hposearcher.objective.mo_hpo:
-                invalidOperationError(self.tune_trainer.hposearcher.study,
-                                      "You must tune before fit the model.")
-                invalidInputError(use_trial_id is not None,
-                                  "For multibojective HPO, you must specify a trial id for fit.")
-                trial = self.tune_trainer.hposearcher.study.trials[use_trial_id]
-                self.internal = self.tune_internal._model_build(trial)
+                    # This error is only triggered when the python
+                    # interpreter starts additional processes.
+                    # num_process=1 and subprocess will be safely started in the main process,
+                    # so this error will not be triggered.
+                    invalidInputError(is_main_process(),
+                                      "Make sure new Python interpreters can "
+                                      "safely import the main module. ",
+                                      fixMsg="you should use if __name__ == '__main__':, "
+                                      "otherwise performance will be degraded.")
 
-            # fitting
-            if not validation_data:
-                self.trainer.fit(self.internal, data)
-                self.fitted = True
-            else:
-                if isinstance(validation_data, TSDataset):
-                    _rolled = validation_data.numpy_x is None
-                    validation_data =\
-                        validation_data.to_torch_data_loader(
-                            batch_size=batch_size,
-                            roll=_rolled,
-                            lookback=self.data_config['past_seq_len'],
-                            horizon=self.data_config['future_seq_len'],
-                            feature_col=validation_data.roll_feature,
-                            target_col=validation_data.roll_target,
-                            shuffle=False)
-                if isinstance(validation_data, tuple):
-                    validation_data = np_to_dataloader(validation_data, batch_size,
-                                                       self.num_processes)
-                if os.path.exists("./forecaster_tmp_log"):
-                    delete_folder("./forecaster_tmp_log")  # clean the log before fitting
-                if os.path.exists("./validation_tmp_ckpt"):
-                    delete_folder("./validation_tmp_ckpt")  # clean the ckpt before fitting
-                self.trainer.fit(self.internal, data, validation_data)
-                self.fitted = True
-                fit_out = read_csv('./forecaster_tmp_log/version_0/metrics.csv')
-                delete_folder("./forecaster_tmp_log")
-                if validation_mode == 'best_epoch':
-                    self.load('validation_tmp_ckpt/best.ckpt')
-                    delete_folder("./validation_tmp_ckpt")
-                # modify logger attr in trainer, otherwise predict will report error
-                self.trainer._logger_connector.on_trainer_init(
-                    False,
-                    self.trainer.flush_logs_every_n_steps,
-                    self.trainer.log_every_n_steps,
-                    self.trainer.move_metrics_to_cpu)
-                return fit_out
+                    # build internal according to use_trail_id for multi-objective HPO
+                    mo_hpo = self.tune_trainer.hposearcher.objective.mo_hpo
+                    if hasattr(self, "tune_trainer") and mo_hpo:
+                        invalidOperationError(self.tune_trainer.hposearcher.study,
+                                              "You must tune before fit the model.")
+                        invalidInputError(use_trial_id is not None,
+                                          "For multibojective HPO, "
+                                          "you must specify a trial id for fit.")
+                        trial = self.tune_trainer.hposearcher.study.trials[use_trial_id]
+                        self.internal = self.tune_internal._model_build(trial)
+
+                    # fitting
+                    if not validation_data:
+                        self.trainer.fit(self.internal, data)
+                        self.fitted = True
+                    else:
+                        if isinstance(validation_data, TSDataset):
+                            _rolled = validation_data.numpy_x is None
+                            validation_data =\
+                                validation_data.to_torch_data_loader(
+                                    batch_size=batch_size,
+                                    roll=_rolled,
+                                    lookback=self.data_config['past_seq_len'],
+                                    horizon=self.data_config['future_seq_len'],
+                                    feature_col=validation_data.roll_feature,
+                                    target_col=validation_data.roll_target,
+                                    shuffle=False)
+                        if isinstance(validation_data, tuple):
+                            validation_data = np_to_dataloader(validation_data, batch_size,
+                                                               self.num_processes)
+                        self.trainer.fit(self.internal, data, validation_data)
+                        self.fitted = True
+                        fit_csv = os.path.join(forecaster_log_dir,
+                                               "forecaster_tmp_log/version_0/metrics.csv")
+                        best_path = os.path.join(validation_ckpt_dir, "best.ckpt")
+                        fit_out = read_csv(fit_csv)
+                        if validation_mode == 'best_epoch':
+                            self.load(best_path)
+                        # modify logger attr in trainer, otherwise predict will report error
+                        self.trainer._logger_connector.on_trainer_init(
+                            False,
+                            self.trainer.flush_logs_every_n_steps,
+                            self.trainer.log_every_n_steps,
+                            self.trainer.move_metrics_to_cpu)
+                        return fit_out
 
     def optimize(self, train_data,
                  validation_data=None,

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -422,13 +422,17 @@ class BasePytorchForecaster(Forecaster):
                 if isinstance(validation_data, tuple):
                     validation_data = np_to_dataloader(validation_data, batch_size,
                                                        self.num_processes)
+                if os.path.exists("./forecaster_tmp_log"):
+                    delete_folder("./forecaster_tmp_log")  # clean the log before fitting
+                if os.path.exists("./validation_tmp_ckpt"):
+                    delete_folder("./validation_tmp_ckpt")  # clean the ckpt before fitting
                 self.trainer.fit(self.internal, data, validation_data)
                 self.fitted = True
                 fit_out = read_csv('./forecaster_tmp_log/version_0/metrics.csv')
                 delete_folder("./forecaster_tmp_log")
                 if validation_mode == 'best_epoch':
-                    self.load('validation/best.ckpt')
-                    delete_folder("./validation")
+                    self.load('validation_tmp_ckpt/best.ckpt')
+                    delete_folder("./validation_tmp_ckpt")
                 # modify logger attr in trainer, otherwise predict will report error
                 self.trainer._logger_connector.on_trainer_init(
                     False,


### PR DESCRIPTION
## Description

### 1. Why the change?

When users stopped the previous training by CTRL+C or something brute, the ramain folder might make next round of validation fail

### 2. User API changes

nothing

### 3. Summary of the change 
delete the folder before fitting

- [x] move the folder to a tmp place rather than pwd.

### 4. How to test?
- [x] Unit test

