### PR TITLE
Chronos: Export scale and roll to torchscript module

### DIFF
--- a/python/chronos/dev/test/lint-python
+++ b/python/chronos/dev/test/lint-python
@@ -52,7 +52,7 @@ export "PATH=$PYTHONPATH:$PATH"
 #+ first, but we do so so that the check status can
 #+ be output before the report, like with the
 #+ scalastyle and RAT checks.
-python "$PEP8_SCRIPT_PATH" --ignore=E402,E731,E241,W503,E226 --exclude=__init__.py --config=dev/tox.ini $PATHS_TO_CHECK >> "$PEP8_REPORT_PATH"
+python "$PEP8_SCRIPT_PATH" --ignore=E402,E731,E241,W503,E226,E701 --exclude=__init__.py --config=dev/tox.ini $PATHS_TO_CHECK >> "$PEP8_REPORT_PATH"
 pep8_status="${PIPESTATUS[0]}"
 
 if [ "$compile_status" -eq 0 -a "$pep8_status" -eq 0 ]; then

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -1191,3 +1191,58 @@ class TSDataset:
             self.best_cycle_length = int(res.max())
 
         return self.best_cycle_length
+
+    def export_jit(self, drop_dt_col=True):
+        """
+        Exporting data processing pipeline to torchscript so that it can be used without
+        Python environment. For example, when you are deploying a trained model in C++
+        and need to process input data, you can call this method to get a torchscript module
+        containing the data processing pipeline and save it in a .pt file when you finish
+        developing the model, when deploying, you can load the torchscript module from .pt
+        file and run the data processing pipeline in C++ using libtorch APIs, and the output
+        tensor can be fed into the trained model for inference.
+
+        Currently only scale and roll are supported, the pipeline is similar to the following code:
+        >>> tsdata.scale(scaler, fit=False)\
+        >>>       .roll(lookback, horizon, is_predict=True)
+        The output tensor has same shape and value as tsdata.to_numpy().
+
+        Currently there are some limitations:
+        1. Please make sure the value of each column can be converted to Pytorch tensor,
+        for example, id "00" is not allowed because str can not be converted to a tensor,
+        you should use integer (0, 1, ..) as id instead of string.
+        2. Some features in tsdataset.scale and tsdataset.roll are unavailable in this pipeline:
+            a. If self.roll_additional_feature is not None, it can't be processed in scale and roll
+            b. id_sensitive, time_enc and label_len parameter is not supported in roll
+
+        :param drop_dtcol: Whether to delete the datetime column. Since datetime value (like
+               "2022-12-12") can't be converted to Pytorch tensor, you can choose different ways
+               to workaround this. If set to True, the datetime column will be deleted, then you
+               also need to skip the datetime column when reading data from data source (like
+               csv files) in deployment environment to keep the same structure as the data 
+               used in development; if set to False, the datetime column will not be deleted, and
+               you need to make sure the datetime colunm can be successfully converted to Pytorch
+               tenor when reading data in deployment environment, for example, you can set each
+               data in datetime column to an int (or other vaild types) since scale and roll doesn't
+               need datetime column so the value can be arbitrary.
+               The value defaults to True.
+
+        :return: The compiled torchscript module
+
+        """
+        from bigdl.chronos.data.utils.export_torchscript import SCALE_JIT_HELPER_MAP
+        import torch
+
+        if drop_dt_col:
+            self.df.drop(columns=self.dt_col, inplace=True)
+
+        id_index = self.df.columns.tolist().index(self.id_col)
+        target_col = _to_list(self.target_col, "target_col", deploy_mode=True)
+        feature_col = _to_list(self.feature_col, "feature_col", deploy_mode=True)
+
+        # index of target col and feature col, will be used in scale and roll
+        target_feature_index = [self.df.columns.tolist().index(i) for i in target_col + feature_col]
+
+        export_class = SCALE_JIT_HELPER_MAP[type(self.scaler)]
+        return torch.jit.script(export_class(self.scaler, self.lookback,
+                                             id_index, target_feature_index))

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -1203,19 +1203,23 @@ class TSDataset:
         tensor can be fed into the trained model for inference.
 
         Currently only scale and roll are supported, the pipeline is similar to the following code:
-        >>> tsdata.scale(scaler, fit=False)\
+
+        >>> tsdata.scale(scaler, fit=False) \\
         >>>       .roll(lookback, horizon, is_predict=True)
