### PR TITLE
Nano: support getattr from original model

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -102,6 +102,17 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
     def on_forward_end(self, outputs):
         return outputs
 
+    def __getattr__(self, name: str):
+        # automatically unwrap attributes access of model
+        print(name)
+        try:
+            return super().__getattr__(name)
+        except:
+            try:
+                return getattr(self.model, name)
+            except AttributeError:
+                pass
+
     @property
     def status(self):
         status = super().status

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -61,8 +61,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         self.use_ipex = use_ipex
         self.use_jit = use_jit
         self.jit_strict = jit_strict
-        if self.use_ipex is True or self.use_jit is True:
-            self.original_model = model if inplace is False else deepcopy(model)
+        if (self.use_ipex is True or self.use_jit is True) and inplace is False:
+            self.original_model = model
         if self.channels_last:
             self.model = self.model.to(memory_format=torch.channels_last)
         if self.use_ipex:
@@ -87,7 +87,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                                                               precision="fp32",
                                                               thread_num=thread_num)
         self.thread_num = thread_num
-        if self.use_ipex is True or self.use_jit is True:
+        if (self.use_ipex is True or self.use_jit is True) and inplace is False:
             # patch original model's attr to current new model
             for attr in dir(self.original_model):
                 if attr not in dir(self) and not attr.startswith('_') and not\
@@ -121,7 +121,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
             return super().__getattr__(name)
         except AttributeError:
             return getattr(self.model, name)
