### PR TITLE
[Nano] Add API doc for `bigdl.nano.pytorch.nano` decorator

### DIFF
--- a/docs/readthedocs/source/doc/PythonAPI/Nano/pytorch.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Nano/pytorch.rst
@@ -15,7 +15,7 @@ bigdl.nano.pytorch.InferenceOptimizer
 .. autoclass:: bigdl.nano.pytorch.InferenceOptimizer
     :members:
     :undoc-members:
-    :exclude-members: ALL_INFERENCE_ACCELERATION_METHOD, DEFAULT_INFERENCE_ACCELERATION_METHOD
+    :exclude-members: ALL_INFERENCE_ACCELERATION_METHOD, DEFAULT_INFERENCE_ACCELERATION_METHOD, method
     :inherited-members:
 
 TorchNano API

--- a/docs/readthedocs/source/doc/PythonAPI/Nano/pytorch.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Nano/pytorch.rst
@@ -18,10 +18,10 @@ bigdl.nano.pytorch.InferenceOptimizer
     :exclude-members: ALL_INFERENCE_ACCELERATION_METHOD, DEFAULT_INFERENCE_ACCELERATION_METHOD
     :inherited-members:
 
-bigdl.nano.pytorch.TorchNano
+TorchNano API
 ---------------------------
 
-.. autoclass:: bigdl.nano.pytorch.TorchNano
+.. automodule:: bigdl.nano.pytorch.torch_nano
     :members:
     :undoc-members:
     :exclude-members: run

--- a/python/nano/src/bigdl/nano/pytorch/torch_nano.py
+++ b/python/nano/src/bigdl/nano/pytorch/torch_nano.py
@@ -152,18 +152,18 @@ class TorchNano(LightningLite):
         """
         Create a TorchNano with nano acceleration.
 
-        :param num_processes: number of processes in distributed training, defaults to 1
-        :param use_ipex: whether use ipex acceleration, defaults to False
-        :param distributed_backend: use which backend in distributed mode, defaults to \
-            "subprocess", now avaiable backends are 'spawn', 'subprocess' and 'ray'
-        :param precision: Double precision (64), full precision (32), half precision (16)
-            or bfloat16 precision (bf16), defaults to 32.
-            Enable ipex bfloat16 weight prepack when `use_ipex=True` and `precision='bf16'`
+        :param num_processes: number of processes in distributed training, defaults to ``1``
+        :param use_ipex: whether use ipex acceleration, defaults to ``False``
+        :param distributed_backend: use which backend in distributed mode, defaults to
+            ``'subprocess'``, now avaiable backends are ``'spawn'``, ``'subprocess'`` and ``'ray'``
+        :param precision: Double precision (``64``), full precision (``32``), half precision (``16``)
+            or bfloat16 precision (``'bf16'``), defaults to ``32``.
+            Enable ipex bfloat16 weight prepack when ``use_ipex=True`` and ``precision='bf16'``
         :param cpu_for_each_process: specify the cpu cores which will be used by each process,
-            if `None`, cpu cores will be distributed evenly by all processes,
-            only take effect when `num_processes` > 1
-        :param channels_last: whether convert input to channels last memory formats, \
-            defaults to False.
+            if ``None``, cpu cores will be distributed evenly by all processes,
+            only take effect when ``num_processes`` > 1
+        :param channels_last: whether convert input to channels last memory formats,
+            defaults to ``False``.
         """
         self.num_processes = num_processes
         self.use_ipex = use_ipex
@@ -281,10 +281,10 @@ class TorchNano(LightningLite):
 
         :param model: A model to setup
         :param optimizer: The optimizer(s) to setup
-        :param *dataloaders: The dataloader(s) to setup
-        :param move_to_device: If set ``True`` (default), moves the model to the correct device. \
+        :param \*dataloaders: The dataloader(s) to setup
+        :param move_to_device: If set ``True`` (default), moves the model to the correct device.
             Set this to ``False`` and alternatively use :meth:`to_device` manually.
