### PR TITLE
Nano: improve Howto guide of InferenceOptimizer.optimize

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ optimizer.summary()
 The output of `optimizer.summary()` will be something like:
 ```
  -------------------------------- ---------------------- -------------- ----------------------
-|             method             |        status        | latency(ms)  |       accuracy       |
+|             method             |        status        | latency(ms)  |     metric value     |
  -------------------------------- ---------------------- -------------- ----------------------
 |            original            |      successful      |    45.145    |        0.975         |
 |              bf16              |      successful      |    27.549    |        0.975         |
@@ -190,7 +190,7 @@ The output of `optimizer.summary()` will be something like:
 |        onnxruntime_fp32        |      successful      |    20.838    |        0.975*        |
 |    onnxruntime_int8_qlinear    |      successful      |    7.123     |        0.981         |
  -------------------------------- ---------------------- -------------- ----------------------
-* means we assume the accuracy of the traced model does not change, so we don't recompute accuracy to save time.
+* means we assume the metric value of the traced model does not change, so we don't recompute metric value to save time.
 Optimization cost 60.8s in total.
 ```
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ The output of `optimizer.summary()` will be something like:
 |        onnxruntime_fp32        |      successful      |    20.838    |        0.975*        |
 |    onnxruntime_int8_qlinear    |      successful      |    7.123     |        0.981         |
  -------------------------------- ---------------------- -------------- ----------------------
-* means we assume the precision of the traced model does not change, so we don't recompute accuracy to save time.
+* means we assume the accuracy of the traced model does not change, so we don't recompute accuracy to save time.
 Optimization cost 60.8s in total.
 ```
 

--- a/docs/readthedocs/source/doc/Nano/Overview/pytorch_inference.md
+++ b/docs/readthedocs/source/doc/Nano/Overview/pytorch_inference.md
@@ -284,7 +284,6 @@ The output table of `optimize()` looks like:
 |        onnxruntime_fp32        |      successful      |    3.801     |
 |    onnxruntime_int8_qlinear    |      successful      |    4.727     |
  -------------------------------- ---------------------- --------------
-* means we assume the accuracy of the traced model does not change, so we don't recompute accuracy to save time.
 Optimization cost 58.3s in total.
 ```
 

--- a/python/nano/example/pytorch/inference_optimizer/export_model/export_model.py
+++ b/python/nano/example/pytorch/inference_optimizer/export_model/export_model.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
         # If the model is fully quantified, the model weights obtained are all int8
         # Otherwise, if some operations are kept at fp32, the stored weights will be mixed precision
         exported_files = [f"{save_dir}/best_model.pt"]
-    elif "ipex" in option or "channels_last" in option or "jit" in option:
+    elif "ipex" in option or "channels_last" in option or "jit" in option or "bf16" in option:
         # You will see "ckpt.pt" under "best_model" directory
         # if "jit" in option, "ckpt.pt" stores model optimized using just-in-time compilation
         # otherwise, it stores original model weight by torch.save(model.state_dict())
@@ -91,6 +91,4 @@ if __name__ == "__main__":
     else:
         # You will see "save_weight.pt" under "best_model" directory
         # saved by torch.save(model.state_dict())
-        # if "bf16" in option, the model weights obtained are bf16 dtype
-        # otherwise, the model weights obtained are fp32 dtype
         exported_files = [f"{save_dir}/saved_weight.pt"]