-    
+
     @property
     def status(self):
         status = super().status

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -45,7 +45,6 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         :param inplace: whether to perform inplace optimization. Default: ``False``.
         :param jit_strict: Whether recording your mutable container types.
         """
-        model.eval()
         super().__init__(model)
         if from_load:
             self.use_ipex = use_ipex
@@ -57,6 +56,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                                                                   thread_num=thread_num)
             return
         self.channels_last = channels_last
+        self.original_model = model
         self.original_state_dict = model.state_dict()
         self.use_ipex = use_ipex
         self.use_jit = use_jit
@@ -104,12 +104,11 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
 
     def __getattr__(self, name: str):
         # automatically unwrap attributes access of model
-        print(name)
         try:
             return super().__getattr__(name)
-        except:
+        except AttributeError:
             try:
-                return getattr(self.model, name)
+                return getattr(self.original_model, name)
             except AttributeError:
                 pass
 

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -17,7 +17,7 @@
 from bigdl.nano.utils.inference.pytorch.model import AcceleratedLightningModule
 from bigdl.nano.pytorch.context_manager import generate_context_manager
 import torch
-from copy import deepcopy
+from bigdl.nano.pytorch.utils import patch_attrs_from_model_to_object
 
 
 class PytorchIPEXJITModel(AcceleratedLightningModule):
@@ -89,11 +89,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         self.thread_num = thread_num
         if (self.use_ipex is True or self.use_jit is True) and inplace is False:
             # patch original model's attr to current new model
-            for attr in dir(self.original_model):
-                if attr not in dir(self) and not attr.startswith('_') and not\
-                        isinstance(getattr(self.original_model, attr), torch.nn.Module):
-                    setattr(self, attr, getattr(self.original_model, attr))
-            del self.original_model  # save memory
+            patch_attrs_from_model_to_object(self.original_model, self)
+            del self.original_model
 
     @property
     def forward_args(self):

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -107,10 +107,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         try:
             return super().__getattr__(name)
         except AttributeError:
-            try:
-                return getattr(self.original_model, name)
-            except AttributeError:
-                pass
+            return getattr(self.original_model, name)
 
     @property
     def status(self):

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/pytorch/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/pytorch/quantization.py
@@ -64,4 +64,4 @@ class PytorchONNXRuntimeQuantization(BaseONNXRuntimeQuantization, PytorchQuantiz
         else:
             # below code will re-define a new object, and original attrs will be lost.
             return PytorchONNXRuntimeModel(q_model.model,
-                                        onnxruntime_session_options=self.session_options)
+                                           onnxruntime_session_options=self.session_options)

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/pytorch/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/onnx/pytorch/quantization.py
@@ -13,9 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 from copy import deepcopy
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from bigdl.nano.deps.onnxruntime.pytorch.pytorch_onnxruntime_model import PytorchONNXRuntimeModel
 from ..quantization import BaseONNXRuntimeQuantization
 from ...pytorch import PytorchQuantization
@@ -53,10 +52,16 @@ class PytorchONNXRuntimeQuantization(BaseONNXRuntimeQuantization, PytorchQuantiz
             calib_dataloader.collate_fn = numpy_collate_fn_wrapper(calib_dataloader.collate_fn)
 
         if isinstance(model, PytorchONNXRuntimeModel):
+            self.nano_model = model
             model = model.onnx_model
-
         return model, calib_dataloader, metric
 
     def _post_execution(self, q_model):
-        return PytorchONNXRuntimeModel(q_model.model,
-                                       onnxruntime_session_options=self.session_options)
+        if hasattr(self, "nano_model") and isinstance(self.nano_model, PytorchONNXRuntimeModel):
+            self.nano_model.__init__(q_model.model,
+                                     onnxruntime_session_options=self.session_options)
+            return self.nano_model
+        else:
+            # below code will re-define a new object, and original attrs will be lost.
+            return PytorchONNXRuntimeModel(q_model.model,
+                                        onnxruntime_session_options=self.session_options)

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantization.py
@@ -22,6 +22,7 @@ from .metric import PytorchINCMetric
 from .quantized_model import PytorchQuantizedModel
 from torchmetrics import Metric
 import torch
+from bigdl.nano.pytorch.utils import patch_attrs_from_model_to_object
 
 
 class PytorchQuantization(BaseQuantization):
@@ -43,10 +44,7 @@ class PytorchQuantization(BaseQuantization):
         quantized_model = PytorchQuantizedModel(q_model, self.thread_num)
         if hasattr(self, "original_model"):
             # patch original model's attr to current new model
-            for attr in dir(self.original_model):
-                if attr not in dir(quantized_model) and not attr.startswith('_') and not\
-                        isinstance(getattr(self.original_model, attr), torch.nn.Module):
-                    setattr(quantized_model, attr, getattr(self.original_model, attr))
+            patch_attrs_from_model_to_object(self.original_model, quantized_model)
             del self.original_model
         return quantized_model
 

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantization.py
@@ -33,7 +33,7 @@ class PytorchQuantization(BaseQuantization):
         super().__init__(**kwargs)
         self._inc_metric_cls = PytorchINCMetric
         self.thread_num = thread_num
-    
+
     def _pre_execution(self, model, calib_dataloader=None, metric=None):
         if isinstance(model, torch.nn.Module):
             self.original_model = model

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -78,7 +78,8 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
                                                               thread_num=self.thread_num)
         # patch original model's attr to current new model
         for attr in dir(model):
-            if attr not in dir(self) and not attr.startswith('_'):
+            if attr not in dir(self) and not attr.startswith('_') and not\
+                    isinstance(getattr(model, attr), torch.nn.Module):
                 setattr(self, attr, getattr(model, attr))
 
     def on_forward_start(self, inputs):

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -23,6 +23,7 @@ from bigdl.nano.utils.inference.pytorch.model import AcceleratedLightningModule
 from bigdl.nano.utils.inference.pytorch.model_utils import export_to_onnx
 from bigdl.nano.utils.log4Error import invalidInputError
 from bigdl.nano.pytorch.context_manager import generate_context_manager
+from bigdl.nano.pytorch.utils import patch_attrs_from_model_to_object
 
 
 class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
@@ -78,10 +79,7 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
                                                               thread_num=self.thread_num)
         if isinstance(model, torch.nn.Module):
             # patch original model's attr to current new model
-            for attr in dir(model):
-                if attr not in dir(self) and not attr.startswith('_') and not\
-                        isinstance(getattr(model, attr), torch.nn.Module):
-                    setattr(self, attr, getattr(model, attr))
+            patch_attrs_from_model_to_object(model, self)
 
     def on_forward_start(self, inputs):
         if self.ortsess is None:

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -76,11 +76,12 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
         self._nano_context_manager = generate_context_manager(accelerator=None,
                                                               precision="fp32",
                                                               thread_num=self.thread_num)
-        # patch original model's attr to current new model
-        for attr in dir(model):
-            if attr not in dir(self) and not attr.startswith('_') and not\
-                    isinstance(getattr(model, attr), torch.nn.Module):
-                setattr(self, attr, getattr(model, attr))
+        if isinstance(model, torch.nn.Module):
+            # patch original model's attr to current new model
+            for attr in dir(model):
+                if attr not in dir(self) and not attr.startswith('_') and not\
+                        isinstance(getattr(model, attr), torch.nn.Module):
+                    setattr(self, attr, getattr(model, attr))
 
     def on_forward_start(self, inputs):
         if self.ortsess is None:

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -76,6 +76,10 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
         self._nano_context_manager = generate_context_manager(accelerator=None,
                                                               precision="fp32",
                                                               thread_num=self.thread_num)
+        # patch original model's attr to current new model
+        for attr in dir(model):
+            if attr not in dir(self) and not attr.startswith('_'):
+                setattr(self, attr, getattr(model, attr))
 
     def on_forward_start(self, inputs):
         if self.ortsess is None:

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -26,6 +26,7 @@ from bigdl.nano.utils.log4Error import invalidInputError
 from ..core.utils import save
 from torch.utils.data.dataloader import DataLoader
 from bigdl.nano.pytorch.context_manager import generate_context_manager
+from bigdl.nano.pytorch.utils import patch_attrs_from_model_to_object
 
 
 class PytorchOpenVINOModel(AcceleratedLightningModule):
@@ -57,12 +58,9 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         self._nano_context_manager = generate_context_manager(accelerator="openvino",
                                                               precision="fp32",
                                                               thread_num=thread_num)
-        # patch original model's attr to current new model
         if isinstance(model, torch.nn.Module):
-            for attr in dir(model):
-                if attr not in dir(self) and not attr.startswith('_') and not\
-                        isinstance(getattr(model, attr), torch.nn.Module):
-                    setattr(self, attr, getattr(model, attr))
+            # patch original model's attr to current new model
+            patch_attrs_from_model_to_object(model, self)
 
     def on_forward_start(self, inputs):
         self.ov_model._model_exists_or_err()

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -57,6 +57,10 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         self._nano_context_manager = generate_context_manager(accelerator="openvino",
                                                               precision="fp32",
                                                               thread_num=thread_num)
+        # patch original model's attr to current new model
+        for attr in dir(model):
+            if attr not in dir(self) and not attr.startswith('_'):
+                setattr(self, attr, getattr(model, attr))
 
     def on_forward_start(self, inputs):
         self.ov_model._model_exists_or_err()

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -94,7 +94,7 @@ class BF16Model(AcceleratedLightningModule):
         # automatically unwrap attributes access of model
         try:
             return super().__getattr__(name)
-        except:
+        except AttributeError:
             try:
                 return getattr(self.model, name)
             except AttributeError:

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -19,7 +19,6 @@ from logging import warning
 import torch
 import os
 from bigdl.nano.utils.inference.pytorch.model import AcceleratedLightningModule
-from bigdl.nano.utils.inference.pytorch.model import AcceleratedModel
 from bigdl.nano.utils.log4Error import invalidInputError
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10, TORCH_VERSION_LESS_1_12
 from bigdl.nano.utils import CPUInfo
@@ -43,7 +42,6 @@ class BF16Model(AcceleratedLightningModule):
         :param thread_num: the thread num allocated for this model.
         """
         super().__init__(model)
