### PR TITLE
Nano: add thread ctrl in context manager

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
@@ -35,7 +35,7 @@ def ipex_device():
 
 
 def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
-                        use_jit=False, channels_last=None):
+                        use_jit=False, channels_last=None, thread_num=None):
     '''
     :param model: the model(nn.module) to be transform.
     :param input_sample: torch tensor indicate the data sample to be used
@@ -44,14 +44,16 @@ def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
     :param use_jit: if use jit to accelerate the model
     :param channels_last: if set model and data to be channels-last mode.
             the parameter will be ignored if use_ipex is False.
+    :param thread_num: the thread num allocated for this model.
     '''
     from .ipex_inference_model import PytorchIPEXJITModel
     return PytorchIPEXJITModel(model, input_sample=input_sample, use_ipex=use_ipex,
-                               use_jit=use_jit, channels_last=channels_last)
+                               use_jit=use_jit, channels_last=channels_last,
+                               thread_num=thread_num)
 
 
 def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
-                            use_jit=False, channels_last=None):
+                            use_jit=False, channels_last=None, thread_num=None):
     '''
     :param model: the model(nn.module) to be transform.
     :param input_sample: torch tensor indicate the data sample to be used
@@ -60,10 +62,12 @@ def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
     :param use_jit: if use jit to accelerate the model
     :param channels_last: if set model and data to be channels-last mode.
             the parameter will be ignored if use_ipex is False.
+    :param thread_num: the thread num allocated for this model.
     '''
     from .ipex_inference_bf16_model import PytorchIPEXJITBF16Model
     return PytorchIPEXJITBF16Model(model, input_sample=input_sample, use_ipex=use_ipex,
-                                   use_jit=use_jit, channels_last=channels_last)
+                                   use_jit=use_jit, channels_last=channels_last,
+                                   thread_num=thread_num)
 
 
 def load_ipexjit_model(path, model):

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -85,8 +85,12 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
             model.eval()
             model.load_state_dict(state_dict)
             from_load = False
+        if status['thread_num'] is None:
+            thread_num = None
+        else:
+            thread_num = int(status['thread_num'])
         return PytorchIPEXJITBF16Model(model, use_ipex=status['use_ipex'],
                                        use_jit=status['use_jit'],
                                        channels_last=status['channels_last'],
                                        from_load=from_load,
-                                       thread_num=int(status['thread_num']))
+                                       thread_num=thread_num)

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -85,9 +85,8 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
             model.eval()
             model.load_state_dict(state_dict)
             from_load = False
-        if status['thread_num'] is None:
-            thread_num = None
-        else:
+        thread_num = None
+        if status["thread_num"] is not None and status['thread_num'] != {}:
             thread_num = int(status['thread_num'])
         return PytorchIPEXJITBF16Model(model, use_ipex=status['use_ipex'],
                                        use_jit=status['use_jit'],

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -18,14 +18,14 @@
 from ...utils.log4Error import invalidInputError
 
 from .ipex_inference_model import PytorchIPEXJITModel
-from bigdl.nano.pytorch.context_manager import AutocastContextManager
+from bigdl.nano.pytorch.context_manager import generate_context_manager
 from bigdl.nano.utils import CPUInfo
 import torch
 
 
 class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
     def __init__(self, model, input_sample=None, use_ipex=False,
-                 use_jit=False, channels_last=None, from_load=False):
+                 use_jit=False, channels_last=None, thread_num=None, from_load=False):
         '''
         This is the accelerated model for pytorch and ipex/jit.
         All the external API is based on Trainer, so what we have here is
@@ -40,6 +40,7 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         :param use_jit: if use jit to accelerate the model
         :param channels_last: if set model and data to be channels-last mode.
                the parameter will be ignored if use_ipex is False.
+        :param thread_num: the thread num allocated for this model.
         :param from_load: this will only be set by _load method.
         '''
         if use_ipex:
@@ -52,7 +53,9 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         PytorchIPEXJITModel.__init__(self, model, input_sample=input_sample, use_ipex=use_ipex,
                                      dtype=torch.bfloat16, use_jit=use_jit,
                                      channels_last=channels_last, from_load=from_load)
-        self.context_manager = AutocastContextManager()
+        self.context_manager = generate_context_manager(accelerator=None,
+                                                        precision="bf16",
+                                                        thread_num=thread_num)
 
     @property
     def _check_cpu_isa(self):
