### PR TITLE
Nano: Add `inplace` parameter to support model which cannot be copied

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
@@ -35,7 +35,8 @@ def ipex_device():
 
 
 def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
-                        use_jit=False, channels_last=None, thread_num=None):
+                        use_jit=False, channels_last=None, thread_num=None,
+                        inplace=False):
     '''
     :param model: the model(nn.module) to be transform.
     :param input_sample: torch tensor indicate the data sample to be used
@@ -45,15 +46,16 @@ def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
     :param channels_last: if set model and data to be channels-last mode.
             the parameter will be ignored if use_ipex is False.
     :param thread_num: the thread num allocated for this model.
+    :param inplace: whether to perform inplace optimization. Default: ``False``.
     '''
     from .ipex_inference_model import PytorchIPEXJITModel
     return PytorchIPEXJITModel(model, input_sample=input_sample, use_ipex=use_ipex,
                                use_jit=use_jit, channels_last=channels_last,
-                               thread_num=thread_num)
+                               thread_num=thread_num, inplace=inplace)
 
 
 def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
-                            use_jit=False, channels_last=None, thread_num=None):
+                            use_jit=False, channels_last=None, thread_num=None, inplace=False):
     '''
     :param model: the model(nn.module) to be transform.
     :param input_sample: torch tensor indicate the data sample to be used
@@ -63,18 +65,19 @@ def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
     :param channels_last: if set model and data to be channels-last mode.
             the parameter will be ignored if use_ipex is False.
     :param thread_num: the thread num allocated for this model.
+    :param inplace: whether to perform inplace optimization. Default: ``False``.
     '''
     from .ipex_inference_bf16_model import PytorchIPEXJITBF16Model
     return PytorchIPEXJITBF16Model(model, input_sample=input_sample, use_ipex=use_ipex,
                                    use_jit=use_jit, channels_last=channels_last,
-                                   thread_num=thread_num)
+                                   thread_num=thread_num, inplace=inplace)
 
 
-def load_ipexjit_model(path, model):
+def load_ipexjit_model(path, model, inplace=False):
     from .ipex_inference_model import PytorchIPEXJITModel
-    return PytorchIPEXJITModel._load(path, model)
+    return PytorchIPEXJITModel._load(path, model, inplace=inplace)
 
 
-def load_ipexjitbf16_model(path, model):
+def load_ipexjitbf16_model(path, model, inplace=False):
     from .ipex_inference_bf16_model import PytorchIPEXJITBF16Model
-    return PytorchIPEXJITBF16Model._load(path, model)
+    return PytorchIPEXJITBF16Model._load(path, model, inplace=inplace)

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -25,7 +25,8 @@ import torch
 
 class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
     def __init__(self, model, input_sample=None, use_ipex=False,
-                 use_jit=False, channels_last=None, thread_num=None, from_load=False):
+                 use_jit=False, channels_last=None, thread_num=None, from_load=False,
+                 inplace=False):
         '''
         This is the accelerated model for pytorch and ipex/jit.
         All the external API is based on Trainer, so what we have here is
@@ -42,6 +43,7 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
                the parameter will be ignored if use_ipex is False.
         :param thread_num: the thread num allocated for this model.
         :param from_load: this will only be set by _load method.
+        :param inplace: whether to perform inplace optimization. Default: ``False``.
         '''
         if use_ipex:
             invalidInputError(
@@ -52,10 +54,12 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
 
         PytorchIPEXJITModel.__init__(self, model, input_sample=input_sample, use_ipex=use_ipex,
                                      dtype=torch.bfloat16, use_jit=use_jit,
-                                     channels_last=channels_last, from_load=from_load)
+                                     channels_last=channels_last, from_load=from_load,
+                                     inplace=inplace)
         self.context_manager = generate_context_manager(accelerator=None,
                                                         precision="bf16",
                                                         thread_num=thread_num)
+
 
     @property
     def _check_cpu_isa(self):
@@ -70,7 +74,7 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         return status
 
     @staticmethod
-    def _load(path, model):
+    def _load(path, model, inplace=False):
         status = PytorchIPEXJITBF16Model._load_status(path)
         checkpoint_path = path / status['checkpoint']
         if status["use_jit"]:
@@ -92,4 +96,5 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
                                        use_jit=status['use_jit'],
                                        channels_last=status['channels_last'],
                                        from_load=from_load,
-                                       thread_num=thread_num)
+                                       thread_num=thread_num,
+                                       inplace=inplace)

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -60,7 +60,6 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
                                                         precision="bf16",
                                                         thread_num=thread_num)
 
-
     @property
     def _check_cpu_isa(self):
         """Indicator to verify if cpu supports avx512"""

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -17,7 +17,6 @@
 import torch
 from torch import nn
 import time
-from copy import deepcopy
 import multiprocessing as mp
 from typing import Dict, Callable, Tuple, Optional, List, Union, Sequence
 from torch.utils.data import DataLoader
@@ -640,9 +639,6 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 model which is able to run on Pytorch or ONNXRuntime can be fetched by
                 `quantized_model.model`.
                 """
-                # deepcopy model when using int8 quantize and inplace=False
-                if accelerator is None and not inplace:
-                    model = deepcopy(model)
                 return inc_quantize(model, inc_calib_dataloader, metric,
                                     thread_num=thread_num,
                                     framework=framework,

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -76,7 +76,7 @@ class TorchAccelerationOption(AccelerationOption):
             # quantize
             ort_method: str = self.method
             acce_model = \
-                InferenceOptimizer.quantize(model=deepcopy(model),
+                InferenceOptimizer.quantize(model=model,
                                             precision=self.get_precision(),
                                             accelerator=accelerator,
                                             use_ipex=self.ipex,
@@ -470,6 +470,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                  simplification: bool = True,
                  sample_size: int = 100,
                  logging: bool = True,
+                 inplace: bool = False,
                  **export_kwargs):
         """
         Calibrate a torch.nn.Module for post-training quantization.
@@ -550,6 +551,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                             the lower the performance degradation, but the longer the time.
         :param logging: whether to log detailed information of model conversion, only valid when
                         accelerator='openvino', otherwise will be ignored. Default: ``True``.
+        :param inplace: whether to perform inplace optimization. Default: ``False``.
         :param **export_kwargs: will be passed to torch.onnx.export function.
         :return:            A accelerated torch.nn.Module if quantization is sucessful.
         """
@@ -563,7 +565,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                     return PytorchIPEXJITBF16Model(model, input_sample=input_sample,
                                                    use_ipex=use_ipex, use_jit=use_jit,
                                                    channels_last=channels_last,
-                                                   thread_num=thread_num)
+                                                   thread_num=thread_num, inplace=inplace)
                 else:
                     bf16_model = BF16Model(model, channels_last=channels_last)
                     return bf16_model
@@ -638,6 +640,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 model which is able to run on Pytorch or ONNXRuntime can be fetched by
                 `quantized_model.model`.
                 """
+                # deepcopy model when using int8 quantize and inplace=False
+                if accelerator is None and not inplace:
+                    model = deepcopy(model)
                 return inc_quantize(model, inc_calib_dataloader, metric,
                                     thread_num=thread_num,
                                     framework=framework,
@@ -704,6 +709,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
               openvino_config=None,
               simplification: bool = True,
               logging: bool = True,
+              inplace: bool = False,
               **export_kwargs):
         """
         Trace a torch.nn.Module and convert it into an accelerated module for inference.
@@ -732,9 +738,11 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                is set to True, new dependency 'onnxsim' need to be installed.
         :param logging: Whether to log detailed information of model conversion, only valid when
                         accelerator='openvino', otherwise will be ignored. Default: ``True``.
-        :param **kwargs: Other extra advanced settings include those be passed to torch.onnx.export
-                         function, only valid when accelerator='onnxruntime'/'openvino', otherwise
-                         will be ignored.
+        :param inplace: whether to perform inplace optimization. Default: ``False``.
+        :param **export_kwargs: Other extra advanced settings include those be passed to
+                                torch.onnx.export function, only valid when
+                                accelerator='onnxruntime'/'openvino', otherwise
+                                will be ignored.
         :return: Model with different acceleration.
         """
         invalidInputError(
@@ -764,7 +772,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             use_jit = (accelerator == "jit")
             return PytorchIPEXJITModel(model, input_sample=input_sample, use_ipex=use_ipex,
                                        use_jit=use_jit, channels_last=channels_last,
-                                       thread_num=thread_num)
+                                       thread_num=thread_num, inplace=inplace)
         invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))
 
     @staticmethod