+
         The output tensor has same shape and value as tsdata.to_numpy().
 
         Currently there are some limitations:
-        1. Please make sure the value of each column can be converted to Pytorch tensor,
-        for example, id "00" is not allowed because str can not be converted to a tensor,
-        you should use integer (0, 1, ..) as id instead of string.
-        2. Some features in tsdataset.scale and tsdataset.roll are unavailable in this pipeline:
-            a. If self.roll_additional_feature is not None, it can't be processed in scale and roll
-            b. id_sensitive, time_enc and label_len parameter is not supported in roll
-        3. Users are expected to call .scale(scaler, fit=True) before calling export_jit.
-           Single roll operation is not supported for converting now.
+            1. Please make sure the value of each column can be converted to Pytorch tensor,
+               for example, id "00" is not allowed because str can not be converted to a tensor,
+               you should use integer (0, 1, ..) as id instead of string.
+            2. Some features in tsdataset.scale and tsdataset.roll are unavailable in this
+               pipeline:
+                    a. If self.roll_additional_feature is not None, it can't be processed in scale
+                       and roll
+                    b. id_sensitive, time_enc and label_len parameter is not supported in roll
+            3. Users are expected to call .scale(scaler, fit=True) before calling export_jit.
+               Single roll operation is not supported for converting now.
 
         :param path_dir: The path to save the compiled torchscript module, default to None.
                If set to None, you should call torch.jit.save() in your code to save the returned
@@ -1233,7 +1237,7 @@ class TSDataset:
                doesn't need datetime column so the value can be arbitrary.
                The value defaults to True.
 
-        :return: The compiled torchscript module
+        :return: The compiled torchscript module.
 
         """
         from bigdl.chronos.data.utils.export_torchscript import SCALE_JIT_HELPER_MAP
@@ -1253,7 +1257,7 @@ class TSDataset:
         export_class = SCALE_JIT_HELPER_MAP[type(self.scaler)]
 
         compiled_module = torch.jit.script(export_class(self.scaler, self.lookback,
-                                             id_index, target_feature_index))
+                                           id_index, target_feature_index))
 
         if path_dir:
             saved_path = os.path.join(path_dir, "tsdata_preprocessing.pt")

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -1212,10 +1212,10 @@ class TSDataset:
         >>> // deployment in C++
         >>> #include <torch/torch.h>
         >>> #include <torch/script.h>
-        >>> // create input tensor
+        >>> // create input tensor from your data
         >>> // the data to create input tensor should have the same format as the
         >>> // data used in developing
-        >>> torch::Tensor input = create_input_tensor();
+        >>> torch::Tensor input = create_input_tensor(data);
         >>> // load the module
         >>> torch::jit::script::Module preprocessing;
         >>> preprocessing = torch::jit::load(path);

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -1219,7 +1219,7 @@ class TSDataset:
                "2022-12-12") can't be converted to Pytorch tensor, you can choose different ways
                to workaround this. If set to True, the datetime column will be deleted, then you
                also need to skip the datetime column when reading data from data source (like
-               csv files) in deployment environment to keep the same structure as the data 
+               csv files) in deployment environment to keep the same structure as the data
                used in development; if set to False, the datetime column will not be deleted, and
                you need to make sure the datetime colunm can be successfully converted to Pytorch
                tenor when reading data in deployment environment, for example, you can set each

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -1213,6 +1213,8 @@ class TSDataset:
         >>> #include <torch/torch.h>
         >>> #include <torch/script.h>
         >>> // create input tensor
+        >>> // the data to create input tensor should have the same format as the
+        >>> // data used in developing
         >>> torch::Tensor input = create_input_tensor();
         >>> // load the module
         >>> torch::jit::script::Module preprocessing;

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -1207,6 +1207,19 @@ class TSDataset:
         >>> tsdata.scale(scaler, fit=False) \\
         >>>       .roll(lookback, horizon, is_predict=True)
 
+        When deploying, the compiled torchscript module can be used by:
+
+        >>> // deployment in C++
+        >>> #include <torch/torch.h>
+        >>> #include <torch/script.h>
+        >>> // create input tensor
+        >>> torch::Tensor input = create_input_tensor();
+        >>> // load the module
+        >>> torch::jit::script::Module preprocessing;
+        >>> preprocessing = torch::jit::load(path);
+        >>> // run data preprocessing
+        >>> torch::Tensor output = preprocessing.forward(input_tensor).toTensor();
+
         The output tensor has same shape and value as tsdata.to_numpy().
 
         Currently there are some limitations:

--- a/python/chronos/src/bigdl/chronos/data/tsdataset.py
+++ b/python/chronos/src/bigdl/chronos/data/tsdataset.py
@@ -1240,7 +1240,7 @@ class TSDataset:
         :return: The compiled torchscript module.
 
         """