-        self._is_bf16 = None
         self._bf16_check()
         self.model = model  # use mixed precision instead of complete precision
         self.channels_last = channels_last

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -95,10 +95,7 @@ class BF16Model(AcceleratedLightningModule):
         try:
             return super().__getattr__(name)
         except AttributeError:
-            try:
-                return getattr(self.model, name)
-            except AttributeError:
-                pass
+            return getattr(self.model, name)
 
     def on_forward_start(self, inputs):
         return inputs

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -91,7 +91,11 @@ class BF16Model(AcceleratedLightningModule):
         return max_bf16_isa
 
     def __getattr__(self, name: str):
-        # automatically unwrap attributes access of model
+        # the search order is:
+        # 1. current instance, like channels_last will be found at this place
+        # 2. super class, like model will be found at this place
+        # 3. original model, like additional attributes of original model
+        #    will be found at this place
         try:
             return super().__getattr__(name)
         except AttributeError:

--- a/python/nano/src/bigdl/nano/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/pytorch/utils.py
@@ -179,7 +179,13 @@ def load_model(path, model: pl.LightningModule = None, inplace=False):
                           " loading.".format(model_type, type(model)))
 
 
-def patch_attrs_from_model_to_object(model, instance):
+def patch_attrs_from_model_to_object(model: nn.Module, instance):
+    '''
+    Patch non nn.Module public attributes of original nn.Module to a new instance.
+    
+    :param model: a torch.nn.Module
+    :param instance: a instance of any object
+    '''
     for attr in dir(model):
         if attr not in dir(instance) and not attr.startswith('_') and not\
                 isinstance(getattr(model, attr), torch.nn.Module):

