### PR TITLE
Nano: fix documentation typos in tensorflow inference and quantization 

### DIFF
--- a/docs/readthedocs/source/doc/Nano/Overview/tensorflow_inference.md
+++ b/docs/readthedocs/source/doc/Nano/Overview/tensorflow_inference.md
@@ -58,7 +58,7 @@ of INC.
 ### Quantization with Accuracy Control
 A set of arguments that helps to tune the results for both INC and POT quantization:
 
-- `calib_dataset`: A `tf.data.Dataset` object for calibration. Required for static quantization. It's also used as a validation dataloader.
+- `x`: A `tf.data.Dataset` object for calibration. Required for static quantization. It's also used as a validation dataloader.
 - `metric`:  A `tensorflow.keras.metrics.Metric` object for evaluation.
 
 - `accuracy_criterion`: A dictionary to specify the acceptable accuracy drop, e.g. `{'relative': 0.01, 'higher_is_better': True}`
@@ -80,7 +80,7 @@ from torchmetrics.classification import MulticlassAccuracy
 
 q_model = model.quantize(precision='int8',
                          accelerator=None,
-                         calib_dataset= train_dataset,
+                         x= train_dataset,
                          metric=MulticlassAccuracy(num_classes=10),
                          accuracy_criterion={'relative': 0.01, 'higher_is_better': True},
                          approach='static',

--- a/docs/readthedocs/source/doc/Nano/QuickStart/tensorflow_quantization_quickstart.md
+++ b/docs/readthedocs/source/doc/Nano/QuickStart/tensorflow_quantization_quickstart.md
@@ -76,9 +76,14 @@ model.fit(train_ds, epochs=1)
 ```python
 from tensorflow.keras.metrics import CategoricalAccuracy
 q_model = InferenceOptimizer.quantize(model,
-                                      calib_dataset=dataset,
+                                      x=dataset,
+                                      precision='bf16',
+                                      accelerator='openvino',
                                       metric=CategoricalAccuracy(),
-                                      tuning_strategy='basic'
+                                      accuracy_criterion={'relative': 0.01, 'higher_is_better': True},
+                                      tuning_strategy='basic',
+                                      timeout=0,
+                                      max_trials=10,
                                       )
 ```
 The quantized model can be called to do inference as normal keras model.


### PR DESCRIPTION
## Description

For quantization API in tensorflow inference engine, there's no keyword argument of "calib_dataset", instead using "x" simply. 
