### PR TITLE
Nano: fix load error of jit+ipex and channels_last of quantization

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -71,6 +71,8 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         status = PytorchIPEXJITBF16Model._load_status(path)
         checkpoint_path = path / status['checkpoint']
         if status["use_jit"]:
+            if status["use_ipex"]:
+                import intel_extension_for_pytorch as ipex
             model = torch.jit.load(checkpoint_path)
             model.eval()
             model = torch.jit.freeze(model)

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -58,7 +58,6 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
             self.model = self.model.to(memory_format=torch.channels_last)
         if self.use_ipex:
             import intel_extension_for_pytorch as ipex
-
             self.model = ipex.optimize(self.model, dtype=dtype)
         if self.use_jit:
             if dtype == torch.bfloat16:

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -48,6 +48,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
             self.use_ipex = use_ipex
             self.use_jit = use_jit
             self.channels_last = channels_last
+            self.context_manager = BaseContextManager()
             return
         self.channels_last = channels_last
         self.original_state_dict = model.state_dict()
@@ -104,6 +105,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         status = PytorchIPEXJITModel._load_status(path)
         checkpoint_path = path / status['checkpoint']
         if status["use_jit"]:
+            if status["use_ipex"]:
+                import intel_extension_for_pytorch as ipex
             model = torch.jit.load(checkpoint_path)
             model.eval()
             model = torch.jit.freeze(model)

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -63,22 +63,14 @@ class TorchAccelerationOption(AccelerationOption):
                     self.channels_last is False:
                 return model
             # trace
-            if accelerator in ("jit", None):
-                acce_model = \
-                    InferenceOptimizer.trace(model=model,
-                                             accelerator=accelerator,
-                                             use_ipex=self.ipex,
-                                             # channels_last is only for jit
-                                             channels_last=self.channels_last,
-                                             input_sample=input_sample)
-            else:
-                acce_model = \
-                    InferenceOptimizer.trace(model=model,
-                                             accelerator=accelerator,
-                                             input_sample=input_sample,
-                                             thread_num=thread_num,
-                                             # remove output of openvino
-                                             logging=logging)
+            acce_model = \
+                InferenceOptimizer.trace(model=model,
+                                         accelerator=accelerator,
+                                         input_sample=input_sample,
+                                         thread_num=thread_num,
+                                         channels_last=self.channels_last,
+                                         # remove output of openvino
+                                         logging=logging)
         else:
             # quantize
             ort_method: str = self.method
@@ -87,6 +79,7 @@ class TorchAccelerationOption(AccelerationOption):
                                             precision=self.get_precision(),
                                             accelerator=accelerator,
                                             use_ipex=self.ipex,
+                                            channels_last=self.channels_last,
                                             calib_data=training_data,
                                             input_sample=input_sample,
                                             method=ort_method,

--- a/python/nano/test/pytorch/tests/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/test_ipex_jit_inference.py
@@ -23,7 +23,7 @@ import torch
 from test.pytorch.utils._train_torch_lightning import create_data_loader, data_transform
 from torch import nn
 
-from bigdl.nano.pytorch import Trainer
+from bigdl.nano.pytorch import InferenceOptimizer
 from bigdl.nano.pytorch.vision.models import vision
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
 import tempfile
@@ -51,30 +51,48 @@ class IPEXJITInference_gt_1_10:
     data_sample = next(iter(data_loader))[0]
 
     def test_ipex_inference(self):
-        model = Trainer.trace(self.model, accelerator=None, use_ipex=True)
-        model(self.data_sample)
+        model = InferenceOptimizer.trace(self.model, accelerator=None, use_ipex=True)
+        with model.context_manager:
+            model(self.data_sample)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
-            Trainer.save(model, tmp_dir_name)
-            new_model = Trainer.load(tmp_dir_name, self.model)
-        new_model(self.data_sample)
+            InferenceOptimizer.save(model, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name, self.model)
+        with new_model.context_manager:
+            new_model(self.data_sample)
 
     def test_jit_inference(self):
-        model = Trainer.trace(self.model, accelerator="jit",
-                              use_ipex=False, input_sample=self.data_sample)
-        model(self.data_sample)
+        model = InferenceOptimizer.trace(self.model, accelerator="jit",
+                                         use_ipex=False, input_sample=self.data_sample)
+        with model.context_manager:
+            model(self.data_sample)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
-            Trainer.save(model, tmp_dir_name)
-            new_model = Trainer.load(tmp_dir_name)
-        new_model(self.data_sample)
+            InferenceOptimizer.save(model, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name)
+        with new_model.context_manager:
+            new_model(self.data_sample)
 
     def test_ipex_jit_inference(self):
-        model = Trainer.trace(self.model, accelerator="jit",
-                              use_ipex=True, input_sample=self.data_sample)
-        model(self.data_sample)
+        model = InferenceOptimizer.trace(self.model, accelerator="jit",
+                                         use_ipex=True, input_sample=self.data_sample)
+        with model.context_manager:
+            model(self.data_sample)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
-            Trainer.save(model, tmp_dir_name)
-            new_model = Trainer.load(tmp_dir_name)
-        new_model(self.data_sample)
+            InferenceOptimizer.save(model, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name)
+        with new_model.context_manager:
+            new_model(self.data_sample)
+    
+    def test_resnest_ipex_jit_inference(self):
+        model = torch.hub.load('zhanghang1989/ResNeSt', 'resnest50', pretrained=False)
+        model = InferenceOptimizer.trace(model, accelerator="jit",
+                                         use_ipex=True, input_sample=self.data_sample)
+        with model.context_manager:
+            model(self.data_sample)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(model, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name)
+        with new_model.context_manager:
+            new_model(self.data_sample)
 
 
 class IPEXJITInference_lt_1_10:

--- a/python/nano/test/pytorch/tests/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/test_ipex_jit_inference.py
@@ -81,18 +81,6 @@ class IPEXJITInference_gt_1_10:
             new_model = InferenceOptimizer.load(tmp_dir_name)
         with new_model.context_manager:
             new_model(self.data_sample)
-    
-    def test_resnest_ipex_jit_inference(self):
-        model = torch.hub.load('zhanghang1989/ResNeSt', 'resnest50', pretrained=False)
-        model = InferenceOptimizer.trace(model, accelerator="jit",
-                                         use_ipex=True, input_sample=self.data_sample)
-        with model.context_manager:
-            model(self.data_sample)
-        with tempfile.TemporaryDirectory() as tmp_dir_name:
-            InferenceOptimizer.save(model, tmp_dir_name)
-            new_model = InferenceOptimizer.load(tmp_dir_name)
-        with new_model.context_manager:
-            new_model(self.data_sample)
 
 
 class IPEXJITInference_lt_1_10:


### PR DESCRIPTION
## Description

During OOB test, found three problems:

- After loading, `PyTorchIPEXJITModel` object has no attribute `context manager`
- ResNest50 can't load model accelerated by jit+ipex
- `channels_last` does not take effect in bf16 quantization methods in `InferenceOptimizer.optimize`

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/222
https://github.com/analytics-zoo/nano/issues/223

### 2. User API changes

No change.

### 3. Summary of the change 

- Fix missing of `context manager`
- Fix error of loading jit+ipex
- Add `channels_last` in quantization methods in `InferenceOptimizer.optimize`

### 4. How to test?
- [x] Unit test
- [x] Application test
