### PR TITLE
Chronos: update electricity example

### DIFF
--- a/python/chronos/use-case/electricity/README.md
+++ b/python/chronos/use-case/electricity/README.md
@@ -73,6 +73,7 @@ and the inference latency is shown like this:
 Inference latency is: 0.0007678081938332728
 Inference latency with onnx is: 0.0009106415060963754
 ```
+*Note: After using `dummy_encoder` to turn TCNForecaster to a Linear Model, predicting with ONNXRuntime suffers overhead on electricity dataset.*
 
 ### AutoformerForecaster
 

--- a/python/chronos/use-case/electricity/README.md
+++ b/python/chronos/use-case/electricity/README.md
@@ -60,18 +60,18 @@ python autoformer.py # for autoformer forecaster
 ### TCNForecaster
 After you run the code, the training process is shown like this:
 ```bash
-Epoch 0:  28%|██████████████████████████                                                                  | 156/550 [00:09<00:25, 15.62it/s, loss=1.13]
+Epoch 0:  22%|█████████████████████████████████▎                                                                                                                   | 123/550 [00:04<00:15, 28.05it/s, loss=0.355]
 ```
 
 After training 30 epochs, MSE is shown like this,
 ```bash
-MSE is: 0.5876001
+MSE is: 0.25367737
 ```
 
 and the inference latency is shown like this:
 ```bash
-Inference latency is: 0.00480920190349875
-Inference latency with onnx is: 0.002660592173564555
+Inference latency is: 0.0007678081938332728
+Inference latency with onnx is: 0.0009106415060963754
 ```
 
 ### AutoformerForecaster

--- a/python/chronos/use-case/electricity/README.md
+++ b/python/chronos/use-case/electricity/README.md
@@ -20,8 +20,7 @@ We recommend you to use conda to prepare the environment.
 ```bash
 conda create -n my_env python=3.7 setuptools=58.0.4 # "my_env" is conda environment name, you can use any name you like.
 conda activate my_env
-pip install --pre --upgrade bigdl-chronos[all]
-pip install torch==1.11.0 # for better performance
+pip install --pre --upgrade bigdl-chronos[pytorch,inference]
 source bigdl-nano-init # accelerate the environment
 ```
 
@@ -61,37 +60,37 @@ python autoformer.py # for autoformer forecaster
 ### TCNForecaster
 After you run the code, the training process is shown like this:
 ```bash
-Epoch 0:  17%|████████▏                                       | 94/550 [00:08<00:39, 11.61it/s, loss=0.95]
+Epoch 0:  28%|██████████████████████████                                                                  | 156/550 [00:09<00:25, 15.62it/s, loss=1.13]
 ```
 
 After training 30 epochs, MSE is shown like this,
 ```bash
-MSE is: [array(0.48502076, dtype=float32)]
+MSE is: 0.5876001
 ```
 
 and the inference latency is shown like this:
 ```bash
-Inference latency is: 0.0060901641845703125
-Inference latency with onnx is: 0.0030126571655273438
+Inference latency is: 0.00480920190349875
+Inference latency with onnx is: 0.002660592173564555
 ```
 
 ### AutoformerForecaster
 
 After you run the code, the training process is shown like this:
 ```bash
-Epoch 0:   2%|██▏                                                                                                                   | 10/550 [00:02<02:08,  4.19it/s, loss=1.18]
+Epoch 0:   4%|████                                                                                         | 24/550 [00:09<03:34,  2.46it/s, loss=1.01]
 ```
 
 After training 3 epochs, MSE is shown like this,
 ```bash
-MSE on test dataset: [{'val_loss': 0.2887305021286011}]
+MSE on test dataset: [{'val_loss': 0.30125972628593445}]
 ```
 *Note: Autoformer suffers overfitting problem on electricity dataset.*
 
 and the inference latency is shown like this:
 ```bash
