### PR TITLE
Nano: Fix passing arguments by kwargs or default value to onnx traced and quantized model

### DIFF
--- a/python/nano/src/bigdl/nano/deps/onnxruntime/tensorflow/tensorflow_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/tensorflow/tensorflow_onnxruntime_model.py
@@ -65,7 +65,7 @@ class KerasONNXRuntimeModel(ONNXRuntimeModel, AcceleratedKerasModel):
                     self._call_fn_args_backup = model._call_fn_args
                 else:
                     from keras.utils import tf_inspect
-                    self._call_fn_args_backup = tf_inspect.getargspec(model.call).args
+                    self._call_fn_args_backup = tf_inspect.getargspec(model.call).args[1:]
             else:
                 onnx_path = model
             ONNXRuntimeModel.__init__(self, onnx_path, session_options=onnxruntime_session_options)
@@ -137,6 +137,6 @@ class KerasONNXRuntimeModel(ONNXRuntimeModel, AcceleratedKerasModel):
         super()._save_model(onnx_path)
         attrs = {"_default_kwargs": self._default_kwargs,
                  "_call_fn_args_backup": self._call_fn_args_backup,
-                 "_inputs_dtypes": self._inputs_dtypes,}
+                 "_inputs_dtypes": self._inputs_dtypes}
         with open(Path(path) / self.status['attr_path'], "wb") as f:
             pickle.dump(attrs, f)

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -476,6 +476,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                                           thread_num=thread_num,
                                                           logging=logging,
                                                           openvino_config=openvino_config)
+            openvino_model = openvino_model.target_obj
             if metric:
                 if not isinstance(accuracy_criterion, dict):
                     accuracy_criterion = {'relative': 0.99, 'higher_is_better': True}
@@ -503,6 +504,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             else:
                 onnx_model = InferenceOptimizer.trace(model=model, accelerator='onnxruntime',
                                                       input_spec=input_spec, thread_num=thread_num)
+            onnx_model = onnx_model.target_obj
 
             # trace onnx model
             method_map = {
@@ -524,6 +526,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                   outputs=outputs,
                                   onnx_option='tensorflow',
                                   onnxruntime_session_options=onnxruntime_session_options)
+            result.default_kwargs = onnx_model.default_kwargs
+            result._call_fn_args_backup = onnx_model._call_fn_args_backup
         else:
             invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))
         patch_compiled(result, model)

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -526,6 +526,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                   outputs=outputs,
                                   onnx_option='tensorflow',
                                   onnxruntime_session_options=onnxruntime_session_options)
+            result._inputs_dtypes = onnx_model._inputs_dtypes
             result._default_kwargs = onnx_model._default_kwargs
             result._call_fn_args_backup = onnx_model._call_fn_args_backup
         else:

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -526,7 +526,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                   outputs=outputs,
                                   onnx_option='tensorflow',
                                   onnxruntime_session_options=onnxruntime_session_options)
-            result.default_kwargs = onnx_model.default_kwargs
+            result._default_kwargs = onnx_model._default_kwargs
             result._call_fn_args_backup = onnx_model._call_fn_args_backup
         else:
             invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))

--- a/python/nano/src/bigdl/nano/tf/utils.py
+++ b/python/nano/src/bigdl/nano/tf/utils.py
@@ -20,6 +20,7 @@ from functools import partial
 from bigdl.nano.common.compare_version import _compare_version
 
 KERAS_VERSION_LESS_2_9 = _compare_version("keras", operator.lt, "2.9")
+KERAS_VERSION_LESS_2_10 = _compare_version("keras", operator.lt, "2.10")
 
 
 class _NanoPartial(partial):

--- a/python/nano/src/bigdl/nano/utils/inference/tf/model.py
+++ b/python/nano/src/bigdl/nano/utils/inference/tf/model.py
@@ -18,6 +18,12 @@ import tensorflow as tf
 from bigdl.nano.utils.log4Error import invalidInputError
 from ..model import AcceleratedModel
 
+try:
+    import torch
+    is_torch_available = True
+except ImportError:
+    is_torch_available = False
+
 
 class AcceleratedKerasModel(AcceleratedModel, tf.keras.Model):
     """A wrapper class for tf.keras.Model with accelerators."""
@@ -57,10 +63,20 @@ class AcceleratedKerasModel(AcceleratedModel, tf.keras.Model):
                 return tensors.numpy().astype(dtype)
         elif isinstance(tensors, np.ndarray) and dtype is not None:
             return tensors.astype(dtype)
