### PR TITLE
[Nano] Support users to choose `jit.trace`/`jit.script` in `InferenceOptimizer.trace`/`quantize`

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
@@ -36,7 +36,7 @@ def ipex_device():
 
 def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
                         use_jit=False, channels_last=None, thread_num=None,
-                        inplace=False, jit_strict=True):
+                        inplace=False, jit_strict=True, jit_converter=None):
     '''
     :param model: the model(nn.module) to be transform.
     :param input_sample: torch tensor indicate the data sample to be used
@@ -48,16 +48,19 @@ def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
     :param thread_num: the thread num allocated for this model.
     :param inplace: whether to perform inplace optimization. Default: ``False``.
     :param jit_strict: Whether recording your mutable container types.
+    :param jit_converter: use ``jit.trace`` or ``jit.script`` to 
+           convert a model to TorchScript.
     '''
     from .ipex_inference_model import PytorchIPEXJITModel
     return PytorchIPEXJITModel(model, input_sample=input_sample, use_ipex=use_ipex,
                                use_jit=use_jit, channels_last=channels_last,
-                               thread_num=thread_num, inplace=inplace, jit_strict=jit_strict)
+                               thread_num=thread_num, inplace=inplace, jit_strict=jit_strict,
+                               jit_converter=jit_converter)
 
 
 def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
                             use_jit=False, channels_last=None, thread_num=None,
-                            inplace=False, jit_strict=True):
+                            inplace=False, jit_strict=True, jit_converter=None):
     '''
     :param model: the model(nn.module) to be transform.
     :param input_sample: torch tensor indicate the data sample to be used
@@ -69,11 +72,14 @@ def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
     :param thread_num: the thread num allocated for this model.
     :param inplace: whether to perform inplace optimization. Default: ``False``.
     :param jit_strict: Whether recording your mutable container types.
+    :param jit_converter: use ``jit.trace`` or ``jit.script`` to 
+           convert a model to TorchScript.
     '''
     from .ipex_inference_bf16_model import PytorchIPEXJITBF16Model
     return PytorchIPEXJITBF16Model(model, input_sample=input_sample, use_ipex=use_ipex,
                                    use_jit=use_jit, channels_last=channels_last,
-                                   thread_num=thread_num, inplace=inplace, jit_strict=jit_strict)
+                                   thread_num=thread_num, inplace=inplace, jit_strict=jit_strict,
+                                   jit_converter=jit_converter)
 
 
 def load_ipexjit_model(path, model, inplace=False):

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
@@ -36,7 +36,7 @@ def ipex_device():
 
 def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
                         use_jit=False, channels_last=None, thread_num=None,
-                        inplace=False, jit_strict=True, jit_converter=None):
+                        inplace=False, jit_strict=True, jit_method=None):
     '''
     :param model: the model(nn.module) to be transform.
     :param input_sample: torch tensor indicate the data sample to be used
@@ -48,19 +48,19 @@ def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
     :param thread_num: the thread num allocated for this model.
     :param inplace: whether to perform inplace optimization. Default: ``False``.
     :param jit_strict: Whether recording your mutable container types.
-    :param jit_converter: use ``jit.trace`` or ``jit.script`` to
+    :param jit_method: use ``jit.trace`` or ``jit.script`` to
            convert a model to TorchScript.
     '''
     from .ipex_inference_model import PytorchIPEXJITModel
     return PytorchIPEXJITModel(model, input_sample=input_sample, use_ipex=use_ipex,
                                use_jit=use_jit, channels_last=channels_last,
                                thread_num=thread_num, inplace=inplace, jit_strict=jit_strict,
-                               jit_converter=jit_converter)
+                               jit_method=jit_method)
 
 
 def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
                             use_jit=False, channels_last=None, thread_num=None,
-                            inplace=False, jit_strict=True, jit_converter=None):
+                            inplace=False, jit_strict=True, jit_method=None):
     '''
     :param model: the model(nn.module) to be transform.
     :param input_sample: torch tensor indicate the data sample to be used
@@ -72,14 +72,14 @@ def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
     :param thread_num: the thread num allocated for this model.
     :param inplace: whether to perform inplace optimization. Default: ``False``.
     :param jit_strict: Whether recording your mutable container types.
-    :param jit_converter: use ``jit.trace`` or ``jit.script`` to
+    :param jit_method: use ``jit.trace`` or ``jit.script`` to
            convert a model to TorchScript.
     '''
     from .ipex_inference_bf16_model import PytorchIPEXJITBF16Model
     return PytorchIPEXJITBF16Model(model, input_sample=input_sample, use_ipex=use_ipex,
                                    use_jit=use_jit, channels_last=channels_last,
                                    thread_num=thread_num, inplace=inplace, jit_strict=jit_strict,
-                                   jit_converter=jit_converter)
+                                   jit_method=jit_method)
 
 
 def load_ipexjit_model(path, model, inplace=False):

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
@@ -48,7 +48,7 @@ def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
     :param thread_num: the thread num allocated for this model.
     :param inplace: whether to perform inplace optimization. Default: ``False``.
     :param jit_strict: Whether recording your mutable container types.
