### PR TITLE
Nano: add `weights_prepack` parameter for `trace`/`quantize`

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
@@ -36,7 +36,8 @@ def ipex_device():
 
 def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
                         use_jit=False, channels_last=None, thread_num=None,
-                        inplace=False, jit_strict=True, jit_method=None):
+                        inplace=False, jit_strict=True, jit_method=None,
+                        weights_prepack=None):
     '''
     :param model: the model(nn.module) to be transform.
     :param input_sample: torch tensor indicate the data sample to be used
@@ -49,17 +50,22 @@ def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
     :param jit_strict: Whether recording your mutable container types.
     :param jit_method: use ``jit.trace`` or ``jit.script`` to
            convert a model to TorchScript.
+    :param weights_prepack: Whether to perform weight prepack for convolution and linear
+           to avoid oneDNN weights reorder. The default value is None. Explicitly setting
+           this knob overwrites the configuration set by level knob. Only valid when
+           ``use_ipex=True``, otherwise will be ignored.
     '''
     from .ipex_inference_model import PytorchIPEXJITModel
     return PytorchIPEXJITModel(model, input_sample=input_sample, use_ipex=use_ipex,
                                use_jit=use_jit, channels_last=channels_last,
                                thread_num=thread_num, inplace=inplace, jit_strict=jit_strict,
-                               jit_method=jit_method)
+                               jit_method=jit_method, weights_prepack=weights_prepack)
 
 
 def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
                             use_jit=False, channels_last=None, thread_num=None,
-                            inplace=False, jit_strict=True, jit_method=None):
+                            inplace=False, jit_strict=True, jit_method=None,
+                            weights_prepack=None):
     '''
     :param model: the model(nn.module) to be transform.
     :param input_sample: torch tensor indicate the data sample to be used
@@ -72,12 +78,16 @@ def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
     :param jit_strict: Whether recording your mutable container types.
     :param jit_method: use ``jit.trace`` or ``jit.script`` to
            convert a model to TorchScript.
+    :param weights_prepack: Whether to perform weight prepack for convolution and linear
+           to avoid oneDNN weights reorder. The default value is None. Explicitly setting
+           this knob overwrites the configuration set by level knob. Only valid when
+           ``use_ipex=True``, otherwise will be ignored.
     '''
     from .ipex_inference_bf16_model import PytorchIPEXJITBF16Model
     return PytorchIPEXJITBF16Model(model, input_sample=input_sample, use_ipex=use_ipex,
                                    use_jit=use_jit, channels_last=channels_last,
                                    thread_num=thread_num, inplace=inplace, jit_strict=jit_strict,
-                                   jit_method=jit_method)
+                                   jit_method=jit_method, weights_prepack=weights_prepack)
 
 
 def PytorchIPEXQuantizationModel(model, calib_data, q_config=None,

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -26,7 +26,7 @@ import torch
 class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
     def __init__(self, model, input_sample=None, use_ipex=False,
                  use_jit=False, channels_last=None, thread_num=None, from_load=False,
-                 inplace=False, jit_strict=True, jit_method=None):
+                 inplace=False, jit_strict=True, jit_method=None, weights_prepack=None):
         '''
         This is the accelerated model for pytorch and ipex/jit.
         All the external API is based on InferenceOptimizer, so what we have here is
@@ -47,6 +47,10 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         :param jit_strict: Whether recording your mutable container types.
         :param jit_method: use ``jit.trace`` or ``jit.script`` to
                convert a model to TorchScript.
+        :param weights_prepack: Whether to perform weight prepack for convolution and linear
+               to avoid oneDNN weights reorder. The default value is None. Explicitly setting
+               this knob overwrites the configuration set by level knob. Only valid when
+               ``use_ipex=True``, otherwise will be ignored.
         '''
         if use_ipex:
             invalidInputError(
@@ -59,7 +63,7 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
                                      dtype=torch.bfloat16, use_jit=use_jit,
                                      channels_last=channels_last, from_load=from_load,
                                      inplace=inplace, jit_strict=jit_strict,
-                                     jit_method=jit_method)
+                                     jit_method=jit_method, weights_prepack=weights_prepack)
         self._nano_context_manager = generate_context_manager(accelerator=None,
                                                               precision="bf16",
                                                               thread_num=thread_num)
@@ -105,4 +109,5 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
                                        thread_num=thread_num,
                                        inplace=inplace,
                                        jit_strict=status.get('jit_strict', True),
