### PR TITLE
Update ncf example

### DIFF
--- a/python/friesian/example/ncf/ncf_train.py
+++ b/python/friesian/example/ncf/ncf_train.py
@@ -139,7 +139,6 @@ if __name__ == '__main__':
         import tensorflow as tf
 
         model = build_model(num_users, num_items, 5)
-        print(model.summary())
         optimizer = tf.keras.optimizers.Adam(config["lr"])
         model.compile(optimizer=optimizer,
                       loss='sparse_categorical_crossentropy',
@@ -150,7 +149,6 @@ if __name__ == '__main__':
     val_steps = math.ceil(test.size() / args.batch_size)
 
     estimator = Estimator.from_keras(model_creator=model_creator,
-                                     verbose=False,
                                      config=config,
                                      backend=args.backend,
                                      model_dir=args.model_dir)
@@ -162,11 +160,17 @@ if __name__ == '__main__':
                   steps_per_epoch=steps_per_epoch,
                   validation_data=test.df,
                   validation_steps=val_steps)
+    result = estimator.evaluate(test.df,
+                                batch_size=args.batch_size,
+                                feature_cols=['user', 'item'],
+                                label_cols=['label'],
+                                num_steps=val_steps)
+    print('Evaluation results:', result)
 
     predictions = estimator.predict(test.df,
                                     batch_size=args.batch_size,
                                     feature_cols=['user', 'item'])
-    print("Predictions on validation dataset:")
+    print("Predictions on the validation dataset:")
     predictions.show(5, truncate=False)
 
     print("Saving model to: ", save_path)

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -60,7 +60,7 @@ def find_free_port():
 
 
 def _try_import_strategy():
-    """Late import for Tesnorflow"""
+    """Late import for TensorFlow"""
     import tensorflow as tf
     return tf.distribute.experimental.MultiWorkerMirroredStrategy
 


### PR DESCRIPTION
1. Add evaluate
2. Remove print in model_creator as model_creator would be invoked by predict multiples, not recommended to print