### PR TITLE
Nano: a better support on openvino and onnxruntime for models whose forward args with default value

### DIFF
--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/model.py
@@ -44,6 +44,7 @@ class AcceleratedLightningModule(AcceleratedModel, LightningModule):
 
     @staticmethod
     def tensors_to_numpy(tensors):
+        # TODO: add more type transformation here
         np_data = tuple(map(
             lambda x: x.cpu().numpy() if isinstance(x, torch.Tensor) else x,
             tensors))

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
@@ -85,7 +85,7 @@ def get_tensor_args(model):
         # check if defaults is Tensor
         default_args_start_from = args_length - defaults_length
         if i >= default_args_start_from:
-            if type(forward_defaults[i-default_args_start_from]) == torch.Tensor:
+            if type(forward_defaults[i - default_args_start_from]) == torch.Tensor:
                 tensor_args.append(arg)
             continue
         # nothing is provided, we assume it is a Tensor
@@ -115,11 +115,12 @@ def complement_input_sample(model, input_sample):
     # complement the input sample by defaults
     if isinstance(input_sample, Sequence):
         input_sample_complement = input_sample
-        input_sample_complement += forward_defaults[-(len(forward_args)-input_sample_length):]
+        input_sample_complement += forward_defaults[-(len(forward_args) - input_sample_length):]
     else:
         input_sample_complement = []
         input_sample_complement.append(input_sample)
-        input_sample_complement += list(forward_defaults[-(len(forward_args)-input_sample_length):])
+        input_sample_complement +=\
+            list(forward_defaults[-(len(forward_args) - input_sample_length):])
 
     return tuple(input_sample_complement)
 

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
@@ -27,6 +27,10 @@ def get_forward_args(model):
     '''
     This function is to get all the arguments(excepts *args and **kwargs)
     It will return a list of arg name
+    E.g.
+    def forward(self, a, b=1, c: int = 3, *args, **kwargs):
+        pass
+    it will return ['a', 'b', 'c']
     '''
     forward_args = inspect.getfullargspec(model.forward).args[1:]
     if isinstance(model, LightningModule):
@@ -40,6 +44,10 @@ def get_forward_defaults(model):
     '''
     This function is to get all the defaults
     It will return a list of default values
+    E.g.
+    def forward(self, a, b=1, c: int = 3, *args, **kwargs):
+        pass
+    it will return (1, 3)
     '''
     forward_defaults = inspect.getfullargspec(model.forward).defaults
     if isinstance(model, LightningModule):
@@ -53,6 +61,10 @@ def get_forward_annotations(model):
     '''
     This function is to get all the annotations
     It will return a dict of {args: annotations}
+    E.g.
+    def forward(self, a, b=1, c: int = 3, *args, **kwargs):
+        pass
+    it will return {'c': <class 'int'>}
     '''
     forward_annotations = inspect.getfullargspec(model.forward).annotations
     if isinstance(model, LightningModule):
@@ -66,6 +78,10 @@ def get_tensor_args(model):
     '''
     This function will return all the parameters that (might) be a tensor type
     It will return a list or tensor args name
+    E.g.
+    def forward(self, a, b=1, c: int = 3, *args, **kwargs):
+        pass
+    it will return ['a']
     '''
     forward_args = get_forward_args(model)
     forward_defaults = get_forward_defaults(model)

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/model_utils.py
@@ -24,12 +24,104 @@ from bigdl.nano.utils.inference.pytorch.model import AcceleratedLightningModule
 
 
 def get_forward_args(model):
+    '''
+    This function is to get all the arguments(excepts *args and **kwargs)
+    It will return a list of arg name
+    '''
     forward_args = inspect.getfullargspec(model.forward).args[1:]
     if isinstance(model, LightningModule):
         if not isinstance(model, AcceleratedLightningModule):
             # forward param list for compiled model
             forward_args = get_forward_args(model.model)
     return forward_args
