### PR TITLE
[Nano API doc] Add deprecated warning in API doc for `Model/Sequential.trace/quantize`

### DIFF
--- a/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference_utils.py
@@ -115,6 +115,11 @@ class InferenceUtils:
         :param logging: whether to log detailed information of model conversion, only valid when
                         accelerator='openvino', otherwise will be ignored. Default: ``True``.
         :return:            A TensorflowBaseModel for INC. If there is no model found, return None.
+
+        .. warning::
+           This function will be deprecated in future release.
+
+           Please use ``bigdl.nano.tf.keras.InferenceOptimizer.quantize`` instead.
         """
         from bigdl.nano.tf.keras import InferenceOptimizer
 
@@ -169,6 +174,11 @@ class InferenceUtils:
         :param logging: whether to log detailed information of model conversion, only valid when
                         accelerator='openvino', otherwise will be ignored. Default: ``True``.
         :return: Model with different acceleration(OpenVINO/ONNX Runtime).
+
+        .. warning::
+           This function will be deprecated in future release.
+
+           Please use ``bigdl.nano.tf.keras.InferenceOptimizer.trace`` instead.
         """
         from bigdl.nano.tf.keras import InferenceOptimizer
 

--- a/python/nano/src/bigdl/nano/tf/keras/training_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/training_utils.py
@@ -53,7 +53,7 @@ class TrainingUtils:
         tf.keras.Model.fit.
 
         Additional parameters:
-        
+
         :param num_processes: when num_processes is not None, it specifies how many sub-processes
                        to launch to run pseudo-distributed training; when num_processes is None,
                        training will run in the current process.

--- a/python/nano/src/bigdl/nano/tf/keras/training_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/training_utils.py
@@ -53,6 +53,7 @@ class TrainingUtils:
         tf.keras.Model.fit.
 
         Additional parameters:
+        
         :param num_processes: when num_processes is not None, it specifies how many sub-processes
                        to launch to run pseudo-distributed training; when num_processes is None,
                        training will run in the current process.


### PR DESCRIPTION
- Add deprecated warning in API doc for `bigdl.nano.tf.keras.Model/Sequential.trace/quantize`
- fix problematic api doc in `bigdl.nano.tf.keras.Model/Sequential.fit`

Document test: https://yuwentestdocs.readthedocs.io/en/nano-tf-api-doc-fix/doc/PythonAPI/Nano/tensorflow.html#bigdl.nano.tf.keras.Model.quantize