### PR TITLE
Nano: fix install `bigdl-nano` only

### DIFF
--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -171,7 +171,7 @@ def setup_package():
         url='https://github.com/intel-analytics/BigDL',
         install_requires=install_requires,
         # "" means user run `pip install bigdl-nano`, install all dependencies in this case
-        extras_require={"": pytorch_requires + tensorflow_requires + inference_requires,
+        extras_require={" ": ["bigdl-nano[pytorch,tensorflow,inference]"],
                         "tensorflow": tensorflow_requires,
                         "tensorflow_27": tensorflow_27_requires,
                         "tensorflow_28": tensorflow_28_requires,

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -170,7 +170,9 @@ def setup_package():
         author_email='bigdl-user-group@googlegroups.com',
         url='https://github.com/intel-analytics/BigDL',
         install_requires=install_requires,
-        extras_require={"tensorflow": tensorflow_requires,
+        # "" means user run `pip install bigdl-nano`, install all dependencies in this case
+        extras_require={"": pytorch_requires + tensorflow_requires + inference_requires,
+                        "tensorflow": tensorflow_requires,
                         "tensorflow_27": tensorflow_27_requires,
                         "tensorflow_28": tensorflow_28_requires,
                         "tensorflow_29": tensorflow_29_requires,


### PR DESCRIPTION
## Description

Before this PR, if user run `pip install bigdl-nano`,  `pytorch-lightning` won't be installed automatically. However, `Trainer`, `TorchNano` and `InferenceOptimizer` are all depending on `pytorch-lightning`.

User must run `pip install bigdl-nano[pytorch]` to use `Trainer` and `TrochNano`, or run `pip install bigdl-nano[pytorch,inference]` to use all these features

After this PR, if user run `pip install bigdl-nano`, it is equivalent to running `pip install bigdl-nano[pytorch,tensorflow,inference]`, so that he can use all these features
