### PR TITLE
Nano: Update examples and tutorials

### DIFF
--- a/docs/readthedocs/source/doc/Nano/Howto/install_in_colab.md
+++ b/docs/readthedocs/source/doc/Nano/Howto/install_in_colab.md
@@ -56,7 +56,7 @@ To enable OpenVINO acceleration, or use POT for quantization, you need to instal
 
 ```eval_rst
 .. note::
-    If you meet ``ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject`` when using ``Trainer.trace`` or ``Trainer.quantize`` function, you could try to solve it by upgrading ``numpy`` through:
+    If you meet ``ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject`` when using ``InferenceOptimizer.trace`` or ``InferenceOptimizer.quantize`` function, you could try to solve it by upgrading ``numpy`` through:
     
     .. code-block:: python
 

--- a/docs/readthedocs/source/doc/Nano/QuickStart/pytorch_onnxruntime.md
+++ b/docs/readthedocs/source/doc/Nano/QuickStart/pytorch_onnxruntime.md
@@ -78,8 +78,8 @@ When you're ready, you can simply append the following part to enable your ONNXR
 # you have run `trainer.fit` before trace
 # Model has `example_input_array` set
 # Model is a LightningModule with any dataloader attached.
-from bigdl.nano.pytorch import Trainer
-ort_model = Trainer.trace(model_ft, accelerator="onnxruntime", input_sample=torch.rand(1, 3, 224, 224))
+from bigdl.nano.pytorch import InferenceOptimizer
+ort_model = InferenceOptimizer.trace(model_ft, accelerator="onnxruntime", input_sample=torch.rand(1, 3, 224, 224))
 
 # The usage is almost the same with any PyTorch module
 y_hat = ort_model(x)

--- a/docs/readthedocs/source/doc/Nano/QuickStart/pytorch_openvino.md
+++ b/docs/readthedocs/source/doc/Nano/QuickStart/pytorch_openvino.md
@@ -78,8 +78,8 @@ When you're ready, you can simply append the following part to enable your OpenV
 # The argument `input_sample` is not required in the following cases:
 # you have run `trainer.fit` before trace
 # The Model has `example_input_array` set
-from bigdl.nano.pytorch import Trainer
-ov_model = Trainer.trace(model_ft, accelerator="openvino", input_sample=torch.rand(1, 3, 224, 224))
+from bigdl.nano.pytorch import InferenceOptimizer
+ov_model = InferenceOptimizer.trace(model_ft, accelerator="openvino", input_sample=torch.rand(1, 3, 224, 224))
 
 # The usage is almost the same with any PyTorch module
 y_hat = ov_model(x)

--- a/docs/readthedocs/source/doc/Nano/QuickStart/pytorch_quantization_inc.md
+++ b/docs/readthedocs/source/doc/Nano/QuickStart/pytorch_quantization_inc.md
@@ -74,12 +74,13 @@ y_hat.argmax(dim=1)
 ```
 
 ### Step 3: Quantization using Intel Neural Compressor
-Quantization is widely used to compress models to a lower precision, which not only reduces the model size but also accelerates inference. BigDL-Nano provides `Trainer.quantize()` API for users to quickly obtain a quantized model with accuracy control by specifying a few arguments.
+Quantization is widely used to compress models to a lower precision, which not only reduces the model size but also accelerates inference. BigDL-Nano provides `InferenceOptimizer.quantize()` API for users to quickly obtain a quantized model with accuracy control by specifying a few arguments.
 
-Without extra accelerator, `Trainer.quantize()` returns a pytorch module with desired precision and accuracy. You can add quantization as below:
+Without extra accelerator, `InferenceOptimizer.quantize()` returns a pytorch module with desired precision and accuracy. You can add quantization as below:
 ```python
+from bigdl.nano.pytorch import InferenceOptimizer
 from torchmetrics.functional import accuracy
-q_model = trainer.quantize(model, calib_dataloader=train_dataloader, metric=accuracy)
+q_model = InferenceOptimizer.quantize(model, calib_data=train_dataloader, metric=accuracy)
 
 # run simple prediction
 y_hat = q_model(x)

--- a/docs/readthedocs/source/doc/Nano/QuickStart/pytorch_quantization_inc_onnx.md
+++ b/docs/readthedocs/source/doc/Nano/QuickStart/pytorch_quantization_inc_onnx.md
@@ -73,12 +73,13 @@ y_hat.argmax(dim=1)
 ```
 
 ### Step 3: Quantization with ONNXRuntime accelerator