-        from bigdl.chronos.data.utils.export_torchscript import SCALE_JIT_HELPER_MAP
+        from bigdl.chronos.data.utils.export_torchscript import export_processing_to_jit
         import torch
         import os
 
@@ -1254,13 +1254,12 @@ class TSDataset:
         # index of target col and feature col, will be used in scale and roll
         target_feature_index = [self.df.columns.tolist().index(i) for i in target_col + feature_col]
 
-        export_class = SCALE_JIT_HELPER_MAP[type(self.scaler)]
-
-        compiled_module = torch.jit.script(export_class(self.scaler, self.lookback,
-                                           id_index, target_feature_index))
+        preprocessing_module = export_processing_to_jit(self.scaler, self.lookback,
+                                                        id_index,
+                                                        target_feature_index)
 
         if path_dir:
-            saved_path = os.path.join(path_dir, "tsdata_preprocessing.pt")
-            torch.jit.save(compiled_module, saved_path)
+            preprocess_path = os.path.join(path_dir, "tsdata_preprocessing.pt")
+            torch.jit.save(preprocessing_module, preprocess_path)
 
-        return compiled_module
+        return preprocessing_module

--- a/python/chronos/src/bigdl/chronos/data/utils/export_torchscript.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/export_torchscript.py
@@ -47,8 +47,8 @@ class ExportJITBase(nn.Module):
         if len(non_zero) == 0:
             return [data]
 
-        cutpoints: List[int] = non_zero[0]
-        cutpoints = cutpoints.add(1).tolist()
+        cutpoints = non_zero[0]
+        cutpoints: List[int] = cutpoints.add(1).tolist()
         res: List[torch.Tensor] = []
         for start, end in zip([0] + cutpoints, cutpoints + [len(colunm)]):
             index, _ = order[start:end].sort(0)

--- a/python/chronos/src/bigdl/chronos/data/utils/export_torchscript.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/export_torchscript.py
@@ -19,6 +19,7 @@ import torch.nn as nn
 from typing import List
 from sklearn.preprocessing import StandardScaler, MaxAbsScaler, MinMaxScaler, RobustScaler
 
+
 class ExportJITBase(nn.Module):
     def __init__(self, lookback: int, id_index: int, target_feature_index: List[int]) -> None:
         super().__init__()
@@ -46,8 +47,8 @@ class ExportJITBase(nn.Module):
         if len(non_zero) == 0:
             return [data]
 
-        cutpoints = non_zero[0]
-        cutpoints: List[int] = cutpoints.add(1).tolist()
+        cutpoints: List[int] = non_zero[0]
+        cutpoints = cutpoints.add(1).tolist()
         res: List[torch.Tensor] = []
         for start, end in zip([0] + cutpoints, cutpoints + [len(colunm)]):
             index, _ = order[start:end].sort(0)
@@ -58,7 +59,8 @@ class ExportJITBase(nn.Module):
     def _roll_tensor(self, data, lookback: int, target_feature_index: List[int]):
         data = data[:, target_feature_index]
         data = torch.unsqueeze(data, 1)
-        roll_data = torch.concatenate([self._shift(data, i) for i in range(0, -lookback, -1)], dim=1)
+        roll_data = torch.concatenate([self._shift(data, i) for i in range(0, -lookback, -1)],
+                                      dim=1)
         window_idx = torch.arange(lookback)
         if data.size()[0] >= lookback:
             roll_data = roll_data[:data.size()[0]-lookback+1, window_idx, :]
@@ -88,7 +90,7 @@ class ExportWithStandardScaler(ExportJITBase):
     def __init__(self, scaler: StandardScaler, lookback: int,
                  id_index: int, target_feature_index: List[int]) -> None:
         super().__init__(lookback, id_index, target_feature_index)
-        self.scale_ : List[float] = scaler.scale_.tolist()
+        self.scale_: List[float] = scaler.scale_.tolist()
         self.mean_: List[float] = scaler.mean_.tolist()
         self.with_mean: bool = bool(scaler.with_mean)
         self.with_std: bool = bool(scaler.with_std)
