### PR TITLE
Nano: fix some output format issue

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -474,8 +474,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                                        self._calculate_accuracy)
         if self._calculate_accuracy:
             # only show this line when there is accuracy data
-            self._optimize_result += "* means we assume the accuracy of the traced model does "\
-                "not change, so we don't recompute accuracy to save time.\n"
+            self._optimize_result += "* means we assume the metric value of the traced "\
+                "model does not change, so we don't recompute metric value to save time.\n"
         # save time cost to self._optimize_result
         time_cost = time.perf_counter() - start_time
         time_cost_str = f"Optimization cost {time_cost:.1f}s in total."

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -473,9 +473,10 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         self._optimize_result = format_optimize_result(self.optimized_model_dict,
                                                        self._calculate_accuracy)
         if self._calculate_accuracy:
-            # only show this line when there is accuracy data
-            self._optimize_result += "* means we assume the metric value of the traced "\
-                "model does not change, so we don't recompute metric value to save time.\n"
+            if precision is None or 'fp32' in precision:
+                # only show this line when there is traced model and metric value
+                self._optimize_result += "* means we assume the metric value of the traced "\
+                    "model does not change, so we don't recompute metric value to save time.\n"
         # save time cost to self._optimize_result
         time_cost = time.perf_counter() - start_time
         time_cost_str = f"Optimization cost {time_cost:.1f}s in total."

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -285,8 +285,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                                        self._calculate_accuracy)
         if self._calculate_accuracy:
             # only show this line when there is accuracy data
-            self._optimize_result += "* means we assume the accuracy of the traced model does "\
-                "not change, so we don't recompute accuracy to save time.\n"
+            self._optimize_result += "* means we assume the metric value of the traced "\
+                "model does not change, so we don't recompute metric value to save time.\n"
         # save time cost to self._optimize_result
         time_cost = time.perf_counter() - start_time
         time_cost_str = f"Optimization cost {time_cost:.1f}s in total."

--- a/python/nano/src/bigdl/nano/utils/inference/common/utils.py
+++ b/python/nano/src/bigdl/nano/utils/inference/common/utils.py
@@ -121,7 +121,7 @@ def format_optimize_result(optimize_result_dict: dict,
             .format("-" * 32, "-" * 22, "-" * 14, "-" * 22)
         repr_str = horizontal_line
         repr_str += "| {0:^30} | {1:^20} | {2:^12} | {3:^20} |\n" \
-            .format("method", "status", "latency(ms)", "accuracy")
+            .format("method", "status", "latency(ms)", "metric value")
         repr_str += horizontal_line
         for method, result in optimize_result_dict.items():
             status = result["status"]

--- a/python/nano/src/bigdl/nano/utils/inference/common/utils.py
+++ b/python/nano/src/bigdl/nano/utils/inference/common/utils.py
@@ -130,7 +130,6 @@ def format_optimize_result(optimize_result_dict: dict,
             if latency != "None":
                 latency = round(latency, 3)
             accuracy = result.get("accuracy", "None")
-            print(method, accuracy)
             if accuracy != "None" and isinstance(accuracy, float):
                 accuracy = round(accuracy, 3)
             elif isinstance(accuracy, numbers.Real):

--- a/python/nano/src/bigdl/nano/utils/inference/common/utils.py
+++ b/python/nano/src/bigdl/nano/utils/inference/common/utils.py
@@ -16,6 +16,7 @@
 
 from collections import namedtuple
 import time
+import numbers
 import numpy as np
 from typing import Dict
 from abc import abstractmethod
@@ -100,7 +101,7 @@ def format_acceleration_option(method_name: str,
                 repr_str = repr_str + "int8" + " + "
             else:
                 repr_str = repr_str + key + " + "
-        elif isinstance(value, str):
+        elif isinstance(value, str) and value != 'ipex':
             repr_str = repr_str + value + " + "
     if len(repr_str) > 0:
         # remove " + " at last
@@ -130,6 +131,10 @@ def format_optimize_result(optimize_result_dict: dict,
                 latency = round(latency, 3)
             accuracy = result.get("accuracy", "None")
             if accuracy != "None" and isinstance(accuracy, float):
+                accuracy = round(accuracy, 3)
+            elif isinstance(accuracy, numbers.Real):
+                # support more types
+                accuracy = float(accuracy)
                 accuracy = round(accuracy, 3)
             else:
                 try:

--- a/python/nano/src/bigdl/nano/utils/inference/common/utils.py
+++ b/python/nano/src/bigdl/nano/utils/inference/common/utils.py
@@ -130,6 +130,7 @@ def format_optimize_result(optimize_result_dict: dict,
             if latency != "None":
                 latency = round(latency, 3)
             accuracy = result.get("accuracy", "None")
+            print(method, accuracy)
             if accuracy != "None" and isinstance(accuracy, float):
                 accuracy = round(accuracy, 3)
             elif isinstance(accuracy, numbers.Real):


### PR DESCRIPTION
## Description

fix some output format issue

### 1. Why the change?

https://github.com/intel-analytics/IBM-Watson-PoC/pull/3

### 2. User API changes

No change.

### 3. Summary of the change 

- change `accuracy` to `metric value` in the output table of `optimize`
- fix output option name of static_int8_ipex ， `inc + ipex + ipex` -> `inc + ipex`
- support more types of accuracy, like numpy.fp32 / numpy.fp64

demo output after fix:
![image](https://user-images.githubusercontent.com/105281011/208630518-76903844-15e8-4588-9832-268b70b83ea9.png)

### 4. How to test?
- [x] Unit test

