### PR TITLE
Nano: fix bug of openvino cannot infer input shape

### DIFF
--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -85,7 +85,7 @@ def load_openvino_model(path, framework='pytorch', device=None):
                           " Please choose from 'pytorch'/'tensorflow'.")
 
 
-def KerasOpenVINOModel(model, input_spec=None, precision='fp32', 
+def KerasOpenVINOModel(model, input_spec=None, precision='fp32',
                        thread_num=None, device='CPU', config=None,
                        logging=True):
     """

--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -85,13 +85,16 @@ def load_openvino_model(path, framework='pytorch', device=None):
                           " Please choose from 'pytorch'/'tensorflow'.")
 
 
-def KerasOpenVINOModel(model, precision='fp32', thread_num=None,
-                       device='CPU', config=None, logging=True):
+def KerasOpenVINOModel(model, input_spec=None, precision='fp32', 
+                       thread_num=None, device='CPU', config=None,
+                       logging=True):
     """
     Create a OpenVINO model from Keras.
 
     :param model: Keras model to be converted to OpenVINO for inference or
                   path to Openvino saved model.
+    :param input_spec: A (tuple or list of) tf.TensorSpec or numpy array defining
+                       the shape/dtype of the input
     :param precision: Global precision of model, supported type: 'fp32', 'fp16',
                       defaults to 'fp32'.
     :param thread_num: a int represents how many threads(cores) is needed for
@@ -104,6 +107,7 @@ def KerasOpenVINOModel(model, precision='fp32', thread_num=None,
     """
     from .tf.model import KerasOpenVINOModel
     return KerasOpenVINOModel(model=model,
+                              input_spec=input_spec,
                               precision=precision,
                               thread_num=thread_num,
                               device=device,

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -311,7 +311,6 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                             backend. 'openvino' and 'onnxruntime' are supported for now.
         :param input_spec: A (tuple or list of) tf.TensorSpec or numpy array defining the
                            shape/dtype of the input when using 'onnxruntime' accelerator.
-                           It will be ignored if accelerator is 'openvino'.
         :param thread_num: (optional) a int represents how many threads(cores) is needed for
                            inference, only valid for accelerator='onnxruntime'
                            or accelerator='openvino'.
@@ -338,6 +337,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             if openvino_config is not None:
                 final_openvino_option.update(openvino_config)
             result = KerasOpenVINOModel(model,
+                                        input_spec=input_spec,
                                         precision='fp32',
                                         thread_num=thread_num,
                                         device=device,
@@ -405,7 +405,6 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                 None means staying in tensorflow.
         :param input_spec: A (tuple or list of) tf.TensorSpec or numpy array defining the
                            shape/dtype of the input when using 'onnxruntime' accelerator.
-                           It will be ignored if accelerator is 'openvino'.
         :param metric:          A tensorflow.keras.metrics.Metric object for evaluation.
         :param accuracy_criterion:  Tolerable accuracy drop.
                                     accuracy_criterion = {'relative': 0.1, 'higher_is_better': True}
@@ -474,6 +473,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                               "fp16 is not supported on {} accelerator.".format(accelerator))
             from bigdl.nano.deps.openvino.tf.model import KerasOpenVINOModel    # type: ignore
             result = KerasOpenVINOModel(model,
+                                        input_spec=input_spec,
                                         precision=precision,
                                         thread_num=thread_num,
                                         device=device,
@@ -491,6 +491,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 final_openvino_option.update(openvino_config)
             from bigdl.nano.deps.openvino.tf.model import KerasOpenVINOModel    # type: ignore
             result = KerasOpenVINOModel(model,
+                                        input_spec=input_spec,
                                         precision=precision,
                                         thread_num=thread_num,
                                         device=device,
@@ -538,6 +539,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 # For CPU: fp32 -> int8, for GPU: fp16 -> int8
                 _precision = 'fp16' if device != 'CPU' else 'fp32'
                 openvino_model = KerasOpenVINOModel(model,
+                                                    input_spec=input_spec,
                                                     precision=_precision,
                                                     thread_num=thread_num,
                                                     device=device,

--- a/python/nano/test/tf/keras/test_trace_and_quantize.py
+++ b/python/nano/test/tf/keras/test_trace_and_quantize.py
@@ -54,6 +54,7 @@ class MyModelReturnList(tf.keras.Model):
 class TestTraceAndQuantize(TestCase):
     def test_attribute_access_after_trace(self):
         x = 100
+        # for onnxruntime
         model = MyModel(x)
         traced_model = InferenceOptimizer.trace(model, accelerator="onnxruntime",
                                                 input_spec=tf.TensorSpec(shape=(None, 4), dtype=tf.float32))
@@ -69,9 +70,26 @@ class TestTraceAndQuantize(TestCase):
             new_model = InferenceOptimizer.load(tmp_dir_name, model)
         new_model.do_nothing()
         assert new_model.get_x() == traced_model.x == x
+        
+        # for openvino
+        model = MyModel(x)
+        traced_model = InferenceOptimizer.trace(model, accelerator="openvino",
+                                                input_spec=tf.TensorSpec(shape=(None, 4), dtype=tf.float32))
+        # try to access some custom attributes
+        traced_model.do_nothing()
+        assert traced_model.get_x() == traced_model.x == x
+        traced_model(np.random.random((1, 4)).astype(np.float32))
+
+        # test save/load
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(traced_model, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name, model)
+        new_model.do_nothing()
+        assert new_model.get_x() == traced_model.x == x
 
     def test_attribute_access_after_quantize(self):
         x = 100
+        # for onnxruntime
         model = MyModel(x)
         quantized_model = InferenceOptimizer.quantize(model,
                                                       accelerator="onnxruntime",
@@ -93,13 +111,51 @@ class TestTraceAndQuantize(TestCase):
         new_model.do_nothing()
         assert new_model.get_x() == quantized_model.x == x
 
+        # for openvino
+        model = MyModel(x)
+        quantized_model = InferenceOptimizer.quantize(model,
+                                                      accelerator="openvino",
+                                                      input_spec=tf.TensorSpec(shape=(None, 4), dtype=tf.float32),
+                                                      x=np.random.random((100, 4)),
+                                                      y=np.random.random((100, 5)),
+                                                      accuracy_criterion = {'relative': 0,
+                                                                            'higher_is_better': True})
+        # try to access some custom attributes
+        quantized_model.do_nothing()
+        assert quantized_model.get_x() == quantized_model.x == x
+        quantized_model(np.random.random((1, 4)).astype(np.float32))
+
+        # test save/load
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(quantized_model, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name, model)
+        new_model.do_nothing()
+        assert new_model.get_x() == quantized_model.x == x
+
     def test_evaluate_after_trace(self):
+        # test onnxxruntime
         model = MyModel(100)
         model.compile(loss='mse', metrics=MeanSquaredError())
         x = np.random.random((100, 4))
         y = np.random.random((100, 5))
 
         traced_model = InferenceOptimizer.trace(model, accelerator="onnxruntime",
+                                                input_spec=tf.TensorSpec(shape=(None, 4), dtype=tf.float32))
+        traced_model.evaluate(x=x, y=y)
+
+        # test save/load
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(traced_model, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name, model)
+        new_model.evaluate(x=x, y=y)
+
+        # test openvino
+        model = MyModel(100)
+        model.compile(loss='mse', metrics=MeanSquaredError())
+        x = np.random.random((100, 4))
+        y = np.random.random((100, 5))
+
+        traced_model = InferenceOptimizer.trace(model, accelerator="openvino",
                                                 input_spec=tf.TensorSpec(shape=(None, 4), dtype=tf.float32))
         traced_model.evaluate(x=x, y=y)
 


### PR DESCRIPTION
## Description

fix bug of openvino cannot infer input shape.

### 1. Why the change?

If user defines a custom model, which inherent from keras.Model, but don't contain explicit input layer, he will meet below error when trace/quantize with openvino:
```bash
cannot be saved either because the input shape is not available or because the forward pass of the model is not defined.To define a forward pass, please override `Model.call()`. To specify an input shape, either call `build(input_shape)` directly, or call the model on actual data using `Model()`, `Model.fit()`, or `Model.predict()`. 
```

### 2. User API changes

Now, `input_spec` works for openvino accelerator:
```python
# trace
traced_model = InferenceOptimizer.trace(model, accelerator="openvino",
                                        input_spec=tf.TensorSpec(shape=(None, 4), dtype=tf.float32))
# quantize
quantized_model = InferenceOptimizer.quantize(model,
                                              accelerator="openvino",
                                              input_spec=tf.TensorSpec(shape=(None, 4), dtype=tf.float32),
                                              x=np.random.random((100, 4)),
                                              y=np.random.random((100, 5)),
                                              accuracy_criterion = {'relative': 0,
                                                                    'higher_is_better': True})
```

### 3. Summary of the change 

- setting input shape of model by `model.compute_output_shape(input_shape)`
- related uts

### 4. How to test?
- [ ] Unit test

