### PR TITLE
Add model_dir to PYTHONPATH in model_load.py.

### DIFF
--- a/ppml/trusted-python-toolkit/Dockerfile
+++ b/ppml/trusted-python-toolkit/Dockerfile
@@ -50,8 +50,8 @@ RUN pip3 install --upgrade pip && \
     mkdir -p ${JAVA_HOME} && \
     cp -r /usr/lib/jvm/java-${JDK_VERSION}-openjdk-amd64/* ${JAVA_HOME} && \
     sed -i '/MAX_FAILURE_THRESHOLD = 5/ios.environ\[\"MPLCONFIGDIR\"\]=\"\/tmp\/matplotlib\"' /usr/local/lib/python3.7/dist-packages/ts/model_service_worker.py && \
-    sed -i '/import abc/iimport sys' /usr/local/lib/python3.7/dist-packages/ts/torch_handler/base_handler.py && \
-    sed -i '/module = importlib.import_module/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.7/dist-packages/ts/torch_handler/base_handler.py && \
+    sed -i '/import json/iimport sys' /usr/local/lib/python3.7/dist-packages/ts/model_loader.py && \
+    sed -i '/manifest_file\ =\ os.path.join/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.7/dist-packages/ts/model_loader.py && \
     sed -i 's/SOCKET_ACCEPT_TIMEOUT = 30.0/SOCKET_ACCEPT_TIMEOUT = 3000.0/' /usr/local/lib/python3.7/dist-packages/ts/model_service_worker.py && \
     mkdir -p /ppml/tests/numpy && \
     mkdir -p /ppml/tests/pandas && \

--- a/ppml/trusted-python-toolkit/start-scripts/start-torchserve-sgx.sh
+++ b/ppml/trusted-python-toolkit/start-scripts/start-torchserve-sgx.sh
@@ -9,21 +9,22 @@ do
 done
 cd /ppml
 ./init.sh
+port=9000
 cat $configFile | while read line
 do
-        if [[ $line =~ "minWorkers" ]]
-        then
+        while [[ $line =~ "minWorkers" ]]
+        do
                 line=${line#*\"minWorkers\": }
-                line=${line%%,*}
+                num=${line%%,*}
+                line=${line#*,}
 
-                port=9000
-                for ((i=0;i<line;i++,port++))
+                for ((i=0;i<num;i++,port++))
                 do
                 (
                         bash /ppml/work/start-scripts/start-backend-sgx.sh -p $port
                 )&
                 done
-        fi
+        done
 done
 (
         bash /ppml/work/start-scripts/start-frontend-sgx.sh -c $configFile


### PR DESCRIPTION
## Description

Add model_dir to PYTHONPATH in model_load.py.
Fix error in start-torchserve-sgx.sh.

### 1. Why the change?

When user define handler.py theirself, model_dir will be called in model_load.py. Therefore, we need to add it into PYTHON_PATH.
If serveral attributes 'MinWorkers' are defined in one line, it will only creat  backend threads of the number of the first one.