+        elif is_torch_available and isinstance(tensors, torch.Tensor):
+            return tensors.numpy()
         else:
             return tensors
 
     @staticmethod
     def numpy_to_tensors(np_arrays):
-        tensors = tuple(map(lambda x: tf.convert_to_tensor(x), np_arrays))
-        return tensors[0] if len(tensors) == 1 else tensors
+        if isinstance(np_arrays, (list, tuple)):
+            return type(np_arrays)(AcceleratedKerasModel.numpy_to_tensors(array)
+                                   for array in np_arrays)
+        elif isinstance(np_arrays, dict):
+            return {key: AcceleratedKerasModel.numpy_to_tensors(value)
+                    for key, value in np_arrays.items()}
+        elif isinstance(np_arrays, np.ndarray):
+            return tf.convert_to_tensor(np_arrays)
+        else:
+            return np_arrays

--- a/python/nano/src/bigdl/nano/utils/inference/tf/model.py
+++ b/python/nano/src/bigdl/nano/utils/inference/tf/model.py
@@ -50,21 +50,22 @@ class AcceleratedKerasModel(AcceleratedModel, tf.keras.Model):
 
     @staticmethod
     def tensors_to_numpy(tensors, dtype=None):
+        if isinstance(dtype, tf.DType):
+            dtype = dtype.as_numpy_dtype
         if isinstance(tensors, (list, tuple)):
             return type(tensors)(AcceleratedKerasModel.tensors_to_numpy(tensor, dtype)
                                  for tensor in tensors)
         elif isinstance(tensors, dict):
             return {key: AcceleratedKerasModel.tensors_to_numpy(value, dtype)
                     for key, value in tensors.items()}
-        elif isinstance(tensors, tf.Tensor):
+        elif isinstance(tensors, tf.Tensor) or is_torch_available and isinstance(tensors,
+                                                                                 torch.Tensor):
             if dtype is None:
                 return tensors.numpy()
             else:
                 return tensors.numpy().astype(dtype)
         elif isinstance(tensors, np.ndarray) and dtype is not None:
             return tensors.astype(dtype)
-        elif is_torch_available and isinstance(tensors, torch.Tensor):
-            return tensors.numpy()
         else:
             return tensors
 

--- a/python/nano/src/bigdl/nano/utils/util.py
+++ b/python/nano/src/bigdl/nano/utils/util.py
@@ -16,6 +16,7 @@
 
 import os
 import warnings
+import inspect
 from functools import wraps
 import cpuinfo
 from bigdl.nano.utils.log4Error import invalidInputError
@@ -192,3 +193,18 @@ class spawn_new_process(object):
             return return_val
         else:
             return self.func(*args, **kwargs)
+
+
+def get_default_args(func):
+    """
+    Check function `func` and get its arguments which has default value.
+
+    :param func: Function to check.
+    :return: A dict, contains arguments and their default values.
+    """
+    default_args = {}
+    signature = inspect.signature(func)
+    for param in signature.parameters.values():
+        if param.default is not param.empty:
+            default_args[param.name] = param.default
+    return default_args

--- a/python/nano/test/tf/keras/test_trace_and_quantize.py
+++ b/python/nano/test/tf/keras/test_trace_and_quantize.py
@@ -51,6 +51,8 @@ class TestTraceAndQuantize(TestCase):
         # try to access some custom attributes
         traced_model.do_nothing()
         assert traced_model.get_x() == traced_model.x == x
+        traced_model(np.random.random((1, 4)).astype(np.float32))
+        traced_model(inputs=np.random.random((1, 4)).astype(np.float32))
 
     def test_attribute_access_after_quantize(self):
         x = 100
@@ -65,6 +67,8 @@ class TestTraceAndQuantize(TestCase):
         # try to access some custom attributes
         quantized_model.do_nothing()
         assert quantized_model.get_x() == quantized_model.x == x
+        quantized_model(np.random.random((1, 4)).astype(np.float32))
+        quantized_model(inputs=np.random.random((1, 4)).astype(np.float32))
 
     def test_evaluate_after_trace(self):
         model = MyModel(100)


### PR DESCRIPTION
## Description

Fix passing arguments by kwargs or default value to keras onnx traced and quantized model

### 1. Why the change?

Support more cases

### 2. User API changes

User can pass argument by kwargs or default value now

### 3. Summary of the change 

- Fix passing arguments by kwargs or default value to keras onnx traced and quantized model
- Add a simple UT
- Add a util function to get default value of function's parameters


### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...
