### PR TITLE
[nano] update KMP_AFFINITY to fine,none

### DIFF
--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -154,7 +154,7 @@ if [ -f "${LIB_DIR}/libiomp5.so" ]; then
 	fi
 
 	echo "Setting KMP_AFFINITY..."
-	export KMP_AFFINITY=granularity=fine
+	export KMP_AFFINITY=granularity=fine,none
 
 	echo "Setting KMP_BLOCKTIME..."
 	export KMP_BLOCKTIME=1


### PR DESCRIPTION
## Description
In #5764, we change default value of KMP_AFFINITY to `granularity=fine`. The `type` is `none` by default, so the `granularity=fine` should means `granularity=fine,none`,  but we found in some case, like creating run openvino in a subprocess, openvino will recognized as `granularity=fine,compact,0,0`. So we should declare the type `none` explictly.

### 1. Why the change?

in some case, like creating run openvino in a subprocess, openvino will recognized as `granularity=fine,compact,0,0`. So we should declare the type `none` explicitly.

### 2. User API changes

None

### 3. Summary of the change 

Set default  KMP_AFFINITY to granularity=fine,none

### 4. How to test?
- [ ] N/A
- [ ] Unit test


