### PR TITLE
Fix typo in wnd readme

### DIFF
--- a/apps/wide-deep-recommendation/README.md
+++ b/apps/wide-deep-recommendation/README.md
@@ -20,7 +20,7 @@ jupyter notebook
 ```
 
 ## Run Demo
-This demo uses Twitter Recsys Challenge 2021 dataset, you can download it from [here](https://recsys-twitter.com/data/show-downloads#). If you fail to download it, please run [`generate_dummy_data.py`](./generate_dummy_data.py) to generate a dummy dataset.
+This demo uses Twitter Recsys Challenge 2021 dataset, you can download it from [here](http://www.recsyschallenge.com/2021/). If you fail to download it, please run [`generate_dummy_data.py`](./generate_dummy_data.py) to generate a dummy dataset.
 
 After having a dataset, modify the paths in following notebooks, both HDFS path and local path are acceptable.
 

--- a/apps/wide-deep-recommendation/feature_engineering.ipynb
+++ b/apps/wide-deep-recommendation/feature_engineering.ipynb
@@ -13,7 +13,7 @@
    "id": "52ea4cc7",
    "metadata": {},
    "source": [
-    "This demo uses the [Twitter Recsys Challenge 2021 dataset](https://recsys-twitter.com/data/show-downloads#) and the [Wide & Deep Model](https://arxiv.org/abs/1606.07792). The dataset includes 46 million users and 340 million tweets (items) and each record contains the tweet along with engagement features, user features, and tweet features.\n",
+    "This demo uses the [Twitter Recsys Challenge 2021 dataset](http://www.recsyschallenge.com/2021/) and the [Wide & Deep Model](https://arxiv.org/abs/1606.07792). The dataset includes 46 million users and 340 million tweets (items) and each record contains the tweet along with engagement features, user features, and tweet features.\n",
     "\n",
     "At the very beginning, let's have a high-level overview of general recommendation systems. The diagram below demonstrates the common components of a recommendation system, which typically consists of three stages:\n",
     "- Offline: Perform feature engineering on the raw data and use the preprocessed data to train embeddings and deep learning models.\n",

--- a/apps/wide-deep-recommendation/model_training.ipynb
+++ b/apps/wide-deep-recommendation/model_training.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Wide & Deep Recommendation for large scale data - Deep Learning Model Training\n",
     "\n",
-    "This notebook demonstrates the distributed training for [Wide & Deep Learning](https://arxiv.org/abs/1606.07792) with the preprocessed features of the [Twitter Recsys Challenge 2021 dataset](https://recsys-twitter.com/data/show-downloads#)."
+    "This notebook demonstrates the distributed training for [Wide & Deep Learning](https://arxiv.org/abs/1606.07792) with the preprocessed features of the [Twitter Recsys Challenge 2021 dataset](http://www.recsyschallenge.com/2021/)."
    ]
   },
   {

--- a/python/friesian/example/deep_fm/README.md
+++ b/python/friesian/example/deep_fm/README.md
@@ -1,5 +1,5 @@
 # Train a DeepFM model using recsys data
-This example demonstrates how to use our Friesian to train a DeepFM model using [Twitter Recsys Challenge 2021 data](https://recsys-twitter.com/data/show-downloads#).
+This example demonstrates how to use our Friesian to train a DeepFM model using [Twitter Recsys Challenge 2021 data](http://www.recsyschallenge.com/2021/).
 
 ## Prepare the environment
 We recommend you to use [Anaconda](https://www.anaconda.com/distribution/#linux) to prepare the environments, especially if you want to run on a yarn cluster (yarn-client mode only).
@@ -12,7 +12,7 @@ pip install numba
 ```
 
 ## Preprocess data
