### PR TITLE
[PPML] python KMS lib

### DIFF
--- a/python/ppml/src/bigdl/ppml/kms/__init__.py
+++ b/python/ppml/src/bigdl/ppml/kms/__init__.py
@@ -1,0 +1,15 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/ppml/src/bigdl/ppml/kms/client.py
+++ b/python/ppml/src/bigdl/ppml/kms/client.py
@@ -1,0 +1,123 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+import os
+import fileoperator, keymanager
+
+def generate_primary_key(ip, port):
+    keymanager.generate_primary_key_ciphertext(ip, port)
+
+
+def generate_data_key(ip, port, encrypted_primary_key_path):
+    keymanager.generate_data_key_ciphertext(ip, port, encrypted_primary_key_path)
+
+
+def encrypt_file_without_key(data_file_path, ip, port):
+    keymanager.generate_primary_key_ciphertext(ip, port)
+    keymanager.generate_data_key_ciphertext(ip, port, './encrypted_primary_key')
+    fileoperator.encrypt_data_file(ip, port, data_file_path, './encrypted_primary_key', './encrypted_data_key')
+
+
+def encrypt_file_with_key(data_file_path, ip, port, encrypted_primary_key_path, encrypted_data_key_path):
+    fileoperator.encrypt_data_file(ip, port, data_file_path, encrypted_primary_key_path, encrypted_data_key_path)
+
+
+def decrypt_file(data_file_path, ip, port, encrypted_primary_key_path, encrypted_data_key_path):
+    fileoperator.decrypt_data_file(ip, port, data_file_path, encrypted_primary_key_path, encrypted_data_key_path)
+
+
+def encrypt_directory_with_key(dir_path, ip, port,encrypted_primary_key_path, encrypted_data_key_path, save_dir=None):
+    fileoperator.encrypt_directory_automation(ip, port, dir_path, encrypted_primary_key_path, encrypted_data_key_path,save_dir)
+
+
+def encrypt_directory_without_key(dir_path, ip, port, save_dir=None):
+    keymanager.generate_primary_key_ciphertext(ip, port)
+    keymanager.generate_data_key_ciphertext(ip, port, './encrypted_primary_key')
+    fileoperator.encrypt_directory_automation(ip, port, dir_path, './encrypted_primary_key', './encrypted_data_key',save_dir)
+
+
+def get_data_key_plaintext(ip, port, encrypted_primary_key_path, encrypted_data_key_path):
+    data_key_plaintext = keymanager.retrieve_data_key_plaintext(ip, port, encrypted_primary_key_path, encrypted_data_key_path)
+    print(data_key_plaintext)
+    return data_key_plaintext
+
+
+def decrypt_csv_columns(ip, port, encrypted_primary_key_path, encrypted_data_key_path, input_dir):
+    fileoperator.decrypt_csv_columns_automation(ip, port, encrypted_primary_key_path, encrypted_data_key_path, input_dir)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-api', '--api', type=str, help='name of the API to use', required=True)
+    parser.add_argument('-ip', '--ip', type=str, help='ip address of the ehsm_kms_server', required=True)
+    parser.add_argument('-port', '--port', type=str, help='port of the ehsm_kms_server',default='3000', required=False)
+    parser.add_argument('-pkp', '--pkp', type=str, help='path of the primary key storage file', required=False)
+    parser.add_argument('-dkp', '--dkp', type=str, help='path of the data key storage file', required=False)
+    parser.add_argument('-dfp', '--dfp', type=str, help='path of the data file to encrypt', required=False)
+    parser.add_argument('-dir', '--dir', type=str, help='path of the directory containing column-encrypted CSVs or the directory to be encrypted', required=False)
+    parser.add_argument('-sdp', '--sdp', type=str, help='path of the save directory output to',required=False)
+    args = parser.parse_args()
+
+    api = args.api
+    ip = args.ip
+    port = args.port
+
+    if os.getenv('APPID') is None:
+        print("Please set appid to docker environment variable or k8s secret APPID")
+        exit(1)
+
+    if os.getenv('APIKEY') is None:
+        print("Please set apikey to docker environment variable or k8s secret APIKEY")
+        exit(1)
+
+    if api == 'encrypt_file_without_key':
+        data_file_path = args.dfp
+        encrypt_file_without_key(data_file_path, ip, port)
+    elif api == 'generate_primary_key':
+        generate_primary_key(ip, port)
+    elif api == 'generate_data_key':
+        encrypted_primary_key_path = args.pkp
+        generate_data_key(ip, port, encrypted_primary_key_path)
+    elif api == 'encrypt_file_with_key':
+        data_file_path = args.dfp
+        encrypted_primary_key_path = args.pkp
+        encrypted_data_key_path = args.dkp
+        encrypt_file_with_key(data_file_path, ip, port, encrypted_primary_key_path, encrypted_data_key_path)
+    elif api == 'decrypt_file':
+        data_file_path = args.dfp
+        encrypted_primary_key_path = args.pkp
+        encrypted_data_key_path = args.dkp
+        decrypt_file(data_file_path, ip, port, encrypted_primary_key_path, encrypted_data_key_path)
+    elif api == 'encrypt_directory_without_key':
+        dir_path = args.dir
+        save_path = args.sdp
+        encrypt_directory_without_key(dir_path, ip, port, save_path)
+    elif api == 'encrypt_directory_with_key':
+        dir_path = args.dir
+        encrypted_primary_key_path = args.pkp
+        encrypted_data_key_path = args.dkp
+        save_path = args.sdp
+        encrypt_directory_with_key(dir_path, ip, port, encrypted_primary_key_path, encrypted_data_key_path,save_path)
+    elif api == 'get_data_key_plaintext':
+        encrypted_primary_key_path = args.pkp
+        encrypted_data_key_path = args.dkp
+        get_data_key_plaintext(ip, port, encrypted_primary_key_path, encrypted_data_key_path)
+    elif api == 'decrypt_csv_columns':
+        encrypted_primary_key_path = args.pkp
+        encrypted_data_key_path = args.dkp
+        input_dir = args.dir
+        decrypt_csv_columns(ip, port, encrypted_primary_key_path, encrypted_data_key_path, input_dir)

