### PR TITLE
Nano: provide an internal function to give suggestions to users in a conspicuous way

### DIFF
--- a/python/nano/src/bigdl/nano/__init__.py
+++ b/python/nano/src/bigdl/nano/__init__.py
@@ -40,7 +40,9 @@ def _check_nano_envs():
 # disable env check for now, as it does not work for tf and windows
 # _check_nano_envs()
 
+
 import atexit
 from bigdl.nano.utils.log4warning import output_suggestions
+
 
 atexit.register(output_suggestions)

--- a/python/nano/src/bigdl/nano/__init__.py
+++ b/python/nano/src/bigdl/nano/__init__.py
@@ -39,3 +39,8 @@ def _check_nano_envs():
 
 # disable env check for now, as it does not work for tf and windows
 # _check_nano_envs()
+
+import atexit
+from bigdl.nano.utils.log4warning import output_suggestions
+
+atexit.register(output_suggestions)

--- a/python/nano/src/bigdl/nano/utils/log4warning.py
+++ b/python/nano/src/bigdl/nano/utils/log4warning.py
@@ -1,0 +1,34 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import logging
+
+logger = logging.getLogger(__name__)
+warning_messages = []
+
+
+def output_suggestions():
+    global warning_messages
+    if len(warning_messages) > 0:
+        logger.warning(f"\n*****************Nano performance Suggestions*****************")
+        for message in warning_messages:
+            logger.warning(message)
+        logger.warning(f"\n*****************Nano performance Suggestions*****************")
+
+
+def regist_suggestion(warning_message):
+    global warning_messages
+    warning_messages.append(warning_message)

--- a/python/nano/src/bigdl/nano/utils/log4warning.py
+++ b/python/nano/src/bigdl/nano/utils/log4warning.py
@@ -29,6 +29,6 @@ def output_suggestions():
         logger.warning(f"\n*****************Nano performance Suggestions*****************")
 
 
-def regist_suggestion(warning_message):
+def register_suggestion(warning_message):
     global warning_messages
     warning_messages.append(warning_message)

--- a/python/nano/src/bigdl/nano/utils/log4warning.py
+++ b/python/nano/src/bigdl/nano/utils/log4warning.py
@@ -15,9 +15,11 @@
 #
 
 import logging
+from typing import List
+
 
 logger = logging.getLogger(__name__)
-warning_messages = []
+warning_messages: List[str] = []
 
 
 def output_suggestions():

--- a/python/nano/src/bigdl/nano/utils/log4warning.py
+++ b/python/nano/src/bigdl/nano/utils/log4warning.py
@@ -31,4 +31,8 @@ def output_suggestions():
 
 def register_suggestion(warning_message):
     global warning_messages
+
+    # in case core dump / seg fault
+    print(warning_message, flush=True)
+
     warning_messages.append(warning_message)

--- a/python/nano/src/bigdl/nano/utils/log4warning.py
+++ b/python/nano/src/bigdl/nano/utils/log4warning.py
@@ -29,7 +29,7 @@ def output_suggestions():
         logger.warning(f"\n*****************Nano performance Suggestions*****************")
 
 
-def register_suggestion(warning_message):
+def register_suggestion(warning_message: str):
     global warning_messages
 
     # in case core dump / seg fault


### PR DESCRIPTION
## Description

### 1. Why the change?
We may check if users break or fails to follow some BKMs, while we could not transparently apply them for our users. We prefer to tell our users that they could do something to further improve their performance once they stopped the script/completed the script in a conspicuous way.

### 2. User API changes
nothing, this is an internal function.
For developers, they could register a suggestion any time they want in nano's src.

```python
from bigdl.nano.utils.log4warning import register_suggestion
register_suggestion("You should call `bigdl-nano-init -p`")
```

And when users complete their application, they will see the suggestion **at the bottom of** their output, so that they are unlikely to miss the message.:
```bash
*****************Nano performance Suggestions*****************
You should call `bigdl-nano-init -p`

*****************Nano performance Suggestions*****************
```

The suggestions will also be shown even if our users interrupt the program
```bash
^CTraceback (most recent call last):
  File "test.py", line 6, in <module>
    time.sleep(10)
KeyboardInterrupt

*****************Nano performance Suggestions*****************
You should call `bigdl-nano-init -p`

*****************Nano performance Suggestions*****************
```

### 3. Summary of the change 
1. register a print function to print the suggestions, it won't do anything if no suggestion could be provided

### 4. How to test?
- [ ] Unit test

