### PR TITLE
Nano: fix affinity detection error

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/__init__.py
@@ -19,16 +19,43 @@ __all__ = ["Trainer", "TorchNano", "InferenceOptimizer"]
 # unset the KMP_INIT_AT_FORK
 # which will cause significant slow down in multiprocessing training
 import os
+import torch
+import platform
+import warnings
+
+
 if 'KMP_INIT_AT_FORK' in os.environ:
     del os.environ['KMP_INIT_AT_FORK']
 
 # reset the num of threads
-import platform
 if platform.system() == "Linux":
     # only UNIX-like system applied
-    import torch
-    affinity_core_num = len(os.sched_getaffinity(0))
     preset_thread_nums = torch.get_num_threads()
+
+    # When using proclist to bind cores,
+    # `os.sched_getaffinity(0)` will return only the first bound core,
+    # so we need to parse KMP_AFFINITY manually in this case
+    KMP_AFFINITY = os.environ.get("KMP_AFFINITY", "")
+    if "proclist" not in KMP_AFFINITY:
+        affinity_core_num = len(os.sched_getaffinity(0))
+    else:
+        try:
+            start_pos = KMP_AFFINITY.find('[', KMP_AFFINITY.find("proclist")) + 1
+            end_pos = KMP_AFFINITY.find(']', start_pos)
+            proclist_str = KMP_AFFINITY[start_pos:end_pos].replace(" ", "")
+            core_list = []
+            for n in proclist_str.split(','):
+                if '-' not in n:
+                    core_list.append(int(n))
+                else:
+                    start, end = n.split('-')
+                    core_list.extend(range(start, end + 1))
+            affinity_core_num = len(core_list)
+        except Exception as _e:
+            warnings.warn(f"Failed to parse KMP_AFFINITY: '{KMP_AFFINITY}'."
+                          f" Will use default thread number: {preset_thread_nums}")
+            affinity_core_num = preset_thread_nums
+
     if preset_thread_nums > affinity_core_num:
         torch.set_num_threads(affinity_core_num)
 

--- a/python/nano/src/bigdl/nano/pytorch/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/__init__.py
@@ -49,7 +49,7 @@ if platform.system() == "Linux":
                     core_list.append(int(n))
                 else:
                     start, end = n.split('-')
-                    core_list.extend(range(start, end + 1))
+                    core_list.extend(range(int(start), int(end) + 1))
             affinity_core_num = len(core_list)
         except Exception as _e:
             warnings.warn(f"Failed to parse KMP_AFFINITY: '{KMP_AFFINITY}'."


### PR DESCRIPTION
## Description

Fix affinity detection error.

When using `KMP_AFFINITY=proclist=[...]` to bind core, `os.shed_getaffinity(0)` will only return the first bound core, which causes every sub-process will use only one thread. #7099

This PR parse `KMP_AFFINITY` manually to get the right cores.