--- a/python/nano/example/pytorch/inference_optimizer/resnet/README.md
+++ b/python/nano/example/pytorch/inference_optimizer/resnet/README.md
@@ -53,7 +53,7 @@ Then you may find the result for inference as follows. The actual number may var
 ```
 ==========================Optimization Results==========================
  -------------------------------- ---------------------- -------------- ----------------------
-|             method             |        status        | latency(ms)  |       accuracy       |
+|             method             |        status        | latency(ms)  |     metric value     |
  -------------------------------- ---------------------- -------------- ----------------------
 |            original            |      successful      |    45.145    |        0.975         |
 |              bf16              |      successful      |    27.549    |        0.975         |
@@ -67,7 +67,7 @@ Then you may find the result for inference as follows. The actual number may var
 |        onnxruntime_fp32        |      successful      |    20.838    |        0.975*        |
 |    onnxruntime_int8_qlinear    |      successful      |    7.123     |        0.981         |
  -------------------------------- ---------------------- -------------- ----------------------
-* means we assume the accuracy of the traced model does not change, so we don't recompute accuracy to save time.
+* means we assume the metric value of the traced model does not change, so we don't recompute metric value to save time.
 Optimization cost 60.8s in total.
 ===========================Stop Optimization===========================
 When accuracy drop less than 5%, the model with minimal latency is:  openvino + int8

--- a/python/nano/example/pytorch/inference_optimizer/resnet/README.md
+++ b/python/nano/example/pytorch/inference_optimizer/resnet/README.md
@@ -67,7 +67,7 @@ Then you may find the result for inference as follows. The actual number may var
 |        onnxruntime_fp32        |      successful      |    20.838    |        0.975*        |
 |    onnxruntime_int8_qlinear    |      successful      |    7.123     |        0.981         |
  -------------------------------- ---------------------- -------------- ----------------------
-* means we assume the precision of the traced model does not change, so we don't recompute accuracy to save time.
+* means we assume the accuracy of the traced model does not change, so we don't recompute accuracy to save time.
 Optimization cost 60.8s in total.
 ===========================Stop Optimization===========================
 When accuracy drop less than 5%, the model with minimal latency is:  openvino + int8

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -384,7 +384,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 print(f"----------Start test {method} model "
                       f"({idx+1}/{len(available_dict)})----------")
                 option: AccelerationOption = self.ALL_INFERENCE_ACCELERATION_METHOD[method]
-                precision = option.get_precision()
+                _precision = option.get_precision()
                 try:
                     acce_model = option.optimize(model, training_data=training_data,
                                                  input_sample=input_sample,
@@ -428,7 +428,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                     if self._calculate_accuracy:
                         # here we suppose trace don't change accuracy,
                         # so we jump it to reduce time cost of optimize
-                        if precision == "fp32" and method != "original":
+                        if _precision == "fp32" and method != "original":
                             _accuracy = result_map["original"]["accuracy"]
                             if isinstance(_accuracy, torch.Tensor):
                                 _accuracy = _accuracy.item()

--- a/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
@@ -153,10 +153,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 1. Default search_mode\n",
+    "### 1. Default search mode\n",
     "To find acceleration method with the minimum inference latency, you could import `InferenceOptimizer` and call `optimize` method. The `optimize` method will run all possible acceleration combinations and output the result, it will take about 1 minute."
    ]
   },
@@ -228,10 +229,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2. All search_mode\n",
+    "### 2. All search mode\n",
     "When calling `optimize`, to make sure the runnng time is not too long, as shown in the above table, by default, we only iterate 10 acceleration methods that we think are generally good. However currently we have 22 acceleration methods in all, if you want to get the global optimal acceleration model, you can specify `search_mode=all` when calling `optimize`."
    ]
   },
@@ -442,10 +444,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 4. Diable validation during optimize\n",
+    "### 4. Disable validation during optimize\n",
     "\n",
     "If you can't get corresponding validation dataloader for you model, or you don't care about the possible accuracy drop, you could just disable validation by don't specify `validation_data`, `metric`, `direction` paramater:"
    ]

--- a/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
@@ -23,35 +23,32 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To inference using Bigdl-nano InferenceOptimizer, the following packages need to be installed first. We recommend you to use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to prepare the environment and install the following packages in a conda environment. \n",
+    "To inference using BigDL-Nano InferenceOptimizer, the following packages need to be installed first. We recommend you to use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to prepare the environment and install the following packages in a conda environment. \n",
     "\n",
     "You can create a conda environment by executing:\n",
     "\n",
-    "```\n",
+    "```bash\n",
     "# \"nano\" is conda environment name, you can use any name you like.\n",
     "conda create -n nano python=3.7 setuptools=58.0.4  \n",
     "conda activate nano\n",
-    "!pip install --pre --upgrade bigdl-nano[pytorch,inference]  # install the nightly-built version\n",
+    "pip install --pre --upgrade bigdl-nano[pytorch,inference]  # install the nightly-built version\n",
     "```\n"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then initialize environment variables with script `bigdl-nano-init` installed with bigdl-nano."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!source bigdl-nano-init"
+    "Then initialize environment variables with script `bigdl-nano-init` installed with bigdl-nano.\n",
+    "\n",
+    "```bash\n",
+    "source bigdl-nano-init\n",
+    "```"
    ]
   },
   {
@@ -191,6 +188,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -212,7 +210,7 @@
     "|        onnxruntime_fp32        |      successful      |    19.792    |        0.794*        |\n",
     "|    onnxruntime_int8_qlinear    |      successful      |     7.34     |         0.79         |\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
-    "* means we assume the precision of the traced model does not change, so we don't recompute accuracy to save time.\n",
+    "* means we assume the accuracy of the traced model does not change, so we don't recompute accuracy to save time.\n",
     "Optimization cost 94.2s in total.\n",
     "```"
    ]
@@ -254,6 +252,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -287,17 +286,19 @@
     "|    onnxruntime_int8_qlinear    |      successful      |    7.726     |         0.79         |\n",
     "|    onnxruntime_int8_integer    |   fail to convert    |     None     |         None         |\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
-    "* means we assume the precision of the traced model does not change, so we don't recompute accuracy to save time.\n",
+    "* means we assume the accuracy of the traced model does not change, so we don't recompute accuracy to save time.\n",
     "Optimization cost 152.7s in total.\n",
     "```"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### 3. Filter acceleration methods\n",
     "In some cases, you may just want to test or compare several specific methods, there are two ways to achieve this.\n",
+    "\n",
     "1. If you just want to test very little methods, you could just set `includes` parameter:"
    ]
   },
