### PR TITLE
Chronos: add numpy implemented scaling to reduce latency

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/utils/scale.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/scale.py
@@ -73,3 +73,13 @@ UNSCALE_HELPER_MAP = {StandardScaler: _standard_scaler_unscale_timeseries_numpy,
 
 def unscale_timeseries_numpy(data, scaler, scaler_index):
     return UNSCALE_HELPER_MAP[type(scaler)](data, scaler, scaler_index)
+
+
+def _standard_scaler_scale_timeseries_numpy(data, scaler):
+    data_scale = np.zeros(data.shape)
+    feature_counter = 0
+    for i in range(data.shape[1]):
+        value_mean = scaler.mean_[i] if scaler.with_mean else 0
+        value_scale = scaler.scale_[i] if scaler.with_std else 1
+        data_scale[:, i] = (data[:, i] - value_mean) / value_scale
+    return data_scale

--- a/python/chronos/test/bigdl/chronos/data/utils/test_scale.py
+++ b/python/chronos/test/bigdl/chronos/data/utils/test_scale.py
@@ -1,0 +1,56 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+import pandas as pd
+import numpy as np
+
+from unittest import TestCase
+from sklearn.preprocessing import StandardScaler
+from bigdl.chronos.data.utils.scale import _standard_scaler_scale_timeseries_numpy
+from numpy.testing import assert_array_almost_equal
+
+from ... import op_torch, op_tf2, op_diff_set_all
+
+
+def get_ts_df():
+    sample_num = np.random.randint(100, 200)
+    train_df = pd.DataFrame({"datetime": pd.date_range('1/1/2019', periods=sample_num),
+                             "value": np.random.randn(sample_num),
+                             "id": np.array(['00']*sample_num),
+                             "extra feature": np.random.randn(sample_num)})
+    return train_df
+
+
+class TestScaleNumpy(TestCase):
+    def setup_method(self, method):
+        pass
+
+    def teardown_method(self, method):
+        pass
+
+    @op_torch
+    @op_tf2
+    @op_diff_set_all
+    def test_unscale_timeseries_numpy(self):
+        df = get_ts_df()
+        scaler = StandardScaler()
+        col_list = ["value", "extra feature"]
+        scaler.fit(df[col_list])
+        scaled_data_scaler = scaler.transform(df[col_list])
+        scaled_data_numpy = \
+            _standard_scaler_scale_timeseries_numpy(df[col_list].values, scaler)
+        assert_array_almost_equal(scaled_data_scaler, scaled_data_numpy)


### PR DESCRIPTION
## Description

### 1. Why the change?

We are having a high latency caused by `scaler.transform`, which cost more than 1ms for even small dataset. We decided to implement by numpy, which is proved to reduce the latency by ~60%.

### 2. User API changes

nothing

### 3. Summary of the change 

add a numpy implementation to `bigdl.chronos.data.utils.scale` for standardscaler.

### 4. How to test?
- [ ] Unit test
