### PR TITLE
Chronos: nightly test different install options on python3.8

### DIFF
--- a/.github/workflows/chronos-install-option-py38-test.yml
+++ b/.github/workflows/chronos-install-option-py38-test.yml
@@ -13,6 +13,8 @@ on:
     paths:
       - '.github/workflows/chronos-install-option-py38-test.yml'
   # Allows you to run this workflow manually from the Actions tab
+  schedule:
+    - cron: '0 18 * * *' # GMT time, 18:00 GMT == 02:00 China
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -47,6 +49,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos[pytorch]
+          pip install numpy==1.23.5
           bash python/chronos/dev/test/run-installation-options.sh "torch and not inference and not automl and not distributed and not diff_set_all"
           source deactivate
           conda remove -n chronos-py38-env -y --all


### PR DESCRIPTION
## Description

Chronos PR validation is only tested on python3.7. To support python3.8, we need nightly test.

### 2. User API changes

nothing

### 3. Summary of the change 

add trigger
limit numpy version to solve AttributeError

### 4. How to test?
- [x] Unit test