-    :param jit_converter: use ``jit.trace`` or ``jit.script`` to 
+    :param jit_converter: use ``jit.trace`` or ``jit.script`` to
            convert a model to TorchScript.
     '''
     from .ipex_inference_model import PytorchIPEXJITModel
@@ -72,7 +72,7 @@ def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
     :param thread_num: the thread num allocated for this model.
     :param inplace: whether to perform inplace optimization. Default: ``False``.
     :param jit_strict: Whether recording your mutable container types.
-    :param jit_converter: use ``jit.trace`` or ``jit.script`` to 
+    :param jit_converter: use ``jit.trace`` or ``jit.script`` to
            convert a model to TorchScript.
     '''
     from .ipex_inference_bf16_model import PytorchIPEXJITBF16Model

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -26,7 +26,7 @@ import torch
 class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
     def __init__(self, model, input_sample=None, use_ipex=False,
                  use_jit=False, channels_last=None, thread_num=None, from_load=False,
-                 inplace=False, jit_strict=True):
+                 inplace=False, jit_strict=True, jit_converter=None):
         '''
         This is the accelerated model for pytorch and ipex/jit.
         All the external API is based on InferenceOptimizer, so what we have here is
@@ -45,6 +45,8 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         :param from_load: this will only be set by _load method.
         :param inplace: whether to perform inplace optimization. Default: ``False``.
         :param jit_strict: Whether recording your mutable container types.
+        :param jit_converter: use ``jit.trace`` or ``jit.script`` to 
+               convert a model to TorchScript.
         '''
         if use_ipex:
             invalidInputError(
@@ -56,7 +58,8 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         PytorchIPEXJITModel.__init__(self, model, input_sample=input_sample, use_ipex=use_ipex,
                                      dtype=torch.bfloat16, use_jit=use_jit,
                                      channels_last=channels_last, from_load=from_load,
-                                     inplace=inplace, jit_strict=jit_strict)
+                                     inplace=inplace, jit_strict=jit_strict,
+                                     jit_converter=jit_converter)
         self._nano_context_manager = generate_context_manager(accelerator=None,
                                                               precision="bf16",
                                                               thread_num=thread_num)
@@ -98,4 +101,6 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
                                        channels_last=status['channels_last'],
                                        from_load=from_load,
                                        thread_num=thread_num,
-                                       inplace=inplace)
+                                       inplace=inplace,
+                                       jit_strict=status["jit_strict"],
+                                       jit_converter=status["jit_converter"])

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -45,7 +45,7 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         :param from_load: this will only be set by _load method.
         :param inplace: whether to perform inplace optimization. Default: ``False``.
         :param jit_strict: Whether recording your mutable container types.
-        :param jit_converter: use ``jit.trace`` or ``jit.script`` to 
+        :param jit_converter: use ``jit.trace`` or ``jit.script`` to
                convert a model to TorchScript.
         '''
         if use_ipex:

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -26,7 +26,7 @@ import torch
 class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
     def __init__(self, model, input_sample=None, use_ipex=False,
                  use_jit=False, channels_last=None, thread_num=None, from_load=False,
-                 inplace=False, jit_strict=True, jit_converter=None):
+                 inplace=False, jit_strict=True, jit_method=None):
         '''
         This is the accelerated model for pytorch and ipex/jit.
         All the external API is based on InferenceOptimizer, so what we have here is
@@ -45,7 +45,7 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         :param from_load: this will only be set by _load method.
         :param inplace: whether to perform inplace optimization. Default: ``False``.
         :param jit_strict: Whether recording your mutable container types.
