### PR TITLE
[PPML] Fix API name typo in KMS readme

### DIFF
--- a/python/ppml/src/bigdl/ppml/kms/README.md
+++ b/python/ppml/src/bigdl/ppml/kms/README.md
@@ -27,7 +27,7 @@ As they are the user certificates for KMS, please export them only in trusted an
 - Request a data key with prepared primary key and save it locally in ciphertext:
 
   ```bash
-  python client.py -api generate_primary_key -ip <KMS_IP> [-port <KMS_PORT>] -pkp <PRIMARYED_KEY_PATH>
+  python client.py -api generate_data_key -ip <KMS_IP> [-port <KMS_PORT>] -pkp <PRIMARYED_KEY_PATH> [-dkl <DATA_KEY_LENGTH_16_OR_32>]
   ```
 
 - Encrypt a file without holding keys (keys will be generated automatically):


### PR DESCRIPTION
## Description

As the title.

### 1. Why the change?

The API name is wrong.

### 2. User API changes

None.

### 3. Summary of the change 

Fix API name typo in KMS readme

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...
