### PR TITLE
Nano : add get_context() method

### DIFF
--- a/python/nano/example/pytorch/inference_optimizer/resnet/inference_pipeline.py
+++ b/python/nano/example/pytorch/inference_optimizer/resnet/inference_pipeline.py
@@ -52,5 +52,6 @@ if __name__ == "__main__":
     print("When accuracy drop less than 5%, the model with minimal latency is: ", option)
 
     # 5. Inference with accelerated model
-    x_input = next(iter(datamodule.train_dataloader(batch_size=1)))[0]
-    output = acc_model(x_input)
+    with InferenceOptimizer.get_context(acc_model):  # make sure set context manager
+        x_input = next(iter(datamodule.train_dataloader(batch_size=1)))[0]
+        output = acc_model(x_input)

--- a/python/nano/example/pytorch/inference_optimizer/vision_transformers/vision_transformer.ipynb
+++ b/python/nano/example/pytorch/inference_optimizer/vision_transformers/vision_transformer.ipynb
@@ -317,8 +317,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "input_sample = next(iter(val_dataloader))[0]\n",
-    "target = acc_model(input_sample).argmax()"
+    "with InferenceOptimizer.get_context(acc_model):\n",
+    "    input_sample = next(iter(val_dataloader))[0]\n",
+    "    target = acc_model(input_sample).argmax()"
    ]
   },
   {
@@ -761,7 +762,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.7.10 ('ruonan_nano')",
    "language": "python",
    "name": "python3"
   },
@@ -775,11 +776,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.7.10"
   },
   "vscode": {
    "interpreter": {
-    "hash": "75c4387adfc215da0f2d9d02c27ad9a4df553a9f0187eec0365fe565a2e50216"
+    "hash": "d347a5dca25745bedb029e46e41f7d6c8c9b5181ecb97033e2e81a7538459254"
    }
   }
  },

--- a/python/nano/example/quantization/neural-compressor/pytorch-lightning/cifar_resnet18/README.md
+++ b/python/nano/example/quantization/neural-compressor/pytorch-lightning/cifar_resnet18/README.md
@@ -3,7 +3,7 @@ This example shows the usage of pytorch quantization based on Intel Neural Compr
 
 ## Environment Setup
 ```shell
-pip install --pre --upgrade bigdl-nano[pytorch] # install the nightly-bulit version
+pip install --pre --upgrade bigdl-nano[pytorch,inference]  # install the nightly-bulit version
 pip install lightning-bolts
 ```
 

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -763,12 +763,25 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))
 
     @staticmethod
+    def get_context_manager(model: nn.Module):
+        """
+        Obtain corresponding context manager from model, defaults to BaseContextManager().
+
+        :param model: Any model of torch.nn.Module, including all models accelareted by
+               InferenceOptimizer.trace/InferenceOptimizer.quantize.
+        :return: a context manager.
+        """
+        if hasattr(model, "context_manager"):
+            return model.context_manager
+        return BaseContextManager()
+
+    @staticmethod
     def save(model: nn.Module, path):
         """
         Save the model to local file.
 
         :param model: Any model of torch.nn.Module, including all models accelareted by
-               Trainer.trace/Trainer.quantize.
+               InferenceOptimizer.trace/InferenceOptimizer.quantize.
         :param path: Path to saved model. Path should be a directory.
         """
         save_model(model, path)
@@ -780,8 +793,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
 
         :param path: Path to model to be loaded. Path should be a directory.
         :param model: Required FP32 model to load pytorch model, it is needed if you accelerated
-               the model with accelerator=None by Trainer.trace/Trainer.quantize. model
-               should be set to None if you choose accelerator="onnxruntime"/"openvino"/"jit".
+               the model with accelerator=None by InferenceOptimizer.trace/
+               InferenceOptimizer.quantize. model should be set to None if you choose
+               accelerator="onnxruntime"/"openvino"/"jit".
         :return: Model with different acceleration(None/OpenVINO/ONNX Runtime/JIT) or
                  precision(FP32/FP16/BF16/INT8).
         """

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -763,7 +763,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))
 
     @staticmethod
-    def get_context_manager(model: nn.Module):
+    def get_context(model: nn.Module):
         """
         Obtain corresponding context manager from model, defaults to BaseContextManager().
 

--- a/python/nano/test/inc/pytorch/test_trainer_quantize.py
+++ b/python/nano/test/inc/pytorch/test_trainer_quantize.py
@@ -178,7 +178,7 @@ class TestTrainer(TestCase):
         qmodel = InferenceOptimizer.quantize(pl_model,
                                              calib_data=self.train_loader)
         assert qmodel
-        with qmodel.context_manager:
+        with InferenceOptimizer.get_context(qmodel):
             out = qmodel(x)
         assert out.shape == torch.Size([256, 10])
         
@@ -186,6 +186,6 @@ class TestTrainer(TestCase):
             InferenceOptimizer.save(qmodel, tmp_dir_name)
             model = InferenceOptimizer.load(tmp_dir_name, pl_model)
 
-        with model.context_manager:
+        with InferenceOptimizer.get_context(model):
             out = model(x)
         assert out.shape == torch.Size([256, 10])

--- a/python/nano/test/onnx/pytorch/test_inc_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_inc_onnx.py
@@ -191,14 +191,14 @@ class TestOnnx(TestCase):
                                                  accelerator='onnxruntime',
                                                  method='qlinear',
                                                  calib_data=train_loader)
