### PR TITLE
Nano: fix keras onnx model output shape

### DIFF
--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -593,6 +593,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                   outputs=outputs,
                                   onnx_option='tensorflow',
                                   onnxruntime_session_options=onnxruntime_session_options)
+            result._nesting_level = onnx_model._nesting_level
             result._inputs_dtypes = onnx_model._inputs_dtypes
             result._default_kwargs = onnx_model._default_kwargs
             result._call_fn_args_backup = onnx_model._call_fn_args_backup

--- a/python/nano/src/bigdl/nano/tf/utils.py
+++ b/python/nano/src/bigdl/nano/tf/utils.py
@@ -15,6 +15,7 @@
 #
 import inspect
 import operator
+import tensorflow as tf
 from tensorflow.keras import Model
 from functools import partial
 from bigdl.nano.common.compare_version import _compare_version
@@ -96,3 +97,14 @@ def patch_compiled(target_model: Model, source_model: Model):
             kwargs["weighted_metrics"] = source_model.compiled_metrics._user_weighted_metrics
         target_model.compile(**kwargs)
     return target_model
+
+
+def fake_tensor_from_spec(tensor_spec: tf.TensorSpec):
+    """Fake a `Tensor` from `TensorSpec`."""
+    shape = tensor_spec.shape
+    dtype = tensor_spec.dtype
+    shape = tuple(dim if dim is not None else 1 for dim in shape)
+    if shape == () and dtype == tf.bool:
+        # This may be the `training` parameter, we should assume it is False
+        return False
+    return tf.ones(shape=shape, dtype=dtype)

--- a/python/nano/test/tf/keras/test_trace_and_quantize.py
+++ b/python/nano/test/tf/keras/test_trace_and_quantize.py
@@ -114,10 +114,10 @@ class TestTraceAndQuantize(TestCase):
         x = np.random.random((100, 4))
         traced_model = InferenceOptimizer.trace(model, accelerator="onnxruntime",
                                                 input_spec=tf.TensorSpec(shape=(None, 4), dtype=tf.float32))
-        outputs = traced_model(x, tf.convert_to_tensor(True))
+        outputs = traced_model(x)
         assert isinstance(outputs, list) and isinstance(outputs[0], tf.Tensor)
 
         quantized_model = InferenceOptimizer.quantize(model, accelerator="onnxruntime", 
                                                       input_spec=tf.TensorSpec(shape=(None, 4)), x=x)
-        outputs = quantized_model(x, tf.convert_to_tensor(True))
+        outputs = quantized_model(x)
         assert isinstance(outputs, list) and isinstance(outputs[0], tf.Tensor)

--- a/python/nano/test/tf/keras/test_trace_and_quantize.py
+++ b/python/nano/test/tf/keras/test_trace_and_quantize.py
@@ -42,6 +42,15 @@ class MyModel(tf.keras.Model):
         pass
 
 
+class MyModelReturnList(tf.keras.Model):
+    def __init__(self):
+        super().__init__()
+        self.dense1 = tf.keras.layers.Dense(4, activation=tf.nn.relu)
+
+    def call(self, inputs: tf.Tensor):
+        return [self.dense1(inputs)]
+
+
 class TestTraceAndQuantize(TestCase):
     def test_attribute_access_after_trace(self):
         x = 100
@@ -99,3 +108,16 @@ class TestTraceAndQuantize(TestCase):
             InferenceOptimizer.save(traced_model, tmp_dir_name)
             new_model = InferenceOptimizer.load(tmp_dir_name, model)
         new_model.evaluate(x=x, y=y)
+
+    def test_inference_output_shape(self):
+        model = MyModelReturnList()
+        x = np.random.random((100, 4))
+        traced_model = InferenceOptimizer.trace(model, accelerator="onnxruntime",
+                                                input_spec=tf.TensorSpec(shape=(None, 4), dtype=tf.float32))
+        outputs = traced_model(x, tf.convert_to_tensor(True))
+        assert isinstance(outputs, list) and isinstance(outputs[0], tf.Tensor)
+
+        quantized_model = InferenceOptimizer.quantize(model, accelerator="onnxruntime", 
+                                                      input_spec=tf.TensorSpec(shape=(None, 4)), x=x)
+        outputs = quantized_model(x, tf.convert_to_tensor(True))
+        assert isinstance(outputs, list) and isinstance(outputs[0], tf.Tensor)


### PR DESCRIPTION
## Description

Fix the output shape of keras onnx model

### 1. Why the change?

`tf.py_function(func, ..., Tout=tf.float32)` will convert the output of `func` to a single Tensor, that means `[t]` or `[[t]]` (`t` is a `tf.Tensor`) all will be converted to `t`.

Besides, if the original model return a single tensor `t`, then after tracing, onnxruntime model will return `[t]`.

These two rules will destroy the output shape when the original output is a single tensor, or a list of tensor with only one element, or a list of list of tensor with only one element, ...

Before this PR, we simply check whether the output is a list and has only one element, if is, then return its first element. We use this method to 

However, this method cannot distinguish whether the original model return `t` or `[t]` (onnxruntime model will return `[t]` in both case). And we don't handle the influence of `tf.py_function`.

This PR fix both, it save the right output shape first, and convert the final output to this right shape.

### 2. User API changes

N/A

### 3. Summary of the change 

N/A

### 4. How to test?
- [ ] Unit test