--- a/python/nano/src/bigdl/nano/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/pytorch/utils.py
@@ -182,7 +182,7 @@ def load_model(path, model: pl.LightningModule = None, inplace=False):
 def patch_attrs_from_model_to_object(model: nn.Module, instance):
     '''
     Patch non nn.Module public attributes of original nn.Module to a new instance.
-    
+
     :param model: a torch.nn.Module
     :param instance: a instance of any object
     '''

--- a/python/nano/src/bigdl/nano/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/pytorch/utils.py
@@ -177,3 +177,10 @@ def load_model(path, model: pl.LightningModule = None, inplace=False):
         invalidInputError(False,
                           "ModelType {} or argument 'model={}' is not acceptable for pytorch"
                           " loading.".format(model_type, type(model)))
+
+
+def patch_attrs_from_model_to_object(model, instance):
+    for attr in dir(model):
+        if attr not in dir(instance) and not attr.startswith('_') and not\
+                isinstance(getattr(model, attr), torch.nn.Module):
+            setattr(instance, attr, getattr(model, attr))

--- a/python/nano/src/bigdl/nano/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/pytorch/utils.py
@@ -180,12 +180,12 @@ def load_model(path, model: pl.LightningModule = None, inplace=False):
 
 
 def patch_attrs_from_model_to_object(model: nn.Module, instance):