-                                       jit_method=status.get('jit_method', None))
+                                       jit_method=status.get('jit_method', None),
+                                       weights_prepack=status.get('weights_prepack', None))

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -23,7 +23,7 @@ from bigdl.nano.pytorch.utils import patch_attrs_from_model_to_object
 class PytorchIPEXJITModel(AcceleratedLightningModule):
     def __init__(self, model: torch.nn.Module, input_sample=None, use_ipex=False, dtype=None,
                  use_jit=False, channels_last=None, thread_num=None, from_load=False,
-                 inplace=False, jit_strict=True, jit_method=None):
+                 inplace=False, jit_strict=True, jit_method=None, weights_prepack=None):
         """
         This is the accelerated model for pytorch and ipex/jit.
         All the external API is based on InferenceOptimizer, so what we have here is
@@ -47,6 +47,10 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         :param jit_strict: Whether recording your mutable container types.
         :param jit_method: use ``jit.trace`` or ``jit.script`` to
                convert a model to TorchScript.
+        :param weights_prepack: Whether to perform weight prepack for convolution and linear
+               to avoid oneDNN weights reorder. The default value is None. Explicitly setting
+               this knob overwrites the configuration set by level knob. Only valid when
+               ``use_ipex=True``, otherwise will be ignored.
         """
         super().__init__(model)
         if from_load:
@@ -55,6 +59,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
             self.channels_last = channels_last
             self.jit_strict = jit_strict
             self.jit_method = jit_method
+            self.weights_prepack = weights_prepack
             self._nano_context_manager = generate_context_manager(accelerator=None,
                                                                   precision="fp32",
                                                                   thread_num=thread_num)
@@ -65,12 +70,14 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         self.use_jit = use_jit
         self.jit_strict = jit_strict
         self.jit_method = jit_method
+        self.weights_prepack = weights_prepack
         self.original_model = model
         if self.channels_last:
             self.model = self.model.to(memory_format=torch.channels_last)
         if self.use_ipex:
             import intel_extension_for_pytorch as ipex
-            self.model = ipex.optimize(self.model, dtype=dtype, inplace=inplace)
+            self.model = ipex.optimize(self.model, dtype=dtype, inplace=inplace,
+                                       weights_prepack=weights_prepack)
         if self.use_jit:
             if dtype == torch.bfloat16:
                 with torch.no_grad():
@@ -147,7 +154,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                        "checkpoint": "ckpt.pth",
                        "thread_num": self.thread_num,
                        "jit_strict": self.jit_strict,
-                       'jit_method': self.jit_method})
+                       'jit_method': self.jit_method,
+                       'weights_prepack': self.weights_prepack})
         return status
 
     @staticmethod
@@ -178,7 +186,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                                    thread_num=thread_num,
                                    inplace=inplace,
                                    jit_strict=status.get('jit_strict', True),
-                                   jit_method=status.get('jit_method', None))
+                                   jit_method=status.get('jit_method', None),
+                                   weights_prepack=status.get('weights_prepack', None))
 
     def _save_model(self, path):
         if self.use_jit:

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_quantization_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_quantization_model.py
@@ -66,8 +66,6 @@ class PytorchIPEXQuantizationModel(AcceleratedLightningModule):
         self.jit_strict = jit_strict
         self.original_model = model
         if self.channels_last:
-            print("channels last is true")
-            print("change model")
             self.model = self.model.to(memory_format=torch.channels_last)
         self._nano_context_manager = generate_context_manager(accelerator="jit",
                                                               precision="int8",

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -502,6 +502,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                  sample_size: int = 100,
                  logging: bool = True,
                  inplace: bool = False,
+                 weights_prepack: Optional[bool] = None,
                  q_config=None,
                  **export_kwargs):
         """
@@ -606,6 +607,11 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :param logging: whether to log detailed information of model conversion, only valid when
                         accelerator='openvino', otherwise will be ignored. Default: ``True``.
         :param inplace: whether to perform inplace optimization. Default: ``False``.
+        :param weights_prepack: Whether to perform weight prepack for convolution and linear to avoid
+                                oneDNN weights reorder. The default value is None. Explicitly setting
+                                this knob overwrites the configuration set by level knob. Only valid
+                                when ``use_ipex=True``, otherwise will be ignored. You can try to
+                                reduce the occupied memory size by setting this parameter to ``False``.
         :param q_config: describes how to quantize a layer or a part of the network
                          by providing settings (observer classes) for activations and weights
                          respectively. Note that QConfig needs to contain observer classes
@@ -634,7 +640,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                                    channels_last=channels_last,
                                                    thread_num=thread_num, inplace=inplace,
                                                    jit_strict=jit_strict,
-                                                   jit_method=jit_method)
+                                                   jit_method=jit_method,
+                                                   weights_prepack=weights_prepack)
                 else:
                     bf16_model = BF16Model(model, channels_last=channels_last,
                                            thread_num=thread_num)
@@ -796,6 +803,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
               dynamic_axes: Union[bool, dict] = True,
               logging: bool = True,
               inplace: bool = False,
+              weights_prepack: Optional[bool] = None,
               **export_kwargs):
         """
         Trace a torch.nn.Module and convert it into an accelerated module for inference.
