### PR TITLE
Nano: support VPU quantization

### DIFF
--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -90,8 +90,8 @@ class OpenVINOModel:
             self._compiled_model = self._ie.compile_model(model=self.ie_network,
                                                           device_name=self._device,
                                                           config=config)
+            self._infer_request = self._compiled_model.create_infer_request()
         self.final_config = config
-        self._infer_request = self._compiled_model.create_infer_request()
         input_names = [t.any_name for t in self._ie_network.inputs]
         self._forward_args = input_names
 

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -25,11 +25,13 @@ import numpy as np
 
 
 class OpenVINOModel:
-    def __init__(self, ie_network: str, device='CPU', thread_num=None, config=None):
+    def __init__(self, ie_network: str, device='CPU', precision='fp32',
+                 thread_num=None, config=None):
         self._ie = Core()
         # check device
         self._check_device(self._ie, device)
         self._device = device
+        self._precision = precision
         self.thread_num = thread_num
         self.additional_config = config
         self.ie_network = ie_network
@@ -82,9 +84,12 @@ class OpenVINOModel:
         if self.additional_config is not None and self._device == 'CPU':
             # TODO: check addition config based on device
             config.update(self.additional_config)
-        self._compiled_model = self._ie.compile_model(model=self.ie_network,
-                                                      device_name=self._device,
-                                                      config=config)
+        if self._device != 'VPUX' or self._precision == 'int8':
+            # For VPU, now only int8 quantizaton model works
+            # fp16 model always meets compilation error
+            self._compiled_model = self._ie.compile_model(model=self.ie_network,
+                                                          device_name=self._device,
+                                                          config=config)
         self.final_config = config
         self._infer_request = self._compiled_model.create_infer_request()
         input_names = [t.any_name for t in self._ie_network.inputs]

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -79,6 +79,7 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
 
             self.ov_model = OpenVINOModel(ov_model_path,
                                           device=device,
+                                          precision=precision,
                                           thread_num=thread_num,
                                           config=config)
             super().__init__(None)
@@ -163,7 +164,10 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
                                   n_requests=n_requests, sample_size=sample_size)
         # below code will re-define a new object, and original attrs will be lost.
         # return PytorchOpenVINOModel(model, thread_num=thread_num, config=config)
-        self.__init__(model, thread_num=thread_num, config=config)
+        self.__init__(model,
+                      thread_num=thread_num,
+                      precision='int8',
+                      config=config)
         return self
 
     def _save_model(self, path):

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -46,7 +46,7 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         :param thread_num: a int represents how many threads(cores) is needed for
                            inference. default: None.
         :param device: A string represents the device of the inference. Default to 'CPU'.
-                       'CPU', 'GPU' and 'VPU' are supported for now.
+                       'CPU', 'GPU' and 'VPUX' are supported for now.
         :param dynamic_axes: dict or boolean, default to True. By default the exported onnx model
                              will have the first dim of each Tensor input as a dynamic batch_size.
                              If dynamic_axes=False, the exported model will have the shapes of all

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -54,6 +54,7 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
                 ov_model_path = dir / 'tmp.xml'
             self.ov_model = OpenVINOModel(ov_model_path,
                                           device=device,
+                                          precision=precision,
                                           thread_num=thread_num,
                                           config=config)
             super().__init__(None)
@@ -99,7 +100,8 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
         model = self.ov_model.pot(dataloader, metric=metric, drop_type=drop_type,
                                   maximal_drop=maximal_drop, max_iter_num=max_iter_num,
                                   n_requests=n_requests, sample_size=sample_size)
-        return KerasOpenVINOModel(model, config=config, thread_num=thread_num)
+        return KerasOpenVINOModel(model, precision='int8',
+                                  config=config, thread_num=thread_num)
 
     @staticmethod
     def _load(path, device=None):

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -38,7 +38,7 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
         :param thread_num: a int represents how many threads(cores) is needed for
                     inference. default: None.
         :param device: A string represents the device of the inference. Default to 'CPU'.
-                       'CPU', 'GPU' and 'VPU' are supported for now.
+                       'CPU', 'GPU' and 'VPUX' are supported for now.
         :param config: The config to be inputted in core.compile_model.
                        inference. default: None.
         :param logging: whether to log detailed information of model conversion.

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -831,7 +831,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 invalidInputError(False,
                                   "Accelerator {} is invalid.".format(accelerator))
         if precision == 'fp16':
