### PR TITLE
Nano: add new parameter for jit's strict mode

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
@@ -36,7 +36,7 @@ def ipex_device():
 
 def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
                         use_jit=False, channels_last=None, thread_num=None,
-                        inplace=False):
+                        inplace=False, jit_strict=True):
     '''
     :param model: the model(nn.module) to be transform.
     :param input_sample: torch tensor indicate the data sample to be used
@@ -47,15 +47,17 @@ def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
             the parameter will be ignored if use_ipex is False.
     :param thread_num: the thread num allocated for this model.
     :param inplace: whether to perform inplace optimization. Default: ``False``.
+    :param jit_strict: Whether recording your mutable container types.
     '''
     from .ipex_inference_model import PytorchIPEXJITModel
     return PytorchIPEXJITModel(model, input_sample=input_sample, use_ipex=use_ipex,
                                use_jit=use_jit, channels_last=channels_last,
-                               thread_num=thread_num, inplace=inplace)
+                               thread_num=thread_num, inplace=inplace, jit_strict=jit_strict)
 
 
 def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
-                            use_jit=False, channels_last=None, thread_num=None, inplace=False):
+                            use_jit=False, channels_last=None, thread_num=None,
+                            inplace=False, jit_strict=True):
     '''
     :param model: the model(nn.module) to be transform.
     :param input_sample: torch tensor indicate the data sample to be used
@@ -66,12 +68,12 @@ def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
             the parameter will be ignored if use_ipex is False.
     :param thread_num: the thread num allocated for this model.
     :param inplace: whether to perform inplace optimization. Default: ``False``.
+    :param jit_strict: Whether recording your mutable container types.
     '''
     from .ipex_inference_bf16_model import PytorchIPEXJITBF16Model
     return PytorchIPEXJITBF16Model(model, input_sample=input_sample, use_ipex=use_ipex,
                                    use_jit=use_jit, channels_last=channels_last,
-                                   thread_num=thread_num, inplace=inplace)
-
+                                   thread_num=thread_num, inplace=inplace, jit_strict=jit_strict)
 
 def load_ipexjit_model(path, model, inplace=False):
     from .ipex_inference_model import PytorchIPEXJITModel

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
@@ -75,6 +75,7 @@ def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
                                    use_jit=use_jit, channels_last=channels_last,
                                    thread_num=thread_num, inplace=inplace, jit_strict=jit_strict)
 
+
 def load_ipexjit_model(path, model, inplace=False):
     from .ipex_inference_model import PytorchIPEXJITModel
     return PytorchIPEXJITModel._load(path, model, inplace=inplace)

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -26,7 +26,7 @@ import torch
 class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
     def __init__(self, model, input_sample=None, use_ipex=False,
                  use_jit=False, channels_last=None, thread_num=None, from_load=False,
-                 inplace=False):
+                 inplace=False, jit_strict=True):
         '''
         This is the accelerated model for pytorch and ipex/jit.
         All the external API is based on Trainer, so what we have here is
@@ -44,6 +44,7 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         :param thread_num: the thread num allocated for this model.
         :param from_load: this will only be set by _load method.
         :param inplace: whether to perform inplace optimization. Default: ``False``.
+        :param jit_strict: Whether recording your mutable container types.
         '''
         if use_ipex:
             invalidInputError(
@@ -55,7 +56,7 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         PytorchIPEXJITModel.__init__(self, model, input_sample=input_sample, use_ipex=use_ipex,
                                      dtype=torch.bfloat16, use_jit=use_jit,
                                      channels_last=channels_last, from_load=from_load,
-                                     inplace=inplace)
+                                     inplace=inplace, jit_strict=jit_strict)
         self.context_manager = generate_context_manager(accelerator=None,
                                                         precision="bf16",
                                                         thread_num=thread_num)

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -467,6 +467,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                  onnxruntime_session_options=None,
                  openvino_config=None,
                  simplification: bool = True,
