### PR TITLE
Nano: fix abnormal accuracy of optimize in InferenceOptimizer

### DIFF
--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -87,7 +87,7 @@ def setup_package():
 
     pytorch_112_requires = ["torch==1.12.1",
                             "torchvision==0.13.1",
-                            "intel_extension_for_pytorch==1.12.100;platform_system!='Windows'"]
+                            "intel_extension_for_pytorch==1.12.300;platform_system!='Windows'"]
 
     pytorch_111_requires = ["torch==1.11.0",
                             "torchvision==0.12.0",

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -109,7 +109,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             "bf16_ipex_channels_last": TorchAccelerationOption(bf16=True, ipex=True,
                                                                channels_last=True),
             "int8": TorchAccelerationOption(inc=True),
-            "int8_ipex": TorchAccelerationOption(inc=True, method="ipex"),
+            "int8_ipex": TorchAccelerationOption(inc=True, method="ipex", ipex=True),
             "jit_fp32": TorchAccelerationOption(jit=True),
             "jit_fp32_channels_last": TorchAccelerationOption(jit=True,
                                                               channels_last=True),


### PR DESCRIPTION
## Description

Based on results of OOB and some feedback from customers, we found sometimes the output accuracy of `InferenceOptimizer.optmize` is very abnormal.
After some debugging, I found this bug only occurs after `import intel_extension_for_pytorch as ipex`.
In my test case, upgrading ipex to version 1.12.300 can solve this problem.


### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/215

### 2. User API changes

No change.

### 3. Summary of the change 

- fix abnormal accuracy of optimize by upgrade ipex to 1.12.300
- fix ipex option don't work for int8_ipex

### 4. How to test?
- [ ] Unit test
- [ ] Application test

