### PR TITLE
Nano: fix jit_bf16 add support jit_channels_last

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -63,7 +63,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                     with torch.cpu.amp.autocast():
                         self.model = torch.jit.trace(self.model, input_sample,
                                                      check_trace=False)
-                        self.model = torch.jit.freeze(self.model)
+                        if self.use_ipex:
+                            self.model = torch.jit.freeze(self.model)
             else:
                 with torch.no_grad():
                     self.model = torch.jit.trace(self.model, input_sample,

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -116,7 +116,11 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             "int8": TorchAccelerationOption(inc=True),
             "int8_ipex": TorchAccelerationOption(inc=True, method="ipex"),
             "jit_fp32": TorchAccelerationOption(jit=True),
+            "jit_fp32_channels_last": TorchAccelerationOption(jit=True,
+                                                              channels_last=True),
             "jit_bf16": TorchAccelerationOption(jit=True, bf16=True),
+            "jit_bf16_channels_last": TorchAccelerationOption(jit=True, bf16=True,
+                                                              channels_last=True),
             "jit_fp32_ipex": TorchAccelerationOption(jit=True, ipex=True),
             "jit_fp32_ipex_channels_last": TorchAccelerationOption(jit=True, ipex=True,
                                                                    channels_last=True),
@@ -260,6 +264,10 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         invalidInputError(isinstance(model, nn.Module), "model should be a nn module.")
         invalidInputError(direction in ['min', 'max'],
                           "Only support direction 'min', 'max'.")
+        invalidInputError(accelerator is None or isinstance(accelerator, tuple),
+                          "accelerator must be a tuple.")
+        invalidInputError(precision is None or isinstance(precision, tuple),
+                          "precison must be a tuple.")
         _check_accelerator = accelerator is None or all(
             ac in [None, 'onnxruntime', 'openvino', 'jit'] for ac in accelerator)
         invalidInputError(_check_accelerator is True,

--- a/python/nano/test/pytorch/tests/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/test_inference_optimizer.py
@@ -408,7 +408,7 @@ class TestInferencePipeline(TestCase):
                                thread_num=4,
                                precision=('bf16', 'int8'))
         optim_dict = inference_opt.optimized_model_dict
-        assert len(optim_dict) == 13
+        assert len(optim_dict) == 14
         with pytest.raises(RuntimeError):
             acc_model, option = inference_opt.get_best_model(precision="fp32")
 


### PR DESCRIPTION
## Description

- update the error message when user don't pass in a tuple for `accelerator` and `precision` in `optimize`
- add jit_channels_last for fp32 and bf16
- fix error of bf16_jit

### How to test?
- [x] Unit test
- [x] Application test