--- a/python/ppml/src/bigdl/ppml/kms/client.py
+++ b/python/ppml/src/bigdl/ppml/kms/client.py
@@ -22,8 +22,8 @@ def generate_primary_key(ip, port):
     keymanager.generate_primary_key_ciphertext(ip, port)
 
 
-def generate_data_key(ip, port, encrypted_primary_key_path):
-    keymanager.generate_data_key_ciphertext(ip, port, encrypted_primary_key_path)
+def generate_data_key(ip, port, encrypted_primary_key_path, data_key_length):
+    keymanager.generate_data_key_ciphertext(ip, port, encrypted_primary_key_path, data_key_length)
 
 
 def encrypt_file_without_key(data_file_path, ip, port):
@@ -64,12 +64,13 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('-api', '--api', type=str, help='name of the API to use', required=True)
     parser.add_argument('-ip', '--ip', type=str, help='ip address of the ehsm_kms_server', required=True)
-    parser.add_argument('-port', '--port', type=str, help='port of the ehsm_kms_server',default='3000', required=False)
+    parser.add_argument('-port', '--port', type=str, help='port of the ehsm_kms_server', default='3000', required=False)
     parser.add_argument('-pkp', '--pkp', type=str, help='path of the primary key storage file', required=False)
     parser.add_argument('-dkp', '--dkp', type=str, help='path of the data key storage file', required=False)
     parser.add_argument('-dfp', '--dfp', type=str, help='path of the data file to encrypt', required=False)
     parser.add_argument('-dir', '--dir', type=str, help='path of the directory containing column-encrypted CSVs or the directory to be encrypted', required=False)
     parser.add_argument('-sdp', '--sdp', type=str, help='path of the save directory output to',required=False)
+    parser.add_argument('-klen', '--klen', type=str, help='length of data key, e.g. 16 or 32', default=32, required=False)
     args = parser.parse_args()
 
     api = args.api
@@ -91,7 +92,8 @@ if __name__ == "__main__":
         generate_primary_key(ip, port)
     elif api == 'generate_data_key':
         encrypted_primary_key_path = args.pkp
-        generate_data_key(ip, port, encrypted_primary_key_path)
+        data_key_length = args.klen
+        generate_data_key(ip, port, encrypted_primary_key_path, data_key_length)
     elif api == 'encrypt_file_with_key':
         data_file_path = args.dfp
         encrypted_primary_key_path = args.pkp
@@ -111,7 +113,7 @@ if __name__ == "__main__":
         encrypted_primary_key_path = args.pkp
         encrypted_data_key_path = args.dkp
         save_path = args.sdp
