### PR TITLE
Nano: add threadnum check with sched_getaffinity to avoid bad performance

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/__init__.py
@@ -30,7 +30,7 @@ if platform.system() == "Linux":
     affinity_core_num = len(os.sched_getaffinity(0))
     preset_thread_nums = torch.get_num_threads()
     if preset_thread_nums > affinity_core_num:
-        torch.set_num_threads(preset_thread_nums)
+        torch.set_num_threads(affinity_core_num)
 
 from .dispatcher import patch_torch, unpatch_torch
 from bigdl.nano.pytorch.inference import InferenceOptimizer

--- a/python/nano/src/bigdl/nano/pytorch/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/__init__.py
@@ -21,6 +21,17 @@ __all__ = ["Trainer", "TorchNano", "InferenceOptimizer"]
 import os
 if 'KMP_INIT_AT_FORK' in os.environ:
     del os.environ['KMP_INIT_AT_FORK']
+
+# reset the num of threads
+import platform
+if platform.system() == "Linux":
+    # only UNIX-like system applied
+    import torch
+    affinity_core_num = len(os.sched_getaffinity(0))
+    preset_thread_nums = torch.get_num_threads()
+    if preset_thread_nums > affinity_core_num:
+        torch.set_num_threads(preset_thread_nums)
+
 from .dispatcher import patch_torch, unpatch_torch
 from bigdl.nano.pytorch.inference import InferenceOptimizer
 from bigdl.nano.pytorch.trainer import Trainer


### PR DESCRIPTION
## Description
This pr is to automatically control the thread num to avoid unproper thread num setting when using `taskset` or `numactl`.

### 1. Why the change?
`OMP_NUM_THREADS` is set by `source bigdl-nano-init` to physical core num, which is proper. while users may use less core by using `taskset` or `numactl`.
E.g.
```bash
taskset -c 0-7 python some-nano-application.py
```

### 2. User API changes

nothing

### 3. Summary of the change 

add a thread num check in bigdl.nano.pytorch.

```python
# test.py
import os
from bigdl.nano.pytorch import InferenceOptimizer, Trainer
import torch

print(os.sched_getaffinity(0))
print(torch.get_num_threads())
```

```bash
(chronos) junweid@junweid-Z390-AORUS-ELITE:~/bug-reproduce$ export OMP_NUM_THREADS=8
(chronos) junweid@junweid-Z390-AORUS-ELITE:~/bug-reproduce/taskset-test$ taskset -c 0-3 python test.py
{0, 1, 2, 3}
4
(chronos) junweid@junweid-Z390-AORUS-ELITE:~/bug-reproduce/taskset-test$ taskset -c 0-5 python test.py
{0, 1, 2, 3, 4, 5}
6
```

### 4. How to test?
- [x] Unit test

