### PR TITLE
Nano: Update tensorflow example and UT

### DIFF
--- a/python/nano/notebooks/tensorflow/tutorial/tensorflow_quantization.ipynb
+++ b/python/nano/notebooks/tensorflow/tutorial/tensorflow_quantization.ipynb
@@ -31,7 +31,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "BigDL-Nano provides several APIs which can help users easily apply optimizations on inference pipelines to improve latency and throughput. The Keras Model(`bigdl.nano.tf.keras.Model`) and Sequential(`bigdl.nano.tf.keras.Sequential`) provides the APIs for all optimizations you need for inference.\n"
+    "BigDL-Nano provides several APIs which can help users easily apply optimizations on inference pipelines to improve latency and throughput. The Keras InferenceOptimizer(`bigdl.nano.tf.keras.InferenceOptimizer`) provides the APIs for all optimizations you need for inference.\n"
    ]
   },
   {
@@ -40,7 +40,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bigdl.nano.tf.keras import Model, Sequential"
+    "from bigdl.nano.tf.keras import Sequential"
    ]
   },
   {
@@ -188,7 +188,6 @@
     "x = layers.Dense(512, activation='relu')(x)\n",
     "outputs = layers.Dense(num_classes, activation='softmax')(x)\n",
     "\n",
-    "model = Model(inputs=inputs, outputs=outputs)\n",
     "model.compile(loss=\"categorical_crossentropy\", optimizer=\"adam\", metrics=['accuracy'])\n",
     "\n"
    ]

--- a/python/nano/notebooks/tensorflow/tutorial/tensorflow_quantization.ipynb
+++ b/python/nano/notebooks/tensorflow/tutorial/tensorflow_quantization.ipynb
@@ -178,7 +178,7 @@
    "outputs": [],
    "source": [
     "from tensorflow.keras.applications import ResNet50\n",
-    "from tensorflow.keras import layers\n",
+    "from tensorflow.keras import layers, Model\n",
     "inputs = tf.keras.layers.Input(shape=(224, 224, 3))\n",
     "x = tf.cast(inputs, tf.float32)\n",
     "x = tf.keras.applications.resnet50.preprocess_input(x)\n",
@@ -188,6 +188,7 @@
     "x = layers.Dense(512, activation='relu')(x)\n",
     "outputs = layers.Dense(num_classes, activation='softmax')(x)\n",
     "\n",
+    "model = Model(inputs=inputs, outputs=outputs)\n",
     "model.compile(loss=\"categorical_crossentropy\", optimizer=\"adam\", metrics=['accuracy'])\n",
     "\n"
    ]

--- a/python/nano/test/tf/keras/test_inf_optimizer.py
+++ b/python/nano/test/tf/keras/test_inf_optimizer.py
@@ -15,18 +15,14 @@
 
 from unittest import TestCase
 import tensorflow as tf
-from tensorflow.keras import Model
-from bigdl.nano.tf.keras import Sequential
 from bigdl.nano.tf.keras import InferenceOptimizer
 import numpy as np
-from bigdl.nano.tf.keras import Model as NanoModel
 from tensorflow.keras.applications.resnet import ResNet50
 
 
 class TestInferencePipeline(TestCase):
     def test_optimize_nano_model_without_accuracy(self):
         model = ResNet50(weights=None, input_shape=[40, 40, 3], classes=10)
-        model = NanoModel(inputs=model.inputs, outputs=model.outputs)
         # prepare dataset
         train_examples = np.random.random((100, 40, 40, 3))
         train_labels = np.random.randint(0, 10, size=(100,))
@@ -54,7 +50,6 @@ class TestInferencePipeline(TestCase):
 
     def test_optimize_nano_model_without_accuracy_large_batch(self):
         model = ResNet50(weights=None, input_shape=[40, 40, 3], classes=10)
-        model = NanoModel(inputs=model.inputs, outputs=model.outputs)
         # prepare dataset
         train_examples = np.random.random((100, 40, 40, 3))
         train_labels = np.random.randint(0, 10, size=(100,))
@@ -69,7 +64,6 @@ class TestInferencePipeline(TestCase):
 
     def test_optimize_model_with_accuracy(self):
         model = ResNet50(weights=None, input_shape=[40, 40, 3], classes=10)
