### PR TITLE
dllib: The error message thrown does not contain the real reason

### DIFF
--- a/python/dllib/src/bigdl/dllib/utils/common.py
+++ b/python/dllib/src/bigdl/dllib/utils/common.py
@@ -630,7 +630,7 @@ def callBigDlFunc(bigdl_type, name, *args):
         except Exception as e:
             error = e
             regex = re.compile(r'Method\s' + name + r'.*does not exist')
-            # if the invoked method exist but something else went wrong, throw the exception 
+            # if the invoked method exist but something else went wrong, throw the exception
             if not regex.match(str(e)):
                 invalidOperationError(False, str(e), cause=e)
         else:

--- a/python/dllib/src/bigdl/dllib/utils/common.py
+++ b/python/dllib/src/bigdl/dllib/utils/common.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import re
 import os
 import sys
 import six
@@ -628,8 +629,12 @@ def callBigDlFunc(bigdl_type, name, *args):
             result = callJavaFunc(api, *args)
         except Exception as e:
             error = e
-            if "does not exist" not in str(e):
+            regex = re.compile(r'Method\s' + name + r'.*does not exist')
+            if regex.match(str(e)):
                 invalidOperationError(False, str(e), cause=e)
+            else:
+                # if the invoked method exist but something else went wrong, raise the exception 
+                raise e
         else:
             return result
     invalidOperationError(False, "Cannot find function: %s" % name, cause=error)

--- a/python/dllib/src/bigdl/dllib/utils/common.py
+++ b/python/dllib/src/bigdl/dllib/utils/common.py
@@ -630,7 +630,7 @@ def callBigDlFunc(bigdl_type, name, *args):
         except Exception as e:
             error = e
             regex = re.compile(r'Method\s' + name + r'.*does not exist')
-            # if the invoked method exist but something else went wrong, raise the exception 
+            # if the invoked method exist but something else went wrong, throw the exception 
             if not regex.match(str(e)):
                 invalidOperationError(False, str(e), cause=e)
         else:

--- a/python/dllib/src/bigdl/dllib/utils/common.py
+++ b/python/dllib/src/bigdl/dllib/utils/common.py
@@ -630,11 +630,9 @@ def callBigDlFunc(bigdl_type, name, *args):
         except Exception as e:
             error = e
             regex = re.compile(r'Method\s' + name + r'.*does not exist')
-            if regex.match(str(e)):
+            # if the invoked method exist but something else went wrong, raise the exception 
+            if not regex.match(str(e)):
                 invalidOperationError(False, str(e), cause=e)
-            else:
-                # if the invoked method exist but something else went wrong, raise the exception 
-                raise e
         else:
             return result
     invalidOperationError(False, "Cannot find function: %s" % name, cause=error)


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

When using ppml_context.py to encrypt data, the following error was thrown.
![MicrosoftTeams-image (14)](https://user-images.githubusercontent.com/61072813/207798642-e18da6ae-ff09-4ef8-a26f-14c202a082ec.png)

This log indicates that the method createPPMLContext does not exist, but in fact, createPPMLContext does exist, the true reason is we specified the wrong path for the primarykey. 

![image](https://user-images.githubusercontent.com/61072813/207801267-da00d621-cf22-4a77-9317-4d4eb8d4168e.png)
https://github.com/intel-analytics/BigDL/blob/b67db454b486c7ac5829cbf55751411ad7636cb1/python/dllib/src/bigdl/dllib/utils/common.py#L631
Whenever the error message contains "does not exist", it is assumed that the method does not exist, and when the path of the key does not exist, it is also considered to be “method does not exist” and then the real cause of the error will be caught and not thrown out.



