### PR TITLE
Nano: update join logic in context manager

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -44,7 +44,6 @@ from bigdl.nano.pytorch.context_manager import generate_context_manager,\
 from .multi_instance import _MultiInstanceModel, _multi_instance_helper
 import traceback
 import warnings
-from copy import deepcopy
 # Filter out useless Userwarnings
 warnings.filterwarnings('ignore', category=UserWarning, module='pytorch_lightning')
 warnings.filterwarnings('ignore', category=DeprecationWarning, module='pytorch_lightning')

--- a/python/nano/test/pytorch/tests/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/test_inference_optimizer.py
@@ -500,9 +500,10 @@ class TestInferencePipeline(TestCase):
             with InferenceOptimizer.get_context(self.model, bf16_model):
                 output = self.model(input_sample)
                 assert output.dtype == torch.bfloat16
-            
-            with pytest.raises(RuntimeError):
-                InferenceOptimizer.get_context(ipex_model, bf16_model)
+
+            with InferenceOptimizer.get_context(ipex_model, bf16_model):
+                output = bf16_model(input_sample)
+                assert output.dtype == torch.bfloat16
 
         # test thread
         ipex_thread_model = InferenceOptimizer.trace(self.model,

--- a/python/nano/test/pytorch/tests/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/test_inference_optimizer.py
@@ -497,8 +497,9 @@ class TestInferencePipeline(TestCase):
             has_bf16 = False
 
         if has_bf16:
-            with pytest.raises(RuntimeError):
-                InferenceOptimizer.get_context(self.model, bf16_model)
+            with InferenceOptimizer.get_context(self.model, bf16_model):
+                output = self.model(input_sample)
+                assert output.dtype == torch.bfloat16
             
             with pytest.raises(RuntimeError):
                 InferenceOptimizer.get_context(ipex_model, bf16_model)

--- a/python/nano/test/pytorch/tests/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/test_inference_optimizer.py
@@ -519,5 +519,6 @@ class TestInferencePipeline(TestCase):
             ipex_model(input_sample)
             assert torch.get_num_threads() == 2
 
-        with pytest.raises(RuntimeError):
-            InferenceOptimizer.get_context(jit_thread_model, ipex_thread_model)
+        with InferenceOptimizer.get_context(jit_thread_model, ipex_thread_model):
+            ipex_model(input_sample)
+            assert torch.get_num_threads() == 4


### PR DESCRIPTION
## Description

This PR updates the logic of how to join multi context managers in `get_context` as it's better to report warning instead of throwing error to block the user. 
1. If two context managers have difference precision (bf16 and non bf16), we will return `AutocastContextManager()`
2. If only one context manager have `thread_num`, we will set `thread_num` to that value
3. If two context managers have different `thread_num`, we will set `thread_num` to the larger one

### How to test?
- [x] Unit test
- [x] Application test