@@ -318,6 +319,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -331,7 +333,7 @@
     "|         openvino_fp32          |      successful      |    24.334    |        0.794*        |\n",
     "|        onnxruntime_fp32        |      successful      |    20.872    |        0.794*        |\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
-    "* means we assume the precision of the traced model does not change, so we don't recompute accuracy to save time.\n",
+    "* means we assume the accuracy of the traced model does not change, so we don't recompute accuracy to save time.\n",
     "Optimization cost 22.8s in total.\n",
     "```"
    ]
@@ -362,6 +364,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -381,7 +384,7 @@
     "|     jit_bf16_channels_last     |      successful      |    29.236    |        0.794         |\n",
     "|         openvino_fp32          |      successful      |    24.312    |        0.794*        |\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
-    "* means we assume the precision of the traced model does not change, so we don't recompute accuracy to save time.\n",
+    "* means we assume the accuracy of the traced model does not change, so we don't recompute accuracy to save time.\n",
     "Optimization cost 60.8s in total.\n",
     "```"
    ]
@@ -419,6 +422,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -438,7 +442,7 @@
     "|         openvino_fp32          |      successful      |    24.585    |        0.794*        |\n",
     "|        onnxruntime_fp32        |      successful      |    19.452    |        0.794*        |\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
-    "* means we assume the precision of the traced model does not change, so we don't recompute accuracy to save time.\n",
+    "* means we assume the accuracy of the traced model does not change, so we don't recompute accuracy to save time.\n",
     "Optimization cost 53.2s in total.\n",
     "```"
    ]
@@ -448,9 +452,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 4. Disable validation during optimize\n",
+    "### 4. Disable validation during optimization\n",
     "\n",
-    "If you can't get corresponding validation dataloader for you model, or you don't care about the possible accuracy drop, you could just disable validation by don't specify `validation_data`, `metric`, `direction` paramater:"
+    "If you can't get corresponding validation dataloader for you model, or you don't care about the possible accuracy drop, you could omit `validation_data`, `metric`, `direction` paramaters to disable validation:"
    ]
   },
   {
@@ -466,10 +470,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 5. More flexiable input format\n",
+    "### 5. More flexible input format\n",
     "Now that, `optimize` can not only accept `Dataloader`, but also accept `Tensor` or tuple of `Tensor` as input, as we will automatic turn them into `Dataloader` internally."
    ]
   },
@@ -652,7 +657,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.10 (default, Jun  4 2021, 14:48:32) \n[GCC 7.5.0]"
   },
   "vscode": {
    "interpreter": {

--- a/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
@@ -23,7 +23,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -40,7 +39,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -60,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -150,7 +148,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -188,7 +185,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -196,7 +192,7 @@
     "\n",
     "```bash\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
-    "|             method             |        status        | latency(ms)  |       accuracy       |\n",
+    "|             method             |        status        | latency(ms)  |     metric value     |\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
     "|            original            |      successful      |    29.796    |        0.794         |\n",
     "|              bf16              |      successful      |    16.853    |        0.794         |\n",
@@ -210,7 +206,7 @@
     "|        onnxruntime_fp32        |      successful      |    19.792    |        0.794*        |\n",
     "|    onnxruntime_int8_qlinear    |      successful      |     7.34     |         0.79         |\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
-    "* means we assume the accuracy of the traced model does not change, so we don't recompute accuracy to save time.\n",
+    "* means we assume the metric value of the traced model does not change, so we don't recompute metric value to save time.\n",
     "Optimization cost 94.2s in total.\n",
     "```"
    ]
@@ -227,7 +223,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -252,7 +247,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -260,7 +254,7 @@
     "\n",
     "```bash\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
-    "|             method             |        status        | latency(ms)  |       accuracy       |\n",
+    "|             method             |        status        | latency(ms)  |     metric value     |\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
     "|            original            |      successful      |    30.457    |        0.794         |\n",
     "|       fp32_channels_last       |      successful      |    28.973    |        0.794*        |\n",
@@ -286,13 +280,12 @@
     "|    onnxruntime_int8_qlinear    |      successful      |    7.726     |         0.79         |\n",
     "|    onnxruntime_int8_integer    |   fail to convert    |     None     |         None         |\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
-    "* means we assume the accuracy of the traced model does not change, so we don't recompute accuracy to save time.\n",
+    "* means we assume the metric value of the traced model does not change, so we don't recompute metric value to save time.\n",
     "Optimization cost 152.7s in total.\n",
     "```"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -319,7 +312,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -327,13 +319,13 @@
     "\n",
     "```bash\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
-    "|             method             |        status        | latency(ms)  |       accuracy       |\n",
+    "|             method             |        status        | latency(ms)  |     metric value     |\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
     "|            original            |      successful      |    29.859    |        0.794         |\n",
     "|         openvino_fp32          |      successful      |    24.334    |        0.794*        |\n",
     "|        onnxruntime_fp32        |      successful      |    20.872    |        0.794*        |\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
-    "* means we assume the accuracy of the traced model does not change, so we don't recompute accuracy to save time.\n",
+    "* means we assume the metric value of the traced model does not change, so we don't recompute metric value to save time.\n",
     "Optimization cost 22.8s in total.\n",
     "```"
    ]