-        with onnx_model.context_manager:
+        with InferenceOptimizer.get_context(onnx_model):
             output = onnx_model(x)
         
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(onnx_model, tmp_dir_name)
             model = InferenceOptimizer.load(tmp_dir_name)
 
-        with model.context_manager:
+        with InferenceOptimizer.get_context(model):
             output = model(x)
 
 

--- a/python/nano/test/onnx/pytorch/test_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_onnx.py
@@ -165,14 +165,14 @@ class TestOnnx(TestCase):
                                               input_sample=train_loader,
                                               thread_num=1)
 
-        with onnx_model.context_manager:
+        with InferenceOptimizer.get_context(onnx_model):
             output = onnx_model(x)
         
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(onnx_model, tmp_dir_name)
             model = InferenceOptimizer.load(tmp_dir_name)
         
-        with model.context_manager:
+        with InferenceOptimizer.get_context(model):
             output = onnx_model(x)
 
 

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -116,13 +116,12 @@ class TestOpenVINO(TestCase):
 
         openvino_model = InferenceOptimizer.trace(model, input_sample=x,
                                                   accelerator='openvino')
-
-        with openvino_model.context_manager:
+        with InferenceOptimizer.get_context(openvino_model):
             y1 = openvino_model(x[0:1])
     
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(openvino_model, tmp_dir_name)
             model = InferenceOptimizer.load(tmp_dir_name)
 
-        with model.context_manager:
+        with InferenceOptimizer.get_context(model):
             y2 = model(x[0:1])

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -119,13 +119,11 @@ class TestOpenVINO(TestCase):
                                                      accelerator='openvino',
                                                      calib_data=dataloader,
                                                      metric=F1(10))
-
-        with openvino_model.context_manager:
+        with InferenceOptimizer.get_context(openvino_model):
             y1 = openvino_model(x[0:1])
     
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(openvino_model, tmp_dir_name)
             model = InferenceOptimizer.load(tmp_dir_name)
-
-        with model.context_manager:
+        with InferenceOptimizer.get_context(model):
             y2 = model(x[0:1])

--- a/python/nano/test/pytorch/tests/test_bf16.py
+++ b/python/nano/test/pytorch/tests/test_bf16.py
@@ -52,7 +52,7 @@ class Pytorch1_12:
         x = torch.rand((10, 3, 256, 256))
         y = torch.ones((10,), dtype=torch.long)
         bf16_model = InferenceOptimizer.quantize(model, precision='bf16')
-        with bf16_model.context_manager:
+        with InferenceOptimizer.get_context(bf16_model):
             y_hat = bf16_model(x)
 
     @patch("bigdl.nano.pytorch.amp.bfloat16.BF16Model._max_bf16_isa", return_value=None)
@@ -71,7 +71,7 @@ class Pytorch1_12:
         x = torch.rand((10, 3, 256, 256))
 
         bf16_model = InferenceOptimizer.quantize(model, precision='bf16')
-        with bf16_model.context_manager:
+        with InferenceOptimizer.get_context(bf16_model):
             bf16_model(x)
 
     @patch.dict('os.environ', {"ALLOW_NON_BF16_ISA": "1"})
@@ -86,7 +86,7 @@ class Pytorch1_12:
 
         bf16_model = InferenceOptimizer.quantize(model, precision='bf16')
         # Debug mode to test functionality, make sure forward is called sucessfully
-        with bf16_model.context_manager:
+        with InferenceOptimizer.get_context(bf16_model):
             y_hat = bf16_model(x)
         assert y_hat.shape == (10, 10) and y_hat.dtype == torch.bfloat16
 
@@ -99,7 +99,7 @@ class Pytorch1_12:
         bf16_model = InferenceOptimizer.quantize(model, precision='bf16')
         with patch.object(type(bf16_model), "_has_bf16_isa", PropertyMock(return_value=True)):
             bf16_model._max_bf16_isa = MagicMock(return_value="AMX")
-            with bf16_model.context_manager:
+            with InferenceOptimizer.get_context(bf16_model):
                 y_hat = bf16_model(x)
         assert y_hat.shape == (10, 10) and y_hat.dtype == torch.bfloat16
 
@@ -112,7 +112,7 @@ class Pytorch1_12:
         bf16_model = InferenceOptimizer.quantize(model, precision='bf16')
         with patch.object(type(bf16_model), "_has_bf16_isa", PropertyMock(return_value=True)):
             bf16_model._max_bf16_isa = MagicMock(return_value="AVX512")
-            with bf16_model.context_manager:
+            with InferenceOptimizer.get_context(bf16_model):
                 y_hat = bf16_model(x)
         assert y_hat.shape == (10, 10) and y_hat.dtype == torch.bfloat16
 
@@ -122,8 +122,7 @@ class Pytorch1_12:
         # test bf16
         x = torch.rand((10, 3, 256, 256))
         bf16_model = InferenceOptimizer.quantize(model, precision='bf16')
-        context_manager = InferenceOptimizer.get_context_magaer(bf16_model)
-        with context_manager:
+        with InferenceOptimizer.get_context(bf16_model):
             y_hat1 = bf16_model(x)
         assert y_hat1.shape == (10, 10) and y_hat1.dtype == torch.bfloat16
 
