### PR TITLE
Nano: fix some typos of web documentation

### DIFF
--- a/docs/readthedocs/source/doc/Nano/Overview/pytorch_inference.md
+++ b/docs/readthedocs/source/doc/Nano/Overview/pytorch_inference.md
@@ -68,7 +68,7 @@ You can simply append the following part to enable your [ONNXRuntime](https://on
 ```python
 # step 4: trace your model as an ONNXRuntime model
 # if you have run `trainer.fit` before trace, then argument `input_sample` is not required.
-ort_model = InferenceOptimizer.trace(model, accelerator='onnruntime', input_sample=x)
+ort_model = InferenceOptimizer.trace(model, accelerator='onnxruntime', input_sample=x)
 
 # step 5: use returned model for transparent acceleration
 # The usage is almost the same with any PyTorch module

--- a/docs/readthedocs/source/doc/Nano/QuickStart/pytorch_train_quickstart.md
+++ b/docs/readthedocs/source/doc/Nano/QuickStart/pytorch_train_quickstart.md
@@ -66,7 +66,7 @@ class LitResnet(LightningModule):
     def __init__(self, learning_rate=0.05, num_processes=1):
         super().__init__()
 
-        self.save_hyperparameters()
+        self.save_hyperparameters('learning_rate', 'num_processes')
         self.model = create_model()
 
     def forward(self, x):


### PR DESCRIPTION
## Description

- Change "onnruntime" to "onnxruntime" in web document "Overview/pytorch_inference.md" .
- Add hyperparameter specification to function `save_hyperparameters('learning_rate', 'num_processes')` in "/QuickStart/pytorch_train_quickstart.md"