@@ -109,7 +111,7 @@ class ExportWithMaxAbsScaler(ExportJITBase):
     def __init__(self, scaler: MaxAbsScaler, lookback: int,
                  id_index: int, target_feature_index: List[int]) -> None:
         super().__init__(lookback, id_index, target_feature_index)
-        self.scale_ : List[float] = scaler.scale_.tolist()
+        self.scale_: List[float] = scaler.scale_.tolist()
         self.lookback: int = lookback
         self.id_index = id_index
         self.target_feature_index = target_feature_index
@@ -126,7 +128,7 @@ class ExportWithMinMaxScaler(ExportJITBase):
     def __init__(self, scaler: MinMaxScaler, lookback: int,
                  id_index: int, target_feature_index: List[int]) -> None:
         super().__init__(lookback, id_index, target_feature_index)
-        self.scale_ : List[float] = scaler.scale_.tolist()
+        self.scale_: List[float] = scaler.scale_.tolist()
         self.min_: List[float] = scaler.min_.tolist()
         self.lookback: int = lookback
         self.id_index: int = id_index
@@ -145,7 +147,7 @@ class ExportWithRobustScaler(ExportJITBase):
     def __init__(self, scaler: RobustScaler, lookback: int,
                  id_index: int, target_feature_index: List[int]) -> None:
         super().__init__(lookback, id_index, target_feature_index)
-        self.scale_ : List[float] = scaler.scale_.tolist()
+        self.scale_: List[float] = scaler.scale_.tolist()
         self.center_: List[float] = scaler.center_.tolist()
         self.with_centering: bool = bool(scaler.with_centering)
         self.with_scaling: bool = bool(scaler.with_scaling)

--- a/python/chronos/src/bigdl/chronos/data/utils/export_torchscript.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/export_torchscript.py
@@ -59,7 +59,7 @@ class JITPreprocessingBase(nn.Module):
     def _roll_tensor(self, data, lookback: int, target_feature_index: List[int]):
         data = data[:, target_feature_index]
         data = torch.unsqueeze(data, 1)
-        roll_data = torch.concatenate([self._shift(data, i) for i in range(0, -lookback, -1)],
+        roll_data = torch.cat([self._shift(data, i) for i in range(0, -lookback, -1)],
                                       dim=1)
         window_idx = torch.arange(lookback)
         if data.size()[0] >= lookback:
@@ -75,7 +75,7 @@ class JITPreprocessingBase(nn.Module):
         for group in res:
             roll_result.append(self._roll_tensor(group, lookback, target_feature_index))
 
-        return torch.concatenate(roll_result, dim=0)
+        return torch.cat(roll_result, dim=0)
 
     def scale(self, data):
         return data

--- a/python/chronos/src/bigdl/chronos/data/utils/export_torchscript.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/export_torchscript.py
@@ -106,9 +106,9 @@ class ExportWithStandardScaler(ExportJIT):
         data_scale = torch.zeros(data.size(), dtype=torch.float64)
         for i in range(data.size()[1]):
             value_mean = self.mean_[i] if self.with_mean \
-                                       else torch.zeros(self.mean_.size(), dtype=torch.float64)
+                else torch.zeros(self.mean_.size(), dtype=torch.float64)
             value_scale = self.scale_[i] if self.with_std \
-                                         else torch.ones(self.scale_.size(), dtype=torch.float64)
+                else torch.ones(self.scale_.size(), dtype=torch.float64)
             data_scale[:, i] = (data[:, i] - value_mean) / value_scale
         return data_scale
 
@@ -117,7 +117,7 @@ class ExporWithMaxAbsScaler(ExportJIT):
     def __init__(self, scaler: MaxAbsScaler, lookback: int,
                  id_index: int, target_feature_index: List[int]) -> None:
         super().__init__(lookback, id_index, target_feature_index)
-        self.scale_= torch.from_numpy(scaler.scale_).type(torch.float64)
+        self.scale_ = torch.from_numpy(scaler.scale_).type(torch.float64)
         self.lookback: int = lookback
         self.id_index = id_index
         self.target_feature_index = target_feature_index
@@ -165,11 +165,9 @@ class ExportWithRobustScaler(ExportJIT):
         data_scale = torch.zeros(data.size(), dtype=torch.float64)
         for i in range(data.size()[1]):
             value_center = self.center_[i] if self.with_centering \
-                                           else torch.zeros(self.center_.size(),
-                                                            dtype=torch.float64)
+                else torch.zeros(self.center_.size(), dtype=torch.float64)
             value_scale = self.scale_[i] if self.with_scaling \
-                                         else torch.ones(self.scale_.size(),
-                                                         dtype=torch.float64)
+                else torch.ones(self.scale_.size(), dtype=torch.float64)
             data_scale[:, i] = (data[:, i] - value_center) / value_scale
         return data_scale
 

--- a/python/chronos/src/bigdl/chronos/data/utils/export_torchscript.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/export_torchscript.py
@@ -60,7 +60,7 @@ class JITPreprocessingBase(nn.Module):
         data = data[:, target_feature_index]
         data = torch.unsqueeze(data, 1)
         roll_data = torch.cat([self._shift(data, i) for i in range(0, -lookback, -1)],
-                                      dim=1)
+                              dim=1)
         window_idx = torch.arange(lookback)
         if data.size()[0] >= lookback:
             roll_data = roll_data[:data.size()[0]-lookback+1, window_idx, :]