@@ -364,7 +356,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -372,7 +363,7 @@
     "\n",
     "```bash\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
-    "|             method             |        status        | latency(ms)  |       accuracy       |\n",
+    "|             method             |        status        | latency(ms)  |     metric value     |\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
     "|            original            |      successful      |    30.978    |        0.794         |\n",
     "|       fp32_channels_last       |      successful      |    29.663    |        0.794*        |\n",
@@ -384,7 +375,7 @@
     "|     jit_bf16_channels_last     |      successful      |    29.236    |        0.794         |\n",
     "|         openvino_fp32          |      successful      |    24.312    |        0.794*        |\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
-    "* means we assume the accuracy of the traced model does not change, so we don't recompute accuracy to save time.\n",
+    "* means we assume the metric value of the traced model does not change, so we don't recompute metric value to save time.\n",
     "Optimization cost 60.8s in total.\n",
     "```"
    ]
@@ -422,7 +413,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -430,7 +420,7 @@
     "\n",
     "```bash\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
-    "|             method             |        status        | latency(ms)  |       accuracy       |\n",
+    "|             method             |        status        | latency(ms)  |     metric value     |\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
     "|            original            |      successful      |    31.872    |        0.794         |\n",
     "|              bf16              |      successful      |    17.326    |        0.794         |\n",
@@ -442,13 +432,12 @@
     "|         openvino_fp32          |      successful      |    24.585    |        0.794*        |\n",
     "|        onnxruntime_fp32        |      successful      |    19.452    |        0.794*        |\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