-        encrypt_directory_with_key(dir_path, ip, port, encrypted_primary_key_path, encrypted_data_key_path,save_path)
+        encrypt_directory_with_key(dir_path, ip, port, encrypted_primary_key_path, encrypted_data_key_path, save_path)
     elif api == 'get_data_key_plaintext':
         encrypted_primary_key_path = args.pkp
         encrypted_data_key_path = args.dkp

--- a/python/ppml/src/bigdl/ppml/kms/client.py
+++ b/python/ppml/src/bigdl/ppml/kms/client.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
     parser.add_argument('-dfp', '--dfp', type=str, help='path of the data file to encrypt', required=False)
     parser.add_argument('-dir', '--dir', type=str, help='path of the directory containing column-encrypted CSVs or the directory to be encrypted', required=False)
     parser.add_argument('-sdp', '--sdp', type=str, help='path of the save directory output to',required=False)
-    parser.add_argument('-klen', '--klen', type=str, help='length of data key, e.g. 16 or 32', default=32, required=False)
+    parser.add_argument('-klen', '--klen', type=int, help='length of data key, e.g. 16 or 32', default=32, required=False)
     args = parser.parse_args()
 
     api = args.api

--- a/python/ppml/src/bigdl/ppml/kms/client.py
+++ b/python/ppml/src/bigdl/ppml/kms/client.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
     parser.add_argument('-dfp', '--dfp', type=str, help='path of the data file to encrypt', required=False)
     parser.add_argument('-dir', '--dir', type=str, help='path of the directory containing column-encrypted CSVs or the directory to be encrypted', required=False)
     parser.add_argument('-sdp', '--sdp', type=str, help='path of the save directory output to',required=False)
-    parser.add_argument('-klen', '--klen', type=int, help='length of data key, e.g. 16 or 32', default=32, required=False)
+    parser.add_argument('-dkl', '--dkl', type=int, help='length of data key, e.g. 16 or 32', default=32, required=False)
     args = parser.parse_args()
 
     api = args.api
@@ -92,7 +92,7 @@ if __name__ == "__main__":
         generate_primary_key(ip, port)
     elif api == 'generate_data_key':
         encrypted_primary_key_path = args.pkp
-        data_key_length = args.klen
+        data_key_length = args.dkl
         generate_data_key(ip, port, encrypted_primary_key_path, data_key_length)
     elif api == 'encrypt_file_with_key':
         data_file_path = args.dfp

--- a/python/ppml/src/bigdl/ppml/kms/fileoperator.py
+++ b/python/ppml/src/bigdl/ppml/kms/fileoperator.py
@@ -1,0 +1,91 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from keymanager import retrieve_data_key_plaintext
+from cryptography.fernet import Fernet
+import os, sqlite3, csv
+
+def read_data_file(data_file_path):
+    with open(data_file_path, 'rb') as file:
+        original = file.read()
+    return original
+
+def write_data_file(data_file_path, content):
+    with open(data_file_path, 'wb') as file:
+        file.write(content)
+
+def encrypt_data_file(ip, port, data_file_path, encrypted_primary_key_path, encrypted_data_key_path, save_path=None):
+    data_key = retrieve_data_key_plaintext(ip, port, encrypted_primary_key_path, encrypted_data_key_path)
+    fernet = Fernet(data_key)
+    encrypted = fernet.encrypt(read_data_file(data_file_path))
+    if save_path is None:
+        save_path = data_file_path + '.encrypted'
+    write_data_file(save_path, encrypted)
+    print('[INFO] Encrypt Successfully! Encrypted Output Is ' + save_path)
+
+def decrypt_data_file(ip, port, data_file_path, encrypted_primary_key_path, encrypted_data_key_path, save_path=None):
+    data_key = retrieve_data_key_plaintext(ip, port, encrypted_primary_key_path, encrypted_data_key_path)
+    fernet = Fernet(data_key)
+    decrypted = fernet.decrypt(read_data_file(data_file_path))
+    if save_path is None:
+        save_path = data_file_path + '.decrypted'
+    write_data_file(save_path, decrypted)
+    print('[INFO] Decrypt Successfully! Decrypted Output Is ' + save_path)
+
+def encrypt_directory_automation(ip, port, input_dir, encrypted_primary_key_path, encrypted_data_key_path, save_dir):
+    print('[INFO] Encrypt Files Start...')
+    if save_dir is None:
+        if input_dir[-1]=='/':
+            input_dir = input_dir[:-1]
+        save_dir = input_dir + '.encrypted'
+    if not os.path.isdir(save_dir):
+        os.mkdir(save_dir)
+    data_key = retrieve_data_key_plaintext(ip, port, encrypted_primary_key_path, encrypted_data_key_path)
+    fernet = Fernet(data_key)
+    for file_name in os.listdir(input_dir):
+        input_path = os.path.join(input_dir, file_name)
+        encrypted = fernet.encrypt(read_data_file(input_path))
+        save_path = os.path.join(save_dir, file_name + '.encrypted')
+        write_data_file(save_path, encrypted)
+        print('[INFO] Encrypt Successfully! Encrypted Output Is ' + save_path)
+    print('[INFO] Encrypted Files.')
+
+def decrypt_csv_columns_automation(ip, port, encrypted_primary_key_path, encrypted_data_key_path, input_dir):
+    from glob import glob
+    import time
+    print('[INFO] Column Decryption Start...')
+    start = time.time()
+    EXT = "*.csv"
+    all_csv_files = [file
+                     for p, subdir, files in os.walk(input_dir)
+                     for file in glob(os.path.join(p, EXT))]
+    data_key = retrieve_data_key_plaintext(ip, port,encrypted_primary_key_path, encrypted_data_key_path)
+    fernet = Fernet(data_key)
+
+    for csv_file in all_csv_files:
+        data = csv.reader(open(csv_file,'r'))
+        csvWriter = csv.writer(open(csv_file + '.col_decrypted', 'w', newline='\n'))
+        next(data)
+        for row in data:
+            write_buffer = []
+            for field in row:
+                plaintext = fernet.decrypt(field.encode('ascii')).decode("utf-8")
+                write_buffer.append(plaintext)
+            csvWriter.writerow(write_buffer)
+        print('[INFO] Decryption Finished. The Output Is ' + csv_file + '.col_decrypted')
+
+    end = time.time()
+    print('[INFO] Total Elapsed Time For Columns Decrytion: ' + str(end - start) + ' s')

