### PR TITLE
Nano: bug fix for multiple calling on bigdl-nano-init with different option

### DIFF
--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -14,7 +14,7 @@ function disable-openmp-var {
 }
 
 function enable-jemalloc-var {
-	echo "Option: Enable jemalloc and unset related variables"
+	echo "Option: Enable jemalloc and set related variables"
 	export ENABLE_JEMALLOC_VAR=1
 }
 
@@ -65,6 +65,7 @@ while getopts ":ojhcp-:" opt; do
 					disable-openmp-var
 					;;
 				enable-jemalloc)
+				    disable-tcmalloc-var
 					enable-jemalloc-var
 					;;
 				disable-tcmalloc)
@@ -87,6 +88,7 @@ while getopts ":ojhcp-:" opt; do
 			disable-openmp-var
 			;;
 		j )
+			disable-tcmalloc-var
 			enable-jemalloc-var
 			;;
 		c )
@@ -165,33 +167,33 @@ echo "Setting MALLOC_CONF..."
 export MALLOC_CONF="oversize_threshold:1,background_thread:false,metadata_thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1"
 
 # Set LD_PRELOAD
-if [ -z "${LD_PRELOAD:-}" ]; then
-	echo "Setting LD_PRELOAD..."
-	if [[ $OPENMP -eq 1 && -z "${DISABLE_OPENMP_VAR:-}" ]]; then
-		export LD_PRELOAD="${LIB_DIR}/libiomp5.so"
-	fi
-	if [[ $JEMALLOC -eq 1 && ! -z "${ENABLE_JEMALLOC_VAR:-}" ]]; then
-	    DISABLE_TCMALLOC_VAR=1
-		if [ -f "${NANO_DIR}/libs/libjemalloc.so" ]; then
-			JEMALLOC_PATH="${NANO_DIR}/libs/libjemalloc.so"
-		elif [ -f "${LIB_DIR}/libjemalloc.so" ]; then
-			JEMALLOC_PATH="${LIB_DIR}/libjemalloc.so"
-		fi
-		# if `LD_PRELOAD` or `JEMLLOC_PATH` is empty, there will be
-		# extra space on the left or right sides, use echo to remove them
-		export LD_PRELOAD=$(echo ${LD_PRELOAD} ${JEMALLOC_PATH})
-	fi
+echo "Setting LD_PRELOAD..."
+if [[ $OPENMP -eq 1 && -z "${DISABLE_OPENMP_VAR:-}" ]]; then
+	export LD_PRELOAD="${LIB_DIR}/libiomp5.so"
+fi
 
-	# Set TCMALLOC lib path
-	if [[ $TCMALLOC -eq 1 && -z "${DISABLE_TCMALLOC_VAR:-}" ]]; then
-		if [ -f "${NANO_DIR}/libs/libtcmalloc.so" ]; then
-			TCMALLOC_PATH="${NANO_DIR}/libs/libtcmalloc.so"
-		elif [ -f "${LIB_DIR}/libtcmalloc.so" ]; then
-			TCMALLOC_PATH="${LIB_DIR}/libtcmalloc.so"
-		fi
-		# the same as above
-		export LD_PRELOAD=$(echo ${LD_PRELOAD} ${TCMALLOC_PATH})
+# Set JEMALLOC lib path
+if [[ $JEMALLOC -eq 1 && ! -z "${ENABLE_JEMALLOC_VAR:-}" ]]; then
+	DISABLE_TCMALLOC_VAR=1
+	if [ -f "${NANO_DIR}/libs/libjemalloc.so" ]; then
+		JEMALLOC_PATH="${NANO_DIR}/libs/libjemalloc.so"
+	elif [ -f "${LIB_DIR}/libjemalloc.so" ]; then
+		JEMALLOC_PATH="${LIB_DIR}/libjemalloc.so"
 	fi
+	# if `LD_PRELOAD` or `JEMLLOC_PATH` is empty, there will be
+	# extra space on the left or right sides, use echo to remove them
+	export LD_PRELOAD=$(echo ${LD_PRELOAD} ${JEMALLOC_PATH})
+fi
+
+# Set TCMALLOC lib path
+if [[ $TCMALLOC -eq 1 && -z "${DISABLE_TCMALLOC_VAR:-}" ]]; then
+	if [ -f "${NANO_DIR}/libs/libtcmalloc.so" ]; then
+		TCMALLOC_PATH="${NANO_DIR}/libs/libtcmalloc.so"
+	elif [ -f "${LIB_DIR}/libtcmalloc.so" ]; then
+		TCMALLOC_PATH="${LIB_DIR}/libtcmalloc.so"
+	fi
+	# the same as above
+	export LD_PRELOAD=$(echo ${LD_PRELOAD} ${TCMALLOC_PATH})
 fi
 
 # Clean up perf var


### PR DESCRIPTION
## Description

### 1. Why the change?
This PR is raised because of following bug
```bash
>>> source bigdl-nano-init
>>> source bigdl-nano-init -j
```
at this time, jemalloc should be applied to `LD_PRELOAD`, while in this case tcmalloc is still applied
```bash
(junweid-nano) icx@icx-5:~$ source bigdl-nano-init -j
Option: Enable jemalloc and unset related variables
conda dir found: /disk0/miniconda3/envs/junweid-nano/bin/..
OpenMP library found...
Setting OMP_NUM_THREADS...
Setting KMP_AFFINITY...
Setting KMP_BLOCKTIME...
Setting MALLOC_CONF...
nano_vars.sh already exists
+++++ Env Variables +++++
LD_PRELOAD=/disk0/miniconda3/envs/junweid-nano/bin/../lib/libiomp5.so /disk0/miniconda3/envs/junweid-nano/lib/python3.7/site-packages/bigdl/nano//libs/libtcmalloc.so
MALLOC_CONF=oversize_threshold:1,background_thread:false,metadata_thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1
OMP_NUM_THREADS=80
KMP_AFFINITY=granularity=fine,none
KMP_BLOCKTIME=1
TF_ENABLE_ONEDNN_OPTS=1
+++++++++++++++++++++++++
Complete.
```

### 2. User API changes
nothing

### 3. Summary of the change 

- add disable tcmalloc var for -j
- remove the logic of LD_PRELOAD checking, LD_PRELOAD will be generated every time `bigdl-nano-init` is called in this PR.

### 4. How to test?
- [x] Unit test

