### PR TITLE
Nano: Support passing only x for keras's `optimize`/`quantize`

### DIFF
--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -436,14 +436,16 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :return:            A TensorflowBaseModel for INC. If there is no model found, return None.
         """
         invalidInputError(approach == 'static', "Only 'static' approach is supported now.")
+
         if not isinstance(x, tf.data.Dataset) and y is None:
             # fake label to make quantization work
             y = range(len(x))
         if isinstance(x, tf.data.Dataset):
-            batch = next(iter(x))
-            if isinstance(batch, tf.Tensor) or isinstance(x, tuple) and len(batch) == 1:
+            batch_data = next(iter(x))
+            if isinstance(batch_data, tf.Tensor) or \
+                    isinstance(batch_data, tuple) and len(batch_data) == 1:
                 # fake label to make quantization work
-                y = range(len(x))
+                y = range(len(x))    # type: ignore
                 y = tf.data.Dataset.from_tensor_slices(y)
                 x = tf.data.Dataset.zip((x, y))
         if accelerator is None:
@@ -454,7 +456,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             if batch:
                 calib_dataset = calib_dataset.batch(batch)
             return inc_quantzie(model, dataloader=calib_dataset,
-                                metric=metric,    # type: ignore
+                                metric=metric,
                                 framework='tensorflow',
                                 conf=conf,
                                 approach=approach,

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -453,17 +453,17 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 calib_dataset = tf.data.Dataset.from_tensor_slices((x, y))
             if batch:
                 calib_dataset = calib_dataset.batch(batch)
-            result = inc_quantzie(model, dataloader=calib_dataset,
-                                  metric=metric,
-                                  framework='tensorflow',
-                                  conf=conf,
-                                  approach=approach,
-                                  tuning_strategy=tuning_strategy,
-                                  accuracy_criterion=accuracy_criterion,
-                                  timeout=timeout,
-                                  max_trials=max_trials,
-                                  inputs=inputs,
-                                  outputs=outputs)
+            return inc_quantzie(model, dataloader=calib_dataset,
+                                metric=metric,    # type: ignore
+                                framework='tensorflow',
+                                conf=conf,
+                                approach=approach,
+                                tuning_strategy=tuning_strategy,
+                                accuracy_criterion=accuracy_criterion,
+                                timeout=timeout,
+                                max_trials=max_trials,
+                                inputs=inputs,
+                                outputs=outputs)
         elif accelerator == 'openvino':
             from bigdl.nano.deps.openvino.tf.model import KerasOpenVINOModel    # type: ignore
             if isinstance(model, KerasOpenVINOModel):    # type: ignore

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -455,17 +455,17 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 calib_dataset = tf.data.Dataset.from_tensor_slices((x, y))
             if batch:
                 calib_dataset = calib_dataset.batch(batch)
-            return inc_quantzie(model, dataloader=calib_dataset,
-                                metric=metric,
-                                framework='tensorflow',
-                                conf=conf,
-                                approach=approach,
-                                tuning_strategy=tuning_strategy,
-                                accuracy_criterion=accuracy_criterion,
-                                timeout=timeout,
-                                max_trials=max_trials,
-                                inputs=inputs,
-                                outputs=outputs)
+            result = inc_quantzie(model, dataloader=calib_dataset,
+                                  metric=metric,
+                                  framework='tensorflow',
+                                  conf=conf,
+                                  approach=approach,
+                                  tuning_strategy=tuning_strategy,
+                                  accuracy_criterion=accuracy_criterion,
+                                  timeout=timeout,
+                                  max_trials=max_trials,
+                                  inputs=inputs,
+                                  outputs=outputs)
         elif accelerator == 'openvino':
             from bigdl.nano.deps.openvino.tf.model import KerasOpenVINOModel    # type: ignore
             if isinstance(model, KerasOpenVINOModel):    # type: ignore

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -149,13 +149,6 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         invalidInputError(isinstance(model, Model), "model should be a Keras Model.")
         invalidInputError(direction in ['min', 'max'],
                           "Only support direction 'min', 'max'.")
-        invalidInputError(y is not None or isinstance(x, tf.data.Dataset),
-                          "y can be omitted only when x is a Dataset which returns \
-                              tuples of (inputs, targets)")
-
-        if not isinstance(model, NanoModel):
-            # turn model into NanoModel to obtain trace and quantize method
-            model = NanoModel(inputs=model.inputs, outputs=model.outputs)
 
         # get the available methods whose dep is met
         available_dict: Dict =\
@@ -443,9 +436,6 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :return:            A TensorflowBaseModel for INC. If there is no model found, return None.
         """
         invalidInputError(approach == 'static', "Only 'static' approach is supported now.")