--- a/python/ppml/src/bigdl/ppml/kms/keymanager.py
+++ b/python/ppml/src/bigdl/ppml/kms/keymanager.py
@@ -1,0 +1,45 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from restcaller import request_parimary_key_ciphertext,request_data_key_ciphertext, request_data_key_plaintext
+
+def read_encrypted_key_file(encrypted_key_path):
+    with open(encrypted_key_path, 'r') as file:
+        original = file.readlines()
+    return original[0]
+
+def write_encrypted_key_file(encrypted_key_path, content):
+    with open(encrypted_key_path, 'w') as file:
+        file.write(content)
+
+def retrieve_data_key_plaintext(ip, port, encrypted_primary_key_path, encrypted_data_key_path):
+    encrypted_primary_key = read_encrypted_key_file(encrypted_primary_key_path)
+    encrypted_data_key = read_encrypted_key_file(encrypted_data_key_path)
+    data_key_plaintext = request_data_key_plaintext(ip, port, encrypted_primary_key, encrypted_data_key)
+    return data_key_plaintext
+
+
+def generate_primary_key_ciphertext(ip, port):
+    primary_key_ciphertext = request_parimary_key_ciphertext(ip, port)
+    write_encrypted_key_file('./encrypted_primary_key', primary_key_ciphertext)
+    print('[INFO] Primary Key Generated Successfully at ./encrypted_primary_key')
+
+
+def generate_data_key_ciphertext(ip, port, encrypted_primary_key_path):
+    encrypted_primary_key=read_encrypted_key_file(encrypted_primary_key_path)
+    data_key_ciphertext = request_data_key_ciphertext(ip, port, encrypted_primary_key)
+    write_encrypted_key_file('./encrypted_data_key', data_key_ciphertext)
+    print('[INFO] Data Key Generated Successfully at ./encrypted_data_key')

--- a/python/ppml/src/bigdl/ppml/kms/keymanager.py
+++ b/python/ppml/src/bigdl/ppml/kms/keymanager.py
@@ -38,8 +38,8 @@ def generate_primary_key_ciphertext(ip, port):
     print('[INFO] Primary Key Generated Successfully at ./encrypted_primary_key')
 
 
-def generate_data_key_ciphertext(ip, port, encrypted_primary_key_path):
+def generate_data_key_ciphertext(ip, port, encrypted_primary_key_path, data_key_length = 32):
     encrypted_primary_key=read_encrypted_key_file(encrypted_primary_key_path)
