### PR TITLE
Add shard_size=batch_size when convert Spark DataFrame to SparkXShards

### DIFF
--- a/python/friesian/example/deeprec/wdl.py
+++ b/python/friesian/example/deeprec/wdl.py
@@ -960,11 +960,11 @@ class RayWorker:
         return self.task_type
 
     def step(self, data_refs, validation_data_refs=None):
-        from bigdl.orca.data.utils import ray_partition_get_data_label
+        from bigdl.orca.data.utils import partition_get_data_label
 
         partition_list = ray.get(data_refs)
         partition_data = [item for partition in partition_list for item in partition]
-        data, label = ray_partition_get_data_label(
+        data, label = partition_get_data_label(
             partition_data, allow_tuple=True, allow_list=False)
         data_size = len(label)
         steps = data_size // self.config["batch_size"] + 1
@@ -977,7 +977,7 @@ class RayWorker:
             validation_partition_list = ray.get(validation_data_refs)
             validation_partition_data = \
                 [item for partition in validation_partition_list for item in partition]
-            validation_data, validation_label = ray_partition_get_data_label(
+            validation_data, validation_label = partition_get_data_label(
                 validation_partition_data, allow_tuple=True, allow_list=False)
             test_data_size = len(validation_label)
             test_steps = test_data_size // self.config["batch_size"] + 1

--- a/python/orca/src/bigdl/orca/automl/search/ray_tune/ray_tune_search_engine.py
+++ b/python/orca/src/bigdl/orca/automl/search/ray_tune/ray_tune_search_engine.py
@@ -410,12 +410,12 @@ def trial_dirname_creator(trial):
 
 
 def get_data_from_part_refs(part_refs):
-    from bigdl.orca.data.utils import ray_partitions_get_data_label
+    from bigdl.orca.data.utils import partitions_get_data_label
 
     partitions = [ray.get(part_ref) for part_ref in part_refs]
 
-    data, label = ray_partitions_get_data_label(partitions,
-                                                allow_tuple=True,
-                                                allow_list=False,
-                                                )
+    data, label = partitions_get_data_label(partitions,
+                                            allow_tuple=True,
+                                            allow_list=False,
+                                            )
     return data, label

--- a/python/orca/src/bigdl/orca/data/utils.py
+++ b/python/orca/src/bigdl/orca/data/utils.py
@@ -195,10 +195,10 @@ def combine(data_list):
     return res
 
 
-def ray_partition_get_data_label(partition_data,
-                                 allow_tuple=True,
-                                 allow_list=True,
-                                 has_label=True):
+def partition_get_data_label(partition_data,
+                             allow_tuple=True,
+                             allow_list=True,
+                             has_label=True):
     """
     :param partition_data: The data partition from Spark RDD, which should be a list of records.
     :param allow_tuple: Boolean. Whether the model accepts a tuple as input. Default is True.
@@ -220,19 +220,22 @@ def ray_partition_get_data_label(partition_data,
     return data, label
 
 
-def ray_partitions_get_data_label(partition_list,
-                                  allow_tuple=True,
-                                  allow_list=True,
-                                  has_label=True):
+def partitions_get_data_label(partition_list,
+                              allow_tuple=True,
+                              allow_list=True,
+                              has_label=True):
+    """
+    Get data and label for multiple partitions.
+    """
     partition_data = [item for partition in partition_list for item in partition]
-    data, label = ray_partition_get_data_label(partition_data,
-                                               allow_tuple=allow_tuple,
-                                               allow_list=allow_list,
-                                               has_label=has_label)
+    data, label = partition_get_data_label(partition_data,
+                                           allow_tuple=allow_tuple,
+                                           allow_list=allow_list,
+                                           has_label=has_label)
     return data, label
 
 
-def ray_partitions_get_tf_dataset(partition_list, has_label=True):
+def partitions_get_tf_dataset(partition_list, has_label=True):
     import tensorflow as tf  # type:ignore
     partition_data = [item for partition in partition_list for item in partition]
     if len(partition_data) != 0:
@@ -242,9 +245,9 @@ def ray_partitions_get_tf_dataset(partition_list, has_label=True):
         if "x" in keys:
             if has_label:
                 invalidInputError("y" in keys, "key y should in each shard if has_label=True")
-            data, label = ray_partition_get_data_label(partition_data,
-                                                       allow_tuple=True,
-                                                       allow_list=False)
+            data, label = partition_get_data_label(partition_data,
+                                                   allow_tuple=True,
+                                                   allow_list=False)
             dataset = tf.data.Dataset.from_tensor_slices((data, label))
         elif "ds_def" in keys and "elem_spec" in keys:
             from tensorflow.python.distribute.coordinator.values import \

--- a/python/orca/src/bigdl/orca/learn/mxnet/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/mxnet/estimator.py
@@ -21,7 +21,7 @@ import subprocess
 import ray
 from dmlc_tracker.tracker import get_host_ip
 
-from bigdl.orca.data.utils import ray_partitions_get_data_label, process_spark_xshards
+from bigdl.orca.data.utils import partitions_get_data_label, process_spark_xshards
 from bigdl.orca.ray import OrcaRayContext
 from bigdl.orca.learn.mxnet.mxnet_runner import MXNetRunner
 from bigdl.orca.learn.mxnet.utils import find_free_port
@@ -35,9 +35,9 @@ def partition_refs_to_creator(partition_refs, shuffle=False):
         import mxnet as mx
         invalidInputError("batch_size" in config,
                           "batch_size must be set in config")
-        data, label = ray_partitions_get_data_label(ray.get(partition_refs),
-                                                    allow_tuple=False,
-                                                    allow_list=False)
+        data, label = partitions_get_data_label(ray.get(partition_refs),
+                                                allow_tuple=False,
+                                                allow_list=False)
 
         train_data_iter = mx.io.NDArrayIter(data=data, label=label,
                                             batch_size=config["batch_size"],

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -39,7 +39,7 @@ from bigdl.dllib.utils.log4Error import *
 
 def partition_to_creator(partition):
     def data_creator(config, batch_size):
-        from bigdl.orca.data.utils import ray_partition_get_data_label, index_data, get_size
+        from bigdl.orca.data.utils import partition_get_data_label, index_data, get_size
         from torch.utils.data import Dataset, DataLoader
 
         class NDArrayDataset(Dataset):
@@ -59,9 +59,9 @@ def partition_to_creator(partition):
                     "multiprocessing_context"]:
             if arg in config:
                 params[arg] = config[arg]
-        data, label = ray_partition_get_data_label(partition,
-                                                   allow_tuple=False,
-                                                   allow_list=False)
+        data, label = partition_get_data_label(partition,
+                                               allow_tuple=False,
+                                               allow_list=False)
         print("Data size on worker: ", len(label))
         dataset = NDArrayDataset(data, label)
         data_loader = DataLoader(dataset, **params)
@@ -226,7 +226,8 @@ class PyTorchPySparkEstimator(BaseEstimator):
                                                            feature_cols=feature_cols,
                                                            label_cols=label_cols,
                                                            mode="fit",
-                                                           num_workers=self.num_workers)
+                                                           num_workers=self.num_workers,
+                                                           shard_size=batch_size)
 
         sc = OrcaContext.get_spark_context()
         _ = self.create_tcpstore_server()
@@ -396,7 +397,8 @@ class PyTorchPySparkEstimator(BaseEstimator):
                                               validation_data=None,
                                               feature_cols=feature_cols,
                                               label_cols=None,
-                                              mode="predict")
+                                              mode="predict",
+                                              shard_size=batch_size)
 
             pred_shards = self._predict_spark_xshards(xshards, init_params, params)
             result = convert_predict_xshards_to_dataframe(data, pred_shards)
@@ -474,7 +476,8 @@ class PyTorchPySparkEstimator(BaseEstimator):
                                              feature_cols=feature_cols,
                                              label_cols=label_cols,
                                              mode="evaluate",
-                                             num_workers=self.num_workers)
+                                             num_workers=self.num_workers,
+                                             shard_size=batch_size)
         if isinstance(data, SparkXShards):
             params["wrap_dataloader"] = False
             if data._get_class_name() == 'pandas.core.frame.DataFrame':

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -139,7 +139,8 @@ class SparkTFEstimator():
                                                            feature_cols, label_cols,
                                                            mode="fit",
                                                            num_workers=self.num_workers,
-                                                           accept_str_col=True)
+                                                           accept_str_col=True,
+                                                           shard_size=batch_size)
 
         # for continuous training
         if self.model_weights:
@@ -265,7 +266,8 @@ class SparkTFEstimator():
                                              label_cols=label_cols,
                                              mode="evaluate",
                                              num_workers=self.num_workers,
-                                             accept_str_col=True)
+                                             accept_str_col=True,
+                                             shard_size=batch_size)
 
         if self.model_weights:
             weights = sc.broadcast(self.model_weights)
@@ -377,7 +379,8 @@ class SparkTFEstimator():
                                               feature_cols=feature_cols,
                                               label_cols=None,
                                               mode="predict",
-                                              accept_str_col=True)
+                                              accept_str_col=True,
+                                              shard_size=batch_size)
 
             def transform_func(iter, init_param, param):
                 partition_data = list(iter)

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -195,7 +195,8 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                                                            feature_cols, label_cols,
                                                            mode="fit",
                                                            num_workers=self.num_workers,
-                                                           accept_str_col=True)
+                                                           accept_str_col=True,
+                                                           shard_size=batch_size)
 
         if isinstance(data, SparkXShards):
             if data._get_class_name() == 'pandas.core.frame.DataFrame':
@@ -333,7 +334,8 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                                              label_cols=label_cols,
                                              mode="evaluate",
                                              num_workers=self.num_workers,
-                                             accept_str_col=True)
+                                             accept_str_col=True,
+                                             shard_size=batch_size)
 
         if isinstance(data, SparkXShards):
             if data._get_class_name() == 'pandas.core.frame.DataFrame':
@@ -459,7 +461,8 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                                               feature_cols=feature_cols,
                                               label_cols=None,
                                               mode="predict",
-                                              accept_str_col=True)
+                                              accept_str_col=True,
+                                              shard_size=batch_size)
             pred_shards = self._predict_spark_xshards(xshards, params)
             result = convert_predict_xshards_to_dataframe(data, pred_shards)
         elif isinstance(data, SparkXShards):

--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -21,7 +21,7 @@ import copy
 
 import tensorflow as tf
 
-from bigdl.orca.data.utils import ray_partition_get_data_label
+from bigdl.orca.data.utils import partition_get_data_label
 from bigdl.orca.data.file import exists
 from bigdl.orca.learn.utils import save_pkl, duplicate_stdout_stderr_to_file,\
     get_rank, process_tensorboard_in_callbacks, save_model, load_model, \
@@ -121,9 +121,9 @@ class TFDistributedDatasetHandler(DatasetHandler):
     def _handle_xshards(self, dataset, steps, local_batch_size, shuffle):
         import tensorflow as tf
 
-        data, label = ray_partition_get_data_label(dataset,
-                                                   allow_tuple=True,
-                                                   allow_list=False)
+        data, label = partition_get_data_label(dataset,
+                                               allow_tuple=True,
+                                               allow_list=False)
 
         def dataset_fn(input_context):
             dataset = tf.data.Dataset.from_tensor_slices((data, label))
@@ -156,9 +156,9 @@ class LocalDatasetHandler(DatasetHandler):
 
     def _handle_xshards(self, dataset, steps, local_batch_size, shuffle):
         import tensorflow as tf
-        data, label = ray_partition_get_data_label(dataset,
-                                                   allow_tuple=True,
-                                                   allow_list=False)
+        data, label = partition_get_data_label(dataset,
+                                               allow_tuple=True,
+                                               allow_list=False)
         dataset = tf.data.Dataset.from_tensor_slices((data, label))
         dataset = dataset.repeat()
         dataset = dataset.take(steps * local_batch_size)

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -42,7 +42,7 @@ import numpy as np
 from contextlib import closing
 
 from bigdl.dllib.utils import log4Error
-from bigdl.orca.data.utils import ray_partitions_get_data_label, ray_partitions_get_tf_dataset
+from bigdl.orca.data.utils import partitions_get_data_label, partitions_get_tf_dataset
 from bigdl.orca.data.file import is_file, get_remote_file_to_local, get_remote_dir_to_local, \
     get_remote_files_with_prefix_to_local, put_local_file_to_remote, \
     put_local_dir_tree_to_remote, put_local_files_with_prefix_to_remote
@@ -153,9 +153,9 @@ class HorovodDatasetHanlder(DatasetHandler):
 
     def _handle_xshards(self, dataset, steps, local_batch_size, shuffle):
         import tensorflow as tf
-        data, label = ray_partitions_get_data_label(ray.get(dataset),
-                                                    allow_tuple=True,
-                                                    allow_list=False)
+        data, label = partitions_get_data_label(ray.get(dataset),
+                                                allow_tuple=True,
+                                                allow_list=False)
         dataset = tf.data.Dataset.from_tensor_slices((data, label))
         options = tf.data.Options()
         options.experimental_distribute.auto_shard_policy = tf.data.experimental.AutoShardPolicy.OFF
@@ -182,7 +182,7 @@ class TFDistributedDatasetHandler(DatasetHandler):
 
     def _handle_xshards(self, dataset, steps, local_batch_size, shuffle):
         import tensorflow as tf
-        tf_dataset = ray_partitions_get_tf_dataset(ray.get(dataset))
+        tf_dataset = partitions_get_tf_dataset(ray.get(dataset))
 
         def dataset_fn(input_context):
             options = tf.data.Options()
@@ -214,9 +214,9 @@ class LocalDatasetHandler(DatasetHandler):
 
     def _handle_xshards(self, dataset, steps, local_batch_size, shuffle):
         import tensorflow as tf
-        data, label = ray_partitions_get_data_label(ray.get(dataset),
-                                                    allow_tuple=True,
-                                                    allow_list=False)
+        data, label = partitions_get_data_label(ray.get(dataset),
+                                                allow_tuple=True,
+                                                allow_list=False)
         dataset = tf.data.Dataset.from_tensor_slices((data, label))
         dataset = dataset.repeat()
         dataset = dataset.take(steps * local_batch_size)

--- a/python/orca/src/bigdl/orca/learn/utils.py
+++ b/python/orca/src/bigdl/orca/learn/utils.py
@@ -358,7 +358,8 @@ def process_xshards_of_pandas_dataframe(data, feature_cols, label_cols=None, val
         return data
 
 
-def _dataframe_to_xshards(data, feature_cols, label_cols=None, accept_str_col=False, shard_size=None):
+def _dataframe_to_xshards(data, feature_cols, label_cols=None,
+                          accept_str_col=False, shard_size=None):
     from bigdl.orca import OrcaContext
     schema = data.schema
     if OrcaContext._shard_size:


### PR DESCRIPTION
1. Add shard_size=batch_size when convert Spark DataFrame to SparkXShards
2. rename ray_partition_get_data_label related functions to partition_get_data_label as they are not related to ray, the name is confusing.