### PR TITLE
[Nano] Add doc strings for `auto_lr` in `Trainer`, `TorchNano` and `@nano`

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/torch_nano.py
+++ b/python/nano/src/bigdl/nano/pytorch/torch_nano.py
@@ -164,6 +164,9 @@ class TorchNano(LightningLite):
             only take effect when ``num_processes`` > 1
         :param channels_last: whether convert input to channels last memory formats,
             defaults to ``False``.
+        :param auto_lr: whether to scale the learning rate linearly by ``num_processes`` times.
+            Defaults to ``True``.
+            If ``num_processes=1`` or other ``lr_scheduler`` is set, ``auto_lr`` will be ignored.
         """
         self.num_processes = num_processes
         self.use_ipex = use_ipex
@@ -386,6 +389,9 @@ def nano(num_processes: Optional[int] = None,
         only take effect when ``num_processes`` > 1
     :param channels_last: whether convert input to channels last memory formats,
         defaults to ``False``.
+    :param auto_lr: whether to scale the learning rate linearly by ``num_processes`` times.
+        Defaults to ``True``.
+        If ``num_processes=1`` or other ``lr_scheduler`` is set, ``auto_lr`` will be ignored.
     """
     if "strategy" in kwargs:
         strategy = kwargs["strategy"]

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -60,7 +60,7 @@ class Trainer(pl.Trainer):
                  cpu_for_each_process: Optional[List[List[int]]] = None,
                  use_hpo=False,
                  channels_last: bool = False,
-                 auto_lr: Union[int, bool] = True,
+                 auto_lr: Union[dict, bool] = True,
                  precision: Union[str, int] = 32,
                  *args: Any, **kwargs: Any) -> None:
         """
@@ -68,16 +68,22 @@ class Trainer(pl.Trainer):
 
         :param num_processes: number of processes in distributed training. default: 1.
         :param use_ipex: whether we use ipex as accelerator for trainer. default: False.
-        :param distributed_backend: use which backend in distributed mode, defaults to \
-            "subprocess", now avaiable backends are 'spawn', 'subprocess' and 'ray'
-        :param cpu_for_each_process: A list of length `num_processes`, each containing a list of
-            indices of cpus each process will be using. default: None, and the cpu will be
+        :param distributed_backend: use which backend in distributed mode, defaults to
+            ``'subprocess'``, now avaiable backends are ``'spawn'``, ``'subprocess'`` and ``'ray'``
+        :param cpu_for_each_process: A list of length ``num_processes``, each containing a list of
+            indices of cpus each process will be using. default: ``None``, and the cpu will be
             automatically and evenly distributed among processes.
-        :param channels_last: whether convert input to channels last memory formats, \
-            defaults to False.
-        :param precision: Double precision (64), full precision (32), half precision (16)
-            or bfloat16 precision (bf16), defaults to 32.
-            Enable ipex bfloat16 weight prepack when `use_ipex=True` and `precision='bf16'`
+        :param channels_last: whether convert input to channels last memory formats,
+            defaults to ``False``.
+        :param auto_lr: whether to scale the learning rate linearly by ``num_processes`` times.
+            Defaults to ``True``.
+            A dict with ``warmup_epochs`` as key is also accepted to control the number of epochs 
+            needed for the learning rate to be scaled by ``num_processes`` times.
+            If ``auto_lr=Ture``, ``warmup_epochs`` will by default be ``max_epochs // 10``.
+            If ``num_processes=1`` or other ``lr_scheduler`` is set, ``auto_lr`` will be ignored.
+        :param precision: Double precision (``64``), full precision (``32``),
+            half precision (``16``) or bfloat16 precision (``'bf16'``), defaults to ``32``.
+            Enable ipex bfloat16 weight prepack when ``use_ipex=True`` and ``precision='bf16'``
         """
         # Check keyword arguments
         if "accelerator" in kwargs:

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -66,8 +66,8 @@ class Trainer(pl.Trainer):
         """
         A pytorch lightning trainer that uses bigdl-nano optimization.
 
-        :param num_processes: number of processes in distributed training. default: 1.
-        :param use_ipex: whether we use ipex as accelerator for trainer. default: False.
+        :param num_processes: number of processes in distributed training. default: ``1``.
+        :param use_ipex: whether we use ipex as accelerator for trainer. default: ``False``.
         :param distributed_backend: use which backend in distributed mode, defaults to
             ``'subprocess'``, now avaiable backends are ``'spawn'``, ``'subprocess'`` and ``'ray'``
         :param cpu_for_each_process: A list of length ``num_processes``, each containing a list of
@@ -77,7 +77,7 @@ class Trainer(pl.Trainer):
             defaults to ``False``.
         :param auto_lr: whether to scale the learning rate linearly by ``num_processes`` times.
             Defaults to ``True``.
-            A dict with ``warmup_epochs`` as key is also accepted to control the number of epochs 
+            A dict with ``warmup_epochs`` as key is also accepted to control the number of epochs
             needed for the learning rate to be scaled by ``num_processes`` times.
             If ``auto_lr=Ture``, ``warmup_epochs`` will by default be ``max_epochs // 10``.
             If ``num_processes=1`` or other ``lr_scheduler`` is set, ``auto_lr`` will be ignored.

--- a/python/nano/tutorial/notebook/training/pytorch-lightning/accelerate_pytorch_lightning_training_multi_instance.ipynb
+++ b/python/nano/tutorial/notebook/training/pytorch-lightning/accelerate_pytorch_lightning_training_multi_instance.ipynb
@@ -194,7 +194,9 @@
     ">\n",
     "> By setting `num_processes`, Nano will launch the specific number of processes to perform data-parallel training. By default, CPU cores will be automatically and evenly distributed among processes to avoid conflicts and maximize training throughput. If you would like to specifiy the CPU cores used by each process, You could set `cpu_for_each_process` to a list of length `num_processes`, in which each item is a list of CPU indices.\n",
     "> \n",
-    "> During multi-instance training, the effective batch size is the `batch_size` (in dataloader) $\\times$ `num_processes`, which will cause the number of iterations in each epoch to reduce by a factor of `num_processes`. A common practice to compensate for this is to gradually increase the learning rate to `num_processes` times. You could find more details of this trick in [this paper](https://arxiv.org/abs/1706.02677) published by Facebook."
+    "> During multi-instance training, the effective batch size is the `batch_size` (in dataloader) $\\times$ `num_processes`, which will cause the number of iterations in each epoch to reduce by a factor of `num_processes`. To achieve the same effect as single instance training, a common practice to compensate is to gradually increase the learning rate to `num_processes` times. BigDL-Nano Trainer enable this pratice by default through `auto_lr=True`\n",
+    ">\n",
+    "> Please refer to the [API doc](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/pytorch.html#bigdl.nano.pytorch.Trainer) for more detailed information regarding multi-instance related parameters in `bigdl.nano.pytorch.Trainer`."
    ]
   },
   {


### PR DESCRIPTION
## Description

- Add doc strings for `auto_lr` in `Trainer`, `TorchNano` and `@nano`
- Add `auto_lr` info in related how-to guides
- Correct related doc string syntax

### 4. How to test?

- [x] Document test: https://yuwentestdocs.readthedocs.io/en/auto_lr-doc/doc/PythonAPI/Nano/pytorch.html#bigdl-nano-pytorch-trainer