@@ -847,6 +855,11 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :param logging: Whether to log detailed information of model conversion, only valid when
                         accelerator='openvino', otherwise will be ignored. Default: ``True``.
         :param inplace: whether to perform inplace optimization. Default: ``False``.
+        :param weights_prepack: Whether to perform weight prepack for convolution and linear to avoid
+                                oneDNN weights reorder. The default value is None. Explicitly setting
+                                this knob overwrites the configuration set by level knob. Only valid
+                                when ``use_ipex=True``, otherwise will be ignored. You can try to
+                                reduce the occupied memory size by setting this parameter to ``False``.
         :param **export_kwargs: Other extra advanced settings include those be passed to
                                 torch.onnx.export function, only valid when
                                 accelerator='onnxruntime'/'openvino', otherwise
@@ -891,7 +904,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             return PytorchIPEXJITModel(model, input_sample=input_sample, use_ipex=use_ipex,
                                        use_jit=use_jit, channels_last=channels_last,
                                        thread_num=thread_num, inplace=inplace,
-                                       jit_strict=jit_strict, jit_method=jit_method)
+                                       jit_strict=jit_strict, jit_method=jit_method,
+                                       weights_prepack=weights_prepack)
         invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))
 
     @staticmethod

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -607,11 +607,12 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :param logging: whether to log detailed information of model conversion, only valid when
                         accelerator='openvino', otherwise will be ignored. Default: ``True``.
         :param inplace: whether to perform inplace optimization. Default: ``False``.
-        :param weights_prepack: Whether to perform weight prepack for convolution and linear to avoid
-                                oneDNN weights reorder. The default value is None. Explicitly setting
-                                this knob overwrites the configuration set by level knob. Only valid
-                                when ``use_ipex=True``, otherwise will be ignored. You can try to
-                                reduce the occupied memory size by setting this parameter to ``False``.
+        :param weights_prepack: Whether to perform weight prepack for convolution and linear to
+                                avoid oneDNN weights reorder. The default value is None. Explicitly
+                                setting this knob overwrites the configuration set by level knob.
+                                Only valid when ``use_ipex=True``, otherwise will be ignored.
+                                You can try to reduce the occupied memory size by setting this
+                                parameter to ``False``.
         :param q_config: describes how to quantize a layer or a part of the network
                          by providing settings (observer classes) for activations and weights
                          respectively. Note that QConfig needs to contain observer classes
@@ -855,11 +856,12 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :param logging: Whether to log detailed information of model conversion, only valid when
                         accelerator='openvino', otherwise will be ignored. Default: ``True``.
         :param inplace: whether to perform inplace optimization. Default: ``False``.
-        :param weights_prepack: Whether to perform weight prepack for convolution and linear to avoid
-                                oneDNN weights reorder. The default value is None. Explicitly setting
-                                this knob overwrites the configuration set by level knob. Only valid
-                                when ``use_ipex=True``, otherwise will be ignored. You can try to
-                                reduce the occupied memory size by setting this parameter to ``False``.
+        :param weights_prepack: Whether to perform weight prepack for convolution and linear to
+                                avoid oneDNN weights reorder. The default value is None. Explicitly
+                                setting this knob overwrites the configuration set by level knob.
+                                Only valid when ``use_ipex=True``, otherwise will be ignored.
+                                You can try to reduce the occupied memory size by setting this
+                                parameter to ``False``.
         :param **export_kwargs: Other extra advanced settings include those be passed to
                                 torch.onnx.export function, only valid when
                                 accelerator='onnxruntime'/'openvino', otherwise

