### PR TITLE
Nano: support more devices and more precision for openvino

### DIFF
--- a/.github/workflows/nano_unit_tests_tensorflow.yml
+++ b/.github/workflows/nano_unit_tests_tensorflow.yml
@@ -153,7 +153,7 @@ jobs:
             bash python/nano/dev/build_and_install.sh linux default false ${{matrix.tf-version}}
           fi
           pip install pytest
-          pip install openvino-dev
+          pip install openvino-dev==2022.2.0
           pip install numpy==1.21.6
           source bigdl-nano-init
           bash python/nano/test/run-nano-tf-openvino-tests.sh

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -27,6 +27,8 @@ import numpy as np
 class OpenVINOModel:
     def __init__(self, ie_network: str, device='CPU', thread_num=None, config=None):
         self._ie = Core()
+        # check device
+        self._check_device(self._ie, device)
         self._device = device
         self.thread_num = thread_num
         self.additional_config = config
@@ -52,6 +54,12 @@ class OpenVINOModel:
 
     def __call__(self, *inputs):
         return self.forward(*inputs)
+
+    def _check_device(self, ie, device):
+        devices = ie.available_devices
+        invalidInputError(device in devices,
+                          "Your machine don't have {} device, please modify the incoming "
+                          "device value.".format(device))
 
     @property
     def forward_args(self):

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -67,7 +67,7 @@ class OpenVINOModel:
             self._ie_network = self._ie.read_model(model=str(model))
         else:
             self._ie_network = model
-        if self.thread_num is not None:
+        if self.thread_num is not None and self._device == 'CPU':
             config = {"CPU_THREADS_NUM": str(self.thread_num)}
         else:
             config = {}

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -71,7 +71,8 @@ class OpenVINOModel:
             config = {"CPU_THREADS_NUM": str(self.thread_num)}
         else:
             config = {}
-        if self.additional_config is not None:
+        if self.additional_config is not None and self._device == 'CPU':
+            # TODO: check addition config based on device
             config.update(self.additional_config)
         self._compiled_model = self._ie.compile_model(model=self.ie_network,
                                                       device_name=self._device,

--- a/python/nano/src/bigdl/nano/deps/openvino/core/utils.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/utils.py
@@ -19,13 +19,17 @@ from bigdl.nano.utils.log4Error import invalidInputError
 from openvino.runtime.passes import Manager
 
 
-def convert_onnx_to_xml(onnx_file_path, xml_path, logging=True, batch_size=1):
+def convert_onnx_to_xml(onnx_file_path, xml_path, precision,
+                        logging=True, batch_size=1):
     xml_path = Path(xml_path)
     model_name, output_dir = str(xml_path.stem), str(xml_path.parent)
-    if logging:
-        mo_cmd = "mo -m {} -n {} -o {}".format(str(onnx_file_path), model_name, output_dir)
-    else:
-        mo_cmd = "mo -m {} --silent -n {} -o {}".format(str(onnx_file_path), model_name, output_dir)
+    logging_cmd = "--silent " if logging is True else ""
+    precision_cmd = "--data_type FP16 " if precision == 'fp16' else ""
+    mo_cmd = "mo -m {} {}{}-n {} -o {}".format(str(onnx_file_path),
+                                               logging_cmd,
+                                               precision_cmd,
+                                               model_name,
+                                               output_dir)
 
     p = subprocess.Popen(mo_cmd.split())
     p.communicate()
@@ -33,17 +37,17 @@ def convert_onnx_to_xml(onnx_file_path, xml_path, logging=True, batch_size=1):
                       "ModelOptimizer fails to convert {}.".format(str(onnx_file_path)))
 
 
-def convert_pb_to_xml(pb_file_path, xml_path, logging=True, batch_size=1):
+def convert_pb_to_xml(pb_file_path, xml_path, precision,
+                      logging=True, batch_size=1):
     xml_path = Path(xml_path)
     model_name, output_dir = str(xml_path.stem), str(xml_path.parent)
