### PR TITLE
Add Torchserve to trusted-deep-learning.

### DIFF
--- a/ppml/trusted-deep-learning/base/Dockerfile
+++ b/ppml/trusted-deep-learning/base/Dockerfile
@@ -102,6 +102,8 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     sed -i '/import abc/iimport sys' /usr/local/lib/python3.7/dist-packages/ts/torch_handler/base_handler.py && \
     sed -i '/module = importlib.import_module/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.7/dist-packages/ts/torch_handler/base_handler.py && \
     sed -i 's/SOCKET_ACCEPT_TIMEOUT = 30.0/SOCKET_ACCEPT_TIMEOUT = 3000.0/' /usr/local/lib/python3.7/dist-packages/ts/model_service_worker.py && \
+    sed -i '/os.path.join/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.7/dist-packages/ts/model_loader.py && \
+    sed -i '/json/iimport sys' /usr/local/lib/python3.7/dist-packages/ts/model_loader.py && \
     cp /usr/local/lib/python3.7/dist-packages/ts/configs/metrics.yaml /ppml && \
     chmod +x /ppml/torchserve/start-backend-sgx.sh && \
     chmod +x /ppml/torchserve/start-frontend-sgx.sh && \

--- a/ppml/trusted-deep-learning/base/Dockerfile
+++ b/ppml/trusted-deep-learning/base/Dockerfile
@@ -102,8 +102,8 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     sed -i '/module = importlib.import_module/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.7/dist-packages/ts/torch_handler/base_handler.py && \
     sed -i 's/SOCKET_ACCEPT_TIMEOUT = 30.0/SOCKET_ACCEPT_TIMEOUT = 3000.0/' /usr/local/lib/python3.7/dist-packages/ts/model_service_worker.py && \
     cp /usr/local/lib/python3.7/dist-packages/ts/configs/metrics.yaml /ppml && \
-    chmod +x /ppml/work/start-scripts/start-backend-sgx.sh && \
-    chmod +x /ppml/work/start-scripts/start-frontend-sgx.sh && \
-    chmod +x /ppml/work/start-scripts/start-torchserve-sgx.sh && \
+    chmod +x /ppml/examples/start-backend-sgx.sh && \
+    chmod +x /ppml/examples/start-frontend-sgx.sh && \
+    chmod +x /ppml/examples/start-torchserve-sgx.sh
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/ppml/trusted-deep-learning/base/Dockerfile
+++ b/ppml/trusted-deep-learning/base/Dockerfile
@@ -34,7 +34,8 @@ ENV JAVA_HOME                           /opt/jdk${JDK_VERSION}
 ARG USE_CUDA=0 USE_CUDNN=0 USE_MKLDNN=1 USE_DISTRIBUTED=1 USE_GLOO=1 USE_GLOO_WITH_OPENSSL=1 USE_MKL=1 BUILD_TEST=0 BLAS=MKL
 ARG CMAKE_PREFIX_PATH="/usr/local/lib/python3.7/dist-packages/:/usr/local/lib/"
 
-RUN mkdir /ppml/examples
+RUN mkdir /ppml/examples && \
+    mkdir /ppml/torchserve
 
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin/tini
 ADD ./entrypoint.sh /opt/entrypoint.sh
@@ -49,10 +50,10 @@ ADD ./bash.manifest.template.patch /bash.manifest.template.patch
 
 # COPY frontend.jar
 COPY --from=temp /ppml/torchserve/frontend.jar /ppml/torchserve/frontend.jar
-# Examples for Torchserve
-ADD ./start-backend-sgx.sh      /ppml/examples/start-backend-sgx.sh
-ADD ./start-frontend-sgx.sh     /ppml/examples/start-frontend-sgx.sh
-ADD ./start-torchserve-sgx.sh   /ppml/examples/start-torchserve-sgx.sh
+# Start Script for Torchserve
+ADD ./start-backend-sgx.sh      /ppml/torchserve/start-backend-sgx.sh
+ADD ./start-frontend-sgx.sh     /ppml/torchserve/start-frontend-sgx.sh
+ADD ./start-torchserve-sgx.sh   /ppml/torchserve/start-torchserve-sgx.sh
 
 
 # PyTorch Dependencies
@@ -101,11 +102,9 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     sed -i '/import abc/iimport sys' /usr/local/lib/python3.7/dist-packages/ts/torch_handler/base_handler.py && \
     sed -i '/module = importlib.import_module/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.7/dist-packages/ts/torch_handler/base_handler.py && \
     sed -i 's/SOCKET_ACCEPT_TIMEOUT = 30.0/SOCKET_ACCEPT_TIMEOUT = 3000.0/' /usr/local/lib/python3.7/dist-packages/ts/model_service_worker.py && \
-    sed -i '/os.path.join/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.7/dist-packages/ts/model_loader.py && \
-    sed -i '/json/iimport sys' /usr/local/lib/python3.7/dist-packages/ts/model_loader.py && \
     cp /usr/local/lib/python3.7/dist-packages/ts/configs/metrics.yaml /ppml && \