--- a/python/chronos/src/bigdl/chronos/data/utils/export_torchscript.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/export_torchscript.py
@@ -20,7 +20,7 @@ from typing import List
 from sklearn.preprocessing import StandardScaler, MaxAbsScaler, MinMaxScaler, RobustScaler
 
 
-class ExportJITBase(nn.Module):
+class JITPreprocessingBase(nn.Module):
     def __init__(self, lookback: int, id_index: int, target_feature_index: List[int]) -> None:
         super().__init__()
         self.lookback = lookback
@@ -86,7 +86,7 @@ class ExportJITBase(nn.Module):
         return data_roll
 
 
-class ExportWithStandardScaler(ExportJITBase):
+class ExportPreprocessingWithStandardScaler(JITPreprocessingBase):
     def __init__(self, scaler: StandardScaler, lookback: int,
                  id_index: int, target_feature_index: List[int]) -> None:
         super().__init__(lookback, id_index, target_feature_index)
@@ -107,7 +107,7 @@ class ExportWithStandardScaler(ExportJITBase):
         return data_scale
 
 
-class ExportWithMaxAbsScaler(ExportJITBase):
+class ExporPreprocessingtWithMaxAbsScaler(JITPreprocessingBase):
     def __init__(self, scaler: MaxAbsScaler, lookback: int,
                  id_index: int, target_feature_index: List[int]) -> None:
         super().__init__(lookback, id_index, target_feature_index)
@@ -124,7 +124,7 @@ class ExportWithMaxAbsScaler(ExportJITBase):
         return data_scale
 
 
-class ExportWithMinMaxScaler(ExportJITBase):
+class ExportPreprocessingWithMinMaxScaler(JITPreprocessingBase):
     def __init__(self, scaler: MinMaxScaler, lookback: int,
                  id_index: int, target_feature_index: List[int]) -> None:
         super().__init__(lookback, id_index, target_feature_index)
@@ -143,7 +143,7 @@ class ExportWithMinMaxScaler(ExportJITBase):
         return data_scale
 
 
-class ExportWithRobustScaler(ExportJITBase):
+class ExportPreprocessingWithRobustScaler(JITPreprocessingBase):
     def __init__(self, scaler: RobustScaler, lookback: int,
                  id_index: int, target_feature_index: List[int]) -> None:
         super().__init__(lookback, id_index, target_feature_index)
@@ -164,7 +164,7 @@ class ExportWithRobustScaler(ExportJITBase):
         return data_scale
 
 
-SCALE_JIT_HELPER_MAP = {StandardScaler: ExportWithStandardScaler,
-                        MaxAbsScaler: ExportWithMaxAbsScaler,
-                        MinMaxScaler: ExportWithMinMaxScaler,
-                        RobustScaler: ExportWithRobustScaler}
+SCALE_JIT_HELPER_MAP = {StandardScaler: ExportPreprocessingWithStandardScaler,
+                        MaxAbsScaler: ExporPreprocessingtWithMaxAbsScaler,
+                        MinMaxScaler: ExportPreprocessingWithMinMaxScaler,
+                        RobustScaler: ExportPreprocessingWithRobustScaler}