-You can download the full Twitter dataset from [here](https://recsys-twitter.com/data/show-downloads#) and then follow the [WideAndDeep Preprocessing](https://github.com/intel-analytics/BigDL/tree/branch-2.0/python/friesian/example/wnd) to preprocess the orginal data.
+You can download the full Twitter dataset from [here](http://www.recsyschallenge.com/2021/) and then follow the [WideAndDeep Preprocessing](https://github.com/intel-analytics/BigDL/tree/branch-2.0/python/friesian/example/wnd) to preprocess the orginal data.
 
 ## Training  tower model
 * Spark local, we can use some sample data to have a trial, example command:

--- a/python/friesian/example/lightGBM/README.md
+++ b/python/friesian/example/lightGBM/README.md
@@ -1,5 +1,5 @@
 # Train an LightGBM model using Twitter dataset
-This example demonstrates how to train an [lightGBM](https://github.com/Microsoft/LightGBM) classification model on Friesian using [Twitter Recsys Challenge 2021 data](https://recsys-twitter.com/data/show-downloads#).
+This example demonstrates how to train an [lightGBM](https://github.com/Microsoft/LightGBM) classification model on Friesian using [Twitter Recsys Challenge 2021 data](http://www.recsyschallenge.com/2021/).
 
 ## Prepare the environment
 We recommend you to use [Anaconda](https://www.anaconda.com/distribution/#linux) to prepare the environments, especially if you want to run on a yarn cluster (yarn-client mode only).
@@ -10,7 +10,7 @@ pip install --pre --upgrade bigdl-friesian
 ```
 
 ## Preprocess the data
-You can download the full Twitter dataset from [here](https://recsys-twitter.com/data/show-downloads#) and then follow the [WideAndDeep Preprocessing](../wnd) to preprocess the original data.
+You can download the full Twitter dataset from [here](http://www.recsyschallenge.com/2021/) and then follow the [WideAndDeep Preprocessing](../wnd) to preprocess the original data.
 
 ## Train lightGBM
 * Spark local, we can use some sample data to have a trial, example command:

--- a/python/friesian/example/two_tower/README.md
+++ b/python/friesian/example/two_tower/README.md
@@ -1,5 +1,5 @@
 # Train a two tower model using recsys data
-This example demonstrates how to use BigDL Friesian to train a two tower model using [Twitter Recsys Challenge 2021 data](https://recsys-twitter.com/data/show-downloads#).
+This example demonstrates how to use BigDL Friesian to train a two tower model using [Twitter Recsys Challenge 2021 data](http://www.recsyschallenge.com/2021/).
 
 ## Prepare the environment
 We recommend you to use [Anaconda](https://www.anaconda.com/distribution/#linux) to prepare the environments, especially if you want to run on a yarn cluster (yarn-client mode only).
@@ -10,7 +10,7 @@ pip install tensorflow==2.6.0
 pip install --pre --upgrade bigdl-friesian[train]
 ```
 ## Preprocess data
-You can download the full Twitter dataset from [here](https://recsys-twitter.com/data/show-downloads#) and then follow the [WideAndDeep Preprocessing](https://github.com/intel-analytics/BigDL/tree/branch-2.0/python/friesian/example/wnd) to preprocess the original data.
+You can download the full Twitter dataset from [here](http://www.recsyschallenge.com/2021/) and then follow the [WideAndDeep Preprocessing](https://github.com/intel-analytics/BigDL/tree/branch-2.0/python/friesian/example/wnd) to preprocess the original data.
 
 ## Training 2 tower model
 * Spark local, we can use some sample data to have a trial, example command:

--- a/python/friesian/example/wnd/train/README.md
+++ b/python/friesian/example/wnd/train/README.md
@@ -1,6 +1,6 @@
 # Train the Twitter Recsys Challenge 2021 dataset for WideAndDeep Model
 This example demonstrates how to use BigDL Friesian to train [WideAndDeep](https://arxiv.org/abs/1606.07792) model with the
-[Twitter Recsys Challenge 2021](https://recsys-twitter.com/data/show-downloads#) dataset.
+[Twitter Recsys Challenge 2021](http://www.recsyschallenge.com/2021/) dataset.
 
 ## Prepare the environment
 We recommend you to use [Anaconda](https://www.anaconda.com/distribution/#linux) to prepare the environments, especially if you want to run on a yarn cluster (yarn-client mode only).
@@ -12,7 +12,7 @@ pip install --pre --upgrade bigdl-friesian[train]
 ```
 
 ## Prepare the data
-You can download the full Twitter dataset from [here](https://recsys-twitter.com/data/show-downloads#), which includes around 1 billion records, more than 40 million records each day over 28 days.
+You can download the full Twitter dataset from [here](http://www.recsyschallenge.com/2021/), which includes around 1 billion records, more than 40 million records each day over 28 days.
  Week 1 - 3 will be used for training and week 4 for evaluation and testing. Each record contains the tweet along with engagement features, user features, and tweet features.
 
 After you download and decompress the files, there is a train parquet directory and validation csv file.

--- a/python/friesian/example/xgb/README.md
+++ b/python/friesian/example/xgb/README.md
@@ -1,5 +1,5 @@
 # Train an XGBoost model using Twitter dataset
-This example demonstrates how to train an [XGBoost](https://xgboost.readthedocs.io/en/stable/) classification model in a distributed way using [Twitter Recsys Challenge 2021 data](https://recsys-twitter.com/data/show-downloads#).
+This example demonstrates how to train an [XGBoost](https://xgboost.readthedocs.io/en/stable/) classification model in a distributed way using [Twitter Recsys Challenge 2021 data](http://www.recsyschallenge.com/2021/).
 
 ## Prepare the environment
 We recommend you to use [Anaconda](https://www.anaconda.com/distribution/#linux) to prepare the environments, especially if you want to run on a yarn cluster (yarn-client mode only).
@@ -11,7 +11,7 @@ pip install xgboost
 ```
 
 ## Preprocess the data
-You can download the full Twitter dataset from [here](https://recsys-twitter.com/data/show-downloads#) and then follow the [WideAndDeep Preprocessing](../wnd) to preprocess the original data.
+You can download the full Twitter dataset from [here](http://www.recsyschallenge.com/2021/) and then follow the [WideAndDeep Preprocessing](../wnd) to preprocess the original data.
 
 ## Train XGBoost
 * Spark local, we can use some sample data to have a trial, example command:


### PR DESCRIPTION
Reported by the ALOps team.

- Some typo in README
- The link for twitter dataset seems to be destroyed, change to recsys2021 homepage as a workaround.