### PR TITLE
Chronos: add deploy mode in `TSDataset`

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -45,6 +45,7 @@ class TSDataset:
         Cascade call is supported for most of the transform methods.
         '''
         self.df = data
+        # whether to use evaluate mode to improve latency in production environment
         self.evaluate = schema["evaluate"]
         if not self.evaluate:
             # detect low-quality data and automatic repair (optional)

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -708,6 +708,9 @@ class TSDataset:
                 invalidInputError(False,
                                   "The time series data should be "
                                   "aligned if id_sensitive is set to True.")
+        else:
+            is_predict = True
+
         feature_col = _to_list(feature_col, "feature_col", evaluate_mode=self.evaluate_mode) \
             if feature_col is not None else self.feature_col
         target_col = _to_list(target_col, "target_col", evaluate_mode=self.evaluate_mode) \
@@ -1056,7 +1059,7 @@ class TSDataset:
             for feature in self.feature_col:
                 if feature not in self.roll_additional_feature:
                     feature_col.append(feature)
-        if fit:
+        if fit and not self.evaluate_mode:
             self.df[self.target_col + feature_col] = \
                 scaler.fit_transform(self.df[self.target_col + feature_col])
         else:

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -395,7 +395,7 @@ class TSDataset:
                               " into a datetime format).")
             from pandas.api.types import is_numeric_dtype
             type_error_list = [val for val in self.target_col + self.feature_col
-                            if not is_numeric_dtype(self.df[val])]
+                               if not is_numeric_dtype(self.df[val])]
             try:
                 for val in type_error_list:
                     self.df[val] = self.df[val].astype(np.float32)

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -146,7 +146,8 @@ class TSDataset:
             tsdataset_df = df
 
         target_col = _to_list(target_col, name="target_col", evaluate_mode=evaluate_mode)
-        feature_col = _to_list(extra_feature_col, name="extra_feature_col", evaluate_mode=evaluate_mode)
+        feature_col = _to_list(extra_feature_col, name="extra_feature_col",
+                               evaluate_mode=evaluate_mode)
 
         if id_col is None:
             tsdataset_df[_DEFAULT_ID_COL_NAME] = _DEFAULT_ID_PLACEHOLDER
@@ -318,7 +319,8 @@ class TSDataset:
         # Only test locally at present
         from bigdl.chronos.data.utils.prometheus_df import GetRangeDataframe
         query_list = _to_list(query, name="query", evaluate_mode=evaluate_mode)
-        columns = {"target_col": _to_list(target_col, name="target_col", evaluate_mode=evaluate_mode),
+        columns = {"target_col": _to_list(target_col, name="target_col",
+                                          evaluate_mode=evaluate_mode),
                    "id_col": _to_list(id_col, name="id_col", evaluate_mode=evaluate_mode),
                    "extra_feature_col": _to_list(extra_feature_col, name="extra_feature_col",
                                                  evaluate_mode=evaluate_mode)}
@@ -388,9 +390,9 @@ class TSDataset:
         if not self.evaluate_mode:
             from bigdl.nano.utils.log4Error import invalidInputError
             invalidInputError(self._is_pd_datetime,
-                            "The time series data does not have a Pandas datetime format "
-                            "(you can use pandas.to_datetime to convert a string"
-                            " into a datetime format).")
+                              "The time series data does not have a Pandas datetime format "
+                              "(you can use pandas.to_datetime to convert a string"
+                              " into a datetime format).")
             from pandas.api.types import is_numeric_dtype
             type_error_list = [val for val in self.target_col + self.feature_col
                             if not is_numeric_dtype(self.df[val])]
@@ -399,8 +401,8 @@ class TSDataset:
                     self.df[val] = self.df[val].astype(np.float32)
             except Exception:
                 invalidInputError(False,
-                                "All the columns of target_col "
-                                "and extra_feature_col should be of numeric type.")
+                                  "All the columns of target_col "
+                                  "and extra_feature_col should be of numeric type.")
         self.df = self.df.groupby([self.id_col]) \
             .apply(lambda df: resample_timeseries_dataframe(df=df,
                                                             dt_col=self.dt_col,

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -458,9 +458,9 @@ class TSDataset:
         if not self.evaluate:
             from bigdl.nano.utils.log4Error import invalidInputError
             invalidInputError(self._is_pd_datetime,
-                            "The time series data does not have a Pandas datetime format"
-                            "(you can use pandas.to_datetime to convert a string into"
-                            " a datetime format.)")
+                              "The time series data does not have a Pandas datetime format"
+                              "(you can use pandas.to_datetime to convert a string into"
+                              " a datetime format.)")
         features_generated = []
         self.df = generate_dt_features(input_df=self.df,
                                        dt_col=self.dt_col,
@@ -691,12 +691,12 @@ class TSDataset:
             from bigdl.nano.utils.log4Error import invalidInputError
             if id_sensitive and not _check_is_aligned(self.df, self.id_col, self.dt_col):
                 invalidInputError(False,
-                                "The time series data should be "
-                                "aligned if id_sensitive is set to True.")
-        feature_col = _to_list(feature_col, "feature_col", evaluate=self.evaluate) if feature_col is not None \
-            else self.feature_col
-        target_col = _to_list(target_col, "target_col", evaluate=self.evaluate) if target_col is not None \
-            else self.target_col
+                                  "The time series data should be "
+                                  "aligned if id_sensitive is set to True.")
+        feature_col = _to_list(feature_col, "feature_col", evaluate=self.evaluate) \
+            if feature_col is not None else self.feature_col
+        target_col = _to_list(target_col, "target_col", evaluate=self.evaluate) \
+            if target_col is not None else self.target_col
         if self.roll_additional_feature:
             additional_feature_col =\
                 list(set(feature_col).intersection(set(self.roll_additional_feature)))
@@ -997,8 +997,8 @@ class TSDataset:
             from bigdl.nano.utils.log4Error import invalidInputError
             if self.numpy_x is None:
                 invalidInputError(False,
-                                "Please call 'roll' method "
-                                "before transform a TSDataset to numpy ndarray!")
+                                  "Please call 'roll' method "
+                                  "before transform a TSDataset to numpy ndarray!")
         if self.numpy_y is None and self.numpy_x_timeenc is None:
             return self.numpy_x
         elif self.numpy_x_timeenc is None:
@@ -1052,8 +1052,8 @@ class TSDataset:
                     invalidInputError(not check_is_fitted(scaler), "scaler is not fittedd")
                 except Exception:
                     invalidInputError(False,
-                                    "When calling scale for the first time, "
-                                    "you need to set fit=True.")
+                                      "When calling scale for the first time, "
+                                      "you need to set fit=True.")
             self.df[self.target_col + feature_col] = \
                 scaler.transform(self.df[self.target_col + feature_col])
         self.scaler = scaler

--- a/python/chronos/src/bigdl/chronos/data/utils/resample.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/resample.py
@@ -45,8 +45,8 @@ def resample_timeseries_dataframe(df,
         invalidInputError(dt_col in df.columns, f"dt_col {dt_col} can not be found in df.")
         invalidInputError(pd.isna(df[dt_col]).sum() == 0, "There is N/A in datetime col")
         invalidInputError(merge_mode in ['max', 'min', 'mean', 'sum'],
-                        "merge_mode should be one of ['max', 'min', 'mean', 'sum'],"
-                        " but found {merge_mode}.")
+                          "merge_mode should be one of ['max', 'min', 'mean', 'sum'],"
+                          " but found {merge_mode}.")
 
     res_df = df.copy()
     id_name = None
@@ -69,7 +69,7 @@ def resample_timeseries_dataframe(df,
     end_time_stamp = pd.Timestamp(end_time) if end_time else res_df.index[-1]
     if not evaluate_mode:
         invalidInputError(start_time_stamp <= end_time_stamp,
-                        "end time must be later than start time.")
+                          "end time must be later than start time.")
 
     offset = (start_time_stamp - res_df.index[0]) % pd.Timedelta(interval)
     new_index = pd.date_range(start=start_time_stamp-offset, end=end_time_stamp, freq=interval)

--- a/python/chronos/src/bigdl/chronos/data/utils/resample.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/resample.py
@@ -24,7 +24,7 @@ def resample_timeseries_dataframe(df,
                                   end_time=None,
                                   id_col=None,
                                   merge_mode="mean",
-                                  evaluate_mode=False):
+                                  deploy_mode=False):
     '''
     resample and return a dataframe with a new time interval.
     :param df: input dataframe.
