### PR TITLE
Nano: support save/load for keras's `openvino`/`inc`/`InferenceOptimizer`

### DIFF
--- a/.github/workflows/nano_howto_guides_tests.yml
+++ b/.github/workflows/nano_howto_guides_tests.yml
@@ -86,6 +86,7 @@ jobs:
           source bigdl-nano-init
           pip install pytest nbmake
           pip install ipykernel==5.5.6
+          pip install torch==1.12.0 torchvision --extra-index-url https://download.pytorch.org/whl/cpu 
           bash python/nano/tutorial/notebook/inference/pytorch/run-nano-howto-guides-inference-pytorch-tests.sh inferenceoptimizer
           source $CONDA/bin/deactivate
           $CONDA/bin/conda remove -n howto-guides-inference-pytorch-openvino --all

--- a/.github/workflows/nano_howto_guides_tests.yml
+++ b/.github/workflows/nano_howto_guides_tests.yml
@@ -86,7 +86,6 @@ jobs:
           source bigdl-nano-init
           pip install pytest nbmake
           pip install ipykernel==5.5.6
-          pip install torch==1.12.0 torchvision --extra-index-url https://download.pytorch.org/whl/cpu 
           bash python/nano/tutorial/notebook/inference/pytorch/run-nano-howto-guides-inference-pytorch-tests.sh inferenceoptimizer
           source $CONDA/bin/deactivate
           $CONDA/bin/conda remove -n howto-guides-inference-pytorch-openvino --all

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
@@ -51,6 +51,12 @@ def quantize(model, dataloader=None, metric=None, thread_num=None, **kwargs):
         quantizer = PytorchQuantization(thread_num=thread_num, **not_none_kwargs)
     if 'onnx' in not_none_kwargs['framework']:
         onnx_option = not_none_kwargs.pop('onnx_option', None)
