### PR TITLE
Nano: support backward compatibility of loading

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -94,7 +94,9 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
             model.load_state_dict(state_dict)
             from_load = False
         thread_num = status.get('thread_num', None)
-        if thread_num is not None and thread_num != {}:
+        if thread_num == {}:
+            thread_num = None
+        if thread_num is not None:
             thread_num = int(status['thread_num'])
         return PytorchIPEXJITBF16Model(model, use_ipex=status['use_ipex'],
                                        use_jit=status['use_jit'],

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -93,9 +93,8 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
             model.eval()
             model.load_state_dict(state_dict)
             from_load = False
-        thread_num = None
-        if hasattr(status, 'thread_num') and status['thread_num'] is not None and\
-                status['thread_num'] != {}:
+        thread_num = status.get('thread_num', None)
+        if thread_num is not None and thread_num != {}:
             thread_num = int(status['thread_num'])
         return PytorchIPEXJITBF16Model(model, use_ipex=status['use_ipex'],
                                        use_jit=status['use_jit'],

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -94,7 +94,8 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
             model.load_state_dict(state_dict)
             from_load = False
         thread_num = None
-        if status["thread_num"] is not None and status['thread_num'] != {}:
+        if hasattr(status, 'thread_num') and status['thread_num'] is not None and\
+                status['thread_num'] != {}:
             thread_num = int(status['thread_num'])
         return PytorchIPEXJITBF16Model(model, use_ipex=status['use_ipex'],
                                        use_jit=status['use_jit'],
@@ -102,5 +103,5 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
                                        from_load=from_load,
                                        thread_num=thread_num,
                                        inplace=inplace,
-                                       jit_strict=status["jit_strict"],
-                                       jit_method=status["jit_method"])
+                                       jit_strict=status.get('jit_strict', True),
+                                       jit_method=status.get('jit_method', None))

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -166,9 +166,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
             model.eval()
             model.load_state_dict(state_dict)
             from_load = False
-        thread_num = None
-        if hasattr(status, 'thread_num') and status['thread_num'] is not None and\
-                status['thread_num'] != {}:
+        thread_num = status.get('thread_num', None)
+        if thread_num is not None and thread_num != {}:
             thread_num = int(status['thread_num'])
         return PytorchIPEXJITModel(model, use_ipex=status['use_ipex'],
                                    use_jit=status['use_jit'],

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -167,7 +167,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
             model.load_state_dict(state_dict)
             from_load = False
         thread_num = None
-        if status["thread_num"] is not None and status['thread_num'] != {}:
+        if hasattr(status, 'thread_num') and status["thread_num"] is not None and\
+                status['thread_num'] != {}:
             thread_num = int(status['thread_num'])
         return PytorchIPEXJITModel(model, use_ipex=status['use_ipex'],
                                    use_jit=status['use_jit'],
@@ -175,8 +176,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                                    from_load=from_load,
                                    thread_num=thread_num,
                                    inplace=inplace,
-                                   jit_strict=status["jit_strict"],
-                                   jit_method=status["jit_method"])
+                                   jit_strict=status.get('jit_strict', True),
+                                   jit_method=status.get('jit_method', None))
 
     def _save_model(self, path):
         if self.use_jit:

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -167,7 +167,9 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
             model.load_state_dict(state_dict)
             from_load = False
         thread_num = status.get('thread_num', None)
-        if thread_num is not None and thread_num != {}:
+        if thread_num == {}:
+            thread_num = None
+        if thread_num is not None:
             thread_num = int(status['thread_num'])
         return PytorchIPEXJITModel(model, use_ipex=status['use_ipex'],
                                    use_jit=status['use_jit'],

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -167,7 +167,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
             model.load_state_dict(state_dict)
             from_load = False
         thread_num = None
-        if hasattr(status, 'thread_num') and status["thread_num"] is not None and\
+        if hasattr(status, 'thread_num') and status['thread_num'] is not None and\
                 status['thread_num'] != {}:
             thread_num = int(status['thread_num'])
         return PytorchIPEXJITModel(model, use_ipex=status['use_ipex'],

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
@@ -58,7 +58,8 @@ class PytorchQuantizedModel(AcceleratedLightningModule):
                 tune_cfg = yaml.safe_load(f)
                 qmodel.tune_cfg = tune_cfg
         thread_num = None
-        if status["thread_num"] is not None and status['thread_num'] != {}:
+        if hasattr(status, 'thread_num') and status["thread_num"] is not None and\
+                status['thread_num'] != {}:
             thread_num = int(status["thread_num"])
         return PytorchQuantizedModel(qmodel, thread_num=thread_num)
 

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
@@ -57,10 +57,9 @@ class PytorchQuantizedModel(AcceleratedLightningModule):
             with open(tune_cfg_file, 'r') as f:
                 tune_cfg = yaml.safe_load(f)
                 qmodel.tune_cfg = tune_cfg
-        thread_num = None
-        if hasattr(status, 'thread_num') and status["thread_num"] is not None and\
-                status['thread_num'] != {}:
-            thread_num = int(status["thread_num"])
+        thread_num = status.get('thread_num', None)
+        if thread_num is not None and thread_num != {}:
+            thread_num = int(status['thread_num'])
         return PytorchQuantizedModel(qmodel, thread_num=thread_num)
 
     def _save_model(self, path):

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
@@ -58,7 +58,9 @@ class PytorchQuantizedModel(AcceleratedLightningModule):
                 tune_cfg = yaml.safe_load(f)
                 qmodel.tune_cfg = tune_cfg
         thread_num = status.get('thread_num', None)
-        if thread_num is not None and thread_num != {}:
+        if thread_num == {}:
+            thread_num = None
+        if thread_num is not None:
             thread_num = int(status['thread_num'])
         return PytorchQuantizedModel(qmodel, thread_num=thread_num)
 

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -133,9 +133,11 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
         onnx_path = Path(path) / status['onnx_path']
         onnxruntime_session_options = onnxruntime.SessionOptions()
         if status.get('intra_op_num_threads', None):
-            onnxruntime_session_options.intra_op_num_threads = status.get('intra_op_num_threads', None)
+            onnxruntime_session_options.intra_op_num_threads = \
+                status.get('intra_op_num_threads', None)
         if status.get('inter_op_num_threads', None):
-            onnxruntime_session_options.inter_op_num_threads = status.get('inter_op_num_threads', None)
+            onnxruntime_session_options.inter_op_num_threads = \
+                status.get('inter_op_num_threads', None)
         return PytorchONNXRuntimeModel(str(onnx_path),
                                        onnxruntime_session_options=onnxruntime_session_options)
 

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -132,10 +132,10 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
                               "nano_model_meta.yml must specify 'onnx_path' for loading.")
         onnx_path = Path(path) / status['onnx_path']
         onnxruntime_session_options = onnxruntime.SessionOptions()
-        if hasattr(status, 'intra_op_num_threads'):
-            onnxruntime_session_options.intra_op_num_threads = status['intra_op_num_threads']
-        if hasattr(status, 'inter_op_num_threads'):
-            onnxruntime_session_options.inter_op_num_threads = status['inter_op_num_threads']
+        if status.get('intra_op_num_threads', None):
+            onnxruntime_session_options.intra_op_num_threads = status.get('intra_op_num_threads', None)
+        if status.get('inter_op_num_threads', None):
+            onnxruntime_session_options.inter_op_num_threads = status.get('inter_op_num_threads', None)
         return PytorchONNXRuntimeModel(str(onnx_path),
                                        onnxruntime_session_options=onnxruntime_session_options)
 

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -132,8 +132,10 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
                               "nano_model_meta.yml must specify 'onnx_path' for loading.")
         onnx_path = Path(path) / status['onnx_path']
         onnxruntime_session_options = onnxruntime.SessionOptions()
-        onnxruntime_session_options.intra_op_num_threads = status['intra_op_num_threads']
-        onnxruntime_session_options.inter_op_num_threads = status['inter_op_num_threads']
+        if hasattr(status, 'intra_op_num_threads'):
+            onnxruntime_session_options.intra_op_num_threads = status['intra_op_num_threads']
+        if hasattr(status, 'inter_op_num_threads'):
+            onnxruntime_session_options.inter_op_num_threads = status['inter_op_num_threads']
         return PytorchONNXRuntimeModel(str(onnx_path),
                                        onnxruntime_session_options=onnxruntime_session_options)
 

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -120,9 +120,13 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
             invalidInputError(False, "nano_model_meta.yml must specify 'xml_path' for loading.")
         xml_path = Path(path) / status['xml_path']
         thread_num = None
-        if "CPU_THREADS_NUM" in status['config']:
-            thread_num = int(status['config']["CPU_THREADS_NUM"])
-        return PytorchOpenVINOModel(xml_path, config=status['config'], thread_num=thread_num)
+        if not hasattr(status, 'config'):
+            config = {}
+        else:
+            config = status['config']
+        if "CPU_THREADS_NUM" in config:
+            thread_num = int(config["CPU_THREADS_NUM"])
+        return PytorchOpenVINOModel(xml_path, config=config, thread_num=thread_num)
 
     def pot(self,
             dataloader,

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -120,10 +120,7 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
             invalidInputError(False, "nano_model_meta.yml must specify 'xml_path' for loading.")
         xml_path = Path(path) / status['xml_path']
         thread_num = None
-        if not hasattr(status, 'config'):
-            config = {}
-        else:
-            config = status['config']
+        config = status.get('config', {})
         if "CPU_THREADS_NUM" in config:
             thread_num = int(config["CPU_THREADS_NUM"])
         return PytorchOpenVINOModel(xml_path, config=config, thread_num=thread_num)

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -178,7 +178,9 @@ class BF16Model(AcceleratedLightningModule):
         model.eval()
         model.load_state_dict(state_dict)
         thread_num = status.get('thread_num', None)
-        if thread_num is not None and thread_num != {}:
+        if thread_num == {}:
+            thread_num = None
+        if thread_num is not None:
             thread_num = int(status['thread_num'])
         return BF16Model(model, channels_last=status['channels_last'],
                          thread_num=thread_num)

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -178,7 +178,8 @@ class BF16Model(AcceleratedLightningModule):
         model.eval()
         model.load_state_dict(state_dict)
         thread_num = None
-        if status["thread_num"] is not None and status['thread_num'] != {}:
+        if hasattr(status, 'thread_num') and status['thread_num'] is not None and\
+                status['thread_num'] != {}:
             thread_num = int(status['thread_num'])
         return BF16Model(model, channels_last=status['channels_last'],
                          thread_num=thread_num)

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -177,9 +177,8 @@ class BF16Model(AcceleratedLightningModule):
         state_dict = torch.load(checkpoint_path)
         model.eval()
         model.load_state_dict(state_dict)
-        thread_num = None
-        if hasattr(status, 'thread_num') and status['thread_num'] is not None and\
-                status['thread_num'] != {}:
+        thread_num = status.get('thread_num', None)
+        if thread_num is not None and thread_num != {}:
             thread_num = int(status['thread_num'])
         return BF16Model(model, channels_last=status['channels_last'],
                          thread_num=thread_num)


### PR DESCRIPTION
## Description

This PR wants to support users to load checkpoint which is saved in earlier version (nano versions of save & load are not unified and load version > save version)

### 1. Why the change?

https://github.com/intel-analytics/BigDL/issues/6968

### 2. User API changes

No change.

### 3. Summary of the change 

- support users to load checkpoint which is saved in earlier version

### 4. How to test?
- [x] Unit test

Have verified this PR in local test with checkpoint save in bigdl-2.1.
