### PR TITLE
Fix TF2 Estimator batch size for predict

### DIFF
--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -349,9 +349,8 @@ class SparkTFEstimator():
         :param data: predict input data.  It can be XShards or Spark DataFrame.
                If data is XShards, each partition can be a Pandas DataFrame or a dictionary of
                {'x': feature}, where feature is a numpy array or a tuple of numpy arrays.
-        :param batch_size: Total batch size for all workers used for inference. Default: None.
-               If not None, each worker's batch size would be this value divide the total
-               number of workers.
+        :param batch_size: Total batch size for all workers used for evaluation. Each worker's batch
+               size would be this value divide the total number of workers. Default: 32.
         :param verbose: Prints output of one model if true.
         :param steps: Total number of steps (batches of samples) before declaring the prediction
                round finished. Ignored with the default value of None.
@@ -361,8 +360,9 @@ class SparkTFEstimator():
                DataFrame or an XShards of Pandas DataFrame. Default: None.
         :return:
         """
-        invalidInputError(isinstance(batch_size, int) and batch_size > 0,
-                          "batch_size should be a positive integer")
+        if batch_size:
+            invalidInputError(isinstance(batch_size, int) and batch_size > 0,
+                              "batch_size should be a positive integer")
         logger.info("Starting predict step.")
         sc = OrcaContext.get_spark_context()
         if self.model_weights:

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -117,7 +117,8 @@ class SparkTFEstimator():
                {'x': feature, 'y': label}, where feature(label) is a numpy array or a tuple of
                numpy arrays.
         :param epochs: Number of epochs to train the model. Default: 1.
-        :param batch_size: Batch size used for training. Default: 32.
+        :param batch_size: Total batch size for all workers used for training. Each worker's batch
+               size would be this value divide the total number of workers. Default: 32.
         :param verbose: Prints output of one model if true.
         :param callbacks: List of Keras compatible callbacks to apply during training.
         :param validation_data: validation data. Validation data type should be the same
@@ -258,7 +259,8 @@ class SparkTFEstimator():
                If data is XShards, each partition can be a Pandas DataFrame or a dictionary of
                {'x': feature, 'y': label}, where feature(label) is a numpy array or a tuple of
                numpy arrays.
-        :param batch_size: Batch size used for evaluation. Default: 32.
+        :param batch_size: Total batch size for all workers used for evaluation. Each worker's batch
+               size would be this value divide the total number of workers. Default: 32.
         :param verbose: Prints output of one model if true.
         :param callbacks: List of Keras compatible callbacks to apply during evaluation.
         :return: validation result
@@ -347,7 +349,9 @@ class SparkTFEstimator():
         :param data: predict input data.  It can be XShards or Spark DataFrame.
                If data is XShards, each partition can be a Pandas DataFrame or a dictionary of
                {'x': feature}, where feature is a numpy array or a tuple of numpy arrays.
-        :param batch_size: Batch size used for inference. Default: None.
+        :param batch_size: Total batch size for all workers used for inference. Default: None.
+               If not None, each worker's batch size would be this value divide the total
+               number of workers.
         :param verbose: Prints output of one model if true.
         :param steps: Total number of steps (batches of samples) before declaring the prediction
                round finished. Ignored with the default value of None.

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -441,9 +441,8 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                orca.data.tf.data.Dataset. If data is XShards, each partition can be a Pandas
                DataFrame or a dictionary of {'x': feature}, where feature is a numpy array or a
                tuple of numpy arrays.
-        :param batch_size: Total batch size for all workers used for inference. Default: None.
-               If not None, each worker's batch size would be this value divide the total
-               number of workers.
+        :param batch_size: Total batch size for all workers used for evaluation. Each worker's batch
+               size would be this value divide the total number of workers. Default: 32.
         :param verbose: Prints output of one model if true.
         :param steps: Total number of steps (batches of samples) before declaring the prediction
                round finished. Ignored with the default value of None.
@@ -462,8 +461,9 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                Default: None.
         :return:
         """