@@ -85,4 +88,5 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         return PytorchIPEXJITBF16Model(model, use_ipex=status['use_ipex'],
                                        use_jit=status['use_jit'],
                                        channels_last=status['channels_last'],
-                                       from_load=from_load)
+                                       from_load=from_load,
+                                       thread_num=int(status['thread_num']))

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -120,11 +120,15 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
             model.eval()
             model.load_state_dict(state_dict)
             from_load = False
+        if status['thread_num'] is None:
+            thread_num = None
+        else:
+            thread_num = int(status['thread_num'])
         return PytorchIPEXJITModel(model, use_ipex=status['use_ipex'],
                                    use_jit=status['use_jit'],
                                    channels_last=status['channels_last'],
                                    from_load=from_load,
-                                   thread_num=int(status['thread_num']))
+                                   thread_num=thread_num)
 
     def _save_model(self, path):
         if self.use_jit:

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -15,13 +15,13 @@
 #
 
 from bigdl.nano.utils.inference.pytorch.model import AcceleratedLightningModule
-from bigdl.nano.pytorch.context_manager import BaseContextManager
+from bigdl.nano.pytorch.context_manager import generate_context_manager
 import torch
 
 
 class PytorchIPEXJITModel(AcceleratedLightningModule):
     def __init__(self, model: torch.nn.Module, input_sample=None, use_ipex=False, dtype=None,
-                 use_jit=False, channels_last=None, from_load=False):
+                 use_jit=False, channels_last=None, thread_num=None, from_load=False):
         """
         This is the accelerated model for pytorch and ipex/jit.
         All the external API is based on Trainer, so what we have here is
@@ -40,6 +40,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         :param use_jit: if use jit to accelerate the model
         :param channels_last: if set model and data to be channels-last mode.
                the parameter will be ignored if use_ipex is False.
+        :param thread_num: the thread num allocated for this model.
         :param from_load: this will only be set by _load method.
         """
         model.eval()
@@ -72,7 +73,10 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                     self.model = torch.jit.trace(self.model, input_sample,
                                                  check_trace=False)
                     self.model = torch.jit.freeze(self.model)
-        self.context_manager = BaseContextManager()
+        self.context_manager = generate_context_manager(accelerator=None,
+                                                        precision="fp32",
+                                                        thread_num=thread_num)
+        self.thread_num = thread_num
 
     @property
     def forward_args(self):
@@ -96,7 +100,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         status.update({"use_ipex": self.use_ipex,
                        "use_jit": self.use_jit,
                        "channels_last": self.channels_last,
-                       "checkpoint": "ckpt.pth"})
+                       "checkpoint": "ckpt.pth",
+                       "thread_num": self.thread_num})
         return status
 
     @staticmethod
@@ -118,7 +123,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         return PytorchIPEXJITModel(model, use_ipex=status['use_ipex'],
                                    use_jit=status['use_jit'],
                                    channels_last=status['channels_last'],
-                                   from_load=from_load)
+                                   from_load=from_load,
+                                   thread_num=int(status['thread_num']))
 
     def _save_model(self, path):
         if self.use_jit:

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -49,7 +49,9 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
             self.use_ipex = use_ipex
             self.use_jit = use_jit
             self.channels_last = channels_last
-            self.context_manager = BaseContextManager()
+            self.context_manager = generate_context_manager(accelerator=None,
+                                                            precision="fp32",
+                                                            thread_num=thread_num)
             return
         self.channels_last = channels_last
         self.original_state_dict = model.state_dict()

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -122,9 +122,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
             model.eval()
             model.load_state_dict(state_dict)
             from_load = False
-        if status['thread_num'] is None:
-            thread_num = None
-        else:
+        thread_num = None
+        if status["thread_num"] is not None and status['thread_num'] != {}:
             thread_num = int(status['thread_num'])
         return PytorchIPEXJITModel(model, use_ipex=status['use_ipex'],
                                    use_jit=status['use_jit'],

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
@@ -28,7 +28,7 @@ def load_inc_model(path, model, framework):
                           " Please choose from 'pytorch'/'tensorflow'.")
 
 