--- a/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
@@ -209,20 +209,22 @@ class Pytorch1_11:
                                         input_sample=input_sample,
                                         jit_method='scriptttt')
 
-    def test_ipex_jit_inference_strict(self):
+    def test_ipex_jit_inference_weights_prepack(self):
+        model = resnet18(num_classes=10)
+        x = torch.rand((10, 3, 256, 256))
         # test jit + ipex
-        model = InferenceOptimizer.trace(self.model, precision='bf16',
+        model = InferenceOptimizer.trace(model, precision='bf16',
                                          accelerator="jit",
                                          use_ipex=True,
-                                         input_sample=self.data_sample,
+                                         input_sample=x,
                                          weights_prepack=False)
         with InferenceOptimizer.get_context(model):
-            model(self.data_sample)
+            model(x)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(model, tmp_dir_name)
             new_model = InferenceOptimizer.load(tmp_dir_name)
         with InferenceOptimizer.get_context(new_model):
-            new_model(self.data_sample)
+            new_model(x)
             assert new_model.weights_prepack is False
 
 

--- a/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
@@ -209,6 +209,23 @@ class Pytorch1_11:
                                         input_sample=input_sample,
                                         jit_method='scriptttt')
 
+    def test_ipex_jit_inference_strict(self):
+        # test jit + ipex
+        model = InferenceOptimizer.trace(self.model, precision='bf16',
+                                         accelerator="jit",
+                                         use_ipex=True,
+                                         input_sample=self.data_sample,
+                                         weights_prepack=False)
+        with InferenceOptimizer.get_context(model):
+            model(self.data_sample)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(model, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name)
+        with InferenceOptimizer.get_context(new_model):
+            new_model(self.data_sample)
+            assert new_model.weights_prepack is False
+
+
 TORCH_VERSION_CLS = Pytorch1_11
 
 

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -315,6 +315,32 @@ class IPEXJITInference_gt_1_10:
                                input_sample=input_sample,
                                jit_method='scriptttt')
 
+    def test_ipex_jit_inference_strict(self):
+        # test jit + ipex
+        model = InferenceOptimizer.trace(self.model, accelerator="jit",
+                                         use_ipex=True, input_sample=self.data_sample,
+                                         weights_prepack=False)
+        with InferenceOptimizer.get_context(model):
+            model(self.data_sample)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(model, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name)
+        with InferenceOptimizer.get_context(new_model):
+            new_model(self.data_sample)
+            assert new_model.weights_prepack is False
+
+        # test ipex
+        model = InferenceOptimizer.trace(self.model, accelerator=None,
+                                         use_ipex=True, weights_prepack=False)
+        with InferenceOptimizer.get_context(model):
+            model(self.data_sample)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(model, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name)
+        with InferenceOptimizer.get_context(new_model):
+            new_model(self.data_sample)
+            assert new_model.weights_prepack is False
+
 class IPEXJITInference_lt_1_10:
     def test_placeholder(self):
         pass

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -315,7 +315,7 @@ class IPEXJITInference_gt_1_10:
                                input_sample=input_sample,
                                jit_method='scriptttt')
 
-    def test_ipex_jit_inference_strict(self):
+    def test_ipex_jit_inference_weights_prepack(self):
         # test jit + ipex
         model = InferenceOptimizer.trace(self.model, accelerator="jit",
                                          use_ipex=True, input_sample=self.data_sample,
@@ -336,7 +336,7 @@ class IPEXJITInference_gt_1_10:
             model(self.data_sample)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(model, tmp_dir_name)
-            new_model = InferenceOptimizer.load(tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name, self.model)
         with InferenceOptimizer.get_context(new_model):
             new_model(self.data_sample)
             assert new_model.weights_prepack is False


### PR DESCRIPTION
## Description

add `weights_prepack` parameter for `trace`/`quantize` to cope with oom.

### 1. Why the change?

The methods related to ipex may go out of memory on machines with small memory.

### 2. User API changes

new `weights_prepack` parameter for `trace`/`quantize`
```
# default is None, you can set to Fasle to reduce memory
model = InferenceOptimizer.trace(model, accelerator="jit",
                                 use_ipex=True, input_sample=sample,
                                 weights_prepack=False)
```

### 3. Summary of the change 

- add `weights_prepack` parameter for `trace`/`quantize` to cope with oom


### 4. How to test?
- [x] Unit test
