### PR TITLE
Nano: set ipex version based on python version

### DIFF
--- a/.github/workflows/nano_unit_tests_pytorch.yml
+++ b/.github/workflows/nano_unit_tests_pytorch.yml
@@ -29,7 +29,7 @@ jobs:
         os: ["ubuntu-20.04"]
         python-version: ["3.7"]
         pytorch-version: [
-          "pytorch_110 neural-compressor==1.13.1",
+          "pytorch_110 neural-compressor==1.11.0",
           "pytorch_111 neural-compressor==1.13.1",
           "pytorch_112 neural-compressor==1.13.1",
           "pytorch_113 neural-compressor==1.14.2",

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -127,9 +127,7 @@ def setup_package():
     pytorch_110_requires = ["torch==1.10.1",
                             "torchvision==0.11.2",
                             "intel_extension_for_pytorch==1.10.100;platform_system=='Linux' and \
-                            python_full_version>='3.9.0'",
-                            "intel_extension_for_pytorch==1.11.0;platform_system=='Linux' and \
-                            python_full_version<'3.9.0'"]
+                            python_full_version>='3.9.0'"]
 
     # this require install option --extra-index-url https://download.pytorch.org/whl/nightly/
     pytorch_nightly_requires = ["torch~=1.14.0.dev",

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -126,7 +126,10 @@ def setup_package():
 
     pytorch_110_requires = ["torch==1.10.1",
                             "torchvision==0.11.2",
-                            "intel_extension_for_pytorch==1.10.100;platform_system=='Linux'"]
+                            "intel_extension_for_pytorch==1.10.100;platform_system=='Linux' and \
+                            python_version>=3.9",
+                            "intel_extension_for_pytorch==1.11.0;platform_system=='Linux' and \
+                            python_version<3.9",]
 
     # this require install option --extra-index-url https://download.pytorch.org/whl/nightly/
     pytorch_nightly_requires = ["torch~=1.14.0.dev",

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -127,9 +127,9 @@ def setup_package():
     pytorch_110_requires = ["torch==1.10.1",
                             "torchvision==0.11.2",
                             "intel_extension_for_pytorch==1.10.100;platform_system=='Linux' and \
-                            python_version>=3.9",
+                            python_version>=3.9.0",
                             "intel_extension_for_pytorch==1.11.0;platform_system=='Linux' and \
-                            python_version<3.9",]
+                            python_version<3.9.0"]
 
     # this require install option --extra-index-url https://download.pytorch.org/whl/nightly/
     pytorch_nightly_requires = ["torch~=1.14.0.dev",

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -127,9 +127,9 @@ def setup_package():
     pytorch_110_requires = ["torch==1.10.1",
                             "torchvision==0.11.2",
                             "intel_extension_for_pytorch==1.10.100;platform_system=='Linux' and \
-                            python_version>=3.9.0",
+                            python_full_version>='3.9.0'",
                             "intel_extension_for_pytorch==1.11.0;platform_system=='Linux' and \
-                            python_version<3.9.0"]
+                            python_full_version<'3.9.0'"]
 
     # this require install option --extra-index-url https://download.pytorch.org/whl/nightly/
     pytorch_nightly_requires = ["torch~=1.14.0.dev",


### PR DESCRIPTION
## Description

ipex 1.10 only uploads the py39 installation files to "pypi.org", more info, please refer to https://pypi.org/project/intel-extension-for-pytorch/1.10.100/#files, and this behavior caused our nano action error.

This PR update pytorch_110_requires in setup to fix this bug by setting ipex version based on python version.

### How to test?
- [ ] Unit test