@@ -131,7 +130,7 @@ class Pytorch1_12:
             InferenceOptimizer.save(bf16_model, tmp_dir_name)
             load_model = InferenceOptimizer.load(tmp_dir_name, model)
 
-        with load_model.context_manager:
+        with InferenceOptimizer.get_context(load_model):
             y_hat2 = load_model(x)
         assert y_hat2.shape == (10, 10) and y_hat2.dtype == torch.bfloat16
         assert y_hat1.equal(y_hat2)
@@ -139,7 +138,7 @@ class Pytorch1_12:
         # test bf16 + channels_last
         bf16_model = InferenceOptimizer.quantize(model, precision='bf16',
                                                  channels_last=True)
-        with bf16_model.context_manager:
+        with InferenceOptimizer.get_context(bf16_model):
             y_hat1 = bf16_model(x)
         assert y_hat1.shape == (10, 10) and y_hat1.dtype == torch.bfloat16
 
@@ -147,8 +146,8 @@ class Pytorch1_12:
             InferenceOptimizer.save(bf16_model, tmp_dir_name)
             load_model = InferenceOptimizer.load(tmp_dir_name, model)
 
-        with load_model.context_manager:
-            y_hat2 = bf16_model(x)
+        with InferenceOptimizer.get_context(load_model):
+            y_hat2 = load_model(x)
         assert y_hat2.shape == (10, 10) and y_hat2.dtype == torch.bfloat16
         assert y_hat1.equal(y_hat2)
 

--- a/python/nano/test/pytorch/tests/test_bf16.py
+++ b/python/nano/test/pytorch/tests/test_bf16.py
@@ -122,7 +122,8 @@ class Pytorch1_12:
         # test bf16
         x = torch.rand((10, 3, 256, 256))
         bf16_model = InferenceOptimizer.quantize(model, precision='bf16')
-        with bf16_model.context_manager:
+        context_manager = InferenceOptimizer.get_context_magaer(bf16_model)
+        with context_manager:
             y_hat1 = bf16_model(x)
         assert y_hat1.shape == (10, 10) and y_hat1.dtype == torch.bfloat16
 

--- a/python/nano/test/pytorch/tests/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/test_bf16_ipex.py
@@ -18,7 +18,7 @@ import pytest
 import torch
 from bigdl.nano.pytorch import InferenceOptimizer
 from torchvision.models.resnet import resnet18
-from unittest.mock import MagicMock, Mock, PropertyMock, patch
+from unittest.mock import PropertyMock, patch
 from bigdl.nano.common import check_avx512
 import tempfile
 
@@ -49,7 +49,7 @@ class Pytorch1_11:
         y = torch.ones((10,), dtype=torch.long)
 
         bf16_model = InferenceOptimizer.quantize(model, precision='bf16', use_ipex=True)
-        with bf16_model.context_manager:
+        with InferenceOptimizer.get_context(bf16_model):
             y_hat = bf16_model(x)
 
         assert y_hat.shape == (10, 10) and y_hat.dtype == torch.bfloat16
@@ -60,8 +60,7 @@ class Pytorch1_11:
         x = torch.rand((10, 3, 256, 256))
         bf16_model = InferenceOptimizer.quantize(model, precision='bf16',
                                                  use_ipex=True)
-
-        with bf16_model.context_manager:
+        with InferenceOptimizer.get_context(bf16_model):
             y_hat = bf16_model(x)
 
         assert y_hat.shape == (10, 10) and y_hat.dtype == torch.bfloat16
@@ -70,7 +69,7 @@ class Pytorch1_11:
             InferenceOptimizer.save(bf16_model, tmp_dir_name)
             load_model = InferenceOptimizer.load(tmp_dir_name, model)
 
-        with load_model.context_manager:
+        with InferenceOptimizer.get_context(load_model):
             y_hat_ = load_model(x)
         assert y_hat_.shape == (10, 10) and y_hat_.dtype == torch.bfloat16
         assert y_hat.equal(y_hat_)
@@ -82,7 +81,8 @@ class Pytorch1_11:
         bf16_model = InferenceOptimizer.quantize(model, precision='bf16',
                                                  use_ipex=True, accelerator="jit",
                                                  input_sample=x)
-        with bf16_model.context_manager:
+
+        with InferenceOptimizer.get_context(bf16_model):
             y_hat = bf16_model(x)
 
         assert y_hat.shape == (10, 10) and y_hat.dtype == torch.bfloat16
@@ -90,8 +90,7 @@ class Pytorch1_11:
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(bf16_model, tmp_dir_name)
             load_model = InferenceOptimizer.load(tmp_dir_name)
-
-        with load_model.context_manager:
+        with InferenceOptimizer.get_context(load_model):
             y_hat_ = load_model(x)
         assert y_hat_.shape == (10, 10) and y_hat_.dtype == torch.bfloat16
         assert y_hat.equal(y_hat_)

--- a/python/nano/test/pytorch/tests/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/test_inference_optimizer.py
@@ -454,15 +454,15 @@ class TestInferencePipeline(TestCase):
         for method, option in optim_dict.items():
             if option["status"] == "successful":
                 model = option["model"]
-                with model.context_manager:
+                with InferenceOptimizer.get_context(model):
                     pass
         # test get_model
         for method in list(InferenceOptimizer.ALL_INFERENCE_ACCELERATION_METHOD.keys()):
             if "model" in optim_dict[method]:
                 model = inference_opt.get_model(method)