@@ -792,7 +800,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         save_model(model, path)
 
     @staticmethod
-    def load(path, model: Optional[nn.Module] = None):
+    def load(path, model: Optional[nn.Module] = None, inplace=False):
         """
         Load a model from local.
 
@@ -801,10 +809,11 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                the model with accelerator=None by InferenceOptimizer.trace/
                InferenceOptimizer.quantize. model should be set to None if you choose
                accelerator="onnxruntime"/"openvino"/"jit".
+        :param inplace: whether to perform inplace optimization. Default: ``False``.
         :return: Model with different acceleration(None/OpenVINO/ONNX Runtime/JIT) or
                  precision(FP32/FP16/BF16/INT8).
         """
-        return load_model(path, model)
+        return load_model(path, model, inplace=inplace)
 
     @staticmethod
     def to_multi_instance(model: nn.Module, num_processes: int) -> _MultiInstanceModel:

--- a/python/nano/src/bigdl/nano/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/pytorch/utils.py
@@ -147,8 +147,6 @@ def load_model(path, model: pl.LightningModule = None, inplace=False):
                           "Argument 'model' must be None for ONNX Runtime loading.")
         return load_onnxruntime_model(path)
     if model_type == 'PytorchQuantizedModel':
-        if not inplace:
-            model = copy.deepcopy(model)
         return load_inc_model(path, model, 'pytorch')
     if model_type == 'PytorchIPEXJITModel':
         return load_ipexjit_model(path, model, inplace=inplace)

--- a/python/nano/src/bigdl/nano/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/pytorch/utils.py
@@ -117,7 +117,7 @@ def save_model(model: pl.LightningModule, path):
         torch.save(model.state_dict(), checkpoint_path)
 
 
-def load_model(path, model: pl.LightningModule = None):
+def load_model(path, model: pl.LightningModule = None, inplace=False):
     """
     Load a model from local.
 
@@ -125,6 +125,7 @@ def load_model(path, model: pl.LightningModule = None):
     :param model: Required FP32 model to load pytorch model, it is needed if you accelerated
             the model with accelerator=None by Trainer.trace/Trainer.quantize. model
             should be set to None if you choose accelerator="onnxruntime"/"openvino"/"jit".
+    :param inplace: whether to perform inplace optimization. Default: ``False``.
     :return: Model with different acceleration(None/OpenVINO/ONNX Runtime/JIT) or
                 precision(FP32/FP16/BF16/INT8).
     """
@@ -146,11 +147,13 @@ def load_model(path, model: pl.LightningModule = None):
                           "Argument 'model' must be None for ONNX Runtime loading.")
         return load_onnxruntime_model(path)
     if model_type == 'PytorchQuantizedModel':
+        if not inplace:
+            model = copy.deepcopy(model)
         return load_inc_model(path, model, 'pytorch')
     if model_type == 'PytorchIPEXJITModel':
-        return load_ipexjit_model(path, model)
+        return load_ipexjit_model(path, model, inplace=inplace)
     if model_type == 'PytorchIPEXJITBF16Model':
-        return load_ipexjitbf16_model(path, model)
+        return load_ipexjitbf16_model(path, model, inplace=inplace)
     if model_type == 'BF16Model':
         return load_bf16_model(path, model)
     if isinstance(model, nn.Module):

--- a/python/nano/test/pytorch/tests/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/test_inference_optimizer.py
@@ -472,9 +472,6 @@ class TestInferencePipeline(TestCase):
                 invalidOperationError(False, "The `deepcopy` function shouldn't be called")
 
         inference_opt = InferenceOptimizer()
-        # int8
-        model = CannotCopyNet()
-        int8_model = inference_opt.quantize(model, calib_data=self.train_loader, inplace=True)
         # bf16+ipex
         model = CannotCopyNet()
         bf16_ipex_model = inference_opt.quantize(model, calib_data=self.train_loader, precision='bf16', use_ipex=True, inplace=True)