-With the ONNXRuntime accelerator, `Trainer.quantize()` will return a model with compressed precision but running inference in the ONNXRuntime engine.
+With the ONNXRuntime accelerator, `InferenceOptimizer.quantize()` will return a model with compressed precision but running inference in the ONNXRuntime engine.
 
 you can add quantization as below:
 ```python
+from bigdl.nano.pytorch import InferenceOptimizer
 from torchmetrics.functional import accuracy
-ort_q_model = trainer.quantize(model, accelerator='onnxruntime', calib_dataloader=train_dataloader, metric=accuracy)
+ort_q_model = InferenceOptimizer.quantize(model, accelerator='onnxruntime', calib_data=train_dataloader, metric=accuracy)
 
 # run simple prediction
 y_hat = ort_q_model(x)

--- a/docs/readthedocs/source/doc/Nano/QuickStart/pytorch_quantization_openvino.md
+++ b/docs/readthedocs/source/doc/Nano/QuickStart/pytorch_quantization_openvino.md
@@ -76,8 +76,9 @@ y_hat.argmax(dim=1)
 ### Step 3: Quantization using Post-training Optimization Tools
 Accelerator='openvino' means using OpenVINO POT to do quantization. The quantization can be added as below:
 ```python
+from bigdl.nano.pytorch import InferenceOptimizer
 from torchmetrics import Accuracy
-ov_q_model = trainer.quantize(model, accelerator="openvino", calib_dataloader=data_loader)
+ov_q_model = InferenceOptimizer.quantize(model, accelerator="openvino", calib_data=data_loader)
 
 # run simple prediction
 batch = torch.stack([data_set[0][0], data_set[1][0]])

