### PR TITLE
[Nano API doc] Hide `ALL_INFERENCE_ACCELERATION_METHOD` in api doc rendering for `bigdl.nano.tf.keras.InferenceOptimizer`

### DIFF
--- a/docs/readthedocs/source/doc/PythonAPI/Nano/tensorflow.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Nano/tensorflow.rst
@@ -16,6 +16,7 @@ bigdl.nano.tf.keras
 .. autoclass:: bigdl.nano.tf.keras.InferenceOptimizer
     :members:
     :undoc-members:
+    :exclude-members: ALL_INFERENCE_ACCELERATION_METHOD
 
 .. autoclass:: bigdl.nano.tf.keras.layers.Embedding
     :members:


### PR DESCRIPTION
Hide `ALL_INFERENCE_ACCELERATION_METHOD` in api doc rendering for `bigdl.nano.tf.keras.InferenceOptimizer`

Document test: https://yuwentestdocs.readthedocs.io/en/fix-nano-api-doc2/doc/PythonAPI/Nano/tensorflow.html#bigdl.nano.tf.keras.InferenceOptimizer