### PR TITLE
Nano: add dynamic_axes parameter for `trace`/`quantize`/`optimize`

### DIFF
--- a/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
@@ -38,10 +38,14 @@ def PytorchONNXRuntimeModel(model, input_sample=None,
                              input and output tensors set to exactly match those given in
                              input_sample. To specify axes of tensors as dynamic (i.e. known only
                              at run-time), set dynamic_axes to a dict with schema:
-                               KEY (str): an input or output name. Each name must also be provided
-                               in input_names or output_names.
-                               VALUE (dict or list): If a dict, keys are axis indices and values are
-                               axis names. If a list, each element is an axis index.
+
+                             | KEY (str): an input or output name. Each name must also be provided
+                             | in input_names or output_names.
+                             |
+                             | VALUE (dict or list): If a dict, keys are axis indices and values
+                             | are axis names. If a list, each element is an axis index.
+
+                             If accelerator != 'openvino'/'onnxruntime', it will be ignored.
         :param **export_kwargs: will be passed to torch.onnx.export function.
         :return: A PytorchONNXRuntimeModel instance
         """

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
@@ -33,11 +33,11 @@ def PytorchONNXRuntimeModel(model, input_sample=None,
                                accelerator='onnxruntime', otherwise will be ignored. If this option
                                is set to True, new dependency 'onnxsim' need to be installed.
         :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
-                             will have the first dim of each input as a dynamic batch_size. If 
-                             dynamic_axes=False, the exported model will have the shapes of all input
-                             and output tensors set to exactly match those given in input_sample.
-                             To specify axes of tensors as dynamic (i.e. known only at run-time),
-                             set dynamic_axes to a dict with schema:
+                             will have the first dim of each input as a dynamic batch_size. If
+                             dynamic_axes=False, the exported model will have the shapes of all
+                             input and output tensors set to exactly match those given in
+                             input_sample. To specify axes of tensors as dynamic (i.e. known only
+                             at run-time), set dynamic_axes to a dict with schema:
                                KEY (str): an input or output name. Each name must also be provided
                                in input_names or output_names.
                                VALUE (dict or list): If a dict, keys are axis indices and values are

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
@@ -33,8 +33,8 @@ def PytorchONNXRuntimeModel(model, input_sample=None,
                                accelerator='onnxruntime', otherwise will be ignored. If this option
                                is set to True, new dependency 'onnxsim' need to be installed.
         :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
-                             will have the first dim of each input as a dynamic batch_size. If
-                             dynamic_axes=False, the exported model will have the shapes of all
+                             will have the first dim of each Tensor input as a dynamic batch_size.
+                             If dynamic_axes=False, the exported model will have the shapes of all
                              input and output tensors set to exactly match those given in
                              input_sample. To specify axes of tensors as dynamic (i.e. known only
                              at run-time), set dynamic_axes to a dict with schema:

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
@@ -17,7 +17,9 @@
 
 def PytorchONNXRuntimeModel(model, input_sample=None,
                             onnxruntime_session_options=None,
-                            simplification=True, **export_kwargs):
+                            simplification=True,
+                            dynamic_axes=True,
+                            **export_kwargs):
     """
         Create a ONNX Runtime model from pytorch.
 
@@ -30,13 +32,25 @@ def PytorchONNXRuntimeModel(model, input_sample=None,
         :param simplification: whether we use onnxsim to simplify the ONNX model, only valid when
                                accelerator='onnxruntime', otherwise will be ignored. If this option
                                is set to True, new dependency 'onnxsim' need to be installed.
+        :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
+                             will have the first dim of each input as a dynamic batch_size. If 
+                             dynamic_axes=False, the exported model will have the shapes of all input
+                             and output tensors set to exactly match those given in input_sample.
+                             To specify axes of tensors as dynamic (i.e. known only at run-time),
+                             set dynamic_axes to a dict with schema:
+                               KEY (str): an input or output name. Each name must also be provided
+                               in input_names or output_names.
+                               VALUE (dict or list): If a dict, keys are axis indices and values are
+                               axis names. If a list, each element is an axis index.
         :param **export_kwargs: will be passed to torch.onnx.export function.
         :return: A PytorchONNXRuntimeModel instance
         """
     from .pytorch.pytorch_onnxruntime_model import PytorchONNXRuntimeModel
     return PytorchONNXRuntimeModel(model, input_sample,
                                    onnxruntime_session_options=onnxruntime_session_options,
-                                   simplification=simplification, **export_kwargs)
+                                   simplification=simplification,
+                                   dynamic_axes=dynamic_axes,
+                                   **export_kwargs)
 
 
 def load_onnxruntime_model(path):

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -36,7 +36,7 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
     '''
 
     def __init__(self, model, input_sample=None, onnxruntime_session_options=None,
-                 simplification=True, **export_kwargs):
+                 simplification=True, dynamic_axes=True, **export_kwargs):
         """
         Create a ONNX Runtime model from pytorch.
 
@@ -49,6 +49,16 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
         :param simplification: whether we use onnxsim to simplify the ONNX model, only valid when
                                accelerator='onnxruntime', otherwise will be ignored. If this option
                                is set to True, new dependency 'onnxsim' need to be installed.
+        :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
+                             will have the first dim of each input as a dynamic batch_size. If 
+                             dynamic_axes=False, the exported model will have the shapes of all input
+                             and output tensors set to exactly match those given in input_sample.
+                             To specify axes of tensors as dynamic (i.e. known only at run-time),
+                             set dynamic_axes to a dict with schema:
+                               KEY (str): an input or output name. Each name must also be provided
+                               in input_names or output_names.
+                               VALUE (dict or list): If a dict, keys are axis indices and values are
+                               axis names. If a list, each element is an axis index.
         :param **export_kwargs: will be passed to torch.onnx.export function.
         """
         # Typically, when model is int8, we use this path
@@ -58,7 +68,7 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
                 onnx_path = os.path.join(tmpdir, "tmp.onnx")
                 # Typically, when model is fp32, we use this path
                 export_to_onnx(model, input_sample=input_sample, onnx_path=onnx_path,
-                               **export_kwargs)
+                               dynamic_axes=dynamic_axes, **export_kwargs)
                 if simplification is True:
                     # simplify model
                     try:

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -53,12 +53,16 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
                              will have the first dim of each input as a dynamic batch_size. If
                              dynamic_axes=False, the exported model will have the shapes of all
                              input and output tensors set to exactly match those given in
-                             input_sample. To specify axes of tensors as dynamic (i.e. known only at
-                             run-time), set dynamic_axes to a dict with schema:
-                               KEY (str): an input or output name. Each name must also be provided
-                               in input_names or output_names.
-                               VALUE (dict or list): If a dict, keys are axis indices and values are
-                               axis names. If a list, each element is an axis index.
+                             input_sample. To specify axes of tensors as dynamic (i.e. known only
+                             at run-time), set dynamic_axes to a dict with schema:
+
+                             | KEY (str): an input or output name. Each name must also be provided
+                             | in input_names or output_names.
+                             |
+                             | VALUE (dict or list): If a dict, keys are axis indices and values
+                             | are axis names. If a list, each element is an axis index.
+
+                             If accelerator != 'openvino'/'onnxruntime', it will be ignored.
         :param **export_kwargs: will be passed to torch.onnx.export function.
         """
         # Typically, when model is int8, we use this path

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -50,8 +50,8 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
                                accelerator='onnxruntime', otherwise will be ignored. If this option
                                is set to True, new dependency 'onnxsim' need to be installed.
         :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
-                             will have the first dim of each input as a dynamic batch_size. If
-                             dynamic_axes=False, the exported model will have the shapes of all
+                             will have the first dim of each Tensor input as a dynamic batch_size.
+                             If dynamic_axes=False, the exported model will have the shapes of all
                              input and output tensors set to exactly match those given in
                              input_sample. To specify axes of tensors as dynamic (i.e. known only
                              at run-time), set dynamic_axes to a dict with schema:

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -50,11 +50,11 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
                                accelerator='onnxruntime', otherwise will be ignored. If this option
                                is set to True, new dependency 'onnxsim' need to be installed.
         :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
-                             will have the first dim of each input as a dynamic batch_size. If 
-                             dynamic_axes=False, the exported model will have the shapes of all input
-                             and output tensors set to exactly match those given in input_sample.
-                             To specify axes of tensors as dynamic (i.e. known only at run-time),
-                             set dynamic_axes to a dict with schema:
+                             will have the first dim of each input as a dynamic batch_size. If
+                             dynamic_axes=False, the exported model will have the shapes of all
+                             input and output tensors set to exactly match those given in
+                             input_sample. To specify axes of tensors as dynamic (i.e. known only at
+                             run-time), set dynamic_axes to a dict with schema:
                                KEY (str): an input or output name. Each name must also be provided
                                in input_names or output_names.
                                VALUE (dict or list): If a dict, keys are axis indices and values are

--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -29,8 +29,8 @@ def PytorchOpenVINOModel(model, input_sample=None, thread_num=None,
     :param thread_num: a int represents how many threads(cores) is needed for
                        inference. default: None.
     :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
-                         will have the first dim of each input as a dynamic batch_size. If
-                         dynamic_axes=False, the exported model will have the shapes of all
+                         will have the first dim of each Tensor input as a dynamic batch_size.
+                         If dynamic_axes=False, the exported model will have the shapes of all
                          input and output tensors set to exactly match those given in
                          input_sample. To specify axes of tensors as dynamic (i.e. known only
                          at run-time), set dynamic_axes to a dict with schema:

--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -34,10 +34,14 @@ def PytorchOpenVINOModel(model, input_sample=None, thread_num=None,
                          input and output tensors set to exactly match those given in
                          input_sample. To specify axes of tensors as dynamic (i.e. known only
                          at run-time), set dynamic_axes to a dict with schema:
-                            KEY (str): an input or output name. Each name must also be provided
-                            in input_names or output_names.
-                            VALUE (dict or list): If a dict, keys are axis indices and values are
-                            axis names. If a list, each element is an axis index.
+
+                        | KEY (str): an input or output name. Each name must also be provided
+                        | in input_names or output_names.
+                        |
+                        | VALUE (dict or list): If a dict, keys are axis indices and values
+                        | are axis names. If a list, each element is an axis index.
+
+                         If accelerator != 'openvino'/'onnxruntime', it will be ignored.
     :param logging: whether to log detailed information of model conversion. default: True.
     :param config: The config to be inputted in core.compile_model.
     :param **export_kwargs: will be passed to torch.onnx.export function.

--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -17,7 +17,8 @@ from functools import partial
 
 
 def PytorchOpenVINOModel(model, input_sample=None, thread_num=None,
-                         logging=True, config=None, **export_kwargs):
+                         dynamic_axes=True, logging=True,
+                         config=None, **export_kwargs):
     """
     Create a OpenVINO model from pytorch.
 
@@ -27,6 +28,16 @@ def PytorchOpenVINOModel(model, input_sample=None, thread_num=None,
                          model is a LightningModule with any dataloader attached, defaults to None.
     :param thread_num: a int represents how many threads(cores) is needed for
                        inference. default: None.
+    :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
+                         will have the first dim of each input as a dynamic batch_size. If 
+                         dynamic_axes=False, the exported model will have the shapes of all input
+                         and output tensors set to exactly match those given in input_sample.
+                         To specify axes of tensors as dynamic (i.e. known only at run-time),
+                         set dynamic_axes to a dict with schema:
+                            KEY (str): an input or output name. Each name must also be provided
+                            in input_names or output_names.
+                            VALUE (dict or list): If a dict, keys are axis indices and values are
+                            axis names. If a list, each element is an axis index.
     :param logging: whether to log detailed information of model conversion. default: True.
     :param config: The config to be inputted in core.compile_model.
     :param **export_kwargs: will be passed to torch.onnx.export function.
@@ -36,6 +47,7 @@ def PytorchOpenVINOModel(model, input_sample=None, thread_num=None,
     return PytorchOpenVINOModel(model=model,
                                 input_sample=input_sample,
                                 thread_num=thread_num,
+                                dynamic_axes=dynamic_axes,
                                 logging=logging,
                                 config=config,
                                 **export_kwargs)

--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -29,11 +29,11 @@ def PytorchOpenVINOModel(model, input_sample=None, thread_num=None,
     :param thread_num: a int represents how many threads(cores) is needed for
                        inference. default: None.
     :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
-                         will have the first dim of each input as a dynamic batch_size. If 
-                         dynamic_axes=False, the exported model will have the shapes of all input
-                         and output tensors set to exactly match those given in input_sample.
-                         To specify axes of tensors as dynamic (i.e. known only at run-time),
-                         set dynamic_axes to a dict with schema:
+                         will have the first dim of each input as a dynamic batch_size. If
+                         dynamic_axes=False, the exported model will have the shapes of all
+                         input and output tensors set to exactly match those given in
+                         input_sample. To specify axes of tensors as dynamic (i.e. known only
+                         at run-time), set dynamic_axes to a dict with schema:
                             KEY (str): an input or output name. Each name must also be provided
                             in input_names or output_names.
                             VALUE (dict or list): If a dict, keys are axis indices and values are

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -31,7 +31,8 @@ from bigdl.nano.pytorch.utils import patch_attrs_from_model_to_object
 
 class PytorchOpenVINOModel(AcceleratedLightningModule):
     def __init__(self, model, input_sample=None, thread_num=None,
-                 logging=True, config=None, **export_kwargs):
+                 dynamic_axes=True, logging=True, config=None,
+                 **export_kwargs):
         """
         Create a OpenVINO model from pytorch.
 
@@ -42,6 +43,16 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
                              defaults to None.
         :param thread_num: a int represents how many threads(cores) is needed for
                            inference. default: None.
+        :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
+                        will have the first dim of each input as a dynamic batch_size. If 
+                        dynamic_axes=False, the exported model will have the shapes of all input
+                        and output tensors set to exactly match those given in input_sample.
+                        To specify axes of tensors as dynamic (i.e. known only at run-time),
+                        set dynamic_axes to a dict with schema:
+                            KEY (str): an input or output name. Each name must also be provided
+                            in input_names or output_names.
+                            VALUE (dict or list): If a dict, keys are axis indices and values are
+                            axis names. If a list, each element is an axis index.
         :param logging: whether to log detailed information of model conversion. default: True.
         :param config: The config to be inputted in core.compile_model.
         :param **export_kwargs: will be passed to torch.onnx.export function.
@@ -50,7 +61,9 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         with TemporaryDirectory() as tmpdir:
             tmpdir = Path(tmpdir)
             if isinstance(model, torch.nn.Module):
-                export(model, input_sample, str(tmpdir / 'tmp.xml'), logging, **export_kwargs)
+                export(model, input_sample, str(tmpdir / 'tmp.xml'),
+                       dynamic_axes=dynamic_axes, logging=logging,
+                       **export_kwargs)
                 ov_model_path = tmpdir / 'tmp.xml'
 
             self.ov_model = OpenVINOModel(ov_model_path, thread_num=thread_num, config=config)

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -44,7 +44,7 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         :param thread_num: a int represents how many threads(cores) is needed for
                            inference. default: None.
         :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
-                        will have the first dim of each input as a dynamic batch_size. If 
+                        will have the first dim of each input as a dynamic batch_size. If
                         dynamic_axes=False, the exported model will have the shapes of all input
                         and output tensors set to exactly match those given in input_sample.
                         To specify axes of tensors as dynamic (i.e. known only at run-time),

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -44,15 +44,19 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         :param thread_num: a int represents how many threads(cores) is needed for
                            inference. default: None.
         :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
-                        will have the first dim of each input as a dynamic batch_size. If
-                        dynamic_axes=False, the exported model will have the shapes of all input
-                        and output tensors set to exactly match those given in input_sample.
-                        To specify axes of tensors as dynamic (i.e. known only at run-time),
-                        set dynamic_axes to a dict with schema:
-                            KEY (str): an input or output name. Each name must also be provided
-                            in input_names or output_names.
-                            VALUE (dict or list): If a dict, keys are axis indices and values are
-                            axis names. If a list, each element is an axis index.
+                             will have the first dim of each input as a dynamic batch_size. If
+                             dynamic_axes=False, the exported model will have the shapes of all
+                             input and output tensors set to exactly match those given in
+                             input_sample. To specify axes of tensors as dynamic (i.e. known only
+                             at run-time), set dynamic_axes to a dict with schema:
+
+                             | KEY (str): an input or output name. Each name must also be provided
+                             | in input_names or output_names.
+                             |
+                             | VALUE (dict or list): If a dict, keys are axis indices and values
+                             | are axis names. If a list, each element is an axis index.
+
+                             If accelerator != 'openvino'/'onnxruntime', it will be ignored.
         :param logging: whether to log detailed information of model conversion. default: True.
         :param config: The config to be inputted in core.compile_model.
         :param **export_kwargs: will be passed to torch.onnx.export function.

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -44,8 +44,8 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         :param thread_num: a int represents how many threads(cores) is needed for
                            inference. default: None.
         :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
-                             will have the first dim of each input as a dynamic batch_size. If
-                             dynamic_axes=False, the exported model will have the shapes of all
+                             will have the first dim of each Tensor input as a dynamic batch_size.
+                             If dynamic_axes=False, the exported model will have the shapes of all
                              input and output tensors set to exactly match those given in
                              input_sample. To specify axes of tensors as dynamic (i.e. known only
                              at run-time), set dynamic_axes to a dict with schema:

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/utils.py
@@ -19,7 +19,8 @@ from bigdl.nano.utils.inference.pytorch.model_utils import export_to_onnx
 from pathlib import Path
 
 
-def export(model, input_sample=None, xml_path="model.xml", logging=True, **kwargs):
+def export(model, input_sample=None, xml_path="model.xml",
+           dynamic_axes=True, logging=True, **kwargs):
     '''
     Function to export pytorch model into openvino and save it to local.
     Any instance of torch.nn.Module including Lightning Module is acceptable.
@@ -27,6 +28,7 @@ def export(model, input_sample=None, xml_path="model.xml", logging=True, **kwarg
     :param model: Model instance of torch.nn.module to be exported.
     :param input_sample: torch.Tensor or a list for the model tracing.
     :param xml_path: The path to save openvino model file.
+    :param dynamic_axes: parameter of torch.onnx.export.
     :param logging: whether to log detailed information of model conversion. default: True.
     :param **kwargs: will be passed to torch.onnx.export function.
     '''
@@ -34,5 +36,6 @@ def export(model, input_sample=None, xml_path="model.xml", logging=True, **kwarg
     with TemporaryDirectory() as folder:
         folder = Path(folder)
         onnx_path = str(folder / 'tmp.onnx')
-        export_to_onnx(model, input_sample, onnx_path, **kwargs)
-        convert_onnx_to_xml(onnx_path, xml_path, logging)
+        export_to_onnx(model, input_sample, onnx_path,
+                       dynamic_axes=dynamic_axes, **kwargs)
+        convert_onnx_to_xml(onnx_path, xml_path, logging=logging)

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -581,8 +581,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                              at run-time), set dynamic_axes to a dict with schema:
                                 KEY (str): an input or output name. Each name must also be provided
                                 in input_names or output_names.
-                                VALUE (dict or list): If a dict, keys are axis indices and values are
-                                axis names. If a list, each element is an axis index.
+                                VALUE (dict or list): If a dict, keys are axis indices and values
+                                are axis names. If a list, each element is an axis index.
                              If accelerator != 'openvino'/'onnxruntime', it will be ignored.
         :param sample_size: (optional) a int represents how many samples will be used for
                             Post-training Optimization Tools (POT) from OpenVINO toolkit,
@@ -782,16 +782,16 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :param jit_strict: Whether recording your mutable container types. This parameter will be
                            passed to torch.jit.trace. if accelerator != 'jit', it will be ignored.
                            Default to True.
-        :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model will
-                             have the first dim of each input as a dynamic batch_size. If
-                             dynamic_axes=False, the exported model will have the shapes of all input
-                             and output tensors set to exactly match those given in input_sample.
-                             To specify axes of tensors as dynamic (i.e. known only at run-time),
-                             set dynamic_axes to a dict with schema:
+        :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
+                             will have the first dim of each input as a dynamic batch_size. If
+                             dynamic_axes=False, the exported model will have the shapes of all
+                             input and output tensors set to exactly match those given in
+                             input_sample. To specify axes of tensors as dynamic (i.e. known only
+                             at run-time), set dynamic_axes to a dict with schema:
                                KEY (str): an input or output name. Each name must also be provided
                                in input_names or output_names.
-                               VALUE (dict or list): If a dict, keys are axis indices and values are
-                               axis names. If a list, each element is an axis index.
+                               VALUE (dict or list): If a dict, keys are axis indices and values
+                               are axis names. If a list, each element is an axis index.
                             If accelerator != 'openvino'/'onnxruntime', it will be ignored.
         :param logging: Whether to log detailed information of model conversion, only valid when
                         accelerator='openvino', otherwise will be ignored. Default: ``True``.

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -573,12 +573,12 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :param jit_strict: Whether recording your mutable container types. This parameter will be
                            passed to torch.jit.trace. if accelerator != 'jit', it will be ignored.
                            Default to True.
-        :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model will
-                             have the first dim of each input as a dynamic batch_size. If 
-                             dynamic_axes=False, the exported model will have the shapes of all input 
-                             and output tensors set to exactly match those given in input_sample. 
-                             To specify axes of tensors as dynamic (i.e. known only at run-time), 
-                             set dynamic_axes to a dict with schema:
+        :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
+                             will have the first dim of each input as a dynamic batch_size. If
+                             dynamic_axes=False, the exported model will have the shapes of all
+                             input and output tensors set to exactly match those given in
+                             input_sample. To specify axes of tensors as dynamic (i.e. known only
+                             at run-time), set dynamic_axes to a dict with schema:
                                 KEY (str): an input or output name. Each name must also be provided
                                 in input_names or output_names.
                                 VALUE (dict or list): If a dict, keys are axis indices and values are

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -251,9 +251,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
 
         :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
                will have the first dim of each input as a dynamic batch_size. If dynamic_axes=False,
-               the exported model will have the shapes of all input and output tensors set to exactly
-               match those given in input_sample. To specify axes of tensors as dynamic (i.e. known
-               only at run-time), set dynamic_axes to a dict with schema:
+               the exported model will have the shapes of all input and output tensors set to
+               exactly match those given in input_sample. To specify axes of tensors as dynamic
+               (i.e. known only at run-time), set dynamic_axes to a dict with schema:
 
                | KEY (str): an input or output name. Each name must also be provided
                | in input_names or output_names.

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -250,16 +250,18 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                | get the search range.
 
         :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
-                             will have the first dim of each input as a dynamic batch_size. If
-                             dynamic_axes=False, the exported model will have the shapes of all
-                             input and output tensors set to exactly match those given in
-                             input_sample. To specify axes of tensors as dynamic (i.e. known only
-                             at run-time), set dynamic_axes to a dict with schema:
-                               KEY (str): an input or output name. Each name must also be provided
-                               in input_names or output_names.
-                               VALUE (dict or list): If a dict, keys are axis indices and values are
-                               axis names. If a list, each element is an axis index.
-                             If accelerator != 'openvino'/'onnxruntime', it will be ignored.
+               will have the first dim of each input as a dynamic batch_size. If dynamic_axes=False,
+               the exported model will have the shapes of all input and output tensors set to exactly
+               match those given in input_sample. To specify axes of tensors as dynamic (i.e. known
+               only at run-time), set dynamic_axes to a dict with schema:
+
+               | KEY (str): an input or output name. Each name must also be provided
+               | in input_names or output_names.
+               |
+               | VALUE (dict or list): If a dict, keys are axis indices and values are
+               | axis names. If a list, each element is an axis index.
+
+               If accelerator != 'openvino'/'onnxruntime', it will be ignored.
         :param logging: whether to log detailed information of model conversion.
                Default: False.
         :param latency_sample_num: (optional) a int represents the number of repetitions
@@ -579,10 +581,13 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                              input and output tensors set to exactly match those given in
                              input_sample. To specify axes of tensors as dynamic (i.e. known only
                              at run-time), set dynamic_axes to a dict with schema:
-                                KEY (str): an input or output name. Each name must also be provided
-                                in input_names or output_names.
-                                VALUE (dict or list): If a dict, keys are axis indices and values
-                                are axis names. If a list, each element is an axis index.
+
+                             | KEY (str): an input or output name. Each name must also be provided
+                             | in input_names or output_names.
+                             |
+                             | VALUE (dict or list): If a dict, keys are axis indices and values
+                             | are axis names. If a list, each element is an axis index.
+
                              If accelerator != 'openvino'/'onnxruntime', it will be ignored.
         :param sample_size: (optional) a int represents how many samples will be used for
                             Post-training Optimization Tools (POT) from OpenVINO toolkit,
@@ -788,11 +793,14 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                              input and output tensors set to exactly match those given in
                              input_sample. To specify axes of tensors as dynamic (i.e. known only
                              at run-time), set dynamic_axes to a dict with schema:
-                               KEY (str): an input or output name. Each name must also be provided
-                               in input_names or output_names.
-                               VALUE (dict or list): If a dict, keys are axis indices and values
-                               are axis names. If a list, each element is an axis index.
-                            If accelerator != 'openvino'/'onnxruntime', it will be ignored.
+
+                             | KEY (str): an input or output name. Each name must also be provided
+                             | in input_names or output_names.
+                             |
+                             | VALUE (dict or list): If a dict, keys are axis indices and values
+                             | are axis names. If a list, each element is an axis index.
+
+                             If accelerator != 'openvino'/'onnxruntime', it will be ignored.
         :param logging: Whether to log detailed information of model conversion, only valid when
                         accelerator='openvino', otherwise will be ignored. Default: ``True``.
         :param inplace: whether to perform inplace optimization. Default: ``False``.

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -250,10 +250,11 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                | get the search range.
 
         :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
-               will have the first dim of each input as a dynamic batch_size. If dynamic_axes=False,
-               the exported model will have the shapes of all input and output tensors set to
-               exactly match those given in input_sample. To specify axes of tensors as dynamic
-               (i.e. known only at run-time), set dynamic_axes to a dict with schema:
+               will have the first dim of each Tensor input as a dynamic batch_size. If
+               dynamic_axes=False, the exported model will have the shapes of all input and output
+               tensors set to exactly match those given in input_sample. To specify axes of
+               tensors as dynamic (i.e. known only at run-time), set dynamic_axes to a dict with
+               schema:
 
                | KEY (str): an input or output name. Each name must also be provided
                | in input_names or output_names.
@@ -576,8 +577,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                            passed to torch.jit.trace. if accelerator != 'jit', it will be ignored.
                            Default to True.
         :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
-                             will have the first dim of each input as a dynamic batch_size. If
-                             dynamic_axes=False, the exported model will have the shapes of all
+                             will have the first dim of each Tensor input as a dynamic batch_size.
+                             If dynamic_axes=False, the exported model will have the shapes of all
                              input and output tensors set to exactly match those given in
                              input_sample. To specify axes of tensors as dynamic (i.e. known only
                              at run-time), set dynamic_axes to a dict with schema:
@@ -788,8 +789,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                            passed to torch.jit.trace. if accelerator != 'jit', it will be ignored.
                            Default to True.
         :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
-                             will have the first dim of each input as a dynamic batch_size. If
-                             dynamic_axes=False, the exported model will have the shapes of all
+                             will have the first dim of each Tensor input as a dynamic batch_size.
+                             If dynamic_axes=False, the exported model will have the shapes of all
                              input and output tensors set to exactly match those given in
                              input_sample. To specify axes of tensors as dynamic (i.e. known only
                              at run-time), set dynamic_axes to a dict with schema:

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -156,6 +156,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                  precision: Optional[Tuple[str]] = None,
                  use_ipex: Optional[bool] = None,
                  search_mode: str = "default",
+                 dynamic_axes: Union[bool, dict] = True,
                  logging: bool = False,
                  latency_sample_num: int = 100,
                  includes: Optional[List[str]] = None,

--- a/python/nano/test/onnx/pytorch/test_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_onnx.py
@@ -274,6 +274,38 @@ class TestOnnx(TestCase):
                                             input_sample=(torch.rand(2,3,1,1),3))
         result_m = accmodel(x, np.array([y]))  # TODO: make y work here
         assert torch.equal(result_true, result_m)
+    
+    def test_onnx_dynamic_axes(self):
+        class CustomModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pool = nn.AvgPool2d(kernel_size=3, stride=3)
+
+            def forward(self, x):
+                return self.pool(x)
+
+        model = CustomModel()
+        x1 = torch.rand(1, 3, 14, 14)
+        x2 = torch.rand(4, 3, 14, 14)
+        x3 = torch.rand(1, 3, 12, 12)
+
+        accmodel = InferenceOptimizer.trace(model,
+                                            accelerator="onnxruntime",
+                                            input_sample=torch.rand(1, 3, 14, 14))
+        accmodel(x1)
+        accmodel(x2)
+        try:
+            accmodel(x3)
+        except Exception as e:
+            assert e
+
+        accmodel = InferenceOptimizer.trace(model,
+                                            accelerator="onnxruntime",
+                                            input_sample=torch.rand(1, 3, 14, 14),
+                                            dynamic_axes={"x": [0, 2, 3]})
+        accmodel(x1)
+        accmodel(x2)
+        accmodel(x3)
 
 
 if __name__ == '__main__':

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -224,3 +224,35 @@ class TestOpenVINO(TestCase):
                                             input_sample=(torch.rand(2,3,1,1), 3))
         result_m = accmodel(x, y)
         assert torch.equal(result_true, result_m)
+
+    def test_openvino_dynamic_axes(self):
+        class CustomModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pool = nn.AvgPool2d(kernel_size=3, stride=3)
+
+            def forward(self, x):
+                return self.pool(x)
+
+        model = CustomModel()
+        x1 = torch.rand(1, 3, 14, 14)
+        x2 = torch.rand(4, 3, 14, 14)
+        x3 = torch.rand(1, 3, 12, 12)
+
+        accmodel = InferenceOptimizer.trace(model,
+                                            accelerator="openvino",
+                                            input_sample=torch.rand(1, 3, 14, 14))
+        accmodel(x1)
+        accmodel(x2)
+        try:
+            accmodel(x3)
+        except Exception as e:
+            assert e
+
+        accmodel = InferenceOptimizer.trace(model,
+                                            accelerator="openvino",
+                                            input_sample=torch.rand(1, 3, 14, 14),
+                                            dynamic_axes={"x": [0, 2, 3]})
+        accmodel(x1)
+        accmodel(x2)
+        accmodel(x3)

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -180,8 +180,7 @@ class TestOpenVINO(TestCase):
 
         accmodel = InferenceOptimizer.quantize(model,
                                                accelerator="openvino",
-                                               calib_data=torch.rand(1, 3, 14, 14),
-                                               metric=F1(10))
+                                               calib_data=torch.rand(1, 3, 14, 14))
         accmodel(x1)
         accmodel(x2)
         try:
