### PR TITLE
Add normalization and decomposition for tf forecasters

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/tf/lstm_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/lstm_forecaster.py
@@ -39,6 +39,8 @@ class LSTMForecaster(BaseTF2Forecaster):
                  output_feature_num,
                  hidden_dim=32,
                  layer_num=1,
+                 normalization=True,
+                 decomposition_kernel_size=0,
                  dropout=0.1,
                  optimizer="Adam",
                  loss="mse",
@@ -58,6 +60,16 @@ class LSTMForecaster(BaseTF2Forecaster):
                The value defaults to 32.
         :param layer_num: Specify the number of lstm layer to be used. The value
                defaults to 1.
+        :param normalization: bool, Specify if to use normalization trick to
+               alleviate distribution shift. It first subtractes the last value
+               of the sequence and add back after the model forwarding.
+        :param decomposition_kernel_size: int, Specify the kernel size in moving
+               average. The decomposition method will be applied if and only if
+               decomposition_kernel_size is greater than 1, which first decomposes
+               the raw sequence into a trend component by a moving average kernel
+               and a remainder(seasonal) component. Then, two models are applied
+               to each component and sum up the two outputs to get the final
+               prediction. This value defaults to 0.
         :param dropout: int or list, Specify the dropout close possibility
                (i.e. the close possibility to a neuron). This value defaults to 0.1.
         :param optimizer: Specify the optimizer used for training. This value
@@ -96,6 +108,8 @@ class LSTMForecaster(BaseTF2Forecaster):
             "loss": loss,
             "lr": lr,
             "optim": optimizer,
+            "normalization": normalization,
+            "decomposition_kernel_size": decomposition_kernel_size,
         }
 
         # model creator settings

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/seq2seq_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/seq2seq_forecaster.py
@@ -42,6 +42,8 @@ class Seq2SeqForecaster(BaseTF2Forecaster):
                  lstm_hidden_dim=64,
                  lstm_layer_num=2,
                  teacher_forcing=False,
+                 normalization=True,
+                 decomposition_kernel_size=0,
                  dropout=0.1,
                  optimizer="Adam",
                  loss="mse",
@@ -64,6 +66,16 @@ class Seq2SeqForecaster(BaseTF2Forecaster):
                The value defaults to 2.
         :param teacher_forcing: If use teacher forcing in training. The value
                defaults to False.
+        :param normalization: bool, Specify if to use normalization trick to
+               alleviate distribution shift. It first subtractes the last value
+               of the sequence and add back after the model forwarding.
+        :param decomposition_kernel_size: int, Specify the kernel size in moving
+               average. The decomposition method will be applied if and only if
+               decomposition_kernel_size is greater than 1, which first decomposes
+               the raw sequence into a trend component by a moving average kernel
+               and a remainder(seasonal) component. Then, two models are applied
+               to each component and sum up the two outputs to get the final
+               prediction. This value defaults to 0.
         :param dropout: Specify the dropout close possibility (i.e. the close
                possibility to a neuron). This value defaults to 0.1.
         :param optimizer: Specify the optimizer used for training. This value
@@ -104,6 +116,8 @@ class Seq2SeqForecaster(BaseTF2Forecaster):
             "loss": loss,
             "lr": lr,
             "optim": optimizer,
+            "normalization": normalization,
+            "decomposition_kernel_size": decomposition_kernel_size
         }
 
         # model creator settings

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/tcn_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/tcn_forecaster.py
@@ -16,7 +16,7 @@
 
 from bigdl.chronos.forecaster.tf.base_forecaster import BaseTF2Forecaster
 from bigdl.chronos.model.tf2.TCN_keras import model_creator, TemporalBlock, TemporalConvNet