-                with model.context_manager:
+                with InferenceOptimizer.get_context(model):
                     pass
         # test get_best_model
         model, option = inference_opt.get_best_model()
-        with model.context_manager:
+        with InferenceOptimizer.get_context(model):
             pass

--- a/python/nano/test/pytorch/tests/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/test_ipex_jit_inference.py
@@ -52,34 +52,34 @@ class IPEXJITInference_gt_1_10:
 
     def test_ipex_inference(self):
         model = InferenceOptimizer.trace(self.model, accelerator=None, use_ipex=True)
-        with model.context_manager:
+        with InferenceOptimizer.get_context(model):
             model(self.data_sample)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(model, tmp_dir_name)
             new_model = InferenceOptimizer.load(tmp_dir_name, self.model)
-        with new_model.context_manager:
+        with InferenceOptimizer.get_context(new_model):
             new_model(self.data_sample)
 
     def test_jit_inference(self):
         model = InferenceOptimizer.trace(self.model, accelerator="jit",
                                          use_ipex=False, input_sample=self.data_sample)
-        with model.context_manager:
+        with InferenceOptimizer.get_context(model):
             model(self.data_sample)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(model, tmp_dir_name)
             new_model = InferenceOptimizer.load(tmp_dir_name)
-        with new_model.context_manager:
+        with InferenceOptimizer.get_context(new_model):
             new_model(self.data_sample)
 
     def test_ipex_jit_inference(self):
         model = InferenceOptimizer.trace(self.model, accelerator="jit",
                                          use_ipex=True, input_sample=self.data_sample)
-        with model.context_manager:
+        with InferenceOptimizer.get_context(model):
             model(self.data_sample)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(model, tmp_dir_name)
             new_model = InferenceOptimizer.load(tmp_dir_name)
-        with new_model.context_manager:
+        with InferenceOptimizer.get_context(new_model):
             new_model(self.data_sample)
 
 

--- a/python/nano/tutorial/inference/pytorch/pytorch_inference_jit_ipex.py
+++ b/python/nano/tutorial/inference/pytorch/pytorch_inference_jit_ipex.py
@@ -35,22 +35,25 @@ if __name__ == "__main__":
     jit_model = InferenceOptimizer.trace(model_ft,
                                          accelerator="jit",
                                          input_sample=torch.rand(1, 3, 224, 224))
-    y_hat = jit_model(x)
-    predictions = y_hat.argmax(dim=1)
-    print(predictions)
+    with InferenceOptimizer.get_context(jit_model):
+        y_hat = jit_model(x)
+        predictions = y_hat.argmax(dim=1)
+        print(predictions)
 
     # IPEX
     ipex_model = InferenceOptimizer.trace(model_ft,
                                           use_ipex=True)
-    y_hat = ipex_model(x)
-    predictions = y_hat.argmax(dim=1)
-    print(predictions)
+    with InferenceOptimizer.get_context(ipex_model):
+        y_hat = ipex_model(x)
+        predictions = y_hat.argmax(dim=1)
+        print(predictions)
 
     # IPEX + JIT
     jit_ipex_model = InferenceOptimizer.trace(model_ft,
                                               accelerator="jit",
                                               use_ipex=True,
                                               input_sample=torch.rand(1, 3, 224, 224))
-    y_hat = jit_ipex_model(x)
-    predictions = y_hat.argmax(dim=1)
-    print(predictions)
+    with InferenceOptimizer.get_context(jit_ipex_model):
+        y_hat = jit_ipex_model(x)
+        predictions = y_hat.argmax(dim=1)
+        print(predictions)

--- a/python/nano/tutorial/inference/pytorch/pytorch_inference_onnx.py
+++ b/python/nano/tutorial/inference/pytorch/pytorch_inference_onnx.py
@@ -39,10 +39,10 @@ if __name__ == "__main__":
     ort_model = InferenceOptimizer.trace(model_ft,
                                          accelerator="onnxruntime",
                                          input_sample=torch.rand(1, 3, 224, 224))
-
-    y_hat = ort_model(x)
-    predictions = y_hat.argmax(dim=1)
-    print(predictions)
+    with InferenceOptimizer.get_context(ort_model):
+        y_hat = ort_model(x)
+        predictions = y_hat.argmax(dim=1)
+        print(predictions)
 
     # Save Optimized Model
     from bigdl.nano.pytorch import Trainer

--- a/python/nano/tutorial/inference/pytorch/pytorch_inference_openvino.py
+++ b/python/nano/tutorial/inference/pytorch/pytorch_inference_openvino.py
@@ -38,9 +38,11 @@ if __name__ == "__main__":
     ov_model = InferenceOptimizer.trace(model_ft,
                                         accelerator="openvino",
                                         input_sample=torch.rand(1, 3, 224, 224))
-    y_hat = ov_model(x)
-    predictions = y_hat.argmax(dim=1)
-    print(predictions)
+    
+    with InferenceOptimizer.get_context(ov_model):
+        y_hat = ov_model(x)
+        predictions = y_hat.argmax(dim=1)
+        print(predictions)
 
     # Save Optimized Model
     from bigdl.nano.pytorch import Trainer