-    '''
+    """
     Patch non nn.Module public attributes of original nn.Module to a new instance.
 
     :param model: a torch.nn.Module
     :param instance: a instance of any object
-    '''
+    """
     for attr in dir(model):
         if attr not in dir(instance) and not attr.startswith('_') and not\
                 isinstance(getattr(model, attr), torch.nn.Module):

--- a/python/nano/test/onnx/pytorch/test_inc_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_inc_onnx.py
@@ -25,8 +25,6 @@ from torch import nn
 from torch.utils.data import TensorDataset, DataLoader
 import torchmetrics
 
-import numpy as np
-
 from bigdl.nano.pytorch import Trainer
 from bigdl.nano.pytorch import InferenceOptimizer
 from bigdl.nano.pytorch.vision.models import vision
@@ -129,7 +127,7 @@ class TestOnnx(TestCase):
 
         for x, y in train_loader:
             forward_res = loaded_onnx_model(x)
-    
+
     def test_trainer_compile_with_onnx_quantize_customized_collate_fn(self):
         model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
         loss = nn.CrossEntropyLoss()
@@ -173,7 +171,7 @@ class TestOnnx(TestCase):
         for x, y in train_loader:
             forward_res = loaded_onnx_model(x)
 
-    def text_onnx_quantize_context_manager(self):
+    def test_trainer_compile_with_onnx_quantize_context_manager(self):
         model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
         loss = nn.CrossEntropyLoss()
         optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
@@ -194,8 +192,10 @@ class TestOnnx(TestCase):
                                                  thread_num=2)
         with InferenceOptimizer.get_context(onnx_model):
             assert torch.get_num_threads() == 2
+            x = torch.rand((2, 3, 256, 256))
             output = onnx_model(x)
-        
+            assert output.shape == (2, 10)
+
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(onnx_model, tmp_dir_name)
             model = InferenceOptimizer.load(tmp_dir_name)
@@ -204,7 +204,7 @@ class TestOnnx(TestCase):
             assert torch.get_num_threads() == 2
             output = model(x)
 
-    def text_onnx_quantize_additional_attributes(self):
+    def test_trainer_compile_with_onnx_quantize_additional_attributes(self):
         model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
         loss = nn.CrossEntropyLoss()
         optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
@@ -231,7 +231,9 @@ class TestOnnx(TestCase):
                                                  thread_num=2)
         with InferenceOptimizer.get_context(onnx_model):
             assert torch.get_num_threads() == 2
+            x = torch.rand((2, 3, 256, 256))
             output = onnx_model(x)
+            assert output.shape == (2, 10)
 
         assert onnx_model.channels == 3
         onnx_model.hello()

--- a/python/nano/test/onnx/pytorch/test_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_onnx.py
@@ -176,6 +176,39 @@ class TestOnnx(TestCase):
         with InferenceOptimizer.get_context(model):
             assert torch.get_num_threads() == 1
             output = onnx_model(x)
+    
+    def test_onnx_additional_attributes(self):
+        model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
+        loss = nn.CrossEntropyLoss()
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+        trainer = Trainer(max_epochs=1)
+
+        pl_model = Trainer.compile(model, loss, optimizer)
+        x = torch.rand((10, 3, 256, 256))
+        y = torch.ones((10, ), dtype=torch.long)
+        ds = TensorDataset(x, y)
+        train_loader = DataLoader(ds, batch_size=2)
+        trainer.fit(pl_model, train_loader)
+        # patch a attribute
+        pl_model.channels = 3
+        def hello():
+            print("hello world!")
+        # patch a function
+        pl_model.hello = hello
+
+        onnx_model = InferenceOptimizer.trace(pl_model,
+                                              accelerator="onnxruntime",
+                                              input_sample=train_loader,
+                                              thread_num=1)
+
+        with InferenceOptimizer.get_context(onnx_model):
+            assert torch.get_num_threads() == 1
+            output = onnx_model(x)
+
+        assert onnx_model.channels == 3
+        onnx_model.hello()
+        with pytest.raises(AttributeError):
+            onnx_model.width
 
 
 if __name__ == '__main__':

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -22,6 +22,7 @@ import torch
 from torch.utils.data.dataset import TensorDataset
 from torch.utils.data.dataloader import DataLoader
 import tempfile
+import pytest
 
 
 class TestOpenVINO(TestCase):
@@ -115,7 +116,7 @@ class TestOpenVINO(TestCase):
         ds = TensorDataset(x, y)
         dataloader = DataLoader(ds, batch_size=2)
 
-        openvino_model = InferenceOptimizer.quantize(model, 
+        openvino_model = InferenceOptimizer.quantize(model,
                                                      accelerator='openvino',
                                                      calib_data=dataloader,
                                                      metric=F1(10),
@@ -132,3 +133,32 @@ class TestOpenVINO(TestCase):
         with InferenceOptimizer.get_context(model):
             assert torch.get_num_threads() == 2
             y2 = model(x[0:1])
+
+    def test_pytorch_openvino_model_additional_attrs(self):
+        model = mobilenet_v3_small(num_classes=10)
+        # patch a attribute
+        model.channels = 3
+        def hello():
+            print("hello world!")
+        # patch a function
+        model.hello = hello
+
+        x = torch.rand((10, 3, 256, 256))
+        y = torch.ones((10, ), dtype=torch.long)
+
+        ds = TensorDataset(x, y)
+        dataloader = DataLoader(ds, batch_size=2)
+
+        openvino_model = InferenceOptimizer.quantize(model,
+                                                     accelerator='openvino',
+                                                     calib_data=dataloader,
+                                                     metric=F1(10),
+                                                     thread_num=2)
+        assert openvino_model.channels == 3
+        openvino_model.hello()
+        with pytest.raises(AttributeError):
+            openvino_model.width
+
+        with InferenceOptimizer.get_context(openvino_model):
+            assert torch.get_num_threads() == 2
+            y1 = openvino_model(x[0:1])

--- a/python/nano/test/pytorch/tests/test_bf16.py
+++ b/python/nano/test/pytorch/tests/test_bf16.py
@@ -151,6 +151,34 @@ class Pytorch1_12:
         assert y_hat2.shape == (10, 10) and y_hat2.dtype == torch.bfloat16
         assert y_hat1.equal(y_hat2)
 
+    def test_model_attr(self):
+        model = resnet18(num_classes=10)
+        x = torch.rand((10, 3, 256, 256))
+        # patch a attribute
+        model.channels = 3
+        def hello():
+            print("hello world!")
+        # patch a function
+        model.hello = hello
+
+        # test bf16
+        bf16_model = InferenceOptimizer.quantize(model,
+                                                 precision='bf16')
+        with InferenceOptimizer.get_context(bf16_model):
+            y_hat1 = bf16_model(x)
+        assert y_hat1.shape == (10, 10) and y_hat1.dtype == torch.bfloat16
+        assert bf16_model.channels == 3
+        bf16_model.hello()
+
+        # test bf16 + channels_last
+        bf16_model = InferenceOptimizer.quantize(model, precision='bf16',
+                                                 channels_last=True)
+        with InferenceOptimizer.get_context(bf16_model):
+            y_hat1 = bf16_model(x)
+        assert y_hat1.shape == (10, 10) and y_hat1.dtype == torch.bfloat16
+        assert bf16_model.channels == 3
+        bf16_model.hello()
+
 
 TORCH_VERSION_CLS = Pytorch1_12
 if TORCH_VERSION_LESS_1_12:

--- a/python/nano/test/pytorch/tests/test_bf16.py
+++ b/python/nano/test/pytorch/tests/test_bf16.py
@@ -178,6 +178,8 @@ class Pytorch1_12:
         assert y_hat1.shape == (10, 10) and y_hat1.dtype == torch.bfloat16
         assert bf16_model.channels == 3
         bf16_model.hello()
+        with pytest.raises(AttributeError):
+            bf16_model.width
 
 
 TORCH_VERSION_CLS = Pytorch1_12

--- a/python/nano/test/pytorch/tests/test_bf16.py
+++ b/python/nano/test/pytorch/tests/test_bf16.py
@@ -151,7 +151,7 @@ class Pytorch1_12:
         assert y_hat2.shape == (10, 10) and y_hat2.dtype == torch.bfloat16
         assert y_hat1.equal(y_hat2)
 
-    def test_model_attr(self):
+    def test_bf16_additional_attrs(self):
         model = resnet18(num_classes=10)
         x = torch.rand((10, 3, 256, 256))
         # patch a attribute

--- a/python/nano/test/pytorch/tests/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/test_bf16_ipex.py
@@ -129,22 +129,22 @@ class Pytorch1_11:
                                              accelerator="jit", use_ipex=True,
                                              input_sample=x)
         with InferenceOptimizer.get_context(new_model):
-            new_model(self.data_sample)
+            new_model(x)
         assert new_model.channels == 3
         new_model.hello()
 
         new_model = InferenceOptimizer.trace(model, precision='bf16',
                                              accelerator="jit",
-                                             input_sample=self.data_sample)
+                                             input_sample=x)
         with InferenceOptimizer.get_context(new_model):
-            new_model(self.data_sample)
+            new_model(x)
         assert new_model.channels == 3
         new_model.hello()
 
         new_model = InferenceOptimizer.trace(model, precision='bf16',
                                              use_ipex=True)
         with InferenceOptimizer.get_context(new_model):
-            new_model(self.data_sample)
+            new_model(x)
         assert new_model.channels == 3
         new_model.hello()
 

--- a/python/nano/test/pytorch/tests/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/test_bf16_ipex.py
@@ -79,7 +79,6 @@ class Pytorch1_11:
 
     def test_bf16_ipex_save_load(self):
         model = resnet18(num_classes=10)
-
         x = torch.rand((10, 3, 256, 256))
         bf16_model = InferenceOptimizer.quantize(model, precision='bf16',
                                                  use_ipex=True)
@@ -99,7 +98,6 @@ class Pytorch1_11:
 
     def test_bf16_ipex_jit_save_load(self):
         model = resnet18(num_classes=10)
-
         x = torch.rand((10, 3, 256, 256))
         bf16_model = InferenceOptimizer.quantize(model, precision='bf16',
                                                  use_ipex=True, accelerator="jit",
@@ -117,6 +115,38 @@ class Pytorch1_11:
             y_hat_ = load_model(x)
         assert y_hat_.shape == (10, 10) and y_hat_.dtype == torch.bfloat16
         assert y_hat.equal(y_hat_)
+
+    def test_bf16_ipex_jit_additional_attrs(self):
+        model = resnet18(num_classes=10)
+        x = torch.rand((10, 3, 256, 256))
+        #  patch a attr
+        model.channels = 3
+        def hello():
+            print("hello world!")
+        # patch a function
+        model.hello = hello
+        new_model = InferenceOptimizer.trace(model, precision='bf16',
+                                             accelerator="jit", use_ipex=True,
+                                             input_sample=x)
+        with InferenceOptimizer.get_context(new_model):
+            new_model(self.data_sample)
+        assert new_model.channels == 3
+        new_model.hello()
+
+        new_model = InferenceOptimizer.trace(model, precision='bf16',
+                                             accelerator="jit",
+                                             input_sample=self.data_sample)
+        with InferenceOptimizer.get_context(new_model):
+            new_model(self.data_sample)
+        assert new_model.channels == 3
+        new_model.hello()
+
+        new_model = InferenceOptimizer.trace(model, precision='bf16',
+                                             use_ipex=True)
+        with InferenceOptimizer.get_context(new_model):
+            new_model(self.data_sample)
+        assert new_model.channels == 3
+        new_model.hello()
 
 
 TORCH_VERSION_CLS = Pytorch1_11

--- a/python/nano/test/pytorch/tests/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/test_bf16_ipex.py
@@ -147,6 +147,8 @@ class Pytorch1_11:
             new_model(x)
         assert new_model.channels == 3
         new_model.hello()
+        with pytest.raises(AttributeError):
+            new_model.width
 
 
 TORCH_VERSION_CLS = Pytorch1_11

--- a/python/nano/test/pytorch/tests/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/test_ipex_jit_inference.py
@@ -90,6 +90,8 @@ class IPEXJITInference_gt_1_10:
             print("hello world!")
         # patch a function
         model.hello = hello
+        
+        # test jit + ipex
         new_model = InferenceOptimizer.trace(model, accelerator="jit",
                                              use_ipex=True,
                                              input_sample=self.data_sample)
@@ -98,14 +100,25 @@ class IPEXJITInference_gt_1_10:
         assert new_model.channels == 3
         new_model.hello()
 
+        # test jit
         new_model = InferenceOptimizer.trace(model, accelerator="jit",
                                              input_sample=self.data_sample)
         with InferenceOptimizer.get_context(new_model):
             new_model(self.data_sample)
         assert new_model.channels == 3
         new_model.hello()
-        
+
+        # test ipex
         new_model = InferenceOptimizer.trace(model, use_ipex=True)
+        with InferenceOptimizer.get_context(new_model):
+            new_model(self.data_sample)
+        assert new_model.channels == 3
+        new_model.hello()
+        with pytest.raises(AttributeError):
+            new_model.width
+        
+        # test channels_last
+        new_model = InferenceOptimizer.trace(model, channels_last=True)
         with InferenceOptimizer.get_context(new_model):
             new_model(self.data_sample)
         assert new_model.channels == 3

--- a/python/nano/test/pytorch/tests/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/test_ipex_jit_inference.py
@@ -81,6 +81,35 @@ class IPEXJITInference_gt_1_10:
             new_model = InferenceOptimizer.load(tmp_dir_name)
         with InferenceOptimizer.get_context(new_model):
             new_model(self.data_sample)
+    
+    def test_ipex_jit_inference_additional_attrs(self):
+        model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
+        #  patch a attr
+        model.channels = 3
+        def hello():
+            print("hello world!")
+        # patch a function
+        model.hello = hello
+        new_model = InferenceOptimizer.trace(model, accelerator="jit",
+                                             use_ipex=True,
+                                             input_sample=self.data_sample)
+        with InferenceOptimizer.get_context(new_model):
+            new_model(self.data_sample)
+        assert new_model.channels == 3
+        new_model.hello()
+
+        new_model = InferenceOptimizer.trace(model, accelerator="jit",
+                                             input_sample=self.data_sample)
+        with InferenceOptimizer.get_context(new_model):
+            new_model(self.data_sample)
+        assert new_model.channels == 3
+        new_model.hello()
+        
+        new_model = InferenceOptimizer.trace(model, use_ipex=True)
+        with InferenceOptimizer.get_context(new_model):
+            new_model(self.data_sample)
+        assert new_model.channels == 3
+        new_model.hello()
 
     def test_ipex_jit_inference_strict(self):
         model = InferenceOptimizer.trace(self.model, accelerator="jit",

--- a/python/nano/test/pytorch/tests/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/test_ipex_jit_inference.py
@@ -110,6 +110,8 @@ class IPEXJITInference_gt_1_10:
             new_model(self.data_sample)
         assert new_model.channels == 3
         new_model.hello()
+        with pytest.raises(AttributeError):
+            new_model.width
 
     def test_ipex_jit_inference_strict(self):
         model = InferenceOptimizer.trace(self.model, accelerator="jit",


### PR DESCRIPTION
## Description

During OOB, we found that model's attributes will be losing after applying `InferenceOptimizer.trace` / `InferenceOptimizer.quantize`, as model becomes an attribute of AcceleratedModel, and we can't get original model's attribute directly.

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/228

### 2. User API changes

No change. But now, after `InferenceOptimizer.trace` / `InferenceOptimizer.quantize`, user can still use original attributes / methods, like following:
```python
model = resnet18(num_classes=10)
x = torch.rand((10, 3, 256, 256))
#  patch a attr
model.channels = 3
def hello():
    print("hello world!")
# patch a function
model.hello = hello

new_model = InferenceOptimizer.trace(model, precision='bf16',
                                     accelerator="jit", use_ipex=True,
                                     input_sample=x)
with InferenceOptimizer.get_context(new_model):
    new_model(self.data_sample)
assert new_model.channels == 3
new_model.hello()
```

### 3. Summary of the change 

- support getattr from original model for BF16Model
- support getattr from original model for PytorchIPEXJITModel
- add related ut for above features

### 4. How to test?
- [x] Unit test
- [x] Application test