-        :return: The tuple of the wrapped model, optimizer, loss_func and dataloaders, \
+        :return: The tuple of the wrapped model, optimizer, loss_func and dataloaders, 
             in the same order they were passed in.
         """
         # convert single optimizer to a optimizer list
@@ -383,7 +383,22 @@ def nano(num_processes: Optional[int] = None,
          channels_last: bool = False,
          auto_lr: bool = True,
          *args, **kwargs):
-    """Run TorchNano.train through a convenient decorator function."""
+    """Run ``TorchNano.train`` through a convenient decorator function.
+    
+    :param num_processes: number of processes in distributed training, defaults to ``1``
+    :param use_ipex: whether use ipex acceleration, defaults to ``False``
+    :param distributed_backend: use which backend in distributed mode, defaults to
+        ``'subprocess'``, now avaiable backends for ``bigdl.nano.pytorch.nano`` decorator
+        are ``'subprocess'`` and ``'ray'``
+    :param precision: Double precision (``64``), full precision (``32``), half precision (``16``)
+        or bfloat16 precision (``'bf16'``), defaults to ``32``.
+        Enable ipex bfloat16 weight prepack when ``use_ipex=True`` and ``precision='bf16'``
+    :param cpu_for_each_process: specify the cpu cores which will be used by each process,
+        if ``None``, cpu cores will be distributed evenly by all processes,
+        only take effect when ``num_processes`` > 1
+    :param channels_last: whether convert input to channels last memory formats,
+        defaults to ``False``.
+    """
     if "strategy" in kwargs:
         strategy = kwargs["strategy"]
         if strategy == "deepspeed" or isinstance(strategy, DeepSpeedStrategy):

--- a/python/nano/src/bigdl/nano/pytorch/torch_nano.py
+++ b/python/nano/src/bigdl/nano/pytorch/torch_nano.py
@@ -383,13 +383,14 @@ def nano(num_processes: Optional[int] = None,
          channels_last: bool = False,
          auto_lr: bool = True,
          *args, **kwargs):
-    """Run ``TorchNano.train`` through a convenient decorator function.
+    """
+    Run ``TorchNano.train`` through a convenient decorator function.
 
     :param num_processes: number of processes in distributed training, defaults to ``1``
     :param use_ipex: whether use ipex acceleration, defaults to ``False``
     :param distributed_backend: use which backend in distributed mode, defaults to
-        ``'subprocess'``, now avaiable backends for ``bigdl.nano.pytorch.nano`` decorator
-        are ``'subprocess'`` and ``'ray'``
+        ``'subprocess'``, now avaiable backends are ``'subprocess'`` and ``'ray'``.
+        ``bigdl.nano.pytorch.nano`` decorator does not support ``'spawn'``.
     :param precision: Double precision (``64``), full precision (``32``), half precision (``16``)
         or bfloat16 precision (``'bf16'``), defaults to ``32``.
         Enable ipex bfloat16 weight prepack when ``use_ipex=True`` and ``precision='bf16'``

--- a/python/nano/src/bigdl/nano/pytorch/torch_nano.py
+++ b/python/nano/src/bigdl/nano/pytorch/torch_nano.py
@@ -156,8 +156,8 @@ class TorchNano(LightningLite):
         :param use_ipex: whether use ipex acceleration, defaults to ``False``
         :param distributed_backend: use which backend in distributed mode, defaults to
             ``'subprocess'``, now avaiable backends are ``'spawn'``, ``'subprocess'`` and ``'ray'``
-        :param precision: Double precision (``64``), full precision (``32``), half precision (``16``)
-            or bfloat16 precision (``'bf16'``), defaults to ``32``.
+        :param precision: Double precision (``64``), full precision (``32``),
+            half precision (``16``) or bfloat16 precision (``'bf16'``), defaults to ``32``.
             Enable ipex bfloat16 weight prepack when ``use_ipex=True`` and ``precision='bf16'``
         :param cpu_for_each_process: specify the cpu cores which will be used by each process,
             if ``None``, cpu cores will be distributed evenly by all processes,
@@ -281,10 +281,10 @@ class TorchNano(LightningLite):
 
         :param model: A model to setup
         :param optimizer: The optimizer(s) to setup
-        :param \*dataloaders: The dataloader(s) to setup
+        :param *dataloaders: The dataloader(s) to setup
         :param move_to_device: If set ``True`` (default), moves the model to the correct device.
             Set this to ``False`` and alternatively use :meth:`to_device` manually.
-        :return: The tuple of the wrapped model, optimizer, loss_func and dataloaders, 
+        :return: The tuple of the wrapped model, optimizer, loss_func and dataloaders,
             in the same order they were passed in.
         """
         # convert single optimizer to a optimizer list
@@ -384,7 +384,7 @@ def nano(num_processes: Optional[int] = None,
          auto_lr: bool = True,
          *args, **kwargs):
     """Run ``TorchNano.train`` through a convenient decorator function.
-    
+
     :param num_processes: number of processes in distributed training, defaults to ``1``
     :param use_ipex: whether use ipex acceleration, defaults to ``False``
     :param distributed_backend: use which backend in distributed mode, defaults to


### PR DESCRIPTION
- Add API doc for `bigdl.nano.pytorch.nano` decorator.
- Correct some syntax/display error for TorchNano related API
- Remove strange `method` in `InferenceOptimizer` api doc
  ![image](https://user-images.githubusercontent.com/54161268/209255662-df4a692d-83a3-4975-880e-80c5f86153ef.png)

Document test: https://yuwentestdocs.readthedocs.io/en/nano-decorator-api/doc/PythonAPI/Nano/pytorch.html#module-bigdl.nano.pytorch.torch_nano