### PR TITLE
Add huggingface encryption

### DIFF
--- a/python/ppml/src/bigdl/ppml/encryption/datasets/__init__.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/__init__.py
@@ -1,0 +1,15 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/__init__.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/__init__.py
@@ -1,0 +1,15 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -134,7 +134,7 @@ def load_with_decryption(dataset_path: str, fs=None, keep_in_memory: Optional[bo
     #     )
     # TODO: test this when keep_in_memory is None
     if key is not None:
-        invalidInputError(keep_in_memory==False, "Currently only support InMemoryTable which requires keep_in_memory set to True")
+        invalidInputError(keep_in_memory==True, "Currently only support InMemoryTable which requires keep_in_memory set to True")
     fs = fsspec.filesystem("file") if fs is None else fs
     dataset_dict_json_path = Path(dataset_path, config.DATASETDICT_JSON_FILENAME).as_posix()
     dataset_info_path = Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix()
@@ -231,7 +231,7 @@ def load_from_disk(dataset_path: str, fs=None, keep_in_memory: Optional[bool] = 
     #     invalidInputError(False, "Please only use filesystem with protocol file, or leave the fs argument to None")
     # invalidInputError(keep_in_memory, "Currently only support keep_in_memory set to True")
     if key is not None:
-        invalidInputError(keep_in_memory==False, "Currently only support InMemoryTable which requires keep_in_memory set to True")
+        invalidInputError(keep_in_memory==True, "Currently only support InMemoryTable which requires keep_in_memory set to True")
     if is_remote_filesystem(fs):
         dest_dataset_path = extract_path_from_uri(dataset_path)
     else:

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -43,7 +43,7 @@ from datasets.table import (
 )
 from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Type, Union
 
-class encrypt_reader_opener(object):
+class encrypt_reader_opener(opener):
     def __init__(self, name, mode, key):
         self.key = Fernet(key)
         opened_file = open(name, mode)

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -57,7 +57,8 @@ def _open_encrypt_file_with_key(file, mode, key: Optional[str] = None):
     if key is not None:
         return encrypt_reader_opener(file, mode, key)
     else:
-        return open(file, mode, encoding="utf-8")
+        # TODO:This is right or not?
+        return open(file, encoding="utf-8")
 
 def decrypt_file_to_pa_buffer(filename, key):
     decryptor = Fernet(key)

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -244,7 +244,8 @@ def load_from_disk(dataset_path: str, fs=None, keep_in_memory: Optional[bool] = 
         invalidInputError(False, f"Directory {dataset_path} not found")
     # TODO: change calling interface
     if fs.isfile(Path(dest_dataset_path, config.DATASET_INFO_FILENAME).as_posix()):
-        return Dataset.load_from_disk(dataset_path, key, fs, keep_in_memory=keep_in_memory)
+        return Dataset.load_from_disk(dataset_path, fs, key=key, keep_in_memory=keep_in_memory)
+    # TODO: test this
     elif fs.isfile(Path(dest_dataset_path, config.DATASETDICT_JSON_FILENAME).as_posix()):
         return DatasetDict.load_from_disk(dataset_path, fs, keep_in_memory=keep_in_memory)
     else:

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -147,7 +147,7 @@ def load_dict_with_decryption(dataset_dict_path: str, fs=None, key: Optional[str
                 if is_remote_filesystem(fs)
                 else Path(dest_dataset_dict_path, k).as_posix()
             )
-            dataset_dict[k] = Dataset.load_from_disk(dataset_dict_split_path, fs, keep_in_memory=keep_in_memory)
+            dataset_dict[k] = Dataset.load_from_disk(dataset_dict_split_path, fs, keep_in_memory=keep_in_memory, key=key)
 
     return dataset_dict
 
@@ -294,7 +294,7 @@ def load_from_disk(dataset_path: str, fs=None, keep_in_memory: Optional[bool] = 
         return Dataset.load_from_disk(dataset_path, fs, key=key, keep_in_memory=keep_in_memory)
     # TODO: test this later, check this later
     elif fs.isfile(Path(dest_dataset_path, config.DATASETDICT_JSON_FILENAME).as_posix()):
-        return DatasetDict.load_from_disk(dataset_path, fs, keep_in_memory=keep_in_memory)
+        return DatasetDict.load_from_disk(dataset_path, fs, keep_in_memory=keep_in_memory, key=key)
     else:
         invalidInputError(False,
             f"Directory {dataset_path} is neither a dataset directory nor a dataset dict directory."

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -87,6 +87,7 @@ def customized_load(dataset_path: str, key:str, fs=None, keep_in_memory: Optiona
     #     state = json.load(state_file)
     with _open_encrypt_file_with_key(Path(dataset_path, config.DATASET_STATE_JSON_FILENAME).as_posix(), 'rb', key) as state_file:
         state = json.load(state_file)
+    print(state, flush=True)
     # with open(Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix(), encoding="utf-8") as dataset_info_file:
     #     dataset_info = DatasetInfo.from_dict(json.load(dataset_info_file))
     with _open_encrypt_file_with_key(Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix(), 'rb', key) as dataset_info_file:

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -132,12 +132,12 @@ def customized_load(dataset_path: str, key:str, fs=None, keep_in_memory: Optiona
 Dataset.load_from_disk = customized_load
 
 # TODO: add fs argument if needed
-def load_from_disk(dataset_path: str, fs=None, keep_in_memory: Optional[bool] = None) -> Union[Dataset, DatasetDict]:
+def load_from_disk(dataset_path: str, key: str, fs=None, keep_in_memory: Optional[bool] = None) -> Union[Dataset, DatasetDict]:
     fs = fsspec.filesystem("file")
     if not fs.exists(dataset_path):
         raise FileNotFoundError(f"Directory {dataset_path} not found")
     if fs.isfile(Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix()):
-        return Dataset.load_from_disk(dataset_path, fs, keep_in_memory=keep_in_memory)
+        return Dataset.load_from_disk(dataset_path, key, fs, keep_in_memory=keep_in_memory)
     elif fs.isfile(Path(dataset_path, config.DATASETDICT_JSON_FILENAME).as_posix()):
         return DatasetDict.load_from_disk(dataset_path, fs, keep_in_memory=keep_in_memory)
     else:

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -61,6 +61,7 @@ def _open_encrypt_file_with_key(file, mode, key):
     return encrypt_reader_opener(file, mode, key)
 
 
+# TODO: do we need to close the buffer afterwards?
 def decrypt_file_to_pa_buffer(filename, key):
     decryptor = Fernet(key)
     opened_file = open(filename, 'rb')
@@ -73,7 +74,7 @@ def decrypt_file_to_pa_buffer(filename, key):
 @staticmethod
 def customized_load(dataset_path: str, key:str, fs=None, keep_in_memory: Optional[bool] = None) -> "Dataset":
     print("customized load") # TODO: delete later
-    # TODO: delete fs later
+    # TODO: delete fs later, or add invalidInputError
     fs = fsspec.filesystem("file") if fs is None else fs
     dataset_dict_json_path = Path(dataset_path, config.DATASETDICT_JSON_FILENAME).as_posix()
     dataset_info_path = Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix()
@@ -144,6 +145,7 @@ def load_from_disk(dataset_path: str, key: str, fs=None, keep_in_memory: Optiona
     if fs.isfile(Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix()):
         return Dataset.load_from_disk(dataset_path, key, fs, keep_in_memory=keep_in_memory)
     elif fs.isfile(Path(dataset_path, config.DATASETDICT_JSON_FILENAME).as_posix()):
+        # TODO: decide if we need to change this
         return DatasetDict.load_from_disk(dataset_path, fs, keep_in_memory=keep_in_memory)
     else:
         raise FileNotFoundError(

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -140,8 +140,8 @@ def load_dict_with_decryption(dataset_dict_path: str, fs=None, key: Optional[str
             f"No such file or directory: '{dataset_dict_json_path}'. Expected to load a DatasetDict object, but got a Dataset. Please use datasets.load_from_disk instead."
         )
     #with _open_encrypted_file_like_with_key(fs.open(dataset_dict_json_path, "r", key=key)) as config:
-    with _open_encrypted_file_like_with_key(dataset_dict_json_path, fs, "r", key=key) as config:
-        for k in json.load(config)["splits"]:
+    with _open_encrypted_file_like_with_key(dataset_dict_json_path, fs, "r", key=key) as load_config:
+        for k in json.load(load_config)["splits"]:
             dataset_dict_split_path = (
                 dataset_dict_path.split("://")[0] + "://" + Path(dest_dataset_dict_path, k).as_posix()
                 if is_remote_filesystem(fs)

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -63,7 +63,7 @@ def _open_encrypt_file_with_key(file, mode, key):
 
 def decrypt_file_to_pa_buffer(filename, key):
     decryptor = Fernet(key)
-    opened_file = open(filename, 'r')
+    opened_file = open(filename, 'rb')
     decrypted_content = decryptor.decrypt(opened_file.read())
     opened_file.close()
     buf = pa.py_buffer(decrypted_content)

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -71,7 +71,7 @@ def decrypt_file_to_pa_buffer(filename, key):
 
 
 @staticmethod
-def customized_load(dataset_path: str, fs=None, keep_in_memory: Optional[bool] = None, key) -> "Dataset":
+def customized_load(dataset_path: str, key:str, fs=None, keep_in_memory: Optional[bool] = None) -> "Dataset":
     print("customized load") # TODO: delete later
     # TODO: delete fs later
     fs = fsspec.filesystem("file") if fs is None else fs

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -103,6 +103,7 @@ def load_with_decryption(dataset_path: str, key:str, fs=None, keep_in_memory: Op
         dataset_info = DatasetInfo.from_dict(json.load(dataset_info_file))
 
     # We always expect keep_in_memory is true
+    # TODO:Modify this
     keep_in_memory = keep_in_memory if keep_in_memory is not None else is_small_dataset(dataset_size)
     table_cls = InMemoryTable if keep_in_memory else MemoryMappedTable
     arrow_table = concat_tables(

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -89,7 +89,7 @@ def customized_load(dataset_path: str, key:str, fs=None, keep_in_memory: Optiona
         state = json.load(state_file)
     # with open(Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix(), encoding="utf-8") as dataset_info_file:
     #     dataset_info = DatasetInfo.from_dict(json.load(dataset_info_file))
-    with _open_encrypt_file_with_key(Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix(), 'rb') as dataset_info_file:
+    with _open_encrypt_file_with_key(Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix(), 'rb', key) as dataset_info_file:
         dataset_info = DatasetInfo.from_dict(json.load(dataset_info_file))
 
     dataset_size = estimate_dataset_size(

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -137,7 +137,35 @@ Dataset.load_from_disk = load_with_decryption
 
 DatasetDict.load_from_disk = load_dict_with_decryption
 
-def load_from_disk(dataset_path: str, key: str, fs=None, keep_in_memory: Optional[bool] = None) -> Union[Dataset, DatasetDict]:
+# TODO: later apply patch here
+def load_from_disk(dataset_path: str, fs=None, keep_in_memory: Optional[bool] = None, key: Optional[str] = None) -> Union[Dataset, DatasetDict]:
+    """
+    Loads a dataset that was previously saved using :meth:`Dataset.save_to_disk` from a dataset directory, or
+    from a filesystem using either :class:`datasets.filesystems.S3FileSystem` or any implementation of
+    ``fsspec.spec.AbstractFileSystem``.
+
+    If key is not None, then dataset stored at dataset_path must be previously encrypted using the key provided
+    here.  At the same time, the keep_in_memory must be set to True.
+
+    If key is None, then this method should perform the same as the previous method.
+
+    Args:
+        dataset_path (:obj:`str`): Path (e.g. `"dataset/train"`) or remote URI (e.g.
+            `"s3://my-bucket/dataset/train"`) of the Dataset or DatasetDict directory where the dataset will be
+            loaded from.
+        fs (:class:`~filesystems.S3FileSystem` or ``fsspec.spec.AbstractFileSystem``, optional, default ``None``):
+            Instance of the remote filesystem used to download the files from.
+        keep_in_memory (:obj:`bool`, default ``None``): Whether to copy the dataset in-memory. If `None`, the dataset
+            will not be copied in-memory unless explicitly enabled by setting `datasets.config.IN_MEMORY_MAX_SIZE` to
+            nonzero. See more details in the :ref:`load_dataset_enhancing_performance` section.
+        key (:obj:`str`, default ``None``): If not None, then the dataset is considered to be encrypted previously using
+            this key.
+
+    Returns:
+        :class:`Dataset` or :class:`DatasetDict`:
+        - If `dataset_path` is a path of a dataset directory: the dataset requested.
+        - If `dataset_path` is a path of a dataset dict directory: a ``datasets.DatasetDict`` with each split.
+    """
     if is_remote_filesystem(fs):
         invalidInputError(False, "Please only use filesystem with protocol file, or leave the fs argument to None")
     invalidInputError(keep_in_memory, "Currently only support keep_in_memory set to True")

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -16,7 +16,7 @@
 
 from datasets.arrow_dataset import Dataset
 from datasets.dataset_dict import DatasetDict
-from datasets.filesystems import is_remote_filesystem
+from datasets.filesystems import is_remote_filesystem, extract_path_from_uri
 from bigdl.ppml.encryption.torch.models import opener
 from datasets import config
 from cryptography.fernet import Fernet
@@ -52,8 +52,12 @@ class encrypt_reader_opener(opener):
         # Close the buffer
         self.file_like.close()
 
-def _open_encrypt_file_with_key(file, mode, key):
-    return encrypt_reader_opener(file, mode, key)
+# TODO: need testing when key is None
+def _open_encrypt_file_with_key(file, mode, key: Optional[str] = None):
+    if key is not None:
+        return encrypt_reader_opener(file, mode, key)
+    else:
+        return open(file, mode, encoding="utf-8")
 
 def decrypt_file_to_pa_buffer(filename, key):
     decryptor = Fernet(key)
@@ -86,31 +90,90 @@ def load_dict_with_decryption(dataset_dict_path: str, key: str, fs=None, keep_in
 
 
 @staticmethod
-def load_with_decryption(dataset_path: str, key:str, fs=None, keep_in_memory: Optional[bool] = None) -> "Dataset":
-    if is_remote_filesystem(fs):
-        invalidInputError(False, "Please only use filesystem with protocol file, or leave the fs argument to None")
-    fs = fsspec.filesystem("file")
+def load_with_decryption(dataset_path: str, fs=None, keep_in_memory: Optional[bool] = None, key: Optional[str] = None) -> "Dataset":
+    """
+    Loads a dataset that was previously saved using :meth:`save_to_disk` from a dataset directory, or from a
+    filesystem using either :class:`~filesystems.S3FileSystem` or any implementation of
+    ``fsspec.spec.AbstractFileSystem``.
+
+    If key is not None, then dataset stored at dataset_path must be previously encrypted using the key provided
+    here.  At the same time, the keep_in_memory must be set to True.
+
+    Args:
+        dataset_path (:obj:`str`): Path (e.g. `"dataset/train"`) or remote URI (e.g.
+            `"s3//my-bucket/dataset/train"`) of the dataset directory where the dataset will be loaded from.
+        fs (:class:`~filesystems.S3FileSystem`, ``fsspec.spec.AbstractFileSystem``, optional, default ``None``):
+            Instance of the remote filesystem used to download the files from.
+        keep_in_memory (:obj:`bool`, default ``None``): Whether to copy the dataset in-memory. If `None`, the
+            dataset will not be copied in-memory unless explicitly enabled by setting
+            `datasets.config.IN_MEMORY_MAX_SIZE` to nonzero. See more details in the
+            :ref:`load_dataset_enhancing_performance` section.
+        key (:obj:`str`, default ``None``): If not None, then the dataset is considered to be encrypted previously using
+            this key.
+
+
+    Returns:
+        :class:`Dataset` or :class:`DatasetDict`:
+        - If `dataset_path` is a path of a dataset directory: the dataset requested.
+        - If `dataset_path` is a path of a dataset dict directory: a ``datasets.DatasetDict`` with each split.
+
+    Example:
+
+    ```py
+    >>> ds = load_from_disk("path/to/dataset/directory", keep_in_memory=True, key=my_key)
+    ```
+    """
+    # if is_remote_filesystem(fs):
+    #     invalidInputError(False, "Please only use filesystem with protocol file, or leave the fs argument to None")
+    # fs = fsspec.filesystem("file")
+    # dataset_dict_json_path = Path(dataset_path, config.DATASETDICT_JSON_FILENAME).as_posix()
+    # dataset_info_path = Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix()
+    # if not fs.isfile(dataset_info_path) and fs.isfile(dataset_dict_json_path):
+    #     invalidInputError(False,
+    #        f"No such file or directory: '{dataset_info_path}'. Expected to load a Dataset object, but got a DatasetDict. Please use datasets.load_from_disk instead."
+    #     )
+    # TODO: test this when keep_in_memory is None
+    if key is not None:
+        invalidInputError(keep_in_memory==False, "Currently only support InMemoryTable which requires keep_in_memory set to True")
+    fs = fsspec.filesystem("file") if fs is None else fs
     dataset_dict_json_path = Path(dataset_path, config.DATASETDICT_JSON_FILENAME).as_posix()
     dataset_info_path = Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix()
     if not fs.isfile(dataset_info_path) and fs.isfile(dataset_dict_json_path):
-        invalidInputError(False,
-           f"No such file or directory: '{dataset_info_path}'. Expected to load a Dataset object, but got a DatasetDict. Please use datasets.load_from_disk instead."
-        )
+        invalidInputError(False, f"No such file or directory: '{dataset_info_path}'. Expected to load a Dataset object, but got a DatasetDict. Please use datasets.load_from_disk instead.")
 
-    with _open_encrypt_file_with_key(Path(dataset_path, config.DATASET_STATE_JSON_FILENAME).as_posix(), 'rb', key) as state_file:
+    # Download the files if on remote filesystem
+    if is_remote_filesystem(fs):
+        src_dataset_path = extract_path_from_uri(dataset_path)
+        dataset_path = Dataset._build_local_temp_path(src_dataset_path)
+        fs.download(src_dataset_path, dataset_path.as_posix(), recursive=True)
+
+    # Based on whether key is provided, do different things
+
+    with _open_encrypt_file_with_key(Path(dataset_path, config.DATASET_STATE_JSON_FILENAME).as_posix(), 'rb', key=key) as state_file:
         state = json.load(state_file)
-    with _open_encrypt_file_with_key(Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix(), 'rb', key) as dataset_info_file:
+    with _open_encrypt_file_with_key(Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix(), 'rb', key=key) as dataset_info_file:
         dataset_info = DatasetInfo.from_dict(json.load(dataset_info_file))
 
-    # We always expect keep_in_memory is true
-    # TODO:Modify this
+    dataset_size = estimate_dataset_size(
+        Path(dataset_path, data_file["filename"]) for data_file in state["_data_files"]
+    )
+ 
     keep_in_memory = keep_in_memory if keep_in_memory is not None else is_small_dataset(dataset_size)
     table_cls = InMemoryTable if keep_in_memory else MemoryMappedTable
-    arrow_table = concat_tables(
-        table_cls.from_buffer(decrypt_file_to_pa_buffer(
-            Path(dataset_path, data_file["filename"]).as_posix(), key))
-        for data_file in state["_data_files"]
-    )
+    # Consider different cases
+    if key is not None:
+        arrow_table = concat_tables(
+            table_cls.from_buffer(decrypt_file_to_pa_buffer(
+                Path(dataset_path, data_file["filename"]).as_posix(), key))
+            for data_file in state["_data_files"]
+        )
+    else:
+        arrow_table = concat_tables(
+            table_cls.from_file(Path(dataset_path, data_file["filename"]).as_posix())
+            for data_file in state["_data_files"]
+        )
+
+
 
     split = state["_split"]
     split = Split(split) if split is not None else split
@@ -147,8 +210,6 @@ def load_from_disk(dataset_path: str, fs=None, keep_in_memory: Optional[bool] = 
     If key is not None, then dataset stored at dataset_path must be previously encrypted using the key provided
     here.  At the same time, the keep_in_memory must be set to True.
 
-    If key is None, then this method should perform the same as the previous method.
-
     Args:
         dataset_path (:obj:`str`): Path (e.g. `"dataset/train"`) or remote URI (e.g.
             `"s3://my-bucket/dataset/train"`) of the Dataset or DatasetDict directory where the dataset will be
@@ -166,15 +227,25 @@ def load_from_disk(dataset_path: str, fs=None, keep_in_memory: Optional[bool] = 
         - If `dataset_path` is a path of a dataset directory: the dataset requested.
         - If `dataset_path` is a path of a dataset dict directory: a ``datasets.DatasetDict`` with each split.
     """
+    # if is_remote_filesystem(fs):
+    #     invalidInputError(False, "Please only use filesystem with protocol file, or leave the fs argument to None")
+    # invalidInputError(keep_in_memory, "Currently only support keep_in_memory set to True")
+    if key is not None:
+        invalidInputError(keep_in_memory==False, "Currently only support InMemoryTable which requires keep_in_memory set to True")
     if is_remote_filesystem(fs):
-        invalidInputError(False, "Please only use filesystem with protocol file, or leave the fs argument to None")
-    invalidInputError(keep_in_memory, "Currently only support keep_in_memory set to True")
-    fs = fsspec.filesystem("file")
-    if not fs.exists(dataset_path):
+        dest_dataset_path = extract_path_from_uri(dataset_path)
+    else:
+        fs = fsspec.filesystem("file")
+        dest_dataset_path = dataset_path
+
+
+    #fs = fsspec.filesystem("file")
+    if not fs.exists(dest_dataset_path):
         invalidInputError(False, f"Directory {dataset_path} not found")
-    if fs.isfile(Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix()):
+    # TODO: change calling interface
+    if fs.isfile(Path(dest_dataset_path, config.DATASET_INFO_FILENAME).as_posix()):
         return Dataset.load_from_disk(dataset_path, key, fs, keep_in_memory=keep_in_memory)
-    elif fs.isfile(Path(dataset_path, config.DATASETDICT_JSON_FILENAME).as_posix()):
+    elif fs.isfile(Path(dest_dataset_path, config.DATASETDICT_JSON_FILENAME).as_posix()):
         return DatasetDict.load_from_disk(dataset_path, fs, keep_in_memory=keep_in_memory)
     else:
         invalidInputError(False,

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -102,9 +102,11 @@ def customized_load(dataset_path: str, key:str, fs=None, keep_in_memory: Optiona
     #     table_cls.from_file(Path(dataset_path, data_file["filename"]).as_posix())
     #     for data_file in state["_data_files"]
     # )
+    # TODO: change later
+    table_cls = InMemoryTable
     arrow_table = concat_tables(
         table_cls.from_buffer(decrypt_file_to_pa_buffer(
-            Path(dataset_path, data_file["filename"]).as_posix()))
+            Path(dataset_path, data_file["filename"]).as_posix()), key)
         for data_file in state["_data_files"]
     )
 

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -16,6 +16,7 @@
 
 from datasets.arrow_dataset import Dataset
 from datasets.dataset_dict import DatasetDict
+from datasets.filesystems import is_remote_filesystem
 from bigdl.ppml.encryption.torch.models import opener
 from datasets import config
 from cryptography.fernet import Fernet
@@ -23,25 +24,18 @@ from pathlib import Path
 import fsspec
 import json
 from io import BytesIO
+from bigdl.nano.utils.log4Error import invalidInputError
 import pyarrow as pa
 from datasets.info import DatasetInfo
 from datasets.utils.info_utils import is_small_dataset
 from datasets.splits import Split
-# TODO: This may incur error, the encrypted filesize is larger
 from datasets.utils.file_utils import estimate_dataset_size
-# TODO: clean
 from datasets.table import (
     InMemoryTable,
     MemoryMappedTable,
-    Table,
     concat_tables,
-    embed_table_storage,
-    list_table_cache_files,
-    table_cast,
-    table_iter,
-    table_visitor,
 )
-from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Type, Union
+from typing import Optional, Union
 
 class encrypt_reader_opener(opener):
     def __init__(self, name, mode, key):
@@ -53,15 +47,14 @@ class encrypt_reader_opener(opener):
         buf.write(decrypted_content)
         buf.seek(0)
         super(encrypt_reader_opener, self).__init__(buf)
+    
+    def __exit__(self, *args):
+        # Close the buffer
+        self.file_like.close()
 
-# TODO: delete comment
-# We knew that file is a path
-# Review later
 def _open_encrypt_file_with_key(file, mode, key):
     return encrypt_reader_opener(file, mode, key)
 
-
-# TODO: do we need to close the buffer afterwards?
 def decrypt_file_to_pa_buffer(filename, key):
     decryptor = Fernet(key)
     opened_file = open(filename, 'rb')
@@ -72,48 +65,52 @@ def decrypt_file_to_pa_buffer(filename, key):
 
 
 @staticmethod
-def customized_load(dataset_path: str, key:str, fs=None, keep_in_memory: Optional[bool] = None) -> "Dataset":
-    print("customized load") # TODO: delete later
-    # TODO: delete fs later, or add invalidInputError
-    fs = fsspec.filesystem("file") if fs is None else fs
+def load_dict_with_decryption(dataset_dict_path: str, key: str, fs=None, keep_in_memory: Optional[bool] = None) -> "DatasetDict":
+    dataset_dict = DatasetDict()
+    if is_remote_filesystem(fs):
+        invalidInputError(False, "Please do not specify files in remote filesystem")
+    else:
+        fs = fsspec.filesystem("file")
+        dest_dataset_dict_path = dataset_dict_path
+    # Construct path
+    dataset_dict_json_path = Path(dest_dataset_dict_path, config.DATASETDICT_JSON_FILENAME).as_posix()
+    dataset_info_path = Path(dest_dataset_dict_path, config.DATASET_INFO_FILENAME).as_posix()
+    if fs.isfile(dataset_info_path) and not fs.isfile(dataset_dict_json_path):
+        invalidInputError(False,
+            f"No such file or directory: '{dataset_dict_json_path}'. Expected to load a DatasetDict object, but got a Dataset. Please use datasets.load_from_disk instead."
+        )
+    for k in json.load(_open_encrypt_file_with_key(dataset_dict_json_path, "rb", key))["splits"]:
+        dataset_dict_split_path = Path(dest_dataset_dict_path, k).as_posix()
+        dataset_dict[k] = Dataset.load_from_disk(dataset_dict_split_path, key, fs, keep_in_memory=True)
+    return dataset_dict
+
+
+@staticmethod
+def load_with_decryption(dataset_path: str, key:str, fs=None, keep_in_memory: Optional[bool] = None) -> "Dataset":
+    if is_remote_filesystem(fs):
+        invalidInputError(False, "Please only use filesystem with protocol file, or leave the fs argument to None")
+    fs = fsspec.filesystem("file")
     dataset_dict_json_path = Path(dataset_path, config.DATASETDICT_JSON_FILENAME).as_posix()
     dataset_info_path = Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix()
     if not fs.isfile(dataset_info_path) and fs.isfile(dataset_dict_json_path):
-        raise FileNotFoundError(
+        invalidInputError(False,
            f"No such file or directory: '{dataset_info_path}'. Expected to load a Dataset object, but got a DatasetDict. Please use datasets.load_from_disk instead."
         )
 
-    # TODO: use own own opener later here
-    # with open(Path(dataset_path, config.DATASET_STATE_JSON_FILENAME).as_posix(), encoding="utf-8") as state_file:
-    #     state = json.load(state_file)
     with _open_encrypt_file_with_key(Path(dataset_path, config.DATASET_STATE_JSON_FILENAME).as_posix(), 'rb', key) as state_file:
         state = json.load(state_file)
-    print(state, flush=True)
-    # with open(Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix(), encoding="utf-8") as dataset_info_file:
-    #     dataset_info = DatasetInfo.from_dict(json.load(dataset_info_file))
     with _open_encrypt_file_with_key(Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix(), 'rb', key) as dataset_info_file:
         dataset_info = DatasetInfo.from_dict(json.load(dataset_info_file))
 
-    dataset_size = estimate_dataset_size(
-        Path(dataset_path, data_file["filename"]) for data_file in state["_data_files"]
-    )
+    # We always expect keep_in_memory is true
     keep_in_memory = keep_in_memory if keep_in_memory is not None else is_small_dataset(dataset_size)
-    # TODO: change others later
     table_cls = InMemoryTable if keep_in_memory else MemoryMappedTable
-    # arrow_table = concat_tables(
-    #     table_cls.from_file(Path(dataset_path, data_file["filename"]).as_posix())
-    #     for data_file in state["_data_files"]
-    # )
-    # TODO: change later
-    table_cls = InMemoryTable
     arrow_table = concat_tables(
         table_cls.from_buffer(decrypt_file_to_pa_buffer(
             Path(dataset_path, data_file["filename"]).as_posix(), key))
         for data_file in state["_data_files"]
     )
 
-    # TODO: close the pa.buffer opened above
-    # TODO: check MemoryMappedTable
     split = state["_split"]
     split = Split(split) if split is not None else split
 
@@ -135,19 +132,22 @@ def customized_load(dataset_path: str, key:str, fs=None, keep_in_memory: Optiona
     return dataset
 
 
-Dataset.load_from_disk = customized_load
+Dataset.load_from_disk = load_with_decryption
 
-# TODO: add fs argument if needed
+DatasetDict.load_from_disk = load_dict_with_decryption
+
 def load_from_disk(dataset_path: str, key: str, fs=None, keep_in_memory: Optional[bool] = None) -> Union[Dataset, DatasetDict]:
+    if is_remote_filesystem(fs):
+        invalidInputError(False, "Please only use filesystem with protocol file, or leave the fs argument to None")
+    invalidInputError(keep_in_memory, "Currently only support keep_in_memory set to True")
     fs = fsspec.filesystem("file")
     if not fs.exists(dataset_path):
-        raise FileNotFoundError(f"Directory {dataset_path} not found")
+        invalidInputError(False, f"Directory {dataset_path} not found")
     if fs.isfile(Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix()):
         return Dataset.load_from_disk(dataset_path, key, fs, keep_in_memory=keep_in_memory)
     elif fs.isfile(Path(dataset_path, config.DATASETDICT_JSON_FILENAME).as_posix()):
-        # TODO: decide if we need to change this
         return DatasetDict.load_from_disk(dataset_path, fs, keep_in_memory=keep_in_memory)
     else:
-        raise FileNotFoundError(
+        invalidInputError(False,
             f"Directory {dataset_path} is neither a dataset directory nor a dataset dict directory."
         )

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -111,6 +111,8 @@ def customized_load(dataset_path: str, key:str, fs=None, keep_in_memory: Optiona
         for data_file in state["_data_files"]
     )
 
+    # TODO: close the pa.buffer opened above
+    # TODO: check MemoryMappedTable
     split = state["_split"]
     split = Split(split) if split is not None else split
 

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -245,7 +245,7 @@ def load_from_disk(dataset_path: str, fs=None, keep_in_memory: Optional[bool] = 
     # TODO: change calling interface
     if fs.isfile(Path(dest_dataset_path, config.DATASET_INFO_FILENAME).as_posix()):
         return Dataset.load_from_disk(dataset_path, fs, key=key, keep_in_memory=keep_in_memory)
-    # TODO: test this
+    # TODO: test this later
     elif fs.isfile(Path(dest_dataset_path, config.DATASETDICT_JSON_FILENAME).as_posix()):
         return DatasetDict.load_from_disk(dataset_path, fs, keep_in_memory=keep_in_memory)
     else:

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -1,0 +1,42 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from datasets.arrow_dataset import Dataset
+from datasets.dataset_dict import DatasetDict
+from datasets import config
+from pathlib import Path
+import fsspec
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Type, Union
+
+@staticmethod
+def test():
+    print("test")
+
+Dataset.load_from_disk = test
+
+# TODO: add fs argument if needed
+def load_from_disk(dataset_path: str, fs: None, keep_in_memory: Optional[bool] = None) -> Union[Dataset, DatasetDict]:
+    fs = fsspec.filesystem("file")
+    if not fs.exists(dataset_path):
+        raise FileNotFoundError(f"Directory {dataset_path} not found")
+    if fs.isfile(Path(dataset_path, config.DATASET_INFO_FILENAME).as_posix()):
+        return Dataset.load_from_disk(dataset_path, fs, keep_in_memory=keep_in_memory)
+    elif fs.isfile(Path(dataset_path, config.DATASETDICT_JSON_FILENAME).as_posix()):
+        return DatasetDict.load_from_disk(dataset_path, fs, keep_in_memory=keep_in_memory)
+    else:
+        raise FileNotFoundError(
+            f"Directory {dataset_path} is neither a dataset directory nor a dataset dict directory."
+        )

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load.py
@@ -106,7 +106,7 @@ def customized_load(dataset_path: str, key:str, fs=None, keep_in_memory: Optiona
     table_cls = InMemoryTable
     arrow_table = concat_tables(
         table_cls.from_buffer(decrypt_file_to_pa_buffer(
-            Path(dataset_path, data_file["filename"]).as_posix()), key)
+            Path(dataset_path, data_file["filename"]).as_posix(), key))
         for data_file in state["_data_files"]
     )
 

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
@@ -51,7 +51,7 @@ def encrypt():
 
 
 def main():
-    temp = load_from_disk("/ppml/save-datasets/train")
+    temp = load_from_disk("/ppml/save-datasets-encrypted/test", _create_random(32))
 
 
 

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
@@ -17,9 +17,11 @@
 # simple test, delete later
 import os
 from bigdl.ppml.encryption.datasets.hf.load import load_from_disk
+import datasets
 from cryptography.fernet import Fernet
 import random
 import base64
+import torch
 
 def _create_random(length) -> str:
     random.seed(0)
@@ -73,9 +75,25 @@ def main():
 def main2():
     temp = load_from_disk("/ppml/save-datasets/test")
     print(temp[0])
+    torch.save(temp, "tempsave.pt")
 
 
+def main3():
+    temp_dataset = torch.load("tempsave.pt")
+    print(temp_dataset[0])
+
+
+def generate_datasetdict():
+    train_dataset = load_from_disk("/ppml/save-datasets/train")
+    test_dataset = load_from_disk("/ppml/save-datasets/test")
+    dataset_dict = datasets.dataset_dict.DatasetDict({'train': train_dataset, 'test': test_dataset})
+    return dataset_dict
+
+def save_datasetdict_to_disk():
+    temp = generate_datasetdict()
+    temp.save_to_disk("/ppml/datasetdict")
+    torch.save(temp, "datasetdict.pt")
 
 
 if __name__ == "__main__":
-    main2()
+    save_datasetdict_to_disk()

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
@@ -45,7 +45,9 @@ def encrypt_directory_automation(input_dir, save_dir):
 
 
 def encrypt():
-    encrypt_directory_automation("/ppml/save-datasets/", "/ppml/save-datasets-encrypted/")
+    encrypt_directory_automation("/ppml/save-datasets/train/", "/ppml/save-datasets-encrypted/train/")
+    encrypt_directory_automation("/ppml/save-datasets/test/", "/ppml/save-datasets-encrypted/test/")
+    encrypt_directory_automation("/ppml/save-datasets/valid/", "/ppml/save-datasets-encrypted/valid/")
 
 
 def main():

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
@@ -67,7 +67,7 @@ def encrypt():
 
 
 def main():
-    temp = load_from_disk("/ppml/save-datasets-encrypted/test", key=_create_random(32))
+    temp = load_from_disk("/ppml/save-datasets-encrypted/test", keep_in_memory=True, key=_create_random(32))
 
 
 

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
@@ -1,9 +1,51 @@
 # simple test, delete later
+import os
 from bigdl.ppml.encryption.datasets.hf.load import load_from_disk
+from cryptography.fernet import Fernet
+import random
+import base64
+
+def _create_random(length) -> str:
+    random.seed(0)
+    ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    chars = []
+    for i in range(length):
+        chars.append(random.choice(ALPHABET))
+    key = "".join(chars)
+    key_bytes = key.encode("ascii")
+    base64_str = base64.b64encode(key_bytes)
+    print(len(base64_str), flush=True)
+    return base64_str
+
+def read_data_file(data_file_path):
+    with open(data_file_path, 'rb') as file:
+        original = file.read()
+    return original
+
+def write_data_file(data_file_path, content):
+    with open(data_file_path, 'wb') as file:
+        file.write(content)
+
+def encrypt_directory_automation(input_dir, save_dir):
+    print('[INFO] Encrypt Files Start...')
+    if save_dir is None:
+        if input_dir[-1] == '/':
+            input_dir = input_dir[:-1]
+        save_dir = input_dir + '.encrypted'
+    if not os.path.isdir(save_dir):
+        os.mkdir(save_dir)
+    fernet = Fernet(_create_random(32))
+    for file_name in os.listdir(input_dir):
+        input_path = os.path.join(input_dir, file_name)
+        encrypted = fernet.encrypt(read_data_file(input_path))
+        save_path = os.path.join(save_dir, file_name + '.encrypted')
+        write_data_file(save_path, encrypted)
+        print('[INFO] Encrypt Successfully! Encrypted Output Is ' + save_path)
+    print('[INFO] Encrypted Files.')
 
 
-
-
+def encrypt():
+    encrypt_directory_automation("/ppml/save-datasets/", "/ppml/save-datasets-encrypted/")
 
 
 def main():
@@ -13,4 +55,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    encrypt()

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
@@ -17,6 +17,7 @@
 # simple test, delete later
 import os
 from bigdl.ppml.encryption.datasets.hf.load import load_from_disk
+#from bigdl.nano.pytorch.patching import patch_encryption
 import datasets
 from cryptography.fernet import Fernet
 import random
@@ -105,5 +106,20 @@ def try_load_from_disk():
     print(dc)
 
 
+def test_encryption():
+    patch_encryption()
+    dc = load_from_disk("/ppml/datasetdict")
+    torch.save(dc, "encryption.pt", encryption_key=_create_random(32))
+
+
+def test_encryption_load():
+    patch_encryption()
+    test = torch.load("encryption.pt", decryption_key=_create_random(32))
+    print(test)
+
+def test_load_dict():
+    test = load_from_disk("/ppml/datasetdict-en/", keep_in_memory=True, key=_create_random(32))
+    print(test)
+
 if __name__ == "__main__":
-    save_datasetdict_to_disk()
+    test_load_dict()

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
@@ -38,7 +38,7 @@ def encrypt_directory_automation(input_dir, save_dir):
     for file_name in os.listdir(input_dir):
         input_path = os.path.join(input_dir, file_name)
         encrypted = fernet.encrypt(read_data_file(input_path))
-        save_path = os.path.join(save_dir, file_name + '.encrypted')
+        save_path = os.path.join(save_dir, file_name)
         write_data_file(save_path, encrypted)
         print('[INFO] Encrypt Successfully! Encrypted Output Is ' + save_path)
     print('[INFO] Encrypted Files.')

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
@@ -95,5 +95,15 @@ def save_datasetdict_to_disk():
     torch.save(temp, "datasetdict.pt")
 
 
+def test():
+    dc = torch.load("datasetdict.pt")
+    print(dc['train'][1])
+
+
+def try_load_from_disk():
+    dc = load_from_disk("/ppml/datasetdict")
+    print(dc)
+
+
 if __name__ == "__main__":
     save_datasetdict_to_disk()

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
@@ -1,3 +1,19 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 # simple test, delete later
 import os
 from bigdl.ppml.encryption.datasets.hf.load import load_from_disk

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
@@ -67,7 +67,7 @@ def encrypt():
 
 
 def main():
-    temp = load_from_disk("/ppml/save-datasets-encrypted/test", _create_random(32))
+    temp = load_from_disk("/ppml/save-datasets-encrypted/test", key=_create_random(32))
 
 
 

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
@@ -57,4 +57,4 @@ def main():
 
 
 if __name__ == "__main__":
-    encrypt()
+    main()

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
@@ -68,9 +68,14 @@ def encrypt():
 
 def main():
     temp = load_from_disk("/ppml/save-datasets-encrypted/test", keep_in_memory=True, key=_create_random(32))
+    print(temp[0])
+
+def main2():
+    temp = load_from_disk("/ppml/save-datasets/test")
+    print(temp[0])
 
 
 
 
 if __name__ == "__main__":
-    main()
+    main2()

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/load_test.py
@@ -1,0 +1,16 @@
+# simple test, delete later
+from bigdl.ppml.encryption.datasets.hf.load import load_from_disk
+
+
+
+
+
+
+def main():
+    temp = load_from_disk("/ppml/save-datasets/train")
+
+
+
+
+if __name__ == "__main__":
+    main()

--- a/python/ppml/src/bigdl/ppml/encryption/datasets/hf/pert_disk.py
+++ b/python/ppml/src/bigdl/ppml/encryption/datasets/hf/pert_disk.py
@@ -1,0 +1,288 @@
+import torch
+import argparse
+import os
+import logging
+import time
+from torch import nn
+from contextlib import nullcontext
+from datasets import load_dataset
+from torch.utils.data import DataLoader
+from torch.utils.data.distributed import DistributedSampler
+import torch.distributed as dist
+from transformers import BertTokenizer, BertModel, AdamW
+from bigdl.ppml.encryption.datasets.hf.load import load_from_disk
+from cryptography.fernet import Fernet
+import random
+import base64
+
+def _create_random(length) -> str:
+    random.seed(0)
+    ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    chars = []
+    for i in range(length):
+        chars.append(random.choice(ALPHABET))
+    key = "".join(chars)
+    key_bytes = key.encode("ascii")
+    base64_str = base64.b64encode(key_bytes)
+    print(len(base64_str), flush=True)
+    return base64_str
+
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", 1))
+RANK = int(os.environ.get("RANK", 0))
+
+parser = argparse.ArgumentParser(description="PyTorch PERT Example")
+
+parser.add_argument("--batch-size", type=int, default=16, metavar="N",
+                    help="input batch size for training (default: 16)")
+parser.add_argument("--test-batch-size", type=int, default=1000, metavar="N",
+                    help="input batch size for testing (default: 1000)")
+parser.add_argument("--epochs", type=int, default=1, metavar="N",
+                    help="number of epochs to train (default: 10)")
+parser.add_argument("--lr", type=float, default=1e-5, metavar="LR",
+                    help="learning rate (default: 0.01)")
+parser.add_argument("--seed", type=int, default=1, metavar="S",
+                    help="random seed (default: 1)")
+parser.add_argument("--dataset", type=int, default=1, metavar="D",
+                    help="dataset size (default 1 * 9600)")
+parser.add_argument("--save-model", action="store_true", default=False,
+                    help="For Saving the current Model")
+parser.add_argument("--local-only", action="store_true", default=False,
+                    help="If set to true, then load model from disk")
+parser.add_argument("--model-path", type=str, default="/ppml/model",
+                    help="Where to load model")
+# Only for test purpose
+parser.add_argument("--load-model", action="store_true", default=False,
+                    help="For loading the current model")
+
+parser.add_argument("--mini-batch", type=int, default=0, metavar="M",
+                    help="If set, the PyTorch will conduct M local-batch computation before doing a all_reduce sync")
+
+parser.add_argument("--log-interval", type=int, default=2, metavar="N",
+                    help="how many batches to wait before logging training status")
+
+parser.add_argument("--log-path", type=str, default="",
+                    help="Path to save logs. Print to StdOut if log-path is not set")
+
+args = parser.parse_args()
+
+
+def should_distribute():
+    return dist.is_available() and WORLD_SIZE > 1
+
+
+def is_distributed():
+    return dist.is_available() and dist.is_initialized()
+
+# Define dataset, so it is easier to load different split in the dataset
+
+
+class Dataset(torch.utils.data.Dataset):
+    # data_type is actually split, so that we can define dataset for train set/validate set
+    def __init__(self, data_type, dataset_load):
+        self.dataset_load = dataset_load
+        self.data = self.load_data(data_type)
+
+    def load_data(self, data_type):
+        #tmp_dataset = load_dataset(path='seamew/ChnSentiCorp', split=data_type)
+        tmp_dataset = load_from_disk(data_type, _create_random(32), keep_in_memory=True)
+        Data = {}
+        # So enumerate will return a index, and  the line?
+        # line is a dict, including 'text', 'label'
+        if data_type == 'train':
+            for i in range(self.dataset_load):
+                for idx, line in enumerate(tmp_dataset):
+                    sample = line
+                    Data[idx + i * len(tmp_dataset)] = sample
+        else:
+            for idx, line in enumerate(tmp_dataset):
+                sample = line
+                Data[idx] = sample
+        return Data
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        return self.data[idx]
+
+
+if args.local_only:
+    checkpoint = args.model_path
+    tokenizer = BertTokenizer.from_pretrained(
+        checkpoint, model_max_length=512, local_files_only=True)
+else:
+    checkpoint = 'hfl/chinese-pert-base'
+    tokenizer = BertTokenizer.from_pretrained(checkpoint, model_max_length=512)
+
+
+# Return a batch of data, which is used for training
+def collate_fn(batch_samples):
+    batch_text = []
+    batch_label = []
+    for sample in batch_samples:
+        batch_text.append(sample['text'])
+        batch_label.append(int(sample['label']))
+    # The tokenizer will make the data to be a good format for our model to understand
+    X = tokenizer(
+        batch_text,
+        padding=True,
+        truncation=True,
+        return_tensors="pt"
+    )
+    y = torch.tensor(batch_label)
+    return X, y
+
+
+class NeuralNetwork(nn.Module):
+    def __init__(self):
+        super(NeuralNetwork, self).__init__()
+        if args.local_only:
+            self.bert_encoder = BertModel.from_pretrained(
+                checkpoint, local_files_only=True)
+        else:
+            self.bert_encoder = BertModel.from_pretrained(checkpoint)
+        self.classifier = nn.Linear(768, 2)
+
+    def forward(self, x):
+        bert_output = self.bert_encoder(**x)
+        cls_vectors = bert_output.last_hidden_state[:, 0]
+        logits = self.classifier(cls_vectors)
+        return logits
+
+
+device = 'cpu'
+
+
+def train_loop(args, dataloader, model, loss_fn, optimizer, epoch, total_loss):
+    # Set to train mode
+    model.train()
+    total_dataset = 0
+    optimizer.zero_grad(set_to_none=True)
+    enumerator = enumerate(dataloader, start=1)
+    for batch, (X, y) in enumerator:
+        my_context = model.no_sync if WORLD_SIZE > 1 and args.mini_batch > 0 and batch % args.mini_batch != 0 else nullcontext
+        with my_context():
+            X, y = X.to(device), y.to(device)
+        # Forward pass
+            pred = model(X)
+            loss = loss_fn(pred, y)
+            loss.backward()
+            total_loss += loss.item()
+        if args.mini_batch == 0 or batch % args.mini_batch == 0:
+            optimizer.step()
+            optimizer.zero_grad(set_to_none=True)
+
+        total_dataset += args.batch_size
+        if batch % args.log_interval == 0:
+            msg = "Train Epoch: {} [{}/{} ({:.0f}%)]\tloss={:.4f}".format(
+                epoch, batch, len(dataloader),
+                100. * batch / len(dataloader), loss.item())
+            logging.info(msg)
+
+    return total_loss, total_dataset
+
+
+def test_loop(dataloader, model, mode='Test'):
+    assert mode in ['Valid', 'Test']
+    size = len(dataloader.dataset)
+    correct = 0
+
+    model.eval()
+    with torch.no_grad():
+        for X, y in dataloader:
+            X, y = X.to(device), y.to(device)
+            pred = model(X)
+            correct += (pred.argmax(1) == y).type(torch.float).sum().item()
+
+    correct = correct / (size / WORLD_SIZE)
+    print(f"{mode} Accuracy: {(100*correct):>0.1f}%\n")
+    return correct
+
+
+def main():
+    if args.log_path == "":
+        logging.basicConfig(
+            format="%(asctime)s %(levelname)-8s %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%SZ",
+            level=logging.DEBUG)
+    else:
+        logging.basicConfig(
+            format="%(asctime)s %(levelname)-8s %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%SZ",
+            level=logging.DEBUG,
+            filename=args.log_path)
+
+    torch.manual_seed(args.seed)
+    if should_distribute():
+        print("Using distributed PyTorch with {} backend".format(
+            "GLOO"), flush=True)
+        dist.init_process_group(backend=dist.Backend.GLOO)
+
+    # Load the data and dataset
+    before_load = time.perf_counter()
+    print("[INFO]Before data get loaded", flush=True)
+    train_data = Dataset(
+        '/ppml/save-datasets-encrypted/train', args.dataset)
+    print("[INFO]train data length:", len(train_data.data), flush=True)
+    valid_data = Dataset('/ppml/save-datasets-encrypted/valid', 1)
+    after_load = time.perf_counter()
+    print("[INFO]After data get loaded", flush=True)
+    print(f"[INFO] Elapsed time:", after_load - before_load, flush=True)
+    if is_distributed():
+        train_sampler = DistributedSampler(
+            train_data, num_replicas=WORLD_SIZE, rank=RANK, shuffle=True, drop_last=False, seed=args.seed)
+        valid_sampler = DistributedSampler(
+            valid_data, num_replicas=WORLD_SIZE, rank=RANK, shuffle=True, drop_last=False, seed=args.seed)
+        train_dataloader = DataLoader(
+            train_data, batch_size=args.batch_size, collate_fn=collate_fn, sampler=train_sampler)
+        valid_dataloader = DataLoader(
+            valid_data, batch_size=args.test_batch_size, collate_fn=collate_fn, sampler=valid_sampler)
+    else:
+        train_dataloader = DataLoader(
+            train_data, batch_size=args.batch_size, shuffle=True, collate_fn=collate_fn)
+        valid_dataloader = DataLoader(
+            valid_data, batch_size=args.test_batch_size, shuffle=True, collate_fn=collate_fn)
+
+    print("[INFO]Data get loaded successfully", flush=True)
+
+    model = NeuralNetwork().to(device)
+    if (args.load_model):
+        model.load_state_dict('./pert.bin')
+
+    if is_distributed():
+        Distributor = nn.parallel.DistributedDataParallel
+        model = Distributor(model, find_unused_parameters=True)
+    loss_fn = nn.CrossEntropyLoss()
+    optimizer = AdamW(model.parameters(), lr=args.lr)
+
+    total_loss = 0.
+    best_acc = 0.
+
+    for t in range(args.epochs):
+        print(f"Epoch {t+1}/{args.epochs + 1}\n-------------------------------")
+        if is_distributed():
+            train_dataloader.sampler.set_epoch(t)
+            valid_dataloader.sampler.set_epoch(t)
+        start = time.perf_counter()
+        total_loss, total_dataset = train_loop(
+            args, train_dataloader, model, loss_fn, optimizer, t+1, total_loss)
+        end = time.perf_counter()
+        print(f"Epoch {t+1}/{args.epochs + 1} Elapsed time:",
+              end - start, flush=True)
+        print(f"Epoch {t+1}/{args.epochs + 1} Processed dataset length:",
+              total_dataset, flush=True)
+        msg = "Epoch {}/{} Throughput: {: .4f}".format(
+            t+1, args.epochs+1, 1.0 * total_dataset / (end-start))
+        print(msg, flush=True)
+        valid_acc = test_loop(valid_dataloader, model, mode='Valid')
+
+    print("[INFO]Finish all test", flush=True)
+
+    if (args.save_model):
+        torch.save(model.state_dict(), "pert.bin")
+    if is_distributed():
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/ppml/src/bigdl/ppml/encryption/torch/models.py
+++ b/python/ppml/src/bigdl/ppml/encryption/torch/models.py
@@ -77,7 +77,7 @@ def _open_file_or_buffer(file_like, mode):
         elif 'r' in mode:
             return _open_buffer_reader(file_like)
         else:
-            invalidInputError(f"Expected 'r' or 'w' in mode but got {mode}")
+            invalidInputError(False, f"Expected 'r' or 'w' in mode but got {mode}")
 
 def save(obj, f: Union[str, os.PathLike, BinaryIO, IO[bytes]], encryption_key: str, pickle_module = pickle, pickle_protocol=DEFAULT_PROTOCOL, _use_new_zipfile_serialization=True) -> None:
     buffer = io.BytesIO()

--- a/python/ppml/src/bigdl/ppml/encryption/torch/models.py
+++ b/python/ppml/src/bigdl/ppml/encryption/torch/models.py
@@ -42,7 +42,7 @@ class _buf_operator(object):
         decrypted_content = self.secret_key.decrypt(buffer.getvalue())
         decrypted_buffer.write(decrypted_content)
 
-class _opener(object):
+class opener(object):
     def __init__(self, file_like):
         self.file_like = file_like
 
@@ -52,7 +52,7 @@ class _opener(object):
     def __exit__(self, *args):
         pass
 
-class _open_file(_opener):
+class _open_file(opener):
     def __init__(self, name, mode):
         super(_open_file, self).__init__(open(name, mode))
     
@@ -60,11 +60,11 @@ class _open_file(_opener):
         # Flush is automatically done when closing the file
         self.file_like.close()
 
-class _open_buffer_reader(_opener):
+class _open_buffer_reader(opener):
     def __init__(self, buffer):
         super(_open_buffer_reader, self).__init__(buffer)
 
-class _open_buffer_writer(_opener):
+class _open_buffer_writer(opener):
     def __exit__(self, *args):
         self.file_like.flush()
 


### PR DESCRIPTION
## Description

This PR adds new methods that help to decrypt the datasets files before loading it back to memory.

### 1. Why the change?

To enable end-to-end security.

### 2. User API changes

In the original interface, there is an argument called **keep_in_memory**.  When this argument is set to false, the datasets will use mmap to only load part of the file into memory.

The use of mmap will use less memory.  However, decrypt only part of the file is impossible in the current situation.  Therefore, we banned the use of **keep_in_memory**.  When user set **keep_in_memory** to false, an invalidInputError will be raised.

### 3. Summary of the change 

Provide method to decrypt datasets before loading it back to disk.

### 4. How to test?
- [x] Manually test

### 5. TODO
- [ ] Change to patch format

