### PR TITLE
Nano: add Neural Coder example and document

### DIFF
--- a/docs/readthedocs/source/doc/Nano/Overview/pytorch_inference.md
+++ b/docs/readthedocs/source/doc/Nano/Overview/pytorch_inference.md
@@ -375,7 +375,7 @@ with InferenceOptimizer.get_context(ipex_model, classifer):
     Neural Compressor >= 2.0 is needed for this function. You may call ``pip install --upgrade neural-compressor`` before using this functionality.
 ```
 
-We also provides a no-code method for users to accelerate their pytorch inferencing workflow through neural coder. Users could call
+We also provides a no-code method for users to accelerate their pytorch inferencing workflow through Neural Coder. Neural Coder is a novel component under Intel® Neural Compressor to further simplify the deployment of deep learning models via one-click. BigDL-Nano is now a backend in Neural Coder. Users could call
 
 ```bash
 python -m neural_coder -o <acceleration_name> example.py
@@ -383,7 +383,7 @@ python -m neural_coder -o <acceleration_name> example.py
 
 For `example.py`, it could be a common pytorch inference script without any code changes needed. For `<acceleration_name>`, please check following table.
 
-| Optimization Set | <acceleration_name> | 
+| Optimization Set | `<acceleration_name>` | 
 | ------------- | ------------- | 
 | BF16 + Channels Last | `nano_bf16_channels_last` | 
 | BF16 + IPEX + Channels Last | `nano_bf16_ipex_channels_last` | 

--- a/docs/readthedocs/source/doc/Nano/Overview/pytorch_inference.md
+++ b/docs/readthedocs/source/doc/Nano/Overview/pytorch_inference.md
@@ -368,3 +368,40 @@ with InferenceOptimizer.get_context(ipex_model, classifer):
     output = classifer(x) 
     assert torch.get_num_threads() == 4  # this line just to let you know Nano has provided thread control automatically : )
 ```
+
+## One-click Accleration Without Code Change
+```eval_rst
+.. note::
+    Neural Compressor >= 2.0 is needed for this function. You may call ``pip install --upgrade neural-compressor`` before using this functionality.
+```
+
+We also provides a no-code method for users to accelerate their pytorch inferencing workflow through neural coder. Users could call
+
+```bash
+python -m neural_coder -o <acceleration_name> example.py
+```
+
+For `example.py`, it could be a common pytorch inference script without any code changes needed. For `<acceleration_name>`, please check following table.
+
+| Optimization Set | <acceleration_name> | 
+| ------------- | ------------- | 
+| BF16 + Channels Last | `nano_bf16_channels_last` | 
+| BF16 + IPEX + Channels Last | `nano_bf16_ipex_channels_last` | 
+| BF16 + IPEX | `nano_bf16_ipex` | 
+| BF16 | `nano_bf16` | 
+| Channels Last | `nano_fp32_channels_last` | 
+| IPEX + Channels Last | `nano_fp32_ipex_channels_last` | 
+| IPEX | `nano_fp32_ipex` | 
+| INT8 | `nano_int8` | 
+| JIT + BF16 + Channels Last | `nano_jit_bf16_channels_last` | 
+| JIT + BF16 + IPEX + Channels Last | `nano_jit_bf16_ipex_channels_last` | 
+| JIT + BF16 + IPEX | `nano_jit_bf16_ipex` | 
+| JIT + BF16 | `nano_jit_bf16` | 
+| JIT + Channels Last | `nano_jit_fp32_channels_last` | 
+| JIT + IPEX + Channels Last | `nano_jit_fp32_ipex_channels_last` | 
+| JIT + IPEX | `nano_jit_fp32_ipex` | 
+| JIT | `nano_jit_fp32` | 
+| ONNX Runtime | `nano_onnxruntime_fp32` | 
+| ONNX Runtime + INT8 | `nano_onnxruntime_int8_qlinear` | 
+| OpenVINO | `nano_openvino_fp32` | 
+| OpenVINO + INT8 | `nano_openvino_int8` |

--- a/python/nano/tutorial/inference/pytorch/neural_coder/example.py
+++ b/python/nano/tutorial/inference/pytorch/neural_coder/example.py
@@ -1,0 +1,28 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
+import torch
+from torchvision.models import resnet18
+
+if __name__ == "__main__":
+
+    model_ft = resnet18(pretrained=True)
+
+    x = torch.rand(2, 3, 224, 224)
+    y_hat = model_ft(x)
+    predictions = y_hat.argmax(dim=1)
+    print(predictions)

--- a/python/nano/tutorial/inference/pytorch/neural_coder/readme.md
+++ b/python/nano/tutorial/inference/pytorch/neural_coder/readme.md
@@ -1,0 +1,40 @@
+# One-click Accleration Without Code Change
+
+## Introduction
+We also provides a no-code method for users to accelerate their pytorch inferencing workflow through neural coder.
+
+## Environment preparation
+Neural Compressor >= 2.0 is needed for this function. You may call ``pip install --upgrade neural-compressor`` before using this functionality.
+
+## Run
+```bash
+# FP32 + Channels_last
+python -m neural_coder -o nano_fp32_channels_last example.py
+```
+Then a new script `example_optimized.py` will be generated and be executed. You may choose other acceleration method name.
+
+## Acceleration Name Table
+For `<acceleration_name>`, please check following table.
+
+| Optimization Set | <acceleration_name> | 
+| ------------- | ------------- | 
+| BF16 + Channels Last | `nano_bf16_channels_last` | 
+| BF16 + IPEX + Channels Last | `nano_bf16_ipex_channels_last` | 
+| BF16 + IPEX | `nano_bf16_ipex` | 
+| BF16 | `nano_bf16` | 
+| Channels Last | `nano_fp32_channels_last` | 
+| IPEX + Channels Last | `nano_fp32_ipex_channels_last` | 
+| IPEX | `nano_fp32_ipex` | 
+| INT8 | `nano_int8` | 
+| JIT + BF16 + Channels Last | `nano_jit_bf16_channels_last` | 
+| JIT + BF16 + IPEX + Channels Last | `nano_jit_bf16_ipex_channels_last` | 
+| JIT + BF16 + IPEX | `nano_jit_bf16_ipex` | 
+| JIT + BF16 | `nano_jit_bf16` | 
+| JIT + Channels Last | `nano_jit_fp32_channels_last` | 
+| JIT + IPEX + Channels Last | `nano_jit_fp32_ipex_channels_last` | 
+| JIT + IPEX | `nano_jit_fp32_ipex` | 
+| JIT | `nano_jit_fp32` | 
+| ONNX Runtime | `nano_onnxruntime_fp32` | 
+| ONNX Runtime + INT8 | `nano_onnxruntime_int8_qlinear` | 
+| OpenVINO | `nano_openvino_fp32` | 
+| OpenVINO + INT8 | `nano_openvino_int8` |


### PR DESCRIPTION
## Description

### 1. Why the change?
Neural Coder (in Neural Compressor 2.0) has now supported nano as an accelerated method. This PR add document and examples for this functionality.

https://bigdl-junweid.readthedocs.io/en/nc-nano-document/doc/Nano/Overview/pytorch_inference.html#one-click-accleration-without-code-change

### 2. User API changes

Provide a no-code method for users to accelerate their pytorch inferencing workflow through neural coder. Users could call
```bash
python -m neural_coder -o <acceleration_name> example.py
```
For `example.py`, it could be a common pytorch inference script without any code changes needed. For `<acceleration_name>`, please check following table.

### 3. Summary of the change 
1. add the functionality to key feature
2. add an example to tutorial

### 4. How to test?
- [ ] Application test
- [ ] Document test
