### PR TITLE
Fix transform SparkXShards of Pandas Dataframe from MinMaxScaler

### DIFF
--- a/python/orca/src/bigdl/orca/learn/utils.py
+++ b/python/orca/src/bigdl/orca/learn/utils.py
@@ -365,8 +365,11 @@ def transform_to_shard_dict(data, feature_cols, label_cols=None):
                            for feature_col in feature_cols]
 
         if label_cols:
-            result["y"] = [single_col_to_numpy(df[label_col], col_types[label_col])
-                           for label_col in label_cols]
+            y = [single_col_to_numpy(df[label_col], col_types[label_col])
+                 for label_col in label_cols]
+            if len(label_cols) == 1:
+                y = y[0]
+            result["y"] = y
 
         return result
 

--- a/python/orca/src/bigdl/orca/learn/utils.py
+++ b/python/orca/src/bigdl/orca/learn/utils.py
@@ -341,18 +341,14 @@ arrays2pandas = partial(arrays2others, generate_func=_generate_output_pandas_df)
 
 def transform_to_shard_dict(data, feature_cols, label_cols=None):
     def single_col_to_numpy(col_series, dtype):
-        if dtype == np.int32:
-            return col_series.to_numpy(dtype=np.int32)
-        elif dtype == np.int64:
-            return col_series.to_numpy(dtype=np.int64)
-        elif dtype == np.float32:
-            return col_series.to_numpy(dtype=np.float32)
-        elif dtype == np.float64:
-            return col_series.to_numpy(dtype=np.float64)
-        elif dtype == np.str:
-            return col_series.to_numpy(dtype=np.str)
-        else:  # e.g. np.object
-            return col_series.to_numpy(dtype=np.float32)
+        if dtype == np.ndarray:
+            # In this case, directly calling to_numpy will make the result
+            # ndarray have type np.object.
+            # Need to explicitly specify the dtype.
+            dtype = col_series[0].dtype
+            return col_series.to_numpy(dtype=dtype)
+        else:
+            return col_series.to_numpy()
 
     def to_shard_dict(df):
         result = dict()

--- a/python/orca/src/bigdl/orca/learn/utils.py
+++ b/python/orca/src/bigdl/orca/learn/utils.py
@@ -345,7 +345,7 @@ def transform_to_shard_dict(data, feature_cols, label_cols=None):
             # In this case, directly calling to_numpy will make the result
             # ndarray have type np.object.
             # Need to explicitly specify the dtype.
-            dtype = col_series[0].dtype
+            dtype = col_series.iloc[0].dtype
             return col_series.to_numpy(dtype=dtype)
         else:
             return col_series.to_numpy()


### PR DESCRIPTION
From MinMaxScaler, the result type of column is of numpy.object (numpy.ndarray), if directly call to_numpy(), will result in numpy.object as well, which can't be put into TensorFlow dataset.from_tensor_slices.

```
  File "/home/yingzhe/anaconda3/envs/bigdl_spark3/lib/python3.7/site-packages/tensorflow/python/framework/constant_op.py", line 304, in _constant_eager_impl
    t = convert_to_eager_tensor(value, ctx, dtype)
  File "/home/yingzhe/anaconda3/envs/bigdl_spark3/lib/python3.7/site-packages/tensorflow/python/framework/constant_op.py", line 102, in convert_to_eager_tensor
    return ops.EagerTensor(value, ctx.device_name, dtype)
ValueError: Failed to convert a NumPy array to a Tensor (Unsupported object type list).
```