-        :param jit_converter: use ``jit.trace`` or ``jit.script`` to
+        :param jit_method: use ``jit.trace`` or ``jit.script`` to
                convert a model to TorchScript.
         '''
         if use_ipex:
@@ -59,7 +59,7 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
                                      dtype=torch.bfloat16, use_jit=use_jit,
                                      channels_last=channels_last, from_load=from_load,
                                      inplace=inplace, jit_strict=jit_strict,
-                                     jit_converter=jit_converter)
+                                     jit_method=jit_method)
         self._nano_context_manager = generate_context_manager(accelerator=None,
                                                               precision="bf16",
                                                               thread_num=thread_num)
@@ -103,4 +103,4 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
                                        thread_num=thread_num,
                                        inplace=inplace,
                                        jit_strict=status["jit_strict"],
-                                       jit_converter=status["jit_converter"])
+                                       jit_method=status["jit_method"])

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -45,7 +45,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         :param from_load: this will only be set by _load method.
         :param inplace: whether to perform inplace optimization. Default: ``False``.
         :param jit_strict: Whether recording your mutable container types.
-        :param jit_converter: use ``jit.trace`` or ``jit.script`` to 
+        :param jit_converter: use ``jit.trace`` or ``jit.script`` to
                convert a model to TorchScript.
         """
         super().__init__(model)
@@ -77,16 +77,16 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                     with torch.cpu.amp.autocast():
                         if self.jit_converter == 'trace':
                             self.model = torch.jit.trace(self.model, input_sample,
-                                                        check_trace=False,
-                                                        strict=jit_strict)
+                                                         check_trace=False,
+                                                         strict=jit_strict)
                         elif self.jit_converter == 'script':
                             self.model = torch.jit.script(self.model)
                         else:
                             try:
                                 self.model = torch.jit.trace(self.model, input_sample,
-                                                        check_trace=False,
-                                                        strict=jit_strict)
-                            except:
+                                                             check_trace=False,
+                                                             strict=jit_strict)
+                            except Exception:
                                 self.model = torch.jit.script(self.model)
                         if self.use_ipex:
                             self.model = torch.jit.freeze(self.model)
@@ -94,16 +94,16 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                 with torch.no_grad():
                     if self.jit_converter == 'trace':
                         self.model = torch.jit.trace(self.model, input_sample,
-                                                    check_trace=False,
-                                                    strict=jit_strict)
+                                                     check_trace=False,
+                                                     strict=jit_strict)
                     elif self.jit_converter == 'script':
                         self.model = torch.jit.script(self.model)
                     else:
                         try:
                             self.model = torch.jit.trace(self.model, input_sample,
-                                                    check_trace=False,
-                                                    strict=jit_strict)
-                        except:
+                                                         check_trace=False,
+                                                         strict=jit_strict)
+                        except Exception:
                             self.model = torch.jit.script(self.model)
                     self.model = torch.jit.freeze(self.model)
         self._nano_context_manager = generate_context_manager(accelerator=None,

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -23,7 +23,7 @@ from bigdl.nano.pytorch.utils import patch_attrs_from_model_to_object
 class PytorchIPEXJITModel(AcceleratedLightningModule):
     def __init__(self, model: torch.nn.Module, input_sample=None, use_ipex=False, dtype=None,
                  use_jit=False, channels_last=None, thread_num=None, from_load=False,
-                 inplace=False, jit_strict=True, jit_converter=None):
+                 inplace=False, jit_strict=True, jit_method=None):
         """
         This is the accelerated model for pytorch and ipex/jit.
         All the external API is based on InferenceOptimizer, so what we have here is
@@ -45,7 +45,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         :param from_load: this will only be set by _load method.
         :param inplace: whether to perform inplace optimization. Default: ``False``.
         :param jit_strict: Whether recording your mutable container types.
-        :param jit_converter: use ``jit.trace`` or ``jit.script`` to
+        :param jit_method: use ``jit.trace`` or ``jit.script`` to
                convert a model to TorchScript.
         """
         super().__init__(model)
@@ -54,7 +54,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
             self.use_jit = use_jit
             self.channels_last = channels_last
             self.jit_strict = jit_strict
-            self.jit_converter = jit_converter
+            self.jit_method = jit_method
             self._nano_context_manager = generate_context_manager(accelerator=None,
                                                                   precision="fp32",
                                                                   thread_num=thread_num)
@@ -64,7 +64,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         self.use_ipex = use_ipex
         self.use_jit = use_jit
         self.jit_strict = jit_strict
-        self.jit_converter = jit_converter
+        self.jit_method = jit_method
         self.original_model = model
         if self.channels_last:
             self.model = self.model.to(memory_format=torch.channels_last)
@@ -75,11 +75,11 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
             if dtype == torch.bfloat16:
                 with torch.no_grad():
                     with torch.cpu.amp.autocast():
-                        if self.jit_converter == 'trace':
+                        if self.jit_method == 'trace':
                             self.model = torch.jit.trace(self.model, input_sample,
                                                          check_trace=False,
                                                          strict=jit_strict)
-                        elif self.jit_converter == 'script':
+                        elif self.jit_method == 'script':
                             self.model = torch.jit.script(self.model)
                         else:
                             try:
@@ -92,11 +92,11 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                             self.model = torch.jit.freeze(self.model)
             else:
                 with torch.no_grad():
-                    if self.jit_converter == 'trace':
+                    if self.jit_method == 'trace':
                         self.model = torch.jit.trace(self.model, input_sample,
                                                      check_trace=False,
                                                      strict=jit_strict)
-                    elif self.jit_converter == 'script':
+                    elif self.jit_method == 'script':
                         self.model = torch.jit.script(self.model)
                     else:
                         try:
@@ -147,7 +147,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                        "checkpoint": "ckpt.pth",
                        "thread_num": self.thread_num,
                        "jit_strict": self.jit_strict,
-                       'jit_converter': self.jit_converter})
+                       'jit_method': self.jit_method})
         return status
 
     @staticmethod
@@ -176,7 +176,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                                    thread_num=thread_num,
                                    inplace=inplace,
                                    jit_strict=status["jit_strict"],
-                                   jit_converter=status["jit_converter"])
+                                   jit_method=status["jit_method"])
 
     def _save_model(self, path):
         if self.use_jit:

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -23,7 +23,7 @@ from bigdl.nano.pytorch.utils import patch_attrs_from_model_to_object
 class PytorchIPEXJITModel(AcceleratedLightningModule):
     def __init__(self, model: torch.nn.Module, input_sample=None, use_ipex=False, dtype=None,
                  use_jit=False, channels_last=None, thread_num=None, from_load=False,
-                 inplace=False, jit_strict=True):
+                 inplace=False, jit_strict=True, jit_converter=None):
         """
         This is the accelerated model for pytorch and ipex/jit.
         All the external API is based on InferenceOptimizer, so what we have here is
@@ -45,6 +45,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         :param from_load: this will only be set by _load method.
         :param inplace: whether to perform inplace optimization. Default: ``False``.
         :param jit_strict: Whether recording your mutable container types.
+        :param jit_converter: use ``jit.trace`` or ``jit.script`` to 
+               convert a model to TorchScript.
         """
         super().__init__(model)
         if from_load:
@@ -52,6 +54,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
             self.use_jit = use_jit
             self.channels_last = channels_last
             self.jit_strict = jit_strict
+            self.jit_converter = jit_converter
             self._nano_context_manager = generate_context_manager(accelerator=None,
                                                                   precision="fp32",
                                                                   thread_num=thread_num)
@@ -61,6 +64,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         self.use_ipex = use_ipex
         self.use_jit = use_jit
         self.jit_strict = jit_strict
+        self.jit_converter = jit_converter
         self.original_model = model
         if self.channels_last:
             self.model = self.model.to(memory_format=torch.channels_last)
@@ -71,16 +75,36 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
             if dtype == torch.bfloat16:
                 with torch.no_grad():
                     with torch.cpu.amp.autocast():
-                        self.model = torch.jit.trace(self.model, input_sample,
-                                                     check_trace=False,
-                                                     strict=jit_strict)
+                        if self.jit_converter == 'trace':
+                            self.model = torch.jit.trace(self.model, input_sample,
+                                                        check_trace=False,
+                                                        strict=jit_strict)
+                        elif self.jit_converter == 'script':
+                            self.model = torch.jit.script(self.model)
+                        else:
+                            try:
+                                self.model = torch.jit.trace(self.model, input_sample,
+                                                        check_trace=False,
+                                                        strict=jit_strict)
+                            except:
+                                self.model = torch.jit.script(self.model)
                         if self.use_ipex:
                             self.model = torch.jit.freeze(self.model)
             else:
                 with torch.no_grad():
-                    self.model = torch.jit.trace(self.model, input_sample,
-                                                 check_trace=False,
-                                                 strict=jit_strict)
+                    if self.jit_converter == 'trace':
+                        self.model = torch.jit.trace(self.model, input_sample,
+                                                    check_trace=False,
+                                                    strict=jit_strict)
+                    elif self.jit_converter == 'script':
+                        self.model = torch.jit.script(self.model)
+                    else:
+                        try:
+                            self.model = torch.jit.trace(self.model, input_sample,
+                                                    check_trace=False,
+                                                    strict=jit_strict)
+                        except:
+                            self.model = torch.jit.script(self.model)
                     self.model = torch.jit.freeze(self.model)
         self._nano_context_manager = generate_context_manager(accelerator=None,
                                                               precision="fp32",
@@ -122,7 +146,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                        "channels_last": self.channels_last,
                        "checkpoint": "ckpt.pth",
                        "thread_num": self.thread_num,
-                       "jit_strict": self.jit_strict})
+                       "jit_strict": self.jit_strict,
+                       'jit_converter': self.jit_converter})
         return status
 
     @staticmethod
@@ -150,7 +175,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                                    from_load=from_load,
                                    thread_num=thread_num,
                                    inplace=inplace,
-                                   jit_strict=status["jit_strict"])
+                                   jit_strict=status["jit_strict"],
+                                   jit_converter=status["jit_converter"])
 
     def _save_model(self, path):
         if self.use_jit:

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -575,12 +575,12 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                accelerator='onnxruntime', otherwise will be ignored. If this option
                                is set to True, new dependency 'onnxsim' need to be installed.
         :param jit_strict: Whether recording your mutable container types. This parameter will be
-                           passed to ``torch.jit.trace``. if ``accelerator != 'jit'`` or 
+                           passed to ``torch.jit.trace``. if ``accelerator != 'jit'`` or
                            ``jit_converter='script'``, it will be ignored. Default to True.
         :param jit_converter: Whether to use ``jit.trace`` or ``jit.script`` to convert a model
-                              to TorchScript. Accepected values are ``'trace'``, ``'script'``, 
-                              and ``None``. Default to be ``None`` meaning the try-except logic 
-                              to use ``jit.trace`` or ``jit.script``. If ``accelerator != 'jit'``, 
+                              to TorchScript. Accepected values are ``'trace'``, ``'script'``,
+                              and ``None``. Default to be ``None`` meaning the try-except logic
+                              to use ``jit.trace`` or ``jit.script``. If ``accelerator != 'jit'``,
                               this parameter will be ignored.
         :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
                              will have the first dim of each Tensor input as a dynamic batch_size.
@@ -616,12 +616,12 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                     use_jit = (accelerator == "jit")
                     if use_jit:
                         invalidInputError(jit_converter in [None, 'trace', 'script'],
-                                        "JIT converter {} is invalid.".format(jit_converter))
+                                          "JIT converter {} is invalid.".format(jit_converter))
                     return PytorchIPEXJITBF16Model(model, input_sample=input_sample,
                                                    use_ipex=use_ipex, use_jit=use_jit,
                                                    channels_last=channels_last,
                                                    thread_num=thread_num, inplace=inplace,
-                                                   jit_strict=jit_strict, 
+                                                   jit_strict=jit_strict,
                                                    jit_converter=jit_converter)
                 else:
                     bf16_model = BF16Model(model, channels_last=channels_last,
@@ -797,12 +797,12 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                accelerator='onnxruntime', otherwise will be ignored. If this option
                                is set to True, new dependency 'onnxsim' need to be installed.
         :param jit_strict: Whether recording your mutable container types. This parameter will be
-                           passed to ``torch.jit.trace``. if ``accelerator != 'jit'`` or 
+                           passed to ``torch.jit.trace``. if ``accelerator != 'jit'`` or
                            ``jit_converter='script'``, it will be ignored. Default to True.
         :param jit_converter: Whether to use ``jit.trace`` or ``jit.script`` to convert a model
-                              to TorchScript. Accepected values are ``'trace'``, ``'script'``, 
-                              and ``None``. Default to be ``None`` meaning the try-except logic 
-                              to use ``jit.trace`` or ``jit.script``. If ``accelerator != 'jit'``, 
+                              to TorchScript. Accepected values are ``'trace'``, ``'script'``,
+                              and ``None``. Default to be ``None`` meaning the try-except logic
+                              to use ``jit.trace`` or ``jit.script``. If ``accelerator != 'jit'``,
                               this parameter will be ignored.
         :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
                              will have the first dim of each Tensor input as a dynamic batch_size.
@@ -861,7 +861,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             use_jit = (accelerator == "jit")
             if use_jit:
                 invalidInputError(jit_converter in [None, 'trace', 'script'],
-                    "JIT converter {} is invalid.".format(jit_converter))
+                                  "JIT converter {} is invalid.".format(jit_converter))
             return PytorchIPEXJITModel(model, input_sample=input_sample, use_ipex=use_ipex,
                                        use_jit=use_jit, channels_last=channels_last,
                                        thread_num=thread_num, inplace=inplace,

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -496,7 +496,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                  openvino_config=None,
                  simplification: bool = True,
                  jit_strict: bool = True,
-                 jit_converter: Optional[str] = None,
+                 jit_method: Optional[str] = None,
                  dynamic_axes: Union[bool, dict] = True,
                  sample_size: int = 100,
                  logging: bool = True,
@@ -576,12 +576,12 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                is set to True, new dependency 'onnxsim' need to be installed.
         :param jit_strict: Whether recording your mutable container types. This parameter will be
                            passed to ``torch.jit.trace``. if ``accelerator != 'jit'`` or
-                           ``jit_converter='script'``, it will be ignored. Default to True.
-        :param jit_converter: Whether to use ``jit.trace`` or ``jit.script`` to convert a model
-                              to TorchScript. Accepected values are ``'trace'``, ``'script'``,
-                              and ``None``. Default to be ``None`` meaning the try-except logic
-                              to use ``jit.trace`` or ``jit.script``. If ``accelerator != 'jit'``,
-                              this parameter will be ignored.
+                           ``jit_method='script'``, it will be ignored. Default to True.
+        :param jit_method: Whether to use ``jit.trace`` or ``jit.script`` to convert a model
+                           to TorchScript. Accepected values are ``'trace'``, ``'script'``,
+                           and ``None``. Default to be ``None`` meaning the try-except logic
+                           to use ``jit.trace`` or ``jit.script``. If ``accelerator != 'jit'``,
+                           this parameter will be ignored.
         :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
                              will have the first dim of each Tensor input as a dynamic batch_size.
                              If dynamic_axes=False, the exported model will have the shapes of all
@@ -615,14 +615,14 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                           "torch version should >=1.10 to use ipex")
                     use_jit = (accelerator == "jit")
                     if use_jit:
-                        invalidInputError(jit_converter in [None, 'trace', 'script'],
-                                          "JIT converter {} is invalid.".format(jit_converter))
+                        invalidInputError(jit_method in [None, 'trace', 'script'],
+                                          "jit_method {} is invalid.".format(jit_method))
                     return PytorchIPEXJITBF16Model(model, input_sample=input_sample,
                                                    use_ipex=use_ipex, use_jit=use_jit,
                                                    channels_last=channels_last,
                                                    thread_num=thread_num, inplace=inplace,
                                                    jit_strict=jit_strict,
-                                                   jit_converter=jit_converter)
+                                                   jit_method=jit_method)
                 else:
                     bf16_model = BF16Model(model, channels_last=channels_last,
                                            thread_num=thread_num)
@@ -766,7 +766,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
               openvino_config=None,
               simplification: bool = True,
               jit_strict: bool = True,
-              jit_converter: Optional[str] = None,
+              jit_method: Optional[str] = None,
               dynamic_axes: Union[bool, dict] = True,
               logging: bool = True,
               inplace: bool = False,
@@ -798,12 +798,12 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                is set to True, new dependency 'onnxsim' need to be installed.
         :param jit_strict: Whether recording your mutable container types. This parameter will be
                            passed to ``torch.jit.trace``. if ``accelerator != 'jit'`` or
-                           ``jit_converter='script'``, it will be ignored. Default to True.
-        :param jit_converter: Whether to use ``jit.trace`` or ``jit.script`` to convert a model
-                              to TorchScript. Accepected values are ``'trace'``, ``'script'``,
-                              and ``None``. Default to be ``None`` meaning the try-except logic
-                              to use ``jit.trace`` or ``jit.script``. If ``accelerator != 'jit'``,
-                              this parameter will be ignored.
+                           ``jit_method='script'``, it will be ignored. Default to True.
+        :param jit_method: Whether to use ``jit.trace`` or ``jit.script`` to convert a model
+                           to TorchScript. Accepected values are ``'trace'``, ``'script'``,
+                           and ``None``. Default to be ``None`` meaning the try-except logic
+                           to use ``jit.trace`` or ``jit.script``. If ``accelerator != 'jit'``,
+                           this parameter will be ignored.
         :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
                              will have the first dim of each Tensor input as a dynamic batch_size.
                              If dynamic_axes=False, the exported model will have the shapes of all
@@ -860,12 +860,12 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                   "torch version should >=1.10 to use ipex")
             use_jit = (accelerator == "jit")
             if use_jit:
-                invalidInputError(jit_converter in [None, 'trace', 'script'],
-                                  "JIT converter {} is invalid.".format(jit_converter))
+                invalidInputError(jit_method in [None, 'trace', 'script'],
+                                  "jit_method {} is invalid.".format(jit_method))
             return PytorchIPEXJITModel(model, input_sample=input_sample, use_ipex=use_ipex,
                                        use_jit=use_jit, channels_last=channels_last,
                                        thread_num=thread_num, inplace=inplace,
-                                       jit_strict=jit_strict, jit_converter=jit_converter)
+                                       jit_strict=jit_strict, jit_method=jit_method)
         invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))
 
     @staticmethod

--- a/python/nano/test/pytorch/tests/inference/test_bf16.py
+++ b/python/nano/test/pytorch/tests/inference/test_bf16.py
@@ -17,6 +17,7 @@
 from unittest import TestCase
 import pytest
 import torch
+from torch import nn
 from bigdl.nano.pytorch import InferenceOptimizer
 from torchvision.models.resnet import resnet18
 from unittest.mock import MagicMock, PropertyMock, patch
@@ -192,25 +193,25 @@ class Pytorch1_12:
         model = Net()
 
         input_sample = torch.rand(1,3,1,1)
-        input = torch.rand(2,3,1,1)
-        expected_output = torch.tensor([0])
+        input = torch.rand(5,3,1,1)
+        expected_output_len = 5
 
         # test with jit.script
         accmodel = InferenceOptimizer.quantize(model, precision='bf16',
                                                accelerator='jit', 
                                                input_sample=input_sample, 
                                                jit_converter='script')
-        with InferenceOptimizer.get_context(model):
+        with InferenceOptimizer.get_context(accmodel):
             output = accmodel(input)
-        assert output == expected_output
+        assert output.shape[0] == expected_output_len
 
         with tempfile.TemporaryDirectory() as tmp_dir_name:
-            InferenceOptimizer.save(acc_model, tmp_dir_name)
+            InferenceOptimizer.save(accmodel, tmp_dir_name)
             loaded_model = InferenceOptimizer.load(tmp_dir_name)
-        with InferenceOptimizer.get_context(new_model):
-            loaded_model(input)
-            assert output == expected_output
-            assert loaded_model.jit_converter == 'script'
+        with InferenceOptimizer.get_context(loaded_model):
+            output = loaded_model(input)
+        assert output.shape[0] == expected_output_len
+        assert loaded_model.jit_converter == 'script'
 
 
         # test with jit.trace
@@ -218,17 +219,17 @@ class Pytorch1_12:
                                                accelerator='jit', 
                                                input_sample=input_sample, 
                                                jit_converter='trace')
-        with InferenceOptimizer.get_context(model):
+        with InferenceOptimizer.get_context(accmodel):
             output = accmodel(input)
-        assert output != expected_output
+        assert output.shape[0] != expected_output_len
 
         # test with deafult jit_converter
         accmodel = InferenceOptimizer.quantize(model, precision='bf16',
                                                accelerator='jit', 
                                                input_sample=input_sample)
-        with InferenceOptimizer.get_context(model):
+        with InferenceOptimizer.get_context(accmodel):
             output = accmodel(input)
-        assert output != expected_output
+        assert output.shape[0] != expected_output_len
 
         # test with invalidInputError
         with pytest.raises(RuntimeError):

--- a/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
@@ -16,6 +16,7 @@
 from unittest import TestCase
 import pytest
 import torch
+from torch import nn
 from bigdl.nano.pytorch import InferenceOptimizer
 from torchvision.models.resnet import resnet18
 from unittest.mock import PropertyMock, patch
@@ -150,6 +151,65 @@ class Pytorch1_11:
         with pytest.raises(AttributeError):
             new_model.width
 
+    def test_bf16_ipex_jit_converter(self):
+
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+            def forward(self, x):
+                return torch.arange(len(x))
+
+        model = Net()
+
+        input_sample = torch.rand(1,3,1,1)
+        input = torch.rand(5,3,1,1)
+        expected_output_len = 5
+
+        # test with jit.script
+        accmodel = InferenceOptimizer.quantize(model, precision='bf16',
+                                               accelerator='jit', 
+                                               use_ipex=True,
+                                               input_sample=input_sample, 
+                                               jit_converter='script')
+        with InferenceOptimizer.get_context(accmodel):
+            output = accmodel(input)
+        assert output.shape[0] == expected_output_len
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(accmodel, tmp_dir_name)
+            loaded_model = InferenceOptimizer.load(tmp_dir_name)
+        with InferenceOptimizer.get_context(loaded_model):
+            output = loaded_model(input)
+        assert output.shape[0] == expected_output_len
+        assert loaded_model.jit_converter == 'script'
+
+
+        # test with jit.trace
+        accmodel = InferenceOptimizer.quantize(model, precision='bf16',
+                                               accelerator='jit', 
+                                               use_ipex=True,
+                                               input_sample=input_sample, 
+                                               jit_converter='trace')
+        with InferenceOptimizer.get_context(accmodel):
+            output = accmodel(input)
+        assert output.shape[0] != expected_output_len
+
+        # test with deafult jit_converter
+        accmodel = InferenceOptimizer.quantize(model, precision='bf16',
+                                               accelerator='jit',
+                                               use_ipex=True,
+                                               input_sample=input_sample)
+        with InferenceOptimizer.get_context(accmodel):
+            output = accmodel(input)
+        assert output.shape[0] != expected_output_len
+
+        # test with invalidInputError
+        with pytest.raises(RuntimeError):
+            InferenceOptimizer.quantize(model, precision='bf16',
+                                        accelerator='jit',
+                                        use_ipex=True,
+                                        input_sample=input_sample,
+                                        jit_converter='scriptttt')
 
 TORCH_VERSION_CLS = Pytorch1_11
 

--- a/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
@@ -151,7 +151,7 @@ class Pytorch1_11:
         with pytest.raises(AttributeError):
             new_model.width
 
-    def test_bf16_ipex_jit_converter(self):
+    def test_bf16_ipex_jit_method(self):
 
         class Net(nn.Module):
             def __init__(self):
@@ -170,7 +170,7 @@ class Pytorch1_11:
                                                accelerator='jit', 
                                                use_ipex=True,
                                                input_sample=input_sample, 
-                                               jit_converter='script')
+                                               jit_method='script')
         with InferenceOptimizer.get_context(accmodel):
             output = accmodel(input)
         assert output.shape[0] == expected_output_len
@@ -181,7 +181,7 @@ class Pytorch1_11:
         with InferenceOptimizer.get_context(loaded_model):
             output = loaded_model(input)
         assert output.shape[0] == expected_output_len
-        assert loaded_model.jit_converter == 'script'
+        assert loaded_model.jit_method == 'script'
 
 
         # test with jit.trace (with ipex)
@@ -189,12 +189,12 @@ class Pytorch1_11:
                                                accelerator='jit', 
                                                use_ipex=True,
                                                input_sample=input_sample, 
-                                               jit_converter='trace')
+                                               jit_method='trace')
         with InferenceOptimizer.get_context(accmodel):
             output = accmodel(input)
         assert output.shape[0] != expected_output_len
 
-        # test with deafult jit_converter
+        # test with deafult jit_method
         accmodel = InferenceOptimizer.quantize(model, precision='bf16',
                                                accelerator='jit',
                                                input_sample=input_sample)
@@ -207,7 +207,7 @@ class Pytorch1_11:
             InferenceOptimizer.quantize(model, precision='bf16',
                                         accelerator='jit',
                                         input_sample=input_sample,
-                                        jit_converter='scriptttt')
+                                        jit_method='scriptttt')
 
 TORCH_VERSION_CLS = Pytorch1_11
 

--- a/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
@@ -165,7 +165,7 @@ class Pytorch1_11:
         input = torch.rand(5,3,1,1)
         expected_output_len = 5
 
-        # test with jit.script
+        # test with jit.script (with ipex)
         accmodel = InferenceOptimizer.quantize(model, precision='bf16',
                                                accelerator='jit', 
                                                use_ipex=True,
@@ -184,7 +184,7 @@ class Pytorch1_11:
         assert loaded_model.jit_converter == 'script'
 
 
-        # test with jit.trace
+        # test with jit.trace (with ipex)
         accmodel = InferenceOptimizer.quantize(model, precision='bf16',
                                                accelerator='jit', 
                                                use_ipex=True,
@@ -197,7 +197,6 @@ class Pytorch1_11:
         # test with deafult jit_converter
         accmodel = InferenceOptimizer.quantize(model, precision='bf16',
                                                accelerator='jit',
-                                               use_ipex=True,
                                                input_sample=input_sample)
         with InferenceOptimizer.get_context(accmodel):
             output = accmodel(input)
@@ -207,7 +206,6 @@ class Pytorch1_11:
         with pytest.raises(RuntimeError):
             InferenceOptimizer.quantize(model, precision='bf16',
                                         accelerator='jit',
-                                        use_ipex=True,
                                         input_sample=input_sample,
                                         jit_converter='scriptttt')
 

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -173,7 +173,7 @@ class IPEXJITInference_gt_1_10:
             new_model(self.data_sample)
             assert new_model.jit_strict is False
 
-    def test_ipex_jit_inference_converter(self):
+    def test_ipex_jit_inference_jit_method(self):
         class Net(nn.Module):
             def __init__(self):
                 super().__init__()
@@ -190,7 +190,7 @@ class IPEXJITInference_gt_1_10:
         accmodel = InferenceOptimizer.trace(model, accelerator='jit',
                                             use_ipex=True, 
                                             input_sample=input_sample, 
-                                            jit_converter='script')
+                                            jit_method='script')
         with InferenceOptimizer.get_context(accmodel):
             output = accmodel(input)
         assert output.shape[0] == expected_output_len
@@ -201,19 +201,19 @@ class IPEXJITInference_gt_1_10:
         with InferenceOptimizer.get_context(loaded_model):
             output = loaded_model(input)
         assert output.shape[0] == expected_output_len
-        assert loaded_model.jit_converter == 'script'
+        assert loaded_model.jit_method == 'script'
 
 
         # test with jit.trace (with ipex)
         accmodel = InferenceOptimizer.trace(model, accelerator='jit', 
                                       use_ipex=True,
                                       input_sample=input_sample, 
-                                      jit_converter='trace')
+                                      jit_method='trace')
         with InferenceOptimizer.get_context(accmodel):
             output = accmodel(input)
         assert output.shape[0] != expected_output_len
 
-        # test with deafult jit_converter
+        # test with deafult jit_method
         accmodel = InferenceOptimizer.trace(model, accelerator='jit', 
                                       input_sample=input_sample)
         with InferenceOptimizer.get_context(accmodel):
@@ -224,7 +224,7 @@ class IPEXJITInference_gt_1_10:
         with pytest.raises(RuntimeError):
             InferenceOptimizer.trace(model, accelerator='jit', 
                                input_sample=input_sample,
-                               jit_converter='scriptttt')
+                               jit_method='scriptttt')
 
 class IPEXJITInference_lt_1_10:
     def test_placeholder(self):

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -173,6 +173,56 @@ class IPEXJITInference_gt_1_10:
             new_model(self.data_sample)
             assert new_model.jit_strict is False
 
+    def test_jit_inference_converter(self):
+        class Net(nn.Module):
+            def __init__(self):
+                super().__init__()
+            def forward(self, x):
+                return torch.arange(len(x))
+
+        model = Net()
+
+        input_sample = torch.rand(1,3,1,1)
+        input = torch.rand(2,3,1,1)
+        expected_output = torch.tensor([0])
+
+        # test with jit.script
+        accmodel = InferenceOptimizer.trace(model, accelerator='jit', 
+                                            input_sample=input_sample, 
+                                            jit_converter='script')
+        with InferenceOptimizer.get_context(model):
+            output = accmodel(input)
+        assert output == expected_output
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(acc_model, tmp_dir_name)
+            loaded_model = InferenceOptimizer.load(tmp_dir_name)
+        with InferenceOptimizer.get_context(new_model):
+            loaded_model(input)
+            assert output == expected_output
+            assert loaded_model.jit_converter == 'script'
+
+
+        # test with jit.trace
+        accmodel = InferenceOptimizer.trace(model, accelerator='jit', 
+                                      input_sample=input_sample, 
+                                      jit_converter='trace')
+        with InferenceOptimizer.get_context(model):
+            output = accmodel(input)
+        assert output != expected_output
+
+        # test with deafult jit_converter
+        accmodel = InferenceOptimizer.trace(model, accelerator='jit', 
+                                      input_sample=input_sample)
+        with InferenceOptimizer.get_context(model):
+            output = accmodel(input)
+        assert output != expected_output
+
+        # test with invalidInputError
+        with pytest.raises(RuntimeError):
+            InferenceOptimizer.trace(model, accelerator='jit', 
+                               input_sample=input_sample,
+                               jit_converter='scriptttt')
 
 class IPEXJITInference_lt_1_10:
     def test_placeholder(self):


### PR DESCRIPTION
## Description

Support users to choose `jit.trace`/`jit.script` when applying `jit` as the accelerator in `InferenceOptimizer.trace`/`quantize`

### 1. Why the change?

When converting a model to TorchScript, users could either use `jit.trace` or `jit.script`, or even mix both of them. These two converting methods have their own prons and cons. For example, for a model that are both scriptable and traceable, `jit.trace` could always generate a simpler graph (thus probably better performance). However, `jit.trace` would cause problems when the model includes dynamic workflows, it could also capture variables as constants, etc. (Reference: this [blog](https://ppwwyyxx.com/blog/2022/TorchScript-Tracing-vs-Scripting/#Let-Tracing-Generalize))

Currently, in `InferenceOptimizer.trace`/`quantize`, we are only using `jit.trace`. For better flexibility, we should enable users to choose either of them. A try-except logic will also be used (first `jit.trace`, failed then `jit.script`) by default to increase the success rate of converting the model.


### 2. User API changes

Added a `jit_method` parameter to  `InferenceOptimizer.trace`/`quantize` for users to choose whether to use `jit.trace` or `jit.srcipt`. By default,  a try-except logic will be used (first `jit.trace`, failed then `jit.script`) .

```python
# use jit.trace
accmodel = InferenceOptimizer.trace(model, accelerator='jit', 
                                    input_sample=input_sample, 
                                    jit_method='trace')

# use jit.script
accmodel = InferenceOptimizer.trace(model, accelerator='jit', 
                                    input_sample=input_sample, 
                                    jit_method='script')

# use try-except logic
accmodel = InferenceOptimizer.trace(model, accelerator='jit', 
                                    input_sample=input_sample)
```

### 3. Summary of the change 
- Added a `jit_method` parameter to  `InferenceOptimizer.trace`/`quantize`
- Added the missing `jit_strict` parameter when loading a `PytorchIPEXJITBF16Model` model


### 4. How to test?
- [x] Unit test
- [x] Document test for related API: https://yuwentestdocs.readthedocs.io/en/nano-jit-script-trace/doc/PythonAPI/Nano/pytorch.html#bigdl.nano.pytorch.InferenceOptimizer.quantize

### 5. New dependencies

N/A

### 6. Possible further improvements
Try to detect/inform the case that `jit.trace` causes problems in `InferenceOptimizer.optimize` due to problems in dynamic workflows, capturing variables as constants, etc,