-        model = NanoModel(inputs=model.inputs, outputs=model.outputs)
         # prepare dataset
         train_examples = np.random.random((100, 40, 40, 3))
         train_labels = np.random.randint(0, 10, size=(100,))
@@ -88,7 +82,6 @@ class TestInferencePipeline(TestCase):
 
     def test_optimize_model_without_dataset(self):
         model = ResNet50(weights=None, input_shape=[40, 40, 3], classes=10)
-        model = NanoModel(inputs=model.inputs, outputs=model.outputs)
 
         train_examples = np.random.random((100, 40, 40, 3))
         train_labels = np.random.randint(0, 10, size=(100,))

--- a/python/nano/tutorial/inference/tensorflow/tensorflow_inference_onnx.py
+++ b/python/nano/tutorial/inference/tensorflow/tensorflow_inference_onnx.py
@@ -26,7 +26,7 @@ import tensorflow as tf
 import tensorflow_datasets as tfds
 from tensorflow.keras.applications import ResNet50
 
-from bigdl.nano.tf.keras import Model, InferenceOptimizer
+from bigdl.nano.tf.keras import InferenceOptimizer
 
 
 def create_dataset(img_size, batch_size):
@@ -61,7 +61,6 @@ if __name__ == '__main__':
     # then you can use the returned model for inference, all inference will be 
     # accelerated automatically after that.
     #
-    model = Model(inputs=model.inputs, outputs=model.outputs)
     spec = tf.TensorSpec((None, 224, 224, 3), tf.float32)
     onnx_model = InferenceOptimizer.trace(model, accelerator='onnxruntime', input_spec=spec)
     onnx_preds = onnx_model.predict(dataset)

--- a/python/nano/tutorial/inference/tensorflow/tensorflow_inference_openvino.py
+++ b/python/nano/tutorial/inference/tensorflow/tensorflow_inference_openvino.py
@@ -19,7 +19,7 @@
 import os
 import numpy as np
 import tensorflow as tf
-from tensorflow.keras import layers
+from tensorflow.keras import layers, Model
 from tensorflow.keras.applications import ResNet50
 import tensorflow_datasets as tfds
 
@@ -56,6 +56,7 @@ def create_model(num_classes, img_size):
     x = layers.Dense(512, activation='relu')(x)
     outputs = layers.Dense(num_classes, activation='softmax')(x)
 
+    model = Model(inputs=inputs, outputs=outputs)
     model.compile(loss="categorical_crossentropy", optimizer="adam", metrics=['accuracy'])
     return model
 

--- a/python/nano/tutorial/inference/tensorflow/tensorflow_inference_openvino.py
+++ b/python/nano/tutorial/inference/tensorflow/tensorflow_inference_openvino.py
@@ -25,7 +25,7 @@ import tensorflow_datasets as tfds
 
 # Use `Model` and `Sequential` in `bigdl.nano.tf.keras` instead of tensorflow's
 # Use `InferenceOptimizer` for OpenVINO acceleration
-from bigdl.nano.tf.keras import Model, InferenceOptimizer
+from bigdl.nano.tf.keras import InferenceOptimizer
 
 
 def create_datasets(img_size, batch_size):
@@ -56,7 +56,6 @@ def create_model(num_classes, img_size):
     x = layers.Dense(512, activation='relu')(x)
     outputs = layers.Dense(num_classes, activation='softmax')(x)
 
-    model = Model(inputs=inputs, outputs=outputs)
     model.compile(loss="categorical_crossentropy", optimizer="adam", metrics=['accuracy'])
     return model
 

--- a/python/nano/tutorial/inference/tensorflow/tensorflow_quantization.py
+++ b/python/nano/tutorial/inference/tensorflow/tensorflow_quantization.py
@@ -21,7 +21,7 @@ from keras import layers
 from keras import losses, metrics
 
 # Use `InferenceOptimizer` for quantization
-from bigdl.nano.tf.keras import Model, InferenceOptimizer
+from bigdl.nano.tf.keras import InferenceOptimizer
 
 # Model / data parameters
 num_classes = 10


### PR DESCRIPTION
## Description

Update tensorflow example and UT:

- remove `model = Model(model.inputs, model.outputs)` because we don't need it any more