@@ -192,7 +191,6 @@ class TestOpenVINO(TestCase):
         accmodel = InferenceOptimizer.quantize(model,
                                                accelerator="openvino",
                                                calib_data=torch.rand(1, 3, 14, 14),
-                                               metric=F1(10),
                                                dynamic_axes={"x": [0, 2, 3]})
         accmodel(x1)
         accmodel(x2)

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -19,6 +19,7 @@ from bigdl.nano.pytorch import Trainer
 from bigdl.nano.pytorch import InferenceOptimizer
 from torchvision.models.mobilenetv3 import mobilenet_v3_small
 import torch
+from torch import nn
 from torch.utils.data.dataset import TensorDataset
 from torch.utils.data.dataloader import DataLoader
 import tempfile
@@ -162,3 +163,37 @@ class TestOpenVINO(TestCase):
         with InferenceOptimizer.get_context(openvino_model):
             assert torch.get_num_threads() == 2
             y1 = openvino_model(x[0:1])
+
+    def test_openvino_quantize_dynamic_axes(self):
+        class CustomModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.pool = nn.AvgPool2d(kernel_size=3, stride=3)
+
+            def forward(self, x):
+                return self.pool(x)
+
+        model = CustomModel()
+        x1 = torch.rand(1, 3, 14, 14)
+        x2 = torch.rand(4, 3, 14, 14)
+        x3 = torch.rand(1, 3, 12, 12)
+
+        accmodel = InferenceOptimizer.quantize(model,
+                                               accelerator="openvino",
+                                               calib_data=torch.rand(1, 3, 14, 14),
+                                               metric=F1(10))
+        accmodel(x1)
+        accmodel(x2)
+        try:
+            accmodel(x3)
+        except Exception as e:
+            assert e
+
+        accmodel = InferenceOptimizer.quantize(model,
+                                               accelerator="openvino",
+                                               calib_data=torch.rand(1, 3, 14, 14),
+                                               metric=F1(10),
+                                               dynamic_axes={"x": [0, 2, 3]})
+        accmodel(x1)
+        accmodel(x2)
+        accmodel(x3)


### PR DESCRIPTION
## Description

Add `dynamic_axes` parameter for `trace`/`quantize`/`optimize`, so if input shape will vary during inference, user can specify this parameter manually.

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/241

### 2. User API changes

Add new `dynamic_axes` parameter for  `trace`/`quantize`/`optimize`, so if input shape will vary during inference, user can specify this parameter manually.

```
dynamic_axes = {}
# 'im' is the param name for input data in the arguments of the model's forward method
dynamic_axes['im'] = {0: 'batch_size', 2: 'width', 3: 'height'}
# Or just specify a list
dynamic_axes['im'] = [0, 2, 3]

model = InferenceOptimizer.trace(model=model,
                                 accelerator='onnxruntime',
                                 input_sample=input_sample,
                                 dynamic_axes=dynamic_axes)
```

### 3. Summary of the change 

- add new paramter `dynamic_axes` for add dynamic_axes parameter for `trace`/`quantize`/`optimize`

### 4. How to test?
- [x] Unit test
- [x] Document test
https://ruonantetdoc.readthedocs.io/en/add_dynamic_axes_and_update_api_doc/doc/PythonAPI/Nano/pytorch.html#bigdl-nano-pytorch-inferenceoptimizer

