### PR TITLE
Nano: fix fp32_channels_last

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -58,9 +58,10 @@ class TorchAccelerationOption(AccelerationOption):
                  thread_num=None, logging=False, sample_size_for_pot=100):
         accelerator = self.get_accelerator()
         if self.get_precision() == "fp32":
-            # trace
-            if accelerator is None and self.ipex is False:
+            if accelerator is None and self.ipex is False and \
+                    self.channels_last is False:
                 return model
+            # trace
             if accelerator in ("jit", None):
                 acce_model = \
                     InferenceOptimizer.trace(model=model,


### PR DESCRIPTION
## Description

 fp32_channels_last option seems just returning original model now.

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/221

### 2. User API changes

No change

### 3. Summary of the change 

Make  fp32_channels_last return right model.

### 4. How to test?
- [x] Unit test
- [x] Application test