-    data_key_ciphertext = request_data_key_ciphertext(ip, port, encrypted_primary_key)
+    data_key_ciphertext = request_data_key_ciphertext(ip, port, encrypted_primary_key, data_key_length)
     write_encrypted_key_file('./encrypted_data_key', data_key_ciphertext)
     print('[INFO] Data Key Generated Successfully at ./encrypted_data_key')

--- a/python/ppml/src/bigdl/ppml/kms/restcaller.py
+++ b/python/ppml/src/bigdl/ppml/kms/restcaller.py
@@ -66,11 +66,11 @@ def request_parimary_key_ciphertext(ip, port):
     primary_key_ciphertext = post_request(ip, port, action, payload)['keyid']
     return primary_key_ciphertext
 
-def request_data_key_ciphertext(ip, port, encrypted_primary_key):
+def request_data_key_ciphertext(ip, port, encrypted_primary_key, data_key_length):
     action = "GenerateDataKeyWithoutPlaintext"
     payload = {
         "keyid":encrypted_primary_key,
-        "keylen": 32,
+        "keylen": data_key_length,
         "aad": "test",
     }
     data_key_ciphertext = post_request(ip, port, action, payload)['ciphertext']

--- a/python/ppml/src/bigdl/ppml/kms/restcaller.py
+++ b/python/ppml/src/bigdl/ppml/kms/restcaller.py
@@ -1,0 +1,87 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import requests
+import json
+import base64
+import time
+import random
+import hmac
+from hashlib import sha256
+import os
+from collections import OrderedDict
+import urllib.parase
+from requests.packages import urllib3
+
+# default app auth conf
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+appid = os.getenv('APPID')
+apikey = os.getenv('APIKEY')
+headers = {"Content-Type":"application/json"}
+use_secure_cert = False
+
+def request_params(payload):
+    params = OrderedDict()
+    params["appid"] = appid
+    ord_payload = OrderedDict(sorted(payload.items(), key=lambda k: k[0]))
+    params["payload"] = urllib.parse.unquote(urllib.parse.urlencode(ord_payload))
+    params["timestamp"] = str(int(time.time()*1000))
+    sign_string = urllib.parse.unquote(urllib.parse.urlencode(params))
+    sign = str(base64.b64encode(hmac.new(apikey.encode('utf-8'),
+                                         sign_string.encode('utf-8'),
+                                         digestmod=sha256).digest()),'utf-8')
+    params["payload"] = ord_payload
+    params["sign"] = sign
+    return params
+
+def construct_url(ip, port, action):
+    return "https://" + ip + ":" + port + "/ehsm?Action=" + action
+
+def post_request(ip, port, action, payload):
+    url = construct_url(ip, port, action)
+    params = request_params(payload)
+    create_resp = requests.post(url=url, data=json.dumps(params), headers=headers, timeout=100, verify=use_secure_cert)
+    result = json.loads(create_resp.text)['result']
+    return result
+
+def request_parimary_key_ciphertext(ip, port):
+    action = "CreateKey"
+    payload = {
+        "keyspec":"EH_AES_GCM_128",
+        "origin":"EH_INTERNAL_KEY"
+    }
+    primary_key_ciphertext = post_request(ip, port, action, payload)['keyid']
+    return primary_key_ciphertext
+
+def request_data_key_ciphertext(ip, port, encrypted_primary_key):
+    action = "GenerateDataKeyWithoutPlaintext"
+    payload = {
+        "keyid":encrypted_primary_key,
+        "keylen": 32,
+        "aad": "test",
+    }
+    data_key_ciphertext = post_request(ip, port, action, payload)['ciphertext']
+    return data_key_ciphertext
+
+def request_data_key_plaintext(ip, port, encrypted_primary_key, encrypted_data_key):
+    action = "Decrypt"
+    payload = {
+        "keyid":encrypted_primary_key,
+        "ciphertext":encrypted_data_key,
+        "aad":"test",
+    }
+    data_key_plaintext = post_request(ip, port, action, payload)['plaintext']
+    return data_key_plaintext


### PR DESCRIPTION
## Description

Add python KMS support.

### 1. Why the change?

We used to call pykms by python -> scala jars -> spark -> jvm, which is low-performance and has to depend on scala and spark, and this is too heavy for python application such as trusted pytorch. As a result, a pure-python implementation of KMS is needed.

### 2. User API changes

Users are allowed to use kms in their python codes instead of a heavy ppml context.

### 3. Summary of the change 

Add python KMS lib.

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies


- [X] New Python dependencies
       requests
       argparse
       cryptography==3.3.2
