### PR TITLE
Chronos: add forecaster alg choose guide and some cleaning for how to guide

### DIFF
--- a/docs/readthedocs/source/_toc.yml
+++ b/docs/readthedocs/source/_toc.yml
@@ -203,6 +203,7 @@ subtrees:
                 - file: doc/Chronos/Howto/how_to_export_torchscript_files
                 - file: doc/Chronos/Howto/how_to_preprocess_my_data
                 - file: doc/Chronos/Howto/how_to_process_data_in_production_environment
+                - file: doc/Chronos/Howto/how_to_choose_forecasting_alg
           - file: doc/Chronos/QuickStart/index
             title: "Tutorials"
             subtrees:

--- a/docs/readthedocs/source/doc/Chronos/Howto/how_to_choose_forecasting_alg.md
+++ b/docs/readthedocs/source/doc/Chronos/Howto/how_to_choose_forecasting_alg.md
@@ -6,6 +6,7 @@ The flowchart below is designed to guide our users which forecasting model to tr
 
 ```eval_rst
 .. mermaid::
+
     flowchart TD
         StartPoint[I want to build a forecasting model]
         StartPoint-- always start from --> TCN[TCNForecaster]

--- a/docs/readthedocs/source/doc/Chronos/Howto/how_to_choose_forecasting_alg.md
+++ b/docs/readthedocs/source/doc/Chronos/Howto/how_to_choose_forecasting_alg.md
@@ -5,6 +5,13 @@ How to choose a forecasting model among so many built-in models (or build one by
 The flowchart below is designed to guide our users which forecasting model to try on your own data. Click on the blocks in the chart below to see its documentation/examples.
 
 ```eval_rst
+.. note::
+
+    Following flowchart may need some time to load.
+```
+
+
+```eval_rst
 .. mermaid::
 
     flowchart TD
@@ -29,12 +36,11 @@ The flowchart below is designed to guide our users which forecasting model to tr
         click LSTMForecaster2 "https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/forecasting.html#lstmforecaster"
         click NBeatsForecaster "https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/forecasting.html#nbeatsforecaster"
         click Seq2SeqForecaster "https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/forecasting.html#seq2seqforecaster"
-        click AutoformerForecaster "."
+        click AutoformerForecaster "https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/forecasting.html#AutoformerForecaster"
 
-        click StartPoint "https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/forecasting.html#seq2seqforecaster"
         click TCN_OPT "https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/speed_up.html"
         click SER "https://github.com/intel-analytics/BigDL/blob/main/python/chronos/example/hpo/muti_objective_hpo_with_builtin_latency_tutorial.ipynb"
-        click Tune "https://bigdl.readthedocs.io/en/latest/doc/Chronos/QuickStart/chronos-autotsest-quickstart.html"
+        click Tune "https://bigdl.readthedocs.io/en/latest/doc/Chronos/Howto/how_to_tune_forecaster_model.html"
         click CUS "https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/speed_up.html"
 
         classDef Model fill:#FFF,stroke:#0f29ba,stroke-width:1px;

