### PR TITLE
Nano: Change the API of keras optmizer and quantize

### DIFF
--- a/python/nano/notebooks/tensorflow/tutorial/tensorflow_quantization.ipynb
+++ b/python/nano/notebooks/tensorflow/tutorial/tensorflow_quantization.ipynb
@@ -1275,7 +1275,7 @@
    ],
    "source": [
     "from tensorflow.keras.metrics import CategoricalAccuracy\n",
-    "q_model = model.quantize(calib_dataset=test_ds,\n",
+    "q_model = model.quantize(x=test_ds,\n",
     "                         metric=CategoricalAccuracy(),\n",
     "                         tuning_strategy='basic'\n",
     "                         )"

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/tensorflow/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/tensorflow/quantization.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-
+import numpy as np
 import tensorflow as tf
 
 from bigdl.nano.deps.onnxruntime.tensorflow.tensorflow_onnxruntime_model \
@@ -68,4 +68,5 @@ class KerasNumpyDataset():
                 yield AcceleratedKerasModel.tensors_to_numpy(batch, self.dtype)
         else:
             for x, y in zip(self.x, self.y):
-                yield AcceleratedKerasModel.tensors_to_numpy((x, y), self.dtype)
+                x, y = AcceleratedKerasModel.tensors_to_numpy((x, y), self.dtype)
+                yield np.expand_dims(x, axis=0), np.expand_dims(y, axis=0)

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/tensorflow/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/tensorflow/quantization.py
@@ -21,8 +21,8 @@ from bigdl.nano.deps.onnxruntime.tensorflow.tensorflow_onnxruntime_model \
     import KerasONNXRuntimeModel
 
 from ..quantization import BaseONNXRuntimeQuantization
-from ...tensorflow import TensorflowQuantization
 from .metric import KerasONNXRuntimeINCMetic
+from bigdl.nano.utils.inference.tf.model import AcceleratedKerasModel
 
 
 class KerasONNXRuntimeQuantization(BaseONNXRuntimeQuantization):
@@ -37,7 +37,8 @@ class KerasONNXRuntimeQuantization(BaseONNXRuntimeQuantization):
 
     def _pre_execution(self, model, calib_dataset=None, metric=None):
         if calib_dataset:
-            calib_dataset = KerasNumpyDataset(calib_dataset, model.dtype)
+            x, y = calib_dataset
+            calib_dataset = KerasNumpyDataset(x, y, model.dtype)
 
         if isinstance(model, KerasONNXRuntimeModel):
             model = model.onnx_model
@@ -45,24 +46,26 @@ class KerasONNXRuntimeQuantization(BaseONNXRuntimeQuantization):
         return model, calib_dataset, metric
 
     def _post_execution(self, q_model):
-        return KerasONNXRuntimeModel(q_model.model, input_sample=None,
+        return KerasONNXRuntimeModel(q_model.model,
                                      onnxruntime_session_options=self.session_options)
 
 
 # we cannot call `.numpy()` in `Dataset.map()`,
 # so we use this wrapper to transform the output of dataset to numpy array
 class KerasNumpyDataset():
-    def __init__(self, dataset, dtype):
-        self.dataset = dataset
+    def __init__(self, x, y, dtype):
+        self.x = x
+        self.y = y
         self.batch_size = 1     # it's necessary
         self.dtype = dtype      # the dtype of dataset and model must be exactly the same
 
     def __len__(self):
-        return len(self.dataset)
+        return len(self.x)
 
     def __iter__(self):
-        for batch in self.dataset:
-            yield tuple(
-                map(lambda x: x.numpy().astype(self.dtype) if isinstance(x, tf.Tensor) else x,
-                    batch)
-            )
+        if isinstance(self.x, tf.data.Dataset):
+            for batch in self.x.batch(1):
+                yield AcceleratedKerasModel.tensors_to_numpy(batch, self.dtype)
+        else:
+            for x, y in zip(self.x, self.y):
+                yield AcceleratedKerasModel.tensors_to_numpy((x, y), self.dtype)

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
@@ -44,19 +44,19 @@ def load_onnxruntime_model(path):
     return PytorchONNXRuntimeModel._load(path)
 
 
-def KerasONNXRuntimeModel(model, input_sample,
+def KerasONNXRuntimeModel(model, input_spec,
                           onnxruntime_session_options=None,
                           **export_kwargs):
     """
     Create a ONNX Runtime model from tensorflow.
 
     :param model: 1. Keras model to be converted to ONNXRuntime for inference
-                    2. Path to ONNXRuntime saved model
-    :param input_sample: (a tuple or list of) tf.TensorSpec or numpy array defining
-        the shape/dtype of the input
+                  2. Path to ONNXRuntime saved model
+    :param input_spec: A (tuple or list of) tf.TensorSpec or numpy array defining
+                       the shape/dtype of the input
     :param onnxruntime_session_options: will be passed to tf2onnx.convert.from_keras function
     """
     from .tensorflow.tensorflow_onnxruntime_model import KerasONNXRuntimeModel
-    return KerasONNXRuntimeModel(model, input_sample,
+    return KerasONNXRuntimeModel(model, input_spec,
                                  onnxruntime_session_options=onnxruntime_session_options,
                                  **export_kwargs)

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/tensorflow/tensorflow_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/tensorflow/tensorflow_onnxruntime_model.py
@@ -35,23 +35,25 @@ class KerasONNXRuntimeModel(ONNXRuntimeModel, AcceleratedKerasModel):
     '''
         This is the accelerated model for tensorflow and onnxruntime.
     '''
-    def __init__(self, model, input_sample, onnxruntime_session_options=None,
+    def __init__(self, model, input_spec=None, onnxruntime_session_options=None,
                  **export_kwargs):
         """
         Create a ONNX Runtime model from tensorflow.
 
         :param model: 1. Keras model to be converted to ONNXRuntime for inference
                       2. Path to ONNXRuntime saved model
-        :param input_sample: a (tuple or list of) tf.TensorSpec or numpy array defining
-            the shape/dtype of the input
+        :param input_spec: A (tuple or list of) tf.TensorSpec or numpy array defining
+                           the shape/dtype of the input
         :param onnxruntime_session_options: will be passed to tf2onnx.convert.from_keras function
         """
         with TemporaryDirectory() as tmpdir:
             if isinstance(model, tf.keras.Model):
                 onnx_path = os.path.join(tmpdir, "tmp.onnx")
-                if not isinstance(input_sample, (tuple, list)):
-                    input_sample = (input_sample, )
-                tf2onnx.convert.from_keras(model, input_signature=input_sample,
+                if input_spec is None:
+                    input_spec = tf.TensorSpec((model.input_shape), model.dtype)
+                if not isinstance(input_spec, (tuple, list)):
+                    input_spec = (input_spec, )
+                tf2onnx.convert.from_keras(model, input_signature=input_spec,
                                            output_path=onnx_path, **export_kwargs)
             else:
                 onnx_path = model

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -73,7 +73,8 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
         return status
 
     def pot(self,
-            dataset,
+            x,
+            y,
             metric=None,
             higher_better=True,
             drop_type="relative",
@@ -85,7 +86,7 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
             thread_num=None):
         if metric:
             metric = KerasOpenVINOMetric(metric=metric, higher_better=higher_better)
-        dataloader = KerasOpenVINODataLoader(dataset, collate_fn=self.tensors_to_numpy)
+        dataloader = KerasOpenVINODataLoader(x, y, collate_fn=self.tensors_to_numpy)
         model = self.ov_model.pot(dataloader, metric=metric, drop_type=drop_type,
                                   maximal_drop=maximal_drop, max_iter_num=max_iter_num,
                                   n_requests=n_requests, sample_size=sample_size)

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -16,8 +16,9 @@
 
 import os
 import time
+import numpy as np
 import tensorflow as tf
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Union
 from bigdl.nano.utils.inference.common.base_optimizer import BaseInferenceOptimizer
 from bigdl.nano.utils.inference.common.checker import available_acceleration_combination
 from bigdl.nano.utils.inference.common.utils import AccelerationOption,\
@@ -30,7 +31,7 @@ from tensorflow.keras.metrics import Metric
 
 
 class TFAccelerationOption(AccelerationOption):
-    def optimize(self, model, training_data=None, input_sample=None,
+    def optimize(self, model, x=None, y=None,
                  thread_num=None, logging=False, sample_size_for_pot=100):
         accelerator = self.get_accelerator()
         if self.get_precision() == "fp32":
@@ -39,7 +40,6 @@ class TFAccelerationOption(AccelerationOption):
                 return model
             else:
                 acce_model = model.trace(accelerator=accelerator,
-                                         input_sample=input_sample,
                                          thread_num=thread_num,
                                          # remove output of openvino
                                          logging=logging)
@@ -48,7 +48,8 @@ class TFAccelerationOption(AccelerationOption):
             ort_method: str = self.method
             acce_model = model.quantize(precision=self.get_precision(),
                                         accelerator=accelerator,
-                                        calib_dataset=training_data,
+                                        x=x,
+                                        y=y,
                                         method=ort_method,
                                         thread_num=thread_num,
                                         sample_size=sample_size_for_pot,
@@ -75,7 +76,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         }  # type: ignore
 
     def optimize(self, model: Model,
-                 training_data: Dataset,
+                 x: Union[tf.Tensor, np.ndarray, tf.data.Dataset],
+                 y: Union[tf.Tensor, np.ndarray] = None,
                  validation_data: Optional[Dataset] = None,
                  batch_size: int = 1,
                  metric: Optional[Metric] = None,
@@ -93,12 +95,21 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         The available methods are "original", "openvino_fp32", "onnxruntime_fp32", "int8".
 
         :param model: A keras.Model to be optimized
-        :param training_data: An unbatched tf.data.Dataset object which is used for training.
-                              This dataset will be used as calibration dataset for
-                              Post-Training Static Quantization (PTQ), as well as be used for
-                              generating input_sample to calculate latency.
-                              To avoid data leak during calibration, please use training
-                              dataset as much as possible.
+        :param x: Input data which is used for training. It could be:
+                  | 1. a Numpy array (or array-like), or a list of arrays (in case the model
+                  | has multiple inputs).
+                  |
+                  | 2. a TensorFlow tensor, or a list of tensors (in case the model has
+                  | multiple inputs).
+                  |
+                  | 3. an unbatched tf.data.dataset. Should return a tuple of (inputs, targets).
+
+                  X will be used as calibration dataset for Post-Training Static Quantization (PTQ),
+                  as well as be used for generating input_sample to calculate latency.
+                  To avoid data leak during calibration, please use training dataset.
+        :param y: Target data. Like the input data x, it could be either Numpy array(s) or
+                  TensorFlow tensor(s). Its length should be consistent with x.
+                  If x is a dataset, y will be ignored (since targets will be obtained from x).
         :param validation_data: (optional) An unbatched tf.data.Dataset object for accuracy
                evaluation. This is only needed when users care about the possible accuracy drop.
         :param metric: (optional) A tensorflow.keras.metrics.Metric object which is used for
@@ -122,6 +133,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         invalidInputError(isinstance(model, Model), "model should be a Keras Model.")
         invalidInputError(direction in ['min', 'max'],
                           "Only support direction 'min', 'max'.")
+        invalidInputError(y is not None or isinstance(x, tf.data.Dataset),
+                          "y can be omitted only when x is a Dataset which returns \
+                              tuples of (inputs, targets)")
 
         if not isinstance(model, NanoModel):
             # turn model into NanoModel to obtain trace and quantize method
@@ -152,10 +166,13 @@ class InferenceOptimizer(BaseInferenceOptimizer):
 
         result_map: Dict[str, Dict] = {}
 
-        batched_training_data = training_data.batch(batch_size)
-        input_sample = next(iter(batched_training_data))
-        # TODO: how to obtain input from output of training_data
-        input_sample = input_sample[:-1]
+        if isinstance(x, Dataset):
+            batched_training_dataset = x.batch(batch_size)
+            input_sample = next(iter(batched_training_dataset))
+            # TODO: how to obtain input from output of training_dataset
+            input_sample = input_sample[:-1]
+        else:
+            input_sample = tf.convert_to_tensor(x[:batch_size])
 
         if isinstance(input_sample, (list, tuple)) and len(input_sample) == 1:
             input_sample = input_sample[0]
@@ -168,7 +185,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 model(*input_sample)
         except Exception:
             invalidInputError(False,
-                              "training_data is incompatible with your model input.")
+                              "x is incompatible with your model input.")
         baseline_time = time.perf_counter() - st
         if baseline_time > 0.1:  # 100ms
             sample_size_for_pot = 15
@@ -188,10 +205,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 precision: str = option.get_precision()
                 try:
                     acce_model = option.optimize(model=model,
-                                                 training_data=training_data,
-                                                 input_sample=tf.TensorSpec(
-                                                     shape=input_sample.shape,
-                                                     dtype=tf.float32),
+                                                 x=x,
+                                                 y=y,
                                                  thread_num=thread_num,
                                                  logging=logging,
                                                  sample_size_for_pot=sample_size_for_pot)

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -102,7 +102,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                   | 2. a TensorFlow tensor, or a list of tensors (in case the model has
                   | multiple inputs).
                   |
-                  | 3. an unbatched tf.data.dataset. Should return a tuple of (inputs, targets).
+                  | 3. an unbatched tf.data.Dataset. Should return a tuple of (inputs, targets).
 
                   X will be used as calibration dataset for Post-Training Static Quantization (PTQ),
                   as well as be used for generating input_sample to calculate latency.

--- a/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
@@ -57,15 +57,14 @@ class InferenceUtils:
                   | 2. a TensorFlow tensor, or a list of tensors (in case the model has
                   | multiple inputs).
                   |
-                  | 3. an unbatched tf.data.dataset. Should return a tuple of (inputs, targets).
+                  | 3. an unbatched tf.data.Dataset. Should return a tuple of (inputs, targets).
 
                   X will be used as calibration dataset for Post-Training Static Quantization (PTQ),
                   as well as be used for generating input_sample to calculate latency.
                   To avoid data leak during calibration, please use training dataset.
         :param y: Target data. Like the input data x, it could be either Numpy array(s) or
-                  TensorFlow tensor(s). It should be consistent with x (you cannot have Numpy inputs
-                  and tensor targets, or inversely). If x is a dataset, y will be ignored (since
-                  targets will be obtained from x).
+                  TensorFlow tensor(s). Its length should be consistent with x.
+                  If x is a dataset, y will be ignored (since targets will be obtained from x).
         :param precision:       Global precision of quantized model,
                                 supported type: 'int8', defaults to 'int8'.
         :param accelerator:     Use accelerator 'None', 'onnxruntime', 'openvino', defaults to None.

--- a/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
@@ -13,21 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import List
-from bigdl.nano.deps.neural_compressor.inc_api import quantize as inc_quantzie
+from typing import Optional, List, Union
+import numpy as np
 import tensorflow as tf
 from tensorflow.keras.metrics import Metric
+from bigdl.nano.deps.neural_compressor.inc_api import quantize as inc_quantzie
 from bigdl.nano.utils.log4Error import invalidInputError
 from bigdl.nano.deps.openvino.openvino_api import KerasOpenVINOModel
 from bigdl.nano.deps.onnxruntime.onnxruntime_api import KerasONNXRuntimeModel
-from typing import Optional, List
 
 
 class InferenceUtils:
     """A mixedin class for nano keras Sequential and Model, adding more functions for Inference."""
 
     def quantize(self,
-                 calib_dataset: tf.data.Dataset,
+                 x: Union[tf.Tensor, np.ndarray, tf.data.Dataset],
+                 y: Union[tf.Tensor, np.ndarray] = None,
                  precision: str = 'int8',
                  accelerator: Optional[str] = None,
                  metric: Optional[Metric] = None,
@@ -49,9 +50,22 @@ class InferenceUtils:
         """
         Post-training quantization on a keras model.
 
-        :param calib_dataset:   An unbatched tf.data.Dataset object for calibration.
-                                Required for static quantization.
-                                It's also used as validation dataloader.
+        :param x: Input data which is used for training. It could be:
+                  | 1. a Numpy array (or array-like), or a list of arrays (in case the model
+                  | has multiple inputs).
+                  |
+                  | 2. a TensorFlow tensor, or a list of tensors (in case the model has
+                  | multiple inputs).
+                  |
+                  | 3. an unbatched tf.data.dataset. Should return a tuple of (inputs, targets).
+
+                  X will be used as calibration dataset for Post-Training Static Quantization (PTQ),
+                  as well as be used for generating input_sample to calculate latency.
+                  To avoid data leak during calibration, please use training dataset.
+        :param y: Target data. Like the input data x, it could be either Numpy array(s) or
+                  TensorFlow tensor(s). It should be consistent with x (you cannot have Numpy inputs
+                  and tensor targets, or inversely). If x is a dataset, y will be ignored (since
+                  targets will be obtained from x).
         :param precision:       Global precision of quantized model,
                                 supported type: 'int8', defaults to 'int8'.
         :param accelerator:     Use accelerator 'None', 'onnxruntime', 'openvino', defaults to None.
@@ -105,7 +119,14 @@ class InferenceUtils:
         :return:            A TensorflowBaseModel for INC. If there is no model found, return None.
         """
         invalidInputError(approach == 'static', "Only 'static' approach is supported now.")
+        invalidInputError(y is not None or isinstance(x, tf.data.Dataset),
+                          "y can be omitted only when x is a Dataset which returns \
+                              tuples of (inputs, targets)")
         if accelerator is None:
+            if isinstance(x, tf.data.Dataset):
+                calib_dataset = x
+            else:
+                calib_dataset = tf.data.Dataset.from_tensor_slices((x, y))
             if batch:
                 calib_dataset = calib_dataset.batch(batch)
             return inc_quantzie(self, dataloader=calib_dataset,
@@ -136,7 +157,8 @@ class InferenceUtils:
                 maximal_drop = accuracy_criterion.get(drop_type, None)
             else:
                 drop_type, higher_is_better, maximal_drop = None, None, None
-            return openvino_model.pot(dataset=calib_dataset.batch(1),    # type: ignore
+            return openvino_model.pot(x=x,  # type: ignore
+                                      y=y,
                                       metric=metric,
                                       higher_better=higher_is_better,
                                       drop_type=drop_type,
@@ -152,10 +174,7 @@ class InferenceUtils:
             if isinstance(self, KerasONNXRuntimeModel):     # type: ignore
                 onnx_model = self
             else:
-                spec = tf.TensorSpec((self.input_shape), self.dtype)    # type: ignore
-                onnx_model = self.trace(accelerator='onnxruntime',
-                                        input_sample=spec,
-                                        thread_num=thread_num)
+                onnx_model = self.trace(accelerator='onnxruntime', thread_num=thread_num)
 
             # trace onnx model
             method_map = {
@@ -164,7 +183,7 @@ class InferenceUtils:
                 None: 'onnxrt_qlinearops'  # default
             }
             framework = method_map.get(method, None)
-            return inc_quantzie(onnx_model, dataloader=calib_dataset.batch(1),
+            return inc_quantzie(onnx_model, dataloader=(x, y),
                                 metric=metric,
                                 framework=framework,
                                 conf=conf,
@@ -182,7 +201,7 @@ class InferenceUtils:
 
     def trace(self,
               accelerator: Optional[str] = None,
-              input_sample=None,
+              input_spec=None,
               thread_num: Optional[int] = None,
               onnxruntime_session_options=None,
               openvino_config=None,
@@ -190,12 +209,11 @@ class InferenceUtils:
         """
         Trace a Keras model and convert it into an accelerated module for inference.
 
-        :param input_sample: A set of inputs for trace, defaults to None. It should be a
-            (tuple or list of) tf.TensorSpec or numpy array defining the shape/dtype of the input
-            when using 'onnxruntime' accelerator. The parameter will be ignored if accelerator
-            is 'openvino'.
         :param accelerator: The accelerator to use, defaults to None meaning staying in Keras
                             backend. 'openvino' and 'onnxruntime' are supported for now.
+        :param input_spec: A (tuple or list of) tf.TensorSpec or numpy array defining the
+                           shape/dtype of the input when using 'onnxruntime' accelerator.
+                           It will be ignored if accelerator is 'openvino'.
         :param thread_num: (optional) a int represents how many threads(cores) is needed for
                            inference, only valid for accelerator='onnxruntime'
                            or accelerator='openvino'.
@@ -222,5 +240,5 @@ class InferenceUtils:
                 if thread_num is not None:
                     onnxruntime_session_options.intra_op_num_threads = thread_num
                     onnxruntime_session_options.inter_op_num_threads = thread_num
-            return KerasONNXRuntimeModel(self, input_sample, onnxruntime_session_options)
+            return KerasONNXRuntimeModel(self, input_spec, onnxruntime_session_options)
         return self

--- a/python/nano/src/bigdl/nano/utils/inference/tf/model.py
+++ b/python/nano/src/bigdl/nano/utils/inference/tf/model.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import numpy as np
 import tensorflow as tf
 from bigdl.nano.utils.log4Error import invalidInputError
 from ..model import AcceleratedModel
@@ -42,8 +43,22 @@ class AcceleratedKerasModel(AcceleratedModel, tf.keras.Model):
         return self.on_forward_end(outputs)
 
     @staticmethod
-    def tensors_to_numpy(tensors):
-        return tuple(map(lambda x: x.numpy(), tensors))
+    def tensors_to_numpy(tensors, dtype=None):
+        if isinstance(tensors, (list, tuple)):
+            return type(tensors)(AcceleratedKerasModel.tensors_to_numpy(tensor, dtype)
+                                 for tensor in tensors)
+        elif isinstance(tensors, dict):
+            return {key: AcceleratedKerasModel.tensors_to_numpy(value, dtype)
+                    for key, value in tensors.items()}
+        elif isinstance(tensors, tf.Tensor):
+            if dtype is None:
+                return tensors.numpy()
+            else:
+                return tensors.numpy().astype(dtype)
+        elif isinstance(tensors, np.ndarray) and dtype is not None:
+            return tensors.astype(dtype)
+        else:
+            return tensors
 
     @staticmethod
     def numpy_to_tensors(np_arrays):

--- a/python/nano/test/onnx/tf/test_inc_onnx.py
+++ b/python/nano/test/onnx/tf/test_inc_onnx.py
@@ -33,7 +33,7 @@ class TestONNX(TestCase):
 
         # quantize a Keras model
         onnx_quantized_model = model.quantize(accelerator='onnxruntime',
-                                              calib_dataset=train_dataset,
+                                              x=train_dataset,
                                               thread_num=8)
 
         y_hat = onnx_quantized_model(input_examples[:10])
@@ -41,6 +41,22 @@ class TestONNX(TestCase):
 
         y_hat = onnx_quantized_model.predict(input_examples, batch_size=5)
         assert y_hat.shape == (100, 10)
+
+        preds = model.predict(input_examples)
+        onnx_preds = onnx_quantized_model.predict(input_examples)
+        np.testing.assert_allclose(preds, onnx_preds, rtol=1e-2)
+
+    def test_model_quantize_onnx_without_dataset(self):
+        model = ResNet50(weights=None, input_shape=[224, 224, 3], classes=10)
+        model = Model(inputs=model.inputs, outputs=model.outputs)
+        input_examples = np.random.random((100, 224, 224, 3))
+        input_features = np.random.randint(0, 10, size=100)
+
+        # quantize a Keras model
+        onnx_quantized_model = model.quantize(accelerator='onnxruntime',
+                                              x=input_examples,
+                                              y=input_features,
+                                              thread_num=8)
 
         preds = model.predict(input_examples)
         onnx_preds = onnx_quantized_model.predict(input_examples)

--- a/python/nano/test/onnx/tf/test_onnx.py
+++ b/python/nano/test/onnx/tf/test_onnx.py
@@ -33,7 +33,7 @@ class TestONNX(TestCase):
 
         # trace a Keras model
         spec = tf.TensorSpec((None, 224, 224, 3), tf.float32)
-        onnx_model = model.trace(accelerator='onnxruntime', input_spce=spec, thread_num=4)
+        onnx_model = model.trace(accelerator='onnxruntime', input_spec=spec, thread_num=4)
 
         y_hat = onnx_model(input_examples[:10])
         assert y_hat.shape == (10, 10)
@@ -52,7 +52,7 @@ class TestONNX(TestCase):
 
         # trace a Keras model
         spec = tf.TensorSpec((None, 224, 224, 3), tf.float32)
-        onnx_model = model.trace(accelerator='onnxruntime', input_spce=spec, thread_num=1)
+        onnx_model = model.trace(accelerator='onnxruntime', input_spec=spec, thread_num=1)
 
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             onnx_model._save(tmp_dir_name)

--- a/python/nano/test/onnx/tf/test_onnx.py
+++ b/python/nano/test/onnx/tf/test_onnx.py
@@ -33,7 +33,7 @@ class TestONNX(TestCase):
 
         # trace a Keras model
         spec = tf.TensorSpec((None, 224, 224, 3), tf.float32)
-        onnx_model = model.trace(accelerator='onnxruntime', input_sample=spec, thread_num=4)
+        onnx_model = model.trace(accelerator='onnxruntime', input_spce=spec, thread_num=4)
 
         y_hat = onnx_model(input_examples[:10])
         assert y_hat.shape == (10, 10)
@@ -52,7 +52,7 @@ class TestONNX(TestCase):
 
         # trace a Keras model
         spec = tf.TensorSpec((None, 224, 224, 3), tf.float32)
-        onnx_model = model.trace(accelerator='onnxruntime', input_sample=spec, thread_num=1)
+        onnx_model = model.trace(accelerator='onnxruntime', input_spce=spec, thread_num=1)
 
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             onnx_model._save(tmp_dir_name)
@@ -65,5 +65,3 @@ class TestONNX(TestCase):
         preds2 = new_onnx_model(input_examples).numpy()
 
         np.testing.assert_almost_equal(preds1, preds2, decimal=5)
-        
-        

--- a/python/nano/test/tf/keras/test_inf_optimizer.py
+++ b/python/nano/test/tf/keras/test_inf_optimizer.py
@@ -34,7 +34,7 @@ class TestInferencePipeline(TestCase):
         # prepare optimizer
         opt = InferenceOptimizer()
         opt.optimize(model=model,
-                     training_data=train_dataset,
+                     x=train_dataset,
                      latency_sample_num=10,
                      thread_num=8)
         model = opt.get_best_model()
@@ -48,7 +48,7 @@ class TestInferencePipeline(TestCase):
         # prepare optimizer
         opt = InferenceOptimizer()
         opt.optimize(model=model,
-                     training_data=train_dataset,
+                     x=train_dataset,
                      latency_sample_num=10)
         model = opt.get_best_model()
 
@@ -62,7 +62,7 @@ class TestInferencePipeline(TestCase):
         # prepare optimizer
         opt = InferenceOptimizer()
         opt.optimize(model=model,
-                     training_data=train_dataset,
+                     x=train_dataset,
                      batch_size=32,
                      latency_sample_num=10)
         model = opt.get_best_model()
@@ -78,10 +78,25 @@ class TestInferencePipeline(TestCase):
         opt = InferenceOptimizer()
         from tensorflow.keras.metrics import CategoricalAccuracy
         opt.optimize(model=model,
-                     training_data=train_dataset,
+                     x=train_dataset,
                      validation_data=train_dataset, # for test
                      batch_size=32,
                      metric=CategoricalAccuracy(),
                      latency_sample_num=10)
         opt.summary()
+        model = opt.get_best_model()
+
+    def test_optimize_model_without_dataset(self):
+        model = ResNet50(weights=None, input_shape=[40, 40, 3], classes=10)
+        model = NanoModel(inputs=model.inputs, outputs=model.outputs)
+
+        train_examples = np.random.random((100, 40, 40, 3))
+        train_labels = np.random.randint(0, 10, size=(100,))
+
+        opt = InferenceOptimizer()
+        opt.optimize(model=model,
+                     x=train_examples,
+                     y=train_labels,
+                     latency_sample_num=10,
+                     thread_num=8)
         model = opt.get_best_model()

--- a/python/nano/tutorial/inference/tensorflow/tensorflow_inference_onnx.py
+++ b/python/nano/tutorial/inference/tensorflow/tensorflow_inference_onnx.py
@@ -57,13 +57,13 @@ if __name__ == '__main__':
     #
     # Use `Model` or `Sequential` in `bigdl.nano.tf.keras` to create model,
     # then call its `trace` method with `accelerator='onnxruntime'` and
-    # pass a `TensorSpec` defining the shape of input to `input_sample` parameter,
+    # pass a `TensorSpec` defining the shape of input to `input_spec` parameter,
     # then you can use the returned model for inference, all inference will be 
     # accelerated automatically after that.
     #
     model = Model(inputs=model.inputs, outputs=model.outputs)
     spec = tf.TensorSpec((None, 224, 224, 3), tf.float32)
-    onnx_model = model.trace(accelerator='onnxruntime', input_sample=spec)
+    onnx_model = model.trace(accelerator='onnxruntime', input_spec=spec)
     onnx_preds = onnx_model.predict(dataset)
 
     # Using ONNX to accelerate inference will cause a very tiny loss of precision,

--- a/python/nano/tutorial/inference/tensorflow/tensorflow_quantization.py
+++ b/python/nano/tutorial/inference/tensorflow/tensorflow_quantization.py
@@ -101,11 +101,10 @@ if __name__ == "__main__":
     # Quantization using Intel Neural Compressor
     # pip install 'neural-compressor'
 
-    # calib_dataset only accept tf.data.Dataset object
     tune_dataset = tf.data.Dataset.from_tensor_slices((x_train, y_train))
 
     # Execute quantization
-    q_model = model.quantize(calib_dataset=tune_dataset)
+    q_model = model.quantize(x=tune_dataset)
 
     # Inference using quantized model
     y_test_hat = q_model(x_test)


### PR DESCRIPTION
## Description

Change the API of keras `InferenceOptimizer` and `quantize`, now is similar to `keras.Model.fit`

### 1. Why the change?

`keras.Model.fit` use `x` and `y` as input dataset, where `x` is tensors or ndarrays of feature, `y` is tensors or ndarrays of label, it also accepts `x` as a `tf.data.Dataset` returning both feature and label. This PR changes current `calib_dataset` parameter to `x` and `y` to be consistent with `keras.Model.fit`

### 2. User API changes

Before:
```python
# quantize
from bigdl.nano.tf.keras import Model

model = Model()
model.quantize(accelerator=..., calib_dataset=train_dataset)

...

# optimize
from tensorflow.keras import Model
from bigdl.nano.tf.keras import InferenceOptimizer

model = Model()
opt = InferenceOptimizer()
opt.optimize(model=model, calib_dataset=train_dataset)
```

Now:
```python
# quantize
from bigdl.nano.tf.keras import Model

model = Model()
model.quantize(accelerator=..., x=train_dataset)
# or
model.quantize(accelerator=..., x=train_features, y=train_labels)

...

# optimize
from tensorflow.keras import Model
from bigdl.nano.tf.keras import InferenceOptimizer

model = Model()
opt = InferenceOptimizer()
opt.optimize(model=model, x=train_dataset)
# or
opt.optimize(model=model, x=train_features, y=train_labels)
```

Before `calib_dataset` must be a dataset which returns tuples of (feature, label)

Now `x` and `y` can be a numpy array or tensor, or `x` is a dataset which returns tuples of (feature, label), i. e.

        :param x: Input data which is used for training. It could be:
                  | 1. a Numpy array (or array-like), or a list of arrays (in case the model
                  | has multiple inputs).
                  |
                  | 2. a TensorFlow tensor, or a list of tensors (in case the model has
                  | multiple inputs).
                  |
                  | 3. an unbatched tf.data.dataset. Should return a tuple of (inputs, targets).

                  X will be used as calibration dataset for Post-Training Static Quantization (PTQ),
                  as well as be used for generating input_sample to calculate latency.
                  To avoid data leak during calibration, please use training dataset.
        :param y: Target data. Like the input data x, it could be either Numpy array(s) or
                  TensorFlow tensor(s). It should be consistent with x (you cannot have Numpy inputs
                  and tensor targets, or inversely). If x is a dataset, y will be ignored (since
                  targets will be obtained from x).


Besides, rename the parameter `input_sample` of `model.trace(...)` to `input_spec`

### 3. Summary of the change 

1. Change the API of keras optmizer and quantize: `calib_dataset` to `x` and `y`
2. Rename the parameter `input_sample` of `model.trace(...)` to `input_spec`
3. Infer input shape when tracing onnx model in `model.trace` instead of in `model.quantize` or `opt.optimize`
4. Better `tensors_to_numpy` function
5. Change and add all related UT

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...
