### PR TITLE
Nano: an internal API to change environment variables dynamically (e.g. `LD_PRELOAD`) by spawning new process

### DIFF
--- a/python/nano/src/bigdl/nano/utils/util.py
+++ b/python/nano/src/bigdl/nano/utils/util.py
@@ -130,6 +130,29 @@ class _append_return_to_pipe(object):
 
 class spawn_new_process(object):
     def __init__(self, func):
+        '''
+        This class is to decorate on another function where you want to run in a new process
+        with brand new environment variables (e.g. OMP/KMP, LD_PRELOAD, ...)
+        an example to use this is
+            ```python
+            def throughput_helper(model, x):
+                st = time.time()
+                for _ in range(100):
+                    model(x)
+                return time.time() - st
+
+            # make this wrapper
+            # note: please name the new function a new func name.
+            new_throughput_helper = spawn_new_process(throughput_helper)
+
+            # this will run in current process
+            duration = throughput_helper(model, x)
+
+            # this will run in a new process with new env var effective
+            duration = throughput_helper(model, x, env_var={"OMP_NUM_THREADS": "1",
+                                                            "LD_PRELOAD": ...})
+            ```
+        '''
         self.func = func
 
     def __call__(self, *args, **kwargs):

--- a/python/nano/src/bigdl/nano/utils/util.py
+++ b/python/nano/src/bigdl/nano/utils/util.py
@@ -14,9 +14,14 @@
 # limitations under the License.
 #
 
+import os
 import warnings
 from functools import wraps
 import cpuinfo
+from bigdl.nano.utils.log4Error import invalidInputError
+
+from multiprocessing import Process
+import multiprocessing as mp
 
 
 def deprecated(func_name=None, message=""):
@@ -112,3 +117,55 @@ class CPUInfo():
     @property
     def has_avx512(self):
         return self._avx512
+
+
+class _append_return_to_pipe(object):
+    def __init__(self, func):
+        self.func = func
+
+    def __call__(self, queue, *args, **kwargs):
+        res = self.func(*args, **kwargs)
+        queue.put(res)
+
+
+class spawn_new_process(object):
+    def __init__(self, func):
+        self.func = func
+
+    def __call__(self, *args, **kwargs):
+        if "env_var" in kwargs:
+            # check env_var should be a dict
+            invalidInputError(isinstance(kwargs['env_var'], dict),
+                              "env_var should be a dict")
+
+            # prepare
+            # 1. save the original env vars
+            # 2. set new ones
+            # 3. change the backend of multiprocessing from fork to spawn
+            # 4. delete "env_var" from kwargs
+            old_env_var = {}
+            for key, value in kwargs['env_var'].items():
+                old_env_var[key] = os.environ.get(key, "")
+                os.environ[key] = value
+            try:
+                mp.set_start_method('spawn')
+            except Exception:
+                pass
+            del kwargs["env_var"]
+
+            # new process
+            # block until return
+            q = mp.Queue()
+            new_func = _append_return_to_pipe(self.func)
+            p = Process(target=new_func, args=(q,) + args, kwargs=kwargs)
+            p.start()
+            return_val = q.get()
+            p.join()
+
+            # recover
+            for key, value in old_env_var.items():
+                os.environ[key] = value
+
+            return return_val
+        else:
+            return self.func(*args, **kwargs)

--- a/python/nano/src/bigdl/nano/utils/util.py
+++ b/python/nano/src/bigdl/nano/utils/util.py
@@ -146,11 +146,11 @@ class spawn_new_process(object):
             new_throughput_helper = spawn_new_process(throughput_helper)
 
             # this will run in current process
-            duration = throughput_helper(model, x)
+            duration = new_throughput_helper(model, x)
 
             # this will run in a new process with new env var effective
