### PR TITLE
Nano: Support best result for each trial in AutoML

### DIFF
--- a/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
@@ -75,6 +75,38 @@ class LatencyCallback(Callback):
         pl_module.time_avg(batch_latency)
 
 
+def is_better(score, current_score, direction):
+    if current_score is None:
+        return True
+    elif direction == "min":
+        if score < current_score:
+            return True
+        return False
+    elif direction == "max":
+        if score < current_score:
+            return False
+        return True
+
+
+class BestMetricCallback(Callback):
+    def __init__(self, target_metric, direction="min") -> None:
+        super().__init__()
+        self.target_metric = target_metric
+        self.direction = direction
+        self.best_score = None
+
+    def on_validation_start(self, trainer, pl_module) -> None:
+        super().on_validation_start(trainer, pl_module)
+
+    def on_validation_epoch_end(self, trainer, pl_module) -> None:
+        super().on_validation_start(trainer, pl_module)
+        score = trainer.callback_metrics[self.target_metric].item()
+        if is_better(score, self.best_score, self.direction):
+            self.best_score = score
+        print("log best value is : ", self.best_score)
+        pl_module.log('best_score', self.best_score)
+
+
 def createModelCheckpoint(metric, filename, dirpath=None, mode='min'):
     from pytorch_lightning.callbacks import ModelCheckpoint
     checkpoint_callback = ModelCheckpoint(

--- a/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
@@ -75,6 +75,19 @@ class LatencyCallback(Callback):
         pl_module.time_avg(batch_latency)
 
 
+def createModelCheckpoint(metric, filename, dirpath=None, mode='min'):
+    from pytorch_lightning.callbacks import ModelCheckpoint
+    checkpoint_callback = ModelCheckpoint(
+        monitor=metric,
+        save_top_k=1,
+        save_last=False,
+        mode=mode,
+        dirpath=dirpath,
+        filename=filename
+    )
+    return checkpoint_callback
+
+
 class CustomEvaluationLoop(EvaluationLoop):
     def __init__(self, verbose: bool = True) -> None:
         super().__init__(verbose=verbose)

--- a/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
@@ -99,12 +99,11 @@ class BestMetricCallback(Callback):
         super().on_validation_start(trainer, pl_module)
 
     def on_validation_epoch_end(self, trainer, pl_module) -> None:
-        super().on_validation_start(trainer, pl_module)
+        super().on_validation_end(trainer, pl_module)
         score = trainer.callback_metrics[self.target_metric].item()
         if is_better(score, self.best_score, self.direction):
             self.best_score = score
-        print("log best value is : ", self.best_score)
-        pl_module.log('best_score', self.best_score)
+        pl_module.log('_best_score', self.best_score)
 
 
 def createModelCheckpoint(metric, filename, dirpath=None, mode='min'):

--- a/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/_helper.py
@@ -78,11 +78,11 @@ class LatencyCallback(Callback):
 def is_better(score, current_score, direction):
     if current_score is None:
         return True
-    elif direction == "min":
+    elif direction == 'minimize' or direction == 'min':
         if score < current_score:
             return True
         return False
-    elif direction == "max":
+    else:
         if score < current_score:
             return False
         return True
@@ -104,19 +104,6 @@ class BestMetricCallback(Callback):
         if is_better(score, self.best_score, self.direction):
             self.best_score = score
         pl_module.log('_best_score', self.best_score)
-
-
-def createModelCheckpoint(metric, filename, dirpath=None, mode='min'):
-    from pytorch_lightning.callbacks import ModelCheckpoint
-    checkpoint_callback = ModelCheckpoint(
-        monitor=metric,
-        save_top_k=1,
-        save_last=False,
-        mode=mode,
-        dirpath=dirpath,
-        filename=filename
-    )
-    return checkpoint_callback
 
 
 class CustomEvaluationLoop(EvaluationLoop):

--- a/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
@@ -68,15 +68,22 @@ class HPOSearcher:
         self.run_kwargs = None
         self.fit_kwargs = None
 
-    def _create_objective(self, model, target_metric, create_kwargs, acceleration,
-                          input_sample, fit_kwargs):
+    def _create_objective(self, model, target_metric, mode, create_kwargs,
+                          acceleration, input_sample, fit_kwargs):
         # target_metric = self._fix_target_metric(target_metric, search_kwargs)
         isprune = True if create_kwargs.get('pruner', None) else False
+        print("_create_objective: ")
+        print(self.create_kwargs)
+        direction = create_kwargs.get('direction', None)
+        directions = create_kwargs.get('directions', None)
         self.objective = Objective(
             searcher=self,
             model=model._model_build,
             target_metric=target_metric,
+            mode=mode,
             pruning=isprune,
+            direction=direction,
+            directions=directions,
             acceleration=acceleration,
             input_sample=input_sample,
             **fit_kwargs,
@@ -114,6 +121,7 @@ class HPOSearcher:
                model,
                resume=False,
                target_metric=None,
+               mode='best',
                n_parallels=1,
                acceleration=False,
                input_sample=None,
@@ -126,6 +134,8 @@ class HPOSearcher:
             defaults to False.
         :param target_metric: the object metric to optimize,
             defaults to None.
+        :param mode: use last epoch's result as trial's score or use best epoch's.
+            defaults to 'best', you can change it to 'last'.
         :param acceleration: Whether to automatically consider the model after
             inference acceleration in the search process. It will only take
             effect if target_metric contains "latency". Default value is False.
@@ -161,7 +171,8 @@ class HPOSearcher:
             self.study = _create_study(resume, self.create_kwargs, self.backend)
 
         if self.objective is None:
-            self._create_objective(model, self.target_metric, self.create_kwargs, acceleration,
+            self._create_objective(model, self.target_metric, mode,
+                                   self.create_kwargs, acceleration,
                                    input_sample, self.fit_kwargs)
 
         if n_parallels and n_parallels > 1:

--- a/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
@@ -72,8 +72,6 @@ class HPOSearcher:
                           acceleration, input_sample, fit_kwargs):
         # target_metric = self._fix_target_metric(target_metric, search_kwargs)
         isprune = True if create_kwargs.get('pruner', None) else False
-        print("_create_objective: ")
-        print(self.create_kwargs)
         direction = create_kwargs.get('direction', None)
         directions = create_kwargs.get('directions', None)
         self.objective = Objective(

--- a/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
@@ -216,8 +216,8 @@ class HPOSearcher:
         # last `_run` call might have set it to `FINISHED`
         self.trainer.state.status = TrainerStatus.RUNNING
         self.trainer.training = True
+        self.trainer.state.fn = TrainerFn.FITTING
         if self.num_process > 1:
-            self.trainer.state.fn = TrainerFn.FITTING  # add in lightning 1.6
             self.trainer.fit(*args, **kwargs)
         else:
             self.trainer._run(*args, **kwargs)

--- a/python/nano/src/bigdl/nano/automl/pytorch/objective.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/objective.py
@@ -237,7 +237,7 @@ class Objective(object):
             scores = self.searcher.trainer.callback_metrics[self.target_metric].item()
 
         if self.mode == "best":
-            scores = self.searcher.trainer.callback_metrics["best_score"].item()
+            scores = self.searcher.trainer.callback_metrics["_best_score"].item()
 
         if self.acceleration:
             scores, optimization = self._auto_acceleration(model, scores)

--- a/python/nano/src/bigdl/nano/automl/pytorch/objective.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/objective.py
@@ -30,6 +30,7 @@ from ._helper import LatencyCallback, createModelCheckpoint, _remove_metric_pref
 import inspect
 import copy
 import os
+import torch
 
 
 def _is_creator(model):
@@ -250,13 +251,13 @@ class Objective(object):
                 scores.append(score)
         else:
             scores = self.searcher.trainer.callback_metrics[self.target_metric].item()
-        self.searcher._validate(model, self.val_dataloaders)
-        self.searcher._validate(model, self.val_dataloaders)
+
         if self.mode == "best":
             # obtain score from loaded best model
             checkpoint_path = self.tmp_dir + self.tmp_filename + ".ckpt"
-            # checkpoint_path = self.tmp_filename + ".ckpt"
-            model.load_from_checkpoint(checkpoint_path)  
+            # model.load_from_checkpoint(checkpoint_path)
+            state_dict = torch.load(checkpoint_path, map_location='cpu')
+            model.load_state_dict(state_dict['state_dict'])
             self.searcher.trainer.validate(model)
             scores = self.searcher.trainer.callback_metrics[self.target_metric].item()
 

--- a/python/nano/src/bigdl/nano/automl/pytorch/objective.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/objective.py
@@ -61,10 +61,10 @@ class Objective(object):
             Defaults to 'best', you can change it to 'last'.
         :param pruning: bool (optional): whether to enable pruning.
             Defaults to False.
-        :param direction: direction for target metric, used when there is only
-            one target metric. Dafaults to 'minimize'.
-        :param directions: directions for target metrics, used when there are multi
-            target metrics. Dafaults to None.
+        :param direction: direction for target metric, which is used when there is
+            only one target metric. Dafaults to 'minimize'.
+        :param directions: directions for target metrics, which is used when there
+            are multi target metrics. Dafaults to None.
         :param acceleration: Whether to automatically consider the model after
             inference acceleration in the search process. It will only take
             effect if target_metric contains "latency". Default value is False.

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -216,6 +216,7 @@ class Trainer(pl.Trainer):
                model,
                resume: bool = False,
                target_metric=None,
+               mode: str = 'best',
                n_parallels=1,
                acceleration=False,
                input_sample=None,
@@ -228,6 +229,8 @@ class Trainer(pl.Trainer):
             defaults to False.
         :param target_metric: the object metric to optimize,
             defaults to None.
+        :param mode: use last epoch's result as trial's score or use best epoch's.
+            defaults to 'best', you can change it to 'last'.
         :param n_parallels: the number of parallel processes for running trials.
         :param acceleration: Whether to automatically consider the model after
             inference acceleration in the search process. It will only take
@@ -243,6 +246,7 @@ class Trainer(pl.Trainer):
         return self.hposearcher.search(model,
                                        resume=resume,
                                        target_metric=target_metric,
+                                       mode=mode,
                                        n_parallels=n_parallels,
                                        acceleration=acceleration,
                                        input_sample=input_sample,

--- a/python/nano/test/automl/pytorch/test_multi_objective.py
+++ b/python/nano/test/automl/pytorch/test_multi_objective.py
@@ -149,7 +149,7 @@ class TestMOHPO(TestCase):
             max_epochs=2,
             use_hpo=True,
         )
-        
+
         best_trials = trainer.search(
             model,
             target_metric=['val_loss', 'latency'],
@@ -216,7 +216,7 @@ class TestMOHPO(TestCase):
             num_processes=2,
             # distributed_backend="ray",
         )
-        
+
         best_trials = trainer.search(
             model,
             target_metric=['val_loss', 'latency'],
@@ -349,7 +349,7 @@ class TestMOHPO(TestCase):
             max_epochs=2,
             use_hpo=True,
         )
-        
+
         best_trials = trainer.search(
             model,
             target_metric=['val_loss', 'latency'],

--- a/python/nano/test/automl/pytorch/test_sampler.py
+++ b/python/nano/test/automl/pytorch/test_sampler.py
@@ -64,7 +64,7 @@ class TestHPOSearcher(TestCase):
             max_epochs=3,
             use_hpo=True,
         )
-        
+
         from bigdl.nano.automl.hpo.backend import SamplerType
         trainer.search(
             model,
@@ -76,7 +76,7 @@ class TestHPOSearcher(TestCase):
         study = trainer.search_summary()
         assert(study)
         assert(study.best_trial)
-    
+
     def test_random_sampler(self):
     
         @hpo.plmodel()

--- a/python/nano/test/automl/pytorch/test_trainer.py
+++ b/python/nano/test/automl/pytorch/test_trainer.py
@@ -195,6 +195,84 @@ class TestTrainer(TestCase):
         # assert(batch_size == 32 or batch_size == 64)
         # score = trainer.callback_metrics["val_loss"].item()
         # print("final val_loss is:", score)
+    
+    def test_last_mode(self):
+        @hpo.plmodel()
+        class CustomModel(BoringModel):
+            """Customized Model."""
+            def __init__(self,
+                        out_dim1,
+                        out_dim2,
+                        dropout_1,
+                        dropout_2,
+                        learning_rate=0.1,
+                        batch_size=16):
+                super().__init__()
+                layers = []
+                input_dim = 32
+                for out_dim, dropout in [(out_dim1, dropout_1),
+                                        (out_dim2,dropout_2)]:
+                    layers.append(torch.nn.Linear(input_dim, out_dim))
+                    layers.append(torch.nn.Tanh())
+                    layers.append(torch.nn.Dropout(dropout))
+                    input_dim = out_dim
+                layers.append(torch.nn.Linear(input_dim, 2))
+                self.layers: torch.nn.Module = torch.nn.Sequential(*layers)
+                self.save_hyperparameters()
+
+            def configure_optimizers(self):
+                # set learning rate in the optimizer
+                print("setting initial learning rate to",str(self.hparams.learning_rate))
+                self.optimizer = torch.optim.Adam(self.layers.parameters(),
+                                                  lr=self.hparams.learning_rate)
+                return [self.optimizer], []
+
+            def train_dataloader(self):
+                print("setting initial learning rate to",str(self.hparams.learning_rate))
+                return DataLoader(RandomDataset(32, 64),
+                                  batch_size=self.hparams.batch_size)
+
+            def val_dataloader(self):
+                return DataLoader(RandomDataset(32, 64),
+                                  batch_size=self.hparams.batch_size)
+
+        model = CustomModel(
+            out_dim1=space.Categorical(16,32),
+            out_dim2=space.Categorical(16,32),
+            dropout_1=space.Categorical(0.1, 0.2, 0.3, 0.4, 0.5),
+            dropout_2 = space.Categorical(0.1,0.2),
+            learning_rate = space.Real(0.001,0.01,log=True),
+            batch_size = space.Categorical(32,64)
+            )
+
+        trainer = Trainer(
+            logger=True,
+            checkpoint_callback=False,
+            max_epochs=2,
+            use_hpo=True,
+        )
+
+        best_model = trainer.search(
+            model,
+            target_metric='val_loss',
+            direction='minimize',
+            n_trials=4,
+            max_epochs=3,
+            mode='last', # default value is best
+        )
+
+        study = trainer.search_summary()
+        assert(study)
+        assert(study.best_trial)
+        assert(best_model.summarize())
+        trainer.fit(best_model)
+        lr = best_model.optimizer.param_groups[0]['lr']
+        assert( lr <= 0.01 and lr >= 0.001)
+        batch_size = best_model.hparams.batch_size
+        assert(batch_size == 32 or batch_size == 64)
+        # score = trainer.callback_metrics["val_loss"].item()
+        # print("final val_loss is:", score)
+
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
## Description

Now NanoHPO selects model based on the last epoch's metric (for example, last epoch's val loss). However, it's more reasonable to select the one with the best metric.

### 1. Why the change?

https://github.com/intel-analytics/BigDL/issues/6760

### 2. User API changes

New parameter `mode` for `trainer.search`:
```python
model = CustomModel(
    out_dim = space.Categorical(16,32),
    dropout = space.Categorical(0.1,0.2),
    learning_rate = space.Real(0.001,0.01,log=True),
    batch_size = space.Categorical(32,64)
)

trainer = Trainer(
    logger=True,
    checkpoint_callback=False,
    max_epochs=2,
    use_hpo=True,
)

best_model = trainer.search(
    model,
    target_metric='val_loss',
    direction='minimize',
    n_trials=4,
    max_epochs=3,
    mode='best',  # default value is best, you can change to last.
)
```

### 3. Summary of the change 

- support obtain the best metric value for each trial
- provide two modes in `trainer.search`
- related ut

### 4. How to test?
- [x] Unit test
- [x] Application test