--- a/python/chronos/src/bigdl/chronos/data/utils/export_torchscript.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/export_torchscript.py
@@ -1,0 +1,168 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import torch
+import torch.nn as nn
+from typing import List
+from sklearn.preprocessing import StandardScaler, MaxAbsScaler, MinMaxScaler, RobustScaler
+
+class ExportJITBase(nn.Module):
+    def __init__(self, lookback: int, id_index: int, target_feature_index: List[int]) -> None:
+        super().__init__()
+        self.lookback = lookback
+        self.target_feature_index = target_feature_index
+        self.id_index = id_index
+
+    def _shift(self, data, i: int):
+        res = torch.empty_like(data)
+        if i < 0:
+            res[:] = torch.roll(data, i, 0)
+            res[i:] = torch.nan
+        elif i == 0:
+            res[:] = data
+        return res
+
+    def _groupby(self, data, colunm):
+        # group the data using unique values in column
+        # This code is adapted from https://github.com/pytorch/pytorch/issues/20613
+
+        sorted_values, order = colunm.sort(0)
+        delta = colunm[1:] - colunm[:-1]
+        non_zero = delta.nonzero()
+
+        if len(non_zero) == 0:
+            return [data]
+
+        cutpoints = non_zero[0]
+        cutpoints: List[int] = cutpoints.add(1).tolist()
+        res: List[torch.Tensor] = []
+        for start, end in zip([0] + cutpoints, cutpoints + [len(colunm)]):
+            index, _ = order[start:end].sort(0)
+            res.append(data[index])
+
+        return res
+
+    def _roll_tensor(self, data, lookback: int, target_feature_index: List[int]):
+        data = data[:, target_feature_index]
+        data = torch.unsqueeze(data, 1)
+        roll_data = torch.concatenate([self._shift(data, i) for i in range(0, -lookback, -1)], dim=1)
+        window_idx = torch.arange(lookback)
+        if data.size()[0] >= lookback:
+            roll_data = roll_data[:data.size()[0]-lookback+1, window_idx, :]
+        else:
+            roll_data = roll_data[:0, window_idx, :]
+        return roll_data
+
+    def roll(self, data, lookback: int, id_index: int, target_feature_index: List[int]):
+        id_col = data[:, id_index]
+        res: List[torch.Tensor] = self._groupby(data, id_col)
+        roll_result: List[torch.Tensor] = []
+        for group in res:
+            roll_result.append(self._roll_tensor(group, lookback, target_feature_index))
+
+        return torch.concatenate(roll_result, dim=0)
+
+    def scale(self, data):
+        return data
+
+    def forward(self, data):
+        data[:, self.target_feature_index] = self.scale(data[:, self.target_feature_index])
+        data_roll = self.roll(data, self.lookback, self.id_index, self.target_feature_index)
+        return data_roll
+
+
+class ExportWithStandardScaler(ExportJITBase):
+    def __init__(self, scaler: StandardScaler, lookback: int,
+                 id_index: int, target_feature_index: List[int]) -> None:
+        super().__init__(lookback, id_index, target_feature_index)
+        self.scale_ : List[float] = scaler.scale_.tolist()
+        self.mean_: List[float] = scaler.mean_.tolist()
+        self.with_mean: bool = bool(scaler.with_mean)
+        self.with_std: bool = bool(scaler.with_std)
+        self.lookback: int = lookback
+        self.id_index: int = id_index
+        self.target_feature_index = target_feature_index
+
+    def scale(self, data):
+        data_scale = torch.zeros(data.size())
+        for i in range(data.size()[1]):
+            value_mean = self.mean_[i] if self.with_mean else 0.0
+            value_scale = self.scale_[i] if self.with_std else 1.0
+            data_scale[:, i] = (data[:, i] - value_mean) / value_scale
+        return data_scale
+
+
+class ExportWithMaxAbsScaler(ExportJITBase):
+    def __init__(self, scaler: MaxAbsScaler, lookback: int,
+                 id_index: int, target_feature_index: List[int]) -> None:
+        super().__init__(lookback, id_index, target_feature_index)
+        self.scale_ : List[float] = scaler.scale_.tolist()
+        self.lookback: int = lookback
+        self.id_index = id_index
+        self.target_feature_index = target_feature_index
+
+    def scale(self, data):
+        data_scale = torch.zeros(data.size())
+        for i in range(data.size()[1]):
+            value_max_abs = self.scale_[i]
+            data_scale[:, i] = data[:, i] / value_max_abs
+        return data_scale
+
+
+class ExportWithMinMaxScaler(ExportJITBase):
+    def __init__(self, scaler: MinMaxScaler, lookback: int,
+                 id_index: int, target_feature_index: List[int]) -> None:
+        super().__init__(lookback, id_index, target_feature_index)
+        self.scale_ : List[float] = scaler.scale_.tolist()
+        self.min_: List[float] = scaler.min_.tolist()
+        self.lookback: int = lookback
+        self.id_index: int = id_index
+        self.target_feature_index = target_feature_index
+
+    def scale(self, data):
+        data_scale = torch.zeros(data.size())
+        for i in range(data.size()[1]):
+            value_min = self.min_[i]
+            value_scale = self.scale_[i]
+            data_scale[:, i] = data[:, i] * value_scale + value_min
+        return data_scale
+
+
+class ExportWithRobustScaler(ExportJITBase):
+    def __init__(self, scaler: RobustScaler, lookback: int,
+                 id_index: int, target_feature_index: List[int]) -> None:
+        super().__init__(lookback, id_index, target_feature_index)
+        self.scale_ : List[float] = scaler.scale_.tolist()
+        self.center_: List[float] = scaler.center_.tolist()
+        self.with_centering: bool = bool(scaler.with_centering)
+        self.with_scaling: bool = bool(scaler.with_scaling)
+        self.lookback: int = lookback
+        self.id_index: int = id_index
+        self.target_feature_index = target_feature_index
+
+    def scale(self, data):
+        data_scale = torch.zeros(data.size())
+        for i in range(data.size()[1]):
+            value_center = self.center_[i] if self.with_centering else 0.0
+            value_scale = self.scale_[i] if self.with_scaling else 1.0
+            data_scale[:, i] = (data[:, i] - value_center) / value_scale
+        return data_scale
+
+
+SCALE_JIT_HELPER_MAP = {StandardScaler: ExportWithStandardScaler,
+                        MaxAbsScaler: ExportWithMaxAbsScaler,
+                        MinMaxScaler: ExportWithMinMaxScaler,
+                        RobustScaler: ExportWithRobustScaler}