-            duration = throughput_helper(model, x, env_var={"OMP_NUM_THREADS": "1",
-                                                            "LD_PRELOAD": ...})
+            duration = new_throughput_helper(model, x, env_var={"OMP_NUM_THREADS": "1",
+                                                                "LD_PRELOAD": ...})
             ```
         '''
         self.func = func

--- a/python/nano/test/pytorch/tests/test_utils.py
+++ b/python/nano/test/pytorch/tests/test_utils.py
@@ -1,0 +1,45 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import tempfile
+import os
+import torch
+import time
+from bigdl.nano.utils.util import spawn_new_process
+from torchvision.models import resnet18
+
+
+def throughput_helper(model, x):
+    st = time.time()
+    model(x)
+    return time.time() - st, torch.get_num_threads()
+
+
+def test_spawn_new_process():
+    x = torch.rand(2, 3, 224, 224)
+    model = resnet18(pretrained=True)
+
+    original_thread = torch.get_num_threads()
+
+    new_throughput_helper = spawn_new_process(throughput_helper)
+    _, thread = new_throughput_helper(model, x)
+    assert thread == original_thread
+
+    _, thread = new_throughput_helper(model, x, env_var={"OMP_NUM_THREADS": "1"})
+    assert thread == 1
+
+    _, thread = new_throughput_helper(model, x, env_var={"OMP_NUM_THREADS": "2"})
+    assert thread == 2


### PR DESCRIPTION
## Description

### 1. Why the change?
It could be tricky to set the environment variable dynamically to the program since once a python interpreter is created it won't read the environment variable any more.

A way we have long talked about was to create a new process, and this PR is an implementation to this idea.

It seems to be an easy implementation while developers may have to consider:
1. return value process (need a queue or something)
2. use spawn rather than fork
3. set and recover the env vars
4. ...

That's why I implement this `bigdl.nano.utils.util.spawn_new_process` for developers.

### 2. User API changes
This is not an external API, just an internal tool.

Developers could
```python
new_throughput_helper = spawn_new_process(throughput_helper)
```
Then a new `env_var` is enabled for the new function

```python
# this will run in current process
duration = new_throughput_helper(model, x)

# this will run in a new process with new env var effective
duration = new_throughput_helper(model, x, env_var={"OMP_NUM_THREADS": "1",
                                                    "LD_PRELOAD": ...})
```

This is **extremely** helpful we want to find the best environment variable for users such as in `InferenceOptimizer`

here is a demo.
```python
import os
import torch
import time
from bigdl.nano.utils.util import spawn_new_process
from torchvision.models import resnet18

def throughput_helper(model, x):
    st = time.time()
    for _ in range(100):
        model(x)
    return time.time() - st


if __name__ == "__main__":
    x = torch.rand(2, 3, 224, 224)
    model = resnet18(pretrained=True)
    new_throughput_helper = spawn_new_process(throughput_helper)

    duration_original = new_throughput_helper(model, x)

    duration_1_thread = new_throughput_helper(model, x, env_var={"OMP_NUM_THREADS": "1"})

    duration_jemalloc = new_throughput_helper(model, x, env_var={"OMP_NUM_THREADS": "80",
        "LD_PRELOAD" :"/disk0/miniconda3/envs/junweid-nano/bin/../lib/libiomp5.so /disk0/miniconda3/envs/junweid-nano/lib/python3.7/site-packages/bigdl/nano//libs/libjemalloc.so",
        "MALLOC_CONF" :"oversize_threshold:1,background_thread:false,metadata_thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1"})
    
    duration_jemalloc_wo_conf = new_throughput_helper(model, x, env_var={"OMP_NUM_THREADS": "80",
        "LD_PRELOAD" :"/disk0/miniconda3/envs/junweid-nano/bin/../lib/libiomp5.so /disk0/miniconda3/envs/junweid-nano/lib/python3.7/site-packages/bigdl/nano//libs/libjemalloc.so"})
    
    print(duration_original)
    print(duration_1_thread)
    print(duration_jemalloc)
    print(duration_jemalloc_wo_conf)

>>> 1.1144320964813232
>>> 10.250067949295044
>>> 1.1166088581085205
>>> 1.9831197261810303
```
#### Some limitation
1. Users should be careful about the function name (a pickle related issue)
```python
# correct
new_throughput_helper = spawn_new_process(throughput_helper)

# false
throughput_helper= spawn_new_process(throughput_helper)

# false
@spawn_new_process
def throughput_helper(..):
```
6. Users should not define the function to be decorated in `__main__`.


### 3. Summary of the change 

a new decorator is added to `bigdl.nano.utils.util`

### 4. How to test?
- [ ] Unit test
