### PR TITLE
Nano: Remove bf16+ipex test from InferenceOptimizer UT

### DIFF
--- a/python/nano/test/pytorch/tests/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/test_inference_optimizer.py
@@ -472,15 +472,9 @@ class TestInferencePipeline(TestCase):
                 invalidOperationError(False, "The `deepcopy` function shouldn't be called")
 
         inference_opt = InferenceOptimizer()
-        # bf16+ipex
-        model = CannotCopyNet()
-        bf16_ipex_model = inference_opt.quantize(model, calib_data=self.train_loader, precision='bf16', use_ipex=True, inplace=True)
         # ipex
         model = CannotCopyNet()
         ipex_model = inference_opt.trace(model, input_sample=self.train_loader, use_ipex=True, inplace=True)
 
-        inference_opt.save(bf16_ipex_model, "bf16_ipex")
         inference_opt.save(ipex_model, "ipex")
-
-        bf16_ipex_model = inference_opt.load("bf16_ipex", model, inplace=True)
         ipex_model = inference_opt.load("ipex", model, inplace=True)


### PR DESCRIPTION
## Description

Remove bf16+ipex test from InferenceOptimizer UT: bf16+ipex requires `avx512` instruction, however, UT may run on machines without `avx512`.

