### PR TITLE
Chronos: update python3.8 support in document

### DIFF
--- a/docs/readthedocs/source/doc/Chronos/Overview/install.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/install.md
@@ -19,7 +19,8 @@
 .. note::
     **Supported Python Version**:
 
-     Chronos only supports Python 3.7.2 ~ latest 3.7.x. We are validating more Python versions.
+     1.Chronos supports all installation options on Python 3.7.2 ~ latest 3.7.x. For details about different installation options, refer to `here <# Install using Conda>`_.
+     2.``bigdl-chronos[distributed]`` is not supported on Python 3.8.
 ```
 
 

--- a/docs/readthedocs/source/doc/Chronos/Overview/install.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/install.md
@@ -21,7 +21,7 @@
 
      1.Chronos supports all installation options on Python 3.7.2 ~ latest 3.7.x. For details about different installation options, refer to `here <#install-using-conda>`_.
 
-     2.``bigdl-chronos[pytorch]``, ``bigdl-chronos[tensorflow]``, ``bigdl-chronos[automl]`` and ``bigdl-chronos[inference]`` are supported on Python 3.8.
+     2. ``bigdl-chronos[pytorch]``, ``bigdl-chronos[tensorflow]``, ``bigdl-chronos[automl]`` and ``bigdl-chronos[inference]`` are supported on Python 3.8.
 ```
 
 

--- a/docs/readthedocs/source/doc/Chronos/Overview/install.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/install.md
@@ -19,9 +19,9 @@
 .. note::
     **Supported Python Version**:
 
-     1.Chronos supports all installation options on Python 3.7.2 ~ latest 3.7.x. For details about different installation options, refer to `here <#install-using-conda>`_.
+     Chronos supports all installation options on Python 3.7.2 ~ latest 3.7.x. For details about different installation options, refer to `here <#install-using-conda>`_.
 
-     2. ``bigdl-chronos[pytorch]``, ``bigdl-chronos[tensorflow]``, ``bigdl-chronos[automl]`` and ``bigdl-chronos[inference]`` are supported on Python 3.8.
+     Moreover, ``bigdl-chronos[pytorch]``, ``bigdl-chronos[tensorflow]``, ``bigdl-chronos[automl]`` and ``bigdl-chronos[inference]`` are supported on Python 3.8.
 ```
 
 

--- a/docs/readthedocs/source/doc/Chronos/Overview/install.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/install.md
@@ -19,8 +19,9 @@
 .. note::
     **Supported Python Version**:
 
-     1.Chronos supports all installation options on Python 3.7.2 ~ latest 3.7.x. For details about different installation options, refer to `here <# Install using Conda>`_.
-     2.``bigdl-chronos[distributed]`` is not supported on Python 3.8.
+     1.Chronos supports all installation options on Python 3.7.2 ~ latest 3.7.x. For details about different installation options, refer to `here <#install-using-conda>`_.
+
+     2.``bigdl-chronos[pytorch]``, ``bigdl-chronos[tensorflow]``, ``bigdl-chronos[automl]`` and ``bigdl-chronos[inference]`` are supported on Python 3.8.
 ```
 
 


### PR DESCRIPTION
## Description

During nightly test, installation options (apart from [distributed]) on Python3.8 can be passed.
We need to update the new feature in document.

### 4. How to test?
- [x] Document test
（https://binbin-doc.readthedocs.io/en/update-py-version-doc/doc/Chronos/Overview/install.html