### PR TITLE
[PPML] Update dcap 1.14 in container pccs

### DIFF
--- a/ppml/services/pccs/docker/Dockerfile
+++ b/ppml/services/pccs/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04 AS builder
 
 # DCAP version (github repo branch, tag or commit hash)
-ARG DCAP_VERSION=DCAP_1.13
+ARG DCAP_VERSION=DCAP_1.14
 ARG http_proxy
 ARG https_proxy
 
@@ -10,25 +10,25 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -yq && \
     apt-get upgrade -yq && \
     apt-get install -yq --no-install-recommends \
-            build-essential \
-            ca-certificates \
-            curl \
-            git \
-            zip  \
-            tzdata \
-            debhelper \
-            libcurl4-openssl-dev \
-            libcurl4 \
-            vim \
-            wget \
-            python \
-            systemctl
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    zip  \
+    tzdata \
+    debhelper \
+    libcurl4-openssl-dev \
+    libcurl4 \
+    vim \
+    wget \
+    python \
+    systemctl
 # install sgxsdk
 RUN mkdir /opt/intel && \
     cd /opt/intel && \
-    wget https://download.01.org/intel-sgx/sgx-dcap/1.13/linux/distro/ubuntu20.04-server/sgx_linux_x64_sdk_2.16.100.4.bin && \
-    chmod a+x ./sgx_linux_x64_sdk_2.16.100.4.bin && \
-    printf "no\n/opt/intel\n"|./sgx_linux_x64_sdk_2.16.100.4.bin && \
+    wget https://download.01.org/intel-sgx/sgx-dcap/1.14/linux/distro/ubuntu20.04-server/sgx_linux_x64_sdk_2.17.100.3.bin && \
+    chmod a+x ./sgx_linux_x64_sdk_2.17.100.3.bin && \
+    printf "no\n/opt/intel\n"|./sgx_linux_x64_sdk_2.17.100.3.bin && \
     . /opt/intel/sgxsdk/environment
 
 # install node.js
@@ -38,7 +38,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends n
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # clone DCAP repo
-RUN git clone https://github.com/Uxito-Ada/SGXDataCenterAttestationPrimitives.git -b ${DCAP_VERSION} --depth 1
+RUN git clone https://github.com/intel/SGXDataCenterAttestationPrimitives.git -b ${DCAP_VERSION} --depth 1
 
 # install MPA
 RUN mkdir /etc/init && cd /SGXDataCenterAttestationPrimitives/tools/SGXPlatformRegistration && \


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

DCAP 1.14 is needed for TDX quote generation/verification and PCE version 2.17. So update the dcap repo in `ppml/services/pccs/docker/Dockerfile`.