-def quantize(model, dataloader=None, metric=None, **kwargs):
+def quantize(model, dataloader=None, metric=None, thread_num=None, **kwargs):
     if kwargs['approach'] not in ['static', 'dynamic']:
         invalidInputError(False,
                           "Approach should be 'static' or 'dynamic', "
@@ -47,7 +47,7 @@ def quantize(model, dataloader=None, metric=None, **kwargs):
     onnxruntime_session_options = not_none_kwargs.pop('onnxruntime_session_options', None)
     if 'pytorch' in not_none_kwargs['framework']:
         from .pytorch.quantization import PytorchQuantization
-        quantizer = PytorchQuantization(**not_none_kwargs)
+        quantizer = PytorchQuantization(thread_num=thread_num, **not_none_kwargs)
     if 'onnx' in not_none_kwargs['framework']:
         onnx_option = not_none_kwargs.pop('onnx_option', None)
         if onnx_option == 'tensorflow':

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantization.py
@@ -25,16 +25,17 @@ import torch
 
 
 class PytorchQuantization(BaseQuantization):
-    def __init__(self, framework='pytorch_fx', **kwargs):
+    def __init__(self, framework='pytorch_fx', thread_num=None, **kwargs):
         """
         Create a Intel Neural Compressor Quantization object for Pytorch.
         """
         kwargs['framework'] = framework
         super().__init__(**kwargs)
         self._inc_metric_cls = PytorchINCMetric
+        self.thread_num = thread_num
 
     def _post_execution(self, q_model):
-        return PytorchQuantizedModel(q_model)
+        return PytorchQuantizedModel(q_model, self.thread_num)
 
     @property
     def valid_frameworks(self):

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
@@ -57,7 +57,10 @@ class PytorchQuantizedModel(AcceleratedLightningModule):
             with open(tune_cfg_file, 'r') as f:
                 tune_cfg = yaml.safe_load(f)
                 qmodel.tune_cfg = tune_cfg
-        return PytorchQuantizedModel(qmodel, thread_num=status["thread_num"])
+        thread_num = None
+        if status["thread_num"] is not None:
+            thread_num = int(status["thread_num"])
+        return PytorchQuantizedModel(qmodel, thread_num=thread_num)
 
     def _save_model(self, path):
         self.quantized.save(path)

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
@@ -58,7 +58,7 @@ class PytorchQuantizedModel(AcceleratedLightningModule):
                 tune_cfg = yaml.safe_load(f)
                 qmodel.tune_cfg = tune_cfg
         thread_num = None
-        if status["thread_num"] is not None:
+        if status["thread_num"] is not None and status['thread_num']!={}:
             thread_num = int(status["thread_num"])
         return PytorchQuantizedModel(qmodel, thread_num=thread_num)
 

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
@@ -20,21 +20,31 @@ from ..core import version as inc_version
 from neural_compressor.utils.pytorch import load
 from neural_compressor.model.model import PyTorchModel
 from bigdl.nano.utils.log4Error import invalidInputError
-from bigdl.nano.pytorch.context_manager import BaseContextManager
+from bigdl.nano.pytorch.context_manager import generate_context_manager
 
 
 class PytorchQuantizedModel(AcceleratedLightningModule):
-    def __init__(self, model):
+    def __init__(self, model, thread_num=None):
         super().__init__(model.model)
         self.quantized = model
-        self.context_manager = BaseContextManager()
+        self.thread_num = thread_num
+        self.context_manager = generate_context_manager(accelerator=None,
+                                                        precision="int8",
+                                                        thread_num=thread_num)
 
     @property
     def _nargs(self):
         return -1
 
+    @property
+    def status(self):
+        status = super().status
+        status.update({"thread_num": self.thread_num})
+        return status
+
     @staticmethod
     def _load(path, model):
+        status = PytorchQuantizedModel._load_status(path)
         invalidInputError(
             model is not None,
             errMsg="FP32 model is required to create a quantized model."
@@ -47,7 +57,7 @@ class PytorchQuantizedModel(AcceleratedLightningModule):
             with open(tune_cfg_file, 'r') as f:
                 tune_cfg = yaml.safe_load(f)
                 qmodel.tune_cfg = tune_cfg
-        return PytorchQuantizedModel(qmodel)
+        return PytorchQuantizedModel(qmodel, thread_num=status["thread_num"])
 
     def _save_model(self, path):
         self.quantized.save(path)

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
@@ -58,7 +58,7 @@ class PytorchQuantizedModel(AcceleratedLightningModule):
                 tune_cfg = yaml.safe_load(f)
                 qmodel.tune_cfg = tune_cfg
         thread_num = None
-        if status["thread_num"] is not None and status['thread_num']!={}:
+        if status["thread_num"] is not None and status['thread_num'] != {}:
             thread_num = int(status["thread_num"])
         return PytorchQuantizedModel(qmodel, thread_num=thread_num)
 

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -69,7 +69,10 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
                 onnx_path = model
             AcceleratedLightningModule.__init__(self, None)
             ONNXRuntimeModel.__init__(self, onnx_path, session_options=onnxruntime_session_options)
-        self.thread_num = onnxruntime_session_options.intra_op_num_threads
+        if onnxruntime_session_options.intra_op_num_threads > 0:
+            self.thread_num = onnxruntime_session_options.intra_op_num_threads
+        else:
+            self.thread_num = None
         self.context_manager = generate_context_manager(accelerator=None,
                                                         precision="fp32",
                                                         thread_num=self.thread_num)

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -22,7 +22,7 @@ import onnxruntime  # should be put behind core's import
 from bigdl.nano.utils.inference.pytorch.model import AcceleratedLightningModule
 from bigdl.nano.utils.inference.pytorch.model_utils import export_to_onnx
 from bigdl.nano.utils.log4Error import invalidInputError
-from bigdl.nano.pytorch.context_manager import BaseContextManager
+from bigdl.nano.pytorch.context_manager import generate_context_manager
 
 
 class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
@@ -69,7 +69,10 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
                 onnx_path = model
             AcceleratedLightningModule.__init__(self, None)
             ONNXRuntimeModel.__init__(self, onnx_path, session_options=onnxruntime_session_options)
-        self.context_manager = BaseContextManager()
+        self.thread_num = onnxruntime_session_options.intra_op_num_threads
+        self.context_manager = generate_context_manager(accelerator=None,
+                                                        precision="fp32",
+                                                        thread_num=self.thread_num)
 
     def on_forward_start(self, inputs):
         if self.ortsess is None:

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -40,7 +40,7 @@ from bigdl.nano.utils.inference.pytorch.dataloader import\
     transform_multiple_input_dataloader_to_inc_mode, automatic_add_label_in_dataloader
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10, save_model, load_model
 from bigdl.nano.common.cpu_schedule import schedule_processors
-from bigdl.nano.pytorch.context_manager import BaseContextManager
+from bigdl.nano.pytorch.context_manager import generate_context_manager
 from .multi_instance import _MultiInstanceModel, _multi_instance_helper
 import traceback
 import warnings
@@ -344,7 +344,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             sample_size_for_pot = 100
 
         # patch context manager
-        model.context_manager = BaseContextManager()
+        model.context_manager = generate_context_manager(accelerator=None, precision="fp32",
+                                                         thread_num=thread_num)
 
         print("==========================Start Optimization==========================")
         start_time = time.perf_counter()
@@ -378,7 +379,6 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                         model(*input_sample)
 
                 with acce_model.context_manager:
-                    torch.set_num_threads(thread_num)
                     try:
                         result_map[method]["latency"], status =\
                             throughput_calculate_helper(latency_sample_num, baseline_time,
@@ -562,7 +562,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                     use_jit = (accelerator == "jit")
                     return PytorchIPEXJITBF16Model(model, input_sample=input_sample,
                                                    use_ipex=use_ipex, use_jit=use_jit,
-                                                   channels_last=channels_last)
+                                                   channels_last=channels_last,
+                                                   thread_num=thread_num)
                 else:
                     bf16_model = BF16Model(model, channels_last=channels_last)
                     return bf16_model
@@ -638,6 +639,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 `quantized_model.model`.
                 """
                 return inc_quantize(model, inc_calib_dataloader, metric,
+                                    thread_num=thread_num,
                                     framework=framework,
                                     conf=conf,
                                     approach=approach,
@@ -761,7 +763,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                   "torch version should >=1.10 to use ipex")
             use_jit = (accelerator == "jit")
             return PytorchIPEXJITModel(model, input_sample=input_sample, use_ipex=use_ipex,
-                                       use_jit=use_jit, channels_last=channels_last)
+                                       use_jit=use_jit, channels_last=channels_last,
+                                       thread_num=thread_num)
         invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))
 
     @staticmethod

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -778,7 +778,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         """
         if hasattr(model, "context_manager"):
             return model.context_manager
-        return BaseContextManager()
+        return generate_context_manager(accelerator=None, precision="fp32")
 
     @staticmethod
     def save(model: nn.Module, path):

--- a/python/nano/src/bigdl/nano/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/pytorch/utils.py
@@ -30,7 +30,7 @@ from bigdl.nano.deps.onnxruntime.onnxruntime_api import load_onnxruntime_model
 from bigdl.nano.deps.neural_compressor.inc_api import load_inc_model
 from bigdl.nano.pytorch.amp.amp_api import load_bf16_model
 from bigdl.nano.utils.log4Error import invalidInputError
-from bigdl.nano.pytorch.context_manager import BaseContextManager
+from bigdl.nano.pytorch.context_manager import generate_context_manager
 from pathlib import Path
 
 TORCH_VERSION_LESS_1_10 = _compare_version("torch", operator.lt, "1.10")
@@ -161,8 +161,9 @@ def load_model(path, model: pl.LightningModule = None):
             checkpoint_path = path / metadata['checkpoint']
             state_dict = torch.load(checkpoint_path, map_location='cpu')
             model.load_state_dict(state_dict)
-            # patch BaseContextMagager to original model to keep behaviour consitent
-            model.context_manager = BaseContextManager()  # type: ignore
+            # patch ContextMagager to original model to keep behaviour consitent
+            model.context_manager = generate_context_manager(accelerator=None, precision="fp32",
+                                                             thread_num=thread_num)  # type: ignore
             return model
         else:
             invalidInputError(False, "Key 'checkpoint' must be specified.")

--- a/python/nano/src/bigdl/nano/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/pytorch/utils.py
@@ -158,7 +158,7 @@ def load_model(path, model: pl.LightningModule = None):
         model = copy.deepcopy(model)
         checkpoint_path = metadata.get('checkpoint', None)
         thread_num = None
-        if metadata["thread_num"] is not None:
+        if "thread_num" in metadata and metadata["thread_num"] is not None:
             thread_num = int(metadata["thread_num"])
         if checkpoint_path:
             checkpoint_path = path / metadata['checkpoint']

--- a/python/nano/src/bigdl/nano/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/pytorch/utils.py
@@ -157,6 +157,9 @@ def load_model(path, model: pl.LightningModule = None):
         # typically for models of nn.Module, pl.LightningModule type
         model = copy.deepcopy(model)
         checkpoint_path = metadata.get('checkpoint', None)
+        thread_num = None
+        if metadata["thread_num"] is not None:
+            thread_num = int(metadata["thread_num"])
         if checkpoint_path:
             checkpoint_path = path / metadata['checkpoint']
             state_dict = torch.load(checkpoint_path, map_location='cpu')

--- a/python/nano/test/inc/pytorch/test_trainer_quantize.py
+++ b/python/nano/test/inc/pytorch/test_trainer_quantize.py
@@ -176,9 +176,12 @@ class TestTrainer(TestCase):
         x = next(train_loader_iter)[0]
 
         qmodel = InferenceOptimizer.quantize(pl_model,
-                                             calib_data=self.train_loader)
+                                             calib_data=self.train_loader,
+                                             thread_num=2)
         assert qmodel
+
         with InferenceOptimizer.get_context(qmodel):
+            assert torch.get_num_threads() == 2
             out = qmodel(x)
         assert out.shape == torch.Size([256, 10])
         
@@ -187,5 +190,6 @@ class TestTrainer(TestCase):
             model = InferenceOptimizer.load(tmp_dir_name, pl_model)
 
         with InferenceOptimizer.get_context(model):
+            assert torch.get_num_threads() == 2
             out = model(x)
         assert out.shape == torch.Size([256, 10])

--- a/python/nano/test/onnx/pytorch/test_inc_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_inc_onnx.py
@@ -190,8 +190,10 @@ class TestOnnx(TestCase):
         onnx_model = InferenceOptimizer.quantize(pl_model,
                                                  accelerator='onnxruntime',
                                                  method='qlinear',
-                                                 calib_data=train_loader)
+                                                 calib_data=train_loader,
+                                                 thread_num=2)
         with InferenceOptimizer.get_context(onnx_model):
