### PR TITLE
Implement MMCVRayEstimator get_model method

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_estimator.py
@@ -102,7 +102,9 @@ class MMCVRayEstimator(BaseRayEstimator):
         pass
 
     def get_model(self):
-        pass
+        state = self.get_state_dict()
+        model_state = state["state_dict"]
+        return model_state
 
     def load_checkpoint(
             self,

--- a/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_estimator.py
@@ -101,7 +101,7 @@ class MMCVRayEstimator(BaseRayEstimator):
     def evaluate(self, **kwargs):
         pass
 
-    def get_model(self):
+    def get_model(self) -> Dict:
         state = self.get_state_dict()
         model_state = state["state_dict"]
         return model_state

--- a/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_runner.py
@@ -342,10 +342,10 @@ class MMCVRayEpochRunner(BaseRunner, EpochBasedRunner):
         if hasattr(model, 'CLASSES') and model.CLASSES is not None:
             meta.update(CLASSES=model.CLASSES)
 
-        from mmcv.runner.checkpoint import weights_to_cpu, get_state_dict
+        from mmcv.runner.checkpoint import get_state_dict as model_state_dict
         state = {
             'meta': meta,
-            'state_dict': weights_to_cpu(get_state_dict(model))
+            'state_dict': model_state_dict(model)
         }
 
         if isinstance(self.optimizer, Optimizer):

--- a/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_runner.py
@@ -23,6 +23,7 @@ import numpy as np
 import torch
 import warnings
 from collections import OrderedDict
+from torch.optim import Optimizer
 from mmcv.runner import EpochBasedRunner
 from mmcv.runner.utils import get_host_info
 from mmcv.parallel import is_module_wrapper

--- a/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_runner.py
@@ -25,6 +25,7 @@ import warnings
 from collections import OrderedDict
 from mmcv.runner import EpochBasedRunner
 from mmcv.runner.utils import get_host_info
+from mmcv.parallel import is_module_wrapper
 from mmcv.parallel.distributed import MMDistributedDataParallel
 from mmcv.fileio.file_client import BaseStorageBackend
 from mmcv.utils.misc import is_list_of
@@ -327,9 +328,33 @@ class MMCVRayEpochRunner(BaseRunner, EpochBasedRunner):
     def remove_checkpoint(self, filepath: str) -> None:
         pass
 
-    def get_state_dict(self) -> None:
+    def get_state_dict(self) -> Dict:
         """Returns the state of the runner."""
-        pass
+        meta = {}
+        if self.meta is not None:
+            meta.update(self.meta)
+        meta.update(epoch=self.epoch, iter=self.iter)
+        model = self.model
+        if is_module_wrapper(model):
+            model = model.module
+
+        if hasattr(model, 'CLASSES') and model.CLASSES is not None:
+            meta.update(CLASSES=model.CLASSES)
+
+        from mmcv.runner.checkpoint import weights_to_cpu, get_state_dict
+        state = {
+            'meta': meta,
+            'state_dict': weights_to_cpu(get_state_dict(model))
+        }
+
+        if isinstance(self.optimizer, Optimizer):
+            state['optimizer'] = self.optimizer.state_dict()
+        elif isinstance(self.optimizer, dict):
+            state['optimizer'] = {}
+            for name, optim in self.optimizer.items():
+                state['optimizer'][name] = optim.state_dict()
+
+        return state
 
     def load_state_dict(self, checkpoint: Dict, strict: bool = False,
                         revise_keys: list = [(r'^module.', '')]) -> None:

--- a/python/orca/test/bigdl/orca/learn/ray/experimental/test_mmcv_estimator_ray_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/experimental/test_mmcv_estimator_ray_backend.py
@@ -250,6 +250,24 @@ class TestMMCVRayEstimator(unittest.TestCase):
         if os.path.exists(TEMP_WORK_DIR):
             shutil.rmtree(TEMP_WORK_DIR)
 
+    def test_get_model(self):
+        model = Model()
+        optimizer = optim.SGD(model.parameters(), lr=0.001, momentum=0.9)
+        cfg = dict(
+            model=model,
+            optimizer=optimizer,
+            batch_processor=None,
+            lr_config=dict(policy='step', step=[2, 3]),
+            optimizer_config=dict(grad_clip=None),
+            checkpoint_config=None,
+            log_config=dict(interval=4, hooks=[dict(type='TextLoggerHook')])
+        )
+        estimator = get_estimator(runner_creator, cfg)
+        estimator.run([train_dataloader_creator], [('train', 1)])
+
+        model_state_dict = estimator.get_model()
+        assert model_state_dict
+
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->
- Implement MMCVRayEstimator get_model() method
- Implement MMCVRayEpochRunner get_state_dict()
- add uint test
### 1. Why the change?

<!-- Provide the related github issue link if available -->
get the state dict of the trained model
### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->
user can get the model state dict through MMCVRayEstimator `get_model()` method
```python
# create a MMCVRayEstimator
estimator = ...

model_state = estimator.get_model()
```
`model_state` is an OrderedDict contains the model state, example as below
```
OrderedDict([('fc1.weight', tensor([[*****]]))])
```

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
- Implement MMCVRayEstimator get_model() method
- Implement MMCVRayEpochRunner get_state_dict()
- add uint test
### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

