### PR TITLE
Change shard size to local batch size for TF2 Estimator

### DIFF
--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -47,6 +47,9 @@ class DatasetHandler:
         config, local_batch_size = self._handle_batch_size(config)
         config['rank'] = self.rank
         config['size'] = self.size
+        # Use global batch size here for data_creator since TensorFlow
+        # will shard the dataset.
+        # batch_size won't be used in data_creator for SparkXShards.
         train_dataset = data_creator(config, config["batch_size"])
         if isinstance(train_dataset, list) and \
            all([isinstance(x, dict) for x in train_dataset]):
@@ -150,6 +153,8 @@ class TFDistributedDatasetHandler(DatasetHandler):
         invalidInputError("batch_size" in config, "batch_size must be set in config")
         if config["batch_size"]:
             local_batch_size = config["batch_size"] // self.size
+            if local_batch_size <= 0:
+                local_batch_size = 1
         else:  # batch_size default to be None for predict
             local_batch_size = None
         return config, local_batch_size


### PR DESCRIPTION
- For Spark DataFrame and SparkXShards, we create distributed tf datasets for each worker and uses the local batch size. Thus it makes more sense to use the local batch size when convert Spark DataFrame to SparkXShards.
- For data loader that returns a tf dataset, it expects global batch size and tf will shard the dataset itself.
- Since both local and global size are needed for tf runner, need to still keep the pass the global batch size to runner and compute the local batch size in runner.