### PR TITLE
Nano: fix bigdl-nano-init

### DIFF
--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -260,8 +260,4 @@ echo "TF_ENABLE_ONEDNN_OPTS=${TF_ENABLE_ONEDNN_OPTS}"
 echo "ENABLE_TF_OPTS=${ENABLE_TF_OPTS}"
 echo "NANO_TF_INTER_OP"=${NANO_TF_INTER_OP}
 echo "+++++++++++++++++++++++++"
-# Run the commands after bigdl-nano-init
 echo "Complete."
-if [ ! $1 = "activate" ] && [ ! $1 = "deactivate" ];then
-    ${@:1}
-fi


### PR DESCRIPTION
## Description

Remove automatically run commands after `source bigdl-nano-init` because it is useless and often causes error