--- a/python/nano/tutorial/inference/pytorch/pytorch_quantization.py
+++ b/python/nano/tutorial/inference/pytorch/pytorch_quantization.py
@@ -16,7 +16,7 @@
 # Required Dependecies
 
 # ```bash
-# pip install neural-compressor==1.11.0
+# pip install neural-compressor==1.13.1
 # ```
 
 
@@ -97,12 +97,13 @@ if __name__ == "__main__":
                                           calib_data=DataLoader(train_dataset, batch_size=32))
 
     # Inference with Quantized Model
-    y_hat = q_model(x)
-    predictions = y_hat.argmax(dim=1)
-    print(predictions)
+    with InferenceOptimizer.get_context(q_model):
+        y_hat = q_model(x)
+        predictions = y_hat.argmax(dim=1)
+        print(predictions)
 
     # Save Quantized Model
-    Trainer.save(q_model, "./quantized_model")
+    InferenceOptimizer.save(q_model, "./quantized_model")
 
     # Load the Quantized Model
     # a original fp32 model is required, as the saved format only contains weights

--- a/python/nano/tutorial/inference/pytorch/pytorch_quantization_onnx.py
+++ b/python/nano/tutorial/inference/pytorch/pytorch_quantization_onnx.py
@@ -17,7 +17,7 @@
 # Required Dependecies
 
 # ```bash
-# pip install neural-compressor==1.11.0 onnx onnxruntime onnxruntime_extensions
+# pip install --pre --upgrade bigdl-nano[pytorch,inference]
 # ```
 
 
@@ -99,13 +99,14 @@ if __name__ == "__main__":
                                  calib_dataloader=DataLoader(train_dataset, batch_size=32))
 
     # Inference with Quantized Model
-    y_hat = q_model(x)
-    predictions = y_hat.argmax(dim=1)
-    print(predictions)
+    with InferenceOptimizer.get_context(q_model):
+        y_hat = q_model(x)
+        predictions = y_hat.argmax(dim=1)
+        print(predictions)
 
     # Save Quantized Model
-    Trainer.save(q_model, "./quantized_model")
+    InferenceOptimizer.save(q_model, "./quantized_model")
 
     # Load the Quantized Model
-    # loaded_model = Trainer.load("./quantized_model")
+    # loaded_model = InferenceOptimizer.load("./quantized_model")
     # print(loaded_model(x).argmax(dim=1))

--- a/python/nano/tutorial/inference/pytorch/pytorch_quantization_openvino.py
+++ b/python/nano/tutorial/inference/pytorch/pytorch_quantization_openvino.py
@@ -98,13 +98,14 @@ if __name__ == "__main__":
                                           calib_dataloader=DataLoader(train_dataset, batch_size=32))
 
     # Inference with Quantized Model
-    y_hat = q_model(x)
-    predictions = y_hat.argmax(dim=1)
-    print(predictions)
+    with InferenceOptimizer.get_context(q_model):
+        y_hat = q_model(x)
+        predictions = y_hat.argmax(dim=1)
+        print(predictions)
 
     # Save Quantized Model
-    Trainer.save(q_model, "./quantized_model")
+    InferenceOptimizer.save(q_model, "./quantized_model")
 
     # Load the Quantized Model
-    # loaded_model = Trainer.load("./quantized_model")
+    # loaded_model = InferenceOptimizer.load("./quantized_model")
     # print(loaded_model(x).argmax(dim=1))

--- a/python/nano/tutorial/inference/pytorch/pytorch_save_and_load_ipex.py
+++ b/python/nano/tutorial/inference/pytorch/pytorch_save_and_load_ipex.py
@@ -38,6 +38,7 @@ if __name__ == "__main__":
     loaded_model = InferenceOptimizer.load("./optimized_model_ipex", model=model_ft)
 
     # Inference with the Loaded Model
-    y_hat = loaded_model(x)
-    predictions = y_hat.argmax(dim=1)
-    print(predictions)
+    with InferenceOptimizer.get_context(loaded_model):
+        y_hat = loaded_model(x)
+        predictions = y_hat.argmax(dim=1)
+        print(predictions)

--- a/python/nano/tutorial/inference/pytorch/pytorch_save_and_load_jit.py
+++ b/python/nano/tutorial/inference/pytorch/pytorch_save_and_load_jit.py
@@ -39,6 +39,7 @@ if __name__ == "__main__":
     loaded_model = InferenceOptimizer.load("./optimized_model_jit")
 
     # Inference with the Loaded Model
-    y_hat = loaded_model(x)
-    predictions = y_hat.argmax(dim=1)
-    print(predictions)
+    with InferenceOptimizer.get_context(loaded_model):
+        y_hat = loaded_model(x)
+        predictions = y_hat.argmax(dim=1)
+        print(predictions)

--- a/python/nano/tutorial/inference/pytorch/pytorch_save_and_load_onnx.py
+++ b/python/nano/tutorial/inference/pytorch/pytorch_save_and_load_onnx.py
@@ -50,6 +50,7 @@ if __name__ == "__main__":
     loaded_model = InferenceOptimizer.load("./optimized_model_ort")
 
     # Inference with the Loaded Model
-    y_hat = loaded_model(x)
-    predictions = y_hat.argmax(dim=1)
-    print(predictions)
+    with InferenceOptimizer.get_context(loaded_model):
+        y_hat = loaded_model(x)
+        predictions = y_hat.argmax(dim=1)
+        print(predictions)