+
+
+def get_forward_defaults(model):
+    '''
+    This function is to get all the defaults
+    It will return a list of default values
+    '''
+    forward_defaults = inspect.getfullargspec(model.forward).defaults
+    if isinstance(model, LightningModule):
+        if not isinstance(model, AcceleratedLightningModule):
+            # forward param list for compiled model
+            forward_defaults = get_forward_defaults(model.model)
+    return forward_defaults
+
+
+def get_forward_annotations(model):
+    '''
+    This function is to get all the annotations
+    It will return a dict of {args: annotations}
+    '''
+    forward_annotations = inspect.getfullargspec(model.forward).annotations
+    if isinstance(model, LightningModule):
+        if not isinstance(model, AcceleratedLightningModule):
+            # forward param list for compiled model
+            forward_annotations = get_forward_annotations(model.model)
+    return forward_annotations
+
+
+def get_tensor_args(model):
+    '''
+    This function will return all the parameters that (might) be a tensor type
+    It will return a list or tensor args name
+    '''
+    forward_args = get_forward_args(model)
+    forward_defaults = get_forward_defaults(model)
+    forward_annotations = get_forward_annotations(model)
+    tensor_args = []
+    if forward_defaults is None:
+        defaults_length = 0
+    else:
+        defaults_length = len(forward_defaults)
+    args_length = len(forward_args)
+    for i, arg in enumerate(forward_args):
+        # check if type hint is provided
+        if arg in forward_annotations:
+            if forward_annotations[arg] == torch.Tensor:
+                tensor_args.append(arg)
+            continue
+        # check if defaults is Tensor
+        default_args_start_from = args_length - defaults_length
+        if i >= default_args_start_from:
+            if type(forward_defaults[i-default_args_start_from]) == torch.Tensor:
+                tensor_args.append(arg)
+            continue
+        # nothing is provided, we assume it is a Tensor
+        tensor_args.append(arg)
+    return tensor_args
+
+
+def complement_input_sample(model, input_sample):
+    '''
+    This function will give a complemented input sample
+    Mainly using default value to complete.
+    '''
+    forward_args = get_forward_args(model)
+    forward_defaults = get_forward_defaults(model)
+    input_sample_length = 1
+    if isinstance(input_sample, Sequence):
+        input_sample_length = len(input_sample)
+
+    # check if need complement
+    if len(forward_args) == input_sample_length:
+        return input_sample
+
+    # check if more input sample should be provided
+    if len(forward_args) > len(forward_defaults) + input_sample_length:
+        invalidInputError(False, "not enough input_sample provided!")
+
+    # complement the input sample by defaults
+    if isinstance(input_sample, Sequence):
+        input_sample_complement = input_sample
+        input_sample_complement += forward_defaults[-(len(forward_args)-input_sample_length):]
+    else:
+        input_sample_complement = []
+        input_sample_complement.append(input_sample)
+        input_sample_complement += list(forward_defaults[-(len(forward_args)-input_sample_length):])
+
+    return tuple(input_sample_complement)
 
 
 def get_input_example(model, input_sample, forward_args):
