### PR TITLE
Chronos: remove channels_last methods from `forecaster.optimize()`

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -601,7 +601,7 @@ class BasePytorchForecaster(Forecaster):
                 metric = None
             else:
                 try:
-                    metric = _str2metric(metric)
+                    metric = _str2optimizer_metrc(metric)
                 except Exception:
                     invalidInputError(False,
                                       "Unable to recognize the metric string you passed in.")
@@ -1930,5 +1930,20 @@ def _str2metric(metric):
             y_label = y_label.numpy()
             y_predict = y_predict.numpy()
             return metric_func(y_label, y_predict)
+        metric.__name__ = metric_name
+    return metric
+
+
+def _str2optimizer_metrc(metric):
+    # map metric str to function for InferenceOptimizer
+    if isinstance(metric, str):
+        metric_name = metric
+        from bigdl.chronos.metric.forecast_metrics import REGRESSION_MAP
+        metric_func = REGRESSION_MAP[metric_name]
+
+        def metric(pred, target):
+            pred = pred.numpy()
+            target = target.numpy()
+            return metric_func(target, pred)
         metric.__name__ = metric_name
     return metric

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -1932,4 +1932,3 @@ def _str2metric(metric):
             return metric_func(y_label, y_predict)
         metric.__name__ = metric_name
     return metric
-

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -608,14 +608,12 @@ class BasePytorchForecaster(Forecaster):
 
         dummy_input = torch.rand(1, self.data_config["past_seq_len"],
                                  self.data_config["input_feature_num"])
-
         excludes = ["fp32_channels_last", "fp32_ipex_channels_last", "bf16_channels_last",
                     "bf16_ipex_channels_last", "jit_fp32_channels_last", "jit_bf16_channels_last",
                     "jit_fp32_ipex_channels_last", "jit_bf16_ipex_channels_last"]
         if not self.quantize_available:
             excludes = excludes + ["static_int8", "openvino_int8", "onnxruntime_int8_qlinear",
                                    "bf16", "jit_bf16_ipex"]
-
         from bigdl.chronos.pytorch import TSInferenceOptimizer as InferenceOptimizer
         opt = InferenceOptimizer()
         opt.optimize(model=self.internal,
@@ -626,7 +624,6 @@ class BasePytorchForecaster(Forecaster):
                      thread_num=thread_num,
                      excludes=excludes,
                      input_sample=dummy_input)
-
         try:
             optim_model, option = opt.get_best_model(
                 accelerator=accelerator,


### PR DESCRIPTION
## Description

Considering that channels_last methods make no sense to time series data, remove it from available methods in `forecaster.optimize()`.


### 2. User API changes

no change

### 4. How to test?
- [x] Unit test
