### PR TITLE
[WIP]Nano OpenVINO lazy compile

### DIFF
--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -67,17 +67,6 @@ class OpenVINOModel:
             self._ie_network = self._ie.read_model(model=str(model))
         else:
             self._ie_network = model
-        if self.thread_num is not None:
-            config = {"CPU_THREADS_NUM": str(self.thread_num)}
-        else:
-            config = {}
-        if self.additional_config is not None:
-            config.update(self.additional_config)
-        self._compiled_model = self._ie.compile_model(model=self.ie_network,
-                                                      device_name=self._device,
-                                                      config=config)
-        self.final_config = config
-        self._infer_request = self._compiled_model.create_infer_request()
         input_names = [t.any_name for t in self._ie_network.inputs]
         self._forward_args = input_names
 
@@ -181,6 +170,19 @@ class OpenVINOModel:
 
     def _model_exists_or_err(self):
         invalidInputError(self.ie_network is not None, "self.ie_network shouldn't be None.")
+        if self._infer_request is None:
+            # Compile model & create infer request
+            if self.thread_num is not None:
+                config = {"CPU_THREADS_NUM": str(self.thread_num)}
+            else:
+                config = {}
+            if self.additional_config is not None:
+                config.update(self.additional_config)
+            self._compiled_model = self._ie.compile_model(model=self.ie_network,
+                                                        device_name=self._device,
+                                                        config=config)
+            self.final_config = config
+            self._infer_request = self._compiled_model.create_infer_request()
 
     def async_predict(self,
                       input_data: Union[List[np.ndarray], List[List[np.ndarray]]],

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -87,11 +87,12 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         return self.ov_model.forward_args
 
     @staticmethod
-    def _load(path):
+    def _load(path, config=None):
         """
         Load an OpenVINO model for inference from directory.
 
         :param path: Path to model to be loaded.
+        :param config: The config to be inputted in core.compile_model.
         :return: PytorchOpenVINOModel model for OpenVINO inference.
         """
         status = PytorchOpenVINOModel._load_status(path)
@@ -103,9 +104,11 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
             invalidInputError(False, "nano_model_meta.yml must specify 'xml_path' for loading.")
         xml_path = Path(path) / status['xml_path']
         thread_num = None
-        if "CPU_THREADS_NUM" in status['config']:
-            thread_num = int(status['config']["CPU_THREADS_NUM"])
-        return PytorchOpenVINOModel(xml_path, config=status['config'], thread_num=thread_num)
+        origin_config = status['config']
+        origin_config.update(config)
+        if "CPU_THREADS_NUM" in origin_config:
+            thread_num = int(origin_config["CPU_THREADS_NUM"])
+        return PytorchOpenVINOModel(xml_path, config=origin_config, thread_num=thread_num)
 
     def pot(self,
             dataloader,


### PR DESCRIPTION
## Description

Nano OpenVINO

compile ov model in __init__ -> compile ov model before the first forward.

### 1. Why the change?

In multiprocessing environment, ov model compile should in the sub-process and the main process should not compile any models, otherwise, the sub-process can only use 1 physical call.

### 2. User API changes

ov _load add config parameter.

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...