@@ -87,7 +179,10 @@ def export_to_onnx(model, input_sample=None, onnx_path="model.onnx", dynamic_axe
     :param **kwargs: will be passed to torch.onnx.export function.
     '''
     forward_args = get_forward_args(model)
+    tensor_args = get_tensor_args(model)
     input_sample = get_input_example(model, input_sample, forward_args)
+    input_sample = complement_input_sample(model, input_sample)
+
     invalidInputError(input_sample is not None,
                       'You should implement at least one of model.test_dataloader, '
                       'model.train_dataloader, model.val_dataloader and '
@@ -97,7 +192,7 @@ def export_to_onnx(model, input_sample=None, onnx_path="model.onnx", dynamic_axe
         pass
     elif dynamic_axes is True:
         dynamic_axes = {}
-        for arg in forward_args:
+        for arg in tensor_args:
             dynamic_axes[arg] = {0: 'batch_size'}  # set all dim0 to be dynamic
     else:
         dynamic_axes = {}

--- a/python/nano/test/onnx/pytorch/test_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_onnx.py
@@ -220,7 +220,7 @@ class TestOnnx(TestCase):
         class Net(nn.Module):
             def __init__(self):
                 super().__init__()
-            def forward(self, x: torch.Tensor, y: int):
+            def forward(self, x: torch.Tensor, y: int = 3):
                 return x+y
 
         model = Net()
@@ -229,6 +229,13 @@ class TestOnnx(TestCase):
         y = 3
         result_true = model(x, y)
         # sample with only required parameters (in a tuple)
+        accmodel = InferenceOptimizer.trace(model,
+                                            accelerator="onnxruntime",
+                                            input_sample=torch.rand(2,3,1,1))
+        result_m = accmodel(x, np.array([y]))  # TODO: make y work here
+        assert torch.equal(result_true, result_m)
+
+        # sample with only all parameters (in a tuple)
         accmodel = InferenceOptimizer.trace(model,
                                             accelerator="onnxruntime",
                                             input_sample=(torch.rand(2,3,1,1),3))

--- a/python/nano/test/onnx/pytorch/test_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_onnx.py
@@ -177,6 +177,64 @@ class TestOnnx(TestCase):
             assert torch.get_num_threads() == 1
             output = onnx_model(x)
 
+    def test_onnx_default_values(self):
+        # default bool values
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+            def forward(self, x, a=True, b=False):
+                if a:
+                    return x+1
+                if b:
+                    return x-1
+                return x
+
+        model = Net()
+
+        data = torch.rand(1,3,1,1)
+        result_true = model(data)
+        # sample with only required parameters (in a tuple)
+        accmodel = InferenceOptimizer.trace(model,
+                                            accelerator="onnxruntime",
+                                            input_sample=(torch.rand(2,3,1,1),))
+        result_m = accmodel(data)
+        assert torch.equal(result_true, result_m)
+
+        # sample with only required parameters
+        accmodel = InferenceOptimizer.trace(model,
+                                            accelerator="onnxruntime",
+                                            input_sample=torch.rand(2,3,1,1))
+        result_m = accmodel(data)
+        assert torch.equal(result_true, result_m)
+
+        data = torch.rand(1,3,1,1)
+        result_true = model(data, False, True)
+        # sample with only required parameters
+        accmodel = InferenceOptimizer.trace(model,
+                                            accelerator="onnxruntime",
+                                            input_sample=(torch.rand(2,3,1,1),False,True))
+        result_m = accmodel(data)
+        assert torch.equal(result_true, result_m)
+
+        # typehint model
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+            def forward(self, x: torch.Tensor, y: int):
+                return x+y
+
+        model = Net()
+
+        x = torch.rand(1,3,1,1)
+        y = 3
+        result_true = model(x, y)
+        # sample with only required parameters (in a tuple)
+        accmodel = InferenceOptimizer.trace(model,
+                                            accelerator="onnxruntime",
+                                            input_sample=(torch.rand(2,3,1,1),3))
+        result_m = accmodel(x, np.array([y]))  # TODO: make y work here
+        assert torch.equal(result_true, result_m)
+
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -175,7 +175,7 @@ class TestOpenVINO(TestCase):
         class Net(nn.Module):
             def __init__(self):
                 super().__init__()
-            def forward(self, x: torch.Tensor, y: int):
+            def forward(self, x: torch.Tensor, y: int = 3):
                 return x+y
 
         model = Net()
@@ -186,6 +186,13 @@ class TestOpenVINO(TestCase):
         # sample with only required parameters (in a tuple)
         accmodel = InferenceOptimizer.trace(model,
                                             accelerator="openvino",
-                                            input_sample=(torch.rand(2,3,1,1),3))
+                                            input_sample=torch.rand(2,3,1,1))
+        result_m = accmodel(x, y)
+        assert torch.equal(result_true, result_m)
+
+        # sample with only all parameters (in a tuple)
+        accmodel = InferenceOptimizer.trace(model,
+                                            accelerator="openvino",
+                                            input_sample=(torch.rand(2,3,1,1), 3))
         result_m = accmodel(x, y)
         assert torch.equal(result_true, result_m)

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -19,6 +19,8 @@ from bigdl.nano.pytorch import Trainer
 from bigdl.nano.pytorch import InferenceOptimizer
 from torchvision.models.mobilenetv3 import mobilenet_v3_small
 import torch
+import torch.nn as nn
+import numpy as np
 from torch.utils.data.dataset import TensorDataset
 from torch.utils.data.dataloader import DataLoader
 import os
@@ -129,3 +131,61 @@ class TestOpenVINO(TestCase):
         with InferenceOptimizer.get_context(model):
             assert torch.get_num_threads() == 2
             y2 = model(x[0:1])
+
+    def test_openvino_default_values(self):
+        # default bool values
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+            def forward(self, x, a=True, b=False):
+                if a:
+                    return x+1
+                if b:
+                    return x-1
+                return x
+
+        model = Net()
+
+        data = torch.rand(1,3,1,1)
+        result_true = model(data)
+        # sample with only required parameters (in a tuple)
+        accmodel = InferenceOptimizer.trace(model,
+                                            accelerator="openvino",
+                                            input_sample=(torch.rand(2,3,1,1),))
+        result_m = accmodel(data)
+        assert torch.equal(result_true, result_m)
+
+        # sample with only required parameters
+        accmodel = InferenceOptimizer.trace(model,
+                                            accelerator="openvino",
+                                            input_sample=torch.rand(2,3,1,1))
+        result_m = accmodel(data)
+        assert torch.equal(result_true, result_m)
+
+        data = torch.rand(1,3,1,1)
+        result_true = model(data, False, True)
+        # sample with only required parameters
+        accmodel = InferenceOptimizer.trace(model,
+                                            accelerator="openvino",
+                                            input_sample=(torch.rand(2,3,1,1),False,True))
+        result_m = accmodel(data)
+        assert torch.equal(result_true, result_m)
+
+        # typehint model
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+            def forward(self, x: torch.Tensor, y: int):
+                return x+y
+
+        model = Net()
+
+        x = torch.rand(1,3,1,1)
+        y = 3
+        result_true = model(x, y)
+        # sample with only required parameters (in a tuple)
+        accmodel = InferenceOptimizer.trace(model,
+                                            accelerator="openvino",
+                                            input_sample=(torch.rand(2,3,1,1),3))
+        result_m = accmodel(x, y)
+        assert torch.equal(result_true, result_m)


### PR DESCRIPTION
## Description

### 1. Why the change?
There has been report that we have bad support for models whose forward args have default values or other parameters
e.g.
```python
class Net(nn.Module):
    def __init__(self):
        super().__init__()
    def forward(self, x, a=True, b=False):
        if a:
            return x+1
        if b:
            return x-1
        return x
```

We should have a much more intelligent args inspectation to:

- [x] generate dynamic axis for only tensor args
e.g., In this case, `a` and `b` will not generate any dynamic axis.
- [x] allow users not inputting input sample for those args who has default values
e.g., In this case, users could
```python
accmodel = InferenceOptimizer.trace(model,
                                    accelerator="onnxruntime",
                                    input_sample=(torch.rand(2,3,1,1),False,True))
```
or just
```python
accmodel = InferenceOptimizer.trace(model,
                                    accelerator="onnxruntime",
                                    input_sample=torch.rand(2,3,1,1))  # the last 2 parameters will use default values (True, False) automatically.
```
- [ ] (Will do next PR, only for onnxruntime) support better type transformation, not only for tensor

### 2. User API changes
Nothing

### 3. Summary of the change 
1. Inspect the forward args and decide which args is tensor by considering
  - users' type hint
  - default values
2. complete the input sample by using the default values

### 4. How to test?
- [ ] Unit test

