### PR TITLE
Orca: Fix 'NoneType' object is not callable when tqdm is not installed

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -389,7 +389,8 @@ class TorchRunner(BaseRunner):
                                            info["num_epochs"])
                 else:
                     desc = "{}e".format(info["epoch_idx"] + 1)
-            invalidInputError(tqdm is not None, "tqdm is not installed, please install with 'pip install tqdm'")
+            invalidInputError(tqdm is not None, 
+                              "tqdm is not installed, please install with 'pip install tqdm'")
             _progress_bar = tqdm(
                 total=len(iterator),
                 desc=desc,

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -389,7 +389,7 @@ class TorchRunner(BaseRunner):
                                            info["num_epochs"])
                 else:
                     desc = "{}e".format(info["epoch_idx"] + 1)
-            invalidInputError(tqdm is not None, 
+            invalidInputError(tqdm is not None,
                               "tqdm is not installed, please install with 'pip install tqdm'")
             _progress_bar = tqdm(
                 total=len(iterator),

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -389,6 +389,7 @@ class TorchRunner(BaseRunner):
                                            info["num_epochs"])
                 else:
                     desc = "{}e".format(info["epoch_idx"] + 1)
+            invalidInputError(tqdm is not None, "tqdm is not installed, please install with 'pip install tqdm'")
             _progress_bar = tqdm(
                 total=len(iterator),
                 desc=desc,


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

When `tqdm` is not installed but the user explictly sets `use_tqdm=True`, the error prompt message is not clear. The user can only get message `TypeError: ‘NoneType’ object is not callable`. 

See issue https://github.com/analytics-zoo/orca/issues/120#issuecomment-1370531368

### 2. Summary of the change 

Add one `invalidInputError`.
<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. How to test?

1. uninstall `tqdm` by `pip uninstall tqdm`
2. cd `BigDL/python/orca/tutorial/NCF` and run `python ./pytorch_train_dataloader.py`
3. can see the following error prompt
```
[2023-01-05 10:54:11] ERROR                                         (0 + 1) / 1]

****************************Usage Error************************
tqdm is not installed, please install with 'pip install tqdm'
[2023-01-05 10:54:11] ERROR    

****************************Call Stack*************************
```