+            assert torch.get_num_threads() == 2
             output = onnx_model(x)
         
         with tempfile.TemporaryDirectory() as tmp_dir_name:
@@ -199,6 +201,7 @@ class TestOnnx(TestCase):
             model = InferenceOptimizer.load(tmp_dir_name)
 
         with InferenceOptimizer.get_context(model):
+            assert torch.get_num_threads() == 2
             output = model(x)
 
 

--- a/python/nano/test/onnx/pytorch/test_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_onnx.py
@@ -166,13 +166,15 @@ class TestOnnx(TestCase):
                                               thread_num=1)
 
         with InferenceOptimizer.get_context(onnx_model):
+            assert torch.get_num_threads() == 1
             output = onnx_model(x)
         
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(onnx_model, tmp_dir_name)
             model = InferenceOptimizer.load(tmp_dir_name)
-        
+
         with InferenceOptimizer.get_context(model):
+            assert torch.get_num_threads() == 1
             output = onnx_model(x)
 
 

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -115,8 +115,11 @@ class TestOpenVINO(TestCase):
         y = torch.ones((10, ), dtype=torch.long)
 
         openvino_model = InferenceOptimizer.trace(model, input_sample=x,
-                                                  accelerator='openvino')
+                                                  accelerator='openvino',
+                                                  thread_num=2)
+
         with InferenceOptimizer.get_context(openvino_model):
