### PR TITLE
Nano: support custom model for keras INC 

### DIFF
--- a/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/quantization.py
@@ -18,6 +18,7 @@ from ..core import BaseQuantization
 from .metric import TensorflowINCMetric
 from .model import KerasQuantizedModel
 from .utils import Dataloader
+import inspect
 
 
 class TensorflowQuantization(BaseQuantization):
@@ -61,10 +62,4 @@ class TensorflowQuantization(BaseQuantization):
         return ('post_training_static_quant')
 
     def sanity_check_before_execution(self, model, calib_dataloader, metric):
-        invalidInputError(model.inputs is not None and model.outputs is not None,
-                          "A keras.Model for quantization must include Input layers. "
-                          "Please create the model by functional API"
-                          " keras.Model(inputs=.., outputs=..).\n"
-                          "More details in https://keras.io/api/models/model/")
-
         super().sanity_check_before_execution(model, calib_dataloader, metric)

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/quantization.py
@@ -18,8 +18,8 @@ from ..core import BaseQuantization
 from .metric import TensorflowINCMetric
 from .model import KerasQuantizedModel
 from .utils import Dataloader
-import inspect
-
+from bigdl.nano.utils.util import compare_version
+import operator
 
 class TensorflowQuantization(BaseQuantization):
     def __init__(self, framework='tensorflow', **kwargs):
@@ -62,4 +62,13 @@ class TensorflowQuantization(BaseQuantization):
         return ('post_training_static_quant')
 
     def sanity_check_before_execution(self, model, calib_dataloader, metric):
+        INC_LESS_14 = compare_version("neural_compressor", operator.lt, "1.14")
+        if INC_LESS_14:
+            invalidInputError(model.inputs is not None and model.outputs is not None,
+                              "A keras.Model for quantization must include Input layers. "
+                              "Please create the model by functional API"
+                              " keras.Model(inputs=.., outputs=..).\n"
+                              "More details in https://keras.io/api/models/model/."
+                              "Or you can upgrade your INC version to 1.14 or higher.")
+
         super().sanity_check_before_execution(model, calib_dataloader, metric)

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/quantization.py
@@ -21,6 +21,7 @@ from .utils import Dataloader
 from bigdl.nano.utils.util import compare_version
 import operator
 
+
 class TensorflowQuantization(BaseQuantization):
     def __init__(self, framework='tensorflow', **kwargs):
         """

--- a/python/nano/src/bigdl/nano/deps/openvino/core/utils.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/utils.py
@@ -66,7 +66,7 @@ def convert_pb_to_xml(pb_file_path, xml_path, precision,
     for key, value in kwargs.items():
         value = str(value)
         value = value.replace(' ', '')  # remove space in param value
-        params_str += "--" + str(key) + " " + str(value)
+        params_str += "--" + str(key) + " " + str(value) + " "
     if OpenVINO_LESS_2022_3:
         logging_str = "--silent" if logging is False else ""
         mo_cmd = "mo --saved_model_dir {0} {1} {2} {3} -n {4} -o {5}".format(

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -585,7 +585,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                     if inputs is None:
                         inputs = input_names
                     if outputs is None:
-                        outputs = "outputs"
+                        outputs = "outputs"    # type: ignore
 
             result = inc_quantzie(model, dataloader=calib_dataset,
                                   metric=metric,

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -313,7 +313,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :param accelerator: The accelerator to use, defaults to None meaning staying in Keras
                             backend. 'openvino' and 'onnxruntime' are supported for now.
         :param input_spec: A (tuple or list of) tf.TensorSpec or numpy array defining the
-                           shape/dtype of the input when using 'onnxruntime' accelerator.
+                           shape/dtype of the input.
         :param thread_num: (optional) a int represents how many threads(cores) is needed for
                            inference, only valid for accelerator='onnxruntime'
                            or accelerator='openvino'.

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -20,6 +20,7 @@ import time
 from pathlib import Path
 import numpy as np
 import traceback
+import inspect
 import tensorflow as tf
 from typing import Dict, Optional, List, Union
 from bigdl.nano.utils.inference.common.base_optimizer import BaseInferenceOptimizer
@@ -412,7 +413,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :param accelerator:     Use accelerator 'None', 'onnxruntime', 'openvino', defaults to None.
                                 None means staying in tensorflow.
         :param input_spec: A (tuple or list of) tf.TensorSpec or numpy array defining the
-                           shape/dtype of the input when using 'onnxruntime' accelerator.
+                           shape/dtype of the input.
         :param metric:          A tensorflow.keras.metrics.Metric object for evaluation.
         :param accuracy_criterion:  Tolerable accuracy drop.
                                     accuracy_criterion = {'relative': 0.1, 'higher_is_better': True}
@@ -559,6 +560,28 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 calib_dataset = tf.data.Dataset.from_tensor_slices((x, y))
             if batch:
                 calib_dataset = calib_dataset.batch(batch)
+
+            saved_model_input_spec_set = model._saved_model_inputs_spec is not None
+            if not model.built and not saved_model_input_spec_set:
+                # model cannot be saved either because the input shape is not available
+                # or because the forward pass of the model is not defined
+                if input_spec is not None:
+                    if isinstance(input_spec, (tuple, list)):
+                        input_shape = (i.shape for i in input_spec)
+                    else:
+                        input_shape = input_spec.shape
+                    model.compute_output_shape(input_shape)
+            if model.inputs is None or model.outputs is None:
+                # try to fake input and output for model
+                signature = inspect.signature(model.call)
+                input_names = []
+                for param in signature.parameters.values():
+                    input_names.append(param.name)
+                if inputs is None:
+                    inputs = input_names
+                if outputs is None:
+                    outputs = "outputs"
+
             result = inc_quantzie(model, dataloader=calib_dataset,
                                   metric=metric,
                                   framework='tensorflow',

--- a/python/nano/src/bigdl/nano/utils/util.py
+++ b/python/nano/src/bigdl/nano/utils/util.py
@@ -227,9 +227,7 @@ def compare_version(package: str, op: Callable, version: str,
     """
     try:
         pkg = importlib.import_module(package)