-        invalidInputError(y is not None or isinstance(x, tf.data.Dataset),
-                          "y can be omitted only when x is a Dataset which returns \
-                              tuples of (inputs, targets)")
         if accelerator is None:
             if isinstance(x, tf.data.Dataset):
                 calib_dataset = x

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -18,7 +18,6 @@ import os
 import time
 import numpy as np
 import traceback
-from copy import deepcopy
 import tensorflow as tf
 from typing import Dict, Optional, List, Union
 from bigdl.nano.utils.inference.common.base_optimizer import BaseInferenceOptimizer

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -439,7 +439,14 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         invalidInputError(approach == 'static', "Only 'static' approach is supported now.")
         if not isinstance(x, tf.data.Dataset) and y is None:
             # fake label to make quantization work
-            y = deepcopy(x)
+            y = range(len(x))
+        # for TensorDataset
+        from tensorflow.python.data.ops.dataset_ops import TensorDataset, TensorSliceDataset
+        if isinstance(x, (TensorDataset, TensorSliceDataset)):
+            if len(x._tensors) == 1:
+                x = x._tensors[0]
+                y = range(len(x))
+                x = tf.data.Dataset.from_tensor_slices((x, y))
         if accelerator is None:
             if isinstance(x, tf.data.Dataset):
                 calib_dataset = x

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -18,6 +18,7 @@ import os
 import time
 import numpy as np
 import traceback
+from copy import deepcopy
 import tensorflow as tf
 from typing import Dict, Optional, List, Union
 from bigdl.nano.utils.inference.common.base_optimizer import BaseInferenceOptimizer