-    chmod +x /ppml/examples/start-backend-sgx.sh && \
-    chmod +x /ppml/examples/start-frontend-sgx.sh && \
-    chmod +x /ppml/examples/start-torchserve-sgx.sh
+    chmod +x /ppml/torchserve/start-backend-sgx.sh && \
+    chmod +x /ppml/torchserve/start-frontend-sgx.sh && \
+    chmod +x /ppml/torchserve/start-torchserve-sgx.sh
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/ppml/trusted-deep-learning/base/Dockerfile
+++ b/ppml/trusted-deep-learning/base/Dockerfile
@@ -2,6 +2,24 @@ ARG BIGDL_VERSION=2.2.0-SNAPSHOT
 ARG TINI_VERSION=v0.18.0
 ARG BASE_IMAGE_NAME
 ARG BASE_IMAGE_TAG
+ARG JDK_VERSION=11
+
+#Stage.1 Torchserve Frontend
+FROM $BASE_IMAGE_NAME:$BASE_IMAGE_TAG as temp
+ARG http_proxy
+ARG https_proxy
+ARG JDK_VERSION
+ENV JDK_HOME                /opt/jdk${JDK_VERSION}
+ENV JAVA_HOME                           /opt/jdk${JDK_VERSION}
+
+RUN apt-get install -y openjdk-${JDK_VERSION}-jdk && \
+    mkdir -p ${JAVA_HOME} && \
+    cp -r /usr/lib/jvm/java-${JDK_VERSION}-openjdk-amd64/* ${JAVA_HOME} && \
+    git clone https://github.com/analytics-zoo/pytorch-serve.git && \
+    cd pytorch-serve/frontend && \
+    ./gradlew clean assemble && \
+    mkdir -p /ppml/torchserve && \
+    mv server/build/libs/server-1.0.jar /ppml/torchserve/frontend.jar
 
 FROM $BASE_IMAGE_NAME:$BASE_IMAGE_TAG
 ARG http_proxy
@@ -9,6 +27,9 @@ ARG https_proxy
 ARG no_proxy
 ARG TINI_VERSION
 ENV TINI_VERSION                        $TINI_VERSION
+ARG JDK_VERSION
+ENV JDK_HOME                            /opt/jdk${JDK_VERSION}
+ENV JAVA_HOME                           /opt/jdk${JDK_VERSION}
 # Environment used for build pytorch
 ARG USE_CUDA=0 USE_CUDNN=0 USE_MKLDNN=1 USE_DISTRIBUTED=1 USE_GLOO=1 USE_GLOO_WITH_OPENSSL=1 USE_MKL=1 BUILD_TEST=0 BLAS=MKL
 ARG CMAKE_PREFIX_PATH="/usr/local/lib/python3.7/dist-packages/:/usr/local/lib/"
@@ -25,6 +46,13 @@ ADD ./pert_ipex.py   /ppml/examples/pert_ipex.py
 # Patch for datasets
 ADD ./filelock.patch /filelock.patch
 ADD ./bash.manifest.template.patch /bash.manifest.template.patch
+
+# COPY frontend.jar
+COPY --from=temp /ppml/torchserve/frontend.jar /ppml/torchserve/frontend.jar
+# Examples for Torchserve
+ADD ./start-backend-sgx.sh      /ppml/examples/start-backend-sgx.sh
+ADD ./start-frontend-sgx.sh     /ppml/examples/start-frontend-sgx.sh
+ADD ./start-torchserve-sgx.sh   /ppml/examples/start-torchserve-sgx.sh
 
 
 # PyTorch Dependencies
@@ -61,7 +89,21 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
 # which is then required by our third-layer gramine make command
     patch /usr/local/lib/python3.7/dist-packages/datasets/utils/filelock.py /filelock.patch && \
     pip3 install --no-cache markupsafe==2.0.1 pyarrow==6.0.1 && \
-    patch /ppml/bash.manifest.template /bash.manifest.template.patch
-
+    patch /ppml/bash.manifest.template /bash.manifest.template.patch && \
+# Torchserve
+    pip install --no-cache-dir torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu && \
+    pip install --no-cache-dir cython pillow==9.0.1 captum packaging nvgpu && \
+    pip install --no-cache-dir torchserve==0.6.1 torch-model-archiver==0.6.1 torch-workflow-archiver==0.2.5 && \
+    apt-get install -y openjdk-${JDK_VERSION}-jdk && \
+    mkdir -p ${JAVA_HOME} && \
+    cp -r /usr/lib/jvm/java-${JDK_VERSION}-openjdk-amd64/* ${JAVA_HOME} && \
+    sed -i '/MAX_FAILURE_THRESHOLD = 5/ios.environ\[\"MPLCONFIGDIR\"\]=\"\/tmp\/matplotlib\"' /usr/local/lib/python3.7/dist-packages/ts/model_service_worker.py && \
+    sed -i '/import abc/iimport sys' /usr/local/lib/python3.7/dist-packages/ts/torch_handler/base_handler.py && \
+    sed -i '/module = importlib.import_module/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.7/dist-packages/ts/torch_handler/base_handler.py && \
+    sed -i 's/SOCKET_ACCEPT_TIMEOUT = 30.0/SOCKET_ACCEPT_TIMEOUT = 3000.0/' /usr/local/lib/python3.7/dist-packages/ts/model_service_worker.py && \
+    cp /usr/local/lib/python3.7/dist-packages/ts/configs/metrics.yaml /ppml && \
+    chmod +x /ppml/work/start-scripts/start-backend-sgx.sh && \
+    chmod +x /ppml/work/start-scripts/start-frontend-sgx.sh && \
+    chmod +x /ppml/work/start-scripts/start-torchserve-sgx.sh && \
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/ppml/trusted-deep-learning/base/Dockerfile
+++ b/ppml/trusted-deep-learning/base/Dockerfile
@@ -101,6 +101,8 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     sed -i '/import abc/iimport sys' /usr/local/lib/python3.7/dist-packages/ts/torch_handler/base_handler.py && \
     sed -i '/module = importlib.import_module/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.7/dist-packages/ts/torch_handler/base_handler.py && \
     sed -i 's/SOCKET_ACCEPT_TIMEOUT = 30.0/SOCKET_ACCEPT_TIMEOUT = 3000.0/' /usr/local/lib/python3.7/dist-packages/ts/model_service_worker.py && \
+    sed -i '/os.path.join/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.7/dist-packages/ts/model_loader.py && \
+    sed -i '/json/iimport sys' /usr/local/lib/python3.7/dist-packages/ts/model_loader.py && \
     cp /usr/local/lib/python3.7/dist-packages/ts/configs/metrics.yaml /ppml && \
     chmod +x /ppml/examples/start-backend-sgx.sh && \
     chmod +x /ppml/examples/start-frontend-sgx.sh && \

--- a/ppml/trusted-deep-learning/base/start-backend-sgx.sh
+++ b/ppml/trusted-deep-learning/base/start-backend-sgx.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+port=9000
+while getopts "p:" opt
+do
+    case $opt in
+        p)
+            port=$OPTARG
+        ;;
+    esac
+done
+
+cd /ppml
+export sgx_command="/usr/bin/python3 /usr/local/lib/python3.7/dist-packages/ts/model_service_worker.py --sock-type tcp --port $port --metrics-config /ppml/metrics.yaml"
+gramine-sgx bash 2>&1 | tee backend-sgx.log
+

--- a/ppml/trusted-deep-learning/base/start-frontend-sgx.sh
+++ b/ppml/trusted-deep-learning/base/start-frontend-sgx.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+configFile=""
+while getopts "c:" opt
+do
+    case $opt in
+        c)
+            configFile=$OPTARG
+        ;;
+    esac
+done
+
+cd /ppml
+export sgx_command="/opt/jdk11/bin/java \
+        -Dmodel_server_home=/usr/local/lib/python3.7/dist-packages \
+        -cp .:/ppml/torchserve/* \
+        -Xmx30g \
+        -Xms30g \
+        org.pytorch.serve.ModelServer \
+        --python /usr/bin/python3 \
+        -f $configFile \
+        -ncs"
+gramine-sgx bash 2>&1 | tee frontend-sgx.log
+

--- a/ppml/trusted-deep-learning/base/start-torchserve-sgx.sh
+++ b/ppml/trusted-deep-learning/base/start-torchserve-sgx.sh
@@ -1,0 +1,33 @@
+configFile=""
+while getopts "c:" opt
+do
+    case $opt in
+        c)
+            configFile=$OPTARG
+        ;;
+    esac
+done
+cd /ppml
+./init.sh
+port=9000
+cat $configFile | while read line
+do
+        while [[ $line =~ "minWorkers" ]]
+        do
+                line=${line#*\"minWorkers\": }
+                num=${line%%,*}
+                line=${line#*,}
+
+                for ((i=0;i<num;i++,port++))
+                do
+                (
+                        bash /ppml/work/start-scripts/start-backend-sgx.sh -p $port
+                )&
+                done
+        done
+done
+(
+        bash /ppml/work/start-scripts/start-frontend-sgx.sh -c $configFile
+)&
+wait
+

--- a/ppml/trusted-deep-learning/base/start-torchserve-sgx.sh
+++ b/ppml/trusted-deep-learning/base/start-torchserve-sgx.sh
@@ -21,13 +21,13 @@ do
                 for ((i=0;i<num;i++,port++))
                 do
                 (
-                        bash /ppml/work/start-scripts/start-backend-sgx.sh -p $port
+                        bash /ppml/torchserve/start-backend-sgx.sh -p $port
                 )&
                 done
         done
 done
 (
-        bash /ppml/work/start-scripts/start-frontend-sgx.sh -c $configFile
+        bash /ppml/torchserve/start-frontend-sgx.sh -c $configFile
 )&
 wait
 


### PR DESCRIPTION
## Description

Add Torchserve to trusted-deep-learning.

### 1. Why the change?

Enable Torchserve in trusted-deep-learning.

### 2. User API changes

You can use Torchserve in sgx like following:
bash start-torchserve-sgx.sh -c your_config_file 