-    "* means we assume the accuracy of the traced model does not change, so we don't recompute accuracy to save time.\n",
+    "* means we assume the metric value of the traced model does not change, so we don't recompute metric value to save time.\n",
     "Optimization cost 53.2s in total.\n",
     "```"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -470,7 +459,32 @@
    ]
   },
   {
-   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The example output of `optimizer.optimize` is shown below.\n",
+    "\n",
+    "```bash\n",
+    " -------------------------------- ---------------------- --------------\n",
+    "|             method             |        status        | latency(ms)  |\n",
+    " -------------------------------- ---------------------- --------------\n",
+    "|            original            |      successful      |    29.387    |\n",
+    "|              bf16              |      successful      |    16.657    |\n",
+    "|          static_int8           |      successful      |    12.323    |\n",
+    "|         jit_fp32_ipex          |      successful      |    18.645    |\n",
+    "|  jit_fp32_ipex_channels_last   |      successful      |    18.478    |\n",
+    "|         jit_bf16_ipex          |      successful      |    9.964     |\n",
+    "|  jit_bf16_ipex_channels_last   |      successful      |    9.993     |\n",
+    "|         openvino_fp32          |      successful      |    23.547    |\n",
+    "|         openvino_int8          |      successful      |    5.711     |\n",
+    "|        onnxruntime_fp32        |      successful      |    20.283    |\n",
+    "|    onnxruntime_int8_qlinear    |      successful      |    7.141     |\n",
+    " -------------------------------- ---------------------- --------------\n",
+    "Optimization cost 49.9s in total.\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -544,7 +558,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -619,7 +632,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -675,7 +687,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10 (default, Jun  4 2021, 14:48:32) \n[GCC 7.5.0]"
+   "version": "3.7.10"
   },
   "vscode": {
    "interpreter": {

--- a/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
@@ -566,7 +566,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "oepnvino_model = optimizer.get_model(mothod_name='openvino_fp32')"
+    "oepnvino_model = optimizer.get_model(method_name='openvino_fp32')"
    ]
   },
   {

--- a/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
@@ -531,8 +531,26 @@
     }
    ],
    "source": [
+    "optimizer.optimize(model=model,\n",
+    "                   training_data=train_dataloader,\n",
+    "                   validation_data=val_dataloader,\n",
+    "                   metric=accuracy,\n",
+    "                   direction=\"max\",\n",
+    "                   thread_num=1,\n",
+    "                   latency_sample_num=100)\n",
+    "\n",
     "acc_model, option = optimizer.get_best_model(accuracy_criterion=0.05)\n",
     "print(\"When accuracy drop less than 5%, the model with minimal latency is: \", option)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 📝 **Note**\n",
+    "> \n",
+    "> If you want to find the best model with `accuracy_criterion` paramter, make sure you have called `optimize` with validation data."
    ]
   },
   {

--- a/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
@@ -593,10 +593,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The model files will be saved at `./best_model` directory. For each type in the `option` of best model, you only need to take the following files for further usage.\n",
+    "The model files will be saved at `./best_model` directory. For different type of the obtained model, you only need to take the following files for further usage.\n",
     "\n",
     "- **OpenVINO**\n",
     "    \n",
@@ -612,15 +613,13 @@
     "\n",
     "    `best_model.pt`: Represents model optimized by Intel® Neural Compressor\n",
     "\n",
-    "- **ipex | channel_last | jit**\n",
+    "- **ipex | channel_last | jit | bf16**\n",
     "    \n",
     "    `ckpt.pt`: If `jit` in option, it stores model optimized using just-in-time compilation, otherwise, it stores original model weight by `torch.save(model.state_dict())`.\n",
     "\n",
     "- **Others**\n",
     "    \n",
-    "    `saved_weight.pt`: Saved by `torch.save(model.state_dict())`.\n",
-    "    \n",
-    "    If `bf16` in option, the model weights obtained are bf16 dtype, otherwise, the model weights obtained are fp32 dtype"
+    "    `saved_weight.pt`: Saved by `torch.save(model.state_dict())`."
    ]
   },
   {

--- a/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
@@ -243,7 +243,7 @@
     "                   direction=\"max\",\n",
     "                   thread_num=1,\n",
     "                   search_mode='all',\n",
-    "                   latency_sample_num=100)"
+    "                   latency_sample_num=20)"
    ]
   },
   {
@@ -687,7 +687,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.10 (default, Jun  4 2021, 14:48:32) \n[GCC 7.5.0]"
   },
   "vscode": {
    "interpreter": {

--- a/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "nbsphinx": "hidden"
    },
@@ -149,7 +149,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To find acceleration method with the minimum inference latency, you could import `InferenceOptimizer` and call `optimize` method. The `optimize` method will run all possible acceleration combinations and output the result, it will take about 2 minutes."
+    "## Obtain available accelaration combinations by `optimize`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Default search_mode\n",
+    "To find acceleration method with the minimum inference latency, you could import `InferenceOptimizer` and call `optimize` method. The `optimize` method will run all possible acceleration combinations and output the result, it will take about 1 minute."
    ]
   },
   {
@@ -178,7 +186,7 @@
     "                   metric=accuracy,\n",
     "                   direction=\"max\",\n",
     "                   thread_num=1,\n",
-    "                   latency_sample_num=30)"
+    "                   latency_sample_num=100)"
    ]
   },
   {
@@ -187,26 +195,24 @@
    "source": [
     "The example output of `optimizer.optimize` is shown below.\n",
     "\n",
-    "```\n",
-    "==========================Optimization Results==========================\n",
+    "```bash\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
     "|             method             |        status        | latency(ms)  |       accuracy       |\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
-    "|            original            |      successful      |    41.304    |         0.86         |\n",
-    "|           fp32_ipex            |      successful      |    38.624    |    not recomputed    |\n",
-    "|              bf16              |   lack dependency    |     None     |         None         |\n",
-    "|           bf16_ipex            |   lack dependency    |     None     |         None         |\n",
-    "|              int8              |      successful      |    23.108    |        0.852         |\n",
-    "|            jit_fp32            |    early stopped     |    75.324    |         None         |\n",
-    "|         jit_fp32_ipex          |      successful      |    65.829    |    not recomputed    |\n",
-    "|  jit_fp32_ipex_channels_last   |    early stopped     |    90.795    |         None         |\n",
-    "|         openvino_fp32          |      successful      |    40.322    |    not recomputed    |\n",
-    "|         openvino_int8          |      successful      |    3.871     |        0.834         |\n",
-    "|        onnxruntime_fp32        |      successful      |    30.08     |    not recomputed    |\n",
-    "|    onnxruntime_int8_qlinear    |      successful      |    18.662    |        0.846         |\n",
-    "|    onnxruntime_int8_integer    |   fail to convert    |     None     |         None         |\n",
+    "|            original            |      successful      |    29.796    |        0.794         |\n",
+    "|              bf16              |      successful      |    16.853    |        0.794         |\n",
+    "|          static_int8           |      successful      |    12.149    |        0.786         |\n",
+    "|         jit_fp32_ipex          |      successful      |    18.647    |        0.794*        |\n",
+    "|  jit_fp32_ipex_channels_last   |      successful      |    21.505    |        0.794*        |\n",
+    "|         jit_bf16_ipex          |      successful      |     9.7      |        0.792         |\n",
+    "|  jit_bf16_ipex_channels_last   |      successful      |     9.84     |        0.792         |\n",
+    "|         openvino_fp32          |      successful      |    24.205    |        0.794*        |\n",
+    "|         openvino_int8          |      successful      |    5.805     |        0.792         |\n",
+    "|        onnxruntime_fp32        |      successful      |    19.792    |        0.794*        |\n",
+    "|    onnxruntime_int8_qlinear    |      successful      |     7.34     |         0.79         |\n",
     " -------------------------------- ---------------------- -------------- ----------------------\n",
-    "Optimization cost 74.2s in total.\n",
+    "* means we assume the precision of the traced model does not change, so we don't recompute accuracy to save time.\n",
+    "Optimization cost 94.2s in total.\n",
     "```"
    ]
   },