@@ -436,6 +437,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :return:            A TensorflowBaseModel for INC. If there is no model found, return None.
         """
         invalidInputError(approach == 'static', "Only 'static' approach is supported now.")
+        if not isinstance(x, tf.data.Dataset) and y is None:
+            # fake label to make quantization work
+            y = deepcopy(x)
         if accelerator is None:
             if isinstance(x, tf.data.Dataset):
                 calib_dataset = x

--- a/python/nano/test/inc/tf/test_keras_quantize.py
+++ b/python/nano/test/inc/tf/test_keras_quantize.py
@@ -66,3 +66,10 @@ class TestModelQuantize(TestCase):
 
         q_model = InferenceOptimizer.quantize(model, x=train_examples, y=train_labels)
         assert q_model(train_examples[0:10]).shape == (10, 10)
+
+    def test_model_quantize_with_only_x(self):
+        model = MobileNetV2(weights=None, input_shape=[40, 40, 3], classes=10)
+        model = Model(inputs=model.inputs, outputs=model.outputs)
+        train_examples = np.random.random((100, 40, 40, 3))
+        q_model = InferenceOptimizer.quantize(model, x=train_examples)
+        assert q_model(train_examples[0:10]).shape == (10, 10)

--- a/python/nano/test/inc/tf/test_keras_quantize.py
+++ b/python/nano/test/inc/tf/test_keras_quantize.py
@@ -70,6 +70,18 @@ class TestModelQuantize(TestCase):
     def test_model_quantize_with_only_x(self):
         model = MobileNetV2(weights=None, input_shape=[40, 40, 3], classes=10)
         model = Model(inputs=model.inputs, outputs=model.outputs)
+        # test numpy array
         train_examples = np.random.random((100, 40, 40, 3))
+        q_model = InferenceOptimizer.quantize(model, x=train_examples)
+        assert q_model(train_examples[0:10]).shape == (10, 10)
+
+        # test tf tensor
+        train_examples = tf.convert_to_tensor(train_examples)
+        q_model = InferenceOptimizer.quantize(model, x=train_examples)
+        assert q_model(train_examples[0:10]).shape == (10, 10)
+
+        # test dataset with only x
+        train_examples = np.random.random((100, 40, 40, 3))
+        train_dataset = tf.data.Dataset.from_tensor_slices(train_examples)
         q_model = InferenceOptimizer.quantize(model, x=train_examples)
         assert q_model(train_examples[0:10]).shape == (10, 10)

--- a/python/nano/test/inc/tf/test_keras_quantize.py
+++ b/python/nano/test/inc/tf/test_keras_quantize.py
@@ -80,8 +80,14 @@ class TestModelQuantize(TestCase):
         q_model = InferenceOptimizer.quantize(model, x=train_examples)
         assert q_model(train_examples[0:10]).shape == (10, 10)
 
-        # test dataset with only x
+        # test dataset with only x (from_tensor_slices)
         train_examples = np.random.random((100, 40, 40, 3))
         train_dataset = tf.data.Dataset.from_tensor_slices(train_examples)
         q_model = InferenceOptimizer.quantize(model, x=train_examples)
         assert q_model(train_examples[0:10]).shape == (10, 10)
+
+        # test dataset with only x (from_tensor)
+        train_examples = np.random.random((1, 40, 40, 3))
+        train_dataset = tf.data.Dataset.from_tensors(train_examples)
+        q_model = InferenceOptimizer.quantize(model, x=train_examples)
+        assert q_model(train_examples).shape == (1, 10)

--- a/python/nano/test/onnx/tf/test_inc_onnx.py
+++ b/python/nano/test/onnx/tf/test_inc_onnx.py
@@ -64,7 +64,7 @@ class TestONNX(TestCase):
         onnx_preds = onnx_quantized_model.predict(input_examples)
         np.testing.assert_allclose(preds, onnx_preds, rtol=1e-2)
 
-     def test_model_quantize_onnx_with_only_x(self):
+    def test_model_quantize_onnx_with_only_x(self):
         model = ResNet50(weights=None, input_shape=[224, 224, 3], classes=10)
         model = Model(inputs=model.inputs, outputs=model.outputs)
         input_examples = np.random.random((100, 224, 224, 3))

--- a/python/nano/test/onnx/tf/test_inc_onnx.py
+++ b/python/nano/test/onnx/tf/test_inc_onnx.py
@@ -63,3 +63,18 @@ class TestONNX(TestCase):
         preds = model.predict(input_examples)
         onnx_preds = onnx_quantized_model.predict(input_examples)
         np.testing.assert_allclose(preds, onnx_preds, rtol=1e-2)
+
+     def test_model_quantize_onnx_with_only_x(self):
+        model = ResNet50(weights=None, input_shape=[224, 224, 3], classes=10)
+        model = Model(inputs=model.inputs, outputs=model.outputs)
+        input_examples = np.random.random((100, 224, 224, 3))
+        # quantize a Keras model
+        onnx_quantized_model = InferenceOptimizer.quantize(model,
+                                                           accelerator='onnxruntime',
+                                                           x=input_examples,
+                                                           y=None,
+                                                           thread_num=8)
+
+        preds = model.predict(input_examples)
+        onnx_preds = onnx_quantized_model.predict(input_examples)
+        np.testing.assert_allclose(preds, onnx_preds, rtol=1e-2)

--- a/python/nano/test/onnx/tf/test_inc_onnx.py
+++ b/python/nano/test/onnx/tf/test_inc_onnx.py
@@ -68,7 +68,33 @@ class TestONNX(TestCase):
         model = ResNet50(weights=None, input_shape=[224, 224, 3], classes=10)
         model = Model(inputs=model.inputs, outputs=model.outputs)
         input_examples = np.random.random((100, 224, 224, 3))
-        # quantize a Keras model
+        # quantize a Keras model based on numpy array
+        onnx_quantized_model = InferenceOptimizer.quantize(model,
+                                                           accelerator='onnxruntime',
+                                                           x=input_examples,
+                                                           y=None,
+                                                           thread_num=8)
+
+        preds = model.predict(input_examples)
+        onnx_preds = onnx_quantized_model.predict(input_examples)
+        np.testing.assert_allclose(preds, onnx_preds, rtol=1e-2)
+
+        # quantize a Keras model based on dataset
+        input_examples = np.random.random((100, 224, 224, 3))
+        train_dataset = tf.data.Dataset.from_tensor_slices(input_examples)
+        onnx_quantized_model = InferenceOptimizer.quantize(model,
+                                                           accelerator='onnxruntime',
+                                                           x=train_dataset,
+                                                           y=None,
+                                                           thread_num=8)
+
+        preds = model.predict(input_examples)
+        onnx_preds = onnx_quantized_model.predict(input_examples)
+        np.testing.assert_allclose(preds, onnx_preds, rtol=1e-2)
+        
+        # quantize a Keras model based on tf tensor
+        input_examples = np.random.random((100, 224, 224, 3))
+        input_examples = tf.convert_to_tensor(input_examples)
         onnx_quantized_model = InferenceOptimizer.quantize(model,
                                                            accelerator='onnxruntime',
                                                            x=input_examples,

--- a/python/nano/test/openvino/tf/test_openvino_quantize.py
+++ b/python/nano/test/openvino/tf/test_openvino_quantize.py
@@ -79,3 +79,17 @@ class TestOpenVINO(TestCase):
         preds = model.predict(train_examples)
         openvino_preds = openvino_quantized_model.predict(train_examples)
         np.testing.assert_allclose(preds, openvino_preds, rtol=1e-2)
+
+    def test_model_quantize_openvino_with_only_x(self):
+        model = MobileNetV2(weights=None, input_shape=[40, 40, 3], classes=10)
+        model = Model(inputs=model.inputs, outputs=model.outputs)
+        train_examples = np.random.random((100, 40, 40, 3))
+
+        openvino_quantized_model = InferenceOptimizer.quantize(model,
+                                                               accelerator='openvino',
+                                                               x=train_examples,
+                                                               y=None)
+
+        preds = model.predict(train_examples)
+        openvino_preds = openvino_quantized_model.predict(train_examples)
+        np.testing.assert_allclose(preds, openvino_preds, rtol=1e-2)

--- a/python/nano/test/openvino/tf/test_openvino_quantize.py
+++ b/python/nano/test/openvino/tf/test_openvino_quantize.py
@@ -83,11 +83,34 @@ class TestOpenVINO(TestCase):
     def test_model_quantize_openvino_with_only_x(self):
         model = MobileNetV2(weights=None, input_shape=[40, 40, 3], classes=10)
         model = Model(inputs=model.inputs, outputs=model.outputs)
+        # test numpy array
         train_examples = np.random.random((100, 40, 40, 3))
-
         openvino_quantized_model = InferenceOptimizer.quantize(model,
                                                                accelerator='openvino',
                                                                x=train_examples,
+                                                               y=None)
+
+        preds = model.predict(train_examples)
+        openvino_preds = openvino_quantized_model.predict(train_examples)
+        np.testing.assert_allclose(preds, openvino_preds, rtol=1e-2)
+        
+        # test tf tensor
+        train_examples = tf.convert_to_tensor(train_examples)
+        openvino_quantized_model = InferenceOptimizer.quantize(model,
+                                                               accelerator='openvino',
+                                                               x=train_examples,
+                                                               y=None)
+
+        preds = model.predict(train_examples)
+        openvino_preds = openvino_quantized_model.predict(train_examples)
+        np.testing.assert_allclose(preds, openvino_preds, rtol=1e-2)
+        
+        # test dataset
+        train_examples = np.random.random((100, 40, 40, 3))
+        train_dataset = tf.data.Dataset.from_tensor_slices(train_examples)
+        openvino_quantized_model = InferenceOptimizer.quantize(model,
+                                                               accelerator='openvino',
+                                                               x=train_dataset,
                                                                y=None)
 
         preds = model.predict(train_examples)

--- a/python/nano/test/tf/keras/test_inf_optimizer.py
+++ b/python/nano/test/tf/keras/test_inf_optimizer.py
@@ -107,6 +107,7 @@ class TestInferencePipeline(TestCase):
         model = opt.get_best_model()
 
         # test tf tensor
+        model = ResNet50(weights=None, input_shape=[40, 40, 3], classes=10)
         train_examples = tf.convert_to_tensor(train_examples)
         opt = InferenceOptimizer()
         opt.optimize(model=model,
@@ -117,6 +118,7 @@ class TestInferencePipeline(TestCase):
         model = opt.get_best_model()
         
         # test dataset with only x
+        model = ResNet50(weights=None, input_shape=[40, 40, 3], classes=10)
         train_examples = np.random.random((100, 40, 40, 3))
         train_dataset = tf.data.Dataset.from_tensor_slices(train_examples)
         opt = InferenceOptimizer()

--- a/python/nano/test/tf/keras/test_inf_optimizer.py
+++ b/python/nano/test/tf/keras/test_inf_optimizer.py
@@ -96,8 +96,19 @@ class TestInferencePipeline(TestCase):
 
     def test_optimize_model_with_only_x(self):
         model = ResNet50(weights=None, input_shape=[40, 40, 3], classes=10)
-
+        # test numpy array
         train_examples = np.random.random((100, 40, 40, 3))
+
+        opt = InferenceOptimizer()
+        opt.optimize(model=model,
+                     x=train_examples,
+                     y=None,
+                     latency_sample_num=10,
+                     thread_num=8)
+        model = opt.get_best_model()
+
+        # test tf tensor
+        train_examples = tf.convert_to_tensor(train_examples)
 
         opt = InferenceOptimizer()
         opt.optimize(model=model,

--- a/python/nano/test/tf/keras/test_inf_optimizer.py
+++ b/python/nano/test/tf/keras/test_inf_optimizer.py
@@ -93,3 +93,18 @@ class TestInferencePipeline(TestCase):
                      latency_sample_num=10,
                      thread_num=8)
         model = opt.get_best_model()
+
+    def test_optimize_model_with_only_x(self):
+        model = ResNet50(weights=None, input_shape=[40, 40, 3], classes=10)
+        model = NanoModel(inputs=model.inputs, outputs=model.outputs)
+
+        train_examples = np.random.random((100, 40, 40, 3))
+        train_labels = np.random.randint(0, 10, size=(100,))
+
+        opt = InferenceOptimizer()
+        opt.optimize(model=model,
+                     x=train_examples,
+                     y=None,
+                     latency_sample_num=10,
+                     thread_num=8)
+        model = opt.get_best_model()

--- a/python/nano/test/tf/keras/test_inf_optimizer.py
+++ b/python/nano/test/tf/keras/test_inf_optimizer.py
@@ -96,10 +96,8 @@ class TestInferencePipeline(TestCase):
 
     def test_optimize_model_with_only_x(self):
         model = ResNet50(weights=None, input_shape=[40, 40, 3], classes=10)
-        model = NanoModel(inputs=model.inputs, outputs=model.outputs)
 
         train_examples = np.random.random((100, 40, 40, 3))
-        train_labels = np.random.randint(0, 10, size=(100,))
 
         opt = InferenceOptimizer()
         opt.optimize(model=model,

--- a/python/nano/test/tf/keras/test_inf_optimizer.py
+++ b/python/nano/test/tf/keras/test_inf_optimizer.py
@@ -98,7 +98,6 @@ class TestInferencePipeline(TestCase):
         model = ResNet50(weights=None, input_shape=[40, 40, 3], classes=10)
         # test numpy array
         train_examples = np.random.random((100, 40, 40, 3))
-
         opt = InferenceOptimizer()
         opt.optimize(model=model,
                      x=train_examples,
@@ -109,7 +108,17 @@ class TestInferencePipeline(TestCase):
 
         # test tf tensor
         train_examples = tf.convert_to_tensor(train_examples)
-
+        opt = InferenceOptimizer()
+        opt.optimize(model=model,
+                     x=train_examples,
+                     y=None,
+                     latency_sample_num=10,
+                     thread_num=8)
+        model = opt.get_best_model()
+        
+        # test dataset with only x
+        train_examples = np.random.random((100, 40, 40, 3))
+        train_dataset = tf.data.Dataset.from_tensor_slices(train_examples)
         opt = InferenceOptimizer()
         opt.optimize(model=model,
                      x=train_examples,


### PR DESCRIPTION
## Description

Support user passing only x without y in InfererenceOptimizer's `quantize` / `optimize` in keras.

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/242#event-8042561418 issue 1

### 2. User API changes

No change, but now user can only pass tensor/numpy (tuple) input x like:
```
model = ResNet50(weights=None, input_shape=[224, 224, 3], classes=10)
model = Model(inputs=model.inputs, outputs=model.outputs)
input_examples = np.random.random((100, 224, 224, 3))
# for quantize
model = InferenceOptimizer.quantize(model,
                                    accelerator='openvino',
                                    x=input_examples)
# for optimize
model = InferenceOptimizer.optimize(model,
                                    x=input_examples)
```


### 3. Summary of the change 

- Support user passing only x without y in InfererenceOptimizer's `quantize` / `optimize` in keras.
- related uts

### 4. How to test?
- [ ] Unit test