--- a/python/nano/tutorial/inference/pytorch/pytorch_save_and_load_openvino.py
+++ b/python/nano/tutorial/inference/pytorch/pytorch_save_and_load_openvino.py
@@ -51,6 +51,7 @@ if __name__ == "__main__":
     loaded_model = InferenceOptimizer.load("./optimized_model_ov")
 
     # Inference with the Loaded Model
-    y_hat = loaded_model(x)
-    predictions = y_hat.argmax(dim=1)
-    print(predictions)
+    with InferenceOptimizer.get_context(loaded_model):
+        y_hat = loaded_model(x)
+        predictions = y_hat.argmax(dim=1)
+        print(predictions)

--- a/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_jit_ipex.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_jit_ipex.ipynb
@@ -39,7 +39,7 @@
       "outputs": [],
       "source": [
         "# for BigDL-Nano\n",
-        "!pip install --pre --upgrade bigdl-nano[pytorch] # install the nightly-bulit version\n",
+        "!pip install --pre --upgrade bigdl-nano[pytorch]  # install the nightly-bulit version\n",
         "# !source bigdl-nano-init"
       ]
     },
@@ -119,9 +119,10 @@
         "jit_model = InferenceOptimizer.trace(model_ft,\n",
         "                                     accelerator=\"jit\",\n",
         "                                     input_sample=torch.rand(1, 3, 224, 224))\n",
-        "y_hat = jit_model(x)\n",
-        "predictions = y_hat.argmax(dim=1)\n",
-        "print(predictions)"
+        "with InferenceOptimizer.get_context(jit_model):\n",
+        "    y_hat = jit_model(x)\n",
+        "    predictions = y_hat.argmax(dim=1)\n",
+        "    print(predictions)"
       ]
     },
     {
@@ -139,9 +140,10 @@
       "source": [
         "ipex_model = InferenceOptimizer.trace(model_ft,\n",
         "                                      use_ipex=True)\n",
-        "y_hat = ipex_model(x)\n",
-        "predictions = y_hat.argmax(dim=1)\n",
-        "print(predictions)"
+        "with InferenceOptimizer.get_context(ipex_model):\n",
+        "    y_hat = ipex_model(x)\n",
+        "    predictions = y_hat.argmax(dim=1)\n",
+        "    print(predictions)"
       ]
     },
     {
@@ -161,9 +163,10 @@
         "                                          accelerator=\"jit\",\n",
         "                                          use_ipex=True,\n",
         "                                          input_sample=torch.rand(1, 3, 224, 224))\n",
-        "y_hat = jit_ipex_model(x)\n",
-        "predictions = y_hat.argmax(dim=1)\n",
-        "print(predictions)"
+        "with InferenceOptimizer.get_context(jit_ipex_model):\n",
+        "    y_hat = jit_ipex_model(x)\n",
+        "    predictions = y_hat.argmax(dim=1)\n",
+        "    print(predictions)"
       ]
     },
     {
@@ -190,7 +193,7 @@
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "Python 3.7.13 ('junwang-resnext-oob')",
+      "display_name": "Python 3.7.10 ('ruonan_nano')",
       "language": "python",
       "name": "python3"
     },
@@ -204,12 +207,12 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.7.13"
+      "version": "3.7.10"
     },
     "orig_nbformat": 4,
     "vscode": {
       "interpreter": {
-        "hash": "2c2c667a59d63f4d9cf9e9a8f7eff73ad81424da777ad3c4a3346b0ce2b012b2"
+        "hash": "d347a5dca25745bedb029e46e41f7d6c8c9b5181ecb97033e2e81a7538459254"
       }
     }
   },

--- a/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_onnx.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_onnx.ipynb
@@ -136,11 +136,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x = torch.rand(2, 3, 224, 224)\n",
-    "# use the optimized model here\n",
-    "y_hat = ort_model(x)\n",
-    "predictions = y_hat.argmax(dim=1)\n",
-    "print(predictions)"
+    "with InferenceOptimizer.get_context(ort_model):\n",
+    "    x = torch.rand(2, 3, 224, 224)\n",
+    "    # use the optimized model here\n",
+    "    y_hat = ort_model(x)\n",
+    "    predictions = y_hat.argmax(dim=1)\n",
+    "    print(predictions)"
    ]
   },
   {
@@ -156,18 +157,18 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.13 ('nano-pytorch': conda)",
+   "display_name": "Python 3.7.10 ('ruonan_nano')",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "name": "python",
-   "version": "3.7.13"
+   "version": "3.7.10"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "09344c7f3239fd422839751f876786d6b1a624c40f19af1b43cb2737f421c2b2"
+    "hash": "d347a5dca25745bedb029e46e41f7d6c8c9b5181ecb97033e2e81a7538459254"
    }
   }
  },