+                 jit_strict: bool = True,
                  sample_size: int = 100,
                  logging: bool = True,
                  inplace: bool = False,
@@ -543,6 +544,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :param simplification: whether we use onnxsim to simplify the ONNX model, only valid when
                                accelerator='onnxruntime', otherwise will be ignored. If this option
                                is set to True, new dependency 'onnxsim' need to be installed.
+        :param jit_strict: Whether recording your mutable container types. This parameter will be
+                           passed to torch.jit.trace. if accelerator != 'jit', it will be ignored.
+                           Default to True.
         :param sample_size: (optional) a int represents how many samples will be used for
                             Post-training Optimization Tools (POT) from OpenVINO toolkit,
                             only valid for accelerator='openvino'. Default to 100.
@@ -564,7 +568,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                     return PytorchIPEXJITBF16Model(model, input_sample=input_sample,
                                                    use_ipex=use_ipex, use_jit=use_jit,
                                                    channels_last=channels_last,
-                                                   thread_num=thread_num, inplace=inplace)
+                                                   thread_num=thread_num, inplace=inplace,
+                                                   jit_strict=jit_strict)
                 else:
                     bf16_model = BF16Model(model, channels_last=channels_last)
                     return bf16_model
@@ -704,6 +709,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
               onnxruntime_session_options=None,
               openvino_config=None,
               simplification: bool = True,
+              jit_strict: bool = True,
               logging: bool = True,
               inplace: bool = False,
               **export_kwargs):
@@ -732,6 +738,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :param simplification: Whether we use onnxsim to simplify the ONNX model, only valid when
                                accelerator='onnxruntime', otherwise will be ignored. If this option
                                is set to True, new dependency 'onnxsim' need to be installed.
+        :param jit_strict: Whether recording your mutable container types. This parameter will be
+                           passed to torch.jit.trace. if accelerator != 'jit', it will be ignored.
+                           Default to True.
         :param logging: Whether to log detailed information of model conversion, only valid when
                         accelerator='openvino', otherwise will be ignored. Default: ``True``.
         :param inplace: whether to perform inplace optimization. Default: ``False``.
@@ -768,7 +777,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             use_jit = (accelerator == "jit")
             return PytorchIPEXJITModel(model, input_sample=input_sample, use_ipex=use_ipex,
                                        use_jit=use_jit, channels_last=channels_last,
-                                       thread_num=thread_num, inplace=inplace)
+                                       thread_num=thread_num, inplace=inplace,
+                                       jit_strict=jit_strict)
         invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))
 
     @staticmethod

--- a/python/nano/test/pytorch/tests/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/test_ipex_jit_inference.py
@@ -82,6 +82,18 @@ class IPEXJITInference_gt_1_10:
         with InferenceOptimizer.get_context(new_model):
             new_model(self.data_sample)
 
+    def test_ipex_jit_inference_strict(self):
+        model = InferenceOptimizer.trace(self.model, accelerator="jit",
+                                         jit_strict=False, input_sample=self.data_sample)
+        with InferenceOptimizer.get_context(model):
+            model(self.data_sample)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(model, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name)
+        with InferenceOptimizer.get_context(new_model):
+            new_model(self.data_sample)
+            assert new_model.jit_strict is False
+
 
 class IPEXJITInference_lt_1_10:
     def test_placeholder(self):


### PR DESCRIPTION
## Description

### 1. Why the change?
We are adding more **optional** parameters for users to resolve the error they meet.
@Litchilitchy 

### 2. User API changes
```python
InferenceOptimizer.trace(accelerator="jit",...,  jit_strict=False)
InferenceOptimizer.quantize(accelerator="jit",..., jit_strict=False)
```

### 3. Summary of the change 
Add a parameter that will be passed to `torch.jit.trace`
https://pytorch.org/docs/stable/generated/torch.jit.trace.html

### 4. How to test?
- [ ] Unit test
