### PR TITLE
Nano: fix problem of default values in forward args for onnxruntime int8 quantization

### DIFF
--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/dataloader.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/dataloader.py
@@ -14,7 +14,8 @@
 # limitations under the License.
 #
 
-from bigdl.nano.utils.inference.pytorch.model_utils import get_forward_args
+from bigdl.nano.utils.inference.pytorch.model_utils import get_forward_args, \
+    get_tensor_args
 from typing import Sequence
 from copy import deepcopy
 import torch
@@ -72,7 +73,7 @@ def automatic_add_label_in_dataloader(model, dataloader, input_sample=None):
 
 def _need_dataloader_type_transformation(model, dataloader):
     # get forward method's parameter number
-    forward_args = get_forward_args(model)
+    forward_args = get_tensor_args(model)
     forward_args_len = len(forward_args)
 
     # if the model is a simple model(x) format

--- a/python/nano/src/bigdl/nano/utils/inference/pytorch/dataloader.py
+++ b/python/nano/src/bigdl/nano/utils/inference/pytorch/dataloader.py
@@ -73,7 +73,7 @@ def automatic_add_label_in_dataloader(model, dataloader, input_sample=None):
 
 def _need_dataloader_type_transformation(model, dataloader):
     # get forward method's parameter number
-    forward_args = get_conditional_args(model, include="all", exclude=(bool,))
+    forward_args = get_conditional_args(model, include="all", exclude=(bool, type(None),))
     forward_args_len = len(forward_args)
 
     # if the model is a simple model(x) format
@@ -97,7 +97,7 @@ def _check_whether_add_label(model, dataloader, input_sample=None):
     to add a (dummy) label at last.
     '''
     # get forward method's parameter number and input sample
-    forward_args = get_conditional_args(model, include="all", exclude=(bool,))
+    forward_args = get_conditional_args(model, include="all", exclude=(bool, type(None),))
     forward_args_len = len(forward_args)
     loader_input_sample = next(iter(dataloader))
 

--- a/python/nano/test/onnx/pytorch/test_inc_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_inc_onnx.py
@@ -319,6 +319,25 @@ class TestOnnx(TestCase):
                                                calib_data=(torch.rand(2,3,1,1), 5))
         result_m = accmodel(data, np.array([5]))  # TODO: make this 5
 
+        # default None values
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+            def forward(self, x, a=None):
+                if a is None:
+                    return x
+                else:
+                    return x + 1
+        model = Net()
+
+        data = torch.rand(1,3,1,1)
+
+        # sample with only required parameters (in a tuple)
+        accmodel = InferenceOptimizer.quantize(model,
+                                               accelerator="onnxruntime",
+                                               calib_data=torch.rand(2,3,1,1))
+        result_m = accmodel(data)
+
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/python/nano/test/onnx/pytorch/test_inc_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_inc_onnx.py
@@ -273,6 +273,35 @@ class TestOnnx(TestCase):
         accmodel(x2)
         accmodel(x3)
 
+    def test_onnx_inc_default_values(self):
+        # default bool values
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+            def forward(self, x, a=True, b=False):
+                if a:
+                    return x+1
+                if b:
+                    return x-1
+                return x
+
+        model = Net()
+
+        data = torch.rand(1,3,1,1)
+        result_true = model(data)
+        # sample with only required parameters (in a tuple)
+        accmodel = InferenceOptimizer.quantize(model,
+                                               accelerator="onnxruntime",
+                                               calib_data=torch.rand(2,3,1,1))
+        result_m = accmodel(data)
+
+        # sample with only required parameters (in a tuple)
+        accmodel = InferenceOptimizer.quantize(model,
+                                               accelerator="onnxruntime",
+                                               calib_data=torch.rand(2,3,1,1),
+                                               input_sample=(torch.rand(2,3,1,1), False, True))
+        result_m = accmodel(data)
+
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/python/nano/test/onnx/pytorch/test_inc_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_inc_onnx.py
@@ -24,6 +24,7 @@ import torch
 from torch import nn
 from torch.utils.data import TensorDataset, DataLoader
 import torchmetrics
+import numpy as np
 
 from bigdl.nano.pytorch import Trainer
 from bigdl.nano.pytorch import InferenceOptimizer
@@ -301,6 +302,22 @@ class TestOnnx(TestCase):
                                                calib_data=torch.rand(2,3,1,1),
                                                input_sample=(torch.rand(2,3,1,1), False, True))
         result_m = accmodel(data)
+
+        # default bool values
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+            def forward(self, x, a=3):
+                return x + a
+        model = Net()
+
+        data = torch.rand(1,3,1,1)
+
+        # sample with only required parameters (in a tuple)
+        accmodel = InferenceOptimizer.quantize(model,
+                                               accelerator="onnxruntime",
+                                               calib_data=(torch.rand(2,3,1,1), 5))
+        result_m = accmodel(data, np.array([5]))  # TODO: make this 5
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

### 1. Why the change?
This change is to make model with kwargs can be run through onnxruntime int8 quantization.

This PR  solves
- When the forward args has only bool and tensor type input
e.g.,
```python
class Net(nn.Module):
    def __init__(self):
        super().__init__()
    def forward(self, x, a=True, b=False):
        if a:
            return x+1
        if b:
            return x-1
        return x
```

- When the forward args has int or other type (with some limit)
e.g.,
```python
class Net(nn.Module):
    def __init__(self):
        super().__init__()
    def forward(self, x, a=3):
        return x + a
```
Here users should always input all the parameter as calib_data, nano will not patch the default values for them (TODO).

### 2. User API changes

Nothing changed

### 3. Summary of the change 

change a minor bug in dataloader_type_transformation

### 4. How to test?
- [ ] Unit test