@@ -225,7 +231,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You could call `get_best_model` method to obtain the best model under specific restrictions or without restrictions. Here we get the model with minimal latency when accuracy drop less than 5%."
+    "### 2. All search_mode\n",
+    "When calling `optimize`, to make sure the runnng time is not too long, as shown in the above table, by default, we only iterate 10 acceleration methods that we think are generally good. However currently we have 22 acceleration methods in all, if you want to get the global optimal acceleration model, you can specify `search_mode=all` when calling `optimize`."
    ]
   },
   {
@@ -233,6 +240,288 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
+   "source": [
+    "optimizer.optimize(model=model,\n",
+    "                   training_data=train_dataloader,\n",
+    "                   validation_data=val_dataloader,\n",
+    "                   metric=accuracy,\n",
+    "                   direction=\"max\",\n",
+    "                   thread_num=1,\n",
+    "                   search_mode='all',\n",
+    "                   latency_sample_num=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The example output of `optimizer.optimize` is shown below.\n",
+    "\n",
+    "```bash\n",
+    " -------------------------------- ---------------------- -------------- ----------------------\n",
+    "|             method             |        status        | latency(ms)  |       accuracy       |\n",
+    " -------------------------------- ---------------------- -------------- ----------------------\n",
+    "|            original            |      successful      |    30.457    |        0.794         |\n",
+    "|       fp32_channels_last       |      successful      |    28.973    |        0.794*        |\n",
+    "|           fp32_ipex            |      successful      |    22.663    |        0.794*        |\n",
+    "|    fp32_ipex_channels_last     |      successful      |    22.669    |        0.794*        |\n",
+    "|              bf16              |      successful      |    17.378    |        0.794         |\n",
+    "|       bf16_channels_last       |      successful      |    17.207    |        0.794         |\n",
+    "|           bf16_ipex            |      successful      |    12.634    |        0.792         |\n",
+    "|    bf16_ipex_channels_last     |      successful      |    13.36     |        0.792         |\n",
+    "|          static_int8           |      successful      |    12.317    |        0.786         |\n",
+    "|        static_int8_ipex        |   fail to convert    |     None     |         None         |\n",
+    "|            jit_fp32            |      successful      |    18.114    |        0.794*        |\n",
+    "|     jit_fp32_channels_last     |      successful      |    18.434    |        0.794*        |\n",
+    "|            jit_bf16            |      successful      |    28.988    |        0.794         |\n",
+    "|     jit_bf16_channels_last     |      successful      |    28.907    |        0.794         |\n",
+    "|         jit_fp32_ipex          |      successful      |    18.021    |        0.794*        |\n",
+    "|  jit_fp32_ipex_channels_last   |      successful      |    18.088    |        0.794*        |\n",
+    "|         jit_bf16_ipex          |      successful      |    9.838     |        0.792         |\n",
+    "|  jit_bf16_ipex_channels_last   |      successful      |    10.315    |        0.792         |\n",
+    "|         openvino_fp32          |      successful      |    24.521    |        0.794*        |\n",
+    "|         openvino_int8          |      successful      |    5.774     |        0.794         |\n",
+    "|        onnxruntime_fp32        |      successful      |    19.682    |        0.794*        |\n",
+    "|    onnxruntime_int8_qlinear    |      successful      |    7.726     |         0.79         |\n",
+    "|    onnxruntime_int8_integer    |   fail to convert    |     None     |         None         |\n",
+    " -------------------------------- ---------------------- -------------- ----------------------\n",
+    "* means we assume the precision of the traced model does not change, so we don't recompute accuracy to save time.\n",
+    "Optimization cost 152.7s in total.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3. Filter acceleration methods\n",
+    "In some cases, you may just want to test or compare several specific methods, there are two ways to achieve this.\n",
+    "1. If you just want to test very little methods, you could just set `includes` parameter:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimizer.optimize(model=model,\n",
+    "                   training_data=train_dataloader,\n",
+    "                   validation_data=val_dataloader,\n",
+    "                   metric=accuracy,\n",
+    "                   direction=\"max\",\n",
+    "                   thread_num=1,\n",
+    "                   includes=[\"openvino_fp32\", \"onnxruntime_fp32\"],\n",
+    "                   latency_sample_num=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The example output of `optimizer.optimize` is shown below.\n",
+    "\n",
+    "```bash\n",
+    " -------------------------------- ---------------------- -------------- ----------------------\n",
+    "|             method             |        status        | latency(ms)  |       accuracy       |\n",
+    " -------------------------------- ---------------------- -------------- ----------------------\n",
+    "|            original            |      successful      |    29.859    |        0.794         |\n",
+    "|         openvino_fp32          |      successful      |    24.334    |        0.794*        |\n",
+    "|        onnxruntime_fp32        |      successful      |    20.872    |        0.794*        |\n",
+    " -------------------------------- ---------------------- -------------- ----------------------\n",
+    "* means we assume the precision of the traced model does not change, so we don't recompute accuracy to save time.\n",
+    "Optimization cost 22.8s in total.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "2. If you want to test methods with specific precision / accelerator, or you want to test methods with / without `ipex`, you could specify `precision` / `accelerator` / `use_ipex` parameter:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimizer.optimize(model=model,\n",
+    "                   training_data=train_dataloader,\n",
+    "                   validation_data=val_dataloader,\n",
+    "                   metric=accuracy,\n",
+    "                   direction=\"max\",\n",
+    "                   thread_num=1,\n",
+    "                   accelerator=('openvino', 'jit', None),\n",
+    "                   precision=('fp32', 'bf16'),\n",
+    "                   use_ipex=False,\n",
+    "                   latency_sample_num=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The example output of `optimizer.optimize` is shown below.\n",
+    "\n",
+    "```bash\n",
+    " -------------------------------- ---------------------- -------------- ----------------------\n",
+    "|             method             |        status        | latency(ms)  |       accuracy       |\n",
+    " -------------------------------- ---------------------- -------------- ----------------------\n",
+    "|            original            |      successful      |    30.978    |        0.794         |\n",
+    "|       fp32_channels_last       |      successful      |    29.663    |        0.794*        |\n",
+    "|              bf16              |      successful      |    17.12     |        0.794         |\n",
+    "|       bf16_channels_last       |      successful      |    17.709    |        0.794         |\n",
+    "|            jit_fp32            |      successful      |    18.411    |        0.794*        |\n",
+    "|     jit_fp32_channels_last     |      successful      |    18.872    |        0.794*        |\n",
+    "|            jit_bf16            |      successful      |    29.355    |        0.794         |\n",
+    "|     jit_bf16_channels_last     |      successful      |    29.236    |        0.794         |\n",
+    "|         openvino_fp32          |      successful      |    24.312    |        0.794*        |\n",
+    " -------------------------------- ---------------------- -------------- ----------------------\n",
+    "* means we assume the precision of the traced model does not change, so we don't recompute accuracy to save time.\n",
+    "Optimization cost 60.8s in total.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 📝 **Note**\n",
+    "> \n",
+    "> You must pass a tuple input for parameter `accelerator` / `precision`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In some cases, if you expect that some acceleration methods will not work for your model / not work well / run for too long / cause exceptions to the program, you could avoid running these methods by specifying `excludes` paramater:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimizer.optimize(model=model,\n",
+    "                   training_data=train_dataloader,\n",
+    "                   validation_data=val_dataloader,\n",
+    "                   metric=accuracy,\n",
+    "                   direction=\"max\",\n",
+    "                   thread_num=1,\n",
+    "                   excludes=[\"onnxruntime_int8_qlinear\", \"openvino_int8\"],\n",
+    "                   latency_sample_num=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The example output of `optimizer.optimize` is shown below.\n",
+    "\n",
+    "```bash\n",
+    " -------------------------------- ---------------------- -------------- ----------------------\n",
+    "|             method             |        status        | latency(ms)  |       accuracy       |\n",
+    " -------------------------------- ---------------------- -------------- ----------------------\n",
+    "|            original            |      successful      |    31.872    |        0.794         |\n",
+    "|              bf16              |      successful      |    17.326    |        0.794         |\n",
+    "|          static_int8           |      successful      |    12.39     |        0.786         |\n",
+    "|         jit_fp32_ipex          |      successful      |    18.871    |        0.794*        |\n",
+    "|  jit_fp32_ipex_channels_last   |      successful      |    18.453    |        0.794*        |\n",
+    "|         jit_bf16_ipex          |      successful      |    9.863     |        0.792         |\n",
+    "|  jit_bf16_ipex_channels_last   |      successful      |    9.871     |        0.792         |\n",
+    "|         openvino_fp32          |      successful      |    24.585    |        0.794*        |\n",
+    "|        onnxruntime_fp32        |      successful      |    19.452    |        0.794*        |\n",
+    " -------------------------------- ---------------------- -------------- ----------------------\n",
+    "* means we assume the precision of the traced model does not change, so we don't recompute accuracy to save time.\n",
+    "Optimization cost 53.2s in total.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4. Diable validation during optimize\n",
+    "\n",
+    "If you can't get corresponding validation dataloader for you model, or you don't care about the possible accuracy drop, you could just disable validation by don't specify `validation_data`, `metric`, `direction` paramater:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimizer.optimize(model=model,\n",
+    "                   training_data=train_dataloader,\n",
+    "                   thread_num=1,\n",
+    "                   latency_sample_num=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5. More flexiable input format\n",
+    "Now that, `optimize` can not only accept `Dataloader`, but also accept `Tensor` or tuple of `Tensor` as input, as we will automatic turn them into `Dataloader` internally."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 📝 **Note**\n",
+    "> \n",
+    "> This function is mainly aimed at users who cannot obtain the corresponding dataloader and help users debug.\n",
+    ">\n",
+    "> If you want to maximize the accuracy of quantized model, please pass in the original training/validation `Dataloader` as much as possible"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample = next(iter(train_dataloader))\n",
+    "\n",
+    "optimizer.optimize(model=model,\n",
+    "                   training_data=sample,\n",
+    "                   thread_num=1,\n",
+    "                   latency_sample_num=100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Obtain specific model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You could call `get_best_model` method to obtain the best model under specific restrictions or without restrictions. Here we get the model with minimal latency when accuracy drop less than 5%."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "When accuracy drop less than 5%, the model with minimal latency is:  openvino + int8\n"
+     ]
+    }
+   ],
    "source": [
     "acc_model, option = optimizer.get_best_model(accuracy_criterion=0.05)\n",
     "print(\"When accuracy drop less than 5%, the model with minimal latency is: \", option)"
@@ -242,12 +531,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then you could use the best model for inference. "
+    "If you just want to obtain a specific model although it doesn't have the minimal latency, you could call `get_model` method and specify `method_name`. Here we take `openvino_fp32` as an example:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oepnvino_model = optimizer.get_model(mothod_name='openvino_fp32')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then you could use the obtained model for inference. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,12 +572,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To export the best model, you could simply call `save` method and pass the path to it."
+    "## Export model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To export the obtained model, you could simply call `InferenceOptimizer.save` method and pass the path to it."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -317,7 +636,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.10 ('ruonan_nano')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -333,7 +652,6 @@
    "pygments_lexer": "ipython3",
    "version": "3.7.10"
   },
