### PR TITLE
Orca docs: The mv command in the document k8s.md needs to be modified

### DIFF
--- a/docs/readthedocs/source/doc/Orca/Tutorial/k8s.md
+++ b/docs/readthedocs/source/doc/Orca/Tutorial/k8s.md
@@ -214,13 +214,13 @@ Please download the Fashion-MNIST dataset manually on your __Develop Node__ and 
 git clone https://github.com/zalandoresearch/fashion-mnist.git
 
 # Move the dataset to NFS under the folder FashionMNIST/raw
-mv /path/to/fashion-mnist/data/fashion /bigdl/nfsdata/dataset/FashionMNIST/raw
+mv /path/to/fashion-mnist/data/fashion/* /bigdl/nfsdata/dataset/FashionMNIST/raw
 
 # Extract FashionMNIST archives
 gzip -dk /bigdl/nfsdata/dataset/FashionMNIST/raw/*
 ```
 
-In the given example, you can specify the argument `--remote_dir` to be the directory on NFS for the Fashion-MNIST dataset.
+In the given example, you can specify the argument `--remote_dir` to be the directory on NFS for the Fashion-MNIST dataset. The directory should contain `FashionMNIST/raw/train-images-idx3-ubyte` and `FashionMNIST/raw/t10k-images-idx3`.
 
 
 ---


### PR DESCRIPTION
The mv command in the document needs to be modified to mv /path/to/fashion-mnist/data/fashion/* /path/to/local/data/FashionMNIST/raw. According to the official regulations of FashionMNIST, the training data should be under Fashion/raw, not under Fashion/raw/fashion.