### PR TITLE
Chronos: add excludes for s2s model since it has not support quantization

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -608,6 +608,10 @@ class BasePytorchForecaster(Forecaster):
 
         dummy_input = torch.rand(1, self.data_config["past_seq_len"],
                                  self.data_config["input_feature_num"])
+        excludes = None
+        if not self.quantize_available:
+            excludes = ["static_int8", "openvino_int8", "onnxruntime_int8_qlinear",
+                        "bf16", "jit_bf16_ipex", "jit_bf16_ipex_channels_last"]
         from bigdl.chronos.pytorch import TSInferenceOptimizer as InferenceOptimizer
         opt = InferenceOptimizer()
         opt.optimize(model=self.internal,
@@ -616,6 +620,7 @@ class BasePytorchForecaster(Forecaster):
                      metric=metric,
                      direction="min",
                      thread_num=thread_num,
+                     excludes=excludes,
                      input_sample=dummy_input)
         try:
             optim_model, option = opt.get_best_model(


### PR DESCRIPTION
## Description

Try to fix the core dump problem in chronos pr action.

Seq2seq has not supported quantization, so exclude low precision items in optimize method

### 4. How to test?
- [ ] Unit test