-  "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
     "hash": "d347a5dca25745bedb029e46e41f7d6c8c9b5181ecb97033e2e81a7538459254"

--- a/python/nano/tutorial/notebook/inference/pytorch/run-nano-howto-guides-inference-pytorch-tests.sh
+++ b/python/nano/tutorial/notebook/inference/pytorch/run-nano-howto-guides-inference-pytorch-tests.sh
@@ -22,7 +22,7 @@ if [ ${dependency} == 'openvino' ]; then
 elif [ ${dependency} == 'onnx' ]; then
     python -m pytest -s --nbmake --nbmake-timeout=600 --nbmake-kernel=python3 ${NANO_HOWTO_GUIDES_TEST_DIR}/accelerate_pytorch_inference_onnx.ipynb ${NANO_HOWTO_GUIDES_TEST_DIR}/quantize_pytorch_inference_inc.ipynb
 else
-    python -m pytest -s --nbmake --nbmake-timeout=600 --nbmake-kernel=python3 ${NANO_HOWTO_GUIDES_TEST_DIR}/inference_optimizer_optimize.ipynb
+    python -m pytest -s --nbmake --nbmake-kernel=python3 ${NANO_HOWTO_GUIDES_TEST_DIR}/inference_optimizer_optimize.ipynb
 fi 
 
 now=$(date "+%s")

