### PR TITLE
Chronos: fix errors of running benchmark-chronos with `-f tensorflow`

### DIFF
--- a/.github/workflows/chronos-howto-guides-test.yml
+++ b/.github/workflows/chronos-howto-guides-test.yml
@@ -12,6 +12,7 @@ on:
     branches: [ main ]
     paths:
       - 'python/chronos/colab-notebook/howto/**'
+      - 'python/chronos/benchmark/**'
       - '.github/workflows/chronos-howto-guides-test.yml'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -66,6 +67,24 @@ jobs:
           BIGDL_ROOT: ${{ github.workspace }}
           ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
 
+  chronos-benchmark-tool-test:
+    runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7.10"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: ./.github/actions/jdk-setup-action
+      - name: Set up Maven
+        uses: ./.github/actions/maven-setup-action
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Run tests for Chronos-benchmark-tool
         shell: bash
         run: |
@@ -75,29 +94,15 @@ jobs:
           fi
           conda create -n chronos-benchmakr-tool-env -y python==3.7.10 setuptools==58.0.4 -c ${GONDOLIN_CONDA_CHANNEL} --override-channels
           source activate chronos-benchmakr-tool-env
-          pip install pytest==5.4.1
-          pip install prophet==1.1
-          pip install pmdarima==1.8.4
-          pip install tsfresh==0.17.0
-          pip install ray==1.9.2 ray[tune]==1.9.2 ray[default]==1.9.2
-          pip install pyarrow==6.0.1
-          pip install ConfigSpace==0.5.0
-          pip install optuna==2.10.1
-          pip install neural-compressor==1.11
-          pip install onnxruntime==1.11.1
-          pip install onnx==1.11.0
-          pip install onnxruntime-extensions==0.4.2
-          pip install onnxsim==0.4.8
-          pip install scipy==1.5.4
-          pip install cloudpickle
           apt-get update
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
+          wget https://raw.githubusercontent.com/analytics-zoo/gha-cicd-env/main/python-requirements/requirements-chronos-python-ut.txt -O ${{ github.workspace }}/requirements-chronos-python-ut.txt
           sed -i "s/pyspark==2.4.6/pyspark==3.1.3/g" python/dllib/src/setup.py
           bash python/dev/release_default_linux_spark313.sh default false false
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
           whl_name=`ls python/nano/dist/`
-          pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[tensorflow,pytorch]
+          pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[tensorflow,pytorch,inference]
           pip install -i https://pypi.python.org/simple python/dllib/src/dist/bigdl_dllib_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/orca/src/dist/bigdl_orca_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/chronos/src/dist/bigdl_chronos_*-py3-none-manylinux1_x86_64.whl

--- a/python/chronos/dev/test/run-benchmark-tool.sh
+++ b/python/chronos/dev/test/run-benchmark-tool.sh
@@ -20,18 +20,18 @@
 cd "`dirname $0`"
 cd ../../script
 
-benchmark-chronos -l 96 -o 720 -m tcn -s train -d nyc_taxi
-benchmark-chronos -l 96 -o 720 -m tcn -s latency -d nyc_taxi
-benchmark-chronos -l 96 -o 720 -m tcn -s throughput -d nyc_taxi
-benchmark-chronos -l 96 -o 720 -m tcn -s accuracy -d nyc_taxi
+# benchmark-chronos -l 96 -o 720 -m tcn -s train -d nyc_taxi
+# benchmark-chronos -l 96 -o 720 -m tcn -s latency -d nyc_taxi
+# benchmark-chronos -l 96 -o 720 -m tcn -s throughput -d nyc_taxi
+# benchmark-chronos -l 96 -o 720 -m tcn -s accuracy -d nyc_taxi
 
-benchmark-chronos -l 96 -o 720 -m lstm -s train -d nyc_taxi
-benchmark-chronos -l 96 -o 720 -m seq2seq -s train -d nyc_taxi
-benchmark-chronos -l 96 -o 720 -m autoformer -s train -d nyc_taxi
-benchmark-chronos -l 96 -o 720 -m nbeats -s train -d nyc_taxi
+# benchmark-chronos -l 96 -o 720 -m lstm -s train -d nyc_taxi
+# benchmark-chronos -l 96 -o 720 -m seq2seq -s train -d nyc_taxi
+# benchmark-chronos -l 96 -o 720 -m autoformer -s train -d nyc_taxi
+# benchmark-chronos -l 96 -o 720 -m nbeats -s train -d nyc_taxi
 
-benchmark-chronos -l 96 -o 720 -m tcn -s latency -d nyc_taxi --inference_framework onnx
-benchmark-chronos -l 96 -o 720 -m tcn -s latency -d nyc_taxi --inference_framework openvino
-benchmark-chronos -l 96 -o 720 -m tcn -s latency -d nyc_taxi --inference_framework jit
+# benchmark-chronos -l 96 -o 720 -m tcn -s latency -d nyc_taxi --inference_framework onnx
+# benchmark-chronos -l 96 -o 720 -m tcn -s latency -d nyc_taxi --inference_framework openvino
+# benchmark-chronos -l 96 -o 720 -m tcn -s latency -d nyc_taxi --inference_framework jit
 
 benchmark-chronos -l 96 -o 720 -f tensorflow -m tcn -s train -d nyc_taxi

--- a/python/chronos/dev/test/run-benchmark-tool.sh
+++ b/python/chronos/dev/test/run-benchmark-tool.sh
@@ -33,3 +33,5 @@ benchmark-chronos -l 96 -o 720 -m nbeats -s train -d nyc_taxi
 benchmark-chronos -l 96 -o 720 -m tcn -s latency -d nyc_taxi --inference_framework onnx
 benchmark-chronos -l 96 -o 720 -m tcn -s latency -d nyc_taxi --inference_framework openvino
 benchmark-chronos -l 96 -o 720 -m tcn -s latency -d nyc_taxi --inference_framework jit