--- a/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_openvino.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_openvino.ipynb
@@ -147,11 +147,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x = torch.rand(2, 3, 224, 224)\n",
-    "# use the optimized model here\n",
-    "y_hat = ov_model(x)\n",
-    "predictions = y_hat.argmax(dim=1)\n",
-    "print(predictions)"
+    "with InferenceOptimizer.get_context(ov_model):\n",
+    "    x = torch.rand(2, 3, 224, 224)\n",
+    "    # use the optimized model here\n",
+    "    y_hat = ov_model(x)\n",
+    "    predictions = y_hat.argmax(dim=1)\n",
+    "    print(predictions)"
    ]
   },
   {
@@ -167,18 +168,18 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.13 ('nano-pytorch': conda)",
+   "display_name": "Python 3.7.10 ('ruonan_nano')",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "name": "python",
-   "version": "3.7.13"
+   "version": "3.7.10"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "09344c7f3239fd422839751f876786d6b1a624c40f19af1b43cb2737f421c2b2"
+    "hash": "d347a5dca25745bedb029e46e41f7d6c8c9b5181ecb97033e2e81a7538459254"
    }
   }
  },

--- a/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
@@ -251,8 +251,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x = next(iter(train_dataloader))[0]\n",
-    "output = acc_model(x)"
+    "with InferenceOptimizer.get_context(acc_model):\n",
+    "    x = next(iter(train_dataloader))[0]\n",
+    "    output = acc_model(x)"
    ]
   },
   {

--- a/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
@@ -317,7 +317,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.12 ('nano')",
+   "display_name": "Python 3.7.10 ('ruonan_nano')",
    "language": "python",
    "name": "python3"
   },
@@ -331,12 +331,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.7.10"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "75c4387adfc215da0f2d9d02c27ad9a4df553a9f0187eec0365fe565a2e50216"
+    "hash": "d347a5dca25745bedb029e46e41f7d6c8c9b5181ecb97033e2e81a7538459254"
    }
   }
  },

--- a/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_ipex.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_ipex.ipynb
@@ -143,10 +143,11 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "x = torch.rand(2, 3, 224, 224)\n",
-        "y_hat = loaded_model(x)\n",
-        "predictions = y_hat.argmax(dim=1)\n",
-        "print(predictions)"
+        "with InferenceOptimizer.get_context(loaded_model):\n",
+        "    x = torch.rand(2, 3, 224, 224)\n",
+        "    y_hat = loaded_model(x)\n",
+        "    predictions = y_hat.argmax(dim=1)\n",
+        "    print(predictions)"
       ]
     },
     {

--- a/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_jit.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_jit.ipynb
@@ -133,10 +133,11 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "x = torch.rand(2, 3, 224, 224)\n",
-        "y_hat = loaded_model(x)\n",
-        "predictions = y_hat.argmax(dim=1)\n",
-        "print(predictions)"
+        "with InferenceOptimizer.get_context(loaded_model):\n",
+        "    x = torch.rand(2, 3, 224, 224)\n",
+        "    y_hat = loaded_model(x)\n",
+        "    predictions = y_hat.argmax(dim=1)\n",
+        "    print(predictions)"
       ]
     },
     {
@@ -153,7 +154,7 @@
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "Python 3.7.13 ('junwang-resnext-oob')",
+      "display_name": "Python 3.7.10 ('ruonan_nano')",
       "language": "python",
       "name": "python3"
     },
@@ -167,12 +168,12 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.7.13"
+      "version": "3.7.10"
     },
     "orig_nbformat": 4,
     "vscode": {
       "interpreter": {
-        "hash": "2c2c667a59d63f4d9cf9e9a8f7eff73ad81424da777ad3c4a3346b0ce2b012b2"
+        "hash": "d347a5dca25745bedb029e46e41f7d6c8c9b5181ecb97033e2e81a7538459254"
       }
     }
   },

--- a/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_onnx.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_onnx.ipynb
@@ -90,10 +90,11 @@
         "                                     accelerator=\"onnxruntime\",\n",
         "                                     input_sample=torch.rand(1, 3, 224, 224))\n",
         "\n",
-        "x = torch.rand(2, 3, 224, 224)\n",
-        "y_hat = ort_model(x)\n",
-        "predictions = y_hat.argmax(dim=1)\n",
-        "print(predictions)"
+        "with InferenceOptimizer.get_context(ort_model):\n",
+        "    x = torch.rand(2, 3, 224, 224)\n",
+        "    y_hat = ort_model(x)\n",
+        "    predictions = y_hat.argmax(dim=1)\n",
+        "    print(predictions)"
       ]
     },
     {
@@ -146,9 +147,10 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "y_hat = loaded_model(x)\n",
-        "predictions = y_hat.argmax(dim=1)\n",
-        "print(predictions)\n"
+        "with InferenceOptimizer.get_context(loaded_model):\n",
+        "    y_hat = loaded_model(x)\n",
+        "    predictions = y_hat.argmax(dim=1)\n",
+        "    print(predictions)\n"
       ]
     },
     {
@@ -164,7 +166,7 @@
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "Python 3.7.13 ('junwang-resnext-oob')",
+      "display_name": "Python 3.7.10 ('ruonan_nano')",
       "language": "python",
       "name": "python3"
     },
@@ -178,12 +180,12 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.7.13"
+      "version": "3.7.10"
     },
     "orig_nbformat": 4,
     "vscode": {
       "interpreter": {
-        "hash": "2c2c667a59d63f4d9cf9e9a8f7eff73ad81424da777ad3c4a3346b0ce2b012b2"
+        "hash": "d347a5dca25745bedb029e46e41f7d6c8c9b5181ecb97033e2e81a7538459254"
       }
     }
   },

--- a/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_openvino.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_openvino.ipynb
@@ -85,10 +85,11 @@
         "                                    accelerator=\"openvino\",\n",
         "                                    input_sample=torch.rand(1, 3, 224, 224))\n",
         "\n",
