### PR TITLE
Orca: Restore batch before hook `before_train_iter`

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -484,8 +484,8 @@ class TorchRunner(BaseRunner):
             self.batch = *features, target
         else:
             invalidInputError(False,
-                                "Features should be tensor, list/tuple, "
-                                "but got {}".format(type(features)))
+                              "Features should be tensor, list/tuple, "
+                              "but got {}".format(type(features)))
         self.call_hook(call_backs=callbacks, fn_name="before_train_iter")
 
         # Compute output.
@@ -631,8 +631,8 @@ class TorchRunner(BaseRunner):
             self.batch = *features, target
         else:
             invalidInputError(False,
-                                "Features should be tensor, list/tuple, "
-                                "but got {}".format(type(features)))
+                              "Features should be tensor, list/tuple, "
+                              "but got {}".format(type(features)))
         self.call_hook(call_backs=callbacks, fn_name="before_val_iter")
 
         # compute output

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -514,6 +514,10 @@ class TorchRunner(BaseRunner):
 
         self.call_hook(call_backs=callbacks, fn_name="after_train_iter")
 
+        # User should not see batch from last iteration
+        if hasattr(self, "batch"):
+            del self.batch
+
         return {"train_loss": loss.item(), NUM_SAMPLES: get_batchsize(features)}
 
     def validate(self, data_creator, batch_size=32, num_steps=None, profile=False,
@@ -647,6 +651,10 @@ class TorchRunner(BaseRunner):
             loss = self.criterion(*outputL, *targetL)
 
         self.call_hook(call_backs=callbacks, fn_name="after_val_iter")
+
+        # User should not see batch from last iteration
+        if hasattr(self, "batch"):
+            del self.batch
 
         return output, target, loss
 


### PR DESCRIPTION
## Description

In hook `before_train_iter`, a user expects to see the batch in the original format, so we restore batch format before  `before_train_iter` is called. Also we recycle `self.batch` attribute when this iteration is over.