-
+from bigdl.nano.utils.log4Error import invalidInputError
 
 class TCNForecaster(BaseTF2Forecaster):
     """
@@ -36,8 +36,11 @@ class TCNForecaster(BaseTF2Forecaster):
                  future_seq_len,
                  input_feature_num,
                  output_feature_num,
+                 dummy_encoder=False,
                  num_channels=[16]*3,
                  kernel_size=3,
+                 normalization=True,
+                 decomposition_kernel_size=0,
                  repo_initialization=True,
                  dropout=0.1,
                  optimizer="Adam",
@@ -59,10 +62,23 @@ class TCNForecaster(BaseTF2Forecaster):
         :param future_seq_len: Specify the output time steps (i.e. horizon).
         :param input_feature_num: Specify the feature dimension.
         :param output_feature_num: Specify the output dimension.
+        :param dummy_encoder: bool, no encoder is applied if True, which will
+               turn TCNForecaster to a Linear Model. If True, input_feature_num
+               should equals to output_feature_num.
         :param num_channels: Specify the convolutional layer filter number in
                TCN's encoder. This value defaults to [16]*3.
         :param kernel_size: Specify convolutional layer filter height in TCN's
                encoder. This value defaults to 3.
+        :param normalization: bool, Specify if to use normalization trick to
+               alleviate distribution shift. It first subtractes the last value
+               of the sequence and add back after the model forwarding.
+        :param decomposition_kernel_size: int, Specify the kernel size in moving
+               average. The decomposition method will be applied if and only if
+               decomposition_kernel_size is greater than 1, which first decomposes
+               the raw sequence into a trend component by a moving average kernel
+               and a remainder(seasonal) component. Then, two models are applied
+               to each component and sum up the two outputs to get the final
+               prediction. This value defaults to 0.
         :param repo_initialization: if to use framework default initialization,
                True to use paper author's initialization and False to use the
                framework's default initialization. The value defaults to True.
@@ -93,6 +109,12 @@ class TCNForecaster(BaseTF2Forecaster):
         :param distributed_backend: str, select from "ray" or
                "horovod". The value defaults to "ray".
         """
+        # config check
+        if dummy_encoder:
+            invalidInputError(input_feature_num == output_feature_num,
+                              "if dummy_encoder is set to True, then the "
+                              "model should have equal input_feature_num "
+                              "and output_feature_num.")
         # config setting
         self.model_config = {
             "past_seq_len": past_seq_len,
@@ -106,6 +128,9 @@ class TCNForecaster(BaseTF2Forecaster):
             "loss": loss,
             "lr": lr,
             "optim": optimizer,
+            "normalization": normalization,
+            "decomposition_kernel_size": decomposition_kernel_size,
+            "dummy_encoder": dummy_encoder
         }
 
         # model creator settings

--- a/python/chronos/src/bigdl/chronos/model/tf2/TCN_keras.py
+++ b/python/chronos/src/bigdl/chronos/model/tf2/TCN_keras.py
@@ -136,6 +136,7 @@ class TemporalConvNet(Model):
         self.future_seq_len = future_seq_len
         self.input_feature_num = input_feature_num
         self.output_feature_num = output_feature_num
+        self.dummy_encoder = dummy_encoder
         self.kernel_size = kernel_size
         self.num_channels = num_channels
         self.dropout = dropout
@@ -164,11 +165,11 @@ class TemporalConvNet(Model):
 
     def call(self, x, training=False):
         for layer in self.network:
