### PR TITLE
Nano: Fix keras model.compile

### DIFF
--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -24,8 +24,7 @@ from bigdl.nano.utils.inference.common.base_optimizer import BaseInferenceOptimi
 from bigdl.nano.utils.inference.common.checker import available_acceleration_combination
 from bigdl.nano.utils.inference.common.utils import AccelerationOption,\
     throughput_calculate_helper, format_optimize_result
-from bigdl.nano.tf.keras import Model as NanoModel
-from bigdl.nano.tf.utils import patch_attrs
+from bigdl.nano.tf.utils import patch_compiled, patch_attrs
 from bigdl.nano.utils.log4Error import invalidInputError
 from tensorflow.keras import Model as Model
 from tensorflow.data import Dataset
@@ -336,6 +335,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             result = KerasONNXRuntimeModel(model, input_spec, onnxruntime_session_options)
         else:
             invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))
+        patch_compiled(result, model)
         return patch_attrs(result, model)
 
     @staticmethod
@@ -526,6 +526,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                   onnxruntime_session_options=onnxruntime_session_options)
         else:
             invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))
+        patch_compiled(result, model)
         return patch_attrs(result, model)
 
 

--- a/python/nano/test/tf/keras/test_trace_and_quantize.py
+++ b/python/nano/test/tf/keras/test_trace_and_quantize.py
@@ -17,6 +17,7 @@ from unittest import TestCase
 
 import numpy as np
 import tensorflow as tf
+from tensorflow.keras.metrics import MeanSquaredError
 
 from bigdl.nano.tf.keras import InferenceOptimizer
 
@@ -65,3 +66,12 @@ class TestTraceAndQuantize(TestCase):
         quantized_model.do_nothing()
         assert quantized_model.get_x() == quantized_model.x == x
 
+    def test_evaluate_after_trace(self):
+        model = MyModel(100)
+        model.compile(loss='mse', metrics=MeanSquaredError())
+        x = np.random.random((100, 4))
+        y = np.random.random((100, 5))
+
+        traced_model = InferenceOptimizer.trace(model, accelerator="onnxruntime",
+                                                input_spec=tf.TensorSpec(shape=(None, 4), dtype=tf.float32))
+        traced_model.evaluate(x=x, y=y)


### PR DESCRIPTION
## Description

If a model has called `model.compile()`, then after trace or quantize, it will lose its loss function and metrics and have to call `compile` once again, this PR fix this issue.