--- a/python/chronos/test/bigdl/chronos/data/test_tsdataset.py
+++ b/python/chronos/test/bigdl/chronos/data/test_tsdataset.py
@@ -1543,7 +1543,7 @@ class TestTSDataset(TestCase):
                                                deploy_mode=True)
                 # drop datetime col since it can't be converted to Pytorch tensor
                 tsdata.df.drop(columns=tsdata.dt_col, inplace=True)
-                input_tensor = torch.from_numpy(tsdata.df.values).type(torch.float32)
+                input_tensor = torch.from_numpy(tsdata.df.values).type(torch.float64)
                 preprocess_path = os.path.join(temp_dir, "tsdata_preprocessing.pt")
                 preprocess_module = torch.jit.load(preprocess_path)
                 preprocess_output = preprocess_module.forward(input_tensor)
@@ -1583,7 +1583,7 @@ class TestTSDataset(TestCase):
                 # since datetime col will not be used in scale and roll, so we can give it
                 # a meaningless value
                 tsdata.df["datetime"] = np.array([1000]*len(tsdata.df))
-                input_tensor = torch.from_numpy(tsdata.df.values).type(torch.float32)
+                input_tensor = torch.from_numpy(tsdata.df.values).type(torch.float64)
                 preprocess = torch.jit.load(preprocess_path)
                 preprocess_output = preprocess.forward(input_tensor)
 


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

<!-- Provide the related github issue link if available -->
Since many users prefer deploying models using C++, we can export data processing pipeline in tsdataset to C++ to support it.
### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->
Add a new API `export_jit(path_dir=None, drop_dtcol=True)` in tsdataset.
When users finish developing their model, they can call `tsdataset.export_jit()` to get a compiled torchscript module containing data processing pipeline (only scale and roll is supported now), the module can be saved as a .pt file, while deploying, users can load the module from .pt file and run the data processing pipeline using libtorch API in C++.
### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
- Add a new API `export_jit(path_dir=None, drop_dtcol=True)`
- Implement scale and roll using pytorch (some features are unavailable, see api doc)
api doc: https://zhaojie-doc.readthedocs.io/en/to_torchscript_poc/doc/PythonAPI/Chronos/tsdataset.html#bigdl.chronos.data.tsdataset.TSDataset.export_jit
### 4. How to test?
- [ ] Unit test
