### PR TITLE
revert key length from 256 to 128 in BigDLEncrypt

### DIFF
--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/BigDLEncrypt.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/BigDLEncrypt.scala
@@ -56,7 +56,7 @@ class BigDLEncrypt extends Crypto {
     val secret = dataKeyPlaintext.getBytes()
     // key encrypt
     val signingKey = Arrays.copyOfRange(secret, 0, 16)
-    val encryptKey = Arrays.copyOfRange(secret, 16, 48)
+    val encryptKey = Arrays.copyOfRange(secret, 16, 32)
 //    initializationVector = Arrays.copyOfRange(secret, 0, 16)
     val r = new SecureRandom()
     initializationVector = Array.tabulate(16)(_ => (r.nextInt(256) - 128).toByte)


### PR DESCRIPTION
## Description
Revert BigDLEncrypt's key length in https://github.com/intel-analytics/BigDL/pull/5023.

### 1. Why the change?
https://docs.oracle.com/javase/8/docs/api/javax/crypto/Cipher.html only support 128 key size for AES/CBC/PKCS5Padding.
Creating cipher will throw error, Illegal key size.
### 2. User API changes

None

### 3. Summary of the change 

Revert BigDLEncrypt's key length in https://github.com/intel-analytics/BigDL/pull/5023.

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