-        "x = torch.rand(2, 3, 224, 224)\n",
-        "y_hat = ov_model(x)\n",
-        "predictions = y_hat.argmax(dim=1)\n",
-        "print(predictions)\n"
+        "with InferenceOptimizer.get_context(ov_model):\n",
+        "    x = torch.rand(2, 3, 224, 224)\n",
+        "    y_hat = ov_model(x)\n",
+        "    predictions = y_hat.argmax(dim=1)\n",
+        "    print(predictions)\n"
       ]
     },
     {
@@ -142,9 +143,10 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "y_hat = loaded_model(x)\n",
-        "predictions = y_hat.argmax(dim=1)\n",
-        "print(predictions)"
+        "with InferenceOptimizer.get_context(loaded_model):\n",
+        "    y_hat = loaded_model(x)\n",
+        "    predictions = y_hat.argmax(dim=1)\n",
+        "    print(predictions)"
       ]
     },
     {
@@ -160,7 +162,7 @@
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "Python 3.7.13 ('junwang-resnext-oob')",
+      "display_name": "Python 3.7.10 ('ruonan_nano')",
       "language": "python",
       "name": "python3"
     },
@@ -174,12 +176,12 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.7.13"
+      "version": "3.7.10"
     },
     "orig_nbformat": 4,
     "vscode": {
       "interpreter": {
-        "hash": "2c2c667a59d63f4d9cf9e9a8f7eff73ad81424da777ad3c4a3346b0ce2b012b2"
+        "hash": "d347a5dca25745bedb029e46e41f7d6c8c9b5181ecb97033e2e81a7538459254"
       }
     }
   },

--- a/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_inc.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_inc.ipynb
@@ -39,11 +39,8 @@
    "outputs": [],
    "source": [
     "# for BigDL-Nano\n",
-    "!pip install --pre --upgrade bigdl-nano[pytorch] # install the nightly-bulit version\n",
-    "# !source bigdl-nano-init\n",
-    "\n",
-    "# for INC\n",
-    "!pip install neural-compressor==1.11.0"
+    "!pip install --pre --upgrade bigdl-nano[pytorch,inference]  # install the nightly-bulit version\n",
+    "# !source bigdl-nano-init"
    ]
   },
   {
@@ -55,26 +52,6 @@
     "> 📝 **Note**\n",
     "> \n",
     "> We recommend to run the commands above, especially `source bigdl-nano-init` before jupyter kernel is started, or some of the optimizations may not take effect."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "nbsphinx": "hidden"
-   },
-   "source": [
-    "If you would like to use ONNXRuntime as an extra accelerator, the following dependencies are also required to be installed:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "nbsphinx": "hidden"
-   },
-   "outputs": [],
-   "source": [
-    "!pip install onnx onnxruntime onnxruntime-extensions"
    ]
   },
   {
@@ -248,11 +225,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x = torch.stack([val_dataset[0][0], val_dataset[1][0]])\n",
-    "# use the quantized model here\n",
-    "y_hat = q_model(x)\n",
-    "predictions = y_hat.argmax(dim=1)\n",
-    "print(predictions)"
+    "with InferenceOptimizer.get_context(q_model):\n",
+    "    x = torch.stack([val_dataset[0][0], val_dataset[1][0]])\n",
+    "    # use the quantized model here\n",
+    "    y_hat = q_model(x)\n",
+    "    predictions = y_hat.argmax(dim=1)\n",
+    "    print(predictions)"
    ]
   },
   {

--- a/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_pot.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_pot.ipynb
@@ -221,11 +221,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x = torch.stack([val_dataset[0][0], val_dataset[1][0]])\n",
-    "# use the quantized model here\n",
-    "y_hat = q_model(x)\n",
-    "predictions = y_hat.argmax(dim=1)\n",
-    "print(predictions)"
+    "with InferenceOptimizer.get_context(q_model):\n",
+    "    x = torch.stack([val_dataset[0][0], val_dataset[1][0]])\n",
+    "    # use the quantized model here\n",
+    "    y_hat = q_model(x)\n",
+    "    predictions = y_hat.argmax(dim=1)\n",
+    "    print(predictions)"
    ]
   },
   {


### PR DESCRIPTION
## Description

Here we support `get_context()` method to provide context manager of single model.
`get_context()` for multi-model will be implemented in next PR.

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/210

### 2. User API changes

Provide a new **get_context() static method inside InferenceOptimizer**
```python
from bigdl.nano.pytorch import InferenceOptimizer

#  for traced model
acc_model = InferenceOptimizer.trace(...)
with InferenceOptimizer.get_context(acc_model):
    do_somethig()

# for quantized model
acc_model = InferenceOptimizer.quantize(...)
with InferenceOptimizer.get_context(acc_model):
    do_somethig()

# for optimized model
opt = InferenceOptimizer()
opt.optimize(...)
model = opt.get_best_model()
with InferenceOptimizer.get_context(model):
    do_something()
model = opt.get_model(xxx)
with InferenceOptimizer.get_context(model):
    do_something()
```

### 3. Summary of the change 

- support `get_context` in InferenceOptimizer
- revise related UT / example / how-to guides / tutorials based on `get_context` 

### 4. How to test?
- [x] Unit test
- [x] Application test