-latency(8 cores): 0.013892467462774168
-latency(1 cores): 0.022499848716141295
+latency(8 cores): 0.010854396792372106
+latency(1 cores): 0.019527499927325033
 ```
 
 

--- a/python/chronos/use-case/electricity/autoformer.py
+++ b/python/chronos/use-case/electricity/autoformer.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-from bigdl.chronos.forecaster.autoformer_forecaster import AutoformerForecaster
-from bigdl.chronos.data import TSDataset
+from bigdl.chronos.forecaster import AutoformerForecaster
+from bigdl.chronos.data import TSDataset, get_public_dataset
 
 import pandas as pd
 from sklearn.preprocessing import StandardScaler
@@ -29,16 +29,10 @@ horizon = 720
 label_len = 48
 
 def generate_data():
-    # read the data
-    raw_df = pd.read_csv('electricity.csv', parse_dates=["date"])
-    target = []
-    for i in range(0, 320):
-        target.append(str(i))
-    target.append("OT")
-
-    # use TSDataset to split and preprocess the data
-    tsdata_train, _, tsdata_test =\
-        TSDataset.from_pandas(raw_df, dt_col="date", target_col=target, with_split=True, test_ratio=0.2, val_ratio=0.1)
+    tsdata_train, tsdata_val, tsdata_test = get_public_dataset(name='tsinghua_electricity',
+                                                               with_split=True,
+                                                               val_ratio=0.1,
+                                                               test_ratio=0.2)
     standard_scaler = StandardScaler()
     for tsdata in [tsdata_train, tsdata_test]:
         tsdata.impute()\
@@ -64,7 +58,7 @@ if __name__ == '__main__':
                                       output_feature_num=321,
                                       label_len=label_len,
                                       freq='h',
-                                      seed=2)  # 
+                                      seed=2)
 
     # get data
     train_loader, test_loader, pred_loader = generate_data()

--- a/python/chronos/use-case/electricity/tcn.py
+++ b/python/chronos/use-case/electricity/tcn.py
@@ -46,15 +46,16 @@ if __name__ == '__main__':
     train_loader, test_loader = generate_data()
    
     forecaster = TCNForecaster(past_seq_len = look_back,
-                            future_seq_len = horizon,
-                            input_feature_num = 321,
-                            output_feature_num = 321,
-                            num_channels = [30] * 7,
-                            repo_initialization = False,
-                            kernel_size = 3, 
-                            dropout = 0.1, 
-                            lr = 0.001,
-                            seed = 1)
+                               future_seq_len = horizon,
+                               input_feature_num = 321,
+                               output_feature_num = 321,
+                               dummy_encoder=True,
+                               num_channels = [30] * 7,
+                               repo_initialization = False,
+                               kernel_size = 3, 
+                               dropout = 0.1, 
+                               lr = 0.001,
+                               seed = 1)
     forecaster.num_processes = 1
     forecaster.fit(train_loader, epochs=30, batch_size=32) 
     

--- a/python/chronos/use-case/electricity/tcn.py
+++ b/python/chronos/use-case/electricity/tcn.py
@@ -14,12 +14,11 @@
 # limitations under the License.
 #
 
-from bigdl.chronos.forecaster.tcn_forecaster import TCNForecaster
+from bigdl.chronos.forecaster import TCNForecaster
 import pandas as pd
-from bigdl.chronos.data import TSDataset
+from bigdl.chronos.data import TSDataset, get_public_dataset
 from sklearn.preprocessing import StandardScaler
 from bigdl.chronos.metric.forecast_metrics import Evaluator
-from torch.utils.data.dataloader import DataLoader
 import torch
 import time
 import numpy as np
@@ -28,19 +27,10 @@ look_back = 96
 horizon = 720
 
 def generate_data():
-    raw_df = pd.read_csv("electricity.csv")
-    df = pd.DataFrame(pd.to_datetime(raw_df.date))
-    for i in range(0, 320):
-        df[str(i)] = raw_df[str(i)]
-    df["OT"] = raw_df["OT"]
-
-    target = []
-    for i in range(0, 320):
-        target.append(str(i))
-    target.append("OT")
-
-    tsdata_train, tsdata_val, tsdata_test = TSDataset.from_pandas(df, dt_col="date", target_col=target,
-                                                                  with_split=True, test_ratio=0.2, val_ratio=0.1)
+    tsdata_train, tsdata_val, tsdata_test = get_public_dataset(name='tsinghua_electricity',
+                                                               with_split=True,
+                                                               val_ratio=0.1,
+                                                               test_ratio=0.2)
     standard_scaler = StandardScaler()
     for tsdata in [tsdata_train, tsdata_test]:
         tsdata.impute(mode="last")\
@@ -69,11 +59,8 @@ if __name__ == '__main__':
     forecaster.fit(train_loader, epochs=30, batch_size=32) 
     
 
-    metric = []
-    for x, y in test_loader:
-        yhat = forecaster.predict(x.numpy())
-        metric.append(Evaluator.evaluate("mse", y.detach().numpy(), yhat))
-    print("MSE is:", np.mean(metric))
+    metrics = forecaster.evaluate(test_loader, multioutput='uniform_average')
+    print("MSE is:", metrics[0])
 
     torch.set_num_threads(1)
     latency = []
@@ -82,7 +69,9 @@ if __name__ == '__main__':
             st = time.time()
             yhat = forecaster.predict(x.numpy())
             latency.append(time.time()-st)
-    print("Inference latency is:", np.median(latency))
+    # latency is calculated the mean after ruling out the first 10% and last 10%
+    latency = latency[int(0.1*len(latency)):int(0.9*len(latency))]
+    print("Inference latency is:", np.mean(latency))
 
     forecaster.build_onnx(thread_num=1)
     onnx_latency = []
@@ -91,4 +80,6 @@ if __name__ == '__main__':
             st = time.time()
             y_pred = forecaster.predict_with_onnx(x.numpy())
             onnx_latency.append(time.time()-st)
-    print("Inference latency with onnx is:", np.median(onnx_latency))
+    # latency is calculated the mean after ruling out the first 10% and last 10%
+    onnx_latency = onnx_latency[int(0.1*len(onnx_latency)):int(0.9*len(onnx_latency))]
+    print("Inference latency with onnx is:", np.mean(onnx_latency))


### PR DESCRIPTION
## Description

In the example of chronos forecasters(TCN, Autoformer) on electricity dataset, some out-of-date methods and descriptions need to update.

### 3. Summary of the change 

3.1 utilize `get_public_dataset` and `forecaster.evaluate`
3.2 unify the calculation of latency
3.3 update readme (especially how to prepare env)

