### PR TITLE
Nano: fix early stop and channels_last

### DIFF
--- a/python/nano/src/bigdl/nano/utils/inference/common/utils.py
+++ b/python/nano/src/bigdl/nano/utils/inference/common/utils.py
@@ -63,6 +63,9 @@ def throughput_calculate_helper(iterrun, baseline_time, func, *args):
     '''
     A simple helper to calculate average latency
     '''
+    # test run two times for more accurate latency
+    for i in range(2):
+        func(*args)
     start_time = time.perf_counter()
     time_list = []
     for i in range(iterrun):


### PR DESCRIPTION
## Description

Find three issues during OOB, fix them in this PR.

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/217

### 2. User API changes

No change, just make `channels_last` as a separate parameter now.

### 3. Summary of the change 

- add test run in latency calculation to provide more stable latency
- save model even early stop
- make `channels_last` as a separate parameter now

### 4. How to test?
- [ ] Unit test
- [ ] Application test