-            y = layer(x, training=training)
-        y = self.permute(y)
-        y = self.linear(y)
-        y = self.permute(y)
-        return y
+            x = layer(x, training=training)
+        x = self.permute(x)
+        x = self.linear(x)
+        x = self.permute(x)
+        return x
 
     def get_config(self):
         return {"past_seq_len": self.past_seq_len,

--- a/python/chronos/src/bigdl/chronos/model/tf2/TCN_keras.py
+++ b/python/chronos/src/bigdl/chronos/model/tf2/TCN_keras.py
@@ -45,6 +45,8 @@ import tensorflow as tf
 from bigdl.nano.tf.keras import Model
 from tensorflow.keras.layers import Conv1D, BatchNormalization,\
     Activation, Dropout, Input, Layer
+from bigdl.chronos.model.tf2.normalization import NormalizeTSModel
+from bigdl.chronos.model.tf2.decomposition import DecompositionTSModel
 
 
 class TemporalBlock(Layer):
@@ -121,6 +123,7 @@ class TemporalConvNet(Model):
                  future_seq_len,
                  input_feature_num,
                  output_feature_num,
+                 dummy_encoder=False,
                  num_channels=[30]*8,
                  kernel_size=3,
                  dropout=0.1,
@@ -147,13 +150,14 @@ class TemporalConvNet(Model):
         self.network = []
 
         # The model contains "num_levels" TemporalBlock
-        num_levels = len(num_channels)
+        num_levels = 0 if dummy_encoder else len(num_channels)
         for i in range(num_levels):
             dilation_rate = 2 ** i
             self.network.append(TemporalBlock(dilation_rate, num_channels[i], kernel_size,
                                               padding='causal', dropout_rate=dropout))
-        self.network.append(TemporalBlock(dilation_rate, self.output_feature_num, kernel_size,
-                                          padding='causal', dropout_rate=dropout))
+        if not dummy_encoder:
+            self.network.append(TemporalBlock(dilation_rate, self.output_feature_num, kernel_size,
+                                              padding='causal', dropout_rate=dropout))
 
         self.linear = tf.keras.layers.Dense(future_seq_len, kernel_initializer=init)
         self.permute = tf.keras.layers.Permute((2, 1))
@@ -171,6 +175,7 @@ class TemporalConvNet(Model):
                 "future_seq_len": self.future_seq_len,
                 "input_feature_num": self.input_feature_num,
                 "output_feature_num": self.output_feature_num,
+                "dummy_encoder": self.dummy_encoder,
                 "kernel_size": self.kernel_size,
                 "num_channels": self.num_channels,
                 "dropout": self.dropout,
@@ -194,9 +199,28 @@ def model_creator(config):
                             input_feature_num=config["input_feature_num"],
                             output_feature_num=config["output_feature_num"],
                             num_channels=num_channels.copy(),
+                            dummy_encoder=config.get("dummy_encoder", False),
                             kernel_size=config.get("kernel_size", 7),
                             dropout=config.get("dropout", 0.2),
                             repo_initialization=config.get("repo_initialization", True))
+
+    if config.get("normalization", False):
+        model = NormalizeTSModel(model, config["output_feature_num"])
+    decomposition_kernel_size = config.get("decomposition_kernel_size", 0)
+    if decomposition_kernel_size > 1:
+        model_copy = TemporalConvNet(past_seq_len=config["past_seq_len"],
+                                     input_feature_num=config["input_feature_num"],
+                                     future_seq_len=config["future_seq_len"],
+                                     output_feature_num=config["output_feature_num"],
+                                     num_channels=num_channels.copy(),
+                                     dummy_encoder=config.get("dummy_encoder", False),
+                                     kernel_size=config.get("kernel_size", 7),
+                                     dropout=config.get("dropout", 0.2),
+                                     repo_initialization=config.get("repo_initialization", True))
+        if config.get("normalization", False):
+            model_copy = NormalizeTSModel(model_copy, config["output_feature_num"])
+        model = DecompositionTSModel((model, model_copy), decomposition_kernel_size)
+
     inputs = np.zeros(shape=(1, config["past_seq_len"], config["input_feature_num"]))
     # init weights matrix
     model(inputs)