-        invalidInputError(isinstance(batch_size, int) and batch_size > 0,
-                          "batch_size should be a positive integer")
+        if batch_size:
+            invalidInputError(isinstance(batch_size, int) and batch_size > 0,
+                              "batch_size should be a positive integer")
         logger.info("Starting predict step.")
         params = dict(
             verbose=verbose,

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -143,7 +143,8 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                {'x': feature, 'y': label}, where feature(label) is a numpy array or a tuple of
                numpy arrays.
         :param epochs: Number of epochs to train the model. Default: 1.
-        :param batch_size: Batch size used for training. Default: 32.
+        :param batch_size: Total batch size for all workers used for training. Each worker's batch
+               size would be this value divide the total number of workers. Default: 32.
         :param verbose: Prints output of one model if true.
         :param callbacks: List of Keras compatible callbacks to apply during training.
         :param validation_data: validation data. Validation data type should be the same
@@ -300,7 +301,8 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                If data is XShards, each partition can be a Pandas DataFrame or a dictionary of
                {'x': feature, 'y': label}, where feature(label) is a numpy array or a tuple of
                numpy arrays.
-        :param batch_size: Batch size used for evaluation. Default: 32.
+        :param batch_size: Total batch size for all workers used for evaluation. Each worker's batch
+               size would be this value divide the total number of workers. Default: 32.
         :param num_steps: Total number of steps (batches of samples) before declaring the evaluation
                round finished. Ignored with the default value of `None`.
         :param verbose: Prints output of one model if true.
@@ -439,7 +441,9 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                orca.data.tf.data.Dataset. If data is XShards, each partition can be a Pandas
                DataFrame or a dictionary of {'x': feature}, where feature is a numpy array or a
                tuple of numpy arrays.
-        :param batch_size: Batch size used for inference. Default: None.
+        :param batch_size: Total batch size for all workers used for inference. Default: None.
+               If not None, each worker's batch size would be this value divide the total
+               number of workers.
         :param verbose: Prints output of one model if true.
         :param steps: Total number of steps (batches of samples) before declaring the prediction
                round finished. Ignored with the default value of None.

--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -148,7 +148,10 @@ class TFDistributedDatasetHandler(DatasetHandler):
 
     def _handle_batch_size(self, config):
         invalidInputError("batch_size" in config, "batch_size must be set in config")
-        local_batch_size = config["batch_size"] // self.size
+        if config["batch_size"]:
+            local_batch_size = config["batch_size"] // self.size
+        else:  # batch_size default to be None for predict
+            local_batch_size = None
         return config, local_batch_size
 
 
@@ -454,11 +457,16 @@ class SparkRunner:
         config = copy.copy(self.config)
         if data_config is not None:
             config.update(data_config)
+        config["batch_size"] = batch_size
+        dataset_handler = DatasetHandler.get_handler(self.backend,
+                                                     self.rank,
+                                                     self.size)
+        config, local_batch_size = dataset_handler._handle_batch_size(config)
 
-        dataset = data_creator(config, batch_size)
+        dataset = data_creator(config, local_batch_size)
         partition = dataset
         params = dict(
-            batch_size=batch_size,
+            batch_size=local_batch_size,
             verbose=verbose,
             steps=steps,
             callbacks=callbacks,

--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -459,7 +459,7 @@ class SparkRunner:
             config.update(data_config)
         config["batch_size"] = batch_size
         dataset_handler = DatasetHandler.get_handler(self.backend,
-                                                     self.rank,
+                                                     0,  # no rank for predict
                                                      self.size)
         config, local_batch_size = dataset_handler._handle_batch_size(config)
 

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -480,7 +480,7 @@ class TFRunner:
             config.update(data_config)
         config["batch_size"] = batch_size
         dataset_handler = DatasetHandler.get_handler(self.backend,
-                                                     self.rank,
+                                                     0,  # no rank for predict
                                                      self.size)
         config, local_batch_size = dataset_handler._handle_batch_size(config)
 

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
@@ -326,8 +326,6 @@ class TestTFRayEstimator(TestCase):
 
         sc = init_nncontext()
         rdd = sc.range(0, 10)
-        from pyspark.sql import SparkSession
-        spark = SparkSession(sc)
         from pyspark.ml.linalg import DenseVector
         df = rdd.map(lambda x: (DenseVector(np.random.randn(1,).astype(np.float)),
                                 int(np.random.randint(0, 1, size=())))).toDF(["feature", "label"])


### PR DESCRIPTION
For predict, each worker should use the local batch instead of the global batch, to align with fit and evaluate.