### PR TITLE
Orca: Make loss_creator optional and discuss criterion when fit and eval

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -141,10 +141,6 @@ class PyTorchPySparkEstimator(BaseEstimator):
         self.model_creator = model_creator
         self.optimizer_creator = optimizer_creator
 
-        if not loss_creator:
-            invalidInputError(False,
-                              "You must provide a loss_creator.")
-
         num_nodes, cores_per_node = get_node_and_core_number()
         self.num_workers = num_nodes * workers_per_node
         self.total_cores = num_nodes * cores_per_node

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -118,10 +118,6 @@ class PyTorchRayEstimator(BaseRayEstimator):
         self.sync_stats = sync_stats
         self.backend = backend
 
-        if not loss_creator:
-            invalidInputError(False,
-                              "You must provide a loss_creator.")
-
         self.config = {} if config is None else config
         worker_config = copy.copy(self.config)
         params = dict(

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -304,6 +304,10 @@ class TorchRunner(BaseRunner):
             self.train_loader.sampler.set_epoch(self.epochs)
         self.logger.debug("Begin Training Step {}".format(self.epochs + 1))
 
+        if not self.criterion:
+            invalidInputError(False,
+                              "You must provide a loss_creator.")
+
         info = info or {}
         self._toggle_profiling(profile=profile)
 
@@ -527,6 +531,10 @@ class TorchRunner(BaseRunner):
     def validate(self, data_creator, batch_size=32, num_steps=None, profile=False,
                  info=None, wrap_dataloader=None):
         """Evaluates the model on the validation data set."""
+        if not self.criterion:
+            invalidInputError(False,
+                              "You must provide a loss_creator.")
+
         config = copy.copy(self.config)
         info = info or {}
         self._toggle_profiling(profile=profile)

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -306,7 +306,7 @@ class TorchRunner(BaseRunner):
 
         if not self.criterion:
             invalidInputError(False,
-                              "You must provide a loss_creator.")
+                              "You must provide a loss for train and evaluate.")
 
         info = info or {}
         self._toggle_profiling(profile=profile)
@@ -533,7 +533,7 @@ class TorchRunner(BaseRunner):
         """Evaluates the model on the validation data set."""
         if not self.criterion:
             invalidInputError(False,
-                              "You must provide a loss_creator.")
+                              "You must provide a loss for train and evaluate.")
 
         config = copy.copy(self.config)
         info = info or {}


### PR DESCRIPTION
## Description

When in predict mode, there should be no loss_creator. So we should require loss_creator when fiting or validating instead of init estimator.
https://github.com/intel-analytics/BigDL/issues/7161?notification_referrer_id=NT_kwDOAZp2hLM1MjM4NTY4MjQxOjI2OTAwMTAw