--- a/python/chronos/src/bigdl/chronos/model/tf2/decomposition.py
+++ b/python/chronos/src/bigdl/chronos/model/tf2/decomposition.py
@@ -1,0 +1,76 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import torch.nn as nn
+import torch
+
+
+class moving_avg(nn.Module):
+    """
+    Moving average block to highlight the trend of time series
+    """
+
+    def __init__(self, kernel_size, stride):
+        super(moving_avg, self).__init__()
+        self.kernel_size = kernel_size
+        self.avg = nn.AvgPool1d(kernel_size=kernel_size, stride=stride, padding=0)
+
+    def forward(self, x):
+        # padding on the both ends of time series
+        front = x[:, 0:1, :].repeat(1, (self.kernel_size - 1) // 2, 1)
+        end = x[:, -1:, :].repeat(1, self.kernel_size // 2, 1)
+        x = torch.cat([front, x, end], dim=1)
+        x = self.avg(x.permute(0, 2, 1))
+        x = x.permute(0, 2, 1)
+        return x
+
+
+class series_decomp(nn.Module):
+    """
+    Series decomposition block
+    """
+
+    def __init__(self, kernel_size):
+        super(series_decomp, self).__init__()
+        self.moving_avg = moving_avg(kernel_size, stride=1)
+
+    def forward(self, x):
+        moving_mean = self.moving_avg(x)
+        res = x - moving_mean
+        return res, moving_mean
+
+
+class DecompositionTSModel(nn.Module):
+
+    def __init__(self, models, kernel_size=25):
+        """
+        Build a Decomposition model wrapper.
+
+        :param models: tuple, (model, model_copy) two basic forecaster models.
+        :param kernel_size: int, Specify the kernel size in moving average.
+        """
+        super(DecompositionTSModel, self).__init__()
+        self.decompsition = series_decomp(kernel_size)
+        self.linear_seasonal = models[0]
+        self.linear_trend = models[1]
+
+    def forward(self, x):
+        seasonal_init, trend_init = self.decompsition(x)
+        seasonal_output = self.linear_seasonal(seasonal_init)
+        trend_output = self.linear_trend(trend_init)
+
+        x = seasonal_output + trend_output
+        return x

--- a/python/chronos/src/bigdl/chronos/model/tf2/decomposition.py
+++ b/python/chronos/src/bigdl/chronos/model/tf2/decomposition.py
@@ -14,11 +14,12 @@
 # limitations under the License.
 #
 
-import torch.nn as nn
-import torch
+import tensorflow as tf
+from tensorflow.keras.layers import Layer
+from bigdl.nano.tf.keras import Model
 
 
-class moving_avg(nn.Module):
+class moving_avg(Layer):
     """
     Moving average block to highlight the trend of time series
     """
@@ -26,19 +27,21 @@ class moving_avg(nn.Module):
     def __init__(self, kernel_size, stride):
         super(moving_avg, self).__init__()
         self.kernel_size = kernel_size
-        self.avg = nn.AvgPool1d(kernel_size=kernel_size, stride=stride, padding=0)
+        self.avg = tf.keras.layers.AveragePooling1D(pool_size=kernel_size, strides=stride,
+                                                    padding='valid',
+                                                    data_format='channels_first')
 
-    def forward(self, x):
+    def call(self, x):
         # padding on the both ends of time series
         front = x[:, 0:1, :].repeat(1, (self.kernel_size - 1) // 2, 1)
         end = x[:, -1:, :].repeat(1, self.kernel_size // 2, 1)
-        x = torch.cat([front, x, end], dim=1)
+        x = tf.concat([front, x, end], dim=1)
         x = self.avg(x.permute(0, 2, 1))
         x = x.permute(0, 2, 1)
         return x
 
 
-class series_decomp(nn.Module):
+class series_decomp(Layer):
     """
     Series decomposition block
     """
@@ -47,13 +50,13 @@ class series_decomp(nn.Module):
         super(series_decomp, self).__init__()
         self.moving_avg = moving_avg(kernel_size, stride=1)
 
-    def forward(self, x):
+    def call(self, x):
         moving_mean = self.moving_avg(x)
         res = x - moving_mean
         return res, moving_mean
 
 
-class DecompositionTSModel(nn.Module):
+class DecompositionTSModel(Model):
 
     def __init__(self, models, kernel_size=25):
         """
@@ -67,7 +70,7 @@ class DecompositionTSModel(nn.Module):
         self.linear_seasonal = models[0]
         self.linear_trend = models[1]
 
-    def forward(self, x):
+    def call(self, x):
         seasonal_init, trend_init = self.decompsition(x)
         seasonal_output = self.linear_seasonal(seasonal_init)
         trend_output = self.linear_trend(trend_init)

--- a/python/chronos/src/bigdl/chronos/model/tf2/decomposition.py
+++ b/python/chronos/src/bigdl/chronos/model/tf2/decomposition.py
@@ -30,14 +30,15 @@ class moving_avg(Layer):
         self.avg = tf.keras.layers.AveragePooling1D(pool_size=kernel_size, strides=stride,
                                                     padding='valid',
                                                     data_format='channels_first')
+        self.permute = tf.keras.layers.Permute((2, 1))
 
     def call(self, x):
         # padding on the both ends of time series
-        front = x[:, 0:1, :].repeat(1, (self.kernel_size - 1) // 2, 1)
-        end = x[:, -1:, :].repeat(1, self.kernel_size // 2, 1)
-        x = tf.concat([front, x, end], dim=1)
-        x = self.avg(x.permute(0, 2, 1))
-        x = x.permute(0, 2, 1)
+        front = tf.tile(x[:, 0:1, :], [1, (self.kernel_size - 1) // 2, 1])
+        end = tf.tile(x[:, -1:, :], [1, self.kernel_size // 2, 1])
+        x = tf.concat([front, x, end], axis=1)
+        x = self.avg(self.permute(x))
+        x = self.permute(x)
         return x
 
 

--- a/python/chronos/src/bigdl/chronos/model/tf2/normalization.py
+++ b/python/chronos/src/bigdl/chronos/model/tf2/normalization.py
@@ -1,0 +1,37 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from bigdl.nano.tf.keras import Model
+
+
+class NormalizeTSModel(Model):
+    def __init__(self, model, output_feature_dim):
+        """
+        Build a Normalization model wrapper.
+
+        param model: basic forecaster model.
+        :param output_feature_dim: Specify the output dimension.
+        """
+        super(NormalizeTSModel, self).__init__()
+        self.model = model
+        self.output_feature_dim = output_feature_dim
+
+    def call(self, x):
+        seq_last = x[:, -1:, :]
+        x = x - seq_last
+        y = self.model(x)
+        y = y + seq_last[:, :, :self.output_feature_dim]
+        return y


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?
Refer to #6405 
Despired by the methods mentioned in [Are Transformers Effective for Time Series Forecasting?](https://arxiv.org/abs/2205.13504), adding new extensions to tcn model. And the experiment results on the three datasets (electricity, nyc_taxi and others) demonstrate the effectiveness of the added extensions.

<!-- Provide the related github issue link if available -->

### 2. User API changes
- Add new options "dummy_encoder", "normalization" and "decomposition_kernal_size" to bigdl.chronos.forecaster.tf.tcn_forecaster.TCNForecaster.__init__()
- Add new options "normalization" and "decomposition_kernal_size" to bigdl.chronos.forecaster.tf.seq2seq_forecaster.Seq2SeqForecaster.__init__()
- Add new options "normalization" and "decomposition_kernal_size" to bigdl.chronos.forecaster.tf.lstm_forecaster.LSTMForecaster.__init__()

:param dummy_encoder: bool, no encoder is applied if True, which will turn TCNForecaster to a Linear Model. If True, input_feature_num should equals to output_feature_num.

:param normalization: bool, Specify if to use normalization trick to alleviate distribution shift. It first subtractes the last value
of the sequence and add back after the model forwarding.

:param decomposition_kernel_size: int, Specify the kernel size in moving average. The decomposition method will be applied if and only if decomposition_kernel_size is greater than 1, which first decomposes the raw sequence into a trend component by a moving average kernel and a remainder(seasonal) component. Then, two models are applied to each component and sum up the two outputs to get the final prediction. This value defaults to 0.

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 
Add dd new tricka for tf forecasters.
<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] ...
