### PR TITLE
Nano: Release m series for pypi nano

### DIFF
--- a/python/dev/release_default_mac.sh
+++ b/python/dev/release_default_mac.sh
@@ -39,6 +39,7 @@ upload=$2
 NANO_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/nano/dev; pwd)"
 echo $NANO_SCRIPT_DIR
 bash ${NANO_SCRIPT_DIR}/release_default_mac.sh ${version} ${upload}
+bash ${NANO_SCRIPT_DIR}/release_default_mac_m1.sh ${version} ${upload}
 # Serving has a universal jar for all platforms and spark versions and is released in the release_default_linux.sh.
 
 # Release default bigdl without suffix

--- a/python/dev/release_default_mac.sh
+++ b/python/dev/release_default_mac.sh
@@ -39,7 +39,7 @@ upload=$2
 NANO_SCRIPT_DIR="$(cd ${BIGDL_DIR}/python/nano/dev; pwd)"
 echo $NANO_SCRIPT_DIR
 bash ${NANO_SCRIPT_DIR}/release_default_mac.sh ${version} ${upload}
-bash ${NANO_SCRIPT_DIR}/release_default_mac_m1.sh ${version} ${upload}
+bash ${NANO_SCRIPT_DIR}/release_default_mac_mseries.sh ${version} ${upload}
 # Serving has a universal jar for all platforms and spark versions and is released in the release_default_linux.sh.
 
 # Release default bigdl without suffix

--- a/python/nano/dev/release.sh
+++ b/python/nano/dev/release.sh
@@ -46,6 +46,9 @@ if [ "$platform" ==  "mac" ]; then
     verbose_pname="macosx_10_11_x86_64"
     sed -i 's/intel-tensorflow/tensorflow/' $BIGDL_PYTHON_DIR/setup.py
 
+if [ "$platform" ==  "mac_m1" ]; then
+    verbose_pname="macosx_12_0_arm64"
+
 elif [ "$platform" == "linux" ]; then
     verbose_pname="manylinux2010_x86_64"
 

--- a/python/nano/dev/release.sh
+++ b/python/nano/dev/release.sh
@@ -46,7 +46,7 @@ if [ "$platform" ==  "mac" ]; then
     verbose_pname="macosx_10_11_x86_64"
     sed -i 's/intel-tensorflow/tensorflow/' $BIGDL_PYTHON_DIR/setup.py
 
-if [ "$platform" ==  "mac_m1" ]; then
+if [ "$platform" ==  "mac_mseries" ]; then
     verbose_pname="macosx_12_0_arm64"
 
 elif [ "$platform" == "linux" ]; then

--- a/python/nano/dev/release.sh
+++ b/python/nano/dev/release.sh
@@ -46,7 +46,7 @@ if [ "$platform" ==  "mac" ]; then
     verbose_pname="macosx_10_11_x86_64"
     sed -i 's/intel-tensorflow/tensorflow/' $BIGDL_PYTHON_DIR/setup.py
 
-if [ "$platform" ==  "mac_mseries" ]; then
+elif [ "$platform" ==  "mac_mseries" ]; then
     verbose_pname="macosx_12_0_arm64"
 
 elif [ "$platform" == "linux" ]; then

--- a/python/nano/dev/release_default_mac_m1.sh
+++ b/python/nano/dev/release_default_mac_m1.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
+echo $RUN_SCRIPT_DIR
+
+if (( $# < 2)); then
+  echo "Usage: release_default_mac_m1.sh version upload"
+  echo "Usage example: bash release_default_mac_m1.sh default true"
+  echo "Usage example: bash release_default_mac_m1.sh 0.14.0.dev1 true"
+  exit -1
+fi
+
+version=$1
+upload=$2
+
+bash ${RUN_SCRIPT_DIR}/release.sh mac_m1 ${version} ${upload}

--- a/python/nano/dev/release_default_mac_mseries.sh
+++ b/python/nano/dev/release_default_mac_mseries.sh
@@ -21,13 +21,13 @@ RUN_SCRIPT_DIR=$(cd $(dirname $0) ; pwd)
 echo $RUN_SCRIPT_DIR
 
 if (( $# < 2)); then
-  echo "Usage: release_default_mac_m1.sh version upload"
-  echo "Usage example: bash release_default_mac_m1.sh default true"
-  echo "Usage example: bash release_default_mac_m1.sh 0.14.0.dev1 true"
+  echo "Usage: release_default_mac_mseries.sh version upload"
+  echo "Usage example: bash release_default_mac_mseries.sh default true"
+  echo "Usage example: bash release_default_mac_mseries.sh 0.14.0.dev1 true"
   exit -1
 fi
 
 version=$1
 upload=$2
 
-bash ${RUN_SCRIPT_DIR}/release.sh mac_m1 ${version} ${upload}
+bash ${RUN_SCRIPT_DIR}/release.sh mac_mseries ${version} ${upload}


### PR DESCRIPTION
## Description

### 1. Why the change?
We need to release a whl for arm64 macos seperately.

### 2. User API changes
no

### 3. Summary of the change 
add release code for m-series chip.

### 4. How to test?
manual check by CI/CD team.