@@ -482,10 +479,8 @@ class TestInferencePipeline(TestCase):
         model = CannotCopyNet()
         ipex_model = inference_opt.trace(model, input_sample=self.train_loader, use_ipex=True, inplace=True)
 
-        inference_opt.save(int8_model, "int8")
         inference_opt.save(bf16_ipex_model, "bf16_ipex")
         inference_opt.save(ipex_model, "ipex")
 
-        int8_model = inference_opt.load("int8", model, inplace=True)
         bf16_ipex_model = inference_opt.load("bf16_ipex", model, inplace=True)
         ipex_model = inference_opt.load("ipex", model, inplace=True)

--- a/python/nano/test/pytorch/tests/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/test_inference_optimizer.py
@@ -471,13 +471,15 @@ class TestInferencePipeline(TestCase):
             def __deepcopy__(self, memo):
                 invalidOperationError(False, "The `deepcopy` function shouldn't be called")
 
-        model = CannotCopyNet()
         inference_opt = InferenceOptimizer()
         # int8
+        model = CannotCopyNet()
         int8_model = inference_opt.quantize(model, calib_data=self.train_loader, inplace=True)
         # bf16+ipex
+        model = CannotCopyNet()
         bf16_ipex_model = inference_opt.quantize(model, calib_data=self.train_loader, precision='bf16', use_ipex=True, inplace=True)
         # ipex
+        model = CannotCopyNet()
         ipex_model = inference_opt.trace(model, input_sample=self.train_loader, use_ipex=True, inplace=True)
 
         inference_opt.save(int8_model, "int8")

--- a/python/nano/test/pytorch/tests/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/test_inference_optimizer.py
@@ -29,6 +29,7 @@ import torch.nn.functional as F
 from test.pytorch.utils._train_torch_lightning import create_data_loader
 from torch.utils.data import TensorDataset, DataLoader
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
+from bigdl.nano.utils.log4Error import invalidOperationError
 
 
 data_transform = transforms.Compose([
@@ -464,3 +465,25 @@ class TestInferencePipeline(TestCase):
         model, option = inference_opt.get_best_model()
         with InferenceOptimizer.get_context(model):
             pass
+
+    def test_inplace(self):
+        class CannotCopyNet(Net):
+            def __deepcopy__(self, memo):
+                invalidOperationError(False, "The `deepcopy` function shouldn't be called")
+
+        model = CannotCopyNet()
+        inference_opt = InferenceOptimizer()
+        # int8
+        int8_model = inference_opt.quantize(model, calib_data=self.train_loader, inplace=True)
+        # bf16+ipex
+        bf16_ipex_model = inference_opt.quantize(model, calib_data=self.train_loader, precision='bf16', use_ipex=True, inplace=True)
+        # ipex
+        ipex_model = inference_opt.trace(model, input_sample=self.train_loader, use_ipex=True, inplace=True)
+
+        inference_opt.save(int8_model, "int8")
+        inference_opt.save(bf16_ipex_model, "bf16_ipex")
+        inference_opt.save(ipex_model, "ipex")
+
+        int8_model = inference_opt.load("int8", model, inplace=True)
+        bf16_ipex_model = inference_opt.load("bf16_ipex", model, inplace=True)
+        ipex_model = inference_opt.load("ipex", model, inplace=True)


### PR DESCRIPTION
## Description

Add `inplace` parameter for `InferenceOptimizer.quantize`, `InferenceOptimizer.trace` and `InferenceOptimizer.load` to support models which cannot be copied

### 1. Why the change?

Some models cannot be copied, while IPEX will call `copy.deepcopy` if we don't pass `inpalce=False`, and now `InferenceOptimizer.optimize` will call `copy.deepcopy`, too

### 2. User API changes

`InferenceOptimizer.quantize`, `InferenceOptimizer.trace` and `InferenceOptimizer.load` now have an optional `inplace` parameter. If `inplace=True`, these functions won't call `copy.deepcopy` when tracing ipex model or quantizing int8 model.

### 3. Summary of the change 

- New added `inplace` parameter will be passed to IPEX
- int8 quantize now deepcopy model by default
- other quantize now won't deepcopy model

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

