### PR TITLE
Nano: fix strange inference behaviour of jit+bf16

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -81,7 +81,8 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
                 import intel_extension_for_pytorch as ipex
             model = torch.jit.load(checkpoint_path)
             model.eval()
-            model = torch.jit.freeze(model)
+            if status["use_ipex"]:
+                model = torch.jit.freeze(model)
             from_load = True
         else:
             state_dict = torch.load(checkpoint_path)

--- a/python/nano/test/pytorch/tests/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/test_bf16_ipex.py
@@ -49,7 +49,7 @@ class Pytorch1_11:
         y = torch.ones((10,), dtype=torch.long)
 
         bf16_model = InferenceOptimizer.quantize(model, precision='bf16',
-                                                 acceleraot='jit',
+                                                 accelerator="jit",
                                                  input_sample=x)
         with InferenceOptimizer.get_context(bf16_model):
             for i in range(10):


### PR DESCRIPTION
## Description

During OOB, @MeouSker77 and @Oscilloscope98 found that `bf16 + jit` failed during multi-instance inference but has successful status in the results of `InferenceOptimizer.optimize`.
After some debugging, I found it was caused by wrong loading behaviour of `bf16 + jit`.

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/232

### 2. User API changes

No change.

### 3. Summary of the change 

- fix wrong loading behaviour of `bf16 + jit`
- add related ut

### 4. How to test?
- [x] Unit test
- [x] Application test