+            assert torch.get_num_threads() == 2
             y1 = openvino_model(x[0:1])
     
         with tempfile.TemporaryDirectory() as tmp_dir_name:
@@ -124,4 +127,5 @@ class TestOpenVINO(TestCase):
             model = InferenceOptimizer.load(tmp_dir_name)
 
         with InferenceOptimizer.get_context(model):
+            assert torch.get_num_threads() == 2
             y2 = model(x[0:1])

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -118,12 +118,17 @@ class TestOpenVINO(TestCase):
         openvino_model = InferenceOptimizer.quantize(model, 
                                                      accelerator='openvino',
                                                      calib_data=dataloader,
-                                                     metric=F1(10))
+                                                     metric=F1(10),
+                                                     thread_num=2)
+
         with InferenceOptimizer.get_context(openvino_model):
+            assert torch.get_num_threads() == 2
             y1 = openvino_model(x[0:1])
     
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(openvino_model, tmp_dir_name)
             model = InferenceOptimizer.load(tmp_dir_name)
+
         with InferenceOptimizer.get_context(model):
+            assert torch.get_num_threads() == 2
             y2 = model(x[0:1])

--- a/python/nano/test/run-nano-codestyle-test.sh
+++ b/python/nano/test/run-nano-codestyle-test.sh
@@ -9,5 +9,5 @@ export NANO_TEST_DIR=${ANALYTICS_ZOO_ROOT}/python/nano/test
 pycodestyle ${NANO_HOME} --config=${NANO_TEST_DIR}/tox.ini
 pydocstyle --ignore D104,D100,D212,D203,D401,D402,D105 \
            --match-dir '(?!common|deps|utils|runtime_binding|transforms|amp|inference|gpu_cpu).*' \
