### PR TITLE
Remove handle_batchsize in DatasetHandler

### DIFF
--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -136,6 +136,10 @@ class SparkTFEstimator():
             if batch_size:
                 invalidInputError(isinstance(batch_size, int) and batch_size > 0,
                                   "batch_size should be a positive integer")
+        if batch_size:
+            batch_size = batch_size // self.num_workers  # Local batch size for each worker
+            if batch_size <= 0:
+                batch_size = 1
         sc = OrcaContext.get_spark_context()
 
         if isinstance(data, SparkXShards):
@@ -273,6 +277,10 @@ class SparkTFEstimator():
             if batch_size:
                 invalidInputError(isinstance(batch_size, int) and batch_size > 0,
                                   "batch_size should be a positive integer")
+        if batch_size:
+            batch_size = batch_size // self.num_workers  # Local batch size for each worker
+            if batch_size <= 0:
+                batch_size = 1
         sc = OrcaContext.get_spark_context()
         logger.info("Starting validation step.")
 
@@ -363,6 +371,9 @@ class SparkTFEstimator():
         if batch_size:
             invalidInputError(isinstance(batch_size, int) and batch_size > 0,
                               "batch_size should be a positive integer")
+            batch_size = batch_size // self.num_workers  # Local batch size for each worker
+            if batch_size <= 0:
+                batch_size = 1
         logger.info("Starting predict step.")
         sc = OrcaContext.get_spark_context()
         if self.model_weights:

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -25,7 +25,6 @@ import ray
 
 from bigdl.dllib.utils import log4Error
 from bigdl.dllib.utils.file_utils import is_local_path
-from bigdl.orca import OrcaContext
 from bigdl.orca.data.file import enable_multi_fs_save, enable_multi_fs_load
 from bigdl.orca.data.ray_xshards import RayXShards
 from bigdl.orca.learn.dl_cluster import RayDLCluster
@@ -184,6 +183,10 @@ class TensorFlow2Estimator(OrcaRayEstimator):
             if batch_size:
                 invalidInputError(isinstance(batch_size, int) and batch_size > 0,
                                   "batch_size should be a positive integer")
+        if batch_size:
+            batch_size = batch_size // self.num_workers  # Local batch size for each worker
+            if batch_size <= 0:
+                batch_size = 1
         params = dict(
             epochs=epochs,
             batch_size=batch_size,
@@ -332,6 +335,10 @@ class TensorFlow2Estimator(OrcaRayEstimator):
             if batch_size:
                 invalidInputError(isinstance(batch_size, int) and batch_size > 0,
                                   "batch_size should be a positive integer")
+        if batch_size:
+            batch_size = batch_size // self.num_workers  # Local batch size for each worker
+            if batch_size <= 0:
+                batch_size = 1
         logger.info("Starting validation step.")
         params = dict(
             batch_size=batch_size,
@@ -464,6 +471,9 @@ class TensorFlow2Estimator(OrcaRayEstimator):
         if batch_size:
             invalidInputError(isinstance(batch_size, int) and batch_size > 0,
                               "batch_size should be a positive integer")
+            batch_size = batch_size // self.num_workers  # Local batch size for each worker
+            if batch_size <= 0:
+                batch_size = 1
         logger.info("Starting predict step.")
         params = dict(
             verbose=verbose,


### PR DESCRIPTION
Put the computation of local batch into fit/predict/evaluate so that this can be aligned with shard_size for the conversion.

For tf-local, it is not used. Even if it will be used, batch_size = batch_size // num_workers would be correct, since for tf-local the worker size is always 1.