-    if logging:
-        mo_cmd = "mo --saved_model_dir {} -n {} -o {}".format(str(pb_file_path),
+    logging_cmd = "--silent " if logging is True else ""
+    precision_cmd = "--data_type FP16 " if precision == 'fp16' else ""
+    mo_cmd = "mo --saved_model_dir {} {}{}-n {} -o {}".format(str(pb_file_path),
+                                                              logging_cmd,
+                                                              precision_cmd,
                                                               model_name,
                                                               output_dir)
-    else:
-        mo_cmd = "mo --saved_model_dir {} --silent -n {} -o {}".format(str(pb_file_path),
-                                                                       model_name,
-                                                                       output_dir)
 
     p = subprocess.Popen(mo_cmd.split())
     p.communicate()

--- a/python/nano/src/bigdl/nano/deps/openvino/core/utils.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/utils.py
@@ -23,11 +23,11 @@ def convert_onnx_to_xml(onnx_file_path, xml_path, precision,
                         logging=True, batch_size=1):
     xml_path = Path(xml_path)
     model_name, output_dir = str(xml_path.stem), str(xml_path.parent)
-    logging_cmd = "--silent " if logging is True else ""
-    precision_cmd = "--data_type FP16 " if precision == 'fp16' else ""
+    logging_str = "--silent " if logging is False else ""
+    precision_str = "--data_type FP16 " if precision == 'fp16' else ""
     mo_cmd = "mo -m {} {}{}-n {} -o {}".format(str(onnx_file_path),
-                                               logging_cmd,
-                                               precision_cmd,
+                                               logging_str,
+                                               precision_str,
                                                model_name,
                                                output_dir)
 
@@ -41,14 +41,14 @@ def convert_pb_to_xml(pb_file_path, xml_path, precision,
                       logging=True, batch_size=1):
     xml_path = Path(xml_path)
     model_name, output_dir = str(xml_path.stem), str(xml_path.parent)
-    logging_cmd = "--silent " if logging is True else ""
-    precision_cmd = "--data_type FP16 " if precision == 'fp16' else ""
+    logging_str = "--silent " if logging is False else ""
+    precision_str = "--data_type FP16 " if precision == 'fp16' else ""
     mo_cmd = "mo --saved_model_dir {} {}{}-n {} -o {}".format(str(pb_file_path),
-                                                              logging_cmd,
-                                                              precision_cmd,
+                                                              logging_str,
+                                                              precision_str,
                                                               model_name,
                                                               output_dir)
-
+    print(mo_cmd)
     p = subprocess.Popen(mo_cmd.split())
     p.communicate()
     invalidInputError(not p.returncode,

--- a/python/nano/src/bigdl/nano/deps/openvino/core/utils.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/utils.py
@@ -48,7 +48,7 @@ def convert_pb_to_xml(pb_file_path, xml_path, precision,
                                                               precision_str,
                                                               model_name,
                                                               output_dir)
-    print(mo_cmd)
+
     p = subprocess.Popen(mo_cmd.split())
     p.communicate()
     invalidInputError(not p.returncode,

--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -16,8 +16,9 @@
 from functools import partial
 
 
-def PytorchOpenVINOModel(model, input_sample=None, thread_num=None,
-                         device='CPU', dynamic_axes=True, logging=True,
+def PytorchOpenVINOModel(model, input_sample=None, precision='fp32',
+                         thread_num=None, device='CPU',
+                         dynamic_axes=True, logging=True,
                          config=None, **export_kwargs):
     """
     Create a OpenVINO model from pytorch.
@@ -26,10 +27,12 @@ def PytorchOpenVINOModel(model, input_sample=None, thread_num=None,
                   path to Openvino saved model.
     :param input_sample: A set of inputs for trace, defaults to None if you have trace before or
                          model is a LightningModule with any dataloader attached, defaults to None.
+    :param precision: Global precision of model, supported type: 'fp32', 'fp16',
+                      defaults to 'fp32'.
     :param thread_num: a int represents how many threads(cores) is needed for
                        inference. default: None.
     :param device: (optional) A string represents the device of the inference. Default to 'CPU'.
-                   'CPU', 'GPU' and 'VPU' are supported for now.
+                   'CPU', 'GPU' and 'VPUX' are supported for now.
     :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
                          will have the first dim of each Tensor input as a dynamic batch_size.
                          If dynamic_axes=False, the exported model will have the shapes of all
@@ -52,6 +55,7 @@ def PytorchOpenVINOModel(model, input_sample=None, thread_num=None,
     from .pytorch.model import PytorchOpenVINOModel
     return PytorchOpenVINOModel(model=model,
                                 input_sample=input_sample,
+                                precision=precision,
                                 thread_num=thread_num,
                                 device=device,
                                 dynamic_axes=dynamic_axes,
@@ -65,23 +69,26 @@ def load_openvino_model(path):
     return PytorchOpenVINOModel._load(path)
 
 
-def KerasOpenVINOModel(model, thread_num=None, device='CPU',
-                       config=None, logging=True):
+def KerasOpenVINOModel(model, precision='fp32', thread_num=None,
+                       device='CPU', config=None, logging=True):
     """
     Create a OpenVINO model from Keras.
 
     :param model: Keras model to be converted to OpenVINO for inference or
                   path to Openvino saved model.
+    :param precision: Global precision of model, supported type: 'fp32', 'fp16',
+                      defaults to 'fp32'.
     :param thread_num: a int represents how many threads(cores) is needed for
                        inference. default: None.
     :param device: (optional) A string represents the device of the inference. Default to 'CPU'.
-                   'CPU', 'GPU' and 'VPU' are supported for now.
+                   'CPU', 'GPU' and 'VPUX' are supported for now.
     :param config: The config to be inputted in core.compile_model.
     :param logging: whether to log detailed information of model conversion. default: True.
     :return: KerasOpenVINOModel model for OpenVINO inference.
     """
     from .tf.model import KerasOpenVINOModel
     return KerasOpenVINOModel(model=model,
+                              precision=precision,
                               thread_num=thread_num,
                               device=device,
                               config=config,

--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -64,9 +64,16 @@ def PytorchOpenVINOModel(model, input_sample=None, precision='fp32',
                                 **export_kwargs)
 
 
-def load_openvino_model(path):
+def load_openvino_model(path, device=None):
+    """
+    Load an OpenVINO model for inference from directory.
+
+    :param path: Path to model to be loaded.
+    :param device: A string represents the device of the inference.
+    :return: PytorchOpenVINOModel model for OpenVINO inference.
+    """
     from .pytorch.model import PytorchOpenVINOModel
-    return PytorchOpenVINOModel._load(path)
+    return PytorchOpenVINOModel._load(path, device=device)
 
 
 def KerasOpenVINOModel(model, precision='fp32', thread_num=None,

--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -17,7 +17,7 @@ from functools import partial
 
 
 def PytorchOpenVINOModel(model, input_sample=None, thread_num=None,
-                         dynamic_axes=True, logging=True,
+                         device='CPU', dynamic_axes=True, logging=True,
                          config=None, **export_kwargs):
     """
     Create a OpenVINO model from pytorch.
@@ -28,6 +28,8 @@ def PytorchOpenVINOModel(model, input_sample=None, thread_num=None,
                          model is a LightningModule with any dataloader attached, defaults to None.
     :param thread_num: a int represents how many threads(cores) is needed for
                        inference. default: None.
+    :param device: (optional) A string represents the device of the inference. Default to 'CPU'.
+                   'CPU', 'GPU' and 'VPU' are supported for now.
     :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
                          will have the first dim of each Tensor input as a dynamic batch_size.
                          If dynamic_axes=False, the exported model will have the shapes of all
@@ -51,6 +53,7 @@ def PytorchOpenVINOModel(model, input_sample=None, thread_num=None,
     return PytorchOpenVINOModel(model=model,
                                 input_sample=input_sample,
                                 thread_num=thread_num,
+                                device=device,
                                 dynamic_axes=dynamic_axes,
                                 logging=logging,
                                 config=config,
@@ -62,7 +65,8 @@ def load_openvino_model(path):
     return PytorchOpenVINOModel._load(path)
 
 
-def KerasOpenVINOModel(model, thread_num=None, config=None, logging=True):
+def KerasOpenVINOModel(model, thread_num=None, device='CPU',
+                       config=None, logging=True):
     """
     Create a OpenVINO model from Keras.
 
@@ -70,12 +74,18 @@ def KerasOpenVINOModel(model, thread_num=None, config=None, logging=True):
                   path to Openvino saved model.
     :param thread_num: a int represents how many threads(cores) is needed for
                        inference. default: None.
+    :param device: (optional) A string represents the device of the inference. Default to 'CPU'.
+                   'CPU', 'GPU' and 'VPU' are supported for now.
     :param config: The config to be inputted in core.compile_model.
     :param logging: whether to log detailed information of model conversion. default: True.
     :return: KerasOpenVINOModel model for OpenVINO inference.
     """
     from .tf.model import KerasOpenVINOModel
-    return KerasOpenVINOModel(model, thread_num=thread_num, config=config, logging=logging)
+    return KerasOpenVINOModel(model=model,
+                              thread_num=thread_num,
+                              device=device,
+                              config=config,
+                              logging=logging)
 
 
 def OpenVINOModel(model, device='CPU'):

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -73,8 +73,8 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
                     # workaround for dynamic shape issue on GPU/VPU plugin
                     dynamic_axes = False
                 export(model, input_sample, str(tmpdir / 'tmp.xml'),
-                       dynamic_axes=dynamic_axes, logging=logging,
-                       **export_kwargs)
+                       precision=precision, dynamic_axes=dynamic_axes,
+                       logging=logging, **export_kwargs)
                 ov_model_path = tmpdir / 'tmp.xml'
 
             self.ov_model = OpenVINOModel(ov_model_path,

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -31,8 +31,8 @@ from bigdl.nano.pytorch.utils import patch_attrs_from_model_to_object
 
 class PytorchOpenVINOModel(AcceleratedLightningModule):
     def __init__(self, model, input_sample=None, thread_num=None,
-                 dynamic_axes=True, logging=True, config=None,
-                 **export_kwargs):
+                 device='CPU', dynamic_axes=True, logging=True,
+                 config=None, **export_kwargs):
         """
         Create a OpenVINO model from pytorch.
 
@@ -43,6 +43,8 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
                              defaults to None.
         :param thread_num: a int represents how many threads(cores) is needed for
                            inference. default: None.
+        :param device: A string represents the device of the inference. Default to 'CPU'.
+                       'CPU', 'GPU' and 'VPU' are supported for now.
         :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
                              will have the first dim of each Tensor input as a dynamic batch_size.
                              If dynamic_axes=False, the exported model will have the shapes of all
@@ -70,7 +72,10 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
                        **export_kwargs)
                 ov_model_path = tmpdir / 'tmp.xml'
 
-            self.ov_model = OpenVINOModel(ov_model_path, thread_num=thread_num, config=config)
+            self.ov_model = OpenVINOModel(ov_model_path,
+                                          device=device,
+                                          thread_num=thread_num,
+                                          config=config)
             super().__init__(None)
         self._nano_context_manager = generate_context_manager(accelerator="openvino",
                                                               precision="fp32",

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/utils.py
@@ -20,7 +20,8 @@ from pathlib import Path
 
 
 def export(model, input_sample=None, xml_path="model.xml",
-           dynamic_axes=True, logging=True, **kwargs):
+           precision='fp32', dynamic_axes=True, logging=True,
+           **kwargs):
     '''
     Function to export pytorch model into openvino and save it to local.
     Any instance of torch.nn.Module including Lightning Module is acceptable.
@@ -28,6 +29,8 @@ def export(model, input_sample=None, xml_path="model.xml",
     :param model: Model instance of torch.nn.module to be exported.
     :param input_sample: torch.Tensor or a list for the model tracing.
     :param xml_path: The path to save openvino model file.
+    :param precision: Global precision of model, supported type: 'fp32', 'fp16',
+                      defaults to 'fp32'.
     :param dynamic_axes: parameter of torch.onnx.export.
     :param logging: whether to log detailed information of model conversion. default: True.
     :param **kwargs: will be passed to torch.onnx.export function.
@@ -38,4 +41,5 @@ def export(model, input_sample=None, xml_path="model.xml",
         onnx_path = str(folder / 'tmp.onnx')
         export_to_onnx(model, input_sample, onnx_path,
                        dynamic_axes=dynamic_axes, **kwargs)
-        convert_onnx_to_xml(onnx_path, xml_path, logging=logging)
+        convert_onnx_to_xml(onnx_path, xml_path, precision=precision,
+                            logging=logging)

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -26,7 +26,8 @@ from ..core.utils import save
 
 
 class KerasOpenVINOModel(AcceleratedKerasModel):
-    def __init__(self, model, thread_num=None, config=None, logging=True):
+    def __init__(self, model, thread_num=None, device='CPU',
+                 config=None, logging=True):
         """
         Create a OpenVINO model from Keras.
 
@@ -34,6 +35,8 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
                       path to Openvino saved model.
         :param thread_num: a int represents how many threads(cores) is needed for
                     inference. default: None.
+        :param device: A string represents the device of the inference. Default to 'CPU'.
+                       'CPU', 'GPU' and 'VPU' are supported for now.
         :param config: The config to be inputted in core.compile_model.
                        inference. default: None.
         :param logging: whether to log detailed information of model conversion.
@@ -46,6 +49,7 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
                 export(model, str(dir / 'tmp.xml'), logging=logging)
                 ov_model_path = dir / 'tmp.xml'
             self.ov_model = OpenVINOModel(ov_model_path,
+                                          device=device,
                                           thread_num=thread_num,
                                           config=config)
             super().__init__(None)

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -26,13 +26,15 @@ from ..core.utils import save
 
 
 class KerasOpenVINOModel(AcceleratedKerasModel):
-    def __init__(self, model, thread_num=None, device='CPU',
-                 config=None, logging=True):
+    def __init__(self, model, precision='fp32', thread_num=None,
+                 device='CPU', config=None, logging=True):
         """
         Create a OpenVINO model from Keras.
 
         :param model: Keras model to be converted to OpenVINO for inference or
                       path to Openvino saved model.
+        :param precision: Global precision of model, supported type: 'fp32', 'fp16',
+                          defaults to 'fp32'.
         :param thread_num: a int represents how many threads(cores) is needed for
                     inference. default: None.
         :param device: A string represents the device of the inference. Default to 'CPU'.
@@ -46,7 +48,9 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
         with TemporaryDirectory() as dir:
             dir = Path(dir)
             if isinstance(model, tf.keras.Model):
-                export(model, str(dir / 'tmp.xml'), logging=logging)
+                export(model, str(dir / 'tmp.xml'),
+                       precision=precision,
+                       logging=logging)
                 ov_model_path = dir / 'tmp.xml'
             self.ov_model = OpenVINOModel(ov_model_path,
                                           device=device,

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/utils.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/utils.py
@@ -18,18 +18,20 @@ from ..core.utils import convert_pb_to_xml
 from pathlib import Path
 
 
-def export(model, xml_path="model.xml", logging=True):
+def export(model, xml_path="model.xml", precision='fp32', logging=True):
     '''
     Function to export pytorch model into openvino and save it to local.
     Any instance of torch.nn.Module including Lightning Module is acceptable.
 
     :param model: Model instance of torch.nn.module to be exported.
-    :param input_sample: torch.Tensor or a list for the model tracing.
     :param xml_path: The path to save openvino model file.
+    :param precision: Global precision of model, supported type: 'fp32', 'fp16',
+                      defaults to 'fp32'.
+    :param logging: whether to log detailed information of model conversion. default: True.
     '''
     # export a model with dynamic axes to enable IR to accept different batches and resolutions
     with TemporaryDirectory() as folder:
         folder = Path(folder)
         pb_path = str(folder)
         model.save(str(folder))
-        convert_pb_to_xml(pb_path, xml_path, logging=logging)
+        convert_pb_to_xml(pb_path, xml_path, precision=precision, logging=logging)

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -802,7 +802,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                                  **export_kwargs)
                 invalidInputError(type(model).__name__ == 'PytorchOpenVINOModel',
                                   "Invalid model to quantize. Please use a nn.Module or a model "
-                                  "from trainer.trance(accelerator=='openvino')")
+                                  "from InferenceOptimizer.trace(accelerator=='openvino')")
                 drop_type = None
                 higher_is_better = None
                 maximal_drop = None
@@ -830,8 +830,10 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 invalidInputError(False,
                                   "Accelerator {} is invalid.".format(accelerator))
         if precision == 'fp16':
-            invalidInputError(accelerator != 'openvino' or device not in ('GPU', 'VPUX'),
+            invalidInputError(device in ('GPU', 'VPUX'),
                               "fp16 is not supported on {} device.".format(device))
+            invalidInputError(accelerator == 'openvino',
+                              "fp16 is not supported on {} accelerator.".format(accelerator))
             if openvino_config is not None:
                 final_openvino_option = openvino_config
             return PytorchOpenVINOModel(model, input_sample,

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -790,14 +790,16 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                     if input_sample is None:
                         # input_sample can be a dataloader
                         input_sample = calib_dataloader
-                    model = InferenceOptimizer.trace(model,
-                                                     input_sample=input_sample,
-                                                     accelerator='openvino',
-                                                     thread_num=thread_num,
-                                                     device=device,
-                                                     dynamic_axes=dynamic_axes,
-                                                     logging=logging,
-                                                     **export_kwargs)
+                    # For CPU: fp32 -> int8, for GPU: fp16 -> int8
+                    _precision = 'fp16' if device != 'CPU' else 'fp32'
+                    model = PytorchOpenVINOModel(model, input_sample,
+                                                 precision=_precision,
+                                                 thread_num=thread_num,
+                                                 device=device,
+                                                 dynamic_axes=dynamic_axes,
+                                                 logging=logging,
+                                                 config=openvino_config,
+                                                 **export_kwargs)
                 invalidInputError(type(model).__name__ == 'PytorchOpenVINOModel',
                                   "Invalid model to quantize. Please use a nn.Module or a model "
                                   "from trainer.trance(accelerator=='openvino')")

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -587,7 +587,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                            parameter.
         :param device: (optional) A string represents the device of the inference. Default to 'CPU',
                         only valid when accelerator='openvino', otherwise will be ignored.
-                        'CPU', 'GPU' and 'VPU' are supported for now.
+                        'CPU', 'GPU' and 'VPUX' are supported for now.
         :param onnxruntime_session_options: The session option for onnxruntime, only valid when
                                             accelerator='onnxruntime', otherwise will be ignored.
         :param openvino_config: The config to be inputted in core.compile_model. Only valid when
@@ -647,8 +647,11 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         invalidInputError(precision not in ['int8', 'fp16', 'bf16'],
                           "Only support 'int8', 'bf16', 'fp16' now, "
                           "no support for {}.".format(precision))
-        invalidInputError(device != 'CPU' and accelerator != 'openvino',
-                          "Now we only support {} device when accelerator is openvino.".format(device))
+        invalidInputError(device == 'CPU' or 'GPU' in device or device == 'VPUX',
+                          "Now we only support CPU, GPU and VPUX, not {}".format(device))
+        if device != 'CPU' and accelerator != 'openvino':
+            invalidInputError(False,
+                              "Now we only support {} device when accelerator is openvino.".format(device))
         if precision == 'bf16':
             if accelerator is None or accelerator == "jit":
                 if use_ipex or accelerator == "jit":
@@ -880,7 +883,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                            parameter.
         :param device: (optional) A string represents the device of the inference. Default to 'CPU',
                                   only valid when accelerator='openvino', otherwise will be ignored.
-                                  'CPU', 'GPU' and 'VPU' are supported for now.
+                                  'CPU', 'GPU' are supported for now.
         :param onnxruntime_session_options: The session option for onnxruntime, only valid when
                                             accelerator='onnxruntime', otherwise will be ignored.
         :param openvino_config: The config to be inputted in core.compile_model. Only valid when
@@ -930,8 +933,11 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             "Expect a nn.Module instance that is not traced or quantized"
             "but got type {}".format(type(model))
         )
-        invalidInputError(device != 'CPU' and accelerator != 'openvino',
-                          "Now we only support {} device when accelerator is openvino.".format(device))
+        invalidInputError(device == 'CPU' or 'GPU' in device,
+                          "Now we only support fp32 for CPU and GPU, not {}".format(device))
+        if device != 'CPU' and accelerator != 'openvino':
+            invalidInputError(False,
+                              "Now we only support {} device when accelerator is openvino.".format(device))
         if accelerator == 'openvino':  # openvino backend will not care about ipex usage
             final_openvino_option = {"INFERENCE_PRECISION_HINT": "f32"}
             if openvino_config is not None:

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -505,6 +505,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                  input_sample=None,
                  channels_last: bool = False,
                  thread_num: Optional[int] = None,
+                 device: Optional[str] = 'CPU',
                  onnxruntime_session_options=None,
                  openvino_config=None,
                  simplification: bool = True,
@@ -584,6 +585,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                            later inference process of your obtained accelerated model. In other
                            words, the process of model conversion won't be restricted by this
                            parameter.
+        :param device: (optional) A string represents the device of the inference. Default to 'CPU',
+                        only valid when accelerator='openvino', otherwise will be ignored.
+                        'CPU', 'GPU' and 'VPU' are supported for now.
         :param onnxruntime_session_options: The session option for onnxruntime, only valid when
                                             accelerator='onnxruntime', otherwise will be ignored.
         :param openvino_config: The config to be inputted in core.compile_model. Only valid when
@@ -768,6 +772,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                                      input_sample=input_sample,
                                                      accelerator='openvino',
                                                      thread_num=thread_num,
+                                                     device=device,
                                                      dynamic_axes=dynamic_axes,
                                                      logging=logging,
                                                      **export_kwargs)
@@ -810,6 +815,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
               use_ipex: bool = False,
               channels_last: bool = False,
               thread_num: Optional[int] = None,
+              device: Optional[str] = 'CPU',
               onnxruntime_session_options=None,
               openvino_config=None,
               simplification: bool = True,
@@ -840,6 +846,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                            later inference process of your obtained accelerated model. In other
                            words, the process of model conversion won't be restricted by this
                            parameter.
+        :param device: (optional) A string represents the device of the inference. Default to 'CPU',
+                                  only valid when accelerator='openvino', otherwise will be ignored.
+                                  'CPU', 'GPU' and 'VPU' are supported for now.
         :param onnxruntime_session_options: The session option for onnxruntime, only valid when
                                             accelerator='onnxruntime', otherwise will be ignored.
         :param openvino_config: The config to be inputted in core.compile_model. Only valid when
@@ -895,6 +904,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 final_openvino_option.update(openvino_config)
             return PytorchOpenVINOModel(model, input_sample,
                                         thread_num=thread_num,
+                                        device=device,
                                         dynamic_axes=dynamic_axes,
                                         logging=logging,
                                         config=final_openvino_option,

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -675,7 +675,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                            thread_num=thread_num)
                     return bf16_model
             elif accelerator == "openvino":
-                invalidInputError(device != 'CPU',
+                invalidInputError(device == 'CPU',
                                   "Device {} don't support bfloat16.".format(device))
                 final_openvino_option = {"INFERENCE_PRECISION_HINT": "bf16"}
                 if openvino_config is not None:

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -647,6 +647,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         invalidInputError(precision in ['int8', 'fp16', 'bf16'],
                           "Only support 'int8', 'bf16', 'fp16' now, "
                           "no support for {}.".format(precision))
+        # device name might be: CPU, GPU, GPU.0, VPUX ...
         invalidInputError(device == 'CPU' or 'GPU' in device or device == 'VPUX',
                           "Now we only support CPU, GPU and VPUX, not {}".format(device))
         if device != 'CPU' and accelerator != 'openvino':
@@ -830,7 +831,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 invalidInputError(False,
                                   "Accelerator {} is invalid.".format(accelerator))
         if precision == 'fp16':
-            invalidInputError(device in ('GPU', 'VPUX'),
+            invalidInputError(device == 'VPUX' or 'GPU' in device,
                               "fp16 is not supported on {} device.".format(device))
             invalidInputError(accelerator == 'openvino',
                               "fp16 is not supported on {} accelerator.".format(accelerator))
@@ -938,6 +939,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             "Expect a nn.Module instance that is not traced or quantized"
             "but got type {}".format(type(model))
         )
+        # device name might be: CPU, GPU, GPU.0 ...
         invalidInputError(device == 'CPU' or 'GPU' in device,
                           "Now we only support fp32 for CPU and GPU, not {}".format(device))
         if device != 'CPU' and accelerator != 'openvino':

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -805,6 +805,20 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             else:
                 invalidInputError(False,
                                   "Accelerator {} is invalid.".format(accelerator))
+        if precision == 'fp16':
+            invalidInputError(accelerator != 'openvino' or device not in ('GPU', 'VPUX'),
+                              "fp16 is now only valid for OpenVINO GPU/VPUX plugin")
+            if openvino_config is not None:
+                final_openvino_option = openvino_config
+            return PytorchOpenVINOModel(model, input_sample,
+                                        precision=precision,
+                                        thread_num=thread_num,
+                                        device=device,
+                                        dynamic_axes=dynamic_axes,
+                                        logging=logging,
+                                        config=final_openvino_option,
+                                        **export_kwargs)
+
         invalidInputError(False,
                           "Precision {} is invalid.".format(precision))
 

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -644,14 +644,15 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :param **export_kwargs: will be passed to torch.onnx.export function.
         :return:            A accelerated torch.nn.Module if quantization is sucessful.
         """
-        invalidInputError(precision not in ['int8', 'fp16', 'bf16'],
+        invalidInputError(precision in ['int8', 'fp16', 'bf16'],
                           "Only support 'int8', 'bf16', 'fp16' now, "
                           "no support for {}.".format(precision))
         invalidInputError(device == 'CPU' or 'GPU' in device or device == 'VPUX',
                           "Now we only support CPU, GPU and VPUX, not {}".format(device))
         if device != 'CPU' and accelerator != 'openvino':
             invalidInputError(False,
-                              "Now we only support {} device when accelerator is openvino.".format(device))
+                              "Now we only support {} device when accelerator"
+                              "is openvino.".format(device))
         if precision == 'bf16':
             if accelerator is None or accelerator == "jit":
                 if use_ipex or accelerator == "jit":
@@ -937,7 +938,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                           "Now we only support fp32 for CPU and GPU, not {}".format(device))
         if device != 'CPU' and accelerator != 'openvino':
             invalidInputError(False,
-                              "Now we only support {} device when accelerator is openvino.".format(device))
+                              "Now we only support {} device when accelerator "
+                              "is openvino.".format(device))
         if accelerator == 'openvino':  # openvino backend will not care about ipex usage
             final_openvino_option = {"INFERENCE_PRECISION_HINT": "f32"}
             if openvino_config is not None:

--- a/python/nano/src/bigdl/nano/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/pytorch/utils.py
@@ -118,7 +118,7 @@ def save_model(model: pl.LightningModule, path):
         torch.save(model.state_dict(), checkpoint_path)
 
 
-def load_model(path, model: pl.LightningModule = None, inplace=False):
+def load_model(path, model: pl.LightningModule = None, inplace=False, device=None):
     """
     Load a model from local.
 
@@ -127,6 +127,8 @@ def load_model(path, model: pl.LightningModule = None, inplace=False):
             the model with accelerator=None by Trainer.trace/Trainer.quantize. model
             should be set to None if you choose accelerator="onnxruntime"/"openvino"/"jit".
     :param inplace: whether to perform inplace optimization. Default: ``False``.
+    :param device: A string represents the device of the inference. Default to None.
+                   Only valid for openvino model, otherwise will be ignored.
     :return: Model with different acceleration(None/OpenVINO/ONNX Runtime/JIT) or
                 precision(FP32/FP16/BF16/INT8).
     """
@@ -142,7 +144,7 @@ def load_model(path, model: pl.LightningModule = None, inplace=False):
     if model_type == 'PytorchOpenVINOModel':
         invalidInputError(model is None,
                           "Argument 'model' must be None for OpenVINO loading.")
-        return load_openvino_model(path)
+        return load_openvino_model(path, device=device)
     if model_type == 'PytorchONNXRuntimeModel':
         invalidInputError(model is None,
                           "Argument 'model' must be None for ONNX Runtime loading.")

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -312,7 +312,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                            or accelerator='openvino'.
         :param device: (optional) A string represents the device of the inference. Default to 'CPU',
                         only valid when accelerator='openvino', otherwise will be ignored.
-                        'CPU', 'GPU' and 'VPUX' are supported for now.
+                        'CPU', 'GPU' are supported for now.
         :param onnxruntime_session_options: The session option for onnxruntime, only valid when
                                             accelerator='onnxruntime', otherwise will be ignored.
         :param openvino_config: The config to be inputted in core.compile_model. Only valid when
@@ -321,8 +321,11 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                         accelerator='openvino', otherwise will be ignored. Default: ``True``.
         :return: Model with different acceleration(OpenVINO/ONNX Runtime).
         """
-        invalidInputError(device != 'CPU' and accelerator != 'openvino',
-                          "Now we only support {} device when accelerator is openvino.".format(device))
+        invalidInputError(device == 'CPU' or 'GPU' in device,
+                          "Now we only support fp32 for CPU and GPU, not {}".format(device))
+        if device != 'CPU' and accelerator != 'openvino':
+            invalidInputError(False,
+                              "Now we only support {} device when accelerator is openvino.".format(device))
         if accelerator == 'openvino':
             final_openvino_option = {"INFERENCE_PRECISION_HINT": "f32"} if device is 'CPU' else {}
             if openvino_config is not None:
@@ -449,8 +452,11 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         invalidInputError(precision not in ['int8', 'fp16', 'bf16'],
                           "Only support 'int8', 'bf16', 'fp16' now, "
                           "no support for {}.".format(precision))
-        invalidInputError(device != 'CPU' and accelerator != 'openvino',
-                          "Now we only support {} device when accelerator is openvino.".format(device))
+        invalidInputError(device == 'CPU' or 'GPU' in device or device == 'VPUX',
+                          "Now we only support CPU, GPU and VPUX, not {}".format(device))
+        if device != 'CPU' and accelerator != 'openvino':
+            invalidInputError(False,
+                              "Now we only support {} device when accelerator is openvino.".format(device))
         if precision == 'fp16':
             invalidInputError(accelerator != 'openvino' or device not in ('GPU', 'VPUX'),
                               "fp16 is not supported on {} device.".format(device))

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -325,7 +325,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                           "Now we only support fp32 for CPU and GPU, not {}".format(device))
         if device != 'CPU' and accelerator != 'openvino':
             invalidInputError(False,
-                              "Now we only support {} device when accelerator is openvino.".format(device))
+                              "Now we only support {} device when accelerator "
+                              "is openvino.".format(device))
         if accelerator == 'openvino':
             final_openvino_option = {"INFERENCE_PRECISION_HINT": "f32"} if device is 'CPU' else {}
             if openvino_config is not None:
@@ -449,14 +450,15 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                         accelerator='openvino', otherwise will be ignored. Default: ``True``.
         :return:            A TensorflowBaseModel for INC. If there is no model found, return None.
         """
-        invalidInputError(precision not in ['int8', 'fp16', 'bf16'],
+        invalidInputError(precision in ['int8', 'fp16', 'bf16'],
                           "Only support 'int8', 'bf16', 'fp16' now, "
                           "no support for {}.".format(precision))
         invalidInputError(device == 'CPU' or 'GPU' in device or device == 'VPUX',
                           "Now we only support CPU, GPU and VPUX, not {}".format(device))
         if device != 'CPU' and accelerator != 'openvino':
             invalidInputError(False,
-                              "Now we only support {} device when accelerator is openvino.".format(device))
+                              "Now we only support {} device when accelerator "
+                              "is openvino.".format(device))
         if precision == 'fp16':
             invalidInputError(accelerator != 'openvino' or device not in ('GPU', 'VPUX'),
                               "fp16 is not supported on {} device.".format(device))
@@ -469,7 +471,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                         config=final_openvino_option,
                                         logging=logging)
             return patch_attrs(result, model)
-        
+
         elif precision == 'bf16':
             invalidInputError(accelerator != 'openvino',
                               "Accelerator {} is invalid for BF16.".format(accelerator))

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -495,7 +495,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
 
         if not isinstance(x, tf.data.Dataset) and y is None:
             # fake label to make quantization work
-            y = range(len(x))
+            y = range(len(x))    # type: ignore
         if isinstance(x, tf.data.Dataset):
             batch_data = next(iter(x))
             if isinstance(batch_data, tf.Tensor) or \

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -461,8 +461,10 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                               "Now we only support {} device when accelerator "
                               "is openvino.".format(device))
         if precision == 'fp16':
-            invalidInputError(accelerator != 'openvino' or device not in ('GPU', 'VPUX'),
+            invalidInputError(device in ('GPU', 'VPUX'),
                               "fp16 is not supported on {} device.".format(device))
+            invalidInputError(accelerator == 'openvino',
+                              "fp16 is not supported on {} accelerator.".format(accelerator))
             if openvino_config is not None:
                 final_openvino_option = openvino_config
             from bigdl.nano.deps.openvino.tf.model import KerasOpenVINOModel    # type: ignore

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -534,7 +534,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                                     precision=_precision,
                                                     thread_num=thread_num,
                                                     device=device,
-                                                    config=final_openvino_option,
+                                                    config=openvino_config,
                                                     logging=logging)
             if metric:
                 if not isinstance(accuracy_criterion, dict):

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -294,6 +294,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
               accelerator: Optional[str] = None,
               input_spec=None,
               thread_num: Optional[int] = None,
+              device: Optional[str] = 'CPU',
               onnxruntime_session_options=None,
               openvino_config=None,
               logging=True):
@@ -309,6 +310,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :param thread_num: (optional) a int represents how many threads(cores) is needed for
                            inference, only valid for accelerator='onnxruntime'
                            or accelerator='openvino'.
+        :param device: (optional) A string represents the device of the inference. Default to 'CPU',
+                        only valid when accelerator='openvino', otherwise will be ignored.
+                        'CPU', 'GPU' and 'VPU' are supported for now.
         :param onnxruntime_session_options: The session option for onnxruntime, only valid when
                                             accelerator='onnxruntime', otherwise will be ignored.
         :param openvino_config: The config to be inputted in core.compile_model. Only valid when
@@ -323,6 +327,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 final_openvino_option.update(openvino_config)
             result = KerasOpenVINOModel(model,
                                         thread_num=thread_num,
+                                        device=device,
                                         config=final_openvino_option,
                                         logging=logging)
         elif accelerator == 'onnxruntime':
@@ -355,6 +360,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                  max_trials: Optional[int] = None,
                  batch: Optional[int] = None,
                  thread_num: Optional[int] = None,
+                 device: Optional[str] = 'CPU',
                  inputs: List[str] = None,
                  outputs: List[str] = None,
                  sample_size: int = 100,
@@ -418,6 +424,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :param thread_num:  (optional) a int represents how many threads(cores) is needed for
                             inference, only valid for accelerator='onnxruntime'
                             or accelerator='openvino'.
+        :param device: (optional) A string represents the device of the inference. Default to 'CPU',
+                        only valid when accelerator='openvino', otherwise will be ignored.
+                        'CPU', 'GPU' and 'VPU' are supported for now.
         :param inputs:      A list of input names.
                             Default: None, automatically get names from graph.
         :param outputs:     A list of output names.
@@ -474,6 +483,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 openvino_model = InferenceOptimizer.trace(model=model,
                                                           accelerator='openvino',
                                                           thread_num=thread_num,
+                                                          device=device,
                                                           logging=logging,
                                                           openvino_config=openvino_config)
             openvino_model = openvino_model.target_obj

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -332,6 +332,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             if openvino_config is not None:
                 final_openvino_option.update(openvino_config)
             result = KerasOpenVINOModel(model,
+                                        precision='fp32',
                                         thread_num=thread_num,
                                         device=device,
                                         config=final_openvino_option,
@@ -481,6 +482,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             if openvino_config is not None:
                 final_openvino_option.update(openvino_config)
             result = KerasOpenVINOModel(model,
+                                        precision=precision,
                                         thread_num=thread_num,
                                         device=device,
                                         config=final_openvino_option,

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -321,6 +321,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                         accelerator='openvino', otherwise will be ignored. Default: ``True``.
         :return: Model with different acceleration(OpenVINO/ONNX Runtime).
         """
+        # device name might be: CPU, GPU, GPU.0, VPUX ...
         invalidInputError(device == 'CPU' or 'GPU' in device,
                           "Now we only support fp32 for CPU and GPU, not {}".format(device))
         if device != 'CPU' and accelerator != 'openvino':
@@ -454,6 +455,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         invalidInputError(precision in ['int8', 'fp16', 'bf16'],
                           "Only support 'int8', 'bf16', 'fp16' now, "
                           "no support for {}.".format(precision))
+        # device name might be: CPU, GPU, GPU.0, VPUX ...
         invalidInputError(device == 'CPU' or 'GPU' in device or device == 'VPUX',
                           "Now we only support CPU, GPU and VPUX, not {}".format(device))
         if device != 'CPU' and accelerator != 'openvino':
@@ -461,7 +463,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                               "Now we only support {} device when accelerator "
                               "is openvino.".format(device))
         if precision == 'fp16':
-            invalidInputError(device in ('GPU', 'VPUX'),
+            invalidInputError(device == 'VPUX' or 'GPU' in device,
                               "fp16 is not supported on {} device.".format(device))
             invalidInputError(accelerator == 'openvino',
                               "fp16 is not supported on {} accelerator.".format(accelerator))

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -207,7 +207,7 @@ class TestOpenVINO(TestCase):
                                                         input_sample=x,
                                                         precision='bf16')
         except RuntimeError as e:
-            assert e.message == "Platform doesn't support BF16 format"
+            assert e.__str__() == "Platform doesn't support BF16 format"
             return
 
         with InferenceOptimizer.get_context(optimized_model):
@@ -241,7 +241,6 @@ class TestOpenVINO(TestCase):
         # GPU don't support dynamic shape
         with pytest.raises(RuntimeError):
             openvino_model(x2)
-
 
         # test GPU int8
         openvino_model = InferenceOptimizer.quanize(model,

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -195,3 +195,19 @@ class TestOpenVINO(TestCase):
         accmodel(x1)
         accmodel(x2)
         accmodel(x3)
+
+    def test_quantize_openvino_bf16(self):
+        model = mobilenet_v3_small(num_classes=10)
+
+        x = torch.rand((10, 3, 256, 256))
+
+        optimized_model = InferenceOptimizer.quantize(model,
+                                                      accelerator='openvino',
+                                                      input_sample=x,
+                                                      precision='bf16')
+
+        with InferenceOptimizer.get_context(optimized_model):
+            y_hat = optimized_model(x[0:3])
+            assert y_hat.shape == (3, 10)
+            y_hat = optimized_model(x)
+            assert y_hat.shape == (10, 10)

--- a/python/nano/test/openvino/tf/test_openvino_quantize.py
+++ b/python/nano/test/openvino/tf/test_openvino_quantize.py
@@ -122,10 +122,14 @@ class TestOpenVINO(TestCase):
         model = Model(inputs=model.inputs, outputs=model.outputs)
         train_examples = np.random.random((100, 40, 40, 3))
 
-        openvino_quantized_model = InferenceOptimizer.quantize(model,
-                                                               accelerator='openvino',
-                                                               precision='bf16')
-        
+        try:
+            openvino_quantized_model = InferenceOptimizer.quantize(model,
+                                                                accelerator='openvino',
+                                                                precision='bf16')
+        except RuntimeError as e:
+            assert e.message == "Platform doesn't support BF16 format"
+            return
+
         y_hat = openvino_quantized_model(train_examples[:10])
         assert y_hat.shape == (10, 10)
 

--- a/python/nano/test/openvino/tf/test_openvino_quantize.py
+++ b/python/nano/test/openvino/tf/test_openvino_quantize.py
@@ -127,7 +127,7 @@ class TestOpenVINO(TestCase):
                                                                 accelerator='openvino',
                                                                 precision='bf16')
         except RuntimeError as e:
-            assert e.message == "Platform doesn't support BF16 format"
+            assert e.__str__() == "Platform doesn't support BF16 format"
             return
 
         y_hat = openvino_quantized_model(train_examples[:10])

--- a/python/nano/test/openvino/tf/test_openvino_quantize.py
+++ b/python/nano/test/openvino/tf/test_openvino_quantize.py
@@ -116,3 +116,22 @@ class TestOpenVINO(TestCase):
         preds = model.predict(train_examples)
         openvino_preds = openvino_quantized_model.predict(train_examples)
         np.testing.assert_allclose(preds, openvino_preds, rtol=1e-2)
+
+    def test_model_quantize_openvino_bf16(self):
+        model = MobileNetV2(weights=None, input_shape=[40, 40, 3], classes=10)
+        model = Model(inputs=model.inputs, outputs=model.outputs)
+        train_examples = np.random.random((100, 40, 40, 3))
+
+        openvino_quantized_model = InferenceOptimizer.quantize(model,
+                                                               accelerator='openvino',
+                                                               precision='bf16')
+        
+        y_hat = openvino_quantized_model(train_examples[:10])
+        assert y_hat.shape == (10, 10)
+
+        y_hat = openvino_quantized_model.predict(train_examples, batch_size=5)
+        assert y_hat.shape == (100, 10)
+
+        preds = model.predict(train_examples)
+        openvino_preds = openvino_quantized_model.predict(train_examples)
+        np.testing.assert_allclose(preds, openvino_preds, rtol=1e-2)


### PR DESCRIPTION
## Description

Support more devices (GPU, VPUX) for openvino, and support more precision (fp16/bf16) for openvino.

### 1. Why the change?

I found even on an iGPU inside laptop, openvino inference on GPU can bring additional performance boost, which can be more obvious with fp16/int8.
https://github.com/analytics-zoo/nano/issues/245

### 2. User API changes

new parameter `device` for `trace`/`quantize`, new value for `precision`, usage for PyTorch is :
```python
# CPU bf16
ov_model = InferenceOptimizer.quantize(model,
                                       accelerator='openvino',
                                       input_sample=sample,
                                       precision='bf16')
# GPU fp32
ov_model = InferenceOptimizer.trace(model,
                                    accelerator='openvino',
                                    input_sample=sample,
                                    device='GPU')
# GPU fp16
ov_model = InferenceOptimizer.quantize(model,
                                       accelerator='openvino',
                                       input_sample=sample,
                                       device='GPU',
                                       precision='bf16')
# GPU int8
ov_model = InferenceOptimizer.quantize(model,
                                       accelerator='openvino',
                                       input_sample=sample,
                                       device='GPU',
                                       precision='int8',
                                       calib_data=data_loader)

# save / load for GPU, only valid for PyTorch now
InferenceOptimizer.save(model, "gpu_model")
model = InferenceOptimizer.load("gpu_model")
# load model into CPU
model = InferenceOptimizer.load("gpu_model", device='CPU')
```
Usage for TensorFlow is similar.

### 3. Summary of the change 

- [x] provide new parameter `device` for `trace`/`quantize`, which could be GPU/VPUX. (PyTorch / Tensorflow)
- [x] support fp16 precision of openvino (PyTorch / Tensorflow) [GPU]
- [x] support int8 precision of openvino (PyTorch / Tensorflow) [GPU]
- [x] support bf16 precision of openvino (PyTorch / Tensorflow) [CPU]
- [x] bf16 related uts for openvino (PyTorch / Tensorflow)
- [x] device and fp16/int8 related uts for openvino (PyTorch / Tensorflow), which is difficult as the limit of hardware
- [x] support save/load behavior for the same/different machine

### 4. How to test?
- [x] Unit test


