### PR TITLE
Remove cache when Spark DataFrame to SparkXShards and fix repartition for PyTorch Estimator spark backend

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -271,8 +271,8 @@ class PyTorchPySparkEstimator(BaseEstimator):
                     isinstance(validation_data, DataFrame) or
                     isinstance(validation_data, SparkXShards),
                     "validation_data should have the same type with train data")
-                if validation_data.rdd.getNumPartitions() != self.num_workers:
-                    validation_data = validation_data.repartition(self.num_workers)
+                if validation_data.rdd.getNumPartitions() != self.num_workers:  # type:ignore
+                    validation_data = validation_data.repartition(self.num_workers)  # type:ignore
         data, validation_data = maybe_dataframe_to_xshards(data,
                                                            validation_data=validation_data,
                                                            feature_cols=feature_cols,

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -454,10 +454,11 @@ class PyTorchPySparkEstimator(BaseEstimator):
             if xshards._get_class_name() == 'pandas.core.frame.DataFrame':
                 xshards = process_xshards_of_pandas_dataframe(xshards, feature_cols)
                 pred_shards = self._predict_spark_xshards(xshards, init_params, params)
-                result = add_predict_to_pd_xshards(xshards, pred_shards)
+                # Should add to the original SparkXShards of Pandas DataFrames
+                result = add_predict_to_pd_xshards(data, pred_shards)
             else:
                 pred_shards = self._predict_spark_xshards(xshards, init_params, params)
-                result = update_predict_xshards(xshards, pred_shards)
+                result = update_predict_xshards(data, pred_shards)
             # Uncache the original data since it is already included in the result
             data.uncache()
         else:

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -266,8 +266,12 @@ class PyTorchPySparkEstimator(BaseEstimator):
         if isinstance(data, DataFrame) or isinstance(data, SparkXShards):
             if data.rdd.getNumPartitions() != self.num_workers:
                 data = data.repartition(self.num_workers)
-            if validation_data and validation_data.rdd.getNumPartitions() != self.num_workers:
-                validation_data = validation_data.repartition(self.num_workers)
+            if validation_data:
+                assert isinstance(validation_data, DataFrame) or \
+                       isinstance(validation_data, SparkXShards),\
+                    "validation_data should have the same type with train data"
+                if validation_data.rdd.getNumPartitions() != self.num_workers:
+                    validation_data = validation_data.repartition(self.num_workers)
         data, validation_data = maybe_dataframe_to_xshards(data,
                                                            validation_data=validation_data,
                                                            feature_cols=feature_cols,

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -267,9 +267,10 @@ class PyTorchPySparkEstimator(BaseEstimator):
             if data.rdd.getNumPartitions() != self.num_workers:
                 data = data.repartition(self.num_workers)
             if validation_data:
-                assert isinstance(validation_data, DataFrame) or \
-                       isinstance(validation_data, SparkXShards),\
-                    "validation_data should have the same type with train data"
+                invalidInputError(
+                    isinstance(validation_data, DataFrame) or
+                    isinstance(validation_data, SparkXShards),
+                    "validation_data should have the same type with train data")
                 if validation_data.rdd.getNumPartitions() != self.num_workers:
                     validation_data = validation_data.repartition(self.num_workers)
         data, validation_data = maybe_dataframe_to_xshards(data,

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -156,9 +156,10 @@ class SparkTFEstimator():
             if data.rdd.getNumPartitions() != self.num_workers:
                 data = data.repartition(self.num_workers)
             if validation_data:
-                assert isinstance(validation_data, DataFrame) or \
-                       isinstance(validation_data, SparkXShards),\
-                    "validation_data should have the same type with train data"
+                invalidInputError(
+                    isinstance(validation_data, DataFrame) or
+                    isinstance(validation_data, SparkXShards),
+                    "validation_data should have the same type with train data")
                 if validation_data.rdd.getNumPartitions() != self.num_workers:
                     validation_data = validation_data.repartition(self.num_workers)
         data, validation_data = maybe_dataframe_to_xshards(data, validation_data,

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -439,11 +439,12 @@ class SparkTFEstimator():
                 xshards = process_xshards_of_pandas_dataframe(xshards, feature_cols)
                 pred_shards = SparkXShards.lazy(xshards.rdd.mapPartitions(
                     lambda iter: transform_func(iter, init_params, params)))
-                result = add_predict_to_pd_xshards(xshards, pred_shards)
+                # Should add to the original SparkXShards of Pandas DataFrames
+                result = add_predict_to_pd_xshards(data, pred_shards)
             else:
                 pred_shards = SparkXShards.lazy(xshards.rdd.mapPartitions(
                     lambda iter: transform_func(iter, init_params, params)))
-                result = update_predict_xshards(xshards, pred_shards)
+                result = update_predict_xshards(data, pred_shards)
             # Uncache the original data since it is already included in the result
             data.uncache()
         else:

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -435,15 +435,15 @@ class SparkTFEstimator():
             result = convert_predict_xshards_to_dataframe(data, pred_shards)
         elif isinstance(data, SparkXShards):  # Computation triggered when updating XShards
             xshards = data.to_lazy()
-            if data._get_class_name() == 'pandas.core.frame.DataFrame':
-                xshards = process_xshards_of_pandas_dataframe(data, feature_cols)
+            if xshards._get_class_name() == 'pandas.core.frame.DataFrame':
+                xshards = process_xshards_of_pandas_dataframe(xshards, feature_cols)
                 pred_shards = SparkXShards.lazy(xshards.rdd.mapPartitions(
                     lambda iter: transform_func(iter, init_params, params)))
-                result = add_predict_to_pd_xshards(data, pred_shards)
+                result = add_predict_to_pd_xshards(xshards, pred_shards)
             else:
-                pred_shards = SparkXShards(xshards.rdd.mapPartitions(
+                pred_shards = SparkXShards.lazy(xshards.rdd.mapPartitions(
                     lambda iter: transform_func(iter, init_params, params)))
-                result = update_predict_xshards(data, pred_shards)
+                result = update_predict_xshards(xshards, pred_shards)
             # Uncache the original data since it is already included in the result
             data.uncache()
         else:

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -155,8 +155,12 @@ class SparkTFEstimator():
         if isinstance(data, DataFrame) or isinstance(data, SparkXShards):
             if data.rdd.getNumPartitions() != self.num_workers:
                 data = data.repartition(self.num_workers)
-            if validation_data and validation_data.rdd.getNumPartitions() != self.num_workers:
-                validation_data = validation_data.repartition(self.num_workers)
+            if validation_data:
+                assert isinstance(validation_data, DataFrame) or \
+                       isinstance(validation_data, SparkXShards),\
+                    "validation_data should have the same type with train data"
+                if validation_data.rdd.getNumPartitions() != self.num_workers:
+                    validation_data = validation_data.repartition(self.num_workers)
         data, validation_data = maybe_dataframe_to_xshards(data, validation_data,
                                                            feature_cols, label_cols,
                                                            mode="fit",

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -160,8 +160,8 @@ class SparkTFEstimator():
                     isinstance(validation_data, DataFrame) or
                     isinstance(validation_data, SparkXShards),
                     "validation_data should have the same type with train data")
-                if validation_data.rdd.getNumPartitions() != self.num_workers:
-                    validation_data = validation_data.repartition(self.num_workers)
+                if validation_data.rdd.getNumPartitions() != self.num_workers:  # type:ignore
+                    validation_data = validation_data.repartition(self.num_workers)  # type:ignore
         data, validation_data = maybe_dataframe_to_xshards(data, validation_data,
                                                            feature_cols, label_cols,
                                                            mode="fit",

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
@@ -389,6 +389,7 @@ class TestPyTorchEstimator(TestCase):
         expr = "sum(cast(feature <> to_array(prediction) as int)) as error"
         assert result.selectExpr(expr).first()["error"] == 0
         predictions = result.collect()
+        assert len(predictions) == 20
 
     def test_xshards_predict_save_load(self):
 

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py
@@ -385,8 +385,10 @@ class TestPyTorchEstimator(TestCase):
                                   model_fn=lambda config: IdentityNet())
         result = estimator.predict(df, batch_size=4,
                                    feature_cols=["feature"])
+        assert "prediction" in result.columns
         expr = "sum(cast(feature <> to_array(prediction) as int)) as error"
         assert result.selectExpr(expr).first()["error"] == 0
+        predictions = result.collect()
 
     def test_xshards_predict_save_load(self):
 

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
@@ -191,6 +191,8 @@ class TestTFEstimator(TestCase):
                                           feature_cols=["user", "item"])
             assert predictions._get_class_name() == "pandas.core.frame.DataFrame"
             prediction_df = predictions.collect()[0]
+            import pandas as pd
+            assert isinstance(prediction_df, pd.DataFrame)
             assert "prediction" in prediction_df
         finally:
             shutil.rmtree(temp_dir)


### PR DESCRIPTION
https://github.com/intel-analytics/BigDL/pull/6756
https://github.com/intel-analytics/BigDL/pull/5271
These two patches for PyTorch.

Tested on the unit test for Spark DataFrames and SparkXShards.
- SparkXShards train and evaluate: https://github.com/intel-analytics/BigDL/blob/main/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py#L241
- SparkXShards predict: https://github.com/intel-analytics/BigDL/blob/main/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py#L391
- Spark DataFrame train and evaluate: https://github.com/intel-analytics/BigDL/blob/main/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py#L278
- Spark DataFrame predict: https://github.com/intel-analytics/BigDL/blob/main/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_pyspark_backend.py#L376