+
+benchmark-chronos -l 96 -o 720 -f tensorflow -m tcn -s train -d nyc_taxi

--- a/python/chronos/dev/test/run-benchmark-tool.sh
+++ b/python/chronos/dev/test/run-benchmark-tool.sh
@@ -20,18 +20,18 @@
 cd "`dirname $0`"
 cd ../../script
 
-# benchmark-chronos -l 96 -o 720 -m tcn -s train -d nyc_taxi
-# benchmark-chronos -l 96 -o 720 -m tcn -s latency -d nyc_taxi
-# benchmark-chronos -l 96 -o 720 -m tcn -s throughput -d nyc_taxi
-# benchmark-chronos -l 96 -o 720 -m tcn -s accuracy -d nyc_taxi
+benchmark-chronos -l 96 -o 720 -m tcn -s train -d nyc_taxi --ckpt checkpoints/torch/tcn
+benchmark-chronos -l 96 -o 720 -m tcn -s latency -d nyc_taxi --ckpt checkpoints/torch/tcn
+benchmark-chronos -l 96 -o 720 -m tcn -s throughput -d nyc_taxi --ckpt checkpoints/torch/tcn
+benchmark-chronos -l 96 -o 720 -m tcn -s accuracy -d nyc_taxi --ckpt checkpoints/torch/tcn
 
-# benchmark-chronos -l 96 -o 720 -m lstm -s train -d nyc_taxi
-# benchmark-chronos -l 96 -o 720 -m seq2seq -s train -d nyc_taxi
-# benchmark-chronos -l 96 -o 720 -m autoformer -s train -d nyc_taxi
-# benchmark-chronos -l 96 -o 720 -m nbeats -s train -d nyc_taxi
+benchmark-chronos -l 96 -o 720 -m lstm -s train -d nyc_taxi --ckpt checkpoints/torch/tcn
+benchmark-chronos -l 96 -o 720 -m seq2seq -s train -d nyc_taxi --ckpt checkpoints/torch/tcn
+benchmark-chronos -l 96 -o 720 -m autoformer -s train -d nyc_taxi --ckpt checkpoints/torch/tcn
+benchmark-chronos -l 96 -o 720 -m nbeats -s train -d nyc_taxi --ckpt checkpoints/torch/tcn
 
-# benchmark-chronos -l 96 -o 720 -m tcn -s latency -d nyc_taxi --inference_framework onnx
-# benchmark-chronos -l 96 -o 720 -m tcn -s latency -d nyc_taxi --inference_framework openvino
-# benchmark-chronos -l 96 -o 720 -m tcn -s latency -d nyc_taxi --inference_framework jit
+benchmark-chronos -l 96 -o 720 -m tcn -s latency -d nyc_taxi --inference_framework onnx --ckpt checkpoints/torch/tcn
+benchmark-chronos -l 96 -o 720 -m tcn -s latency -d nyc_taxi --inference_framework openvino --ckpt checkpoints/torch/tcn
+benchmark-chronos -l 96 -o 720 -m tcn -s latency -d nyc_taxi --inference_framework jit --ckpt checkpoints/torch/tcn
 
-benchmark-chronos -l 96 -o 720 -f tensorflow -m tcn -s train -d nyc_taxi
+benchmark-chronos -l 96 -o 720 -f tensorflow -m tcn -s train -d nyc_taxi --ckpt checkpoints/tf/tcn

--- a/python/chronos/src/bigdl/chronos/benchmark/benchmark_chronos.py
+++ b/python/chronos/src/bigdl/chronos/benchmark/benchmark_chronos.py
@@ -338,7 +338,7 @@ def main():
 
     if args.framework == "tensorflow":
         if not os.path.exists(model_path):
-            os.makedirs(model_path)
+            os.makedirs(model_path, exist_ok=True)
 
     # generate data
     train_loader, val_loader, test_loader = generate_data(args)

--- a/python/chronos/src/bigdl/chronos/benchmark/benchmark_chronos.py
+++ b/python/chronos/src/bigdl/chronos/benchmark/benchmark_chronos.py
@@ -336,6 +336,10 @@ def main():
     path = os.path.abspath(os.path.dirname(__file__))
     model_path = os.path.join(path, args.ckpt)
 
+    if args.framework == "tensorflow":
+        if not os.path.exists(model_path):
+            os.makedirs(model_path)
+
     # generate data
     train_loader, val_loader, test_loader = generate_data(args)
 

--- a/python/chronos/src/bigdl/chronos/benchmark/utils_data.py
+++ b/python/chronos/src/bigdl/chronos/benchmark/utils_data.py
@@ -56,7 +56,7 @@ def generate_data(args):
 
     # transfer to tensorflow or torch dataset
     if args.framework == "tensorflow":
-        for tsdata in [tsdata_train, tsdata_test]:
+        for tsdata in [tsdata_train, tsdata_val, tsdata_test]:
             tsdata.roll(lookback=args.lookback, horizon=args.horizon)
         train_loader = tsdata_train.to_tf_dataset(batch_size=args.training_batchsize)
         val_loader = tsdata_val.to_tf_dataset(batch_size=args.training_batchsize)


### PR DESCRIPTION
## Description

When run benchmark-chronos with command `benchmark-chronos -f tensorflow -l 96 -o 96`, there exists RuntimeError and tensorflow.python.framework.errors_impl.FailedPreconditionError.
Fix above errors and update github action.


### 2. User API changes

nothing

### 3. Summary of the change 

1. call `roll` before transform TSDataset to tf dataset
2. make directory for default `ckpt`
3. update github action and add test of tensorflow backend

### 4. How to test?
- [x] Unit test
