### PR TITLE
[Nano API doc] Remove `DEFAULT_INFERENCE_ACCELERATION_METHOD`

### DIFF
--- a/docs/readthedocs/source/doc/PythonAPI/Nano/pytorch.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Nano/pytorch.rst
@@ -15,7 +15,7 @@ bigdl.nano.pytorch.InferenceOptimizer
 .. autoclass:: bigdl.nano.pytorch.InferenceOptimizer
     :members:
     :undoc-members:
-    :exclude-members: ALL_INFERENCE_ACCELERATION_METHOD
+    :exclude-members: ALL_INFERENCE_ACCELERATION_METHOD, DEFAULT_INFERENCE_ACCELERATION_METHOD
     :inherited-members:
 
 bigdl.nano.pytorch.TorchNano


### PR DESCRIPTION
## Description

Remove `DEFAULT_INFERENCE_ACCELERATION_METHOD` in API doc for `InferenceOptimizer.optimize`

Document test: https://yuwentestdocs.readthedocs.io/en/nano-api-doc-fix/doc/PythonAPI/Nano/pytorch.html#bigdl-nano-pytorch-inferenceoptimizer