-           --match '(?!context_manager).*\.py' \
+           --match '(?!context_manager|_).*\.py' \
            ${NANO_HOME}/bigdl/nano/

--- a/python/nano/test/run-nano-codestyle-test.sh
+++ b/python/nano/test/run-nano-codestyle-test.sh
@@ -9,5 +9,5 @@ export NANO_TEST_DIR=${ANALYTICS_ZOO_ROOT}/python/nano/test
 pycodestyle ${NANO_HOME} --config=${NANO_TEST_DIR}/tox.ini
 pydocstyle --ignore D104,D100,D212,D203,D401,D402,D105 \
            --match-dir '(?!common|deps|utils|runtime_binding|transforms|amp|inference|gpu_cpu).*' \
-           --match '(?!_).*\.py' \
+           --match '(?!context_manager).*\.py' \
            ${NANO_HOME}/bigdl/nano/


### PR DESCRIPTION
## Description

### 1. Why the change?

We have found that thread control could be a tricky setting for users, especially in nano. Since torch's thread num will even affect the performance of onnxruntime and openvino.

### 2. User API changes

nothing, follow the previous context manager usage。
Will add more details once this PR is ready for review

### 3. Summary of the change 
add thread_num in internal APIs.

### 4. How to test?
- [ ] Unit test
