### PR TITLE
Nano: more robust M-series chip support

### DIFF
--- a/python/nano/dev/release.sh
+++ b/python/nano/dev/release.sh
@@ -47,7 +47,7 @@ if [ "$platform" ==  "mac" ]; then
     sed -i 's/intel-tensorflow/tensorflow/' $BIGDL_PYTHON_DIR/setup.py
 
 elif [ "$platform" ==  "mac_mseries" ]; then
-    verbose_pname="macosx_12_0_arm64"
+    verbose_pname="macosx_11_0_arm64"
 
 elif [ "$platform" == "linux" ]; then
     verbose_pname="manylinux2010_x86_64"

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -76,9 +76,7 @@ def setup_package():
     tensorflow_requires = ["intel-tensorflow==2.7.0; platform_machine=='x86_64'",
                            "keras==2.7.0; platform_machine=='x86_64'",
                            "tensorflow-estimator==2.7.0; platform_machine=='x86_64'",
-                           "tf2onnx==1.12.1; platform_machine=='x86_64'",
-                           "tensorflow-macos==2.7.0; platform_machine=='arm64' and sys_platform=='darwin'",
-                           "tensorflow-metal==0.3.0; platform_machine=='arm64' and sys_platform=='darwin'"]
+                           "tf2onnx==1.12.1; platform_machine=='x86_64'"]
 
     # ipex is only avaliable for linux now
     pytorch_113_requires = ["torch==1.13.0",


### PR DESCRIPTION
## Description

- Remove the installation helper for M-series users and ask them to install tensorflow any way they want
- Lower the minimal required macos version from 12 -> 11