--- a/docs/readthedocs/source/doc/Chronos/Howto/how_to_choose_forecasting_alg.md
+++ b/docs/readthedocs/source/doc/Chronos/Howto/how_to_choose_forecasting_alg.md
@@ -4,7 +4,8 @@ How to choose a forecasting model among so many built-in models (or build one by
 
 The flowchart below is designed to guide our users which forecasting model to try on your own data. Click on the blocks in the chart below to see its documentation/examples.
 
-```{mermaid}
+```eval_rst
+.. mermaid::
     flowchart TD
         StartPoint[I want to build a forecasting model]
         StartPoint-- always start from --> TCN[TCNForecaster]

--- a/docs/readthedocs/source/doc/Chronos/Howto/how_to_choose_forecasting_alg.md
+++ b/docs/readthedocs/source/doc/Chronos/Howto/how_to_choose_forecasting_alg.md
@@ -1,0 +1,40 @@
+# Choose proper forecasting model
+
+How to choose a forecasting model among so many built-in models (or build one by yourself) in Chronos? That's a common question when users want to build their first forecasting model. Different forecasting models are more suitable for different data and different metrics(accuracy or performances).
+
+The flowchart below is designed to guide our users which forecasting model to try on your own data. Click on the blocks in the chart below to see its documentation/examples.
+
+```{mermaid}
+    flowchart TD
+        StartPoint[I want to build a forecasting model]
+        StartPoint-- always start from --> TCN[TCNForecaster]
+        TCN -- performance is not satisfying --> TCN_OPT[Make sure optimizations are deploied]
+        TCN_OPT -- further performance improvement is needed --> SER[Performance-awared Hyperparameter Optimization]
+        SER -- only 1 step to be predicted --> LSTMForecaster
+        SER -- only 1 var to be predicted --> NBeatsForecaster
+        LSTMForecaster -- does not work --> CUS[customized model]
+        NBeatsForecaster -- does not work --> CUS[customized model]
+
+        TCN -- accuracy is not satisfying --> Tune[Hyperparameter Optimization]
+        Tune -- only 1 step to be predicted --> LSTMForecaster2[LSTMForecaster]
+        LSTMForecaster2 -- does not work --> AutoformerForecaster
+        Tune -- more than 1 step to be predicted --> AutoformerForecaster
+        AutoformerForecaster -- does not work --> Seq2SeqForecaster
+        Seq2SeqForecaster -- does not work --> CUS[customized model]
+
+        click TCN "https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/forecasting.html#tcnforecaster"
+        click LSTMForecaster "https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/forecasting.html#lstmforecaster"
+        click LSTMForecaster2 "https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/forecasting.html#lstmforecaster"
+        click NBeatsForecaster "https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/forecasting.html#nbeatsforecaster"
+        click Seq2SeqForecaster "https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/forecasting.html#seq2seqforecaster"
+        click AutoformerForecaster "."
+
+        click StartPoint "https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/forecasting.html#seq2seqforecaster"
+        click TCN_OPT "https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/speed_up.html"
+        click SER "https://github.com/intel-analytics/BigDL/blob/main/python/chronos/example/hpo/muti_objective_hpo_with_builtin_latency_tutorial.ipynb"
+        click Tune "https://bigdl.readthedocs.io/en/latest/doc/Chronos/QuickStart/chronos-autotsest-quickstart.html"
+        click CUS "https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/speed_up.html"
+
+        classDef Model fill:#FFF,stroke:#0f29ba,stroke-width:1px;
+        class TCN,LSTMForecaster,NBeatsForecaster,LSTMForecaster2,AutoformerForecaster,Seq2SeqForecaster Model;
+```

--- a/docs/readthedocs/source/doc/Chronos/Howto/index.rst
+++ b/docs/readthedocs/source/doc/Chronos/Howto/index.rst
@@ -2,33 +2,46 @@ Chronos How-to Guides
 =========================
 How-to guides are bite-sized, executable examples where users could check when meeting with some specific topic during the usage.
 
-Install
+Installation
 -------------------------
 
 * `Install Chronos on Windows <windows_guide.html>`__
 * `Use Chronos in container(docker) <docker_guide_single_node.html>`__
 
+Data Processing
+-------------------------
+* `Preprocess my data <how_to_preprocess_my_data.html>`__
+
+
 Forecasting
 -------------------------
 
+Develop a forecaster
+~~~~~~~~~~~~~~~~~~~~~~~~~
+* `Choose a forecaster algorithm <how_to_choose_forecasting_alg.html>`__
 * `Create a forecaster <how_to_create_forecaster.html>`__
 * `Train forecaster on single node <how_to_train_forecaster_on_one_node.html>`__
-* `Save and load a forecaster <how_to_save_and_load_forecaster.html>`__
 * `Tune forecaster on single node <how_to_tune_forecaster_model.html>`__
-* `Speed up inference of forecaster through ONNXRuntime <how_to_speedup_inference_of_forecaster_through_ONNXRuntime.html>`__
-* `Speed up inference of forecaster through OpenVINO <how_to_speedup_inference_of_forecaster_through_OpenVINO.html>`__
 * `Evaluate a forecaster <how_to_evaluate_a_forecaster.html>`__
 * `Use forecaster to predict future data <how_to_use_forecaster_to_predict_future_data.html>`__
 * `Generate confidence interval for prediction <how_to_generate_confidence_interval_for_prediction.html>`__
+
+Speed up a forecaster
+~~~~~~~~~~~~~~~~~~~~~~~~~
+* `Speed up inference of forecaster through ONNXRuntime <how_to_speedup_inference_of_forecaster_through_ONNXRuntime.html>`__
+* `Speed up inference of forecaster through OpenVINO <how_to_speedup_inference_of_forecaster_through_OpenVINO.html>`__
+
+Persist a forecaster
+~~~~~~~~~~~~~~~~~~~~~~~~~
+* `Save and load a forecaster <how_to_save_and_load_forecaster.html>`__
 * `Export the ONNX model files to disk <how_to_export_onnx_files.html>`__
 * `Export the OpenVINO model files to disk <how_to_export_openvino_files.html>`__
 * `Export the TorchScript model files to disk <how_to_export_torchscript_files.html>`__
-* `Preprocess my data <how_to_preprocess_my_data.html>`__
 
-Benchmark
--------------------------
+Benchmark a forecaster
+~~~~~~~~~~~~~~~~~~~~~~~~~
 * `Use Chronos benchmark tool <how_to_use_benchmark_tool.html>`__
 
-Deployment
--------------------------
+Deploy a forecaster
+~~~~~~~~~~~~~~~~~~~~~~~~~
 * `A whole workflow in production environment after my forecaster is developed <how_to_process_data_in_production_environment.html>`__

--- a/docs/readthedocs/source/doc/Chronos/Overview/forecasting.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/forecasting.md
@@ -29,7 +29,8 @@ Besides, _Chronos_ also provides **benchmark tool** to benchmark forecasting per
 | ----------------- | ----- | ------------- | ---------- | ------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- |
 | LSTM    | RR    | ✅             | ❌      | ✅    | ✅   | ✅           | ✅        | ✅          | ✅         | pytorch/tf2  |
 | Seq2Seq     | RR    | ✅             | ✅     | ✅     | ✅     | ✅           | ❌      | ✅          | ✅         | pytorch/tf2  |
-| TCN | RR    | ✅             | ✅     | ✅     | ✅     | ✅           | ✅      | ✅          | ✅         | pytorch  |
+| TCN | RR    | ✅             | ✅     | ✅     | ✅     | ✅           | ✅      | ✅          | ✅         | pytorch/tf2  |
+| Autoformer | RR    | ✅             | ✅     | ✅     | ❌     | ❌           | ❌      | ❌          | ❌         | pytorch  |
 | NBeats | RR    | ❌             | ✅     | ❌     | ✅     | ✅           | ✅      | ❌          | ❌         | pytorch  |
 | MTNet   | RR    | ✅             | ❌    | ✅     | ❌     | ❌          | ❌         | ❌          | ✳️\*\*        | tf2 |
 | TCMF    | TS    | ✅             | ✅    | ✅      | ✳️\*     | ❌          | ❌         | ❌          | ❌         | pytorch  |
@@ -257,6 +258,15 @@ View Stock Prediction [notebook][stock_prediction_prophet] and [ProphetForecaste
 ##### 3.8 NBeatsForecaster
 
 Neural basis expansion analysis for interpretable time series forecasting ([N-BEATS](https://arxiv.org/abs/1905.10437)) is a deep neural architecture based on backward and forward residual links and a very deep stack of fully-connected layers. Nbeats can solve univariate time series point forecasting problems, being interpretable, and fast to train.
+
+[NBeatsForecaster API Doc](../../PythonAPI/Chronos/forecasters.html#nbeatsforecaster) for more details.
+
+<span id="AutoformerForecaster"></span>
+##### 3.9 AutoformerForecaster
+
+Autoformer: Decomposition Transformers with Auto-Correlation for Long-Term Series Forecasting ([Autoformer](https://arxiv.org/abs/2106.13008)) is a Transformer based neural network that could reach SOTA results on many datasets.
+
+[AutoformerForecaster API Doc](../../PythonAPI/Chronos/forecasters.html#autoformerforecaster) for more details.
 
 #### 4. Use Auto forecasting model
 Auto forecasting models are designed to be used exactly the same as Forecasters. The only difference is that you can set hp search function to the hyperparameters and the `.fit()` method will search the best hyperparameter setting.


### PR DESCRIPTION
## Description

### 1. Why the change?
This is a "remake" for https://github.com/intel-analytics/BigDL/pull/5364, since previous PR has too many conflicts.

### 2. User API changes
nothing

### 3. Summary of the change 
choose forecaster guide: https://bigdl-junweid.readthedocs.io/en/forecaster-alg-choose/doc/Chronos/Howto/how_to_choose_forecasting_alg.html
renewed how to guide overview: https://bigdl-junweid.readthedocs.io/en/forecaster-alg-choose/doc/Chronos/Howto/index.html

### 4. How to test?
- [ ] Document test