--- a/python/nano/tutorial/notebook/inference/pytorch/run-nano-howto-guides-inference-pytorch-tests.sh
+++ b/python/nano/tutorial/notebook/inference/pytorch/run-nano-howto-guides-inference-pytorch-tests.sh
@@ -22,7 +22,7 @@ if [ ${dependency} == 'openvino' ]; then
 elif [ ${dependency} == 'onnx' ]; then
     python -m pytest -s --nbmake --nbmake-timeout=600 --nbmake-kernel=python3 ${NANO_HOWTO_GUIDES_TEST_DIR}/accelerate_pytorch_inference_onnx.ipynb ${NANO_HOWTO_GUIDES_TEST_DIR}/quantize_pytorch_inference_inc.ipynb
 else
-    python -m pytest -s --nbmake --nbmake-kernel=python3 ${NANO_HOWTO_GUIDES_TEST_DIR}/inference_optimizer_optimize.ipynb
+    python -m pytest -s --nbmake --nbmake-timeout=1200 --nbmake-kernel=python3 ${NANO_HOWTO_GUIDES_TEST_DIR}/inference_optimizer_optimize.ipynb
 fi 
 
 now=$(date "+%s")


### PR DESCRIPTION
## Description

Update How-to guide of `InferenceOptimizer.optimize`.

### 1. Why the change?

 As we have greatly improved `InferenceOptimizer.optimize` method by extending the input format / extending the combinations of acceleration methods / updating output format / providing more functions or modes for user, we need to introduce these usages to users by How-to guide.

### 2. User API changes

No change.

### 3. Summary of the change 

- [x] update output table of `InferenceOptimizer.optimize`
- [x] add how-to guide for different mode : default / all
- [x] add how-to guide for filtering acceleration methods
- [x] add how-to guide for disable validation
- [x] add how-to guide for Tensor input
- [x] add how-to guide for `get_model`
- [x] update description of exported model

### 4. How to test?
- [x] Unit test
- [x] Document test
https://ruonantetdoc.readthedocs.io/en/update_howto_optimizer/doc/Nano/Howto/Inference/PyTorch/inference_optimizer_optimize.html