-            invalidInputError(device == 'VPUX' or 'GPU' in device,
+            invalidInputError('GPU' in device,
                               "fp16 is not supported on {} device.".format(device))
             invalidInputError(accelerator == 'openvino',
                               "fp16 is not supported on {} accelerator.".format(accelerator))

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -791,7 +791,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                     if input_sample is None:
                         # input_sample can be a dataloader
                         input_sample = calib_dataloader
-                    # For CPU: fp32 -> int8, for GPU: fp16 -> int8
+                    # For CPU: fp32 -> int8, for GPU/VPUX: fp16 -> int8
                     _precision = 'fp16' if device != 'CPU' else 'fp32'
                     model = PytorchOpenVINOModel(model, input_sample,
                                                  precision=_precision,

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -835,15 +835,13 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                               "fp16 is not supported on {} device.".format(device))
             invalidInputError(accelerator == 'openvino',
                               "fp16 is not supported on {} accelerator.".format(accelerator))
-            if openvino_config is not None:
-                final_openvino_option = openvino_config
             return PytorchOpenVINOModel(model, input_sample,
                                         precision=precision,
                                         thread_num=thread_num,
                                         device=device,
                                         dynamic_axes=dynamic_axes,
                                         logging=logging,
-                                        config=final_openvino_option,
+                                        config=openvino_config,
                                         **export_kwargs)
 
         invalidInputError(False,

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -463,7 +463,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                               "Now we only support {} device when accelerator "
                               "is openvino.".format(device))
         if precision == 'fp16':
-            invalidInputError(device == 'VPUX' or 'GPU' in device,
+            invalidInputError('GPU' in device,
                               "fp16 is not supported on {} device.".format(device))
             invalidInputError(accelerator == 'openvino',
                               "fp16 is not supported on {} accelerator.".format(accelerator))

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -467,14 +467,12 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                               "fp16 is not supported on {} device.".format(device))
             invalidInputError(accelerator == 'openvino',
                               "fp16 is not supported on {} accelerator.".format(accelerator))
-            if openvino_config is not None:
-                final_openvino_option = openvino_config
             from bigdl.nano.deps.openvino.tf.model import KerasOpenVINOModel    # type: ignore
             result = KerasOpenVINOModel(model,
                                         precision=precision,
                                         thread_num=thread_num,
                                         device=device,
-                                        config=final_openvino_option,
+                                        config=openvino_config,
                                         logging=logging)
             return patch_attrs(result, model)
 

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -255,7 +255,7 @@ class TestOpenVINO(TestCase):
             openvino_model(x2)
 
     def test_openvino_vpu_quatize(self):
-        # test whether contains GPU
+        # test whether contains VPU
         from openvino.runtime import Core
         core = Core()
         devices = core.available_devices

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -253,3 +253,30 @@ class TestOpenVINO(TestCase):
         # GPU don't support dynamic shape
         with pytest.raises(RuntimeError):
             openvino_model(x2)
+
+    def test_openvino_vpu_quatize(self):
+        # test whether contains GPU
+        from openvino.runtime import Core
+        core = Core()
+        devices = core.available_devices
+        vpu_avaliable = any('VPUX' in x for x in devices)
+        
+        if vpu_avaliable is False:
+            return
+
+        model = mobilenet_v3_small(num_classes=10)
+
+        x = torch.rand((1, 3, 256, 256))
+        x2 = torch.rand((10, 3, 256, 256))
+
+        # test VPU int8
+        openvino_model = InferenceOptimizer.quanize(model,
+                                                    input_sample=x,
+                                                    accelerator='openvino',
+                                                    device='VPUX',
+                                                    precision='int8',
+                                                    calib_data=x)
+        result = openvino_model(x)
+        # VPU don't support dynamic shape
+        with pytest.raises(RuntimeError):
+            openvino_model(x2)


### PR DESCRIPTION
## Description

support VPU quantization in Nano.

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/245

### 2. User API changes

```python
# VPU int8
ov_model = InferenceOptimizer.quantize(model,
                                       accelerator='openvino',
                                       input_sample=sample,
                                       device='VPUX',
                                       precision='int8',
                                       calib_data=data_loader)
```


### 3. Summary of the change 

- support vpu int8 quantization in PyTorch/Keras InferenceOptimizer
- fix a bug of fp16

### 4. How to test?
- [x] Unit test