-        print(pkg)
     except (ImportError, DistributionNotFound):
-        print("cant import")
         return False
     try:
         if hasattr(pkg, "__version__"):

--- a/python/nano/src/bigdl/nano/utils/util.py
+++ b/python/nano/src/bigdl/nano/utils/util.py
@@ -227,7 +227,9 @@ def compare_version(package: str, op: Callable, version: str,
     """
     try:
         pkg = importlib.import_module(package)
+        print(pkg)
     except (ImportError, DistributionNotFound):
+        print("cant import")
         return False
     try:
         if hasattr(pkg, "__version__"):

--- a/python/nano/test/tf/keras/test_trace_and_quantize.py
+++ b/python/nano/test/tf/keras/test_trace_and_quantize.py
@@ -139,9 +139,7 @@ class TestTraceAndQuantize(TestCase):
                                                       accelerator=None,
                                                       input_spec=tf.TensorSpec(shape=(None, 4), dtype=tf.float32),
                                                       x=np.random.random((100, 4)),
-                                                      y=np.random.random((100, 5)),
-                                                      accuracy_criterion = {'relative': 0,
-                                                                            'higher_is_better': True})
+                                                      y=np.random.random((100, 5)))
         # try to access some custom attributes
         quantized_model.do_nothing()
         assert quantized_model.get_x() == quantized_model.x == x

--- a/python/nano/test/tf/keras/test_trace_and_quantize.py
+++ b/python/nano/test/tf/keras/test_trace_and_quantize.py
@@ -15,6 +15,7 @@
 
 from unittest import TestCase
 import tempfile
+import operator
 import numpy as np
 import tensorflow as tf
 from tensorflow.keras.metrics import MeanSquaredError

--- a/python/nano/test/tf/keras/test_trace_and_quantize.py
+++ b/python/nano/test/tf/keras/test_trace_and_quantize.py
@@ -130,7 +130,7 @@ class TestTraceAndQuantize(TestCase):
         
         # for inc
         from bigdl.nano.utils.util import compare_version
-        INC_LESS_14 = compare_version("neural-compressor", operator.lt, "1.14")
+        INC_LESS_14 = compare_version("neural_compressor", operator.lt, "1.14")
         if INC_LESS_14:
             return
         model = MyModel(x)

--- a/python/nano/test/tf/keras/test_trace_and_quantize.py
+++ b/python/nano/test/tf/keras/test_trace_and_quantize.py
@@ -127,6 +127,31 @@ class TestTraceAndQuantize(TestCase):
             new_model = InferenceOptimizer.load(tmp_dir_name, model)
         new_model.do_nothing()
         assert new_model.get_x() == quantized_model.x == x
+        
+        # for inc
+        from bigdl.nano.utils.util import compare_version
+        INC_LESS_14 = compare_version("neural-compressor", operator.lt, "1.14")
+        if INC_LESS_14:
+            return
+        model = MyModel(x)
+        quantized_model = InferenceOptimizer.quantize(model,
+                                                      accelerator=None,
+                                                      input_spec=tf.TensorSpec(shape=(None, 4), dtype=tf.float32),
+                                                      x=np.random.random((100, 4)),
+                                                      y=np.random.random((100, 5)),
+                                                      accuracy_criterion = {'relative': 0,
+                                                                            'higher_is_better': True})
+        # try to access some custom attributes
+        quantized_model.do_nothing()
+        assert quantized_model.get_x() == quantized_model.x == x
+        quantized_model(np.random.random((1, 4)).astype(np.float32))
+
+        # test save/load
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(quantized_model, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name, model)
+        new_model.do_nothing()
+        assert new_model.get_x() == quantized_model.x == x
 
     def test_evaluate_after_trace(self):
         # test onnxxruntime


### PR DESCRIPTION
## Description

Before Nano can only accept model defined by keras.Model(inputs=.., outputs=..) for inc accelerator.
Now we can support more custom model for inc (>= 1.14)

### 1. Why the change?

Support keras model without input layer for inc.

### 2. User API changes

Now `input_spec` works for `accelerator=None` , you should specify this when your model don't have input layer.
```python
quantized_model = InferenceOptimizer.quantize(model,
                                              accelerator=None,
                                              input_spec=tf.TensorSpec(shape=(None, 4), dtype=tf.float32),
                                              x=np.random.random((100, 4)),
                                              y=np.random.random((100, 5)))
```

### 3. Summary of the change 

- Support keras model without input layer for inc(>= 1.14).
- related uts

### 4. How to test?
- [x] Unit test
