### PR TITLE
Remove unnecessary repartition in TF2 ray estimator evaluate

### DIFF
--- a/python/orca/src/bigdl/orca/data/ray_xshards.py
+++ b/python/orca/src/bigdl/orca/data/ray_xshards.py
@@ -273,9 +273,8 @@ class RayXShards(XShards):
         list of ray object refs, otherwise return a list of ray objects. Defaults to be False,
         """
         invalidInputError(self.num_partitions() >= len(actors),
-                          f"Get number of partitions ({self.num_partitions()}) smaller than "
-                          f"number of actors ({len(actors)}). Please submit an issue to"
-                          f" BigDL.")
+                          f"Get the number of partitions ({self.num_partitions()}) smaller than "
+                          f"the number of workers ({len(actors)}).")
         assigned_partitions, _, _ = self.assign_partitions_to_actors(actors)
         result_refs = []
         for actor, part_ids in zip(actors, assigned_partitions):

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -416,10 +416,6 @@ class TensorFlow2Estimator(OrcaRayEstimator):
         if isinstance(data, SparkXShards):
             if data._get_class_name() == 'pandas.core.frame.DataFrame':
                 data = process_xshards_of_pandas_dataframe(data, feature_cols, label_cols)
-
-            if data.num_partitions() != self.num_workers:  # type:ignore
-                data = data.repartition(self.num_workers)  # type:ignore
-
             ray_xshards = RayXShards.from_spark_xshards(data)  # type:ignore
             worker_stats = self._evaluate_ray_xshards(ray_xshards, params)
         elif isinstance(data, Dataset):

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -245,6 +245,9 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                                                            shard_size=local_batch_size)
 
         if isinstance(data, SparkXShards):
+            # Make sure each worker can get at least one data partition
+            if data.num_partitions() < self.num_workers:
+                data = data.repartition(self.num_workers)
             if data._get_class_name() == 'pandas.core.frame.DataFrame':
                 data, validation_data = process_xshards_of_pandas_dataframe(data, feature_cols,
                                                                             label_cols,
@@ -414,6 +417,9 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                                              shard_size=local_batch_size)
 
         if isinstance(data, SparkXShards):
+            # Make sure each worker can get at least one data partition
+            if data.num_partitions() < self.num_workers:
+                data = data.repartition(self.num_workers)
             if data._get_class_name() == 'pandas.core.frame.DataFrame':
                 data = process_xshards_of_pandas_dataframe(data, feature_cols, label_cols)
             ray_xshards = RayXShards.from_spark_xshards(data)  # type:ignore

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_ray_estimator.py
@@ -307,7 +307,7 @@ class TestTFRayEstimator(TestCase):
     def test_sparkxshards(self):
 
         train_data_shard = XShards.partition({"x": np.random.randn(100, 1),
-                                              "y": np.random.randint(0, 1, size=(100))})
+                                              "y": np.random.randint(0, 1, size=(100))}).repartition(8)
 
         config = {
             "lr": 0.8
@@ -321,10 +321,48 @@ class TestTFRayEstimator(TestCase):
         trainer.fit(train_data_shard, epochs=1, batch_size=4, steps_per_epoch=25)
         trainer.evaluate(train_data_shard, batch_size=4, num_steps=25)
 
+    def test_less_partitition_than_workers(self):
+
+        train_data_shard = XShards.partition({"x": np.random.randn(100, 1),
+                                              "y": np.random.randint(0, 1, size=(100))}).repartition(1)
+
+        config = {
+            "lr": 0.8
+        }
+        trainer = Estimator.from_keras(
+            model_creator=model_creator,
+            verbose=True,
+            config=config,
+            workers_per_node=4)
+
+        trainer.fit(train_data_shard, epochs=1, batch_size=4, steps_per_epoch=25)
+        trainer.evaluate(train_data_shard, batch_size=4, num_steps=25)
+        trainer.predict(train_data_shard, batch_size=4).rdd.collect()
+        trainer.shutdown()
+
+        sc = init_nncontext()
+        rdd = sc.range(0, 100).repartition(1)
+        from pyspark.ml.linalg import DenseVector
+        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float)),
+                                int(np.random.randint(0, 1, size=())))).toDF(["feature", "label"])
+        trainer = Estimator.from_keras(
+            model_creator=model_creator,
+            verbose=True,
+            config=config,
+            workers_per_node=2)
+
+        trainer.fit(df, epochs=1, batch_size=4, steps_per_epoch=25,
+                    feature_cols=["feature"],
+                    label_cols=["label"])
+        trainer.evaluate(df, batch_size=4, num_steps=25, feature_cols=["feature"],
+                         label_cols=["label"])
+        trainer.predict(df, feature_cols=["feature"]).collect()
+        trainer.shutdown()
+
     def test_dataframe(self):
 
         sc = init_nncontext()
-        rdd = sc.range(0, 10)
+        rdd = sc.range(0, 100).repartition(9)
         from pyspark.ml.linalg import DenseVector
         df = rdd.map(lambda x: (DenseVector(np.random.randn(1,).astype(np.float)),
                                 int(np.random.randint(0, 1, size=())))).toDF(["feature", "label"])


### PR DESCRIPTION
Since we will assign multiple partitions for each worker, and combine partitions into a single Dataset in the actor, repartition is not needed. @yangw1234 Is it correct?