### PR TITLE
Chronos: utilize get_context() method in forecaster

### DIFF
--- a/python/chronos/example/inference-acceleration/cpu_inference_acceleration.py
+++ b/python/chronos/example/inference-acceleration/cpu_inference_acceleration.py
@@ -19,6 +19,7 @@ from bigdl.chronos.model.tcn import model_creator
 from bigdl.chronos.metric.forecast_metrics import Evaluator
 from bigdl.chronos.data import get_public_dataset
 from sklearn.preprocessing import StandardScaler
+from bigdl.chronos.pytorch import TSInferenceOptimizer as InferenceOptimizer
 
 def gen_dataloader():
     tsdata_train, tsdata_val,\
@@ -42,7 +43,8 @@ def gen_dataloader():
     return tsdata_traindataloader, tsdata_valdataloader, tsdata_testdataloader
 
 def predict_wraper(model, input_sample):
-    model(input_sample)
+    with InferenceOptimizer.get_context(model):
+        model(input_sample)
 
 if __name__ == '__main__':
 
@@ -82,8 +84,8 @@ if __name__ == '__main__':
         break
     input_sample = x[0].unsqueeze(0)
     
-    # speed up the model using Chronos TSTrainer
-    speed_model = Trainer.trace(lit_model, accelerator="onnxruntime", input_sample=input_sample)
+    # speed up the model using Chronos InferenceOptimizer
+    speed_model = InferenceOptimizer.trace(lit_model, accelerator="onnxruntime", input_sample=input_sample)
 
     # evaluate the model's latency
     print("original pytorch latency (ms):", Evaluator.get_latency(predict_wraper, lit_model, input_sample))

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -1492,8 +1492,7 @@ class BasePytorchForecaster(Forecaster):
                                                           input_sample=dummy_input,
                                                           accelerator="onnxruntime",
                                                           onnxruntime_session_options=sess_options)
-        with InferenceOptimizer.get_context(self.accelerated_model):
-            self.accelerate_method = "onnxruntime_fp32"
+        self.accelerate_method = "onnxruntime_fp32"
 
     def build_openvino(self, thread_num=1):
         '''
@@ -1531,8 +1530,7 @@ class BasePytorchForecaster(Forecaster):
                                                           input_sample=dummy_input,
                                                           accelerator="openvino",
                                                           thread_num=thread_num)
-        with InferenceOptimizer.get_context(self.accelerated_model):
-            self.accelerate_method = "openvino_fp32"
+        self.accelerate_method = "openvino_fp32"
 
     def build_jit(self, thread_num=1, use_ipex=False):
         '''
@@ -1576,8 +1574,7 @@ class BasePytorchForecaster(Forecaster):
                                                           use_ipex=use_ipex,
                                                           channels_last=False,
                                                           thread_num=thread_num)
-        with InferenceOptimizer.get_context(self.accelerated_model):
-            self.accelerate_method = "jit_fp32"
+        self.accelerate_method = "jit_fp32"
 
     def export_onnx_file(self, dirname="fp32_onnx", quantized_dirname=None):
         """

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -1492,7 +1492,8 @@ class BasePytorchForecaster(Forecaster):
                                                           input_sample=dummy_input,
                                                           accelerator="onnxruntime",
                                                           onnxruntime_session_options=sess_options)
-        self.accelerate_method = "onnxruntime_fp32"
+        with InferenceOptimizer.get_context(self.accelerated_model):
+            self.accelerate_method = "onnxruntime_fp32"
 
     def build_openvino(self, thread_num=1):
         '''
@@ -1530,7 +1531,8 @@ class BasePytorchForecaster(Forecaster):
                                                           input_sample=dummy_input,
                                                           accelerator="openvino",
                                                           thread_num=thread_num)
-        self.accelerate_method = "openvino_fp32"
+        with InferenceOptimizer.get_context(self.accelerated_model):
+            self.accelerate_method = "openvino_fp32"
 
     def build_jit(self, thread_num=1, use_ipex=False):
         '''
@@ -1574,7 +1576,8 @@ class BasePytorchForecaster(Forecaster):
                                                           use_ipex=use_ipex,
                                                           channels_last=False,
                                                           thread_num=thread_num)
-        self.accelerate_method = "jit_fp32"
+        with InferenceOptimizer.get_context(self.accelerated_model):
+            self.accelerate_method = "jit_fp32"
 
     def export_onnx_file(self, dirname="fp32_onnx", quantized_dirname=None):
         """

--- a/python/chronos/src/bigdl/chronos/pytorch/utils.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/utils.py
@@ -17,6 +17,7 @@ import math
 import torch
 import numpy as np
 from torch.utils.data.dataloader import DataLoader
+from bigdl.chronos.pytorch import TSInferenceOptimizer as InferenceOptimizer
 
 
 def _inference(model, input_sample_list, batch_size):
@@ -47,7 +48,7 @@ def _pytorch_fashion_inference(model, input_data, batch_size=None):
 
     :return: numpy ndarray
     '''
-    with torch.no_grad():
+    with InferenceOptimizer.get_context(model):
         if isinstance(input_data, list):
             input_sample_list = list(map(lambda x: torch.from_numpy(x), input_data))
         elif isinstance(input_data, DataLoader):


### PR DESCRIPTION
## Description

Nano supports get_context() method to implement torch._no_grad, autocast and thread control.
In forecaster, utilize get_context() method to replace torch._no_grad and realize thread control.

### 2. User API changes

nothing

### 4. How to test?
- [x] Unit test