--- a/python/nano/notebooks/pytorch/cifar10/nano-inference-example.ipynb
+++ b/python/nano/notebooks/pytorch/cifar10/nano-inference-example.ipynb
@@ -352,7 +352,7 @@
    "source": [
     "### Get Accelerated Module\n",
     "---\n",
-    "Use Train.trace from bigdl.nano.pytorch.trainer to convert a model into an accelerated module for inference.\n",
+    "Use InferenceOptimizer.trace from bigdl.nano.pytorch.InferenceOptimizer to convert a model into an accelerated module for inference.\n",
     "The definition of trace is:\n",
     "```\n",
     "trace(model: nn.Module, input_sample=None, accelerator=None)\n",
@@ -498,14 +498,14 @@
    },
    "source": [
     "### Quantize Model\n",
-    "Use Trainer.quantize from bigdl.nano.pytorch.trainer to calibrate a Pytorch-Lightning model for post-training quantization. Here are some parameters that might be useful to you:\n",
+    "Use InferenceOptimizer.quantize from bigdl.nano.pytorch.InferenceOptimizer to calibrate a model for post-training quantization. Here are some parameters that might be useful to you:\n",
     "```\n",
-    ":param pl_model:         A Pytorch-Lightning model to be quantized.\n",
+    ":param model:            A model to be quantized. Model should be an instance of torch.nn.Module\n",
     ":param precision         Global precision of quantized model,\n",
     "                         supported type: 'int8', 'bf16', 'fp16', defaults to 'int8'.\n",
     ":param accelerator:      Use accelerator 'None', 'onnxruntime', 'openvino', defaults to None.\n",
     "                         None means staying in pytorch.\n",
-    ":param calib_dataloader:         A torch.utils.data.dataloader.DataLoader object for calibration.     \n",
+    ":param calib_data:       A torch.utils.data.dataloader.DataLoader object for calibration.     \n",
     "                                 Required for static quantization.\n",
     ":param approach:         'static' or 'dynamic'.\n",
     "                         'static': post_training_static_quant,\n",
@@ -513,10 +513,10 @@
     "                          Default: 'static'.\n",
     ":input_sample:           An input example to convert pytorch model into ONNX/OpenVINO.\n",
     "                          \n",
-    ":return                  A accelerated Pytorch-Lightning Model if quantization is sucessful.\n",
+    ":return                  An accelerated torch.nn.Module if quantization is sucessful.\n",
     "\n",
     "```\n",
-    "Access more details from [Source](https://github.com/intel-analytics/BigDL/blob/main/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py#L234)"
+    "Access more details from [Source](https://github.com/intel-analytics/BigDL/blob/main/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py#L452)"
    ]
   },
   {

--- a/python/nano/notebooks/pytorch/openvino/quantization-simplified-mode/quantization-simplified-mode.ipynb
+++ b/python/nano/notebooks/pytorch/openvino/quantization-simplified-mode/quantization-simplified-mode.ipynb
@@ -39,7 +39,7 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
-    "from bigdl.nano.pytorch import Trainer\n",
+    "from bigdl.nano.pytorch import InferenceOptimizer\n",
     "from torch.utils.data.dataloader import DataLoader\n",
     "\n",
     "warnings.filterwarnings(\"ignore\")\n",
@@ -82,7 +82,7 @@
     "## Prepare the Model\n",
     "Model preparation includes the following steps:,\n",
     "- Download PyTorch model from Torchvision repository,\n",
-    "- Use `bigdl.nano.pytorch.Trainer.trace(accelerator='openvino')` to convert Pytorch model to OpenVINO Intermediate Representation (IR)"
+    "- Use `bigdl.nano.pytorch.InferenceOptimizer.trace(accelerator='openvino')` to convert Pytorch model to OpenVINO Intermediate Representation (IR)"
    ]
   },
   {
@@ -99,7 +99,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we convert this model into the OpenVINO IR using `Trainer.trace`:"
+    "Now we convert this model into the OpenVINO IR using `InferenceOptimizer.trace`:"
    ]
   },
   {
@@ -108,10 +108,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ov_model = Trainer.trace(model,\n",
+    "ov_model = InferenceOptimizer.trace(model,\n",
     "                         accelerator='openvino',\n",
     "                         input_sample=dummy_input)\n",
-    "Trainer.save(ov_model, MODEL_DIR)\n",
+    "InferenceOptimizer.save(ov_model, MODEL_DIR)\n",
     "\n",
     "ir_model_xml = Path(MODEL_DIR) / ov_model.status['xml_path']\n",
     "ir_model_bin = ir_model_xml.with_suffix('.bin')"
@@ -122,7 +122,7 @@
    "metadata": {},
    "source": [
     "## Compression stage\n",
-    "Compress the model with `Trainer.quantize` from either traced OpenVINO model(Option 1) or Pytorch model(Option 2)."
+    "Compress the model with `InferenceOptimizer.quantize` from either traced OpenVINO model(Option 1) or Pytorch model(Option 2)."
    ]
   },
   {
@@ -133,13 +133,13 @@
    "source": [
     "dataloader = DataLoader(dataset, batch_size=1)\n",
     "# Option1: compress the model from traced OpenVINO model\n",
-    "optimized_model = Trainer.quantize(ov_model,\n",
+    "optimized_model = InferenceOptimizer.quantize(ov_model,\n",
     "                                   precision='int8',\n",
     "                                   accelerator='openvino',\n",
     "                                   calib_dataloader=dataloader)\n",
     "\n",
     "# Option2: compress the model from Pytorch model\n",
-    "# optimized_model = Trainer.quantize(model,\n",
+    "# optimized_model = InferenceOptimizer.quantize(model,\n",
     "#                                    precision='int8',\n",
     "#                                    accelerator='openvino',\n",
     "#                                    calib_dataloader=dataloader)\n"
@@ -164,7 +164,7 @@
    "source": [
     "optimized_model_path = Path('compressed/optimized')\n",
     "\n",
-    "Trainer.save(optimized_model, optimized_model_path)\n",
+    "InferenceOptimizer.save(optimized_model, optimized_model_path)\n",
     "\n",
     "optimized_model_xml = optimized_model_path / optimized_model.status['xml_path']\n",
     "optimized_model_bin = optimized_model_path / optimized_model.status['weight_path']"
@@ -207,7 +207,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "compiled_model = Trainer.load(optimized_model_path)"
+    "compiled_model = InferenceOptimizer.load(optimized_model_path)"
    ]
   },
   {

--- a/python/nano/notebooks/pytorch/openvino/quantization-simplified-mode/quantization-simplified-mode.ipynb
+++ b/python/nano/notebooks/pytorch/openvino/quantization-simplified-mode/quantization-simplified-mode.ipynb
@@ -136,13 +136,13 @@
     "optimized_model = InferenceOptimizer.quantize(ov_model,\n",
     "                                   precision='int8',\n",
     "                                   accelerator='openvino',\n",
-    "                                   calib_dataloader=dataloader)\n",
+    "                                   calib_data=dataloader)\n",
     "\n",
     "# Option2: compress the model from Pytorch model\n",
     "# optimized_model = InferenceOptimizer.quantize(model,\n",
     "#                                    precision='int8',\n",
     "#                                    accelerator='openvino',\n",
-    "#                                    calib_dataloader=dataloader)\n"
+    "#                                    calib_data=dataloader)\n"
    ]
   },
   {

--- a/python/nano/notebooks/pytorch/tutorial/pytorch_inference_openvino.ipynb
+++ b/python/nano/notebooks/pytorch/tutorial/pytorch_inference_openvino.ipynb
@@ -229,8 +229,8 @@
     }
    ],
    "source": [
-    "from bigdl.nano.pytorch import Trainer\n",
-    "ov_model = Trainer.trace(model_ft, accelerator=\"openvino\", input_sample=torch.rand(1, 3, 224, 224))"
+    "from bigdl.nano.pytorch import InferenceOptimizer\n",
+    "ov_model = InferenceOptimizer.trace(model_ft, accelerator=\"openvino\", input_sample=torch.rand(1, 3, 224, 224))"
    ]
   },
   {

--- a/python/nano/notebooks/pytorch/tutorial/pytorch_quantization_inc.ipynb
+++ b/python/nano/notebooks/pytorch/tutorial/pytorch_quantization_inc.ipynb
@@ -171,7 +171,7 @@
    "source": [
     "### Quantization without extra accelerator\n",
     "To use INC as your quantization engine, you can choose accelerator as None or 'onnxruntime'.<br>\n",
-    "Without extra accelerator, `Trainer.quantize()` returns a pytorch module."
+    "Without extra accelerator, `InferenceOptimizer.quantize()` returns a pytorch module."
    ]
   },
   {
@@ -248,7 +248,7 @@
    "metadata": {},
    "source": [
     "### Quantization with ONNXRuntime accelerator\n",
-    "With the ONNXRuntime accelerator, `Trainer.quantize()` will return a model with compressed precision but running inference in the ONNXRuntime engine."
+    "With the ONNXRuntime accelerator, `InferenceOptimizer.quantize()` will return a model with compressed precision but running inference in the ONNXRuntime engine."
    ]
   },
   {

--- a/python/nano/notebooks/pytorch/tutorial/pytorch_quantization_openvino.ipynb
+++ b/python/nano/notebooks/pytorch/tutorial/pytorch_quantization_openvino.ipynb
@@ -233,7 +233,8 @@
     }
    ],
    "source": [
-    "ov_q_model = trainer.quantize(model, accelerator=\"openvino\", calib_dataloader=train_dataloader)\n",
+    "from bigdl.nano.pytorch import InferenceOptimizer\n",
+    "ov_q_model = InferenceOptimizer.quantize(model, accelerator=\"openvino\", calib_dataloader=train_dataloader)\n",
     "y_hat = ov_q_model(x)\n",
     "y_hat.argmax(dim=1)"
    ]