@@ -36,11 +36,11 @@ def resample_timeseries_dataframe(df,
     :param merge_mode: if current interval is smaller than output interval,
         we need to merge the values in a mode. "max", "min", "mean"
         or "sum" are supported for now.
-    :param evaluate_mode: a bool indicates whether to use evaluate mode, which will be used in
-           production environment to improve the latency of data processing. The value
+    :param deploy_mode: a bool indicates whether to use deploy mode, which will be used in
+           production environment to reduce the latency of data processing. The value
            defaults to False.
     '''
-    if not evaluate_mode:
+    if not deploy_mode:
         from bigdl.nano.utils.log4Error import invalidInputError
         invalidInputError(dt_col in df.columns, f"dt_col {dt_col} can not be found in df.")
         invalidInputError(pd.isna(df[dt_col]).sum() == 0, "There is N/A in datetime col")
@@ -67,7 +67,7 @@ def resample_timeseries_dataframe(df,
 
     start_time_stamp = pd.Timestamp(start_time) if start_time else res_df.index[0]
     end_time_stamp = pd.Timestamp(end_time) if end_time else res_df.index[-1]
-    if not evaluate_mode:
+    if not deploy_mode:
         invalidInputError(start_time_stamp <= end_time_stamp,
                           "end time must be later than start time.")
 

--- a/python/chronos/src/bigdl/chronos/data/utils/resample.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/resample.py
@@ -23,7 +23,8 @@ def resample_timeseries_dataframe(df,
                                   start_time=None,
                                   end_time=None,
                                   id_col=None,
-                                  merge_mode="mean"):
+                                  merge_mode="mean",
+                                  evaluate_mode=False):
     '''
     resample and return a dataframe with a new time interval.
     :param df: input dataframe.
@@ -35,13 +36,17 @@ def resample_timeseries_dataframe(df,
     :param merge_mode: if current interval is smaller than output interval,
         we need to merge the values in a mode. "max", "min", "mean"
         or "sum" are supported for now.
+    :param evaluate_mode: a bool indicates whether to use evaluate mode, which will be used in
+           production environment to improve the latency of data processing. The value
+           defaults to False.
     '''
-    from bigdl.nano.utils.log4Error import invalidInputError
-    invalidInputError(dt_col in df.columns, f"dt_col {dt_col} can not be found in df.")
-    invalidInputError(pd.isna(df[dt_col]).sum() == 0, "There is N/A in datetime col")
-    invalidInputError(merge_mode in ['max', 'min', 'mean', 'sum'],
-                      "merge_mode should be one of ['max', 'min', 'mean', 'sum'],"
-                      " but found {merge_mode}.")
+    if not evaluate_mode:
+        from bigdl.nano.utils.log4Error import invalidInputError
+        invalidInputError(dt_col in df.columns, f"dt_col {dt_col} can not be found in df.")
+        invalidInputError(pd.isna(df[dt_col]).sum() == 0, "There is N/A in datetime col")
+        invalidInputError(merge_mode in ['max', 'min', 'mean', 'sum'],
+                        "merge_mode should be one of ['max', 'min', 'mean', 'sum'],"
+                        " but found {merge_mode}.")
 
     res_df = df.copy()
     id_name = None
@@ -62,8 +67,9 @@ def resample_timeseries_dataframe(df,
 
     start_time_stamp = pd.Timestamp(start_time) if start_time else res_df.index[0]
     end_time_stamp = pd.Timestamp(end_time) if end_time else res_df.index[-1]
-    invalidInputError(start_time_stamp <= end_time_stamp,
-                      "end time must be later than start time.")
+    if not evaluate_mode:
+        invalidInputError(start_time_stamp <= end_time_stamp,
+                        "end time must be later than start time.")
 
     offset = (start_time_stamp - res_df.index[0]) % pd.Timedelta(interval)
     new_index = pd.date_range(start=start_time_stamp-offset, end=end_time_stamp, freq=interval)

--- a/python/chronos/src/bigdl/chronos/data/utils/roll.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/roll.py
@@ -27,7 +27,7 @@ def roll_timeseries_dataframe(df,
                               id_col=None,
                               label_len=0,
                               contain_id=False,
-                              evaluate_mode=False):
+                              deploy_mode=False):
     """
     roll dataframe into numpy ndarray sequence samples.
 
@@ -45,15 +45,15 @@ def roll_timeseries_dataframe(df,
     :param id_col: str, indicate the id col name, only needed when contain_id is True.
     :param label_len: This parameter is only for transformer-based model.
     :param contain_id: This parameter is only for XShardsTSDataset
-    :param evaluate_mode: a bool indicates whether to use evaluate mode, which will be used in
-           production environment to improve the latency of data processing. The value
+    :param deploy_mode: a bool indicates whether to use deploy mode, which will be used in
+           production environment to reduce the latency of data processing. The value
            defaults to False.
     :return: x, y
         x: 3-d numpy array in format (no. of samples, lookback, feature_col length)
         y: 3-d numpy array in format (no. of samples, horizon, target_col length)
     Note: Specially, if `horizon` is set to 0, then y will be None.
     """
-    if evaluate_mode:
+    if deploy_mode:
         return _roll_timeseries_dataframe_test(df,
                                                roll_feature_df,
                                                lookback,

--- a/python/chronos/src/bigdl/chronos/data/utils/roll.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/roll.py
@@ -26,7 +26,8 @@ def roll_timeseries_dataframe(df,
                               target_col,
                               id_col=None,
                               label_len=0,
-                              contain_id=False):
+                              contain_id=False,
+                              evaluate=False):
     """
     roll dataframe into numpy ndarray sequence samples.
 
@@ -44,11 +45,23 @@ def roll_timeseries_dataframe(df,
     :param id_col: str, indicate the id col name, only needed when contain_id is True.
     :param label_len: This parameter is only for transformer-based model.
     :param contain_id: This parameter is only for XShardsTSDataset
+    :param evaluate: a bool indicates whether to use evaluate mode, which will be used in
+           production environment to improve the latency of data processing. The value
+           defaults to False.
     :return: x, y
         x: 3-d numpy array in format (no. of samples, lookback, feature_col length)
         y: 3-d numpy array in format (no. of samples, horizon, target_col length)
     Note: Specially, if `horizon` is set to 0, then y will be None.
     """
+    if evaluate:
+        return _roll_timeseries_dataframe_test(df,
+                                               roll_feature_df,
+                                               lookback,
+                                               feature_col,
+                                               target_col,
+                                               id_col=id_col,
+                                               contain_id=contain_id)
+
     from bigdl.nano.utils.log4Error import invalidInputError
     invalidInputError(isinstance(df, pd.DataFrame), "df is expected to be pandas dataframe")
     invalidInputError(isinstance(lookback, int), "lookback is expected to be int")

--- a/python/chronos/src/bigdl/chronos/data/utils/roll.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/roll.py
@@ -27,7 +27,7 @@ def roll_timeseries_dataframe(df,
                               id_col=None,
                               label_len=0,
                               contain_id=False,
-                              evaluate=False):
+                              evaluate_mode=False):
     """
     roll dataframe into numpy ndarray sequence samples.
 
@@ -45,7 +45,7 @@ def roll_timeseries_dataframe(df,
     :param id_col: str, indicate the id col name, only needed when contain_id is True.
     :param label_len: This parameter is only for transformer-based model.
     :param contain_id: This parameter is only for XShardsTSDataset
-    :param evaluate: a bool indicates whether to use evaluate mode, which will be used in
+    :param evaluate_mode: a bool indicates whether to use evaluate mode, which will be used in
            production environment to improve the latency of data processing. The value
            defaults to False.
     :return: x, y
@@ -53,7 +53,7 @@ def roll_timeseries_dataframe(df,
         y: 3-d numpy array in format (no. of samples, horizon, target_col length)
     Note: Specially, if `horizon` is set to 0, then y will be None.
     """
-    if evaluate:
+    if evaluate_mode:
         return _roll_timeseries_dataframe_test(df,
                                                roll_feature_df,
                                                lookback,

--- a/python/chronos/src/bigdl/chronos/data/utils/utils.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/utils.py
@@ -15,12 +15,12 @@
 #
 
 
-def _to_list(item, name, expect_type=str, evaluate_mode=False):
+def _to_list(item, name, expect_type=str, deploy_mode=False):
     if isinstance(item, list):
         return item
     if item is None:
         return []
-    if not evaluate_mode:
+    if not deploy_mode:
         _check_type(item, name, expect_type)
     return [item]
 

--- a/python/chronos/src/bigdl/chronos/data/utils/utils.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/utils.py
@@ -15,12 +15,13 @@
 #
 
 
-def _to_list(item, name, expect_type=str):
+def _to_list(item, name, expect_type=str, evaluate=False):
     if isinstance(item, list):
         return item
     if item is None:
         return []
-    _check_type(item, name, expect_type)
+    if not evaluate:
+        _check_type(item, name, expect_type)
     return [item]
 
 

--- a/python/chronos/src/bigdl/chronos/data/utils/utils.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/utils.py
@@ -15,12 +15,12 @@
 #
 
 
-def _to_list(item, name, expect_type=str, evaluate=False):
+def _to_list(item, name, expect_type=str, evaluate_mode=False):
     if isinstance(item, list):
         return item
     if item is None:
         return []
-    if not evaluate:
+    if not evaluate_mode:
         _check_type(item, name, expect_type)
     return [item]
 


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

<!-- Provide the related github issue link if available -->
To improve data processing latency in production environment, an `deploy mode` is introduced in `TSDataset`.
This is the first PR of this feature, mainly focusing on removing unnecessary type checks for production environment in data processing pipeline.

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->
In `TSDataset.from_pandas`, a `deploy_mode` parameter is added to indicate whether to use deploy mode.
```python
tsdata = TSDataset.from_pandas(df,
              dt_col="timestamp",
              target_col="value",
              repair=False,
              deploy_mode=True)
```
`deploy_mode` parameter is also added in`from_parquet`, `from_prometheus` and some related methods.
### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
- Add `deploy_mode` parameter in `from_pandas`, `from_parquet` and `from_prometheus`
- Remove unnecessary type checks in several methods.
### 4. How to test?
- [ ] Unit test