+        if onnxruntime_session_options is None:
+            import onnxruntime
+            onnxruntime_session_options = onnxruntime.SessionOptions()
+        if thread_num is not None:
+            onnxruntime_session_options.intra_op_num_threads = thread_num
+            onnxruntime_session_options.inter_op_num_threads = thread_num
         if onnx_option == 'tensorflow':
             from .onnx.tensorflow.quantization import KerasONNXRuntimeQuantization
             quantizer = KerasONNXRuntimeQuantization(

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
@@ -21,7 +21,8 @@ def load_inc_model(path, model, framework):
         from .pytorch.quantized_model import PytorchQuantizedModel
         return PytorchQuantizedModel._load(path, model)
     elif framework == 'tensorflow':
-        invalidInputError(False, "QuantizedTensorflowModel loading is not implemented yet.")
+        from .tensorflow.model import KerasQuantizedModel
+        return KerasQuantizedModel._load(path, model)
     else:
         invalidInputError(False,
                           "The value {} for framework is not supported."

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/model.py
@@ -18,6 +18,7 @@ import yaml
 from ..core import version as inc_version
 from bigdl.nano.utils.inference.tf.model import AcceleratedKerasModel
 from bigdl.nano.utils.log4Error import invalidInputError
+from neural_compressor.model.model import TensorflowModel
 
 
 class KerasQuantizedModel(AcceleratedKerasModel):
@@ -57,7 +58,7 @@ class KerasQuantizedModel(AcceleratedKerasModel):
             model is not None,
             errMsg="FP32 model is required to create a quantized model."
         )
-        qmodel = model.load(path)
+        qmodel = TensorflowModel("saved_model", str(path))
         from packaging import version
         if version.parse(inc_version) < version.parse("1.11"):
             path = Path(path)

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/model.py
@@ -44,7 +44,7 @@ class KerasQuantizedModel(AcceleratedKerasModel):
     @property
     def status(self):
         status = super().status
-        status.update({"ModelType": type(self).__name__})
+        status.update({"ModelType": type(self.target_obj).__name__})
         return status
 
     def _save_model(self, path):

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/quantization.py
@@ -51,6 +51,8 @@ class TensorflowQuantization(BaseQuantization):
 
     def _post_execution(self, q_model):
         # TODO: Need to wrapp q_model similar to Pytorch
+        print(__file__)
+        print(type(q_model))
         return KerasQuantizedModel(q_model)
 
     @property

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/quantization.py
@@ -50,9 +50,6 @@ class TensorflowQuantization(BaseQuantization):
         return model, calib_dataloader, metric
 
     def _post_execution(self, q_model):
-        # TODO: Need to wrapp q_model similar to Pytorch
-        print(__file__)
-        print(type(q_model))
         return KerasQuantizedModel(q_model)
 
     @property

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from bigdl.nano.utils.log4Error import invalidInputError
 
 
 def PytorchONNXRuntimeModel(model, input_sample=None,
@@ -57,9 +58,17 @@ def PytorchONNXRuntimeModel(model, input_sample=None,
                                    **export_kwargs)
 
 
-def load_onnxruntime_model(path):
-    from .pytorch.pytorch_onnxruntime_model import PytorchONNXRuntimeModel
-    return PytorchONNXRuntimeModel._load(path)
+def load_onnxruntime_model(path, framework='pytorch'):
+    if framework == 'pytorch':
+        from .pytorch.pytorch_onnxruntime_model import PytorchONNXRuntimeModel
+        return PytorchONNXRuntimeModel._load(path)
+    elif framework == 'tensorflow':
+        from .tensorflow.tensorflow_onnxruntime_model import KerasONNXRuntimeModel
+        return KerasONNXRuntimeModel._load(path)
+    else:
+        invalidInputError(False,
+                          "The value {} for framework is not supported."
+                          " Please choose from 'pytorch'/'tensorflow'.")
 
 
 def KerasONNXRuntimeModel(model, input_spec,

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/tensorflow/tensorflow_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/tensorflow/tensorflow_onnxruntime_model.py
@@ -97,7 +97,8 @@ class KerasONNXRuntimeModel(ONNXRuntimeModel, AcceleratedKerasModel):
     @property
     def status(self):
         status = super().status
-        status.update({"onnx_path": 'onnx_saved_model.onnx',
+        status.update({"ModelType": type(self.target_obj).__name__,
+                       "onnx_path": 'onnx_saved_model.onnx',
                        "attr_path": "onnx_saved_model_attr.pkl",
                        "intra_op_num_threads": self.session_options.intra_op_num_threads,
                        "inter_op_num_threads": self.session_options.inter_op_num_threads})

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/tensorflow/tensorflow_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/tensorflow/tensorflow_onnxruntime_model.py
@@ -153,10 +153,16 @@ class KerasONNXRuntimeModel(ONNXRuntimeModel, AcceleratedKerasModel):
                 kwargs["loss_weights"] = self.compiled_loss._user_loss_weights
             if self.compiled_metrics is not None:
                 user_metric = self.compiled_metrics._user_metrics
-                kwargs["metrics"] = user_metric._name
+                if isinstance(user_metric, (list, tuple)):
+                    kwargs["metrics"] = [m._name for m in user_metric]
+                else:
+                    kwargs["metrics"] = user_metric._name
                 weighted_metrics = self.compiled_metrics._user_weighted_metrics
                 if weighted_metrics is not None:
-                    kwargs["weighted_metrics"] = weighted_metrics._name
+                    if isinstance(weighted_metrics, (list, str)):
+                        kwargs["weighted_metrics"] = [m._name for m in weighted_metrics]
+                    else:
+                        kwargs["weighted_metrics"] = weighted_metrics._name
         attrs.update(kwargs)
         with open(Path(path) / self.status['attr_path'], "wb") as f:
             pickle.dump(attrs, f)

--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from functools import partial
+from bigdl.nano.utils.log4Error import invalidInputError
 
 
 def PytorchOpenVINOModel(model, input_sample=None, precision='fp32',
@@ -64,16 +64,25 @@ def PytorchOpenVINOModel(model, input_sample=None, precision='fp32',
                                 **export_kwargs)
 
 
-def load_openvino_model(path, device=None):
+def load_openvino_model(path, framework='pytorch', device=None):
     """
     Load an OpenVINO model for inference from directory.
 
     :param path: Path to model to be loaded.
+    :param framework: Only support pytorch and tensorflow now
     :param device: A string represents the device of the inference.
     :return: PytorchOpenVINOModel model for OpenVINO inference.
     """
-    from .pytorch.model import PytorchOpenVINOModel
-    return PytorchOpenVINOModel._load(path, device=device)
+    if framework == 'pytorch':
+        from .pytorch.model import PytorchOpenVINOModel
+        return PytorchOpenVINOModel._load(path, device=device)
+    elif framework == 'tensorflow':
+        from .tf.model import KerasOpenVINOModel
+        return KerasOpenVINOModel._load(path, device=device)
+    else:
+        invalidInputError(False,
+                          "The value {} for framework is not supported."
+                          " Please choose from 'pytorch'/'tensorflow'.")
 
 
 def KerasOpenVINOModel(model, precision='fp32', thread_num=None,

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -75,7 +75,8 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
     @property
     def status(self):
         status = super().status
-        status.update({"xml_path": 'ov_saved_model.xml',
+        status.update({"ModelType": type(self.target_obj).__name__,
+                       "xml_path": 'ov_saved_model.xml',
                        "weight_path": 'ov_saved_model.bin',
                        "config": self.ov_model.final_config,
                        "device": self.ov_model._device})

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -739,16 +739,11 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                         if input_sample is None:
                             # input_sample can be a dataloader
                             input_sample = calib_dataloader
-                        if onnxruntime_session_options is None:
-                            import onnxruntime
-                            onnxruntime_session_options = onnxruntime.SessionOptions()
-                            if thread_num is not None:
-                                onnxruntime_session_options.intra_op_num_threads = thread_num
-                                onnxruntime_session_options.inter_op_num_threads = thread_num
                         model = InferenceOptimizer.trace(
                             model,
                             input_sample=input_sample,
                             accelerator='onnxruntime',
+                            thread_num=thread_num,
                             onnxruntime_session_options=onnxruntime_session_options,
                             simplification=simplification,
                             dynamic_axes=dynamic_axes,
@@ -961,9 +956,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             if onnxruntime_session_options is None:
                 import onnxruntime
                 onnxruntime_session_options = onnxruntime.SessionOptions()
-                if thread_num is not None:
-                    onnxruntime_session_options.intra_op_num_threads = thread_num
-                    onnxruntime_session_options.inter_op_num_threads = thread_num
+            if thread_num is not None:
+                onnxruntime_session_options.intra_op_num_threads = thread_num
+                onnxruntime_session_options.inter_op_num_threads = thread_num
             return PytorchONNXRuntimeModel(model, input_sample,
                                            onnxruntime_session_options,
                                            simplification=simplification,

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -1051,7 +1051,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         save_model(model, path)
 
     @staticmethod
-    def load(path, model: Optional[nn.Module] = None, inplace=False):
+    def load(path, model: Optional[nn.Module] = None, inplace=False, device=None):
         """
         Load a model from local.
 
@@ -1061,10 +1061,12 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                InferenceOptimizer.quantize. model should be set to None if you choose
                accelerator="onnxruntime"/"openvino"/"jit".
         :param inplace: whether to perform inplace optimization. Default: ``False``.
+        :param device: A string represents the device of the inference. Default to None.
+               Only valid for openvino model, otherwise will be ignored.
         :return: Model with different acceleration(None/OpenVINO/ONNX Runtime/JIT) or
                  precision(FP32/FP16/BF16/INT8).
         """
-        return load_model(path, model, inplace=inplace)
+        return load_model(path, model, inplace=inplace, device=device)
 
     @staticmethod
     def to_multi_instance(model: nn.Module, num_processes: int = 4,

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -630,7 +630,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             model.save_weights(checkpoint_path)
 
     @staticmethod
-    def load(path, model: Model = None, device=None):
+    def load(path, model: Model, device=None):
         """
         Load a model from local.
 

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -653,11 +653,11 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         model_type = metadata.get('ModelType', None)
         if model_type == 'KerasOpenVINOModel':
             invalidInputError(model is None,
-                            "Argument 'model' must be None for OpenVINO loading.")
+                              "Argument 'model' must be None for OpenVINO loading.")
             return load_openvino_model(path, framework='tensorflow')
         if model_type == 'KerasONNXRuntimeModel':
             invalidInputError(model is None,
-                            "Argument 'model' must be None for ONNX Runtime loading.")
+                              "Argument 'model' must be None for ONNX Runtime loading.")
             return load_onnxruntime_model(path, framework='tensorflow')
         if model_type == 'KerasQuantizedModel':
             return load_inc_model(path, model, framework='tensorflow')
@@ -675,6 +675,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             invalidInputError(False,
                               "ModelType {} or argument 'model={}' is not acceptable for tensorflow"
                               " loading.".format(model_type, type(model)))
+
 
 def _accuracy_calculate_helper(model, metric, data):
     '''

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -630,7 +630,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             model.save_weights(checkpoint_path)
 
     @staticmethod
-    def load(path, model: Optional[Model] = None):
+    def load(path, model: Optional[Model] = None, device=None):
         """
         Load a model from local.
 
@@ -639,6 +639,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                accelerated the model with accelerator=None by InferenceOptimizer.trace/
                InferenceOptimizer.quantize. model should be set to None if you choose
                accelerator="onnxruntime"/"openvino".
+        :param device: A string represents the device of the inference. Default to None.
+               Only valid for openvino model, otherwise will be ignored.
         :return: Model with different acceleration(None/OpenVINO/ONNX Runtime) or
                  precision(FP32/FP16/BF16/INT8).
         """
@@ -655,7 +657,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         if model_type == 'KerasOpenVINOModel':
             invalidInputError(model is None,
                               "Argument 'model' must be None for OpenVINO loading.")
-            return load_openvino_model(path, framework='tensorflow')
+            return load_openvino_model(path, framework='tensorflow', device=device)
         if model_type == 'KerasONNXRuntimeModel':
             invalidInputError(model is None,
                               "Argument 'model' must be None for ONNX Runtime loading.")

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -16,7 +16,6 @@
 
 import os
 import copy
-import yaml
 import time
 from pathlib import Path
 import numpy as np
@@ -613,6 +612,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                InferenceOptimizer.trace/InferenceOptimizer.quantize.
         :param path: Path to saved model. Path should be a directory.
         """
+        import yaml
         path = Path(path)
         path.mkdir(parents=path.parent, exist_ok=True)
         if hasattr(model, '_save'):
@@ -642,6 +642,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :return: Model with different acceleration(None/OpenVINO/ONNX Runtime) or
                  precision(FP32/FP16/BF16/INT8).
         """
+        import yaml
         path = Path(path)
         if not path.exists():
             invalidInputError(False, "{} doesn't exist.".format(path))

--- a/python/nano/src/bigdl/nano/utils/inference/model.py
+++ b/python/nano/src/bigdl/nano/utils/inference/model.py
@@ -43,7 +43,11 @@ class AcceleratedModel(ABC):
         invalidInputError(False, "Method 'numpy_to_tensors' is not implemented.")
 
     def _dump_status(self, path):
+        print("!!!!!!")
+        print("dump status")
         meta_path = Path(path) / "nano_model_meta.yml"
+        print(meta_path)
+        print(self.status)
         with open(meta_path, 'w') as f:
             yaml.safe_dump(self.status, f)
 

--- a/python/nano/src/bigdl/nano/utils/inference/model.py
+++ b/python/nano/src/bigdl/nano/utils/inference/model.py
@@ -63,8 +63,8 @@ class AcceleratedModel(ABC):
         """
         path = Path(path)
         Path.mkdir(path, exist_ok=True)
-        self._dump_status(path)
         self._save_model(path)
+        self._dump_status(path)
 
     @property
     def status(self):

--- a/python/nano/src/bigdl/nano/utils/inference/model.py
+++ b/python/nano/src/bigdl/nano/utils/inference/model.py
@@ -43,11 +43,7 @@ class AcceleratedModel(ABC):
         invalidInputError(False, "Method 'numpy_to_tensors' is not implemented.")
 
     def _dump_status(self, path):
-        print("!!!!!!")
-        print("dump status")
         meta_path = Path(path) / "nano_model_meta.yml"
-        print(meta_path)
-        print(self.status)
         with open(meta_path, 'w') as f:
             yaml.safe_dump(self.status, f)
 

--- a/python/nano/test/inc/tf/test_keras_quantize.py
+++ b/python/nano/test/inc/tf/test_keras_quantize.py
@@ -105,10 +105,11 @@ class TestModelQuantize(TestCase):
         train_dataset = tf.data.Dataset.from_tensor_slices((train_examples, train_labels))
         q_model = InferenceOptimizer.quantize(model, x=train_dataset)
         assert q_model
-        output = q_model(train_examples[0:10])
-        assert output.shape == (10, 10)
+        output1 = q_model(train_examples[0:10])
+        assert output1.shape == (10, 10)
         with tempfile.TemporaryDirectory() as tmp_dir:
             InferenceOptimizer.save(q_model, tmp_dir)
             load_model = InferenceOptimizer.load(tmp_dir, model)
-            output = load_model(train_examples[0:10])
-            assert output.shape == (10, 10)
+            output2 = load_model(train_examples[0:10])
+            assert output2.shape == (10, 10)
+            np.testing.assert_almost_equal(output1.numpy(), output2.numpy(), decimal=5)

--- a/python/nano/test/onnx/tf/test_inc_onnx.py
+++ b/python/nano/test/onnx/tf/test_inc_onnx.py
@@ -137,7 +137,7 @@ class TestONNX(TestCase):
         
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(onnx_model, tmp_dir_name)
-            new_onnx_model = InferenceOptimizer.load(tmp_dir_name)
+            new_onnx_model = InferenceOptimizer.load(tmp_dir_name, model)
 
         assert new_onnx_model.session_options.intra_op_num_threads == 1
         assert new_onnx_model.session_options.inter_op_num_threads == 1

--- a/python/nano/test/onnx/tf/test_inc_onnx.py
+++ b/python/nano/test/onnx/tf/test_inc_onnx.py
@@ -121,7 +121,7 @@ class TestONNX(TestCase):
         onnx_model = InferenceOptimizer.quantize(model,
                                                  accelerator='onnxruntime',
                                                  x=train_dataset,
-                                                 thread_num=8)
+                                                 thread_num=1)
 
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             onnx_model._save(tmp_dir_name)

--- a/python/nano/test/onnx/tf/test_onnx.py
+++ b/python/nano/test/onnx/tf/test_onnx.py
@@ -70,7 +70,7 @@ class TestONNX(TestCase):
         
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(onnx_model, tmp_dir_name)
-            new_onnx_model = InferenceOptimizer.load(tmp_dir_name)
+            new_onnx_model = InferenceOptimizer.load(tmp_dir_name, model)
 
         assert new_onnx_model.session_options.intra_op_num_threads == 1
         assert new_onnx_model.session_options.inter_op_num_threads == 1

--- a/python/nano/test/onnx/tf/test_onnx.py
+++ b/python/nano/test/onnx/tf/test_onnx.py
@@ -67,3 +67,15 @@ class TestONNX(TestCase):
         preds2 = new_onnx_model(input_examples).numpy()
 
         np.testing.assert_almost_equal(preds1, preds2, decimal=5)
+        
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(onnx_model, tmp_dir_name)
+            new_onnx_model = InferenceOptimizer.load(tmp_dir_name)
+
+        assert new_onnx_model.session_options.intra_op_num_threads == 1
+        assert new_onnx_model.session_options.inter_op_num_threads == 1
+
+        preds1 = onnx_model(input_examples).numpy()
+        preds2 = new_onnx_model(input_examples).numpy()
+
+        np.testing.assert_almost_equal(preds1, preds2, decimal=5)

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -154,7 +154,7 @@ class TestOpenVINO(TestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(openvino_model, tmp_dir_name)
-            model = InferenceOptimizer.load(tmp_dir_name)
+            model = InferenceOptimizer.load(tmp_dir_name, device='CPU')
 
         with InferenceOptimizer.get_context(model):
             assert torch.get_num_threads() == 2
@@ -282,3 +282,8 @@ class TestOpenVINO(TestCase):
         # GPU don't support dynamic shape
         with pytest.raises(RuntimeError):
             openvino_model(x2)
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(openvino_model, tmp_dir_name)
+            model = InferenceOptimizer.load(tmp_dir_name)  # GPU model
+            model = InferenceOptimizer.load(tmp_dir_name, device='CPU')  # CPU model

--- a/python/nano/test/openvino/tf/test_openvino.py
+++ b/python/nano/test/openvino/tf/test_openvino.py
@@ -18,6 +18,8 @@ import tensorflow as tf
 from tensorflow.keras.applications.mobilenet_v2 import MobileNetV2
 import numpy as np
 from bigdl.nano.tf.keras import Model, InferenceOptimizer
+import tempfile
+from bigdl.nano.deps.openvino.tf.model import KerasOpenVINOModel
 
 
 class TestOpenVINO(TestCase):
@@ -44,3 +46,36 @@ class TestOpenVINO(TestCase):
                                                   openvino_config={"PERFORMANCE_HINT": "LATENCY"})
         y_hat = openvino_model(train_examples[:10])
         assert y_hat.shape == (10, 10)
+    
+    def test_model_trace_openvino_save_load(self):
+        model = MobileNetV2(weights=None, input_shape=[40, 40, 3], classes=10)
+        model = Model(inputs=model.inputs, outputs=model.outputs)
+        train_examples = np.random.random((100, 40, 40, 3))
+        train_labels = np.random.randint(0, 10, size=(100,))
+        train_dataset = tf.data.Dataset.from_tensor_slices((train_examples, train_labels)).batch(2)
+
+        # trace a Keras model
+        openvino_model = InferenceOptimizer.trace(model, accelerator='openvino', thread_num=4)
+        y_hat = openvino_model(train_examples[:10])
+        assert y_hat.shape == (10, 10)
+
+        y_hat = openvino_model.predict(train_examples, batch_size=5)
+        assert y_hat.shape == (100, 10)
+        
+        # test original save / load
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            openvino_model._save(tmp_dir_name)
+            new_ov_model = KerasOpenVINOModel._load(tmp_dir_name)
+
+        preds1 = openvino_model(train_examples).numpy()
+        preds2 = new_ov_model(train_examples).numpy()
+        np.testing.assert_almost_equal(preds1, preds2, decimal=5)
+
+        # test InferencOptimizer save / load
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(openvino_model, tmp_dir_name)
+            new_ov_model = InferenceOptimizer.load(tmp_dir_name)
+
+        preds1 = openvino_model(train_examples).numpy()
+        preds2 = new_ov_model(train_examples).numpy()
+        np.testing.assert_almost_equal(preds1, preds2, decimal=5)

--- a/python/nano/test/openvino/tf/test_openvino.py
+++ b/python/nano/test/openvino/tf/test_openvino.py
@@ -74,13 +74,13 @@ class TestOpenVINO(TestCase):
         # test InferencOptimizer save / load
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(openvino_model, tmp_dir_name)
-            new_ov_model = InferenceOptimizer.load(tmp_dir_name)
+            new_ov_model = InferenceOptimizer.load(tmp_dir_name, model)
 
         preds1 = openvino_model(train_examples).numpy()
         preds2 = new_ov_model(train_examples).numpy()
         np.testing.assert_almost_equal(preds1, preds2, decimal=5)
 
-    def test_model_trace_openvino_save_load(self):
+    def test_model_trace_openvino_gpu_save_load(self):
         # test whether contains GPU
         from openvino.runtime import Core
         core = Core()
@@ -104,5 +104,5 @@ class TestOpenVINO(TestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(openvino_model, tmp_dir_name)
-            model = InferenceOptimizer.load(tmp_dir_name)  # GPU model
-            model = InferenceOptimizer.load(tmp_dir_name, device='CPU')  # CPU model
+            load_model = InferenceOptimizer.load(tmp_dir_name, model)  # GPU model
+            load_model = InferenceOptimizer.load(tmp_dir_name, model, device='CPU')  # CPU model

--- a/python/nano/test/openvino/tf/test_openvino_quantize.py
+++ b/python/nano/test/openvino/tf/test_openvino_quantize.py
@@ -174,7 +174,7 @@ class TestOpenVINO(TestCase):
         # test InferencOptimizer save / load
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(openvino_model, tmp_dir_name)
-            new_ov_model = InferenceOptimizer.load(tmp_dir_name)
+            new_ov_model = InferenceOptimizer.load(tmp_dir_name, model)
 
         preds1 = openvino_model(train_examples).numpy()
         preds2 = new_ov_model(train_examples).numpy()

--- a/python/nano/test/openvino/tf/test_openvino_quantize.py
+++ b/python/nano/test/openvino/tf/test_openvino_quantize.py
@@ -18,6 +18,8 @@ import tensorflow as tf
 from tensorflow.keras.applications.mobilenet_v2 import MobileNetV2
 import numpy as np
 from bigdl.nano.tf.keras import Model, InferenceOptimizer
+import tempfile
+from bigdl.nano.deps.openvino.tf.model import KerasOpenVINOModel
 
 
 class TestOpenVINO(TestCase):
@@ -139,3 +141,41 @@ class TestOpenVINO(TestCase):
         preds = model.predict(train_examples)
         openvino_preds = openvino_quantized_model.predict(train_examples)
         np.testing.assert_allclose(preds, openvino_preds, rtol=1e-2)
+
+    def test_model_quantize_openvino_save_load(self):
+        model = MobileNetV2(weights=None, input_shape=[40, 40, 3], classes=10)
+        model = Model(inputs=model.inputs, outputs=model.outputs)
+        train_examples = np.random.random((100, 40, 40, 3))
+        train_labels = np.random.randint(0, 10, size=(100,))
+        train_dataset = tf.data.Dataset.from_tensor_slices((train_examples, train_labels))
+
+        # Case1: Trace and quantize
+        openvino_model = model.trace(accelerator='openvino')
+        openvino_quantized_model = InferenceOptimizer.quantize(openvino_model,
+                                                               accelerator='openvino',
+                                                               x=train_dataset,
+                                                               thread_num=8)
+
+        y_hat = openvino_quantized_model(train_examples[:10])
+        assert y_hat.shape == (10, 10)
+
+        y_hat = openvino_quantized_model.predict(train_examples, batch_size=5)
+        assert y_hat.shape == (100, 10)
+        
+        # test original save / load
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            openvino_model._save(tmp_dir_name)
+            new_ov_model = KerasOpenVINOModel._load(tmp_dir_name)
+
+        preds1 = openvino_model(train_examples).numpy()
+        preds2 = new_ov_model(train_examples).numpy()
+        np.testing.assert_almost_equal(preds1, preds2, decimal=5)
+
+        # test InferencOptimizer save / load
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(openvino_model, tmp_dir_name)
+            new_ov_model = InferenceOptimizer.load(tmp_dir_name)
+
+        preds1 = openvino_model(train_examples).numpy()
+        preds2 = new_ov_model(train_examples).numpy()
+        np.testing.assert_almost_equal(preds1, preds2, decimal=5)

--- a/python/nano/test/tf/keras/test_inf_optimizer.py
+++ b/python/nano/test/tf/keras/test_inf_optimizer.py
@@ -148,16 +148,19 @@ class TestInferencePipeline(TestCase):
         opt = InferenceOptimizer()
         opt.optimize(model=model,
                      x=train_dataset,
+                     y=None,
                      batch_size=4,
                      latency_sample_num=10)
-        optimize_result = opt.optimized_model_dict
-        with tempfile.TemporaryDirectory() as tmp_dir_name:
-            for method, option in optimize_result.items():
-                if 'model' in option:
-                    acc_model = option['model']
+        methods = opt.ALL_INFERENCE_ACCELERATION_METHOD
+        for method in methods.keys():
+            option = opt.optimized_model_dict[method]
+            if 'model' in option:
+                acc_model = option['model']
+                with tempfile.TemporaryDirectory() as tmp_dir_name:
                     dir_name = os.path.join(tmp_dir_name, method)
                     InferenceOptimizer.save(acc_model, dir_name)
                     try:
                         acc_model = InferenceOptimizer.load(dir_name)
                     except:
                         acc_model = InferenceOptimizer.load(dir_name, model)
+                del acc_model

--- a/python/nano/test/tf/keras/test_inf_optimizer.py
+++ b/python/nano/test/tf/keras/test_inf_optimizer.py
@@ -137,6 +137,13 @@ class TestInferencePipeline(TestCase):
         train_examples = np.random.random((100, 40, 40, 3))
         train_labels = np.random.randint(0, 10, size=(100,))
         train_dataset = tf.data.Dataset.from_tensor_slices((train_examples, train_labels))
+        # save load for original model
+        output1 = model(train_examples)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model)
+            output2 = load_model(train_examples)
+            np.testing.assert_almost_equal(output1.numpy(), output2.numpy(), decimal=5)
         # prepare optimizer
         opt = InferenceOptimizer()
         opt.optimize(model=model,

--- a/python/nano/test/tf/keras/test_inf_optimizer.py
+++ b/python/nano/test/tf/keras/test_inf_optimizer.py
@@ -118,7 +118,7 @@ class TestInferencePipeline(TestCase):
                      latency_sample_num=10,
                      thread_num=8)
         model = opt.get_best_model()
-        
+
         # test dataset with only x
         model = ResNet50(weights=None, input_shape=[40, 40, 3], classes=10)
         train_examples = np.random.random((100, 40, 40, 3))
@@ -131,12 +131,10 @@ class TestInferencePipeline(TestCase):
                      thread_num=8)
         model = opt.get_best_model()
 
-    def test_optimize_save_load(self):
+    def test_optimizer_save_load(self):
         model = ResNet50(weights=None, input_shape=[40, 40, 3], classes=10)
         # prepare dataset
         train_examples = np.random.random((100, 40, 40, 3))
-        train_labels = np.random.randint(0, 10, size=(100,))
-        train_dataset = tf.data.Dataset.from_tensor_slices((train_examples, train_labels))
         # save load for original model
         output1 = model(train_examples)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
@@ -144,23 +142,3 @@ class TestInferencePipeline(TestCase):
             load_model = InferenceOptimizer.load(tmp_dir_name, model)
             output2 = load_model(train_examples)
             np.testing.assert_almost_equal(output1.numpy(), output2.numpy(), decimal=5)
-        # prepare optimizer
-        opt = InferenceOptimizer()
-        opt.optimize(model=model,
-                     x=train_dataset,
-                     y=None,
-                     batch_size=4,
-                     latency_sample_num=10)
-        methods = opt.ALL_INFERENCE_ACCELERATION_METHOD
-        for method in methods.keys():
-            option = opt.optimized_model_dict[method]
-            if 'model' in option:
-                acc_model = option['model']
-                with tempfile.TemporaryDirectory() as tmp_dir_name:
-                    dir_name = os.path.join(tmp_dir_name, method)
-                    InferenceOptimizer.save(acc_model, dir_name)
-                    try:
-                        acc_model = InferenceOptimizer.load(dir_name)
-                    except:
-                        acc_model = InferenceOptimizer.load(dir_name, model)
-                del acc_model


### PR DESCRIPTION
## Description

Support save & load for inc, openvino and onnxrutime model, provide `save`/`load` function for keras InferenceOptimizer.

### 1. Why the change?

Support `save`/`load` function for keras InferenceOptimizer to provide a consistent API with torch and help users save/load the model conveniently.

### 2. User API changes

```python
from bigdl.nano.tf.keras import InferenceOptimizer
model = ...

# for original model
InferenceOptimizer.save(model, save_dir)
load_model = InferenceOptimizer.load(save_dir, model)

# for trace
acc_model = InferenceOptimizer.trace(model, accelerator=...)
InferenceOptimizer.save(acc_model, save_dir)
load_model = InferenceOptimizer.load(save_dir) # if accelerator != None
load_model = InferenceOptimizer.load(save_dir, model) # if accelerator = None

# for quantize
acc_model = InferenceOptimizer.quantize(model, accelerator=..., calib_data=...)
InferenceOptimizer.save(acc_model, save_dir)
load_model = InferenceOptimizer.load(save_dir) # if accelerator != None
load_model = InferenceOptimizer.load(save_dir, model) # if accelerator = None
```


### 3. Summary of the change 

- fix thread_num and onnxruntime_session_options bug of keras onnx quantization model
- support save & load for inc model
- support save & load for openvino/onnxruntime model
- support save & load function for keras InferenceOptimizer
- add `device` parameter for InferenceOptimizer's `load` function
- support restoring attributes and compile kwargs after loading keras accelerated model
- related uts

### 4. How to test?
- [x] Unit test