--- a/python/nano/notebooks/pytorch/tutorial/pytorch_quantization_openvino.ipynb
+++ b/python/nano/notebooks/pytorch/tutorial/pytorch_quantization_openvino.ipynb
@@ -234,7 +234,7 @@
    ],
    "source": [
     "from bigdl.nano.pytorch import InferenceOptimizer\n",
-    "ov_q_model = InferenceOptimizer.quantize(model, accelerator=\"openvino\", calib_dataloader=train_dataloader)\n",
+    "ov_q_model = InferenceOptimizer.quantize(model, accelerator=\"openvino\", calib_data=train_dataloader)\n",
     "y_hat = ov_q_model(x)\n",
     "y_hat.argmax(dim=1)"
    ]


### PR DESCRIPTION
## Description

Replace `Trainer.quantize` and `Trainer.trace` with `InferenceOptimizer.quantize` and `InferenceOptimizer.trace` in the following directories:
- BigDL/docs/readthedocs/source/doc/Nano
- BigDL/python/nano/example
- BigDL/python/nano/notebooks
- BigDL/python/nano/tutorial

It seems some chronos examples are also using `Trainer.trace`, e. g.
- BigDL/python/chronos/example/inference-acceleration/cpu_inference_acceleration.py
- BigDL/python/chronos/example/serving/generate_torchscript_pt.py